### PR TITLE
render one matrix canvas image

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -37,7 +37,7 @@ export async function getPlotConfig(opts, app) {
 				samplecount4gene: true,
 				cellbg: '#ececec',
 				colw: 0,
-				colwMin: 0.5,
+				colwMin: 1 / window.devicePixelRatio,
 				colwMax: 18,
 				colspace: 1,
 				colgspace: 8,

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -699,7 +699,7 @@ export class MatrixControls {
 		}
 
 		// hardcode to always be in select mode on first render
-		opts.target.style('cursor', 'crosshair')
+		opts.target.style('cursor', 'default')
 
 		const instance = {
 			opts: Object.assign({}, defaults, opts),
@@ -732,7 +732,7 @@ export class MatrixControls {
 		function setMode(m) {
 			instance.opts.mouseMode = m
 			self.parent.settings.matrix.mouseMode = m
-			opts.target.style('cursor', m == 'select' ? 'crosshair' : 'grab')
+			opts.target.style('cursor', m == 'select' ? 'default' : 'grab')
 			instance.dom.selectBtn.style('background-color', m == 'select' ? instance.opts.activeBgColor : '')
 			instance.dom.grabBtn.style('background-color', m == 'pan' ? instance.opts.activeBgColor : '')
 		}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -8,6 +8,7 @@ export function setInteractivity(self) {
 	self.showCellInfo = function(event) {
 		if (self.activeLabel || self.zoomArea) return
 		if (!(event.target.tagName == 'rect' || event.target.tagName == 'image')) return
+		if (event.target.tagName !== 'rect' && !self.imgBox) self.imgBox = event.target.getBoundingClientRect()
 		const d = event.target.tagName == 'rect' ? event.target.__data__ : self.getImgCell(event)
 		if (!d || !d.term || !d.sample) {
 			self.dom.tip.hide()
@@ -50,19 +51,22 @@ export function setInteractivity(self) {
 	}
 
 	self.getImgCell = function(event) {
-		const d = event.target.__data__
-		const rect = event.target.getBoundingClientRect()
-		const x2 = event.clientX - rect.x
+		//const [x,y] = pointer(event, event.target)
+		const y = event.clientY - self.imgBox.y - event.target.clientTop
+		const d = event.target.__data__.find(series => series.y <= y && y <= series.y + self.dimensions.dy)
+		if (!d) return
+		const x2 = event.clientX - self.imgBox.x - event.target.clientLeft
 		for (const cell of d.cells) {
 			const min = cell.x
 			const max = cell.x + self.dimensions.dx
-			if (min < x2 && x2 <= max) return cell
+			if (min <= x2 && x2 <= max) return cell
 		}
 		return null
 	}
 
 	self.mouseout = function() {
 		if (!self.activeLabel && !self.activeLabel && !self.activeLabel) self.dom.tip.hide()
+		delete self.imgBox
 	}
 
 	self.legendClick = function() {}

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -67,7 +67,7 @@ export async function init(arg, holder, genomes) {
 	})
 
 	const gdcCohort = getGdcCohort(arg)
-	const genes = (await getGenes(arg, gdcCohort, CGConly)).slice(0, 3)
+	const genes = (await getGenes(arg, gdcCohort, CGConly))//.slice(0, 3)
 
 	const opts = {
 		holder,


### PR DESCRIPTION
The number of concurrent offscreen web workers for offscreen canvas may be limited and thus cause rendering slowdown.

To test, add `#canvas` has to the URL, like this: http://localhost:3000/example.gdc.matrix.html#canvas. You can increase the maximum #(sample|cases) in the corresponding control menu.