### PR TITLE
Tests.9

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -1,7 +1,28 @@
 import { select as d3select } from 'd3-selection'
 import { get_base_zindex } from '#common/globals'
 
-// TODO explain arg
+/*
+arg{}
+---All are optional---
+	parent_menu
+		- define if menu is launched within another menu
+	padding: STR
+		- css value for menu.d.style.padding
+	border: STR
+		- css value for menu.d.style.border
+	offsetX: INT 
+		- default = 20
+		- offset for left position (x = x + offsetX)
+	offsetY: INT
+		- default = 20
+		- offset for top position (y = y + offsetY)
+	hideXmute, hideYmute: INT
+		- default = 0
+		- cancel tip hiding if the cursor's X,Y movement is less than the corresponding 
+		hide*mute value. See notes in constructor
+	clearSelector: STR
+		-clear only specific elems within menu.d, not all of menu.d
+*/
 export class Menu {
 	constructor(arg = {}) {
 		this.typename = Math.random().toString()
@@ -106,7 +127,10 @@ export class Menu {
 		else this.d.selectAll('*').remove()
 		return this
 	}
-
+	/*
+	 To note: if shift and scroll are true, shift sets x & y.
+	 Set shift to false to use scroll
+	*/
 	show(_x, _y, shift = true, down = true, scroll = true) {
 		let x = _x
 		let y = _y
@@ -245,5 +269,10 @@ export class Menu {
 		const api = Object.create(this)
 		Object.assign(api, overrides)
 		return api
+	}
+
+	destroy() {
+		//For testing to remove completely from the document.body without using d3select()
+		this.d.remove()
 	}
 }

--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -22,6 +22,8 @@ arg{}
 		hide*mute value. See notes in constructor
 	clearSelector: STR
 		-clear only specific elems within menu.d, not all of menu.d
+	onHide()
+		- override default hide() with callback
 */
 export class Menu {
 	constructor(arg = {}) {

--- a/client/dom/sandbox.js
+++ b/client/dom/sandbox.js
@@ -16,16 +16,33 @@ newSandboxDiv
 */
 
 export function renderSandboxFormDiv(holder, genomes) {
-	const inputdiv = holder.append('div').style('margin', '40px 20px 20px 20px')
-	const p = inputdiv.append('p')
+	//Classes for unit testing
+	holder.classed('sjpp-sandbox-form', true)
+	const inputdiv = holder
+		.append('div')
+		.style('margin', '40px 20px 20px 20px')
+		.classed('sjpp-sandbox-form-inputDiv', true)
+	const p = inputdiv.append('p').classed('sjpp-sandbox-form-gselect', true)
 	p.append('span').html('Genome&nbsp;')
 	const gselect = p.append('select')
 	for (const n in genomes) {
 		gselect.append('option').text(n)
 	}
-	const filediv = inputdiv.append('div').style('margin', '20px 0px')
-	const saydiv = holder.append('div').style('margin', '10px 20px')
-	const visualdiv = holder.append('div').style('margin', '20px')
+	//For file select, pathway input, etc.
+	const filediv = inputdiv
+		.append('div')
+		.style('margin', '20px 0px')
+		.classed('sjpp-sandbox-form-fileDiv', true)
+	//For error messages
+	const saydiv = holder
+		.append('div')
+		.style('margin', '10px 20px')
+		.classed('sjpp-sandbox-form-sayDiv', true)
+	//For displaying output
+	const visualdiv = holder
+		.append('div')
+		.style('margin', '20px')
+		.classed('sjpp-sandbox-form-visualDiv', true)
 	return [inputdiv, gselect.node(), filediv, saydiv, visualdiv]
 }
 

--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -1,0 +1,30 @@
+import tape from 'tape'
+import * as d3s from 'd3-selection'
+import { Menu } from '#dom/Menu'
+
+/*************************
+ reusable helper functions
+**************************/
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', test => {
+	test.pass('-***- dom/menu -***-')
+	test.end()
+})
+
+tape.only('Launch Menu', test => {
+	const x = new Menu()
+	test.end()
+})

--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -17,14 +17,114 @@ function getHolder() {
 
 /**************
  test sections
-***************/
+**************
+
+new Menu()
+
+*/
 
 tape('\n', test => {
 	test.pass('-***- dom/menu -***-')
 	test.end()
 })
 
-tape.only('Launch Menu', test => {
-	const x = new Menu()
+tape('new Menu()', test => {
+	test.timeoutAfter(100)
+
+	const testMenu = new Menu()
+
+	test.equal(typeof testMenu.d, 'object', 'Should have a menu.d object')
+	test.equal(typeof testMenu.clear, 'function', 'Should have a menu.clear() function')
+	test.equal(typeof testMenu.show, 'function', 'Should have a menu.show() function')
+	test.equal(typeof testMenu.showunder, 'function', 'Should have a menu.showunder() function')
+	test.equal(typeof testMenu.hide, 'function', 'Should have a menu.hide() function')
+	test.equal(typeof testMenu.fadeout, 'function', 'Should have a menu.fadeout() function')
+	test.equal(typeof testMenu.toggle, 'function', 'Should have a menu.toggle() function')
+	test.equal(typeof testMenu.getCustomApi, 'function', 'Should have a menu.getCustomApi() function')
+
+	test.end()
+})
+
+tape.only('clear()', test => {
+	test.timeoutAfter(500)
+
+	const holder = getHolder()
+
+	const testMenu1 = new Menu({
+		parent_menu: holder
+	})
+	testMenu1.d.append('div').text('Test')
+
+	// if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('show()', test => {
+	test.timeoutAfter(500)
+
+	// const holder = getHolder()
+	const testMenu = new Menu()
+
+	// if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('showunder()', test => {
+	test.timeoutAfter(500)
+
+	// const holder = getHolder()
+	const testMenu = new Menu()
+
+	// if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('showunderoffset()', test => {
+	test.timeoutAfter(500)
+
+	// const holder = getHolder()
+	const testMenu = new Menu()
+
+	// if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('hide()', test => {
+	test.timeoutAfter(500)
+
+	// const holder = getHolder()
+	const testMenu = new Menu()
+
+	// if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('fadeout()', test => {
+	test.timeoutAfter(500)
+
+	// const holder = getHolder()
+	const testMenu = new Menu()
+
+	// if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('toggle()', test => {
+	test.timeoutAfter(500)
+
+	// const holder = getHolder()
+	const testMenu = new Menu()
+
+	// if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('getCustomApi()', test => {
+	test.timeoutAfter(500)
+
+	// const holder = getHolder()
+	const testMenu = new Menu()
+
+	// if (test._ok) holder.remove()
 	test.end()
 })

--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import * as d3s from 'd3-selection'
 import { Menu } from '#dom/menu'
-import { detectOne } from '../../test/test.helpers.js'
+import { detectStyle } from '../../test/test.helpers.js'
 
 /*************************
  reusable helper functions
@@ -19,6 +19,16 @@ function getHolder() {
 const longText =
 	'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
 
+function getTestMenu() {
+	const menu = new Menu()
+	menu.d
+		.append('div')
+		.text('Test')
+		.style('display', 'block')
+
+	return menu
+}
+
 /**************
  test sections
 **************
@@ -27,6 +37,12 @@ new Menu()
 show(), clear(), and hide(), no args
 clear() with arg
 show() with args
+onHide() callback
+showunder()
+showunderoffset()
+fadeout()
+toggle()
+getCustomApi()
 
 */
 
@@ -59,11 +75,7 @@ tape('show(), clear(), and hide(), no args', async test => {
 	test.timeoutAfter(500)
 	//Test basic function collectively to use freely in later tests
 
-	const testMenu = new Menu()
-	testMenu.d
-		.append('div')
-		.text('Test')
-		.style('display', 'block')
+	const testMenu = getTestMenu()
 	testMenu.show()
 
 	let appendedDiv
@@ -107,14 +119,11 @@ tape.skip('clear() with arg', test => {
 tape('show() with args', async test => {
 	test.timeoutAfter(500)
 
-	const testMenu = new Menu()
+	const testMenu = getTestMenu()
 	testMenu.d
 		.style('max-width', '20vw')
 		.style('max-height', '10vh')
 		.style('overflow', 'hidden')
-		.append('div')
-		.text('Test')
-		.style('display', 'block')
 
 	let posNum
 
@@ -168,7 +177,7 @@ tape('show() with args', async test => {
 	test.end()
 })
 
-tape.skip('showunder()', test => {
+tape.skip('onHide() callback', test => {
 	test.timeoutAfter(500)
 
 	// const holder = getHolder()
@@ -178,23 +187,96 @@ tape.skip('showunder()', test => {
 	test.end()
 })
 
-tape.skip('showunderoffset()', test => {
+tape('showunder()', test => {
 	test.timeoutAfter(500)
 
-	// const holder = getHolder()
-	const testMenu = new Menu()
+	const holder = getHolder()
+	const btn = holder.append('button').text('Button')
+	const testMenu = getTestMenu()
 
-	// if (test._ok) holder.remove()
+	const message = 'Should throw error for missing dom arg'
+	try {
+		testMenu.showunder()
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	testMenu.showunder(btn.node())
+
+	const btnP = btn.node().getBoundingClientRect()
+	const menuP = testMenu.dnode.getBoundingClientRect()
+	test.equal(btnP.x, menuP.x, `Should show menu with the same style.left value as test element.`)
+	const correctYvalue = btnP.top + btnP.height + window.scrollY + 5
+	test.equal(
+		Math.round(correctYvalue),
+		Math.round(menuP.y),
+		`Should show menu with the shifted style.top value relative to test element.`
+	)
+
+	if (test._ok) {
+		testMenu.destroy()
+		holder.remove()
+	}
 	test.end()
 })
 
-tape.skip('fadeout()', test => {
+tape('showunderoffset()', test => {
 	test.timeoutAfter(500)
 
-	// const holder = getHolder()
-	const testMenu = new Menu()
+	const holder = getHolder()
+	const btn = holder.append('button').text('Button')
+	const testMenu = getTestMenu()
 
-	// if (test._ok) holder.remove()
+	const message = 'Should throw error for missing dom arg'
+	try {
+		testMenu.showunderoffset()
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	testMenu.showunderoffset(btn.node())
+
+	const btnP = btn.node().getBoundingClientRect()
+	const menuP = testMenu.dnode.getBoundingClientRect()
+
+	test.equal(
+		Math.round(btnP.x + testMenu.offsetX),
+		Math.round(menuP.x),
+		`Should show menu with the style.left value as test element, offset by ${testMenu.offsetX}px.`
+	)
+	const correctYvalue = btnP.top + btnP.height + window.scrollY + 5
+	test.equal(
+		Math.round(correctYvalue + testMenu.offsetY),
+		Math.round(menuP.y),
+		`Should show menu with style.top value relative to test element, offset by ${testMenu.offsetY}px.`
+	)
+
+	if (test._ok) {
+		testMenu.destroy()
+		holder.remove()
+	}
+	test.end()
+})
+
+tape.skip('fadeout()', async test => {
+	test.timeoutAfter(500)
+
+	const testMenu = getTestMenu()
+	testMenu.d.attr('class', 'menu-fadeout-test')
+	testMenu.show()
+	testMenu.fadeout()
+	const faded = await detectStyle({
+		elem: d3s.select('body').node(),
+		selector: '.menu-fadeout-test',
+		style: {
+			display: 'inline-block'
+		}
+	})
+	console.log(faded)
+
+	// testMenu.destroy()
 	test.end()
 })
 

--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -1,6 +1,7 @@
 import tape from 'tape'
 import * as d3s from 'd3-selection'
-import { Menu } from '#dom/Menu'
+import { Menu } from '#dom/menu'
+import { detectOne } from '../../test/test.helpers.js'
 
 /*************************
  reusable helper functions
@@ -15,11 +16,17 @@ function getHolder() {
 		.style('margin', '5px')
 }
 
+const longText =
+	'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+
 /**************
  test sections
 **************
 
 new Menu()
+show(), clear(), and hide(), no args
+clear() with arg
+show() with args
 
 */
 
@@ -34,6 +41,7 @@ tape('new Menu()', test => {
 	const testMenu = new Menu()
 
 	test.equal(typeof testMenu.d, 'object', 'Should have a menu.d object')
+	test.equal(typeof testMenu.dnode, 'object', 'Should have a menu.dnode (i.e. d.node()) object')
 	test.equal(typeof testMenu.clear, 'function', 'Should have a menu.clear() function')
 	test.equal(typeof testMenu.show, 'function', 'Should have a menu.show() function')
 	test.equal(typeof testMenu.showunder, 'function', 'Should have a menu.showunder() function')
@@ -41,31 +49,122 @@ tape('new Menu()', test => {
 	test.equal(typeof testMenu.fadeout, 'function', 'Should have a menu.fadeout() function')
 	test.equal(typeof testMenu.toggle, 'function', 'Should have a menu.toggle() function')
 	test.equal(typeof testMenu.getCustomApi, 'function', 'Should have a menu.getCustomApi() function')
+	test.equal(typeof testMenu.destroy, 'function', 'Should have a menu.destroy() function')
 
+	testMenu.destroy()
 	test.end()
 })
 
-tape.only('clear()', test => {
+tape('show(), clear(), and hide(), no args', async test => {
 	test.timeoutAfter(500)
+	//Test basic function collectively to use freely in later tests
 
-	const holder = getHolder()
-
-	const testMenu1 = new Menu({
-		parent_menu: holder
-	})
-	testMenu1.d.append('div').text('Test')
-
-	// if (test._ok) holder.remove()
-	test.end()
-})
-
-tape.skip('show()', test => {
-	test.timeoutAfter(500)
-
-	// const holder = getHolder()
 	const testMenu = new Menu()
+	testMenu.d
+		.append('div')
+		.text('Test')
+		.style('display', 'block')
+	testMenu.show()
 
-	// if (test._ok) holder.remove()
+	let appendedDiv
+	appendedDiv = testMenu.dnode.childNodes[0]
+	test.ok(appendedDiv.style.display == 'block' && appendedDiv.innerText == 'Test', `Should display 'Test' tip`)
+
+	testMenu.clear()
+	appendedDiv = testMenu.dnode.childNodes[0]
+	test.ok(!appendedDiv && testMenu.d, `Should remove appended 'Test' div but empty menu tip persists`)
+
+	testMenu.hide()
+	test.ok(testMenu.dnode.style.display == 'none', `Should not display menu`)
+
+	testMenu.destroy()
+	test.end()
+})
+
+tape.skip('clear() with arg', test => {
+	test.timeoutAfter(500)
+
+	const testMenu = new Menu({ clearSelector: '.sjpp-menu-test-div' })
+	testMenu.d
+		.append('div')
+		.text('Main div - should persist')
+		.style('display', 'block')
+
+	testMenu.d
+		.append('div')
+		.attr('class', 'sjpp-menu-test-div')
+		.text('Clear div - should clear')
+		.style('display', 'block')
+
+	testMenu.show()
+	const x = testMenu.d.select('.sjpp-menu-test-div')
+	console.log(x)
+	// testMenu.clear()
+
+	test.end()
+})
+
+tape('show() with args', async test => {
+	test.timeoutAfter(500)
+
+	const testMenu = new Menu()
+	testMenu.d
+		.style('max-width', '20vw')
+		.style('max-height', '10vh')
+		.style('overflow', 'hidden')
+		.append('div')
+		.text('Test')
+		.style('display', 'block')
+
+	let posNum
+
+	//left (x) position
+	posNum = 50
+	testMenu.show(posNum)
+	test.ok(
+		testMenu.dnode.style.left == `${posNum + testMenu.offsetX}px` && testMenu.dnode.style.top == '',
+		`Should show menu left, under header, shifted by .offsetX = ${testMenu.offsetX}px`
+	)
+
+	//top (y) position
+	testMenu.show('', posNum)
+	test.ok(
+		testMenu.dnode.style.left == '20px' && testMenu.dnode.style.top == `${posNum + testMenu.offsetY}px`,
+		`Should show menu at the top, above header, shifted by .offsetY = ${testMenu.offsety}px`
+	)
+
+	// left & top (x & y) position
+	posNum = 100
+	testMenu.show(posNum, posNum)
+	test.ok(
+		testMenu.dnode.style.left == `${posNum + testMenu.offsetX}px` &&
+			testMenu.dnode.style.top == `${posNum + testMenu.offsetY}px`,
+		`Should show menu top left corner, over header, shifted by .offsetX = ${testMenu.offsetX}px & .offsetY = ${testMenu.offsetY}px`
+	)
+
+	//No shift (i.e. additional 20px)
+	testMenu.show(posNum, posNum, false)
+	test.ok(
+		testMenu.dnode.style.left == `${posNum}px` && testMenu.dnode.style.top == `${posNum}px`,
+		`Should show menu top left corner without .offsetX or .offsetY added to left or top, respectively.`
+	)
+
+	//False down appears to have no effect on show()(?)
+	// posNum = 200
+	// testMenu.show(posNum, posNum, false, false)
+	// console.log(testMenu.dnode.style)
+
+	//With scroll
+	posNum = 200
+	testMenu.d.append('div').text(longText)
+	testMenu.show(posNum, posNum, false)
+	test.ok(
+		testMenu.dnode.style.left == `${posNum + window.scrollX}px` &&
+			testMenu.dnode.style.top == `${posNum + window.scrollY}px`,
+		`Should show menu position with window.scrollX = ${window.scrollX} & window.scrollY = ${window.scrollY}`
+	)
+
+	testMenu.destroy()
 	test.end()
 })
 
@@ -80,16 +179,6 @@ tape.skip('showunder()', test => {
 })
 
 tape.skip('showunderoffset()', test => {
-	test.timeoutAfter(500)
-
-	// const holder = getHolder()
-	const testMenu = new Menu()
-
-	// if (test._ok) holder.remove()
-	test.end()
-})
-
-tape.skip('hide()', test => {
 	test.timeoutAfter(500)
 
 	// const holder = getHolder()

--- a/client/dom/test/sandbox.unit.spec.js
+++ b/client/dom/test/sandbox.unit.spec.js
@@ -1,0 +1,60 @@
+import tape from 'tape'
+import * as d3s from 'd3-selection'
+import { newSandboxDiv } from '#dom/sandbox'
+import { detectOne } from '../../test/test.helpers.js'
+
+/*************************
+ reusable helper functions
+**************************/
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', test => {
+	test.pass('-***- dom/sandbox -***-')
+	test.end()
+})
+
+tape('newSandboxDiv(), holder arg only', async test => {
+	test.timeoutAfter(500)
+
+	const holder = getHolder()
+	const sandbox = new newSandboxDiv(holder)
+
+	test.ok(sandbox.header_row, `Should have .header_row`)
+	test.ok(sandbox.header, `Should have .header`)
+	test.ok(sandbox.body, `Should have .body`)
+	test.ok(sandbox.app_div, `Should have .app_div`)
+	test.ok(!sandbox.id, `Should not have .id`)
+
+	const domSandbox = await detectOne({ elem: holder.node(), selector: '.sjpp-sandbox' })
+	//Test will timeout before this finishes
+	test.ok(domSandbox, `Should render basic sandbox`)
+	const header = holder.select('.sjpp-output-sandbox-header').nodes()
+	test.equal(header.length, 1, `Should render one header`)
+	const content = holder.select('.sjpp-output-sandbox-content').nodes()
+	test.ok(content.length && !content.innerHTML, `Should render empty content div`)
+
+	if (test._ok) holder.remove()
+	test.end()
+})
+
+tape.only('newSandboxDiv(), with opts', test => {
+	test.timeoutAfter(500)
+
+	const holder = getHolder()
+	const sandbox = new newSandboxDiv(holder)
+
+	if (test._ok) holder.remove()
+	test.end()
+})

--- a/client/dom/test/sandbox.unit.spec.js
+++ b/client/dom/test/sandbox.unit.spec.js
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import * as d3s from 'd3-selection'
-import { newSandboxDiv } from '#dom/sandbox'
+import { newSandboxDiv, renderSandboxFormDiv } from '#dom/sandbox'
 import { detectOne } from '../../test/test.helpers.js'
 
 /*************************
@@ -16,16 +16,30 @@ function getHolder() {
 		.style('margin', '5px')
 }
 
+function getSandboxOpts(sandbox) {
+	sandbox.header.append('span').text('Test Header')
+	sandbox.body.append('div').html(`Test Content`)
+	return sandbox
+}
+
 /**************
  test sections
-***************/
+**************
+
+newSandboxDiv(), holder arg only and empty
+newSandboxDiv(), with opts and content
+Insert new sandbox at top
+Expand, collapse, and close buttons
+renderSandboxFormDiv()
+
+*/
 
 tape('\n', test => {
 	test.pass('-***- dom/sandbox -***-')
 	test.end()
 })
 
-tape('newSandboxDiv(), holder arg only', async test => {
+tape('newSandboxDiv(), holder arg only and empty', async test => {
 	test.timeoutAfter(500)
 
 	const holder = getHolder()
@@ -37,23 +51,134 @@ tape('newSandboxDiv(), holder arg only', async test => {
 	test.ok(sandbox.app_div, `Should have .app_div`)
 	test.ok(!sandbox.id, `Should not have .id`)
 
-	const domSandbox = await detectOne({ elem: holder.node(), selector: '.sjpp-sandbox' })
-	//Test will timeout before this finishes
-	test.ok(domSandbox, `Should render basic sandbox`)
-	const header = holder.select('.sjpp-output-sandbox-header').nodes()
-	test.equal(header.length, 1, `Should render one header`)
-	const content = holder.select('.sjpp-output-sandbox-content').nodes()
-	test.ok(content.length && !content.innerHTML, `Should render empty content div`)
+	let elem
+	elem = await detectOne({ elem: holder.node(), selector: '.sjpp-sandbox' })
+	//If failing, test will timeout before this finishes
+	test.ok(elem, `Should render basic sandbox`)
+
+	elem = holder.select('.sjpp-output-sandbox-close-bt').node()
+	test.ok(elem, `Should render destroy/delete button`)
+
+	elem = holder.select('.sjpp-output-sandbox-collapse-btn').node()
+	test.equal(elem.style.display, 'inline-block', `Should render collapse button by default`)
+
+	elem = holder.select('.sjpp-output-sandbox-expand-btn').node()
+	test.equal(elem.style.display, 'none', `Should not render expand button by default`)
+
+	elem = holder.select('.sjpp-output-sandbox-header').nodes()
+	test.equal(elem.length, 1, `Should render empty header`)
+
+	elem = holder.select('.sjpp-output-sandbox-content').nodes()
+	test.ok(elem.length && !elem.innerHTML, `Should render empty content div`)
 
 	if (test._ok) holder.remove()
 	test.end()
 })
 
-tape.only('newSandboxDiv(), with opts', test => {
+tape('newSandboxDiv(), with opts and content', test => {
+	test.timeoutAfter(500)
+
+	const holder = getHolder()
+	const sandbox = new newSandboxDiv(holder, { plotId: 1 })
+	test.ok(sandbox.id, `Should have sandbox.id`)
+
+	getSandboxOpts(sandbox)
+	let elem
+
+	elem = sandbox.header.node()
+	test.equal(elem.outerText, 'Test Header', `Should display text in header`)
+
+	elem = sandbox.body.node()
+	test.equal(elem.outerText, 'Test Content', `Should display text in body`)
+
+	if (test._ok) holder.remove()
+	test.end()
+})
+
+tape('Insert new sandbox at top', test => {
+	test.timeoutAfter(500)
+
+	const holder = getHolder()
+	const sandbox1 = new newSandboxDiv(holder, { plotId: 1 })
+	const sandbox2 = new newSandboxDiv(holder, { plotId: 2 })
+
+	let sandboxes
+
+	sandboxes = holder.selectAll(`.sjpp-sandbox`).nodes()
+	test.ok(
+		sandbox2.id == sandboxes[0].id && sandbox1.id == sandboxes[1].id,
+		`Should insert second sandbox before the first sandbox`
+	)
+
+	const sandbox3 = new newSandboxDiv(holder, { plotId: 3 })
+	sandboxes = holder.selectAll(`.sjpp-sandbox`).nodes()
+	test.ok(
+		sandbox3.id == sandboxes[0].id && sandbox2.id == sandboxes[1].id && sandbox1.id == sandboxes[2].id,
+		`Should insert new, third sandbox before the second and first sandbox`
+	)
+
+	if (test._ok) holder.remove()
+	test.end()
+})
+
+tape('Expand, collapse, and close buttons', test => {
 	test.timeoutAfter(500)
 
 	const holder = getHolder()
 	const sandbox = new newSandboxDiv(holder)
+	getSandboxOpts(sandbox)
+
+	let elem
+	elem = holder.select('.sjpp-output-sandbox-collapse-btn').node()
+	elem.click()
+	test.ok(sandbox.body.node().style.display == 'none', `Sandbox content no longer visible after collapse button click`)
+
+	elem = holder.select('.sjpp-output-sandbox-expand-btn').node()
+	elem.click()
+	test.ok(sandbox.body.node().style.display == 'block', `Sandbox content visiable again after expand button click`)
+
+	elem = holder.select('.sjpp-output-sandbox-close-bt').node()
+	elem.click()
+	elem = holder.select('.sjpp-sandbox').node()
+	test.ok(
+		elem.outerHTML == '<div class="sjpp-sandbox"></div>',
+		`Should remove all content from sandbox, leaving an empty div`
+	)
+
+	if (test._ok) holder.remove()
+	test.end()
+})
+
+tape('renderSandboxFormDiv()', async test => {
+	test.timeoutAfter(500)
+
+	const holder = getHolder()
+	const genomes = { hg19: {}, hg38: {} }
+	let inputdiv, gselect, filediv, saydiv, visualdiv
+	;[inputdiv, gselect, filediv, saydiv, visualdiv] = new renderSandboxFormDiv(holder, genomes)
+	const testText = 'Additional input div content'
+	inputdiv.append('span').text(testText)
+	filediv.append('span').text('File Div')
+	saydiv.append('span').text('Say Div')
+	visualdiv.append('span').text('Visual Div')
+
+	let elem
+	elem = await detectOne({ elem: holder.node(), selector: '.sjpp-sandbox-form-inputDiv' })
+	test.ok(elem.childNodes[0].className == 'sjpp-sandbox-form-gselect', `Should render genomes dropdown inside inputdiv`)
+	test.ok(elem.childNodes[1].className == 'sjpp-sandbox-form-fileDiv', `Should render fileDiv inside inputdiv`)
+	test.equal(elem.childNodes[2].innerText, testText, `Should render test content at the end of inputdiv`)
+
+	elem = holder.select('.sjpp-sandbox-form-gselect').node()
+	test.equal(elem.childNodes[0].innerHTML, 'Genome&nbsp;', `Should render 'Genome' prompt first`)
+	const gOptions = elem.childNodes[1].childNodes
+	const g = Object.keys(genomes)
+	test.ok(gOptions[0].innerText == g[0] && gOptions[1].innerText == g[1], `Should render genome options in order`)
+
+	elem = holder.select('.sjpp-sandbox-form-sayDiv').node()
+	test.ok(elem, `Should render sayDiv`)
+
+	elem = holder.select('.sjpp-sandbox-form-visualDiv').node()
+	test.ok(elem, `Should render visualDiv`)
 
 	if (test._ok) holder.remove()
 	test.end()

--- a/client/dom/test/toggleButtons.unit.spec.js
+++ b/client/dom/test/toggleButtons.unit.spec.js
@@ -1,6 +1,7 @@
 import tape from 'tape'
 import { Tabs } from '#dom/toggleButtons'
 import * as d3s from 'd3-selection'
+import { detectGte } from '../../test/test.helpers.js'
 
 /*************************
  reusable helper functions
@@ -13,10 +14,6 @@ function getHolder() {
 		.style('border', '1px solid #aaa')
 		.style('padding', '5px')
 		.style('margin', '5px')
-}
-
-function sleep(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 /**************
@@ -62,13 +59,11 @@ tape('Render Tabs, default settings', async test => {
 	await testTabActivity()
 
 	async function testTabActivity() {
-		await sleep(300)
-		const activeBtn = holder.selectAll('.sjpp-active').nodes()
+		const activeBtn = await detectGte({ elem: holder.node(), selector: '.sjpp-active' })
 		test.equal(activeBtn.length, 1, `Should only display one active button`)
 		const tabBtns = holder.selectAll('.sj-toggle-button').nodes()
 		test.equal(tabBtns.length, tabsData.length, `Should display all tabs in tabs array`)
 
-		await sleep(300)
 		tabBtns[1].click()
 		const oldActiveBtn = Object.values(tabBtns[0].classList).some(d => d == 'sjpp-active')
 		const newActiveBtn = Object.values(tabBtns[1].classList).some(d => d == 'sjpp-active')

--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -121,8 +121,7 @@ tape('single chart, with overlay', function(test) {
 			.done(test)*/
 
 		testBarCount()
-		await sleep(100)
-		testOverlayOrder()
+		await testOverlayOrder()
 		await triggerUncomputableOverlay(barchart)
 		clickLegendToHideOverlay(barchart)
 		await testHiddenOverlayData(barchart)
@@ -137,7 +136,8 @@ tape('single chart, with overlay', function(test) {
 		test.true(numOverlays > numBars, 'number of overlays should be greater than bars')
 	}
 
-	function testOverlayOrder() {
+	async function testOverlayOrder() {
+		await detectOne({ elem: barDiv.node(), selector: '.pp-bars-svg' }) //Fix to remove sleep()
 		const bars_grp = barDiv.selectAll('.bars-cell-grp')
 		const legend_rows = barDiv.selectAll('.legend-row')
 		//flag to indicate unordered bars


### PR DESCRIPTION
- Removed `sleep()` from a few tests
- New `sandbox.unit.spec`, 27 tests total
- New `menu.unit.spec`, 25 tests total
- Added missing todo comments in `menu.js` & `destroy()` for testing