### PR TITLE
Cuminc changes

### DIFF
--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -380,6 +380,7 @@ class MassCumInc {
 			this.app.vocabApi.syncTermData(this.config, data)
 			this.processData(data)
 			this.pj.refresh({ data: this.currData })
+			this.sortSerieses(this.pj.tree.charts)
 			this.setTerm2Color(this.pj.tree.charts)
 			this.render()
 			this.renderSkippedCharts(this.dom.skippedChartsDiv, this.skippedCharts)
@@ -486,6 +487,24 @@ class MassCumInc {
 				}
 			}
 			return skipped
+		}
+	}
+
+	sortSerieses(charts) {
+		for (const chart of charts) {
+			// sort series of chart by sorting series that are not hidden by
+			// default ahead of series that are hidden by default
+			// this will ensure that the default visible series are
+			// assigned the first colors of the color scheme, which
+			// tend to be colors with the best contrasts
+			// NOTE: do not sort by this.settings.hidden because the color
+			// assignments will change when a series changes to hidden/visible
+			const seriesIDs = chart.serieses.map(series => series.seriesId)
+			const seriesOrder = [
+				...seriesIDs.filter(seriesId => !this.settings.defaultHidden.includes(seriesId)),
+				...seriesIDs.filter(seriesId => this.settings.defaultHidden.includes(seriesId))
+			]
+			chart.serieses.sort((a, b) => seriesOrder.indexOf(a.seriesId) - seriesOrder.indexOf(b.seriesId))
 		}
 	}
 

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -987,18 +987,18 @@ function setRenderers(self) {
 		// x-axis ticks
 		if (s.xTickValues?.length) {
 			// custom x-tick values
-			chart.xTickValues = s.xTickValues.filter(v => v === 0 || (v >= chart.xMin && v <= chart.xMax))
+			chart.xTickValues = s.xTickValues.filter(v => v === 0 || (v >= self.pj.tree.xMin && v <= self.pj.tree.xMax))
 		} else {
 			// compute x-tick values
 			// compute width between ticks for a maximum of 5 ticks
-			const tickWidth = (chart.xMax - chart.xMin) / 5
+			const tickWidth = (self.pj.tree.xMax - self.pj.tree.xMin) / 5
 			// round tick width to the nearest 5
 			const log = Math.floor(Math.log10(tickWidth))
 			const tickWidth_rnd = Math.round(tickWidth / (5 * 10 ** log)) * (5 * 10 ** log) || 1 * 10 ** log
 			// compute tick values using tick width
 			chart.xTickValues = [0]
-			let tick = chart.xMin
-			while (tick < chart.xMax) {
+			let tick = self.pj.tree.xMin
+			while (tick < self.pj.tree.xMax) {
 				chart.xTickValues.push(tick)
 				tick = tick + tickWidth_rnd
 			}
@@ -1169,6 +1169,8 @@ export async function getPlotConfig(opts, app) {
 function getPj(self) {
 	const pj = new Partjson({
 		template: {
+			xMin: '>$time',
+			xMax: '<$time',
 			yMin: '>=yMin()',
 			yMax: '<=yMax()',
 			charts: [
@@ -1246,12 +1248,13 @@ function getPj(self) {
 			},
 			xScale(row, context) {
 				const s = self.settings
+				const xMax = s.scale == 'byChart' ? context.self.xMax : context.root.xMax
 				return (
 					scaleLinear()
 						// force min x=0, instead of using min time in server data
 						// add 2 years to x max value to ensure a horizontally flat ending
 						// and avoid the potential for a vertical line ending
-						.domain([0, context.self.xMax + 2])
+						.domain([0, xMax + 2])
 						.range([0, s.svgw - s.svgPadding.left - s.svgPadding.right])
 				)
 			},


### PR DESCRIPTION
Sort series of cuminc chart, so that visible series are sorted ahead of hidden series. This will allow visible series to be assigned with the first colors of a color scheme, which tend to be colors with the best contrasts (e.g. blue-orange). Can test with [this link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Secondary%20Neoplasms%22,%22q%22:{}},%22term2%22:{%22id%22:%22chestrt_yn%22,%22q%22:{%22type%22:%22custom-bin%22,%22mode%22:%22discrete%22,%22lst%22:[{%22startunbounded%22:true,%22stop%22:2000,%22stopinclusive%22:false,%22label%22:%22%3C2000%22},{%22start%22:2000,%22startinclusive%22:true,%22stopunbounded%22:true,%22label%22:%22%E2%89%A52000%22}]}}}],%22nav%22:{%22activeTab%22:1}}).

Use same x-axis when dividing a cuminc chart into multiple charts (same y-axis has already been previously implemented). Can test with [this link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Cardiomyopathy%22,%22q%22:{}},%22term2%22:{%22id%22:%22sex%22},%22term0%22:{%22id%22:%22genetic_race%22}}],%22nav%22:{%22activeTab%22:1}}).