### PR TITLE
Matrix controls

### DIFF
--- a/client/mass/app.js
+++ b/client/mass/app.js
@@ -84,7 +84,7 @@ class MassApp {
 	async init() {
 		// catch initialization error
 		try {
-			this.store = await storeInit({ app: this.api, state: this.opts.state })
+			this.store = await storeInit({ app: this.api, state: this.opts.state, debounceInterval: 250 })
 			this.state = await this.store.copyState()
 			this.components = {}
 			if (this.state.nav.header_mode != 'hidden') {

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -193,7 +193,6 @@ function setNumberInput(opts) {
 
 	const api = {
 		main(plot) {
-			console.log(plot)
 			for (const settingsKey in self.dom.inputs) {
 				self.dom.inputs[settingsKey].property('value', plot.settings[opts.chartType][settingsKey])
 			}

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -4,6 +4,7 @@ import { term1uiInit } from './controls.term1'
 import { divideInit } from './controls.divide'
 import { initRadioInputs } from '../dom/radio2'
 import { termsettingInit } from '../termsetting/termsetting'
+import { rgb } from 'd3-color'
 
 // to be used for assigning unique
 // radio button names by object instance
@@ -337,7 +338,8 @@ function setColorInput(opts) {
 
 	const api = {
 		main(plot) {
-			self.dom.input.property('value', plot.settings[opts.chartType][opts.settingsKey])
+			const color = plot.settings[opts.chartType][opts.settingsKey]
+			self.dom.input.property('value', rgb(color).formatHex())
 		}
 	}
 

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -152,35 +152,51 @@ function setNumberInput(opts) {
 				.html(opts.label)
 				.attr('class', 'sja-termdb-config-row-label')
 				.attr('title', opts.title),
-			inputTd: opts.holder.append('td')
+			inputs: {}
 		}
 	}
 
-	self.dom.input = self.dom.inputTd
-		.append('input')
-		.attr('type', 'number')
-		.attr('min', 'min' in opts ? opts.min : null) // verify that null gives the default html input behavior
-		.attr('max', 'max' in opts ? opts.max : null) // same
-		.attr('step', 'step' in opts ? opts.step : null) //step gives the amount by which user can increment
-		.style('width', (opts.width || 100) + 'px')
-		.on('change', () => {
-			const value = Number(self.dom.input.property('value'))
-			opts.dispatch({
-				type: 'plot_edit',
-				id: opts.id,
-				config: {
-					settings: {
-						[opts.chartType]: {
-							[opts.settingsKey]: opts.processInput ? opts.processInput(value) : value
+	if (!opts.inputs)
+		opts.inputs = [
+			{
+				min: opts.min,
+				max: opts.max,
+				step: opts.step,
+				width: opts.width
+			}
+		]
+
+	for (const input of opts.inputs) {
+		const inputTd = opts.holder.append('td')
+		self.dom.inputs[input.settingsKey] = inputTd
+			.append('input')
+			.attr('type', 'number')
+			.attr('min', 'min' in input ? input.min : null) // verify that null gives the default html input behavior
+			.attr('max', 'max' in input ? input.max : null) // same
+			.attr('step', input.step || opts.step || null) //step gives the amount by which user can increment
+			.style('width', (input.width || opts.width || 100) + 'px')
+			.on('change', () => {
+				const value = Number(self.dom.inputs[input.settingsKey].property('value'))
+				opts.dispatch({
+					type: 'plot_edit',
+					id: opts.id,
+					config: {
+						settings: {
+							[opts.chartType]: {
+								[input.settingsKey]: opts.processInput ? opts.processInput(value) : value
+							}
 						}
 					}
-				}
+				})
 			})
-		})
+	}
 
 	const api = {
 		main(plot) {
-			self.dom.input.property('value', plot.settings[opts.chartType][opts.settingsKey])
+			console.log(plot)
+			for (const settingsKey in self.dom.inputs) {
+				self.dom.inputs[settingsKey].property('value', plot.settings[opts.chartType][settingsKey])
+			}
 		}
 	}
 

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -169,6 +169,27 @@ function setNumberInput(opts) {
 		]
 
 	for (const input of opts.inputs) {
+		let dispatchTimer
+		function debouncedDispatch() {
+			if (dispatchTimer) clearTimeout(dispatchTimer)
+			dispatchTimer = setTimeout(dispatchChange, 100)
+		}
+
+		function dispatchChange() {
+			const value = Number(self.dom.inputs[input.settingsKey].property('value'))
+			opts.dispatch({
+				type: 'plot_edit',
+				id: opts.id,
+				config: {
+					settings: {
+						[opts.chartType]: {
+							[input.settingsKey]: opts.processInput ? opts.processInput(value) : value
+						}
+					}
+				}
+			})
+		}
+
 		const inputTd = opts.holder.append('td')
 		if (!input.settingsKey) {
 			inputTd
@@ -184,20 +205,7 @@ function setNumberInput(opts) {
 				.attr('max', 'max' in input ? input.max : null) // same
 				.attr('step', input.step || opts.step || null) //step gives the amount by which user can increment
 				.style('width', (input.width || opts.width || 100) + 'px')
-				.on('change', () => {
-					const value = Number(self.dom.inputs[input.settingsKey].property('value'))
-					opts.dispatch({
-						type: 'plot_edit',
-						id: opts.id,
-						config: {
-							settings: {
-								[opts.chartType]: {
-									[input.settingsKey]: opts.processInput ? opts.processInput(value) : value
-								}
-							}
-						}
-					})
-				})
+				.on('change', debouncedDispatch)
 		}
 	}
 

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -162,33 +162,42 @@ function setNumberInput(opts) {
 				min: opts.min,
 				max: opts.max,
 				step: opts.step,
-				width: opts.width
+				width: opts.width,
+				settingsKey: opts.settingsKey
 			}
 		]
 
 	for (const input of opts.inputs) {
 		const inputTd = opts.holder.append('td')
-		self.dom.inputs[input.settingsKey] = inputTd
-			.append('input')
-			.attr('type', 'number')
-			.attr('min', 'min' in input ? input.min : null) // verify that null gives the default html input behavior
-			.attr('max', 'max' in input ? input.max : null) // same
-			.attr('step', input.step || opts.step || null) //step gives the amount by which user can increment
-			.style('width', (input.width || opts.width || 100) + 'px')
-			.on('change', () => {
-				const value = Number(self.dom.inputs[input.settingsKey].property('value'))
-				opts.dispatch({
-					type: 'plot_edit',
-					id: opts.id,
-					config: {
-						settings: {
-							[opts.chartType]: {
-								[input.settingsKey]: opts.processInput ? opts.processInput(value) : value
+		if (!input.settingsKey) {
+			inputTd
+				.style('text-align', 'center')
+				.style('color', '#999')
+				.style('cursor', 'default')
+				.html(input.label)
+		} else {
+			self.dom.inputs[input.settingsKey] = inputTd
+				.append('input')
+				.attr('type', 'number')
+				.attr('min', 'min' in input ? input.min : null) // verify that null gives the default html input behavior
+				.attr('max', 'max' in input ? input.max : null) // same
+				.attr('step', input.step || opts.step || null) //step gives the amount by which user can increment
+				.style('width', (input.width || opts.width || 100) + 'px')
+				.on('change', () => {
+					const value = Number(self.dom.inputs[input.settingsKey].property('value'))
+					opts.dispatch({
+						type: 'plot_edit',
+						id: opts.id,
+						config: {
+							settings: {
+								[opts.chartType]: {
+									[input.settingsKey]: opts.processInput ? opts.processInput(value) : value
+								}
 							}
 						}
-					}
+					})
 				})
-			})
+		}
 	}
 
 	const api = {

--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -40,7 +40,7 @@ export class MatrixCluster {
 		this.totalWidth = s.zoomLevel == 1 ? -4 : 0 //4 * Math.max(1, s.colspace)
 
 		for (const xg of this.xGrps) {
-			const dx = d.dx //Math.min(d.dx, s.maxColw + s.colspace)
+			const dx = d.dx //Math.min(d.dx, s.colwMax + s.colspace)
 			const x = xg.prevGrpTotalIndex * dx + s.colgspace * xg.grpIndex + xg.totalHtAdjustments
 			const width = dx * (xg.processedLst || xg.grp.lst).length + xg.grpHtAdjustments
 			this.totalWidth += width + 2 * Math.max(1, s.colspace)

--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -42,12 +42,12 @@ export class MatrixCluster {
 		for (const xg of this.xGrps) {
 			const dx = d.dx //Math.min(d.dx, s.colwMax + s.colspace)
 			const x = xg.prevGrpTotalIndex * dx + s.colgspace * xg.grpIndex + xg.totalHtAdjustments
-			const width = dx * (xg.processedLst || xg.grp.lst).length + xg.grpHtAdjustments
+			const width = dx * (xg.processedLst || xg.grp.lst).length + xg.grpTotals.htAdjustment
 			this.totalWidth += width + 2 * Math.max(1, s.colspace)
 
 			for (const yg of this.yGrps) {
 				const y = yg.prevGrpTotalIndex * d.dy + yg.grpIndex * s.rowgspace + yg.totalHtAdjustments
-				const height = d.dy * (yg.processedLst || yg.grp.lst).length + yg.grpHtAdjustments
+				const height = d.dy * (yg.processedLst || yg.grp.lst).length + yg.grpTotals.htAdjustment
 				const offsetX = Math.max(1, s.colspace)
 				const offsetY = Math.max(1, s.rowspace)
 				clusters.push({

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -101,6 +101,7 @@ export async function getPlotConfig(opts, app) {
 
 	// harcode these overrides for now
 	config.settings.matrix.duration = 0
+	// force auto-dimensions for colw
 	config.settings.matrix.colw = 0
 
 	const promises = []

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -1,0 +1,117 @@
+import { copyMerge } from '../rx'
+import { fillTermWrapper } from '../termsetting/termsetting'
+
+export async function getPlotConfig(opts, app) {
+	const config = {
+		// data configuration
+		termgroups: [],
+		samplegroups: [],
+		divideBy: null,
+
+		// rendering options
+		settings: {
+			controls: {
+				isOpen: false // control panel is hidden by default
+			},
+			matrix: {
+				useCanvas: window.location.hash?.slice(1) == 'canvas',
+				cellEncoding: '', // can be oncoprint
+				margin: {
+					top: 10,
+					right: 5,
+					bottom: 20,
+					left: 50
+				},
+				// set any dataset-defined sample limits and sort priority, otherwise undefined
+				// put in settings, so that later may be overridden by a user
+				maxSample: 0,
+				sortPriority: undefined,
+				truncatePriority: undefined,
+
+				sampleNameFilter: '',
+				sortSamplesBy: 'selectedTerms',
+				sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: {} /*split: {char: '', index: 0}*/ }],
+				sortTermsBy: 'sampleCount', // or 'as listed'
+				samplecount4gene: true,
+				cellbg: '#ececec',
+				colw: 0,
+				colwMin: 0.5,
+				colwMax: 24,
+				colspace: 1,
+				colgspace: 8,
+				collabelpos: 'bottom',
+				collabelvisible: true,
+				colglabelpos: true,
+				collabelgap: 5,
+				collabelpad: 1,
+				rowh: 18,
+				rowspace: 1,
+				rowgspace: 8,
+				rowlabelpos: 'left', // | 'right'
+				rowlabelgap: 5,
+				rowlabelvisible: true,
+				rowlabelpad: 1,
+				grpLabelFontSize: 12,
+				minLabelFontSize: 6,
+				maxLabelFontSize: 16,
+				transpose: false,
+				sampleLabelOffset: 120,
+				sampleGrpLabelOffset: 120,
+				termLabelOffset: 80,
+				termGrpLabelOffset: 80,
+				duration: 0,
+				zoomLevel: 1,
+				zoomCenterPct: 0,
+				zoomIndex: 0,
+				zoomGrpIndex: 0,
+				zoomMin: 0.5,
+				zoomIncrement: 0.5,
+				zoomStep: 10,
+				scrollHeight: 12,
+				controlLabels: {
+					samples: 'Samples',
+					terms: 'Variables'
+				}
+			}
+		}
+	}
+
+	const s = config.settings
+	const fontsize = Math.max(s.matrix.rowh + s.matrix.rowspace - 3 * s.matrix.rowlabelpad, 12)
+
+	s.legend = {
+		ontop: false,
+		lineh: 25,
+		padx: 5,
+		padleft: 0, //150,
+		padright: 20,
+		padbtm: 30,
+		fontsize,
+		iconh: fontsize - 2,
+		iconw: fontsize - 2,
+		hangleft: 1,
+		linesep: false
+	}
+
+	const overrides = app.vocabApi.termdbConfig.matrix || {}
+	copyMerge(config.settings.matrix, overrides.settings)
+
+	// may apply term-specific changes to the default object
+	copyMerge(config, opts)
+
+	// harcode these overrides for now
+	config.settings.matrix.duration = 0
+	config.settings.matrix.colw = 0
+
+	const promises = []
+	for (const grp of config.termgroups) {
+		for (const tw of grp.lst) {
+			// force the saved session to request the most up-to-data dictionary term data from server
+			if (tw.id) delete tw.term
+			promises.push(fillTermWrapper(tw, app.vocabApi))
+		}
+	}
+	if (config.divideBy) promises.push(fillTermWrapper(config.divideBy, app.vocabApi))
+	await Promise.all(promises)
+	return config
+}

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -138,6 +138,21 @@ export class MatrixControls {
 
 					tables: [
 						{
+							header: ['Zoom', 'Min', 'Max'],
+							rows: [
+								{
+									label: 'Column Width',
+									type: 'number',
+									width: 50,
+									chartType: 'matrix',
+									inputs: [
+										{ settingsKey: 'colwMin', min: 0, max: 24, step: 0.2 },
+										{ settingsKey: 'colwMax', min: 10, max: 40, step: 0.2 }
+									]
+								}
+							]
+						},
+						{
 							header: ['Cells', 'Columns', 'Rows'],
 							rows: [
 								{
@@ -360,7 +375,7 @@ export class MatrixControls {
 		const d = this.parent.dimensions
 		if (this.zoomApi)
 			this.zoomApi.update({
-				value: Number(((100 * Math.min(s.colw * s.zoomLevel, s.maxColwZoomed)) / s.maxColwZoomed).toFixed(1))
+				value: Number(((100 * Math.min(s.colw * s.zoomLevel, s.colwMax)) / s.colwMax).toFixed(1))
 			})
 
 		if (this.svgScrollApi) {
@@ -395,7 +410,6 @@ export class MatrixControls {
 		app.tip.clear()
 
 		for (const t of tables) {
-			console.log(381, t.rows)
 			const table = app.tip.d.append('table')
 			//if (d.customHeaderRows) d.customHeaderRows(parent, table)
 
@@ -611,17 +625,17 @@ export class MatrixControls {
 		this.zoomApi = zoom({
 			holder,
 			settings: {
-				min: s.zoomMin, //Math.max(1, Math.floor((100 * 1) / s.maxColw)),
+				min: (100 * s.colwMin) / s.colwMax, //s.zoomMin, //Math.max(1, Math.floor((100 * 1) / s.colwMax)),
 				increment: s.zoomIncrement,
-				//max: 5,
-				step: s.zoomStep || 5
-				//value: s.colw/s.maxColw * 100,
+				max: 100,
+				step: s.zoomStep || 5,
+				value: ((s.colw / s.colwMax) * 100).toFixed(1)
 			},
 			callback: percentValue => {
 				const p = this.parent
 				const d = p.dimensions
 				const s = p.settings.matrix
-				const zoomLevel = (0.01 * percentValue * s.maxColwZoomed) / s.colw
+				const zoomLevel = (0.01 * percentValue * s.colwMax) / s.colw
 				const c = p.getVisibleCenterCell(0)
 				p.app.dispatch({
 					type: 'plot_edit',

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1,4 +1,3 @@
-import { select } from 'd3-selection'
 import { initByInput } from './controls.config'
 import { to_svg } from '../src/client'
 import { fillTermWrapper, termsettingInit } from '../termsetting/termsetting'
@@ -137,7 +136,7 @@ export class MatrixControls {
 					label: 'Dimensions',
 
 					tables: [
-						{
+						/*{
 							header: ['Zoom', 'Min', 'Max'],
 							rows: [
 								{
@@ -151,22 +150,33 @@ export class MatrixControls {
 									]
 								}
 							]
-						},
+						},*/
 						{
 							header: ['Cells', 'Columns', 'Rows'],
 							rows: [
 								{
-									label: 'Width or height',
+									label: 'Row height',
 									type: 'number',
 									width: 50,
 									chartType: 'matrix',
-									inputs: [
-										{ settingsKey: 'colw', min: 1, max: 24, step: 1 },
-										{ settingsKey: 'rowh', min: 8, max: 30, step: 1 }
-									]
+									inputs: [{ label: 'N/A' }, { settingsKey: 'rowh', min: 8, max: 30, step: 1 }]
 								},
 								{
-									label: 'Gaps',
+									label: 'Min col. width',
+									type: 'number',
+									width: 50,
+									chartType: 'matrix',
+									inputs: [{ settingsKey: 'colwMin', min: 0, max: 24, step: 0.2 }, { label: 'N/A' }]
+								},
+								{
+									label: 'Max col. width',
+									type: 'number',
+									width: 50,
+									chartType: 'matrix',
+									inputs: [{ settingsKey: 'colwMax', min: 1, max: 24, step: 0.2 }, { label: 'N/A' }]
+								},
+								{
+									label: 'Spacing',
 									type: 'number',
 									width: 50,
 									chartType: 'matrix',
@@ -176,7 +186,7 @@ export class MatrixControls {
 									]
 								},
 								{
-									label: 'Group gaps',
+									label: 'Group spacing',
 									type: 'number',
 									width: 50,
 									chartType: 'matrix',
@@ -191,7 +201,7 @@ export class MatrixControls {
 							header: ['Labels', 'Columns', 'Rows'],
 							rows: [
 								{
-									label: 'Gaps',
+									label: 'Spacing',
 									type: 'number',
 									width: 50,
 									chartType: 'matrix',
@@ -284,24 +294,6 @@ export class MatrixControls {
 		this.inputGroups = {
 			/*cols: [
 				{
-					label: 'Column width',
-					type: 'number',
-					chartType: 'matrix',
-					settingsKey: 'colw'
-				},
-				{
-					label: 'Column gap',
-					type: 'number',
-					chartType: 'matrix',
-					settingsKey: 'colspace'
-				},
-				{
-					label: 'Group gap',
-					type: 'number',
-					chartType: 'matrix',
-					settingsKey: 'colgspace'
-				},
-				{
 					label: 'Column label pad',
 					type: 'number',
 					chartType: 'matrix',
@@ -323,18 +315,6 @@ export class MatrixControls {
 			],
 
 			rows: [
-				{
-					label: 'Row height',
-					type: 'number',
-					chartType: 'matrix',
-					settingsKey: 'rowh'
-				},
-				{
-					label: 'Row gap',
-					type: 'number',
-					chartType: 'matrix',
-					settingsKey: 'rowspace'
-				},
 				{
 					label: 'Row label pad',
 					type: 'number',
@@ -401,7 +381,6 @@ export class MatrixControls {
 	}
 
 	async callback(event, d) {
-		console.log('test', d)
 		const { clientX, clientY } = event
 		const app = this.opts.app
 		const parent = this.opts.parent
@@ -410,7 +389,7 @@ export class MatrixControls {
 		app.tip.clear()
 
 		for (const t of tables) {
-			const table = app.tip.d.append('table')
+			const table = app.tip.d.append('table').attr('class', 'sjpp-controls-table')
 			//if (d.customHeaderRows) d.customHeaderRows(parent, table)
 
 			if (t.header) {

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -166,7 +166,7 @@ export class MatrixControls {
 									type: 'number',
 									width: 50,
 									chartType: 'matrix',
-									inputs: [{ settingsKey: 'colwMin', min: 0, max: 24, step: 0.2 }, { label: 'N/A' }]
+									inputs: [{ settingsKey: 'colwMin', min: 0.1, max: 16, step: 0.2 }, { label: 'N/A' }]
 								},
 								{
 									label: 'Max col. width',

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -22,7 +22,6 @@ export class MatrixControls {
 		//this.recover = new Recover({app: opts.app})
 		const state = this.parent.getState(appState)
 		this.setButtons(state.config.settings.matrix)
-		this.setInputGroups()
 		this.setZoomInput()
 		this.setDragToggle({
 			holder: this.opts.holder.append('div').style('display', 'inline-block'),
@@ -38,22 +37,221 @@ export class MatrixControls {
 			.selectAll('button')
 			.data([
 				{
-					value: 'samples',
 					label: s.controlLabels.samples || `Samples`,
-					getCount: () => this.parent.sampleOrder.length
+					getCount: () => this.parent.sampleOrder.length,
+					rows: [
+						{
+							label: 'Sort samples',
+							type: 'radio',
+							chartType: 'matrix',
+							settingsKey: 'sortSamplesBy',
+							options: [{ label: 'as-listed', value: 'asListed' }, { label: 'selected terms', value: 'selectedTerms' }]
+						},
+						{
+							label: 'Maximum #samples',
+							type: 'number',
+							chartType: 'matrix',
+							settingsKey: 'maxSample'
+						},
+						{
+							label: 'Group samples by',
+							type: 'term',
+							chartType: 'matrix',
+							configKey: 'divideBy',
+							vocabApi: this.opts.app.vocabApi,
+							state: {
+								vocab: this.opts.vocab
+								//activeCohort: appState.activeCohort
+							},
+							processInput: tw => {
+								if (tw) fillTermWrapper(tw)
+							}
+						},
+						{
+							label: 'Sample name regex filter',
+							type: 'text',
+							chartType: 'matrix',
+							settingsKey: 'sampleNameFilter'
+						}
+					]
 				},
 				{
-					value: 'anno',
 					label: s.controlLabels.terms || `Variables`,
 					getCount: () => this.parent.termOrder.length,
-					customInputs: this.appendTermInputs
+					customInputs: this.appendTermInputs,
+					rows: [
+						/*{
+							label: 'Terms as columns',
+							boxLabel: '',
+							type: 'checkbox',
+							chartType: 'matrix',
+							settingsKey: 'transpose'
+						},*/
+						{
+							label: 'Display sample counts for gene',
+							boxLabel: '',
+							type: 'checkbox',
+							chartType: 'matrix',
+							settingsKey: 'samplecount4gene'
+						},
+						/*{
+							NOTE: this is only by term group, not global to all rows
+							label: 'Minimum #samples',
+							type: 'number',
+							chartType: 'matrix',
+							settingsKey: 'minNumSamples',
+							title: 'Minimum number of hits for a row to be visible'
+						},*/
+						{
+							label: 'Sort terms',
+							type: 'radio',
+							chartType: 'matrix',
+							settingsKey: 'sortTermsBy',
+							options: [{ label: 'as-listed', value: 'asListed' }, { label: 'by sample count', value: 'sampleCount' }]
+						}
+					]
 				},
-				{ value: 'styles', label: 'Styles' },
-				{ value: 'cols', label: 'Column layout' },
-				{ value: 'rows', label: 'Row layout' },
-				{ value: 'legend', label: 'Legend layout' },
-				//{ label: 'Undo', callback: ()=>this.recover.goto(-1) },
-				//{ label: 'Redo', callback: ()=>this.recover.goto(1) },
+
+				{
+					label: 'Styles',
+					rows: [
+						{
+							label: 'Cell encoding',
+							type: 'radio',
+							chartType: 'matrix',
+							settingsKey: 'cellEncoding',
+							options: [{ label: 'Default', value: '' }, { label: 'Oncoprint', value: 'oncoprint' }]
+						},
+						{
+							label: 'Background color',
+							type: 'color',
+							chartType: 'matrix',
+							settingsKey: 'cellbg'
+						}
+					]
+				},
+
+				// { value: 'cols', label: 'Column layout' },
+				// { value: 'rows', label: 'Row layout' },
+				{
+					label: 'Dimensions',
+
+					tables: [
+						{
+							header: ['Cells', 'Columns', 'Rows'],
+							rows: [
+								{
+									label: 'Width or height',
+									type: 'number',
+									width: 50,
+									chartType: 'matrix',
+									inputs: [
+										{ settingsKey: 'colw', min: 1, max: 24, step: 1 },
+										{ settingsKey: 'rowh', min: 8, max: 30, step: 1 }
+									]
+								},
+								{
+									label: 'Gaps',
+									type: 'number',
+									width: 50,
+									chartType: 'matrix',
+									inputs: [
+										{ settingsKey: 'colspace', min: 0, max: 20, step: 1 },
+										{ settingsKey: 'rowspace', min: 0, max: 20, step: 1 }
+									]
+								},
+								{
+									label: 'Group gaps',
+									type: 'number',
+									width: 50,
+									chartType: 'matrix',
+									inputs: [
+										{ settingsKey: 'colgspace', min: 0, max: 20, step: 1 },
+										{ settingsKey: 'rowgspace', min: 0, max: 20, step: 1 }
+									]
+								}
+							]
+						},
+						{
+							header: ['Labels', 'Columns', 'Rows'],
+							rows: [
+								{
+									label: 'Gaps',
+									type: 'number',
+									width: 50,
+									chartType: 'matrix',
+									inputs: [
+										{ settingsKey: 'collabelgap', min: 0, max: 20, step: 1 },
+										{ settingsKey: 'rowlabelgap', min: 0, max: 20, step: 1 }
+									]
+								}
+							]
+						}
+					]
+				},
+
+				{
+					label: 'Legend layout',
+					rows: [
+						//ontop: false,
+						{
+							label: 'Font size',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'fontsize'
+						},
+						{
+							label: 'Line height',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'lineh'
+						},
+						{
+							label: 'Icon height',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'iconh'
+						},
+						{
+							label: 'Icon width',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'iconw'
+						},
+						{
+							label: 'Left margin',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'padleft'
+						},
+						/*{
+							label: 'Bottom margin',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'padbtm'
+						},*/
+						{
+							label: 'Item left pad',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'padx'
+						},
+						{
+							label: 'Item layout',
+							type: 'checkbox',
+							chartType: 'legend',
+							settingsKey: 'linesep',
+							boxLabel: 'Line separated'
+						},
+						{
+							label: 'Left indent',
+							type: 'number',
+							chartType: 'legend',
+							settingsKey: 'hangleft'
+						}
+					]
+				},
+
 				{
 					label: 'Download SVG',
 					callback: () => to_svg(this.opts.getSvg(), 'matrix', { apply_dom_styles: true })
@@ -69,98 +267,7 @@ export class MatrixControls {
 
 	setInputGroups() {
 		this.inputGroups = {
-			samples: [
-				/*{
-					label: 'Sample as rows',
-					boxLabel: '',
-					type: 'checkbox',
-					chartType: 'matrix',
-					settingsKey: 'transpose'
-				},*/
-				{
-					label: 'Sort samples',
-					type: 'radio',
-					chartType: 'matrix',
-					settingsKey: 'sortSamplesBy',
-					options: [{ label: 'as-listed', value: 'asListed' }, { label: 'selected terms', value: 'selectedTerms' }]
-				},
-				{
-					label: 'Maximum #samples',
-					type: 'number',
-					chartType: 'matrix',
-					settingsKey: 'maxSample'
-				},
-				{
-					label: 'Group samples by',
-					type: 'term',
-					chartType: 'matrix',
-					configKey: 'divideBy',
-					vocabApi: this.opts.app.vocabApi,
-					state: {
-						vocab: this.opts.vocab
-						//activeCohort: appState.activeCohort
-					},
-					processInput: tw => {
-						if (tw) fillTermWrapper(tw)
-					}
-				},
-				{
-					label: 'Sample name regex filter',
-					type: 'text',
-					chartType: 'matrix',
-					settingsKey: 'sampleNameFilter'
-				}
-			],
-
-			anno: [
-				/*{
-					label: 'Terms as columns',
-					boxLabel: '',
-					type: 'checkbox',
-					chartType: 'matrix',
-					settingsKey: 'transpose'
-				},*/
-				{
-					label: 'Display sample counts for gene',
-					boxLabel: '',
-					type: 'checkbox',
-					chartType: 'matrix',
-					settingsKey: 'samplecount4gene'
-				},
-				/*{
-					NOTE: this is only by term group, not global to all rows
-					label: 'Minimum #samples',
-					type: 'number',
-					chartType: 'matrix',
-					settingsKey: 'minNumSamples',
-					title: 'Minimum number of hits for a row to be visible'
-				},*/
-				{
-					label: 'Sort terms',
-					type: 'radio',
-					chartType: 'matrix',
-					settingsKey: 'sortTermsBy',
-					options: [{ label: 'as-listed', value: 'asListed' }, { label: 'by sample count', value: 'sampleCount' }]
-				}
-			],
-
-			styles: [
-				{
-					label: 'Cell encoding',
-					type: 'radio',
-					chartType: 'matrix',
-					settingsKey: 'cellEncoding',
-					options: [{ label: 'Default', value: '' }, { label: 'Oncoprint', value: 'oncoprint' }]
-				},
-				{
-					label: 'Background color',
-					type: 'color',
-					chartType: 'matrix',
-					settingsKey: 'cellbg'
-				}
-			],
-
-			cols: [
+			/*cols: [
 				{
 					label: 'Column width',
 					type: 'number',
@@ -238,66 +345,7 @@ export class MatrixControls {
 					settingsKey: 'rowlabelpos',
 					options: [{ label: 'Rows', value: 'left' }, { label: 'Groups', value: 'right' }]
 				}
-			],
-
-			legend: [
-				//ontop: false,
-				{
-					label: 'Font size',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'fontsize'
-				},
-				{
-					label: 'Line height',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'lineh'
-				},
-				{
-					label: 'Icon height',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'iconh'
-				},
-				{
-					label: 'Icon width',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'iconw'
-				},
-				{
-					label: 'Left margin',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'padleft'
-				},
-				/*{
-					label: 'Bottom margin',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'padbtm'
-				},*/
-				{
-					label: 'Item left pad',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'padx'
-				},
-				{
-					label: 'Item layout',
-					type: 'checkbox',
-					chartType: 'legend',
-					settingsKey: 'linesep',
-					boxLabel: 'Line separated'
-				},
-				{
-					label: 'Left indent',
-					type: 'number',
-					chartType: 'legend',
-					settingsKey: 'hangleft'
-				}
-			]
+			],*/
 		}
 	}
 
@@ -338,30 +386,50 @@ export class MatrixControls {
 	}
 
 	async callback(event, d) {
+		console.log('test', d)
 		const { clientX, clientY } = event
 		const app = this.opts.app
 		const parent = this.opts.parent
-		const table = app.tip.clear().d.append('table')
-		//if (d.customHeaderRows) d.customHeaderRows(parent, table)
+		const tables = d.tables || [d]
 
-		for (const inputConfig of this.inputGroups[d.value]) {
-			const input = await initByInput[inputConfig.type](
-				Object.assign(
-					{},
-					{
-						holder: table.append('tr'),
-						dispatch: app.dispatch,
-						id: parent.id,
-						//instanceNum: this.instanceNum,
-						debug: this.opts.debug,
-						parent
-					},
-					inputConfig
+		app.tip.clear()
+
+		for (const t of tables) {
+			console.log(381, t.rows)
+			const table = app.tip.d.append('table')
+			//if (d.customHeaderRows) d.customHeaderRows(parent, table)
+
+			if (t.header) {
+				table
+					.append('tr')
+					.selectAll('th')
+					.data(t.header)
+					.enter()
+					.append('th')
+					.html(d => d)
+			}
+
+			for (const inputConfig of t.rows) {
+				const input = await initByInput[inputConfig.type](
+					Object.assign(
+						{},
+						{
+							holder: table.append('tr'),
+							dispatch: app.dispatch,
+							id: parent.id,
+							//instanceNum: this.instanceNum,
+							debug: this.opts.debug,
+							parent
+						},
+						inputConfig
+					)
 				)
-			)
-			input.main(parent.config)
+				input.main(parent.config)
+			}
+
+			if (t.customInputs) t.customInputs(this, app, parent, table)
 		}
-		if (d.customInputs) d.customInputs(this, app, parent, table)
+
 		app.tip.showunder(event.target)
 	}
 

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -445,7 +445,6 @@ function setTermActions(self) {
 		const [tcopy] = self.getSorterTerms(t)
 		const termgroups = self.termGroups
 		termgroups[t.grpIndex].lst[t.lstIndex] = tcopy
-		termgroups[t.grpIndex].sortTermsBy = 'asListed'
 		for (const g of termgroups) {
 			for (const tw of g.lst) {
 				if (!tw.sortSamples) continue

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -893,8 +893,9 @@ class Matrix {
 						key,
 						totalIndex,
 						grpIndex,
-						row,
-						siblingCells
+						//row,
+						siblingCells,
+						t
 					}
 
 					// will assign x, y, width, height, fill, label, order, etc
@@ -1045,7 +1046,7 @@ export async function getPlotConfig(opts, app) {
 				sortTermsBy: 'sampleCount', // or 'as listed'
 				samplecount4gene: true,
 				cellbg: '#ececec',
-				colw: 0,
+				colw: 8,
 				maxColw: 16,
 				maxColwZoomed: 34,
 				colspace: 1,
@@ -1061,8 +1062,6 @@ export async function getPlotConfig(opts, app) {
 				rowlabelpos: 'left', // | 'right'
 				rowlabelgap: 5,
 				rowlabelvisible: true,
-				rowglabelpos: true,
-				rowlabelgap: 5,
 				rowlabelpad: 1,
 				grpLabelFontSize: 12,
 				minLabelFontSize: 6,

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -632,18 +632,21 @@ class Matrix {
 		else this.autoDimensions.delete('rowh')
 
 		const s = this.settings.matrix
+		this.computedSettings = {}
 		if (this.autoDimensions.has('colw')) {
 			const offset = !s.transpose
 				? s.termLabelOffset + s.termGrpLabelOffset
 				: s.sampleLabelOffset + s.sampleGrpLabelOffset
 			const colw = Math.round((document.body.clientWidth - 300 - offset) / this.sampleOrder.length)
-			s.colw = Math.max(s.colwMin, Math.min(colw, s.colwMax)) //; console.log(640, [colw, s.colw, s.colwMin, s.colwMax])
-			s.colspace = s.zoomLevel * s.colw <= 2 ? 0 : 1
+			this.computedSettings.colw = Math.max(s.colwMin, Math.min(colw, s.colwMax)) //; console.log(640, [colw, s.colw, s.colwMin, s.colwMax])
+			this.computedSettings.colspace = s.zoomLevel * this.computedSettings.colw <= 2 ? 0 : s.colspace || 1
 		}
 
 		if (this.autoDimensions.has('rowh')) {
-			s.rowh = Math.max(5, Math.round(screen.availHeight / this.numTerms))
+			this.computedSettings.rowh = Math.max(5, Math.round(screen.availHeight / this.numTerms))
 		}
+
+		copyMerge(this.settings.matrix, this.computedSettings)
 	}
 
 	setLabelsAndScales() {

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -60,7 +60,7 @@ class Matrix {
 		this.dom = {
 			header: opts.header,
 			holder,
-			contentNode: opts.holder.node().closest('.sjpp-output-sandbox-content'),
+			contentNode: opts.holder.node().closest('.sjpp-output-sandbox-content') || opts.holder.node().parentNode,
 			errdiv,
 			controls,
 			loadingDiv,
@@ -632,12 +632,14 @@ class Matrix {
 
 		const s = this.settings.matrix
 		this.computedSettings = {}
-		this.availContentWidth = this.dom.contentNode.getBoundingClientRect().width - 66 - s.margin.right - xOffset
+		// TODO: the additional 65 space should not be hardcoded, but determined based on matrix holder/config
+		this.availContentWidth = this.dom.contentNode.getBoundingClientRect().width - 65 - s.margin.right - xOffset
 		if (this.autoDimensions.has('colw')) {
 			const offset = !s.transpose
 				? s.termLabelOffset + s.termGrpLabelOffset
 				: s.sampleLabelOffset + s.sampleGrpLabelOffset
-			const colw = this.availContentWidth / this.sampleOrder.length
+			// TODO: the additional 80 space should not be hardcoded, but determined on matrix holder/config
+			const colw = (this.availContentWidth - 80) / this.sampleOrder.length
 			this.computedSettings.colw = Math.max(s.colwMin, Math.min(colw, s.colwMax))
 		}
 		this.computedSettings.colspace = s.zoomLevel * this.computedSettings.colw < 2 ? 0 : s.colspace

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -80,7 +80,7 @@ export function setRenderers(self) {
 				if (!window.OffscreenCanvas) canvas.remove()
 			}
 		} else {
-			const rects = g.selectAll('rect').data(series.cells, (cell, i) => cell.sample + ';;' + cell.tw.$id + ';;' + i)
+			const rects = g.selectAll('rect').data(series.cells, cell => cell.sample + ';;' + cell.tw.$id)
 			rects.exit().remove()
 			rects.each(self.renderCell)
 			rects

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -68,7 +68,7 @@ export async function init(arg, holder, genomes) {
 
 	const gdcCohort = getGdcCohort(arg)
 	console.log(arg, gdcCohort)
-	const genes = (await getGenes(arg, gdcCohort, CGConly)).slice(0, 3)
+	const genes = await getGenes(arg, gdcCohort, CGConly) //.slice(0, 3)
 
 	const opts = {
 		holder,

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -67,7 +67,8 @@ export async function init(arg, holder, genomes) {
 	})
 
 	const gdcCohort = getGdcCohort(arg)
-	const genes = await getGenes(arg, gdcCohort, CGConly)
+	console.log(arg, gdcCohort)
+	const genes = (await getGenes(arg, gdcCohort, CGConly)).slice(0, 3)
 
 	const opts = {
 		holder,

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -830,7 +830,7 @@ h2 {
 
 .sjpp-controls-table tr:hover {
   /*font-weight: 600;*/
-  text-shadow:0px 0px 1px black;
+  text-shadow:0px 0px 0.5px black;
   background-color: rgba(240, 236, 123, 0.5);
 }
 

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -824,6 +824,16 @@ h2 {
     vertical-align: middle;
 }
 
+.sjpp-controls-table {
+  margin-bottom: 10px;
+}
+
+.sjpp-controls-table tr:hover {
+  /*font-weight: 600;*/
+  text-shadow:0px 0px 1px black;
+  background-color: rgba(240, 236, 123, 0.5);
+}
+
 .sja_edit_btn {
     display: inline-block;
     color: black;
@@ -1160,6 +1170,3 @@ sandbox header
     -ms-user-select: none;
     -user-select: none;
 }
-
-
-


### PR DESCRIPTION
Many imrpovements and fixes:
- combine column and row dimensions control menus
- default to auto-dimensions based on the available width of the matrix parent holder
- debounce dispatched changes that could freeze the re-render of a very dense matrix
- bug fix to not force the matrix sortTermsBy to asListed when sorting samples against a term
- bug fix for visible downloaded svg image