### PR TITLE
Nav.groups

### DIFF
--- a/client/dom/table.js
+++ b/client/dom/table.js
@@ -259,6 +259,10 @@ export function renderTable({
 		}
 		for (const [colIdx, cell] of row.entries()) {
 			const td = rowtable.append('td').attr('class', 'sjpp_table_item')
+
+			// attach <td> for external code to modify
+			cell.__td = td
+
 			const column = columns[colIdx]
 			if (column.editCallback && cell.value) {
 				td.on('click', () => {

--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -387,6 +387,71 @@ class FilterRxComp extends Filter {
 
 export const filterRxCompInit = getCompInit(FilterRxComp)
 
+class FilterPrompt extends Filter {
+	constructor(opts) {
+		super(opts)
+		this.api = {
+			// make sure to bind the 'this' context to the filter instance
+			// instead of to the this.api object
+			main: this.main.bind(this),
+			/*
+				WARNING!!!
+				When using this filter.api.getNormalRoot(),
+				make sure this instance has been updated before the caller,
+				otherwise the normalized root will be stale
+
+				or for reliability, import getNormalRoot() directly 
+				from the common/filter.js component and supply the 
+				caller's known raw filter state
+			*/
+			getNormalRoot: () => getNormalRoot(this.rawFilter),
+			getPromise: name => this.promises[name]
+		}
+	}
+
+	async main(rawFilter, opts = {}) {
+		this.dom.controlsTip.hide()
+		this.dom.treeTip.hide()
+		const activeCohort = 'activeCohort' in opts ? opts.activeCohort : this.activeCohort
+		const filterUiRoot = getFilterItemByTag(rawFilter, 'filterUiRoot')
+		// always replace the filterUiRoot with a tvslst object that has an empty lst,
+		// so that the prompt will always be displayed
+		if (filterUiRoot) delete filterUiRoot.tag
+		rawFilter.lst.push({
+			tag: 'filterUiRoot',
+			type: 'tvslst',
+			join: '',
+			lst: []
+		})
+		const rawCopy = JSON.stringify(rawFilter)
+		// if the filter data and active cohort has not changed, do not trigger a re-render
+		if (this.rawCopy == rawCopy && JSON.stringify(this.activeCohort) == JSON.stringify(activeCohort)) return
+		await super.main(rawCopy, opts)
+	}
+
+	refresh(filterUiRoot) {
+		this.dom.controlsTip.hide()
+		this.dom.treeTip.hide()
+		const rootCopy = JSON.parse(JSON.stringify(this.rawFilter))
+		const rawParent = findParent(rootCopy, this.filter.$id)
+		if (!rawParent || this.rawFilter.$id === this.filter.$id) {
+			this.opts.callback(rootCopy)
+		} else {
+			const i = rawParent.lst.findIndex(f => f.$id == this.filter.$id)
+			rawParent.lst[i] = filterUiRoot
+			this.opts.callback(rootCopy)
+		}
+		// remove the filled-in filterUiRoot from this filter prompt,
+		// so that the selected filter data does not get carried over
+		// to future selections from this prompt
+		const i = rootCopy.lst.findIndex(f => f.$id === filterUiRoot.$id)
+		rootCopy.lst.splice(i, 1)
+		this.main(rootCopy)
+	}
+}
+
+export const filterPromptInit = getInitFxn(FilterPrompt)
+
 // will assign an incremented index to each filter UI instance
 // to help namespace the body.on('click') event handler;
 // other click handlers are specific to the rendered

--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -400,14 +400,9 @@ function setRenderers(self) {
 		} else {
 			self.dom.newBtn = self.dom.holder
 				.append('div')
-				.attr('class', 'sja_new_filter_btn')
+				.attr('class', 'sja_new_filter_btn sja_menuoption')
 				.html(self.opts.emptyLabel)
 				.style('display', 'inline-block')
-				.style('margin', '2px 10px 2px 2px')
-				.style('padding', '5px')
-				.style('border-radius', '5px')
-				.style('background-color', '#ececec')
-				.style('cursor', 'pointer')
 				.on('click', self.displayTreeNew)
 		}
 

--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -423,6 +423,7 @@ class FilterPrompt extends Filter {
 			join: '',
 			lst: []
 		})
+		rawFilter.join = rawFilter.lst.length > 1 ? 'and' : ''
 		const rawCopy = JSON.stringify(rawFilter)
 		// if the filter data and active cohort has not changed, do not trigger a re-render
 		if (this.rawCopy == rawCopy && JSON.stringify(this.activeCohort) == JSON.stringify(activeCohort)) return

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -1,6 +1,6 @@
 import { getCompInit } from '#rx'
 import { Menu } from '#dom/menu'
-import { filterInit, getNormalRoot } from '#filter/filter'
+import { filterInit, getNormalRoot, filterPromptInit } from '#filter/filter'
 import { select } from 'd3-selection'
 import { appInit } from '#termdb/app'
 import { renderTable } from '#dom/table'
@@ -49,7 +49,7 @@ class MassGroups {
 	}
 
 	async main() {
-		console.log(this)
+		//console.log(this)
 		await updateUI(this)
 	}
 
@@ -199,15 +199,11 @@ async function updateUI(self) {
 	// but not in init()
 	self.dom.addNewGroupBtnHolder.selectAll('*').remove()
 
-	filterInit({
+	filterPromptInit({
 		holder: self.dom.addNewGroupBtnHolder,
 		vocab: self.app.opts.state.vocab,
 		emptyLabel: 'Add new group',
 		termdbConfig: self.state.termdbConfig,
-
-		// can add later
-		doNotShowWholeFilterWhenNoUiRootTag: true,
-
 		callback: f => {
 			// create new group
 			const name = 'New group'
@@ -219,7 +215,7 @@ async function updateUI(self) {
 			}
 			const newGroup = {
 				name: name + (i == 0 ? '' : ' ' + i),
-				filter: getJoinedFilter(self, { filter: f })
+				filter: f
 			}
 			groups.push(newGroup)
 			self.app.dispatch({
@@ -309,25 +305,6 @@ async function updateUI(self) {
 	}
 
 	self.updateLaunchBtn()
-}
-
-function getJoinedFilter(self, group) {
-	// group = { filter{} }
-	// if there's global filter, clone it and join with group.filter to return; tag group filter as visible part
-	// otherwise, only return group filter
-	const joinedFilter = self.getMassFilter()
-	const gf = structuredClone(group.filter)
-
-	if (!joinedFilter || joinedFilter.lst.length == 0) {
-		// there's no global filter
-		return gf
-	}
-
-	// has global filter, join with gf (label as visible), and return
-	gf.tag = 'filterUiRoot'
-	joinedFilter.lst.push(gf)
-	if (joinedFilter.lst.length > 1) joinedFilter.join = 'and'
-	return joinedFilter
 }
 
 function clickLaunchBtn(self) {

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -1,0 +1,257 @@
+import { getCompInit } from '#rx'
+import { Menu } from '#dom/menu'
+import { filterInit, getNormalRoot } from '#filter/filter'
+import { select } from 'd3-selection'
+import { appInit } from '#termdb/app'
+
+/*
+this
+	app
+		vocabApi
+		opts
+			genome{}
+			state
+				vocab{}
+	state {}
+		groups []
+			group.name=str
+			group.filter={}
+		termfilter{}
+			filter{}
+		termdbConfig{}
+*/
+
+const tip = new Menu({ padding: '0px' })
+const tip2 = new Menu({ padding: '0px' }) // to show tree ui
+
+class MassGroups {
+	constructor(opts = {}) {
+		this.type = 'groups'
+		this.filterUI = {} // key: group name, value: filter instance for this group
+	}
+
+	async init() {
+		this.dom = {
+			holder: this.opts.holder.append('div').style('margin', '20px')
+		}
+		initUI(this)
+	}
+
+	getState(appState) {
+		const state = {
+			termfilter: appState.termfilter,
+			groups: appState.groups,
+			termdbConfig: appState.termdbConfig
+		}
+		return state
+	}
+
+	async main() {
+		console.log(this)
+		await updateUI(this)
+	}
+
+	async showTree(div, callback, state = { tree: { usecase: { detail: 'term' } } }) {
+		tip2.clear().showunderoffset(div.node())
+		appInit({
+			holder: tip2.d,
+			vocabApi: this.app.vocabApi,
+			state,
+			tree: {
+				termfilter: this.state.termfilter,
+				click_term: term => {
+					callback(term)
+					tip.hide()
+					tip2.hide()
+				}
+			}
+		})
+	}
+	async openSummaryPlot(term, groups) {
+		const tw = { id: term.id, term }
+		const plot_name = 'Summary scatter'
+		//const disabled = !('sample' in groups[0].values[0])
+		const config = {
+			chartType: 'summary',
+			childType: 'barchart',
+			term: tw, // self is a termsetting, not a term
+			term2: {
+				term: { name: plot_name + ' groups', type: 'samplelst' },
+				q: {
+					mode: 'custom-groupsetting',
+					groups: groups,
+					groupsetting: { disabled: true }
+				}
+			}
+			//insertBefore: self.id
+		}
+		await this.app.dispatch({
+			type: 'plot_create',
+			config
+		})
+	}
+}
+
+export const groupsInit = getCompInit(MassGroups)
+
+function initUI(self) {
+	self.dom.filterTable = self.dom.holder.append('table')
+
+	// bottom row of buttons
+	const btnRow = self.dom.holder.append('div').style('margin-top', '10px')
+
+	// btn 1: prompt to add new group
+	self.dom.addNewGroupBtnHolder = btnRow.append('span')
+
+	// btn 2: launch plot
+	self.dom.launchBtn = btnRow
+		.append('button')
+		.style('margin-left', '20px')
+		.on('click', () => clickLaunchBtn(self))
+}
+
+async function updateUI(self) {
+	// reset prompt button;
+	// prompt button is an instance to a blank filter, can only make the button after state is filled
+	// but not in init()
+	self.dom.addNewGroupBtnHolder.selectAll('*').remove()
+
+	filterInit({
+		holder: self.dom.addNewGroupBtnHolder,
+		vocab: self.app.opts.state.vocab,
+		emptyLabel: 'Add new group',
+		termdbConfig: self.state.termdbConfig,
+		callback: f => {
+			// create new group
+			const name = 'New group'
+			let i = 0
+			while (1) {
+				const name2 = name + (i == 0 ? '' : ' ' + i)
+				if (!groups.find(g => g.name == name2)) break
+				i++
+			}
+			const newGroup = {
+				name: name + (i == 0 ? '' : ' ' + i),
+				filter: f
+			}
+			groups.push(newGroup)
+			self.app.dispatch({
+				//type:'groups_edit',
+				type: 'app_refresh',
+				state: { groups }
+			})
+		}
+	}).main(self.state.termfilter.filter)
+
+	// duplicate groups[] array to be mutable, and add to action.state for dispatching
+	const groups = structuredClone(self.state.groups)
+
+	if (!groups.length) {
+		// no groups, do not show launch button
+		self.dom.launchBtn.style('display', 'none')
+		return
+	}
+
+	// display table and create header
+	self.dom.filterTable
+		.style('display', '')
+		.selectAll('*')
+		.remove()
+	const tr = self.dom.filterTable.append('tr').style('opacity', 0.5)
+	tr.append('td').text('Name')
+	tr.append('td')
+		.text('Filtering criteria')
+		.style('padding-left', '10px') // equal to filter ui padding
+	tr.append('td').text('#sample')
+
+	// render each group
+	for (const group of groups) {
+		const tr = self.dom.filterTable.append('tr')
+		// name
+		{
+			const td = tr.append('td')
+			td.text(group.name)
+			// TODO click to rename and dispatch
+		}
+		// filter
+		{
+			const td = tr.append('td')
+			const fi = filterInit({
+				holder: td,
+				vocab: self.app.opts.state.vocab,
+				termdbConfig: self.state.termdbConfig,
+				callback: f => {
+					if (!f || f.lst.length == 0) {
+						// blank filter (user removed last tvs from this filter), delete group
+						const i = groups.findIndex(g => g.name == group.name)
+						groups.splice(i, 1)
+					} else {
+						// update filter
+						group.filter = f
+					}
+					self.app.dispatch({
+						type: 'app_refresh',
+						state: { groups }
+					})
+				}
+			})
+			fi.main(getJoinedFilter(self, group))
+		}
+
+		// #samples
+		tr.append('td')
+			.text('n=' + (await self.app.vocabApi.getFilteredSampleCount(group.filter)))
+			.style('opacity', 0.5)
+
+		// delete
+	}
+
+	// show launch btn, depends
+	self.dom.launchBtn.style('display', '')
+	self.dom.launchBtn.text(
+		groups.length == 1 ? `Launch plot with "${groups[0].name}"` : 'Select group(s) to launch plot'
+	)
+}
+
+function getJoinedFilter(self, group) {
+	// clone the global filter; group filter will be joined into it
+	const joinedFilter = structuredClone(self.state.termfilter.filter || { type: 'tvslst', in: true, join: '', lst: [] })
+	const gf = structuredClone(group.filter)
+	// tag group filter for it to be rendered in filter ui
+	// rest of state.filter will remain invisible
+	gf.tag = 'filterUiRoot'
+	joinedFilter.lst.push(gf)
+	if (joinedFilter.lst.length > 1) joinedFilter.join = 'and'
+	return joinedFilter
+}
+
+function clickLaunchBtn(self) {
+	tip.clear().showunder(self.dom.launchBtn.node())
+
+	if (self.state.groups.length == 0) return tip.d.append('p').text('No groups')
+
+	if (self.state.groups.length == 1) {
+		{
+			const opt = tip.d
+				.append('div')
+				.attr('class', 'sja_menuoption')
+				.style('border-radius', '0px')
+				.text('Summarize')
+			opt
+				.insert('div')
+				.html('›')
+				.style('float', 'right')
+			opt.on('click', () => {
+				self.showTree(opt, async term => {
+					const lst = await self.app.vocabApi.getFilteredSampleCount(self.state.groups[0].filter, 'list')
+					console.log(lst)
+					//const _group =
+				})
+			})
+		}
+		return
+	}
+
+	// multiple groups
+	tip.d.append('div').text('List groups to select')
+}

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -10,6 +10,11 @@ import { Menu } from '../dom/menu'
 import { getNormalRoot, getFilterItemByTag } from '../filter/filter'
 import { renderTable } from '../dom/table'
 
+/*
+nav {}
+	.tabs[]
+*/
+
 // to be used for assigning unique
 // radio button names by object instance
 // otherwise termdp app popups
@@ -29,8 +34,8 @@ headtip.d.style('z-index', 5555)
 
 // data elements for navigation header tabs
 const cohortTab = { top: 'COHORT', mid: 'NONE', btm: '', subheader: 'cohort' }
-const groupsTab = { top: 'GROUPS', mid: 'NONE', btm: '', subheader: 'groups' }
 const chartTab = { top: 'CHARTS', mid: 'NONE', btm: '', subheader: 'charts' }
+const groupsTab = { top: 'GROUPS', mid: 'NONE', btm: '', subheader: 'groups' }
 const filterTab = { top: 'FILTER', mid: 'NONE', btm: '', subheader: 'filter' }
 const cartTab = { top: 'CART', mid: 'NONE', btm: '', subheader: 'cart' }
 
@@ -119,7 +124,8 @@ class TdbNav {
 			activeCohort: appState.activeCohort,
 			termdbConfig: appState.termdbConfig,
 			filter: appState.termfilter.filter,
-			plots: appState.plots
+			plots: appState.plots,
+			groups: appState.groups
 		}
 	}
 
@@ -232,7 +238,7 @@ function setRenderers(self) {
 				.html('<br/>Cart feature under construction - work in progress<br/>&nbsp;<br/>')
 		})
 
-		self.tabs = [groupsTab, chartTab, filterTab /*, cartTab*/]
+		self.tabs = [chartTab, groupsTab, filterTab /*, cartTab*/]
 		if (appState.termdbConfig.selectCohort) self.tabs.unshift(cohortTab) // dataset has "sub-cohorts", show the Cohort tab at the beginning
 
 		const table = self.dom.tabDiv.append('table').style('border-collapse', 'collapse')
@@ -353,6 +359,11 @@ function setRenderers(self) {
 			.style('background-color', d => (d.colNum == self.activeTab ? '#ececec' : 'transparent'))
 			.html(function(d, i) {
 				if (d.key == 'top') return this.innerHTML
+
+				if (d.subheader == 'groups') {
+					if (d.key == 'mid') return self.state.groups.length || 'NONE'
+					return ''
+				}
 
 				if (d.subheader === 'charts') {
 					const n = self.state.plots.length

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -1,18 +1,19 @@
-import { getCompInit, multiInit } from '../rx'
+import { getCompInit, multiInit } from '#rx'
 import { recoverInit } from '../rx/src/recover'
 import { searchInit } from './search'
-import { filterRxCompInit } from '../filter/filter'
 import { chartsInit } from './charts'
 import { groupsInit } from './groups'
 import { select } from 'd3-selection'
-import { dofetch3 } from '../common/dofetch'
-import { Menu } from '../dom/menu'
-import { getNormalRoot, getFilterItemByTag } from '../filter/filter'
-import { renderTable } from '../dom/table'
+import { dofetch3 } from '#common/dofetch'
+import { Menu } from '#dom/menu'
+import { getNormalRoot, getFilterItemByTag, filterRxCompInit } from '#filter/filter'
+import { renderTable } from '#dom/table'
 
 /*
 nav {}
 	.tabs[]
+
+todo: steps to add a new tab
 */
 
 // to be used for assigning unique

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -3,6 +3,7 @@ import { recoverInit } from '../rx/src/recover'
 import { searchInit } from './search'
 import { filterRxCompInit } from '../filter/filter'
 import { chartsInit } from './charts'
+import { groupsInit } from './groups'
 import { select } from 'd3-selection'
 import { dofetch3 } from '../common/dofetch'
 import { Menu } from '../dom/menu'
@@ -25,6 +26,13 @@ let id = (+new Date()).toString().slice(-8)
 const headtip = new Menu({ padding: '0px', offsetX: 0, offsetY: 0 })
 headtip.d.style('z-index', 5555)
 // headtip must get a crazy high z-index so it can stay on top of all, no matter if server config has base_zindex or not
+
+// data elements for navigation header tabs
+const cohortTab = { top: 'COHORT', mid: 'NONE', btm: '', subheader: 'cohort' }
+const groupsTab = { top: 'GROUPS', mid: 'NONE', btm: '', subheader: 'groups' }
+const chartTab = { top: 'CHARTS', mid: 'NONE', btm: '', subheader: 'charts' }
+const filterTab = { top: 'FILTER', mid: 'NONE', btm: '', subheader: 'filter' }
+const cartTab = { top: 'CART', mid: 'NONE', btm: '', subheader: 'cart' }
 
 function getId() {
 	return idPrefix + '_' + id++
@@ -72,6 +80,11 @@ class TdbNav {
 				charts: chartsInit({
 					app: this.app,
 					holder: this.dom.subheader.charts,
+					vocab: this.opts.vocab
+				}),
+				groups: groupsInit({
+					app: this.app,
+					holder: this.dom.subheader.groups,
 					vocab: this.opts.vocab
 				}),
 				recover: recoverInit({
@@ -209,6 +222,7 @@ function setRenderers(self) {
 
 		self.dom.subheader = Object.freeze({
 			search: self.dom.subheaderDiv.append('div').style('display', 'none'),
+			groups: self.dom.subheaderDiv.append('div').style('display', 'none'),
 			charts: self.dom.subheaderDiv.append('div').style('display', 'none'),
 			cohort: self.dom.subheaderDiv.append('div').style('display', 'none'),
 			filter: self.dom.subheaderDiv.append('div').style('display', 'none'),
@@ -218,14 +232,10 @@ function setRenderers(self) {
 				.html('<br/>Cart feature under construction - work in progress<br/>&nbsp;<br/>')
 		})
 
+		self.tabs = [groupsTab, chartTab, filterTab /*, cartTab*/]
+		if (appState.termdbConfig.selectCohort) self.tabs.unshift(cohortTab) // dataset has "sub-cohorts", show the Cohort tab at the beginning
+
 		const table = self.dom.tabDiv.append('table').style('border-collapse', 'collapse')
-		const chartTab = { top: 'CHARTS', mid: 'NONE', btm: '', subheader: 'charts' }
-		const cohortTab = { top: 'COHORT', mid: 'NONE', btm: '', subheader: 'cohort' }
-		const filterTab = { top: 'FILTER', mid: 'NONE', btm: '', subheader: 'filter' }
-		const cartTab = { top: 'CART', mid: 'NONE', btm: '', subheader: 'cart' }
-		self.tabs = appState.termdbConfig.selectCohort
-			? [cohortTab, chartTab, filterTab /*, cartTab*/]
-			: [chartTab, filterTab /*, cartTab*/]
 
 		// using a table layout for tabs, iterate through each tab
 		// once for each of [top, mid, btm] row

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -43,6 +43,7 @@ const defaultState = {
 			byName: {}
 		}
 	},
+	groups: [], // element: {name=str, filter={}}, to show in Groups tab
 	autoSave: true
 }
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -343,7 +343,7 @@ export class TermdbVocab extends Vocab {
 			genome: this.vocab.genome,
 			dslabel: this.vocab.dslabel,
 			getsamplecount: getSampleLst || 'count',
-			filter: filterJSON
+			filter: typeof filterJSON == 'string' ? filterJSON : getNormalRoot(filterJSON)
 		}
 		const data = await dofetch3('termdb', { body }, this.opts.fetchOpts)
 		if (!data) throw `missing data`

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -338,16 +338,20 @@ export class TermdbVocab extends Vocab {
 		}
 	}
 
-	async getFilteredSampleCount(filterJSON) {
+	async getFilteredSampleCount(filterJSON, getSampleLst) {
 		const body = {
 			genome: this.vocab.genome,
 			dslabel: this.vocab.dslabel,
-			getsamplecount: 1,
+			getsamplecount: getSampleLst || 'count',
 			filter: filterJSON
 		}
 		const data = await dofetch3('termdb', { body }, this.opts.fetchOpts)
 		if (!data) throw `missing data`
 		if (data.error) throw data.error
+		if (getSampleLst) {
+			if (!Array.isArray(data)) throw 'data is not array'
+			return data
+		}
 		return data[0].samplecount
 	}
 

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -59,7 +59,7 @@ export function handle_request_closure(genomes) {
 			}
 			if (q.gettermdbconfig) return termdbConfig.make(q, res, ds, genome)
 			if (q.getcohortsamplecount) return trigger_getcohortsamplecount(q, res, ds)
-			if (q.getsamplecount) return res.send(await termdbsql.get_samplecount(q, ds))
+			if (q.getsamplecount) return res.send(await getSampleCount(q, ds))
 			if (q.getsamples) return await trigger_getsamples(q, res, ds)
 			if (q.getcuminc) return await trigger_getincidence(q, res, ds)
 			if (q.getsurvival) return await trigger_getsurvival(q, res, ds)
@@ -127,6 +127,11 @@ async function trigger_getsamples(q, res, ds) {
 	const lst = await termdbsql.get_samples(q.filter, ds)
 	const samples = lst.map(i => ds.cohort.termdb.q.id2sampleName(i))
 	res.send({ samples })
+}
+
+async function getSampleCount(q, ds) {
+	if (q.getsamplecount == 'list') return await termdbsql.get_samples(q.filter, ds)
+	return await termdbsql.get_samplecount(q, ds)
 }
 
 function trigger_gettermbyid(q, res, tdb) {

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -57,7 +57,7 @@ return an array of sample names passing through the filter
 	const filter = await getFilterCTEs(qfilter, ds) // if qfilter is blank, it returns null
 
 	const sql = ds.cohort.db.connection.prepare(
-		filter ? `WITH ${filter.filters} SELECT sample FROM ${filter.CTEname}` : 'SELECT name AS sample FROM sampleidmap'
+		filter ? `WITH ${filter.filters} SELECT sample FROM ${filter.CTEname}` : 'SELECT id AS sample FROM sampleidmap' // both statements must return sample id as a uniform behavior
 	)
 
 	let re


### PR DESCRIPTION
the `GROUPS` tab is added to mass nav header
the ui uses table.js to display created groups
initial tests showed it's working for both pnet and sjlife
filter tests all passed
created groups work independently from global filter and subcohort
groups are tracked in state (state.groups[]) and can be saved
more functionalities will be added to `Launch plot`

some code duplication with sampleScatter, including function for creating samplelst tw, and launching new plots. later can improve