### PR TITLE
Fix to check second group others using in. 

### DIFF
--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -531,8 +531,8 @@ export function setInteractivity(self) {
 		for (const group of groups) {
 			values[group.name] = { key: group.name, label: group.name }
 			const qgroup = {
-				name: group.name,
 				key: 'sample',
+				in: true,
 				values: getGroupValues(group)
 			}
 			qgroups.push(qgroup)
@@ -540,7 +540,6 @@ export function setInteractivity(self) {
 		if (groups.length == 1) {
 			values['Others'] = { key: 'Others', label: 'Others' }
 			qgroups.push({
-				name: 'Others',
 				key: 'sample',
 				in: false,
 				values: getGroupValues(groups[0])

--- a/client/termsetting/handlers/samplelst.js
+++ b/client/termsetting/handlers/samplelst.js
@@ -6,8 +6,8 @@ export function getHandler(self) {
 		showEditMenu(div) {
 			div.selectAll('*').remove()
 			const groups = self.q.groups
-
-			for (const group of groups) {
+			const keys = Object.keys(self.term.values)
+			for (const [i, group] of groups.entries()) {
 				const groupDiv = div
 					.append('div')
 					.style('display', 'inline-block')
@@ -15,7 +15,8 @@ export function getHandler(self) {
 				const noButtonCallback = (i, node) => {
 					group.values[i].checked = node.checked
 				}
-				addTable(groupDiv, group, noButtonCallback)
+				const name = group.in ? keys[i] : 'Others will exclude these samples'
+				addTable(groupDiv, name, group, noButtonCallback)
 			}
 			div
 				.append('div')
@@ -39,8 +40,7 @@ export function getHandler(self) {
 	}
 }
 
-function addTable(div, group, noButtonCallback) {
-	const name = group.name == 'Others' ? 'Others will exclude these samples' : group.name
+function addTable(div, name, group, noButtonCallback) {
 	div
 		.style('padding', '6px')
 		.append('div')

--- a/server/src/termdb.sql.samplelst.js
+++ b/server/src/termdb.sql.samplelst.js
@@ -4,24 +4,17 @@ export const sampleLstSql = {
 			samples,
 			samplesString
 		for (const [i, group] of tw.q.groups.entries()) {
+			const name = Object.keys(tw.term.values)[i]
 			samples = group.values.map(value => value.sampleId)
 			samplesString = samples.map(() => '?').join(',')
-			if (i == 1 && group.name == 'Others') {
-				sql += `
-				SELECT id as sample, ? as key, ? as value
-				FROM sampleidmap
-				WHERE sample NOT IN (${samplesString})`
-				values.push(group.name, group.name, ...samples)
-				break
-			}
 
 			sql += `SELECT id as sample, ? as key, ? as value
 				FROM sampleidmap
-				WHERE sample IN (${samplesString})
+				WHERE sample ${group.in ? '' : 'NOT'} IN (${samplesString})
 			`
 			if (i != tw.q.groups.length - 1) sql += 'UNION ALL '
 
-			values.push(group.name, group.name, ...samples)
+			values.push(name, name, ...samples)
 		}
 		return { sql: `${tablename} AS (${sql})`, tablename }
 	}


### PR DESCRIPTION
Instead of checking group name, using **in** property in from the q group to handle second group fakely created. Also removed group name from the q and read instead from the term values.