### PR TITLE
Matrix scroll

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -60,7 +60,7 @@ export function dofetch(path, arg, opts = null) {
 }
 
 const cachedServerDataKeys = []
-const maxNumOfServerDataKeys = 120
+const maxNumOfServerDataKeys = 360
 
 export function dofetch2(path, init = {}, opts = {}) {
 	/*

--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -494,9 +494,43 @@ export const icons = {
 		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-search" viewBox="0 0 16 16">
 		<path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
 	  </svg>`
+	},
+	crosshair: (elem, opts = {}) => {
+		const _opts = { color: 'black', width: 18, height: 18, d: 2 }
+		const w = _opts.width
+		const h = _opts.height
+		const d = _opts.d
+		Object.assign(_opts, opts)
+		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" style='vertical-align: middle'>
+		<!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+		<path d="M${w / 2},${d}L${w / 2},${h - d}Z" stroke='${_opts.color}'/>
+		<path d="M${d},${h / 2}L${w - d},${h / 2}Z" stroke='${_opts.color}'/>
+		</svg>`
 		elem
 			.html(svg)
 			.on('click', opts.handler)
 			.style('cursor', 'pointer')
+	},
+	grab: (elem, opts = {}) => {
+		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
+		Object.assign(_opts, opts)
+		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" viewBox="0 0 448 512">
+		<!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+		<path transform='${_opts.transform}' d="M144 64c0-8.8 7.2-16 16-16s16 7.2 16 16c0 9.1 5.1 17.4 13.3 21.5s17.9 3.2 25.1-2.3c2.7-2 6-3.2 9.6-3.2c8.8 0 16 7.2 16 16c0 9.1 5.1 17.4 13.3 21.5s17.9 3.2 25.1-2.3c2.7-2 6-3.2 9.6-3.2c8.8 0 16 7.2 16 16c0 9.1 5.1 17.4 13.3 21.5s17.9 3.2 25.1-2.3c2.7-2 6-3.2 9.6-3.2c8.8 0 16 7.2 16 16V264c0 31.3-20 58-48 67.9c-9.6 3.4-16 12.5-16 22.6V488c0 13.3 10.7 24 24 24s24-10.7 24-24V370.2c38-20.1 64-60.1 64-106.2V160c0-35.3-28.7-64-64-64c-2.8 0-5.6 .2-8.3 .5C332.8 77.1 311.9 64 288 64c-2.8 0-5.6 .2-8.3 .5C268.8 45.1 247.9 32 224 32c-2.8 0-5.6 .2-8.3 .5C204.8 13.1 183.9 0 160 0C124.7 0 96 28.7 96 64v64.3c-11.7 7.4-22.5 16.4-32 26.9l17.8 16.1L64 155.2l-9.4 10.5C40 181.8 32 202.8 32 224.6v12.8c0 49.6 24.2 96.1 64.8 124.5l13.8-19.7L96.8 361.9l8.9 6.2c6.9 4.8 14.4 8.6 22.3 11.3V488c0 13.3 10.7 24 24 24s24-10.7 24-24V359.9c0-12.6-9.8-23.1-22.4-23.9c-7.3-.5-14.3-2.9-20.3-7.1l-13.1 18.7 13.1-18.7-8.9-6.2C96.6 303.1 80 271.3 80 237.4V224.6c0-9.9 3.7-19.4 10.3-26.8l9.4-10.5c3.8-4.2 7.9-8.1 12.3-11.6V208c0 8.8 7.2 16 16 16s16-7.2 16-16V142.3 128 64z"/>
+		</svg>`
+		elem.html(svg).style('cursor', 'pointer')
+
+		if (opts.handler) elem.on('click', opts.handler)
+	},
+	arrowPointer: (elem, opts = {}) => {
+		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
+		Object.assign(_opts, opts)
+		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" viewBox="0 0 320 512">
+		<!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+		<path transform='${_opts.transform}' d="M0 55.2V426c0 12.2 9.9 22 22 22c6.3 0 12.4-2.7 16.6-7.5L121.2 346l58.1 116.3c7.9 15.8 27.1 22.2 42.9 14.3s22.2-27.1 14.3-42.9L179.8 320H297.9c12.2 0 22.1-9.9 22.1-22.1c0-6.3-2.7-12.3-7.4-16.5L38.6 37.9C34.3 34.1 28.9 32 23.2 32C10.4 32 0 42.4 0 55.2z"/>
+		</svg>`
+		elem.html(svg).style('cursor', 'pointer')
+
+		if (opts.handler) elem.on('click', opts.handler)
 	}
 }

--- a/client/dom/svg.scroll.js
+++ b/client/dom/svg.scroll.js
@@ -39,7 +39,8 @@ export function svgScroll(_opts) {
 
 	function scrollStop(e) {
 		if (!('x' in ref)) return
-		opts.callback(ref.dxFactor * (e.clientX - ref.x), 'up')
+		const dx = e.clientX - ref.x
+		opts.callback(ref.dxFactor * Math.min(ref.maxDx, Math.max(dx, ref.minDx)), 'up')
 		delete ref.x
 		select('body')
 			.on('mousemove.sjppSvgScroll', null)
@@ -53,6 +54,7 @@ export function svgScroll(_opts) {
 		.attr('stroke', '#aaa')
 		.attr('stroke-width', 1)
 		.attr('fill', '#ccc')
+		.attr('rx', opts.height / 2)
 		.on('mousedown', scrollInit)
 		.on('mousemove', scrollMove)
 		.on('mouseup', scrollStop)
@@ -83,9 +85,12 @@ export function svgScroll(_opts) {
 				ref.dxFactor = (t - v) / (v - ref.sliderWidth)
 			}
 
-			const center = v * (opts.zoomCenter / t)
+			const center = v * (opts.zoomCenter / t) //; console.log(87, 'svg.scroll', center, opts.zoomCenter)
 			ref.sliderX = center - ref.sliderWidth / 2
 			slider.attr('width', ref.sliderWidth).attr('x', ref.sliderX)
+
+			ref.maxDx = opts.visibleWidth - ref.sliderX - ref.sliderWidth
+			ref.minDx = -ref.sliderX
 			delete ref.x
 		}
 	}

--- a/client/dom/svg.scroll.js
+++ b/client/dom/svg.scroll.js
@@ -1,7 +1,9 @@
+import { select } from 'd3-selection'
+
 export function svgScroll(_opts) {
 	if (!_opts.holder) throw `missing svgScroll.opts.holder argument`
 	const defaults = {
-		height: 36,
+		height: 12,
 		zoomLevel: 1
 	}
 
@@ -19,17 +21,29 @@ export function svgScroll(_opts) {
 
 	const ref = {}
 
+	function scrollInit(e) {
+		ref.x = e.clientX
+		select('body')
+			.on('mousemove.sjppSvgScroll', scrollMove)
+			.on('mouseup.sjppSvgScroll', scrollStop)
+	}
+
+	function scrollMove(e) {
+		if (!('x' in ref)) return
+		const dx = e.clientX - ref.x
+		if (ref.sliderX + ref.sliderWidth + dx > opts.visibleWidth + 1) return
+		if (ref.sliderX + dx < -1) return
+		slider.attr('x', ref.sliderX + dx)
+		opts.callback(ref.dxFactor * dx, 'move')
+	}
+
 	function scrollStop(e) {
 		if (!('x' in ref)) return
-		if (opts.noTextHighlight) {
-			opts.noTextHighlight
-				.style('-webkit-user-select', '')
-				.style('-moz-user-select', '')
-				.style('-ms-user-select', '')
-				.style('user-select', '')
-		}
 		opts.callback(ref.dxFactor * (e.clientX - ref.x), 'up')
 		delete ref.x
+		select('body')
+			.on('mousemove.sjppSvgScroll', null)
+			.on('mouseup.sjppSvgScroll', null)
 	}
 
 	const slider = opts.holder
@@ -39,29 +53,14 @@ export function svgScroll(_opts) {
 		.attr('stroke', '#aaa')
 		.attr('stroke-width', 1)
 		.attr('fill', '#ccc')
-		.on('mousedown', e => {
-			if (opts.noTextHighlight) {
-				opts.noTextHighlight
-					.style('-webkit-user-select', 'none')
-					.style('-moz-user-select', 'none')
-					.style('-ms-user-select', 'none')
-					.style('user-select', 'none')
-			}
-			ref.x = e.clientX
-		})
-		.on('mousemove', e => {
-			if (!('x' in ref)) return
-			const dx = e.clientX - ref.x
-			if (ref.sliderX + ref.sliderWidth + dx > opts.visibleWidth + 1) return
-			if (ref.sliderX + dx < -1) return
-			slider.attr('x', ref.sliderX + dx)
-			opts.callback(ref.dxFactor * dx, 'move')
-		})
+		.on('mousedown', scrollInit)
+		.on('mousemove', scrollMove)
 		.on('mouseup', scrollStop)
-		.on('mouseout', scrollStop)
+	//.on('mouseout', scrollStop)
 
 	const api = {
 		update(_opts) {
+			const prev = { v: opts.visibleWidth, t: opts.totalWidth, z: opts.zoomCenter }
 			Object.assign(opts, _opts)
 			const t = opts.totalWidth
 			const v = opts.visibleWidth
@@ -72,17 +71,19 @@ export function svgScroll(_opts) {
 			opts.holder.attr('transform', `translate(${opts.x},${opts.y})`).attr('display', '')
 			rect.attr('width', v)
 
-			// multiply visibleWidth by the ratio of v:t,
-			// to make the slider width proportional to v:t
-			ref.sliderWidth = (v * v) / t
-			// each slider dx movement is equivalent to the ratio of
-			// the open slider space on its left and right side
-			// versus the unseen left and right portions of the element to be scrolled;
-			// in other words, the available slidable segment of the scrollbar handle
-			// proprotionally represents the unseen segment of the svg element
-			ref.dxFactor = (t - v) / (v - ref.sliderWidth)
+			if (v != prev.v || t != prev.t) {
+				// multiply visibleWidth by the ratio of v:t,
+				// to make the slider width proportional to v:t
+				ref.sliderWidth = (v * v) / t
+				// each slider dx movement is equivalent to the ratio of
+				// the open slider space on its left and right side
+				// versus the unseen left and right portions of the element to be scrolled;
+				// in other words, the available slidable segment of the scrollbar handle
+				// proprotionally represents the unseen segment of the svg element
+				ref.dxFactor = (t - v) / (v - ref.sliderWidth)
+			}
 
-			const center = v * (1 - opts.zoomCenter / t)
+			const center = v * (opts.zoomCenter / t)
 			ref.sliderX = center - ref.sliderWidth / 2
 			slider.attr('width', ref.sliderWidth).attr('x', ref.sliderX)
 			delete ref.x

--- a/client/dom/svg.scroll.js
+++ b/client/dom/svg.scroll.js
@@ -4,22 +4,11 @@ export function svgScroll(_opts) {
 	if (!_opts.holder) throw `missing svgScroll.opts.holder argument`
 	const defaults = {
 		height: 12,
-		zoomLevel: 1
+		zoomLevel: 1,
+		opacity: 0.7
 	}
 
 	const opts = Object.assign({}, defaults, _opts)
-
-	opts.holder.attr('display', 'none')
-
-	// assumes horizontal for now
-	const rect = opts.holder
-		.append('rect')
-		.style('height', opts.height)
-		.style('stroke', '#999')
-		.style('stroke-width', 1)
-		.style('fill', '#fff')
-
-	const ref = {}
 
 	function scrollInit(e) {
 		ref.x = e.clientX
@@ -47,18 +36,76 @@ export function svgScroll(_opts) {
 			.on('mouseup.sjppSvgScroll', null)
 	}
 
+	function scrollByClick(e) {
+		ref.x = e.clientX
+		const i = e.clientX < slideElem.getBoundingClientRect().x ? -1 : 1
+		scrollStop({ clientX: Math.round(ref.x + i * ref.arrowDx) })
+	}
+
+	opts.holder
+		.attr('display', 'none')
+		.attr('opacity', opts.opacity)
+		.on('mouseover', () => opts.holder.attr('opacity', 1))
+		.on('mouseout', () => opts.holder.attr('opacity', opts.opacity))
+
+	// assumes horizontal for now
+	const rect = opts.holder
+		.append('rect')
+		.style('height', opts.height)
+		.style('stroke', 'none')
+		//.style('stroke-width', 1)
+		//.attr('rx', opts.height / 2)
+		.style('fill', '#fff')
+		.on('click', scrollByClick)
+
+	const line = opts.holder
+		.append('line')
+		.style('stroke', '#ccc')
+		.style('stroke-width', 1)
+		.on('click', scrollByClick)
+
+	const leftArrow = opts.holder
+		.append('path')
+		.attr('y', -opts.height)
+		.attr('d', `M0,${opts.height / 2}L${opts.height},0L${opts.height},${opts.height}Z`)
+		.style('stroke', '#ccc')
+		.style('stroke-width', 1)
+		//.attr('rx', opts.height / 2)
+		.style('fill', '#ccc')
+		.on('click', e => {
+			ref.x = e.clientX
+			scrollStop({ clientX: Math.round(ref.x - ref.arrowDx) })
+		})
+
+	const rtArrow = opts.holder
+		.append('path')
+		.attr('y', -opts.height)
+		.style('stroke', '#ccc')
+		.style('stroke-width', 1)
+		//.attr('rx', opts.height / 2)
+		.style('fill', '#ccc')
+		.attr('d', `M0,0L${opts.height},${opts.height / 2}L0,${opts.height}Z`)
+		.on('click', e => {
+			ref.x = e.clientX
+			scrollStop({ clientX: Math.round(ref.x + ref.arrowDx) })
+		})
+
+	const sliderHt = opts.height - 4
 	const slider = opts.holder
 		.append('rect')
-		.attr('y', 1)
-		.attr('height', opts.height - 2)
+		.attr('y', 2)
+		.attr('height', sliderHt)
 		.attr('stroke', '#aaa')
 		.attr('stroke-width', 1)
 		.attr('fill', '#ccc')
-		.attr('rx', opts.height / 2)
+		.attr('rx', sliderHt / 2)
 		.on('mousedown', scrollInit)
 		.on('mousemove', scrollMove)
 		.on('mouseup', scrollStop)
-	//.on('mouseout', scrollStop)
+
+	const slideElem = slider.node()
+
+	const ref = {}
 
 	const api = {
 		update(_opts) {
@@ -71,7 +118,18 @@ export function svgScroll(_opts) {
 				return
 			}
 			opts.holder.attr('transform', `translate(${opts.x},${opts.y})`).attr('display', '')
+
 			rect.attr('width', v)
+
+			line
+				.attr('x1', 0)
+				.attr('x2', v)
+				.attr('y1', opts.height / 2)
+				.attr('y2', opts.height / 2)
+
+			leftArrow.attr('transform', `translate(0,0)`)
+
+			rtArrow.attr('transform', `translate(${v - opts.height},0)`)
 
 			if (v != prev.v || t != prev.t) {
 				// multiply visibleWidth by the ratio of v:t,
@@ -91,6 +149,7 @@ export function svgScroll(_opts) {
 
 			ref.maxDx = opts.visibleWidth - ref.sliderX - ref.sliderWidth
 			ref.minDx = -ref.sliderX
+			ref.arrowDx = Math.round(0.1 * opts.visibleWidth)
 			delete ref.x
 		}
 	}

--- a/client/dom/svg.scroll.js
+++ b/client/dom/svg.scroll.js
@@ -1,0 +1,93 @@
+export function svgScroll(_opts) {
+	if (!_opts.holder) throw `missing svgScroll.opts.holder argument`
+	const defaults = {
+		height: 36,
+		zoomLevel: 1
+	}
+
+	const opts = Object.assign({}, defaults, _opts)
+
+	opts.holder.attr('display', 'none')
+
+	// assumes horizontal for now
+	const rect = opts.holder
+		.append('rect')
+		.style('height', opts.height)
+		.style('stroke', '#999')
+		.style('stroke-width', 1)
+		.style('fill', '#fff')
+
+	const ref = {}
+
+	function scrollStop(e) {
+		if (!('x' in ref)) return
+		if (opts.noTextHighlight) {
+			opts.noTextHighlight
+				.style('-webkit-user-select', '')
+				.style('-moz-user-select', '')
+				.style('-ms-user-select', '')
+				.style('user-select', '')
+		}
+		opts.callback(ref.dxFactor * (e.clientX - ref.x), 'up')
+		delete ref.x
+	}
+
+	const slider = opts.holder
+		.append('rect')
+		.attr('y', 1)
+		.attr('height', opts.height - 2)
+		.attr('stroke', '#aaa')
+		.attr('stroke-width', 1)
+		.attr('fill', '#ccc')
+		.on('mousedown', e => {
+			if (opts.noTextHighlight) {
+				opts.noTextHighlight
+					.style('-webkit-user-select', 'none')
+					.style('-moz-user-select', 'none')
+					.style('-ms-user-select', 'none')
+					.style('user-select', 'none')
+			}
+			ref.x = e.clientX
+		})
+		.on('mousemove', e => {
+			if (!('x' in ref)) return
+			const dx = e.clientX - ref.x
+			if (ref.sliderX + ref.sliderWidth + dx > opts.visibleWidth + 1) return
+			if (ref.sliderX + dx < -1) return
+			slider.attr('x', ref.sliderX + dx)
+			opts.callback(ref.dxFactor * dx, 'move')
+		})
+		.on('mouseup', scrollStop)
+		.on('mouseout', scrollStop)
+
+	const api = {
+		update(_opts) {
+			Object.assign(opts, _opts)
+			const t = opts.totalWidth
+			const v = opts.visibleWidth
+			if (t <= v) {
+				opts.holder.attr('display', 'none')
+				return
+			}
+			opts.holder.attr('transform', `translate(${opts.x},${opts.y})`).attr('display', '')
+			rect.attr('width', v)
+
+			// multiply visibleWidth by the ratio of v:t,
+			// to make the slider width proportional to v:t
+			ref.sliderWidth = (v * v) / t
+			// each slider dx movement is equivalent to the ratio of
+			// the open slider space on its left and right side
+			// versus the unseen left and right portions of the element to be scrolled;
+			// in other words, the available slidable segment of the scrollbar handle
+			// proprotionally represents the unseen segment of the svg element
+			ref.dxFactor = (t - v) / (v - ref.sliderWidth)
+
+			const center = v * (1 - opts.zoomCenter / t)
+			ref.sliderX = center - ref.sliderWidth / 2
+			slider.attr('width', ref.sliderWidth).attr('x', ref.sliderX)
+			delete ref.x
+		}
+	}
+
+	return api
+}

--- a/client/dom/svg.scroll.js
+++ b/client/dom/svg.scroll.js
@@ -39,7 +39,7 @@ export function svgScroll(_opts) {
 	function scrollByClick(e) {
 		ref.x = e.clientX
 		const i = e.clientX < slideElem.getBoundingClientRect().x ? -1 : 1
-		scrollStop({ clientX: Math.round(ref.x + i * ref.arrowDx) })
+		scrollStop({ clientX: Math.floor(ref.x + i * ref.arrowDx) })
 	}
 
 	opts.holder
@@ -143,8 +143,8 @@ export function svgScroll(_opts) {
 				ref.dxFactor = (t - v) / (v - ref.sliderWidth)
 			}
 
-			const center = v * (opts.zoomCenter / t) //; console.log(87, 'svg.scroll', center, opts.zoomCenter)
-			ref.sliderX = center - ref.sliderWidth / 2
+			const center = v * (opts.zoomCenter / t)
+			ref.sliderX = Math.max(0, Math.min(center - ref.sliderWidth / 2, v - ref.sliderWidth - 1))
 			slider.attr('width', ref.sliderWidth).attr('x', ref.sliderX)
 
 			ref.maxDx = opts.visibleWidth - ref.sliderX - ref.sliderWidth

--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -71,9 +71,9 @@ function setRenderers(self) {
 		const s = self.settings
 		const d = self.currData.dimensions
 		self.dom.clipRect
-			.attr('x', s.zoomLevel <= 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW)
+			.attr('x', s.zoomLevel <= 1 && d.mainw >= d.zoomedMainW ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW)
 			.attr('y', 0)
-			.attr('width', d.mainw / this.totalWidth) // d.zoomedMainW)
+			.attr('width', Math.min(d.mainw, d.maxMainW) / this.totalWidth) // d.zoomedMainW)
 			.attr('height', 1)
 
 		renderOutlines(clusters, s, d)

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -574,7 +574,7 @@ export class MatrixControls {
 					.attr('title', 'Click the matrix to select data')
 					.style('display', 'inline-block')
 					.style('width', '25px')
-					.style('height', '24px')
+					.style('height', '24.5px')
 					.style('background-color', defaults.activeBgColor)
 					.on('click', () => {
 						opts.target.style('cursor', 'crosshair')
@@ -588,7 +588,7 @@ export class MatrixControls {
 					.attr('title', 'Click the matrix to drag and move')
 					.style('display', 'inline-block')
 					.style('width', '25px')
-					.style('height', '24px')
+					.style('height', '24.5px')
 					.on('click', () => {
 						opts.target.style('cursor', 'grab')
 						this.parent.settings.matrix.mouseMode = 'pan'

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -306,7 +306,7 @@ export class MatrixControls {
 			.style('text-decoration', d => (d.active ? 'underline' : ''))
 			.style('color', d => (d.active ? '#3a3' : ''))
 
-		const s = this.parent.config.settings.matrix //; console.log(302, s.colw, s.maxColw, Math.round(100* s.colw / s.maxColw))
+		const s = this.parent.config.settings.matrix
 		if (this.zoomApi)
 			this.zoomApi.update({
 				value: Number(((100 * Math.min(s.colw * s.zoomLevel, s.maxColwZoomed)) / s.maxColwZoomed).toFixed(1))

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -570,14 +570,17 @@ export class MatrixControls {
 			.append('button')
 			.html('Reset')
 			.on('click', () => {
-				this.parent.settings.matrix.mouseMode = 'zoom'
+				const s = this.parent.settings.matrix
+				const d = this.parent.dimensions
+				s.mouseMode = 'zoom'
 				this.parent.app.dispatch({
 					type: 'plot_edit',
 					id: this.parent.id,
 					config: {
 						settings: {
 							matrix: {
-								zoomLevel: 1
+								zoomLevel: 1,
+								zoomCenterPct: 0
 							}
 						}
 					}

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -20,7 +20,8 @@ export class MatrixControls {
 			may use subapp state/recovery later
 		 */
 		//this.recover = new Recover({app: opts.app})
-		this.setButtons()
+		const state = this.parent.getState(appState)
+		this.setButtons(state.config.settings.matrix)
 		this.setInputGroups()
 		if (!this.parent.optionalFeatures.includes('zoom')) return
 		this.setZoomInput()
@@ -29,23 +30,22 @@ export class MatrixControls {
 			target: this.parent.dom.seriesesG
 		})
 		this.setResetInput()
-		const state = this.parent.getState(appState)
 		this.setSvgScroll(state)
 	}
 
-	setButtons() {
+	setButtons(s) {
 		this.btns = this.opts.holder
 			.style('margin', '10px 10px 20px 10px')
 			.selectAll('button')
 			.data([
 				{
 					value: 'samples',
-					label: `Samples`,
+					label: s.controlLabels.samples || `Samples`,
 					getCount: () => this.parent.sampleOrder.length
 				},
 				{
 					value: 'anno',
-					label: `Variables`,
+					label: s.controlLabels.samples || `Variables`,
 					getCount: () => this.parent.termOrder.length,
 					customInputs: this.appendTermInputs
 				},
@@ -71,13 +71,13 @@ export class MatrixControls {
 	setInputGroups() {
 		this.inputGroups = {
 			samples: [
-				{
+				/*{
 					label: 'Sample as rows',
 					boxLabel: '',
 					type: 'checkbox',
 					chartType: 'matrix',
 					settingsKey: 'transpose'
-				},
+				},*/
 				{
 					label: 'Sort samples',
 					type: 'radio',
@@ -114,13 +114,13 @@ export class MatrixControls {
 			],
 
 			anno: [
-				{
+				/*{
 					label: 'Terms as columns',
 					boxLabel: '',
 					type: 'checkbox',
 					chartType: 'matrix',
 					settingsKey: 'transpose'
-				},
+				},*/
 				{
 					label: 'Display sample counts for gene',
 					boxLabel: '',
@@ -310,19 +310,21 @@ export class MatrixControls {
 			.style('color', d => (d.active ? '#3a3' : ''))
 
 		const s = this.parent.config.settings.matrix
+		const d = this.parent.dimensions
 		if (this.zoomApi)
 			this.zoomApi.update({
 				value: Number(((100 * Math.min(s.colw * s.zoomLevel, s.maxColwZoomed)) / s.maxColwZoomed).toFixed(1))
 			})
 
-		const d = this.parent.dimensions
-		this.svgScrollApi.update({
-			x: d.xOffset,
-			y: d.yOffset - s.scrollHeight,
-			totalWidth: d.zoomedMainW,
-			visibleWidth: d.mainw,
-			zoomCenter: s.zoomCenterPct * d.mainw - d.seriesXoffset
-		})
+		if (this.svgScrollApi) {
+			this.svgScrollApi.update({
+				x: d.xOffset,
+				y: d.yOffset - s.scrollHeight,
+				totalWidth: d.zoomedMainW,
+				visibleWidth: d.mainw,
+				zoomCenter: s.zoomCenterPct * d.mainw - d.seriesXoffset
+			})
+		}
 	}
 
 	async callback(event, d) {

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1430,14 +1430,19 @@ function setZoomPanActions(self) {
 	self.seriesesGdrag = function(event) {
 		const s = self.settings.matrix
 		const e = self.clickedSeriesCell.event
-		const dx = event.clientX - e.clientX
-		self.clickedSeriesCell.dx = dx
 		const d = self.dimensions
-		// should use a function for layout.top.boxTransform(....)
+		const _dx = event.clientX - e.clientX
+		console.log(1433, 'dx=', _dx, d.xOffset + d.seriesXoffset + _dx, d.xOffset, d.seriesXoffset)
+		const dx = d.xOffset + d.seriesXoffset + _dx >= d.xOffset ? 0 : _dx
+		self.clickedSeriesCell.dx = dx
 		self.dom.seriesesG.attr('transform', `translate(${d.xOffset + d.seriesXoffset + dx},${d.yOffset})`)
+		self.dom.clipRect.attr('x', s.zoomLevel == 1 ? 0 : dx === 0 ? 0 : Math.abs(d.seriesXoffset + dx) / d.zoomedMainW)
 		self.layout.top.attr.adjustBoxTransform(dx)
 		self.layout.btm.attr.adjustBoxTransform(dx)
-		self.dom.clipRect.attr('x', s.zoomLevel == 1 ? 0 : Math.abs(d.seriesXoffset + dx) / d.zoomedMainW)
+
+		self.svgScrollApi.update({
+			x: d.xOffset + dx
+		})
 	}
 
 	self.seriesesGcancelDrag = function(event) {

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1515,7 +1515,7 @@ function setZoomPanActions(self) {
 		self.layout.top.attr.adjustBoxTransform(dx)
 		self.layout.btm.attr.adjustBoxTransform(dx)
 		const computedCenter = s.zoomCenterPct * d.mainw - d.seriesXoffset - dx
-		self.svgScrollApi.update({ zoomCenter: computedCenter })
+		self.controlsRenderer.svgScrollApi.update({ zoomCenter: computedCenter })
 	}
 
 	self.seriesesGcancelDrag = function(event) {

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1437,7 +1437,6 @@ function setLabelDragEvents(self, prefix) {
 
 function setZoomPanActions(self) {
 	self.seriesesGMousedown = function(event) {
-		if (!self.optionalFeatures.includes('zoom')) return
 		event.stopPropagation()
 		const startCell = self.getCellByPos(event)
 		if (!startCell) return
@@ -1541,8 +1540,7 @@ function setZoomPanActions(self) {
 					matrix: {
 						zoomCenterPct: 0.5,
 						zoomIndex: c.totalIndex,
-						zoomGrpIndex: c.grpIndex,
-						mouseMode: 'pan'
+						zoomGrpIndex: c.grpIndex
 					}
 				}
 			}
@@ -1620,8 +1618,7 @@ function setZoomPanActions(self) {
 						zoomLevel,
 						zoomCenterPct: zoomLevel < 1 && d.mainw >= d.zoomedMainW ? 0.5 : zoomCenter / d.mainw,
 						zoomIndex,
-						zoomGrpIndex: centerCell.grpIndex,
-						mouseMode: 'select'
+						zoomGrpIndex: centerCell.grpIndex
 					}
 				}
 			}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1519,12 +1519,14 @@ function setZoomPanActions(self) {
 		const d = self.dimensions
 		const cc = self.clickedSeriesCell
 		const _dx = event.clientX - cc.event.clientX
-		if (Math.abs(_dx) < 1 || _dx < cc.dxMinPad || _dx > cc.dxMaxPad) {
+		const dx = Math.min(cc.dxMax, Math.max(_dx, cc.dxMin))
+		if (Math.abs(_dx) < 1 || Math.abs(dx) < 1) {
+			//} || _dx < cc.dxMinPad || _dx > cc.dxMaxPad) {
 			console.log(1518, 'no dispatch')
 			self.translateElems(0, d, s, cc)
 			return
 		}
-		const dx = Math.min(cc.dxMax, Math.max(_dx, cc.dxMin))
+		self.translateElems(dx, d, s, cc)
 		console.log('dispatch()!!! dx=', dx, '_dx=', _dx, 'dxMax=', cc.dxMax, 'dxMin=', cc.dxMin, 'diff', _dx)
 		// zoomIndex change is in the opposite direction of dragging
 		const i = s.zoomIndex - Math.round(dx / d.dx)
@@ -1619,7 +1621,7 @@ function setZoomPanActions(self) {
 						zoomCenterPct: zoomLevel < 1 && d.mainw >= d.zoomedMainW ? 0.5 : zoomCenter / d.mainw,
 						zoomIndex,
 						zoomGrpIndex: centerCell.grpIndex,
-						mouseMode: 'zoom'
+						mouseMode: 'select'
 					}
 				}
 			}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1272,7 +1272,6 @@ function setTermGroupActions(self) {
 		.map(d => `.sjpp-matrix-${d}-label-g`)
 		.join(',')
 	self.enableTextHighlight = event => {
-		console.log('1272', event.target, select(event.target.closest(labelParentSelectors)).node())
 		select(event.target.closest(labelParentSelectors))
 			.selectAll('.sjpp-matrix-label text')
 			//.selectAll('text')
@@ -1285,7 +1284,7 @@ function setTermGroupActions(self) {
 	}
 
 	self.disableTextHighlight = event => {
-		select(event.target)
+		select(event.target.closest(labelParentSelectors))
 			.selectAll('.sjpp-matrix-label text')
 			.style('-webkit-user-select', 'none')
 			.style('-moz-user-select', 'none')

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -88,7 +88,20 @@ export function setInteractivity(self) {
 	setTermGroupActions(self)
 	setSampleGroupActions(self)
 	setZoomPanActions(self)
+	setResizeHandler(self)
 }
+
+function setResizeHandler(self) {
+	let resizeId
+	select(window).on(`resize.sjpp-${self.id}`, () => {
+		clearTimeout(resizeId)
+		resizeId = setTimeout(resize, 200)
+	})
+	function resize() {
+		self.main()
+	}
+}
+
 /*
 // TODO: may add drag events for sample labels
 function setSampleActions(self) {

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -55,7 +55,7 @@ export function setInteractivity(self) {
 		const x2 = event.clientX - rect.x
 		for (const cell of d.cells) {
 			const min = cell.x
-			const max = cell.x + self.dimensions.colw
+			const max = cell.x + self.dimensions.dx
 			if (min < x2 && x2 <= max) return cell
 		}
 		return null
@@ -81,6 +81,13 @@ export function setInteractivity(self) {
 		self.dragged.clone.remove()
 		delete self.dragged
 		delete self.clicked
+	}
+
+	self.getVisibleCenterCell = function(dx) {
+		const s = self.settings.matrix
+		const d = self.dimensions
+		const i = Math.round((0.5 * d.mainw - d.seriesXoffset - dx) / d.dx)
+		return self.sampleOrder[i]
 	}
 
 	//setSampleActions(self)
@@ -131,7 +138,7 @@ function setSampleActions(self) {
 				.style('-ms-user-select', 'none')
 				.style('user-select', 'none')
 
-			const label = self.clicked.event.target.closest('.sjpp-matrix-label') //console.log(68, label)
+			const label = self.clicked.event.target.closest('.sjpp-matrix-label')
 			// TODO: use a native or D3 transform accessor
 			const [x, y] = select(label)
 				.attr('transform')
@@ -151,7 +158,7 @@ function setSampleActions(self) {
 				y,
 				clientX: event.clientX,
 				clientY: event.clientY
-			} //; console.log(this.dragged)
+			}
 			self.dragged.clone.selectAll('text').style('fill', 'red')
 		}
 		if (!self.dragged) return
@@ -169,10 +176,8 @@ function setSampleActions(self) {
 			if (self.hovered) {
 				// reposition the dragged row/column
 				const d = self.dragged
-				const t = d.orig.__data__; console.log(t.grpIndex, self.sampleGroups)
+				const t = d.orig.__data__
 				const h = self.hovered
-				// console.log(t, self.config.termgroups)
-				// console.log([99, numRows, t.index, toIndex], self.config.termgroups[t.grpIndex].lst.slice())
 				// NOTE: currently, the rendered order does not have to match the termgroup.lst order
 				// ??? actually resort termgroup.lst to reflect the current term order ???
 				for (const grp of self.sampleGroups) {
@@ -186,7 +191,7 @@ function setSampleActions(self) {
 					})
 				}
 
-				const sample = self.sampleGroups[t.grpIndex].lst.splice(t.index, 1)[0] //if (tw != t.tw) {console.log(tw, t.tw); throw `t????`}
+				const sample = self.sampleGroups[t.grpIndex].lst.splice(t.index, 1)[0]
 				self.config.termgroups[h.grpIndex].lst.splice(h.index, 0, sample)
 
 				self.app.dispatch({
@@ -720,7 +725,6 @@ function setTermActions(self) {
 	}
 
 	self.showSortMenu = () => {
-		//console.log(self.termOrder)
 		/* 
 			sort rows and samples by:
 			- #hits 
@@ -1336,7 +1340,7 @@ function setLabelDragEvents(self, prefix) {
 				.style('-ms-user-select', 'none')
 				.style('user-select', 'none')
 
-			const label = self.clicked.event.target.closest('.sjpp-matrix-label') //console.log(68, label)
+			const label = self.clicked.event.target.closest('.sjpp-matrix-label')
 			// TODO: use a native or D3 transform accessor
 			const [x, y] = select(label)
 				.attr('transform')
@@ -1356,7 +1360,7 @@ function setLabelDragEvents(self, prefix) {
 				y,
 				clientX: event.clientX,
 				clientY: event.clientY
-			} //; console.log(this.dragged)
+			}
 			self.dragged.clone.selectAll('text').style('fill', 'red')
 		}
 		if (!self.dragged) return
@@ -1379,11 +1383,9 @@ function setLabelDragEvents(self, prefix) {
 				const h = self.hovered
 
 				if (prefix == 'termGrp') {
-					const grp = self.config.termgroups.splice(t.grpIndex, 1)[0] //if (tw != t.tw) {console.log(tw, t.tw); throw `t????`}
+					const grp = self.config.termgroups.splice(t.grpIndex, 1)[0]
 					self.config.termgroups.splice(h.grpIndex, 0, grp)
 				} else {
-					// console.log(t, self.config.termgroups)
-					// console.log([99, numRows, t.index, toIndex], self.config.termgroups[t.grpIndex].lst.slice())
 					// NOTE: currently, the rendered order does not have to match the termgroup.lst order
 					// ??? actually resort termgroup.lst to reflect the current term order ???
 					for (const grp of self.config.termgroups) {
@@ -1397,7 +1399,7 @@ function setLabelDragEvents(self, prefix) {
 						})
 					}
 
-					const tw = self.config.termgroups[t.grpIndex].lst.splice(t.index, 1)[0] //if (tw != t.tw) {console.log(tw, t.tw); throw `t????`}
+					const tw = self.config.termgroups[t.grpIndex].lst.splice(t.index, 1)[0]
 					self.config.termgroups[h.grpIndex].lst.splice(h.index, 0, t.tw)
 				}
 
@@ -1436,7 +1438,6 @@ function setLabelDragEvents(self, prefix) {
 function setZoomPanActions(self) {
 	self.seriesesGMousedown = function(event) {
 		if (!self.optionalFeatures.includes('zoom')) return
-		//console.log(1425, 'mousedown')
 		event.stopPropagation()
 		const startCell = self.getCellByPos(event)
 		if (!startCell) return
@@ -1462,13 +1463,13 @@ function setZoomPanActions(self) {
 			if (event.target.__data__?.sample) return event.target.__data__
 			if (event.target.__data__?.xg) {
 				const visibleWidth = event.clientX - event.target.getBoundingClientRect().x + d.seriesXoffset
-				const i = Math.floor(visibleWidth / d.colw)
+				const i = Math.floor(visibleWidth / d.dx)
 				return self.sampleOrder[i]
 			}
 		}
 		if (event.target.tagName == 'image' && s.useCanvas) {
 			const visibleWidth = event.clientX - event.target.getBoundingClientRect().x + d.seriesXoffset
-			const i = Math.floor(visibleWidth / d.colw)
+			const i = Math.floor(visibleWidth / d.dx)
 			return self.sampleOrder[i]
 		}
 	}
@@ -1487,7 +1488,6 @@ function setZoomPanActions(self) {
 		c.dxMaxPad = c.dxMax + c.dxPad
 		c.dxMin = d.mainw - d.zoomedMainW - d.seriesXoffset
 		c.dxMinPad = c.dxMin - c.dxPad
-		console.log('dxMin=', c.dxMin, 'dxMax=', c.dxMax, d.seriesXoffset)
 		const halfw = 0.5 * d.mainw
 		c.center = {
 			max: halfw + (d.zoomedMainW - d.mainw),
@@ -1501,13 +1501,12 @@ function setZoomPanActions(self) {
 		const d = self.dimensions
 		const dx = event.clientX - c.event.clientX
 		if (Math.abs(dx) < 1) return
-		if (dx < c.dxMinPad || dx > c.dxMaxPad) return //; console.log(1489, dx, c.dxMin, c.dxMax)
+		if (dx < c.dxMinPad || dx > c.dxMaxPad) return
 		self.clickedSeriesCell.dx = dx
 		self.translateElems(dx, d, s, c)
 	}
 
 	self.translateElems = function(dx, d, s, c) {
-		//console.log(d.xOffset, d.seriesXoffset, dx)
 		self.dom.seriesesG.attr('transform', `translate(${d.xOffset + d.seriesXoffset + dx},${d.yOffset})`)
 		self.dom.clipRect.attr(
 			'x',
@@ -1516,15 +1515,10 @@ function setZoomPanActions(self) {
 		self.layout.top.attr.adjustBoxTransform(dx)
 		self.layout.btm.attr.adjustBoxTransform(dx)
 		const computedCenter = s.zoomCenterPct * d.mainw - d.seriesXoffset - dx
-		//console.log(1502, 'dx=', dx, 'computedCenter', computedCenter, Math.max(c.center.min, Math.min(c.center.max, computedCenter)))
-		//s.zoomCenterPct * d.mainw - d.seriesXoffset
-		self.svgScrollApi.update({
-			zoomCenter: computedCenter //Math.max(c.center.min, Math.min(c.center.max, computedCenter))
-		})
+		self.svgScrollApi.update({ zoomCenter: computedCenter })
 	}
 
 	self.seriesesGcancelDrag = function(event) {
-		console.log(1498, 'mouseup')
 		select('body')
 			.on('mousemove.sjppMatrixDrag', null)
 			.on('mouseup.sjppMatrixDrag', null)
@@ -1534,25 +1528,18 @@ function setZoomPanActions(self) {
 		const _dx = event.clientX - cc.event.clientX
 		const dx = Math.min(cc.dxMax, Math.max(_dx, cc.dxMin))
 		if (Math.abs(_dx) < 1 || Math.abs(dx) < 1) {
-			//} || _dx < cc.dxMinPad || _dx > cc.dxMaxPad) {
-			console.log(1518, 'no dispatch')
 			self.translateElems(0, d, s, cc)
 			return
 		}
 		self.translateElems(dx, d, s, cc)
-		console.log('dispatch()!!! dx=', dx, '_dx=', _dx, 'dxMax=', cc.dxMax, 'dxMin=', cc.dxMin, 'diff', _dx)
-		// zoomIndex change is in the opposite direction of dragging
-		const i = s.zoomIndex - Math.round(dx / d.dx)
-		console.log('i=', i, 'zoomIndex=', s.zoomIndex, 'zoomCenterPct=', s.zoomCenterPct)
-		const c = self.sampleOrder[i]
-		console.log('dx=', dx, 's.zoomIndex=', s.zoomIndex, [cc.dxMin, cc.dxMax])
+		const c = self.getVisibleCenterCell(dx)
 		self.app.dispatch({
 			type: 'plot_edit',
 			id: self.id,
 			config: {
 				settings: {
 					matrix: {
-						zoomCenterPct: s.zoomCenterPct,
+						zoomCenterPct: 0.5,
 						zoomIndex: c.totalIndex,
 						zoomGrpIndex: c.grpIndex,
 						mouseMode: 'pan'
@@ -1622,7 +1609,7 @@ function setZoomPanActions(self) {
 		const zoomIndex = Math.floor(start.totalIndex + Math.abs(c.endCell.totalIndex - c.startCell.totalIndex) / 2)
 		const centerCell = self.sampleOrder[zoomIndex] || self.getImgCell(event)
 		const zoomLevel = d.mainw / self.zoomWidth
-		const zoomCenter = centerCell.totalIndex * d.colw + (centerCell.grpIndex - 1) * s.colgspace + d.seriesXoffset
+		const zoomCenter = centerCell.totalIndex * d.dx + (centerCell.grpIndex - 1) * s.colgspace + d.seriesXoffset
 
 		self.app.dispatch({
 			type: 'plot_edit',

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -146,12 +146,7 @@ class Matrix {
 					this.layout.top.attr.adjustBoxTransform(-dx)
 					this.layout.btm.attr.adjustBoxTransform(-dx)
 				} else if (eventType == 'up') {
-					const i = s.zoomIndex + Math.round(dx / d.dx)
-					const c = this.sampleOrder[i]
-					console.log(149, 'i=', i, s.zoomCenterPct)
-					//console.log(1333, i, c, d.seriesXoffset)
-					//const zoomCenter = s.zoomCenterPct * d.mainw + dx //; console.log(152, "scroll i=", i, 'zoomCenter=', zoomCenter, "dx=", dx)
-					//c.totalIndex * d.colw + c.grpIndex * s.colgspace + d.colw + dx + d.seriesXoffset
+					const c = this.getVisibleCenterCell(-dx)
 					this.app.dispatch({
 						type: 'plot_edit',
 						id: this.id,
@@ -744,7 +739,6 @@ class Matrix {
 	}
 
 	setLayout() {
-		console.log('setLayout')
 		const s = this.settings.matrix
 		const [col, row] = !s.transpose ? ['sample', 'term'] : ['term', 'sample']
 		const [_t_, _b_] = s.collabelpos == 'top' ? ['', 'Grp'] : ['Grp', '']
@@ -871,11 +865,6 @@ class Matrix {
 		const centerCellX = s.zoomIndex * dx + s.zoomGrpIndex * s.colgspace
 		const zoomedMainW = nx * dx + (this[`${col}Grps`].length - 1) * s.colgspace
 		const seriesXoffset = s.zoomLevel <= 1 && mainw >= zoomedMainW ? 0 : zoomCenter - centerCellX
-		console.log('centerCellX=', centerCellX, 'mainw=', mainw, zoomCenter)
-
-		//console.log(841, 'zoomCenter', zoomCenter, centerCellX)
-		console.log(842, 'seriesXoffset=', seriesXoffset, seriesXoffset > 0 ? 0 : seriesXoffset)
-
 		this.dimensions = {
 			dx,
 			dy,
@@ -885,7 +874,7 @@ class Matrix {
 			mainh,
 			colw,
 			zoomedMainW,
-			seriesXoffset: seriesXoffset > 0 ? 0 : seriesXoffset, // Math.max(seriesXoffset, -zoomedMainW + mainw),
+			seriesXoffset: seriesXoffset > 0 ? 0 : seriesXoffset,
 			maxMainW: Math.max(mainwByColDimensions, mainwByScreen)
 		}
 	}

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -1027,6 +1027,7 @@ export const matrixInit = getCompInit(Matrix)
 export const componentInit = matrixInit
 
 export async function getPlotConfig(opts, app) {
+	const overrides = app.vocabApi.termdbConfig.matrix || {}
 	const config = {
 		// data configuration
 		termgroups: [],
@@ -1040,7 +1041,7 @@ export async function getPlotConfig(opts, app) {
 			},
 			matrix: {
 				useCanvas: window.location.hash?.slice(1) == 'canvas',
-				cellEncoding: '', // can be oncoprint
+				cellEncoding: overrides.cellEncoding || '', // can be oncoprint
 				margin: {
 					top: 10,
 					right: 5,
@@ -1049,9 +1050,9 @@ export async function getPlotConfig(opts, app) {
 				},
 				// set any dataset-defined sample limits and sort priority, otherwise undefined
 				// put in settings, so that later may be overridden by a user (TODO)
-				maxSample: app.vocabApi.termdbConfig.matrix?.maxSample,
-				sortPriority: app.vocabApi.termdbConfig.matrix?.sortPriority,
-				truncatePriority: app.vocabApi.termdbConfig.matrix?.truncatePriority,
+				maxSample: overrides.maxSample,
+				sortPriority: overrides.sortPriority,
+				truncatePriority: overrides.truncatePriority,
 
 				sampleNameFilter: '',
 				sortSamplesBy: 'selectedTerms',

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -425,11 +425,8 @@ class Matrix {
 			const offset = !s.transpose
 				? s.termLabelOffset + s.termGrpLabelOffset
 				: s.sampleLabelOffset + s.sampleGrpLabelOffset
-			s.colw = Math.min(
-				s.maxColw,
-				Math.max(1, Math.round((screen.availWidth - offset - 300) / this.sampleOrder.length - s.colspace))
-			)
-			if (s.colw == 1) s.colspace = 0
+			s.colw = Math.min(s.maxColw, Math.round((screen.availWidth - offset - 30) / this.sampleOrder.length))
+			s.colspace = s.zoomLevel * s.colw <= 2 ? 0 : 1
 		}
 
 		if (this.autoDimensions.has('rowh')) {
@@ -863,10 +860,7 @@ class Matrix {
 			colw,
 			zoomedMainW,
 			seriesXoffset: seriesXoffset > 0 ? 0 : seriesXoffset, // Math.max(seriesXoffset, -zoomedMainW + mainw),
-			maxMainW:
-				nx * (s.maxColw + s.colspace) +
-				(this[`${col}Grps`].length - 1) * s.colgspace +
-				(this[`${col}s`].slice(-1)[0]?.totalHtAdjustments || 0)
+			maxMainW: Math.max(mainwByColDimensions, mainwByScreen)
 		}
 	}
 

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -1010,7 +1010,6 @@ export const matrixInit = getCompInit(Matrix)
 export const componentInit = matrixInit
 
 export async function getPlotConfig(opts, app) {
-	const overrides = app.vocabApi.termdbConfig.matrix || {}
 	const config = {
 		// data configuration
 		termgroups: [],
@@ -1024,7 +1023,7 @@ export async function getPlotConfig(opts, app) {
 			},
 			matrix: {
 				useCanvas: window.location.hash?.slice(1) == 'canvas',
-				cellEncoding: overrides.cellEncoding || '', // can be oncoprint
+				cellEncoding: '', // can be oncoprint
 				margin: {
 					top: 10,
 					right: 5,
@@ -1032,10 +1031,10 @@ export async function getPlotConfig(opts, app) {
 					left: 50
 				},
 				// set any dataset-defined sample limits and sort priority, otherwise undefined
-				// put in settings, so that later may be overridden by a user (TODO)
-				maxSample: overrides.maxSample,
-				sortPriority: overrides.sortPriority,
-				truncatePriority: overrides.truncatePriority,
+				// put in settings, so that later may be overridden by a user
+				maxSample: 0,
+				sortPriority: undefined,
+				truncatePriority: undefined,
 
 				sampleNameFilter: '',
 				sortSamplesBy: 'selectedTerms',
@@ -1079,7 +1078,11 @@ export async function getPlotConfig(opts, app) {
 				zoomMin: 0.5,
 				zoomIncrement: 0.5,
 				zoomStep: 10,
-				scrollHeight: 12
+				scrollHeight: 12,
+				controlLabels: {
+					samples: 'Samples',
+					terms: 'Variables'
+				}
 			}
 		}
 	}
@@ -1101,8 +1104,12 @@ export async function getPlotConfig(opts, app) {
 		linesep: false
 	}
 
+	const overrides = app.vocabApi.termdbConfig.matrix || {}
+	copyMerge(config.settings.matrix, overrides.settings)
+
 	// may apply term-specific changes to the default object
 	copyMerge(config, opts)
+
 	// harcode these overrides for now
 	config.settings.matrix.duration = 0
 	config.settings.matrix.mouseMode = 'select'

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -11,7 +11,6 @@ import { schemeCategory20 } from '#common/legacy-d3-polyfill'
 import { axisLeft, axisTop, axisRight, axisBottom } from 'd3-axis'
 import { fillTermWrapper } from '../termsetting/termsetting'
 import svgLegend from '#dom/svg.legend'
-import { svgScroll } from '#dom/svg.scroll'
 import { mclass } from '#shared/common'
 import { Menu } from '#dom/menu'
 import { getSampleSorter, getTermSorter } from './matrix.sort'
@@ -131,38 +130,6 @@ class Matrix {
 			//.attr('clipPathUnits', 'userSpaceOnUse')
 			.append('rect')
 			.attr('display', 'block')
-
-		const state = this.getState(appState)
-
-		this.svgScrollApi = svgScroll({
-			holder: this.dom.scroll,
-			height: state.config.settings.matrix.scrollHeight,
-			callback: (dx, eventType) => {
-				const s = this.settings.matrix
-				const d = this.dimensions
-				if (eventType == 'move') {
-					this.dom.seriesesG.attr('transform', `translate(${d.xOffset + d.seriesXoffset - dx},${d.yOffset})`)
-					this.dom.clipRect.attr('x', Math.abs(d.seriesXoffset - dx) / d.zoomedMainW)
-					this.layout.top.attr.adjustBoxTransform(-dx)
-					this.layout.btm.attr.adjustBoxTransform(-dx)
-				} else if (eventType == 'up') {
-					const c = this.getVisibleCenterCell(-dx)
-					this.app.dispatch({
-						type: 'plot_edit',
-						id: this.id,
-						config: {
-							settings: {
-								matrix: {
-									zoomCenterPct: s.zoomCenterPct,
-									zoomIndex: c.totalIndex,
-									zoomGrpIndex: c.grpIndex
-								}
-							}
-						}
-					})
-				}
-			}
-		})
 
 		this.dom.tip.onHide = () => {
 			this.lastActiveLabel = this.activeLabel
@@ -861,10 +828,11 @@ class Matrix {
 			s.zoomGrpIndex = this.sampleOrder[s.zoomIndex].grpIndex
 		}
 		// zoomCenter relative to mainw
-		const zoomCenter = s.zoomCenterPct * mainw
-		const centerCellX = s.zoomIndex * dx + s.zoomGrpIndex * s.colgspace
+		const zoomCenter = s.zoomCenterPct * mainw //console.log(831, 's.zoomIndex=', s.zoomIndex)
+		const centerCellX = s.zoomIndex * dx + s.zoomGrpIndex * s.colgspace //console.log(832, centerCellX)
 		const zoomedMainW = nx * dx + (this[`${col}Grps`].length - 1) * s.colgspace
-		const seriesXoffset = s.zoomLevel <= 1 && mainw >= zoomedMainW ? 0 : zoomCenter - centerCellX
+		const seriesXoffset =
+			s.zoomLevel <= 1 && mainw >= zoomedMainW ? 0 : Math.max(zoomCenter - centerCellX, mainw - zoomedMainW)
 		this.dimensions = {
 			dx,
 			dy,

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -242,7 +242,8 @@ class Matrix {
 			if (this.mayRequireToken()) return
 
 			const prevTranspose = this.settings.transpose
-			Object.assign(this.settings, this.config.settings)
+			// controlsRenderer.getSettings() supplies settings that are not tracked in the global app and plot state
+			Object.assign(this.settings, this.config.settings, this.controlsRenderer.getSettings())
 
 			this.computeStateDiff()
 
@@ -1070,7 +1071,6 @@ export async function getPlotConfig(opts, app) {
 				termLabelOffset: 80,
 				termGrpLabelOffset: 80,
 				duration: 0,
-				mouseMode: 'select',
 				zoomLevel: 1,
 				zoomCenterPct: 0,
 				zoomIndex: 0,
@@ -1112,7 +1112,6 @@ export async function getPlotConfig(opts, app) {
 
 	// harcode these overrides for now
 	config.settings.matrix.duration = 0
-	config.settings.matrix.mouseMode = 'select'
 
 	const promises = []
 	for (const grp of config.termgroups) {

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -68,7 +68,9 @@ class Matrix {
 			sampleGrpLabelG: mainG
 				.append('g')
 				.attr('class', 'sjpp-matrix-series-group-label-g')
-				.on('click', this.showSampleGroupMenu),
+				.on('click', this.showSampleGroupMenu)
+				.on('mousedown.sjppMatrixLabelText', this.enableTextHighlight)
+				.on('mouseup.sjppMatrixLabelText', this.disableTextHighlight),
 			termGrpLabelG: mainG
 				.append('g')
 				.attr('class', 'sjpp-matrix-term-group-label-g')
@@ -76,7 +78,9 @@ class Matrix {
 				.on('mouseout', this.termGrpLabelMouseout)
 				.on('mousedown', this.termGrpLabelMousedown)
 				.on('mousemove', this.termGrpLabelMousemove)
-				.on('mouseup', this.termGrpLabelMouseup),
+				.on('mouseup', this.termGrpLabelMouseup)
+				.on('mousedown.sjppMatrixLabelText', this.enableTextHighlight)
+				.on('mouseup.sjppMatrixLabelText', this.disableTextHighlight),
 			cluster: mainG
 				.append('g')
 				.attr('class', 'sjpp-matrix-cluster-g')
@@ -90,7 +94,11 @@ class Matrix {
 				.on('mousedown', this.seriesesGMousedown),
 			//.on('mousemove', this.seriesesGMousemove)
 			//.on('mouseup', this.seriesesGMouseup),
-			sampleLabelG: mainG.append('g').attr('class', 'sjpp-matrix-series-label-g'),
+			sampleLabelG: mainG
+				.append('g')
+				.attr('class', 'sjpp-matrix-series-label-g')
+				.on('mousedown.sjppMatrixLabelText', this.enableTextHighlight)
+				.on('mouseup.sjppMatrixLabelText', this.disableTextHighlight),
 			/* // TODO: sample label drag to move
 				.on('mouseover', this.sampleLabelMouseover)
 				.on('mouseout', this.sampleLabelMouseout)
@@ -104,7 +112,9 @@ class Matrix {
 				.on('mouseout', this.termLabelMouseout)
 				.on('mousedown', this.termLabelMousedown)
 				.on('mousemove', this.termLabelMousemove)
-				.on('mouseup', this.termLabelMouseup),
+				.on('mouseup', this.termLabelMouseup)
+				.on('mousedown.sjppMatrixLabelText', this.enableTextHighlight)
+				.on('mouseup.sjppMatrixLabelText', this.disableTextHighlight),
 			scroll: mainG.append('g'),
 			//legendDiv: holder.append('div').style('margin', '5px 5px 15px 50px'),
 			legendG: mainG.append('g'),
@@ -127,22 +137,23 @@ class Matrix {
 				const s = this.settings.matrix
 				const d = this.dimensions
 				if (eventType == 'move') {
-					this.dom.seriesesG.attr('transform', `translate(${d.xOffset + d.seriesXoffset + dx},${d.yOffset})`)
-					this.dom.clipRect.attr('x', Math.abs(d.seriesXoffset + dx) / d.zoomedMainW)
-					this.layout.top.attr.adjustBoxTransform(dx)
-					this.layout.btm.attr.adjustBoxTransform(dx)
+					this.dom.seriesesG.attr('transform', `translate(${d.xOffset + d.seriesXoffset - dx},${d.yOffset})`)
+					this.dom.clipRect.attr('x', Math.abs(d.seriesXoffset - dx) / d.zoomedMainW)
+					this.layout.top.attr.adjustBoxTransform(-dx)
+					this.layout.btm.attr.adjustBoxTransform(-dx)
 				} else if (eventType == 'up') {
-					const i = Math.floor((s.zoomCenterPct * d.mainw - dx - d.seriesXoffset) / d.dx)
+					const i = s.zoomIndex + Math.floor(dx / d.dx)
 					const c = this.sampleOrder[i]
 					//console.log(1333, i, c, d.seriesXoffset)
-					const zoomCenter = c.totalIndex * d.colw + c.grpIndex * s.colgspace + d.colw + dx + d.seriesXoffset
+					//const zoomCenter = //s.zoomCenterPct * d.mainw - dx //
+					//c.totalIndex * d.colw + c.grpIndex * s.colgspace + d.colw + dx + d.seriesXoffset
 					this.app.dispatch({
 						type: 'plot_edit',
 						id: this.id,
 						config: {
 							settings: {
 								matrix: {
-									zoomCenterPct: zoomCenter / d.mainw,
+									//zoomCenterPct: zoomCenter / d.mainw,
 									zoomIndex: c.totalIndex,
 									zoomGrpIndex: c.grpIndex
 								}

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -148,6 +148,7 @@ class Matrix {
 				} else if (eventType == 'up') {
 					const i = s.zoomIndex + Math.round(dx / d.dx)
 					const c = this.sampleOrder[i]
+					console.log(149, 'i=', i, s.zoomCenterPct)
 					//console.log(1333, i, c, d.seriesXoffset)
 					//const zoomCenter = s.zoomCenterPct * d.mainw + dx //; console.log(152, "scroll i=", i, 'zoomCenter=', zoomCenter, "dx=", dx)
 					//c.totalIndex * d.colw + c.grpIndex * s.colgspace + d.colw + dx + d.seriesXoffset
@@ -837,9 +838,9 @@ class Matrix {
 
 		this.layout = layout
 		if (!s.zoomCenterPct) {
-			console.log(837, 'setting s.zoomCenterPct', s.zoomCenterPct)
-			s.zoomCenterPct = 0.5 //* mainw //console.log(837, s.zoomCenterPct, mainw)
-			s.zoomIndex = Math.round((s.zoomCenterPct * mainw) / dx) //; console.log(842, mainw, s.zoo)
+			//console.log(837, 'setting s.zoomCenterPct', s.zoomCenterPct)
+			s.zoomCenterPct = 0.5
+			s.zoomIndex = Math.round((s.zoomCenterPct * mainw) / dx)
 			s.zoomGrpIndex = this.sampleOrder[s.zoomIndex].grpIndex
 		}
 		// zoomCenter relative to mainw
@@ -847,7 +848,7 @@ class Matrix {
 		const centerCellX = s.zoomIndex * dx + s.zoomGrpIndex * s.colgspace
 		const zoomedMainW = nx * dx + (this[`${col}Grps`].length - 1) * s.colgspace
 		const seriesXoffset = s.zoomLevel <= 1 && mainw >= zoomedMainW ? 0 : zoomCenter - centerCellX
-		console.log('centerCellX=', centerCellX, 'mainw=', mainw)
+		console.log('centerCellX=', centerCellX, 'mainw=', mainw, zoomCenter)
 
 		//console.log(841, 'zoomCenter', zoomCenter, centerCellX)
 		console.log(842, 'seriesXoffset=', seriesXoffset, seriesXoffset > 0 ? 0 : seriesXoffset)
@@ -1092,11 +1093,14 @@ export async function getPlotConfig(opts, app) {
 				termLabelOffset: 80,
 				termGrpLabelOffset: 80,
 				duration: 0,
-				mouseMode: 'zoom',
+				mouseMode: 'select',
 				zoomLevel: 1,
 				zoomCenterPct: 0,
 				zoomIndex: 0,
 				zoomGrpIndex: 0,
+				zoomMin: 0.5,
+				zoomIncrement: 0.5,
+				zoomStep: 10,
 				scrollHeight: 12
 			}
 		}
@@ -1121,7 +1125,10 @@ export async function getPlotConfig(opts, app) {
 
 	// may apply term-specific changes to the default object
 	copyMerge(config, opts)
+	// harcode these overrides for now
 	config.settings.matrix.duration = 0
+	config.settings.matrix.mouseMode = 'select'
+
 	const promises = []
 	for (const grp of config.termgroups) {
 		for (const tw of grp.lst) {

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -208,7 +208,33 @@ class Matrix {
 		})
 
 		this.setPill(appState)
-		//TODO: may conflict with serverconfig.commonOverrides
+
+		/*
+		Levels of mclass overrides, from more general to more specific.
+
+		1. server-level:
+		  - specified as serverconfig.commonOverrides
+		  - applied to the mclass from #shared/common on server startup
+		  - applies to all datasets and charts
+		  - overrides are applied to the static common.mclass object
+		
+		2. dataset-level: 
+		  - specified as termdb.mclass in the dataset's js file
+		  - applied to the termdbConfig.mclass payload as returned from the /termdb?getTermdbConfig=1 route
+		  - applies to all charts rendered for only the dataset/dslabel
+		  - overrides are applied to a copy of common.mclass, not the original "static" object
+
+		3. chart-level: 
+		  - specified as termdb[chartType].mclass in the dataset's js file
+		  - applied to the termdbConfig[chartType].mclass payload as returned from the /termdb?getTermdbConfig=1 route
+		  - applies to only the specific chart type as rendered for the dataset/dslabel
+		  - overrides are applied to a copy of common.mclass + termdb.mclass
+
+		!!! NOTE: 
+			Boolean configuration flags for mutually exclusive values may cause conflicting configurations
+			in the resulting merged overrides, as outputted by rx.copyMerge()
+		!!!
+		*/
 		this.mclass = copyMerge({}, mclass, appState.termdbConfig.mclass || {}, appState.termdbConfig.matrix?.mclass || {})
 	}
 

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -14,14 +14,7 @@ export function setRenderers(self) {
 			.attr('height', 1)
 
 		self.renderSerieses(s, l, d, duration)
-		self.renderLabels(s, l, d, duration) //console.log(18, 'matrix.renderer() s.zoomCenterPct', s.zoomCenterPct, [d.mainw, d.seriesXoffset], 'clipRect.x=', x, 'clipRect.width=', Math.min(d.mainw, d.maxMainW) / d.zoomedMainW)
-		self.svgScrollApi.update({
-			x: d.xOffset,
-			y: d.yOffset - s.scrollHeight,
-			totalWidth: d.zoomedMainW,
-			visibleWidth: d.mainw,
-			zoomCenter: s.zoomCenterPct * d.mainw - d.seriesXoffset
-		})
+		self.renderLabels(s, l, d, duration)
 	}
 
 	self.renderSerieses = function(s, l, d, duration) {

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -55,6 +55,8 @@ export function setRenderers(self) {
 		const height = series.y + last?.y + s.rowh
 
 		if (s.useCanvas) {
+			const df = self.stateDiff
+			if (g.selectAll('image').size() && !df.nonsettings && !df.sorting && !df.cellDimensions) return
 			const pxr = 1 //window.devicePixelRatio; console.log(51, 'pixelRatio', pxr)
 			g.selectAll('*').remove()
 			const canvas = self.dom.holder

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -6,14 +6,25 @@ export function setRenderers(self) {
 		const l = self.layout
 		const d = self.dimensions
 		const duration = self.dom.svg.attr('width') ? s.duration : 0
+		const x = s.zoomLevel <= 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW
 		self.dom.clipRect
-			.attr('x', s.zoomLevel <= 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW)
+			.attr('x', x)
 			.attr('y', 0)
 			.attr('width', Math.min(d.mainw, d.maxMainW) / d.zoomedMainW)
 			.attr('height', 1)
 
 		self.renderSerieses(s, l, d, duration)
 		self.renderLabels(s, l, d, duration)
+		//console.log(17, d.xOffset, s.zoomCenterPct, s.zoomCenterPct * d.mainw, s.zoomCenterPct * d.mainw - d.seriesXoffset)
+		self.svgScrollApi.update({
+			x: d.xOffset,
+			y: d.yOffset - 13, // + d.mainh,
+			totalWidth: d.zoomedMainW,
+			visibleWidth: d.mainw,
+			zoomCenter: s.zoomCenterPct * d.mainw - d.seriesXoffset,
+			zoomLevel: s.zoomLevel,
+			noTextHighlight: self.dom.mainG.selectAll('text')
+		})
 	}
 
 	self.renderSerieses = function(s, l, d, duration) {

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -15,15 +15,12 @@ export function setRenderers(self) {
 
 		self.renderSerieses(s, l, d, duration)
 		self.renderLabels(s, l, d, duration)
-		//console.log(17, d.xOffset, s.zoomCenterPct, s.zoomCenterPct * d.mainw, s.zoomCenterPct * d.mainw - d.seriesXoffset)
 		self.svgScrollApi.update({
 			x: d.xOffset,
 			y: d.yOffset - 13, // + d.mainh,
 			totalWidth: d.zoomedMainW,
 			visibleWidth: d.mainw,
-			zoomCenter: s.zoomCenterPct * d.mainw - d.seriesXoffset,
-			zoomLevel: s.zoomLevel,
-			noTextHighlight: self.dom.mainG.selectAll('text')
+			zoomCenter: s.zoomCenterPct * d.mainw - d.seriesXoffset
 		})
 	}
 

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -6,7 +6,7 @@ export function setRenderers(self) {
 		const l = self.layout
 		const d = self.dimensions
 		const duration = self.dom.svg.attr('width') ? s.duration : 0
-		const x = s.zoomLevel <= 1 ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW
+		const x = s.zoomLevel <= 1 && d.mainw >= d.zoomedMainW ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW
 		self.dom.clipRect
 			.attr('x', x)
 			.attr('y', 0)
@@ -14,10 +14,10 @@ export function setRenderers(self) {
 			.attr('height', 1)
 
 		self.renderSerieses(s, l, d, duration)
-		self.renderLabels(s, l, d, duration)
+		self.renderLabels(s, l, d, duration) //console.log(18, 'matrix.renderer() s.zoomCenterPct', s.zoomCenterPct, [d.mainw, d.seriesXoffset], 'clipRect.x=', x, 'clipRect.width=', Math.min(d.mainw, d.maxMainW) / d.zoomedMainW)
 		self.svgScrollApi.update({
 			x: d.xOffset,
-			y: d.yOffset - 13, // + d.mainh,
+			y: d.yOffset - s.scrollHeight,
 			totalWidth: d.zoomedMainW,
 			visibleWidth: d.mainw,
 			zoomCenter: s.zoomCenterPct * d.mainw - d.seriesXoffset
@@ -266,7 +266,7 @@ export function setRenderers(self) {
 		d.extraWidth = leftBox.width + rtBox.width + s.margin.left + s.margin.right + s.rowlabelgap * 2
 		d.extraHeight = topBox.height + btmBox.height + s.margin.top + s.margin.bottom + s.collabelgap * 2
 		d.svgw = d.mainw + d.extraWidth
-		d.svgh = d.mainh + d.extraHeight + legendBox.height + 20
+		d.svgh = d.mainh + d.extraHeight + legendBox.height + 20 + s.scrollHeight
 		self.dom.svg
 			.transition()
 			.duration(duration)

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1150,6 +1150,16 @@ sandbox header
     width: 18px;
 }
 
+.sjpp-matrix-series-group-label-g text,
+.sjpp-matrix-series-label-g text,
+.sjpp-matrix-term-group-label-g text,
+.sjpp-matrix-term-label-g text,
+.sjpp-matrix-label text {
+    -webkit-user-select:  none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -user-select: none;
+}
 
 
 


### PR DESCRIPTION
This update exposes the matrix zoom/pan by default, the serverconfig.features.matrix option is not required anymore. 

Highlights:
- use `OffscreenCanvas` for better canvas rendering performance
- avoid data request and processing steps when state.config updates are limited to certain settings
- matrix reacts to window resize
- improved auto-dimensions, but see the todo below
- many bug fixes for zoom and pan positions

TODO in separate branch(es):
1. use a dedicated settings.matrix.autoDimensions config, instead of inferring when `s.colw: 0`
2. more optimizations to canvas rendering: for example, only render visible width + buffer for panning/scrolling
3. show a menu when the mouseMode='select':  to zoom, select samples, or other options 
