### PR TITLE
Data download script

### DIFF
--- a/utils/public-support-files-download.sh
+++ b/utils/public-support-files-download.sh
@@ -71,5 +71,6 @@ curl https://proteinpaint.stjude.org/ppSupport/HOCOMOCOv11_full_HUMAN_mono_meme_
 curl https://proteinpaint.stjude.org/ppSupport/HOCOMOCOv11_full_annotation_HUMAN_mono.tsv -O
 
 cd $TP_FOLDER
-curl https://proteinpaint.stjude.org/ppSupport/pp.demo.tgz -O
-tar zxvf pp.demo.tgz # Releases the "proteinpaint_demo/" folder under $TP_FOLDER
+curl https://proteinpaint.stjude.org/ppSupport/ppdemo_bam.tar.gz -O # This tarball only contains the BAM slices which are shown in http://proteinpaint.stjude.org/bam 
+#curl https://proteinpaint.stjude.org/ppSupport/pp.demo.tgz -O
+tar zxvf ppdemo_bam.tar.gz # Releases the "proteinpaint_demo/" folder under $TP_FOLDER


### PR DESCRIPTION
I improved the data download script. 

1) Now it does not download files to "~/data/tp", instead user can specify directory of their own choice or if unspecified, to the current working directory.

2) I changed the proteinpaint_demo tarball. Now the new tarball only has the BAM slices being discussed in https://proteinpaint.stjude.org/bam