### PR TITLE
Group change needs to be reflected in the state

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -7,7 +7,7 @@ import { Menu } from '#dom/menu'
 import { d3lasso } from '#common/lasso'
 import { mclass, dt2label, morigin } from '#shared/common'
 import { scaleLinear as d3Linear } from 'd3-scale'
-import { rgb } from 'd3-color'
+import { rgb, color as d3color } from 'd3-color'
 import { zoom as d3zoom, zoomIdentity } from 'd3-zoom'
 import { controlsInit } from './controls'
 import { axisLeft, axisBottom } from 'd3-axis'
@@ -679,12 +679,12 @@ class Scatter {
 	}
 
 	onColorClick(e, key, category) {
-		console.log(key, category)
+		const color = rgb(category.color)
 		const menu = new Menu()
 		const input = menu.d
 			.append('input')
 			.attr('type', 'color')
-			.attr('value', category.color)
+			.attr('value', color.formatHex())
 			.on('change', () => {
 				// ok to not await here, since no returned value is required
 				// and menu.hide() does not need to wait for the dispatch to finish

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -934,6 +934,7 @@ class Scatter {
 						if (value) group.name = value
 						else input.node().value = group.name
 						groupDiv.html('&nbsp;' + group.name)
+						this.app.dispatch({ type: 'plot_edit', id: this.id, config: { groups: this.config.groups } })
 					})
 				input.node().focus()
 				input.node().select()
@@ -1005,6 +1006,7 @@ class Scatter {
 						if (value) group.name = value
 						else input.node().value = group.name
 						groupDiv.html('&nbsp;' + group.name)
+						this.app.dispatch({ type: 'plot_edit', id: this.id, config: { groups: this.config.groups } })
 					})
 				input.node().focus()
 				input.node().select()

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -1,5 +1,4 @@
 import { getData } from './termdb.matrix'
-import fs from 'fs'
 import path from 'path'
 import utils from './utils'
 import serverconfig from './serverconfig'
@@ -274,7 +273,8 @@ function processSample(dbSample, sample, tw, categoryMap, category) {
 			const class_info = mclass[mutation.class]
 			value = getCategory(mutation)
 			sample.cat_info[category].push(mutation)
-			if (!categoryMap.has(value)) categoryMap.set(value, { color: class_info.color, sampleCount: 1, hasOrigin: 'origin' in mutation})
+			if (!categoryMap.has(value))
+				categoryMap.set(value, { color: class_info.color, sampleCount: 1, hasOrigin: 'origin' in mutation })
 			else {
 				const mapValue = categoryMap.get(value)
 				mapValue.sampleCount++


### PR DESCRIPTION
Fixed the bug reported by Karishma about keeping the group name and also another bug when editing color, sometimes the initial color was not set properly in the input. (Can be seen in mbmeta, before the color was set to black if the color was not in hex format)