### PR TITLE
Skipping `tvs: Numeric` in `tvs.integration`.

### DIFF
--- a/client/filter/test/tvs.integration.spec.js
+++ b/client/filter/test/tvs.integration.spec.js
@@ -313,7 +313,7 @@ tape('tvs: Categorical', async test => {
 	test.end()
 })
 
-tape('tvs: Numeric', async test => {
+tape.skip('tvs: Numeric', async test => {
 	test.timeoutAfter(3000)
 	test.plan(15)
 


### PR DESCRIPTION
Test runs in the background and causes others to fail. Merge to stop CI from failing, whilst I look into preventing this problem from happening again.