### PR TITLE
support filter.main(,{additionalFilter}) with mass global filter

### DIFF
--- a/client/plots/genomeBrowser.controls.js
+++ b/client/plots/genomeBrowser.controls.js
@@ -211,7 +211,6 @@ function render1group_population(self, groupIdx, group, div) {
 function render1group_filter(self, groupIdx, group, div) {
 	/*
 	this group is based on a termdb-filter
-	FIXME the filter instance is not reflecting global mass filter and subcohort change
 	*/
 	filterInit({
 		holder: div,
@@ -227,7 +226,7 @@ function render1group_filter(self, groupIdx, group, div) {
 				config: { snvindel: { details: { groups } } }
 			})
 		}
-	}).main(group.filter)
+	}).main(group.filter, { additionalFilter: self.state.filter })
 
 	const count = self._partialData?.groupSampleCounts?.[groupIdx]
 	if (Number.isInteger(count)) {


### PR DESCRIPTION
test with http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22chr%22:%22chr10%22,%22start%22:61901683,%22stop%22:62096944}}]}

on master, the filter menu shows number of samples from entire cohort