### PR TITLE
Summary scatter bug fix

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -110,6 +110,7 @@ class Scatter {
 			)
 		copyMerge(this.settings, this.config.settings.sampleScatter)
 		const reqOpts = this.getDataRequestOpts()
+		if (reqOpts.coordTWs.length == 1) return //To allow removing a term in the controls, though nothing is rendered (summary tab with violin active)
 		this.data = await this.app.vocabApi.getScatterData(reqOpts)
 
 		if (this.data.error) throw this.data.error


### PR DESCRIPTION
When deleting a term in the violin after accessing the scatter tab, an error was thrown, fixed