### PR TITLE
Moved help icon out of the burguer menu icons

### DIFF
--- a/client/plots/controls.btns.js
+++ b/client/plots/controls.btns.js
@@ -22,12 +22,6 @@ class TdbControlsTopBar {
 				callback: opts.callback,
 				debug
 			}),
-			helpbtn: helpBtnInit({
-				id: opts.id,
-				holder: this.dom.holder.insert('div'),
-				callback: opts.helpHandler,
-				debug
-			}),
 			downloadbtn: downloadBtnInit({
 				id: opts.id,
 				holder: this.dom.holder.insert('div'),
@@ -97,28 +91,6 @@ function downloadBtnInit(opts) {
 		plotTypes: ['summary', 'boxplot', 'scatter'],
 		dom: {
 			btn: downloadDiv
-		}
-	}
-
-	const api = {
-		main(isOpen, plot) {
-			self.dom.btn.style('display', isOpen ? 'inline-block' : 'block')
-		}
-	}
-
-	if (opts.debug) api.Inner = self
-	return Object.freeze(api)
-}
-
-function helpBtnInit(opts) {
-	const helpDiv = opts.holder.style('margin-left', '20px').style('margin-bottom', '15px')
-
-	icon_functions['help'](helpDiv, { handler: opts.callback })
-
-	const self = {
-		plotTypes: ['scatter'],
-		dom: {
-			btn: helpDiv
 		}
 	}
 

--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -17,7 +17,7 @@ let i = 0 // track controls "instances" for assigning unambiguous unique input n
 class TdbPlotControls {
 	constructor(opts) {
 		this.type = 'plotControls'
-		this.customEvents = ['downloadClick', 'infoClick', 'helpClick']
+		this.customEvents = ['downloadClick', 'infoClick']
 		setInteractivity(this)
 		setRenderers(this)
 	}
@@ -32,7 +32,6 @@ class TdbPlotControls {
 					holder: this.dom.topbar,
 					callback: this.toggleVisibility,
 					downloadHandler: () => this.bus.emit('downloadClick'),
-					helpHandler: () => this.bus.emit('helpClick'),
 					infoHandler: isOpen =>
 						this.app.dispatch({
 							type: 'plot_edit',

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -295,9 +295,6 @@ class Scatter {
 		}
 
 		this.components.controls.on('downloadClick.scatter', () => this.downloadSVG(this.svg))
-		this.components.controls.on('helpClick.scatter', () =>
-			window.open('https://github.com/stjude/proteinpaint/wiki/Scatter-plot', '_blank')
-		)
 		this.dom.toolsDiv = this.dom.controls.insert('div')
 	}
 
@@ -1385,6 +1382,14 @@ function setRenderers(self) {
 		toolsDiv.selectAll('*').remove()
 		let display = 'block'
 		if (inline) display = 'inline-block'
+		const helpDiv = toolsDiv
+			.insert('div')
+			.style('display', display)
+			.style('margin', '20px')
+			.attr('name', 'sjpp-reset-btn') //For unit tests
+		icon_functions['help'](helpDiv, {
+			handler: () => window.open('https://github.com/stjude/proteinpaint/wiki/Scatter-plot', '_blank')
+		})
 
 		const homeDiv = toolsDiv
 			.insert('div')


### PR DESCRIPTION
Now it only exists in the scatter plot, no need to hide it in other plots.