### PR TITLE
wip create custom terms from Group filters

### DIFF
--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -1,8 +1,8 @@
-import { getInitFxn, getCompInit, Bus } from '../rx'
+import { getInitFxn, getCompInit, Bus } from '#rx'
 import { select } from 'd3-selection'
-import { Menu } from '../src/client'
+import { Menu } from '#dom/menu'
 import { TVSInit } from './tvs'
-import { vocabInit } from '../termdb/vocabulary'
+import { vocabInit } from '#termdb/vocabulary'
 
 const MENU_OPTION_HIGHLIGHT_COLOR = '#fff'
 
@@ -72,13 +72,19 @@ class Filter {
 	validateOpts(opts) {
 		const o = Object.assign({}, defaults, opts)
 		if (!o.holder) throw '.holder missing'
-		if (!o.vocab) throw '.vocab missing'
 
-		if (o.vocab.dslabel) {
-			if (!o.vocab.genome) throw 'vocab.genome missing'
+		if (o.vocabApi) {
+			this.vocabApi = o.vocabApi
 		} else {
-			if (!o.vocab.terms) throw 'vocab.terms missing'
+			if (!o.vocab) throw '.vocab missing'
+
+			if (o.vocab.dslabel) {
+				if (!o.vocab.genome) throw 'vocab.genome missing'
+			} else {
+				if (!o.vocab.terms) throw 'vocab.terms missing'
+			}
 		}
+
 		if (typeof o.callback != 'function') throw '.callback() is not a function'
 		if (o.getVisibleRoot && typeof o.getVisibleRoot != 'function')
 			throw '.getVisibleRoot() must be a function if set as an option'
@@ -267,10 +273,12 @@ class Filter {
 				genome: state.genome,
 				dslabel: state.dslabel
 			}
-			this.vocabApi = vocabInit({
-				app,
-				state: { vocab }
-			})
+			if (!this.vocabApi) {
+				this.vocabApi = vocabInit({
+					app,
+					state: { vocab }
+				})
+			}
 		}
 
 		this.vocabApi.main()
@@ -1072,10 +1080,10 @@ function setInteractivity(self) {
 
 		const termdb = await import('../termdb/app')
 		termdb.appInit({
+			vocabApi: self.vocabApi,
 			holder: self.dom.termSrcDiv,
 			getCategoriesArguments: self.opts.getCategoriesArguments,
 			state: {
-				vocab: self.opts.vocab,
 				activeCohort: self.activeCohort,
 				termfilter: { filter: rootFilterCopy }
 			},
@@ -1173,10 +1181,10 @@ function setInteractivity(self) {
 
 		const termdb = await import('../termdb/app')
 		termdb.appInit({
+			vocabApi: self.vocabApi,
 			holder: self.dom.termSrcDiv,
 			getCategoriesArguments: self.opts.getCategoriesArguments,
 			state: {
-				vocab: self.opts.vocab,
 				activeCohort: self.activeCohort,
 				header_mode: 'search_only',
 				termfilter: { filter: self.getAdjustedRoot(filter.$id, filter.join) }

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -1,6 +1,6 @@
-import { getCompInit } from '../rx'
+import { getCompInit } from '#rx'
 import { Menu } from '#dom/menu'
-import { getNormalRoot } from '../filter/filter'
+import { getNormalRoot } from '#filter/filter'
 import { select } from 'd3-selection'
 
 class MassCharts {
@@ -308,9 +308,9 @@ function setRenderers(self) {
 
 		const termdb = await import('../termdb/app')
 		termdb.appInit({
+			vocabApi: self.app.vocabApi,
 			holder: self.dom.tip.d.append('div'),
 			state: {
-				vocab: self.state.vocab,
 				activeCohort: self.state.activeCohort,
 				nav: {
 					header_mode: 'search_only'

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -40,11 +40,11 @@ class MassGroups {
 	}
 
 	getState(appState) {
-		this.customTerms = appState.customTerms
 		const state = {
 			termfilter: appState.termfilter,
 			groups: rebaseGroupFilter(appState),
-			termdbConfig: appState.termdbConfig
+			termdbConfig: appState.termdbConfig,
+			customTerms: appState.customTerms
 		}
 		return state
 	}
@@ -135,16 +135,30 @@ class MassGroups {
 	}
 
 	displayCustomTerms() {
-		this.dom.customTermDiv.select('*').remove()
-		if (this.customTerms.length == 0)
-			return this.dom.customTermDiv.append('div').text('No custom variables. Use above controls to create new ones.')
-		for (const { name, tw } of this.customTerms) {
+		this.dom.customTermDiv.selectAll('*').remove()
+		if (this.state.customTerms.length == 0) {
+			this.dom.customTermDiv
+				.append('div')
+				.text('No custom variables. Use above controls to create new ones.')
+				.style('font-size', '.8em')
+			return
+		}
+		this.dom.customTermDiv
+			.append('div')
+			.style('margin-bottom', '10px')
+			.style('font-size', '.8em')
+			.text('Following custom variables are available in all charts where variables are used. Click one to delete.')
+		for (const { name, tw } of this.state.customTerms) {
 			const div = this.dom.customTermDiv.append('div')
 			div
 				.text(name)
 				.attr('class', 'sja_filter_tag_btn')
 				.style('padding', '3px 6px')
 				.style('border-radius', '6px')
+				.style('margin-right', '5px')
+				.on('click', () => {
+					this.app.vocabApi.deleteCustomTerm(name)
+				})
 		}
 	}
 }
@@ -183,8 +197,8 @@ function initUI(self) {
 	// bottom box to list custom terms
 	self.dom.customTermDiv = self.dom.holder
 		.append('div')
-		.style('margin-top', '20px')
-		.style('border', 'solid 1px #eee')
+		.style('margin', '20px')
+		.style('border-left', 'solid 1px black')
 		.style('padding', '10px')
 }
 
@@ -345,7 +359,6 @@ async function clickLaunchBtn(self) {
 	const tw = await self.groups2samplelst(groups)
 	tw.term.name = name
 
-	//await self.app.dispatch({ type:'app_refresh', state:{ customTerms: [...self.customTerms, {name, term: tw.term}]}})
 	self.app.vocabApi.addCustomTerm({ name, term: tw.term })
 
 	self.dom.newTermSpan.style('display', 'none')

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -72,7 +72,7 @@ class TdbNav {
 				}),
 				filter: filterRxCompInit({
 					app: this.app,
-					vocab: this.opts.vocab,
+					vocabApi: this.app.vocabApi,
 					holder: this.dom.subheader.filter.append('div'),
 					hideLabel: this.opts.header_mode === 'with_tabs',
 					emptyLabel: '+Add new filter',

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -116,6 +116,7 @@ class TdbNav {
 		if (action.type == 'plot_create') return true
 		if (action.type == 'plot_delete') return true
 		if (action.type == 'app_refresh') return true
+		if (action.type.endsWith('_customTerm')) return true
 	}
 
 	getState(appState) {

--- a/client/mass/plot.js
+++ b/client/mass/plot.js
@@ -17,6 +17,7 @@ class MassPlot {
 		if (action.type.startsWith('filter')) return true
 		if (action.type.startsWith('cohort')) return true
 		if (action.type == 'app_refresh') return true
+		if (action.type.endsWith('customTerm')) return true
 	}
 
 	getState(appState) {

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -42,6 +42,7 @@ const defaultState = {
 		}
 	},
 	groups: [], // element: {name=str, filter={}}, to show in Groups tab
+	customTerms: [], // element: {name=str, term={}}, able to attach more attr to object if needed
 	autoSave: true
 }
 
@@ -343,6 +344,15 @@ TdbStore.prototype.actions = {
 				}
 			}
 		}
+	},
+
+	add_customTerm(action) {
+		this.state.customTerms.push(action.obj)
+	},
+
+	delete_customTerm({ name }) {
+		const i = this.state.customTerms.findIndex(i => i.name == name)
+		if (i != -1) this.state.customTerms.splice(i, 1)
 	}
 }
 

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -129,6 +129,8 @@ function setRenderers(self) {
 				break
 			case 'geneVariant':
 				break
+			case 'samplelst':
+				break
 			default:
 				throw 'unknown term type'
 		}

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -39,7 +39,8 @@ class MassDict {
 			vocab: appState.vocab,
 			activeCohort: appState.activeCohort,
 			termfilter: appState.termfilter,
-			selectdTerms: appState.selectedTerms
+			selectdTerms: appState.selectedTerms,
+			customTerms: appState.customTerms
 		}
 	}
 

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -1,5 +1,5 @@
-import { getCompInit, copyMerge } from '../rx'
-import { appInit } from '../termdb/app'
+import { getCompInit, copyMerge } from '#rx'
+import { appInit } from '#termdb/app'
 
 class MassDict {
 	constructor(opts) {
@@ -12,6 +12,7 @@ class MassDict {
 
 	async init(appState) {
 		this.tree = await appInit({
+			vocabApi: this.app.vocabApi,
 			holder: this.dom.holder,
 			state: this.getState(appState),
 			tree: {

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -1,4 +1,4 @@
-import { dofetch3, isInSession } from '../common/dofetch'
+import { dofetch3, isInSession } from '#common/dofetch'
 
 export class Vocab {
 	constructor(opts) {
@@ -146,5 +146,27 @@ export class Vocab {
 			}
 			return qlst
 		} else return []
+	}
+
+	async addCustomTerm(obj) {
+		// save one custom term
+		// obj = { name:str, term:{} }
+		await this.app.dispatch({
+			type: 'add_customTerm',
+			obj
+		})
+	}
+	async deleteCustomTerm(name) {
+		// delete by name
+		await this.app.dispatch({
+			type: 'delete_customTerm',
+			name
+		})
+	}
+
+	async getCustomTerms() {
+		if (!Array.isArray(this.state.customTerms)) return [] // only mass state has this, here this instance is missing it. do not crash
+		// return list of term{}; do not return whole object
+		return this.state.customTerms.map(i => i.term)
 	}
 }

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -151,7 +151,6 @@ class TdbApp {
 			this.store = await storeInit({ app: this.api, state: this.opts.state })
 			this.state = await this.store.copyState()
 			await this.setComponents()
-			await this.mayShowCustomTerms()
 			await this.api.dispatch()
 		} catch (e) {
 			this.printError(e)
@@ -199,6 +198,8 @@ class TdbApp {
 		this.dom.submitBtn
 			.property('disabled', !n)
 			.text(!n ? 'Search or click term(s)' : `Submit ${n} term${n > 1 ? 's' : ''}`)
+
+		await this.mayShowCustomTerms()
 	}
 
 	printError(e) {
@@ -213,6 +214,7 @@ class TdbApp {
 			this.dom.customTermDiv.style('display', 'none')
 			return
 		}
+		this.dom.customTermDiv.selectAll('*').remove()
 		// has custom terms, show
 		this.dom.customTermDiv
 			.append('div')

--- a/client/termsetting/handlers/samplelst.js
+++ b/client/termsetting/handlers/samplelst.js
@@ -63,4 +63,18 @@ function addTable(div, name, group, noButtonCallback) {
 	})
 }
 
-export function fillTW(tw, vocabApi) {}
+export function fillTW(tw, vocabApi) {
+	// quick fix!!
+	if (!tw.q.type) tw.q.type = 'custom-groupsetting'
+	if (!tw.q.groups) tw.q.groups = []
+	if (tw.q.groups.length == 0) {
+		for (const k in tw.term.values) {
+			const v = tw.term.values[k]
+			tw.q.groups.push({
+				name: k,
+				inuse: v.inuse,
+				values: v.list
+			})
+		}
+	}
+}

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -355,7 +355,6 @@ function getPj(q, data, tdb, ds) {
 			key: 'key' + i,
 			val: 'val' + i,
 			nval: 'nval' + i,
-			isGenotype: q['term' + i + '_is_genotype'],
 			bins,
 			q: d.q,
 			orderedLabels: getOrderedLabels(d.term, bins, d.q)
@@ -371,12 +370,7 @@ function getPj(q, data, tdb, ds) {
 				// mutates the data row, ok since
 				// rows from db query are unique to request
 				for (const d of terms) {
-					if (d.isGenotype) {
-						const genotype = q.sample2gt.get(row.sample)
-						if (!genotype) return
-						row[d.key] = genotype
-						row[d.val] = genotype
-					} else if (d.term.type == 'condition') {
+					if (d.term.type == 'condition') {
 						row[d.key] = d.q.bar_by_grade && row[d.key] in d.term.values ? d.term.values[row[d.key]].label : row[d.key]
 						row[d.val] = row[d.key]
 					} else if (d.term.type == 'float' || d.term.type == 'integer') {
@@ -514,7 +508,7 @@ export function getOrderedLabels(term, bins, q) {
 function getTermDetails(q, tdb, index) {
 	const termnum_id = 'term' + index + '_id'
 	const termid = q[termnum_id]
-	const term = termid && !q['term' + index + '_is_genotype'] ? tdb.q.termjsonByOneid(termid) : {}
+	const term = q[termid] ? tdb.q.termjsonByOneid(termid) : q[`term${index}`] ? q[`term${index}`] : {}
 	const termIsNumeric = term.type == 'integer' || term.type == 'float'
 	const unannotatedValues = term.values
 		? Object.keys(term.values)

--- a/server/src/termdb.sql.samplelst.js
+++ b/server/src/termdb.sql.samplelst.js
@@ -4,6 +4,8 @@ export const sampleLstSql = {
 			samples,
 			samplesString
 		for (const [i, group] of tw.q.groups.entries()) {
+			// default group.in=true, TODO: put this in fillTW?
+			if (!('in' in group)) group.in = true
 			samples = group.values.map(value => value.sampleId)
 			samplesString = samples.map(() => '?').join(',')
 


### PR DESCRIPTION
tried a few CI and all can pass
todos
1. (done) upon adding a new term, state is changed but app is not notified (the term pill does not show in Group ui)
2. new term seems to be generating wrong charts
3. in termdb app.js,  show custom terms based on usecase (filter by term type)

i think it's fine to merge this, will continue to fix all issues next. if breaking things can't be fixed by monday, can go with nuclear option to disable "Groups" from nav.js altogether until after AACR