### PR TITLE
Matrix width

### DIFF
--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -73,7 +73,7 @@ function setRenderers(self) {
 		const s = self.settings
 		const d = self.currData.dimensions
 		self.dom.clipRect
-			.attr('x', s.zoomLevel <= 1 && d.mainw >= d.zoomedMainW ? 0 : Math.abs(d.seriesXoffset) / d.zoomedMainW)
+			.attr('x', (s.zoomLevel <= 1 && d.mainw >= d.zoomedMainW ? -1 : -1 + Math.abs(d.seriesXoffset)) / d.zoomedMainW)
 			.attr('y', 0)
 			.attr('width', Math.min(d.mainw, d.maxMainW) / this.totalWidth) // d.zoomedMainW)
 			.attr('height', 1)

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -40,7 +40,7 @@ export async function getPlotConfig(opts, app) {
 				gridStroke: '#fff',
 				colw: 0,
 				colwMin: 1 / window.devicePixelRatio,
-				colwMax: 18,
+				colwMax: 16,
 				colspace: 1,
 				colgspace: 8,
 				collabelpos: 'bottom',
@@ -71,6 +71,10 @@ export async function getPlotConfig(opts, app) {
 				zoomMin: 0.5,
 				zoomIncrement: 0.5,
 				zoomStep: 10,
+				// renderedWMax should not be exposed as a user-input
+				// 60000 pixels is based on laptop and external monitor tests,
+				// when a canvas dataURL image in a zoomed-in matrix svg stops rendering
+				renderedWMax: 60000 / window.devicePixelRatio,
 				scrollHeight: 12,
 				controlLabels: {
 					samples: 'Samples',

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -39,7 +39,7 @@ export async function getPlotConfig(opts, app) {
 				showGrid: '', // false | 'pattern' | 'rect'
 				gridStroke: '#fff',
 				colw: 0,
-				colwMin: 1 / window.devicePixelRatio,
+				colwMin: 0.1 / window.devicePixelRatio,
 				colwMax: 16,
 				colspace: 1,
 				colgspace: 8,
@@ -113,7 +113,7 @@ export async function getPlotConfig(opts, app) {
 	// force auto-dimensions for colw
 	m.colw = 0
 	// support deprecated sortSamplesBy value from a saved session
-	if (m.sortSamplesBy === 'selectedSamples') m.sortSamplesBy = 'class'
+	if (m.sortSamplesBy === 'selectedTerms') m.sortSamplesBy = 'class'
 
 	const promises = []
 	for (const grp of config.termgroups) {

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -74,7 +74,7 @@ export async function getPlotConfig(opts, app) {
 				// renderedWMax should not be exposed as a user-input
 				// 60000 pixels is based on laptop and external monitor tests,
 				// when a canvas dataURL image in a zoomed-in matrix svg stops rendering
-				renderedWMax: 60000 / window.devicePixelRatio,
+				imgWMax: 60000 / window.devicePixelRatio,
 				scrollHeight: 12,
 				controlLabels: {
 					samples: 'Samples',

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -850,7 +850,7 @@ export class MatrixControls {
 						config: {
 							settings: {
 								matrix: {
-									zoomCenterPct: s.zoomCenterPct,
+									zoomCenterPct: 0.5,
 									zoomIndex: c.totalIndex,
 									zoomGrpIndex: c.grpIndex
 								}

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -430,7 +430,11 @@ export class MatrixControls {
 		const d = this.parent.dimensions
 		if (this.zoomApi)
 			this.zoomApi.update({
-				value: Number(((100 * Math.min(s.colw * s.zoomLevel, s.colwMax)) / s.colwMax).toFixed(1))
+				value: Number(((100 * Math.min(s.colw * s.zoomLevel, s.colwMax)) / s.colwMax).toFixed(1)),
+				min: (100 * s.colwMin) / s.colwMax, //s.zoomMin, //Math.max(1, Math.floor((100 * 1) / s.colwMax)),
+				increment: s.zoomIncrement,
+				max: 100,
+				step: s.zoomStep || 5
 			})
 
 		if (this.svgScrollApi) {
@@ -833,8 +837,9 @@ export class MatrixControls {
 				const s = p.settings.matrix
 				const d = p.dimensions
 				if (eventType == 'move') {
+					//console.log(d.xOffset + d.seriesXoffset - dx, d.yOffset)
+					p.dom.clipRect.attr('x', -d.seriesXoffset + dx)
 					p.dom.seriesesG.attr('transform', `translate(${d.xOffset + d.seriesXoffset - dx},${d.yOffset})`)
-					p.dom.clipRect.attr('x', Math.abs(d.seriesXoffset - dx) / d.zoomedMainW)
 					p.layout.top.attr.adjustBoxTransform(-dx)
 					p.layout.btm.attr.adjustBoxTransform(-dx)
 				} else if (eventType == 'up') {

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1466,7 +1466,7 @@ function setZoomPanActions(self) {
 			if (event.target.__data__?.sample) return event.target.__data__
 			if (event.target.__data__?.xg) {
 				const width = event.clientX - event.target.getBoundingClientRect().x + d.seriesXoffset
-				const i = Math.floor(visibleWidth / d.dx)
+				const i = Math.floor(width / d.dx)
 				return self.sampleOrder[i]
 			}
 		}

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -136,7 +136,7 @@ export function setRenderers(self) {
 			cell.fill = cell.$id in self.colorScaleByTermId ? self.colorScaleByTermId[cell.$id](cell.key) : getRectFill(cell)
 		const x = cell.x ? cell.x - d.xMin : 0
 		const y = _y ? _y + cell.y : cell.y || 0
-		const width = cell.width || d.colw
+		const width = Math.max(d.pxw, cell.width || d.colw)
 		const height = cell.height || s.rowh
 		ctx.fillStyle = cell.fill
 		ctx.fillRect(x, y, width, height)


### PR DESCRIPTION
This update fixes the issue of canvas not rendering when the matrix is really zoomed-in and causes an extremely wide context width. The solution is to limit the canvas image width to a known maximum that works in the mb16 screen and an external monitor, dependent on devicePixelRatio.

Other changes:
- sharpened the canvas image by using a min pixel width for rendered rects and a non-integer context width
- scrolling and zooming bug fixes