### PR TITLE
Matrix in firefox and safari

### DIFF
--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -113,14 +113,51 @@ export const setCellProps = {
 }
 
 export const maySetEmptyCell = {
-	geneVariant: (siblingCells, cellTemplate, s, d) => {
-		if (siblingCells.find(c => c.value.dt == 4)) return
+	geneVariant: setVariantEmptyCell,
+	integer: setNumericEmptyCell,
+	float: setNumericEmptyCell,
+	categorical: setDefaultEmptyCell
+}
+
+function setVariantEmptyCell(siblingCells, cellTemplate, s, d) {
+	if (siblingCells.find(c => c.value.dt == 4)) return
+	const cell = Object.assign({}, cellTemplate)
+	cell.fill = s.cellbg
+	cell.height = s.rowh
+	cell.width = d.colw
+	cell.x = cell.totalIndex * d.dx + cell.grpIndex * s.colgspace
+	cell.y = 0
+	return cell
+}
+
+function setNumericEmptyCell(siblingCells, cellTemplate, s, d) {
+	const q = cellTemplate.tw.q
+	if (q.mode != 'continuous') {
+		if (siblingCells.length) return
+		setDefaultEmptyCell(siblingCells, cellTemplate, s, d)
+	} else {
+		if (q?.mode != 'continuous') return
+		const tws = cellTemplate.tw.settings
+		const h = tws ? tws.barh + tws.gap : s.rowh
+		if (cellTemplate.height >= h) return
 		const cell = Object.assign({}, cellTemplate)
 		cell.fill = s.cellbg
-		cell.height = s.rowh
+		cell.height = h || s.rowh
 		cell.width = d.colw
 		cell.x = cell.totalIndex * d.dx + cell.grpIndex * s.colgspace
 		cell.y = 0
 		return cell
 	}
+}
+
+function setDefaultEmptyCell(siblingCells, cellTemplate, s, d) {
+	// assumes that valid value(s) will fill-up the cell
+	if (siblingCells.length) return
+	const cell = Object.assign({}, cellTemplate)
+	cell.fill = s.cellbg
+	cell.height = s.rowh
+	cell.width = d.colw
+	cell.x = cell.totalIndex * d.dx + cell.grpIndex * s.colgspace
+	cell.y = 0
+	return cell
 }

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -138,7 +138,7 @@ function setNumericEmptyCell(siblingCells, cellTemplate, s, d) {
 	} else {
 		if (q?.mode != 'continuous') return
 		const tws = cellTemplate.tw.settings
-		const h = tws ? tws.barh + tws.gap : s.rowh
+		const h = tws ? tws.barh + 2 * tws.gap : s.rowh
 		if (cellTemplate.height >= h) return
 		const cell = Object.assign({}, cellTemplate)
 		cell.fill = s.cellbg

--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -43,8 +43,8 @@ export class MatrixCluster {
 			for (const yg of this.yGrps) {
 				const y = yg.prevGrpTotalIndex * d.dy + yg.grpIndex * s.rowgspace + yg.totalHtAdjustments
 				const height = d.dy * (yg.processedLst || yg.grp.lst).length + yg.grpTotals.htAdjustment - s.rowspace
-				const offsetX = Math.max(1, s.colspace)
-				const offsetY = Math.max(1, s.rowspace)
+				const offsetX = 1 //Math.max(1, s.colspace)
+				const offsetY = 1 //Math.max(1, s.rowspace)
 				clusters.push({
 					xg,
 					yg,

--- a/client/plots/matrix.cluster.js
+++ b/client/plots/matrix.cluster.js
@@ -122,7 +122,7 @@ function setRenderers(self) {
 			// - sets cluster rect fill=s.gridStroke under cell rects, where the gaps between rects are perceived as lines
 			//
 			.attr('fill', !s.showGrid ? s.cellbg : s.gridStroke)
-			.attr('stroke', s.gridStroke)
+			.attr('stroke', s.outlineStroke)
 			.attr('stroke-width', 1)
 	}
 

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -38,6 +38,7 @@ export async function getPlotConfig(opts, app) {
 				cellbg: '#ececec',
 				showGrid: '', // false | 'pattern' | 'rect'
 				gridStroke: '#fff',
+				outlineStroke: '#ccc',
 				colw: 0,
 				colwMin: 0.1 / window.devicePixelRatio,
 				colwMax: 16,

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -16,6 +16,7 @@ export async function getPlotConfig(opts, app) {
 			},
 			matrix: {
 				svgCanvasSwitch: 1000, // the number of samples to trigger switching between svg and canvas
+				useMinPixedWidth: false, // canvas may be hazy if false, but more accurately reflects column density
 				cellEncoding: '', // can be oncoprint
 				margin: {
 					top: 10,

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -200,6 +200,15 @@ export class MatrixControls {
 								label: 'Outline color',
 								type: 'color',
 								chartType: 'matrix',
+								settingsKey: 'outlineStroke',
+								colspan: 2,
+								align: 'center'
+								//getDisplayStyle: plot => this.parent.settings.matrix.showGrid ? '' : 'none'
+							},
+							{
+								label: 'Grid line color',
+								type: 'color',
+								chartType: 'matrix',
 								settingsKey: 'gridStroke',
 								colspan: 2,
 								align: 'center'

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -223,7 +223,7 @@ export class MatrixControls {
 								align: 'center'
 							},
 							{
-								label: 'Use canvas when #samples exceeds',
+								label: 'Use canvas if #samples exceeds',
 								type: 'number',
 								chartType: 'matrix',
 								settingsKey: 'svgCanvasSwitch',
@@ -233,6 +233,16 @@ export class MatrixControls {
 								min: 0,
 								max: 10000,
 								step: 1
+							},
+							{
+								label: 'Canvas mininum pixel width',
+								type: 'checkbox',
+								boxLabel: 'apply',
+								chartType: 'matrix',
+								settingsKey: 'useMinPixelWidth',
+								colspan: 2,
+								align: 'center',
+								getDisplayStyle: () => (this.parent.settings.matrix.useCanvas ? '' : 'none')
 							}
 						]
 					},

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -835,6 +835,7 @@ class Matrix {
 				const siblingCells = []
 				for (const [i, value] of values.entries()) {
 					const cell = Object.assign({ key, siblingCells }, cellTemplate)
+					cell.valueIndex = i
 
 					// will assign x, y, width, height, fill, label, order, etc
 					const legend = setCellProps[t.tw.term.type](cell, t.tw, anno, value, s, t, this, width, height, dx, dy, i)

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -683,7 +683,7 @@ class Matrix {
 			ny * dy + (this[`${row}Grps`].length - 1) * s.rowgspace + (this[`${row}s`].slice(-1)[0]?.totalHtAdjustments || 0)
 
 		const colLabelFontSize = Math.min(
-			Math.max(colw + s.colspace - 2 * s.collabelpad, s.minLabelFontSize),
+			Math.max(colw + s.colspace - 2 * s.collabelpad - s.colspace, s.minLabelFontSize),
 			s.maxLabelFontSize
 		)
 
@@ -718,7 +718,9 @@ class Matrix {
 		if (layout.btm.prefix == 'sample') layout.btm.display = colw >= s.minLabelFontSize ? '' : 'none'
 
 		const leftFontSize =
-			_l_ == 'Grp' ? s.grpLabelFontSize : Math.max(s.rowh + s.rowspace - 2 * s.rowlabelpad, s.minLabelFontSize)
+			_l_ == 'Grp'
+				? s.grpLabelFontSize
+				: Math.max(s.rowh + s.rowspace - 2 * s.rowlabelpad - s.rowspace, s.minLabelFontSize)
 		layout.left.attr = {
 			boxTransform: `translate(${xOffset - s.rowlabelgap}, ${yOffset})`,
 			labelTransform: '',
@@ -766,7 +768,7 @@ class Matrix {
 		//
 		// for a canvas-generated image, the image is sharper when the image width is not an integer,
 		// so subtract a negligible decimal value to have a numeric real/float width value
-		const imgW = (s.imgWMax > zoomedMainW ? zoomedMainW : s.imgWMax) - 0.000000001
+		const imgW = (s.imgWMax > zoomedMainW ? zoomedMainW : s.imgWMax) - 0.0000001
 		const halfImgW = 0.5 * imgW
 		// determine how the canvas image will be offset relative to the center of mainw (the visible width)
 		const unwantedRightOvershoot = Math.max(0, centerCellX + halfImgW - zoomedMainW)

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -181,14 +181,12 @@ class Matrix {
 			})
 
 			this.legendRenderer(this.legendData, {
-				settings: Object.assign(
-					{
-						svgw: Math.max(400, d.mainw + d.xOffset - this.settings.matrix.margin.right),
-						svgh: d.mainh + d.yOffset,
-						dimensions: d
-					},
-					this.settings.legend
-				)
+				settings: Object.assign({}, this.settings.legend, {
+					svgw: Math.max(400, d.mainw + d.xOffset - this.settings.matrix.margin.right),
+					svgh: d.mainh + d.yOffset,
+					dimensions: d,
+					padleft: this.settings.legend.padleft + d.xOffset
+				})
 			})
 
 			await this.adjustSvgDimensions(prevTranspose)

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -9,9 +9,9 @@ export function setRenderers(self) {
 		const x = s.zoomLevel <= 1 && d.mainw >= d.zoomedMainW ? 0 : Math.abs(d.seriesXoffset) / d.imgW
 
 		self.dom.clipRect
-			.attr('x', d.xOffset)
+			.attr('x', d.xOffset - 1)
 			.attr('y', 0)
-			.attr('width', d.mainw)
+			.attr('width', d.mainw + 1)
 			// add 500 so that the column labels are not clipped
 			.attr('height', d.mainh + 500)
 
@@ -58,7 +58,9 @@ export function setRenderers(self) {
 		const last = series.cells[series.cells.length - 1]
 		const height = series.y + last?.y + s.rowh
 
-		const rects = g.selectAll('rect').data(series.cells, cell => cell.sample + ';;' + cell.tw.$id)
+		const rects = g
+			.selectAll('rect')
+			.data(series.cells, cell => cell.sample + ';;' + cell.tw.$id + ';;' + cell.valueIndex)
 		rects.exit().remove()
 		rects.each(self.renderCell)
 		rects
@@ -97,9 +99,6 @@ export function setRenderers(self) {
 		}
 
 		if (window.OffscreenCanvas) {
-			//const bitmap = canvas.transferToImageBitmap()
-			//g.append('image').node().getContext('bitmaprenderer').transferFromImageBitmap(bitmap)
-			//const blob =
 			const reader = new FileReader()
 			reader.addEventListener(
 				'load',

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -91,7 +91,7 @@ export function setRenderers(self) {
 		ctx.imageSmoothingQuality = 'high'
 		//ctx.lineWidth = 0.5
 		//ctx.setTransform(pxr, 0, 0, pxr, 0, 0)
-		ctx.scale(pxr, pxr)
+		if (window.OffscreenCanvas) ctx.scale(pxr, pxr)
 		for (const series of serieses) {
 			for (const cell of series.cells) {
 				self.renderCellWithCanvas(ctx, cell, series, s, d, series.y)
@@ -121,6 +121,12 @@ export function setRenderers(self) {
 			)
 			const dataURL = reader.readAsDataURL(await canvas.convertToBlob({ quality: 1 }))
 		} else {
+			_g?.remove()
+			self.dom.seriesesG
+				//.transition()
+				//.duration(duration)
+				.attr('transform', `translate(${d.xOffset + d.seriesXoffset},${d.yOffset})`)
+
 			const dataURL = canvas.toDataURL()
 			g.append('image').attr('xlink:href', dataURL)
 			if (!window.OffscreenCanvas) canvas.remove()


### PR DESCRIPTION
- Fix zoom area not rendering in Firefox
- Fix dom canvas rendering in Safari which does not support OffscreenCanvas
- Fix grid rendering for quantitative/continuous terms
- More control options for grid outline, canvas min-pixel width detection
- Improved auto-width computation, legend offset 