### PR TITLE
search sample and show only group

### DIFF
--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -487,5 +487,16 @@ export const icons = {
 			.html(svg)
 			.on('click', opts.handler)
 			.style('cursor', 'pointer')
+	},
+	search: (elem, opts) => {
+		const _opts = { color: 'black', width: 18, height: 18 }
+		Object.assign(_opts, opts)
+		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-search" viewBox="0 0 16 16">
+		<path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+	  </svg>`
+		elem
+			.html(svg)
+			.on('click', opts.handler)
+			.style('cursor', 'pointer')
 	}
 }

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -222,6 +222,32 @@ export function setInteractivity(self) {
 		})
 	}
 
+	self.searchSample = function(e) {
+		const menu = new Menu()
+		const input = menu.d.append('input').on('change', () => {
+			// ok to not await here, since no returned value is required
+			// and menu.hide() does not need to wait for the dispatch to finish
+			const value = input.node().value
+			const items = []
+			for (const sample of self.cohortSamples)
+				if (sample.sample.toUpperCase().includes(value.toUpperCase())) items.push(sample)
+			if (items.length == 0) {
+				msgDiv.text('No samples found')
+				return
+			}
+			self.config.groups.push({
+				name: `Group ${self.config.groups.length + 1}`,
+				items,
+				index: self.config.groups.length,
+				showOnly: true
+			})
+			self.app.dispatch({ type: 'plot_edit', id: self.id, config: { groups: self.config.groups } })
+			menu.hide()
+		})
+		const msgDiv = menu.d.append('div').style('padding-left', '5px')
+		menu.show(e.clientX, e.clientY, false)
+	}
+
 	self.openSurvivalPlot = async function(term, groups) {
 		const plot_name = self.config.name ? self.config.name : 'Summary scatter'
 		const disabled = !('sample' in groups[0].items[0])
@@ -499,6 +525,14 @@ export function setInteractivity(self) {
 			.text('Add to filter')
 			.on('click', () => {
 				self.addToFilter(group)
+				self.app.dispatch({ type: 'plot_edit', id: self.id, config: { groups: self.config.groups } })
+			})
+		menuDiv
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.text(group.showOnly ? 'Show All' : 'Show Only')
+			.on('click', () => {
+				group.showOnly = !group.showOnly
 				self.app.dispatch({ type: 'plot_edit', id: self.id, config: { groups: self.config.groups } })
 			})
 	}

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -226,7 +226,7 @@ export function setRenderers(self) {
 	self.getColor = function(c) {
 		if (self.config.colorTW?.q.mode == 'continuous' && 'sampleId' in c) return self.colorGenerator(c.category)
 		const category = self.colorLegend.get(c.category)
-		if (self.config.colorTW.term.type == 'geneVariant') {
+		if (self.config.colorTW?.term.type == 'geneVariant') {
 			const mutations = c.cat_info.category
 			const catMutations = mutations.filter(
 				mutation =>

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -252,6 +252,8 @@ export function setRenderers(self) {
 			const opacity = c.hidden['category'] || c.hidden['shape'] ? 0 : self.settings.opacity
 			return opacity
 		}
+		const showOnly = self.config.groups.find(group => group.showOnly)
+		if (showOnly) return 0
 		const refOpacity = self.settings.showRef ? self.settings.opacity : 0
 		return refOpacity
 	}


### PR DESCRIPTION
This PR adds several features: 
Added search sample that creates a group with the samples matching the str (See search icon to the left). 
Added showOnly to show just samples from a group (can be used from the group menu). 
Highlighted samples with multiple mutations from the same type with a darker tone (like the 2 MISSENSE case)