### PR TITLE
restore clinvar link using "m.vcf_id"

### DIFF
--- a/client/mds3/itemtable.js
+++ b/client/mds3/itemtable.js
@@ -405,28 +405,28 @@ function print_mname(div, m) {
 }
 
 export function print_snv(holder, m, tk) {
-	let printto = holder
+	let snvDiv = holder
 
 	const url = tk.mds.queries?.snvindel?.variantUrl
 	if (url && url.key in m) {
 		if (url.shownSeparately) {
+			// create new <span> to print snv into it
+			snvDiv = holder.append('span')
 			// create a separate <a> element for the url, not directly on the Mutation field
-			printto = holder.append('span')
 			holder
 				.append('a')
 				.style('padding-left', '10px')
 				.attr('href', url.base + m[url.key])
 				.attr('target', '_blank')
-				.text(m[url.key])
+				.text(url.linkText || m[url.key])
 		} else {
-			// url is created directly on mutation value
-			const a = holder.append('a')
-			a.attr('href', tk.mds.queries.snvindel.variantUrl.base + m[tk.mds.queries.snvindel.variantUrl.key])
-			a.attr('target', '_blank')
-			printto = a
+			// url is created directly on mutation string
+			snvDiv = holder.append('a')
+			snvDiv.attr('href', tk.mds.queries.snvindel.variantUrl.base + m[tk.mds.queries.snvindel.variantUrl.key])
+			snvDiv.attr('target', '_blank')
 		}
 	}
-	printto.html(`${m.chr}:${m.pos + 1} ${m.ref && m.alt ? m.ref + '>' + m.alt : ''}`)
+	snvDiv.html(`${m.chr}:${m.pos + 1} ${m.ref && m.alt ? m.ref + '>' + m.alt : ''}`)
 }
 
 // function is not used

--- a/server/dataset/clinvar.hg19.js
+++ b/server/dataset/clinvar.hg19.js
@@ -1,7 +1,6 @@
 const clinvar = require('./clinvar')
 module.exports = {
 	isMds3: true,
-	color: '#545454',
 	dsinfo: [
 		{ k: 'Source', v: '<a href=http://www.ncbi.nlm.nih.gov/clinvar/ target=_blank>NCBI ClinVar</a>' },
 		{ k: 'Data type', v: 'SNV/Indel' },
@@ -25,7 +24,9 @@ module.exports = {
 			},
 			variantUrl: {
 				base: 'https://www.ncbi.nlm.nih.gov/clinvar/variation/',
-				key: 'id'
+				key: 'vcf_id',
+				linkText: 'ClinVar',
+				shownSeparately: true
 			},
 			infoUrl: [{ base: 'https://www.ncbi.nlm.nih.gov/snp/rs', key: 'RS' }]
 		}
@@ -47,14 +48,5 @@ module.exports = {
 			clinvar.AF.AF_TGP
 		]
 	},
-
-	url4variant: [
-		{
-			makelabel: m => 'ClinVar Variation ' + m.vcf_ID,
-			makeurl: m => {
-				return 'https://www.ncbi.nlm.nih.gov/clinvar/variation/' + m.vcf_ID
-			}
-		}
-	]
 */
 }

--- a/server/dataset/clinvar.hg38.js
+++ b/server/dataset/clinvar.hg38.js
@@ -1,7 +1,6 @@
 const clinvar = require('./clinvar')
 module.exports = {
 	isMds3: true,
-	color: '#545454',
 	dsinfo: [
 		{ k: 'Source', v: '<a href=http://www.ncbi.nlm.nih.gov/clinvar/ target=_blank>NCBI ClinVar</a>' },
 		{ k: 'Data type', v: 'SNV/Indel' },
@@ -26,7 +25,9 @@ module.exports = {
 			},
 			variantUrl: {
 				base: 'https://www.ncbi.nlm.nih.gov/clinvar/variation/',
-				key: 'id'
+				key: 'vcf_id',
+				linkText: 'ClinVar',
+				shownSeparately: true
 			},
 			infoUrl: [
 				{


### PR DESCRIPTION
please test with http://localhost:3000/?genome=hg38&gene=braf&mds3=clinvar and http://localhost:3000/?genome=hg19&gene=braf&mds3=clinvar

when clicking on a mutation, in the panel a `ClinVar` link will be generated besides the mutation string