### PR TITLE
Matrix zoom

### DIFF
--- a/client/dom/test/zoom.unit.spec.js
+++ b/client/dom/test/zoom.unit.spec.js
@@ -1,0 +1,110 @@
+import tape from 'tape'
+import { select } from 'd3-selection'
+import { zoom } from '#dom/zoom'
+
+/*************************
+ reusable helper functions
+
+/**************
+ test sections
+**************/
+
+tape('\n', test => {
+	test.pass('-***- dom/zoompan -***-')
+	test.end()
+})
+
+tape('renders the expected elements', test => {
+	test.timeoutAfter(100)
+	test.plan(3)
+	const holder = select(document.body)
+		.append('div')
+		.style('margin', '20px')
+		.style('padding', '20px')
+	let currentCallback
+	const callback = value => currentCallback(value)
+	const zoomApi = zoom({ holder, callback, debug: true })
+
+	test.equal([...holder.node().querySelectorAll('button')].length, 2, 'should render two zoom buttons')
+
+	test.equal([...holder.node().querySelectorAll('input[type=range]')].length, 1, 'should render a slider input')
+
+	test.equal([...holder.node().querySelectorAll('input[type=number]')].length, 1, 'should render a number input')
+
+	if (test._ok) holder.remove()
+	test.end()
+})
+
+tape('value synchronization', test => {
+	test.timeoutAfter(100)
+	test.plan(10)
+	const holder = select(document.body)
+		.append('div')
+		.style('margin', '20px')
+		.style('padding', '20px')
+	let currentCallback
+	const callback = value => currentCallback(value)
+	const zoomApi = zoom({ holder, callback, debug: true })
+	const Z = zoomApi.Inner
+	{
+		const expectedValue = 33
+		currentCallback = value => {
+			test.equal(value, expectedValue, 'should supply the expected number input value to the callback')
+			test.equal(
+				+zoomApi.Inner.slider.property('value'),
+				expectedValue,
+				'slider should react to changes in the number input'
+			)
+		}
+		zoomApi.Inner.number.property('value', expectedValue)
+		zoomApi.Inner.number.node().dispatchEvent(new Event('change'))
+	}
+	{
+		const expectedValue = 66
+		currentCallback = value => {
+			test.equal(value, expectedValue, 'should supply the expected slider input value to the callback')
+			test.equal(
+				+zoomApi.Inner.number.property('value'),
+				expectedValue,
+				'number should react to changes in the slider input'
+			)
+		}
+		zoomApi.Inner.slider.property('value', expectedValue)
+		zoomApi.Inner.slider.node().dispatchEvent(new Event('change'))
+	}
+	{
+		currentCallback = expectedValue => {
+			test.equal(
+				0,
+				expectedValue % Z.settings.step,
+				'minus button should supply to the callback a number divisible by settings.step'
+			)
+			test.equal(
+				+zoomApi.Inner.number.property('value'),
+				expectedValue,
+				'number should react to the minus button click'
+			)
+			test.equal(
+				+zoomApi.Inner.slider.property('value'),
+				expectedValue,
+				'slider should react to the minus button click'
+			)
+		}
+		zoomApi.Inner.minusBtn.node().click()
+	}
+	{
+		currentCallback = expectedValue => {
+			test.equal(
+				0,
+				expectedValue % Z.settings.step,
+				'plus button should supply to the callback a number divisible by settings.step'
+			)
+			test.equal(+zoomApi.Inner.number.property('value'), expectedValue, 'number should react to the plus button click')
+			test.equal(+zoomApi.Inner.slider.property('value'), expectedValue, 'slider should react to the plus button click')
+		}
+		zoomApi.Inner.plusBtn.node().click()
+	}
+
+	if (test._ok) holder.remove()
+	test.end()
+})

--- a/client/dom/zoom.js
+++ b/client/dom/zoom.js
@@ -1,0 +1,98 @@
+export function zoom(opts) {
+	if (!opts.holder) throw `zoom requires an opts.holder`
+	if (typeof opts.callback != 'function') throw `zoom requires an opts.callback function`
+
+	const defaultSettings = {
+		min: 1,
+		max: 100,
+		value: 25,
+		step: 10,
+		increment: 1,
+		numberInputWidth: '35px'
+	}
+
+	const settings = Object.assign({}, defaultSettings, opts.settings || {})
+
+	const minusBtn = opts.holder
+		.append('button')
+		.attr('title', 'Zoom in')
+		.style('width', '25px')
+		.html('-')
+		.on('click', () => {
+			const value = Math.max(settings.step * Math.ceil((settings.value - settings.step) / settings.step), settings.min)
+			api.update({ value })
+			opts.callback(value)
+		})
+
+	const slider = opts.holder
+		.append('input')
+		.attr('title', 'slide to desired zoom level')
+		.attr('type', 'range')
+		.attr('min', settings.min)
+		.attr('max', settings.max)
+		.attr('step', settings.increment)
+		.style('margin', '3px 5px')
+		.style('padding', 0)
+		.style('vertical-align', 'middle')
+		.property('value', settings.value)
+		.html('-')
+		.on('input', event => {
+			number.property('value', event.target.value)
+		})
+		.on('change', event => {
+			const value = Number(event.target.value)
+			api.update({ value })
+			opts.callback(value)
+		})
+
+	const number = opts.holder
+		.append('input')
+		.attr('title', 'enter a desired zoom level')
+		.attr('type', 'number')
+		.attr('min', settings.min)
+		.attr('max', settings.max)
+		.attr('step', settings.increment)
+		.style('min-width', settings.numberInputWidth)
+		.style('width', 'fit-content')
+		.style('margin', '3px 5px')
+		.property('value', settings.value)
+		.on('change', event => {
+			const value = Number(event.target.value)
+			api.update({ value })
+			opts.callback(value)
+		})
+
+	opts.holder.append('span').text('%')
+
+	const plusBtn = opts.holder
+		.append('button')
+		.attr('title', 'Zoom out')
+		.style('width', '25px')
+		.html('+')
+		.on('click', () => {
+			const value = Math.min(settings.step * Math.floor((settings.value + settings.step) / settings.step), settings.max)
+			api.update({ value })
+			opts.callback(value)
+		})
+
+	const api = {
+		update(s = {}) {
+			Object.assign(settings, s)
+			slider.property('value', settings.value) //; console.log(74, 'zoom.update() value=', settings.value)
+			number.property('value', settings.value)
+			minusBtn.property('disabled', settings.value <= settings.min)
+			plusBtn.property('disabled', settings.value >= settings.max)
+		}
+	}
+
+	if (opts.debug)
+		api.Inner = {
+			settings,
+			number,
+			slider,
+			minusBtn,
+			plusBtn
+		}
+
+	return api
+}

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -280,6 +280,47 @@ function setTextInput(opts) {
 	return Object.freeze(api)
 }
 
+function setColorInput(opts) {
+	const self = {
+		dom: {
+			row: opts.holder.style('display', 'table-row'),
+			labelTd: opts.holder
+				.append('td')
+				.html(opts.label)
+				.attr('class', 'sja-termdb-config-row-label')
+				.attr('title', opts.title),
+			inputTd: opts.holder.append('td')
+		}
+	}
+
+	self.dom.input = self.dom.inputTd
+		.append('input')
+		.attr('type', 'color')
+		.on('change', () => {
+			const value = self.dom.input.property('value')
+			opts.dispatch({
+				type: 'plot_edit',
+				id: opts.id,
+				config: {
+					settings: {
+						[opts.chartType]: {
+							[opts.settingsKey]: opts.processInput ? opts.processInput(value) : value
+						}
+					}
+				}
+			})
+		})
+
+	const api = {
+		main(plot) {
+			self.dom.input.property('value', plot.settings[opts.chartType][opts.settingsKey])
+		}
+	}
+
+	if (opts.debug) api.Inner = self
+	return Object.freeze(api)
+}
+
 function setRadioInput(opts) {
 	const self = {
 		dom: {
@@ -483,6 +524,7 @@ export const initByInput = {
 	number: setNumberInput,
 	math: setMathExprInput,
 	text: setTextInput,
+	color: setColorInput,
 	radio: setRadioInput,
 	dropdown: setDropdownInput,
 	checkbox: setCheckboxInput,

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -11,12 +11,8 @@ function setNumericCellProps(cell, tw, anno, value, s, t, self, width, height, d
 	const values = tw.term.values || {}
 	cell.label = 'label' in anno ? anno.label : values[key]?.label ? values[key].label : key
 	cell.fill = anno.color || values[anno.key]?.color
-	cell.x = !s.transpose
-		? 0
-		: t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
-	cell.y = !s.transpose
-		? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * i + t.totalHtAdjustments
-		: 0
+	cell.x = !s.transpose ? 0 : t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
+	cell.y = !s.transpose ? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * i + t.totalHtAdjustments : 0
 
 	cell.order = t.ref.bins ? t.ref.bins.findIndex(bin => bin.name == key) : 0
 	if (tw.q?.mode == 'continuous') {
@@ -42,12 +38,8 @@ function setCategoricalCellProps(cell, tw, anno, value, s, t, self, width, heigh
 	const key = anno.key
 	cell.label = 'label' in anno ? anno.label : values[key]?.label ? values[key].label : key
 	cell.fill = anno.color || values[key]?.color
-	cell.x = !s.transpose
-		? 0
-		: t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
-	cell.y = !s.transpose
-		? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * i + t.totalHtAdjustments
-		: 0
+	cell.x = !s.transpose ? 0 : t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
+	cell.y = !s.transpose ? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * i + t.totalHtAdjustments : 0
 	const group = tw.legend?.group || tw.$id
 	return { ref: t.ref, group, value, entry: { key, label: cell.label, fill: cell.fill } }
 }
@@ -60,34 +52,25 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 	cell.class = value.class
 	cell.value = value
 
+	const colw = self.dimensions.colw
 	if (s.cellEncoding != 'oncoprint') {
-		cell.height = !s.transpose ? s.rowh / values.length : s.colw
-		cell.width = !s.transpose ? s.colw : s.colw / values.length
-		cell.x = !s.transpose
-			? 0
-			: t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
-		cell.y = !s.transpose
-			? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * i + t.totalHtAdjustments
-			: 0
+		cell.height = !s.transpose ? s.rowh / values.length : colw
+		cell.width = !s.transpose ? colw : colw / values.length
+		cell.x = !s.transpose ? 0 : t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
+		cell.y = !s.transpose ? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * i + t.totalHtAdjustments : 0
 	} else if (value.dt == 1) {
 		const divisor = s.cellEncoding == 'oncoprint' ? 3 : values.length
-		cell.height = !s.transpose ? s.rowh / divisor : s.colw
-		cell.width = !s.transpose ? s.colw : s.colw / values.length
-		cell.x = !s.transpose
-			? 0
-			: t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
+		cell.height = !s.transpose ? s.rowh / divisor : colw
+		cell.width = !s.transpose ? colw : colw / values.length
+		cell.x = !s.transpose ? 0 : t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
 		cell.y = !s.transpose
 			? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * 0.33333 + t.totalHtAdjustments
 			: 0
 	} else if (value.dt == 4) {
-		cell.height = !s.transpose ? s.rowh : s.colw
-		cell.width = !s.transpose ? s.colw : s.colw / values.length
-		cell.x = !s.transpose
-			? 0
-			: t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
-		cell.y = !s.transpose
-			? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + t.totalHtAdjustments
-			: 0
+		cell.height = !s.transpose ? s.rowh : colw
+		cell.width = !s.transpose ? colw : colw / values.length
+		cell.x = !s.transpose ? 0 : t.totalIndex * dx + t.visibleGrpIndex * s.colgspace + width * i + t.totalHtAdjustments
+		cell.y = !s.transpose ? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + t.totalHtAdjustments : 0
 	} else {
 		throw `cannot set cell props for dt='${value.dt}'`
 	}

--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -31,8 +31,9 @@ export class MatrixCluster {
 		const clusters = []
 
 		for (const xg of this.xGrps) {
-			const x = xg.prevGrpTotalIndex * d.dx + s.colgspace * xg.grpIndex + xg.totalHtAdjustments
-			const width = d.dx * (xg.processedLst || xg.grp.lst).length + xg.grpHtAdjustments
+			const dx = Math.min(d.dx, s.maxColw + s.colspace)
+			const x = xg.prevGrpTotalIndex * dx + s.colgspace * xg.grpIndex + xg.totalHtAdjustments
+			const width = dx * (xg.processedLst || xg.grp.lst).length + xg.grpHtAdjustments
 
 			for (const yg of this.yGrps) {
 				const y = yg.prevGrpTotalIndex * d.dy + yg.grpIndex * s.rowgspace + yg.totalHtAdjustments

--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -5,11 +5,18 @@ export class MatrixCluster {
 		this.parent = opts.parent
 		const svg = opts.svg
 		this.dom = {
-			holder: opts.holder,
+			holder: opts.holder.attr('clip-path', `url(#${this.parent.clusterClipId})`),
 			outlines: opts.holder.append('g').attr('class', 'sjpp-matrix-clusteroutlines'),
 			//clusterrowline: opts.holder.insert('g', 'g').attr('class', 'sjpp-matrix-clusterrowline'),
 			//clustercolline: opts.holder.insert('g', 'g').attr('class', 'sjpp-matrix-clustercolline'),
-			clusterbg: opts.holder.insert('g', 'g').attr('class', 'sjpp-matrix-clusterbg')
+			clusterbg: opts.holder.insert('g', 'g').attr('class', 'sjpp-matrix-clusterbg'),
+			clipRect: opts.holder
+				.append('clipPath')
+				.attr('id', this.parent.clusterClipId)
+				.attr('clipPathUnits', 'objectBoundingBox')
+				//.attr('clipPathUnits', 'userSpaceOnUse')
+				.append('rect')
+				.attr('display', 'block')
 		}
 		setRenderers(this)
 	}
@@ -29,11 +36,14 @@ export class MatrixCluster {
 		const s = this.settings
 		const d = this.currData.dimensions
 		const clusters = []
+		// track total width for zooming, including pads
+		this.totalWidth = s.zoomLevel == 1 ? -4 : 0 //4 * Math.max(1, s.colspace)
 
 		for (const xg of this.xGrps) {
-			const dx = Math.min(d.dx, s.maxColw + s.colspace)
+			const dx = d.dx //Math.min(d.dx, s.maxColw + s.colspace)
 			const x = xg.prevGrpTotalIndex * dx + s.colgspace * xg.grpIndex + xg.totalHtAdjustments
 			const width = dx * (xg.processedLst || xg.grp.lst).length + xg.grpHtAdjustments
+			this.totalWidth += width + 2 * Math.max(1, s.colspace)
 
 			for (const yg of this.yGrps) {
 				const y = yg.prevGrpTotalIndex * d.dy + yg.grpIndex * s.rowgspace + yg.totalHtAdjustments
@@ -60,6 +70,12 @@ function setRenderers(self) {
 	self.render = function(clusters) {
 		const s = self.settings
 		const d = self.currData.dimensions
+		self.dom.clipRect
+			.attr('x', s.zoomLevel <= 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW)
+			.attr('y', 0)
+			.attr('width', d.mainw / this.totalWidth) // d.zoomedMainW)
+			.attr('height', 1)
+
 		renderOutlines(clusters, s, d)
 	}
 
@@ -67,7 +83,7 @@ function setRenderers(self) {
 		self.dom.outlines
 			.transition()
 			.duration(self.dom.outlines.attr('transform') ? s.duration : 0)
-			.attr('transform', `translate(${d.xOffset},${d.yOffset})`)
+			.attr('transform', `translate(${d.xOffset + d.seriesXoffset},${d.yOffset})`)
 
 		const outlines = self.dom.outlines.selectAll('rect').data(clusters, c => c.xg.grp.name + ';;' + c.yg.grp.name)
 		outlines.exit().remove()

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -22,6 +22,26 @@ export class MatrixControls {
 	}
 
 	setButtons() {
+		const zoomBtn = {
+			label: 'Zoom',
+			active: true,
+			callback: () => {
+				this.parent.settings.matrix.mouseMode = 'zoom'
+				zoomBtn.active = true
+				panBtn.active = false
+				this.main()
+			}
+		}
+		const panBtn = {
+			label: 'Pan',
+			callback: () => {
+				this.parent.settings.matrix.mouseMode = 'pan'
+				panBtn.active = true
+				zoomBtn.active = false
+				this.main()
+			}
+		}
+
 		this.btns = this.opts.holder
 			.style('margin', '10px 10px 20px 10px')
 			.selectAll('button')
@@ -33,7 +53,7 @@ export class MatrixControls {
 				},
 				{
 					value: 'anno',
-					label: `Terms`,
+					label: `Dictionary Terms`,
 					getCount: () => this.parent.termOrder.length,
 					customInputs: this.appendTermInputs
 				},
@@ -43,11 +63,17 @@ export class MatrixControls {
 				{ value: 'legend', label: 'Legend layout' },
 				//{ label: 'Undo', callback: ()=>this.recover.goto(-1) },
 				//{ label: 'Redo', callback: ()=>this.recover.goto(1) },
-				{ label: 'Download SVG', callback: () => to_svg(this.opts.getSvg(), 'matrix', { apply_dom_styles: true }) }
+				{
+					label: 'Download SVG',
+					callback: () => to_svg(this.opts.getSvg(), 'matrix', { apply_dom_styles: true })
+				},
+				zoomBtn,
+				panBtn
 			])
 			.enter()
 			.append('button')
 			.style('margin', '2px 0')
+			.property('disabled', d => d.disabled)
 			.text(d => d.label)
 			.on('click', (event, d) => (d.callback ? d.callback(event) : this.callback(event, d)))
 	}
@@ -142,7 +168,7 @@ export class MatrixControls {
 					type: 'text',
 					chartType: 'matrix',
 					settingsKey: 'cellbg'
-				},
+				}
 			],
 
 			cols: [
@@ -288,7 +314,10 @@ export class MatrixControls {
 
 	main() {
 		//this.recover.track()
-		this.btns.text(d => d.label + (d.getCount ? ` (${d.getCount()})` : ''))
+		this.btns
+			.text(d => d.label + (d.getCount ? ` (${d.getCount()})` : ''))
+			.style('text-decoration', d => (d.active ? 'underline' : ''))
+			.style('color', d => (d.active ? '#3a3' : ''))
 	}
 
 	async callback(event, d) {

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -20,6 +20,7 @@ export class MatrixControls {
 		//this.recover = new Recover({app: opts.app})
 		this.setButtons()
 		this.setInputGroups()
+		if (!this.parent.optionalFeatures.includes('zoom')) return
 		this.setZoomInput()
 		this.setPanInput()
 		this.setResetInput()
@@ -302,9 +303,10 @@ export class MatrixControls {
 			.style('color', d => (d.active ? '#3a3' : ''))
 
 		const s = this.parent.config.settings.matrix //; console.log(302, s.colw, s.maxColw, Math.round(100* s.colw / s.maxColw))
-		this.zoomApi.update({
-			value: Math.round((100 * Math.min(s.colw * s.zoomLevel, s.maxColwZoomed)) / s.maxColwZoomed)
-		})
+		if (this.zoomApi)
+			this.zoomApi.update({
+				value: Math.round((100 * Math.min(s.colw * s.zoomLevel, s.maxColwZoomed)) / s.maxColwZoomed)
+			})
 	}
 
 	async callback(event, d) {
@@ -522,6 +524,7 @@ export class MatrixControls {
 				const d = this.parent.dimensions
 				const s = this.parent.settings.matrix
 				const zoomLevel = (0.01 * percentValue * s.maxColwZoomed) / s.colw
+				const zoomCenterPct = 0.5
 				const zoomCenter = s.zoomLevel < 1 && zoomLevel > 1 ? Math.round(d.maxMainW / 2) : Math.round(d.mainw / 2)
 				const centerCell =
 					s.zoomLevel < 1 && zoomLevel > 1
@@ -536,7 +539,7 @@ export class MatrixControls {
 						settings: {
 							matrix: {
 								zoomLevel,
-								zoomCenter,
+								zoomCenterPct,
 								zoomIndex: centerCell.totalIndex,
 								zoomGrpIndex: centerCell.grpIndex,
 								mouseMode: 'zoom'

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1508,18 +1508,21 @@ function setZoomPanActions(self) {
 		const start = c.startCell.totalIndex < c.endCell.totalIndex ? c.startCell : c.endCell
 		const zoomIndex = Math.floor(start.totalIndex + Math.abs(c.endCell.totalIndex - c.startCell.totalIndex) / 2)
 		const centerCell = self.sampleOrder[zoomIndex]
+		const zoomLevel = self.dimensions.mainw / self.zoomWidth
 		self.app.dispatch({
 			type: 'plot_edit',
 			id: self.id,
 			config: {
 				settings: {
 					matrix: {
-						zoomLevel: self.dimensions.mainw / self.zoomWidth,
+						zoomLevel,
 						//zoomCenter: self.zoomPointer[0] - self.dimensions.seriesXoffset - self.dimensions.xOffset + self.zoomWidth / 2,
 						zoomCenter:
-							centerCell.totalIndex * self.dimensions.dx +
-							(centerCell.grpIndex - 1) * s.colgspace +
-							self.dimensions.seriesXoffset,
+							s.zoomLevel < 1 && zoomLevel > 1
+								? self.dimensions.maxMainW / 2
+								: centerCell.totalIndex * self.dimensions.colw +
+								  (centerCell.grpIndex - 1) * s.colgspace +
+								  self.dimensions.seriesXoffset,
 						zoomIndex,
 						zoomGrpIndex: centerCell.grpIndex,
 						mouseMode: 'zoom'

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -31,7 +31,8 @@ class Matrix {
 		const loadingDiv = holder
 			.append('div')
 			.style('position', 'absolute')
-			.style('top', '0px')
+			.style('top', '50px')
+			.style('left', '50px')
 		const errdiv = holder
 			.append('div')
 			.attr('class', 'sja_errorbar')
@@ -652,6 +653,8 @@ class Matrix {
 		const topFontSize = _t_ == 'Grp' ? s.grpLabelFontSize : colLabelFontSize
 		layout.top.attr = {
 			boxTransform: `translate(${xOffset}, ${yOffset - s.collabelgap})`,
+			adjustBoxTransform: dx =>
+				layout.top.box.attr('transform', `translate(${xOffset + dx}, ${yOffset - s.collabelgap})`),
 			labelTransform: 'rotate(-90)',
 			labelAnchor: 'start',
 			labelGY: 0,
@@ -664,6 +667,8 @@ class Matrix {
 		const btmFontSize = _b_ == 'Grp' ? s.grpLabelFontSize : colLabelFontSize
 		layout.btm.attr = {
 			boxTransform: `translate(${xOffset}, ${yOffset + mainh + s.collabelgap})`,
+			adjustBoxTransform: dx =>
+				layout.btm.box.attr('transform', `translate(${xOffset + dx}, ${yOffset + mainh + s.collabelgap})`),
 			labelTransform: 'rotate(-90)',
 			labelAnchor: 'end',
 			labelGY: 0,

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -31,7 +31,7 @@ class Matrix {
 		const loadingDiv = holder
 			.append('div')
 			.style('position', 'absolute')
-			.style('top', '50px')
+			.style('top', this.opts.controls ? 0 : '50px')
 			.style('left', '50px')
 		const errdiv = holder
 			.append('div')
@@ -634,13 +634,13 @@ class Matrix {
 
 		const yOffset = layout.top.offset + s.margin.top
 		const xOffset = layout.left.offset + s.margin.left
-		const colw = Math.min(34, s.colw * s.zoomLevel)
+		const colw = Math.min(s.maxColwZoomed, s.colw * s.zoomLevel)
 		const dx = colw + s.colspace
 		const nx = this[`${col}s`].length
 		const dy = s.rowh + s.rowspace
 		const ny = this[`${row}s`].length
 		const mainw =
-			nx * (s.colw + s.colspace) +
+			nx * (Math.min(colw, s.colw) + s.colspace) +
 			(this[`${col}Grps`].length - 1) * s.colgspace +
 			(this[`${col}s`].slice(-1)[0]?.totalHtAdjustments || 0)
 		const mainh =
@@ -713,8 +713,12 @@ class Matrix {
 			mainw,
 			mainh,
 			colw,
-			seriesXoffset: s.zoomLevel == 1 ? 0 : s.zoomCenter - s.zoomIndex * dx - (s.zoomGrpIndex - 1) * s.colgspace, // + 2*xOffset,
-			zoomedMainW: nx * dx + (this[`${col}Grps`].length - 1) * s.colgspace //+ (this[`${col}s`].slice(-1)[0]?.totalHtAdjustments || 0)
+			seriesXoffset: s.zoomLevel <= 1 ? 0 : s.zoomCenter - s.zoomIndex * dx - (s.zoomGrpIndex - 1) * s.colgspace, // + 2*xOffset,
+			zoomedMainW: nx * dx + (this[`${col}Grps`].length - 1) * s.colgspace, //+ (this[`${col}s`].slice(-1)[0]?.totalHtAdjustments || 0)
+			maxMainW:
+				nx * (s.maxColw + s.colspace) +
+				(this[`${col}Grps`].length - 1) * s.colgspace +
+				(this[`${col}s`].slice(-1)[0]?.totalHtAdjustments || 0)
 		}
 	}
 
@@ -908,6 +912,7 @@ export async function getPlotConfig(opts, app) {
 				cellbg: '#ececec',
 				colw: 0,
 				maxColw: 16,
+				maxColwZoomed: 34,
 				colspace: 1,
 				colgspace: 8,
 				collabelpos: 'bottom',

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -6,6 +6,14 @@ export function setRenderers(self) {
 		const l = self.layout
 		const d = self.dimensions
 		const duration = self.dom.svg.attr('width') ? s.duration : 0
+
+		self.dom.clipRect
+			.attr('x', s.zoomLevel == 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW) //Math.abs(d.seriesXoffset/d.mainw)) // s.zoomLevel == 1 ? 0 : 300)
+			.attr('y', 0)
+			//.attr('transform', `translate(0,0)`)
+			.attr('width', (s.zoomLevel * d.mainw) / d.zoomedMainW)
+			.attr('height', 1)
+
 		self.renderSerieses(s, l, d, duration)
 		self.renderLabels(s, l, d, duration)
 	}
@@ -14,7 +22,7 @@ export function setRenderers(self) {
 		self.dom.seriesesG
 			.transition()
 			.duration(duration)
-			.attr('transform', `translate(${d.xOffset},${d.yOffset})`)
+			.attr('transform', `translate(${d.xOffset + d.seriesXoffset},${d.yOffset})`)
 
 		const sg = self.dom.seriesesG.selectAll('.sjpp-mass-series-g').data(this.serieses, series => series.row.sample)
 
@@ -88,7 +96,7 @@ export function setRenderers(self) {
 			.duration(0) //'x' in cell ? s.duration : 0)
 			.attr('x', 'x' in cell ? cell.x : 0)
 			.attr('y', 'y' in cell ? cell.y : 0)
-			.attr('width', 'width' in cell ? cell.width : s.colw)
+			.attr('width', 'width' in cell ? cell.width : self.dimensions.colw)
 			.attr('height', 'height' in cell ? cell.height : s.rowh)
 			.attr('shape-rendering', 'crispEdges')
 			//.attr('stroke', cell.fill)
@@ -166,10 +174,10 @@ export function setRenderers(self) {
 	self.colLabelGTransform = (lab, grpIndex) => {
 		const s = self.settings.matrix
 		const d = self.dimensions
-		lab.labelOffset = 0.8 * s.colw
+		lab.labelOffset = 0.8 * d.colw
 		const x = lab.grpIndex * s.colgspace + lab.totalIndex * d.dx + lab.labelOffset + lab.totalHtAdjustments
 		const y = 0 //lab.tw?.q?.mode == 'continuous' ? -30 : 0
-		return `translate(${x},${y})`
+		return `translate(${x + d.seriesXoffset},${y})`
 	}
 
 	self.colGrpLabelGTransform = (lab, grpIndex) => {
@@ -182,7 +190,7 @@ export function setRenderers(self) {
 			(len * d.dx) / 2 +
 			s.grpLabelFontSize / 2 +
 			lab.totalHtAdjustments
-		return `translate(${x},0)`
+		return `translate(${x + d.seriesXoffset},0)`
 	}
 
 	self.rowLabelGTransform = (lab, grpIndex) => {

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -6,12 +6,10 @@ export function setRenderers(self) {
 		const l = self.layout
 		const d = self.dimensions
 		const duration = self.dom.svg.attr('width') ? s.duration : 0
-
 		self.dom.clipRect
-			.attr('x', s.zoomLevel == 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW) //Math.abs(d.seriesXoffset/d.mainw)) // s.zoomLevel == 1 ? 0 : 300)
+			.attr('x', s.zoomLevel <= 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW)
 			.attr('y', 0)
-			//.attr('transform', `translate(0,0)`)
-			.attr('width', (s.zoomLevel * d.mainw) / d.zoomedMainW)
+			.attr('width', Math.min(d.mainw, d.maxMainW) / d.zoomedMainW)
 			.attr('height', 1)
 
 		self.renderSerieses(s, l, d, duration)

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -83,6 +83,7 @@ export async function init(arg, holder, genomes) {
 					settings: {
 						matrix: {
 							cellEncoding: 'oncoprint',
+							colw: 2,
 							colspace: 0,
 							cellbg: 'white'
 						}

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -213,6 +213,74 @@ if (fs.existsSync('./package.json')) {
 	serverconfig.version = JSON.parse(pkg).version
 }
 
+serverconfig.commonOverrides = {
+	mclass: {
+		I: {
+			color: 'rgb(98, 60, 53)'
+		},
+		S: {
+			color: 'rgb(31, 112, 31)'
+		},
+		M: {
+			color: '#2379BC' //Best update for the default blue, that is compliant with section508
+		},
+		N: {
+			color: 'rgb(179, 89, 10)'
+		},
+		L: {
+			color: 'rgb(71, 36, 179)'
+		},
+		P: {
+			color: 'rgb(104, 72, 132)'
+		},
+		Utr3: {
+			color: 'rgb(107, 90, 107)'
+		},
+		F: {
+			color: '#a71c25'
+		},
+		D: {
+			color: '#595959'
+		},
+		Utr5: {
+			color: '#566c58'
+		},
+		E: {
+			color: '#595b00'
+		},
+		ITD: {
+			color: 'rgb(179, 78, 179)'
+		},
+		DEL: {
+			color: 'rgb(93, 93, 93)'
+		},
+		SV: {
+			color: 'rgb(93, 93, 93)'
+		},
+		CNV_amp: {
+			color: '#7a425f'
+		},
+		CNV_loss: {
+			color: '#42741a'
+		},
+		CNV_loh: {
+			color: 'rgb(13, 166, 176)'
+		},
+		snv: {
+			color: 'rgb(102, 113, 148)'
+		},
+		mnv: {
+			color: 'rgb(102, 113, 148)'
+		},
+		insertion: {
+			color: 'rgb(132, 99, 102)'
+		},
+		deletion: {
+			color: 'rgb(127, 113, 81)'
+		}
+	}
+}
+
 //Object.freeze(serverconfig)
 module.exports = serverconfig
 

--- a/server/test/serverconfig.json
+++ b/server/test/serverconfig.json
@@ -2,7 +2,8 @@
   "debugmode": true,
   "defaultgenome": "hg38-test",
   "features": {
-    "skip_checkDependenciesAndVersions": 1
+    "skip_checkDependenciesAndVersions": 1,
+    "matrix": ["zoom"]
   },
   "genomes": [
     {


### PR DESCRIPTION
Add this entry to serverconfig.features: `"matrix": ["zoom"]` in order to see and test the feature. Open a small matrix plot to test, the zoom may be triggered via:

1. dragging a rect outline on the matrix: KNOWN BUG (will be fixed with switch to canvas image): the mouse start and stop must be on a rendered "series" rectangle, starting or stopping on an empty column/cell will cause an error
2. dragging the slider
3. entering a number 
4. clicking on the minus or plus buttons

![Screenshot 2023-03-23 at 2 02 46 PM](https://user-images.githubusercontent.com/411031/227321167-266f7e6a-c9b5-4bb1-ad07-44d0ce1e3612.png)

Test zoom controls: http://localhost:3000/testrun.html?name=zoom.unit