### PR TITLE
Burguer color

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -126,6 +126,12 @@ class Barchart {
 						{ label: 'Log', value: 'log', getDisplayStyle: plot => (plot.term2 ? 'none' : 'inline-block') },
 						{ label: 'Proportion', value: 'pct', getDisplayStyle: plot => (plot.term2 ? 'inline-block' : 'none') }
 					]
+				},
+				{
+					label: 'Background color',
+					type: 'color',
+					chartType: 'barchart',
+					settingsKey: 'barColor'
 				}
 			]
 			if (this.app.getState().termdbConfig.multipleTestingCorrection) {
@@ -522,7 +528,7 @@ class Barchart {
 		const group = this.state.ssid && this.state.ssid.groups && this.state.ssid.groups[result.dataId]
 		const bin = this.bins?.[2]?.find(bin => bin.label == result.dataId)
 		this.term2toColor[result.dataId] = !t2
-			? 'rgb(144, 23, 57)'
+			? this.config.settings.barchart.barColor
 			: group && 'color' in group
 			? group.color
 			: bin
@@ -891,7 +897,6 @@ function setInteractivity(self) {
 	self.handlers = getHandlers(self)
 
 	self.download = function() {
-		console.log(769)
 		if (!self.state) return
 		// has to be able to handle multichart view
 		const mainGs = []
@@ -978,7 +983,8 @@ export function getDefaultBarSettings(app) {
 		overlay: 'none',
 		divideBy: 'none',
 		rowlabelw: 250,
-		asterisksVisible: app?.getState()?.termdbConfig?.multipleTestingCorrection ? true : false
+		asterisksVisible: app?.getState()?.termdbConfig?.multipleTestingCorrection ? true : false,
+		barColor: 'rgb(144, 23, 57)'
 	}
 }
 

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -220,7 +220,7 @@ class Scatter {
 				max: 1
 			}
 		]
-		if (this.opts.parent?.type == 'summary')
+		if (this.opts.parent?.type == 'summary') {
 			inputs.unshift(
 				...[
 					{
@@ -247,6 +247,13 @@ class Scatter {
 					}
 				]
 			)
+			inputs.push({
+				label: 'Default color',
+				type: 'color',
+				chartType: 'sampleScatter',
+				settingsKey: 'defaultColor'
+			})
+		}
 
 		this.components = {
 			controls: await controlsInit({
@@ -342,6 +349,7 @@ export function getDefaultScatterSettings() {
 		axisTitleFontSize: 16,
 		showAxes: true,
 		showRef: true,
-		opacity: 0.8
+		opacity: 0.8,
+		defaultColor: 'rgb(144, 23, 57)'
 	}
 }

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -225,6 +225,7 @@ export function setRenderers(self) {
 
 	self.getColor = function(c) {
 		if (self.config.colorTW?.q.mode == 'continuous' && 'sampleId' in c) return self.colorGenerator(c.category)
+		if (c.category == 'Default') return self.config.settings.sampleScatter.defaultColor
 		const category = self.colorLegend.get(c.category)
 		return category.color
 	}

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -184,10 +184,9 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 
 	const shapeMap = new Map()
 	const colorMap = new Map()
-
 	for (const sample of cohortSamples) {
 		const dbSample = data.samples[sample.sampleId.toString()]
-		if (!dbSample) {
+		if (!dbSample && q.colorTW) {
 			console.log(JSON.stringify(sample) + ' not in the database or filtered')
 			continue
 		}


### PR DESCRIPTION
The barchart and the scatter plot can customize the default color for the bars/samples. Discussed with @siosonel how to implement it. Remains to set colors for the bars ( without overlay). I will add this soon.