### PR TITLE
remove cohort name as parameter from vocab.getFilteredSampleCount()

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -135,10 +135,8 @@ class TdbNav {
 				if (!this.filterUiRoot || !this.filterUiRoot.lst.length) {
 					this.samplecounts[this.filterJSON] = this.samplecounts[this.activeCohortName]
 				} else {
-					this.samplecounts[this.filterJSON] = await this.app.vocabApi.getFilteredSampleCount(
-						this.activeCohortName,
-						this.filterJSON
-					)
+					const n = await this.app.vocabApi.getFilteredSampleCount(this.filterJSON)
+					this.samplecounts[this.filterJSON] = n
 				}
 			}
 		}
@@ -414,15 +412,12 @@ function setRenderers(self) {
 		const keys = selectCohort.values[self.activeCohort].keys
 		let selector = `tbody > tr > td:nth-child(${self.activeCohort + 2})`
 		const combined = keys.length > 1
-		if(combined)
-		{
+		if (combined) {
 			selector = ''
-			for(const key of keys )
-			{
+			for (const key of keys) {
 				const i = result.cohorts.map(c => c.cohort).indexOf(key)
-				if(selector !== '') selector += ','
-				selector +=  `tbody > tr > td:nth-child(${i + 2})`
-
+				if (selector !== '') selector += ','
+				selector += `tbody > tr > td:nth-child(${i + 2})`
 			}
 		}
 		const activeColumns = self.dom.cohortTable.selectAll(selector)

--- a/client/termdb/FrontendVocab.js
+++ b/client/termdb/FrontendVocab.js
@@ -133,7 +133,13 @@ export class FrontendVocab extends Vocab {
 	}
 
 	/*** To-Do ***/
-	async getFilteredSampleCount(cohortName, filterJSON) {
+
+	async getCohortsData(opts) {
+		return null
+	}
+
+	async getFilteredSampleCount(filterJSON) {
+		/*
 		if (!cohortName) return
 		const term = this.vocab.find(t => t.id === id)
 		if (!term || !term.cohortValues.includes(cohortName)) return
@@ -141,7 +147,8 @@ export class FrontendVocab extends Vocab {
 		if (!(cohortName in term.samplecount)) {
 			term.samplecount[cohortName] = Object.keys(this.vocab.sampleannotation).length
 		}
-		return { samplecount: 'TBD' }
+		*/
+		return 'TBD'
 	}
 
 	async getDensityPlotData(term_id, num_obj, filter) {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -337,20 +337,17 @@ export class TermdbVocab extends Vocab {
 		}
 	}
 
-	async getFilteredSampleCount(cohortName, filterJSON) {
-		if (!cohortName) return
-		const lst = [
-			'genome=' + this.vocab.genome,
-			'dslabel=' + this.vocab.dslabel,
-			'getsamplecount=' + cohortName,
-			'filter=' + encodeURIComponent(filterJSON)
-		]
-		const data = await dofetch3('termdb?' + lst.join('&'), {}, this.opts.fetchOpts)
-		if (!data) throw `missing data`
-		else if (data.error) throw data.error
-		else {
-			return data[0].samplecount
+	async getFilteredSampleCount(filterJSON) {
+		const body = {
+			genome: this.vocab.genome,
+			dslabel: this.vocab.dslabel,
+			getsamplecount: 1,
+			filter: filterJSON
 		}
+		const data = await dofetch3('termdb', { body }, this.opts.fetchOpts)
+		if (!data) throw `missing data`
+		if (data.error) throw data.error
+		return data[0].samplecount
 	}
 
 	/*


### PR DESCRIPTION
i was starting to see the how it calculates number of samples passed filter, to implement checkpoint to prevent filtering down to 10 samples. i thought it doesn't make sense to only run the vocab method when there is a cohort, thus i remove the cohort name from getFilteredSampleCount() parameter

this also allows pnet ui to show number of samples passing filter (after you add a filter)