### PR TITLE
Docker debug1

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -108,14 +108,18 @@ WORKDIR /home/root/pp/app
 RUN mkdir active
 # !!! NOTE: after open-sourcing, will only need the @stjude registry URL, no token required !!!
 WORKDIR /home/root/pp/app/active
-COPY .npmrc ./
 ARG SERVERPKGVER
-RUN if [ -f /home/root/pp/tmppack/stjude-proteinpaint-server-${SERVERPKGVER}.tgz ]; then \
+RUN echo "@stjude:registry=https://npm.pkg.github.com/" > .npmrc && \
+    if [ -f /home/root/pp/tmppack/stjude-proteinpaint-server-${SERVERPKGVER}.tgz ]; then \
       npm install /home/root/pp/tmppack/stjude-proteinpaint-server-${SERVERPKGVER}.tgz; \
     else \
+      echo "@stjude:registry=https://npm.pkg.github.com/" > .npmrc \
       npm install @stjude/proteinpaint-server@${SERVERPKGVER}; \
-    fi; \
-    rm .npmrc
+    fi
+
+# to help with troubleshooting this stage
+# enables container to be active for ssh debugging
+CMD ["sleep", "3600"]
 
 #####################
 # Server-only app
@@ -131,8 +135,8 @@ COPY --from=ppserverdeps /home/root/pp/app/active /home/root/pp/app/active
 WORKDIR /home/root/pp/app/active
 COPY ./server/app.js .
 EXPOSE 3000
-CMD ["sh", "-c", "node app.js"]
-
+# CMD ["sh", "-c", "node app.js"]
+CMD ["sleep", "3600"]
 
 #################
 # Full install
@@ -148,14 +152,18 @@ COPY --from=ppserver /home/root/pp/app/active /home/root/pp/app/active
 
 WORKDIR /home/root/pp/app/active
 # !!! NOTE: after open-sourcing, will only need the @stjude registry URL, no token required !!!
-COPY ./.npmrc .
 ARG FRONTPKGVER
-RUN if [ -f /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz ]; then \
-      npm install /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz; \
-    else \
-      npm install @stjude/proteinpaint-front@${FRONTPKGVER}; \
-    fi; \
-    rm .npmrc
+RUN echo "@stjude:registry=https://npm.pkg.github.com/" > .npmrc
+ # && \
+ #    if [ -f /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz ]; then \
+ #      npm install /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz; \
+ #    else \
+ #      npm install @stjude/proteinpaint-front@${FRONTPKGVER}; \
+ #    fi;
+
+# to help with troubleshooting this stage
+# enables container to be active for ssh debugging
+CMD ["sleep", "3600"]
 
 ############
 # Full app

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -106,14 +106,16 @@ COPY tmppack ./tmppack
 
 WORKDIR /home/root/pp/app 
 RUN mkdir active
-# !!! NOTE: after open-sourcing, will only need the @stjude registry URL, no token required !!!
+
 WORKDIR /home/root/pp/app/active
+# !!! NOTE: after open-sourcing, will only need the @stjude registry URL, no token required !!!
+COPY .npmrc ./
 ARG SERVERPKGVER
-RUN echo "@stjude:registry=https://npm.pkg.github.com/" > .npmrc && \
-    if [ -f /home/root/pp/tmppack/stjude-proteinpaint-server-${SERVERPKGVER}.tgz ]; then \
+RUN if [ -f /home/root/pp/tmppack/stjude-proteinpaint-server-${SERVERPKGVER}.tgz ]; then \
+      echo "installing proteinpaint-server from tarball" && \
       npm install /home/root/pp/tmppack/stjude-proteinpaint-server-${SERVERPKGVER}.tgz; \
     else \
-      echo "@stjude:registry=https://npm.pkg.github.com/" > .npmrc \
+      echo "installing proteinpaint-server from registry" && \
       npm install @stjude/proteinpaint-server@${SERVERPKGVER}; \
     fi
 
@@ -135,8 +137,8 @@ COPY --from=ppserverdeps /home/root/pp/app/active /home/root/pp/app/active
 WORKDIR /home/root/pp/app/active
 COPY ./server/app.js .
 EXPOSE 3000
-# CMD ["sh", "-c", "node app.js"]
-CMD ["sleep", "3600"]
+CMD ["sh", "-c", "node app.js"]
+# CMD ["sleep", "3600"]
 
 #################
 # Full install
@@ -152,14 +154,15 @@ COPY --from=ppserver /home/root/pp/app/active /home/root/pp/app/active
 
 WORKDIR /home/root/pp/app/active
 # !!! NOTE: after open-sourcing, will only need the @stjude registry URL, no token required !!!
+COPY .npmrc ./ 
 ARG FRONTPKGVER
-RUN echo "@stjude:registry=https://npm.pkg.github.com/" > .npmrc
- # && \
- #    if [ -f /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz ]; then \
- #      npm install /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz; \
- #    else \
- #      npm install @stjude/proteinpaint-front@${FRONTPKGVER}; \
- #    fi;
+RUN if [ -f /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz ]; then \
+      echo "installing proteinpaint-front from tarball" && \
+      npm install /home/root/pp/tmppack/stjude-proteinpaint-front-${FRONTPKGVER}.tgz; \
+    else \
+      echo "installing proteinpaint-front from tarball" && \
+      npm install @stjude/proteinpaint-front@${FRONTPKGVER}; \
+    fi;
 
 # to help with troubleshooting this stage
 # enables container to be active for ssh debugging

--- a/container/build.sh
+++ b/container/build.sh
@@ -73,10 +73,15 @@ docker build . --file ./Dockerfile --target ppbase --tag ppbase:$REV --build-arg
 echo "building pprust:$REV image, package version=$TAG"
 docker build . --file ./Dockerfile --target pprust --tag pprust:$REV --build-arg ARCH="$ARCH" $BUILDARGS
 
-echo "building ppserver:$REV image, package version=$TAG"
-docker build . --file ./Dockerfile --target ppserver --tag ppserver:$REV --build-arg IMGVER=$REV --build-arg SERVERPKGVER=$SERVERPKGVER --build-arg CROSSENV="$CROSSENV" $BUILDARGS
+echo "building ppserverdeps:$REV image, package version=$TAG"
+docker build . --file ./Dockerfile --target ppserverdeps --tag ppserverdeps:$REV --build-arg IMGVER=$REV --build-arg SERVERPKGVER=$SERVERPKGVER --build-arg CROSSENV="$CROSSENV" $BUILDARGS
 
-echo "building ppfull:$REV image, package version=$TAG"
-docker build . --file ./Dockerfile --target ppapp --tag ppfull:$REV --build-arg IMGVER=$REV --build-arg SERVERPKGVER=$SERVERPKGVER --build-arg FRONTPKGVER=$FRONTPKGVER --build-arg CROSSENV="$CROSSENV" $BUILDARGS
+# echo "building ppserver:$REV image, package version=$TAG"
+# docker build . --file ./Dockerfile --target ppserver --tag ppserver:$REV --build-arg IMGVER=$REV --build-arg SERVERPKGVER=$SERVERPKGVER --build-arg CROSSENV="$CROSSENV" $BUILDARGS
 
-[ "$(ls -A $(pwd)/tmppack )" ] || rm -r $PWD/tmppack   
+# echo "building ppfull:$REV image, package version=$TAG"
+# docker build . --file ./Dockerfile --target ppapp --tag ppfull:$REV --build-arg IMGVER=$REV --build-arg SERVERPKGVER=$SERVERPKGVER --build-arg FRONTPKGVER=$FRONTPKGVER --build-arg CROSSENV="$CROSSENV" $BUILDARGS
+
+if [[ "$(ls -A $(pwd)/tmppack )" == "" ]]; then 
+	rm -r $PWD/tmppack   
+fi

--- a/container/build.sh
+++ b/container/build.sh
@@ -83,5 +83,5 @@ docker build . --file ./Dockerfile --target ppserverdeps --tag ppserverdeps:$REV
 # docker build . --file ./Dockerfile --target ppapp --tag ppfull:$REV --build-arg IMGVER=$REV --build-arg SERVERPKGVER=$SERVERPKGVER --build-arg FRONTPKGVER=$FRONTPKGVER --build-arg CROSSENV="$CROSSENV" $BUILDARGS
 
 if [[ "$(ls -A $(pwd)/tmppack )" == "" ]]; then 
-	rm -r $PWD/tmppack   
+	rm -rf $PWD/tmppack   
 fi

--- a/container/package.json
+++ b/container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@stjude/proteinpaint-container",
-	"version": "2.11.2-0",
+	"version": "2.11.2-1",
 	"bin": "app.js",
 	"scripts": {
 		"dev": "./pack.sh && ./build.sh",
@@ -8,8 +8,8 @@
 		"postinstall": "./build.sh -m notdev"
 	},
 	"containerDeps": {
-		"server": "2.11.2-0",
-		"front": "2.11.2-0"
+		"server": "2.11.2-1",
+		"front": "2.11.2-1"
 	},
 	"files": [
 		"build.sh",


### PR DESCRIPTION
- must remember to update the containerDeps versions in container/package.json when rebuilding the image: this should be automated similar to how it's done for pp-irt2
- must use an .npmrc with a token in the Dockerfile, until the already visible public registry allows npm install without tokens

@robinpaul85 please check if you are able to rebuild, the usual steps: 
```bash
cd container
./pack.sh
./build.sh
./run.sh ppfull:latest 
```
For a full test prior to creating another versioned release of pp-container, follow the instructions in the `container/README.md`.
