### PR TITLE
handle cases where a global or local filter may have 2+ entries

### DIFF
--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -187,6 +187,15 @@ class Filter {
 		const i = parentCopy.lst.findIndex(f => f.$id === $id)
 		if (i == -1) return null
 		parentCopy.lst.splice(i, 1)
+		return getNormalRoot(rootCopy)
+		/*
+		!!! 
+			The logic below incorectly assumes that there are at most 2 root tvslst.lst entries,
+			a cohortFilter, ONE OTHER, or both
+			- this is mostly true for a global filter
+			- however, a local chart filter may have 3+ entries in its root tvslst: 
+			  a cohortFilter tvs,  aterm filter tvslst, AND the local filter tvslst
+		!!!
 		const cohortFilter = getFilterItemByTag(rootCopy, 'cohortFilter')
 		if (cohortFilter && !parentCopy.lst.find(d => d === cohortFilter)) {
 			return getNormalRoot({
@@ -197,6 +206,7 @@ class Filter {
 		} else {
 			return getNormalRoot(parentCopy)
 		}
+		*/
 	}
 	getAdjustedRoot($id, join) {
 		const rootCopy = JSON.parse(JSON.stringify(this.rawFilter))

--- a/client/plots/genomeBrowser.controls.js
+++ b/client/plots/genomeBrowser.controls.js
@@ -126,8 +126,10 @@ class GbControls {
 		const group = this.state.config.snvindel.details.groups[groupIdx]
 		const div = groupIdx == 0 ? this.dom.group1div : this.dom.group2div
 
-		if (group.type == 'filter' && this.filterUI[groupIdx]) {
+		let canReuse = false
+		if (group?.type == 'filter' && this.filterUI[groupIdx]) {
 			// will reuse an existing filterUI[${groupIdx}] and div
+			canReuse = true
 		} else {
 			delete this.filterUI[groupIdx] // ok to delete even if not existing
 			div.selectAll('*').remove()
@@ -141,7 +143,7 @@ class GbControls {
 		}
 
 		// the group exists; first show the group header button
-		makeGroupHeaderButton(this, groupIdx, div)
+		if (!canReuse) makeGroupHeaderButton(this, groupIdx, div)
 
 		if (group.type == 'info') return render1group_info(this, groupIdx, group, div)
 		if (group.type == 'population') return render1group_population(this, groupIdx, group, div)

--- a/client/plots/genomeBrowser.controls.js
+++ b/client/plots/genomeBrowser.controls.js
@@ -98,7 +98,7 @@ class GbControls {
 				}
 			})
 		const div = this.dom.variantFilterHolder.append('div').style('display', 'none')
-		this.filterUI.variant = await filterInit({
+		filterInit({
 			joinWith: this.state.config.variantFilter.opts.joinWith,
 			emptyLabel: '+Add Filter',
 			holder: div,
@@ -110,9 +110,7 @@ class GbControls {
 					config: { variantFilter: { filter } }
 				})
 			}
-		})
-
-		this.filterUI.variant.main(this.state.config.variantFilter.filter)
+		}).main(this.state.config.variantFilter.filter)
 	}
 
 	/*


### PR DESCRIPTION
 in the root tvslst, and reuse a genomebrowser filterUI if applicable

@xzhou82 The actual issue is that `getFilterExcludingPill($id)` mistakenly assumed that only up to 2 entries can exist in a root filter data, a cohort filter and/or the `filterUiRoot`. We now see that a local filter can have 3 entries: the cohort filter, the global filter UI data, and the local filter UI data.

I did not push to master because there may be other use cases where only the global cohort filter may be needed for a different type of track or chart, so other entries in the root filter was intentionally excluded? This will need to be tested more, even though all filter and tvs integration test pass.