### PR TITLE
Edit filter if allowed

### DIFF
--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -1203,6 +1203,11 @@ function setInteractivity(self) {
 			.style('background-color', self.highlightEditRow)
 		const holder = self.dom.termSrcDiv
 		const item = self.activeData.item
+		if (item.disabled) {
+			alert(`This filter can't be edited. It may contain sensitive information`)
+			self.dom.controlsTip.hide()
+			return
+		}
 		self.dom.treeTip.clear()
 		self.pills[item.$id].showMenu(holder)
 		self.dom.treeTip.showunderoffset(elem.lastChild)

--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -878,6 +878,7 @@ function setInteractivity(self) {
 		self.activeData = { item, filter, elem: this }
 		self.removeBlankPill()
 		self.resetGrpHighlights(this, filter)
+		self.dom.table.selectAll('tr').style('display', d => (d.action == 'edit' && item.noEdit ? 'none' : 'table-row'))
 		self.dom.controlsTip.showunder(this)
 	}
 
@@ -1203,11 +1204,6 @@ function setInteractivity(self) {
 			.style('background-color', self.highlightEditRow)
 		const holder = self.dom.termSrcDiv
 		const item = self.activeData.item
-		if (item.disabled) {
-			alert(`This filter can't be edited. It may contain sensitive information`)
-			self.dom.controlsTip.hide()
-			return
-		}
 		self.dom.treeTip.clear()
 		self.pills[item.$id].showMenu(holder)
 		self.dom.treeTip.showunderoffset(elem.lastChild)

--- a/client/filter/tvs.samplelst.js
+++ b/client/filter/tvs.samplelst.js
@@ -14,7 +14,7 @@ async function fillMenu(self, div, tvs) {
 		.style('margin', '10px')
 		.html(`<b>Select <i>${tvs.term.name}</i> samples:</b>`)
 	const rows = []
-	for (const value of tvs.values) rows.push([{ value: value }])
+	for (const value of tvs.values) rows.push([{ value: value.sample }])
 	const columns = [{ label: 'Sample' }]
 	renderTable({
 		rows,

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -307,7 +307,7 @@ export function setInteractivity(self) {
 					{
 						type: 'tvs',
 						tvs: { term: samplelstTW.term, values },
-						noEdit: true
+						noEdit: !('sample' in values[0])
 					}
 				]
 			}

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -307,7 +307,7 @@ export function setInteractivity(self) {
 					{
 						type: 'tvs',
 						tvs: { term: samplelstTW.term, values },
-						disabled: 'sample' in values[0]
+						noEdit: true
 					}
 				]
 			}

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -296,7 +296,7 @@ export function setInteractivity(self) {
 	self.addToFilter = function(group) {
 		const filterUiRoot = getFilterItemByTag(self.state.termfilter.filter, 'filterUiRoot')
 		const samplelstTW = getSamplelstTW([group])
-		const values = samplelstTW.q.groups[0].values.map(value => value.sampleId)
+		const values = samplelstTW.q.groups[0].values
 		const filter = filterJoin([
 			filterUiRoot,
 			{
@@ -306,7 +306,8 @@ export function setInteractivity(self) {
 				lst: [
 					{
 						type: 'tvs',
-						tvs: { term: samplelstTW.term, values }
+						tvs: { term: samplelstTW.term, values },
+						disabled: 'sample' in values[0]
 					}
 				]
 			}

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -127,7 +127,7 @@ function get_samplelst(tvs, CTEname) {
 					.join(', ')})
 			)`
 		],
-		values: [...tvs.values],
+		values: [...tvs.values.map(value => value.sampleId)],
 		CTEname
 	}
 }


### PR DESCRIPTION
If the samples are not supposed to be shown the filter edit should be disabled. We might want to disable or remove this option instead.