### PR TITLE
Using termwrappers in the custom terms and allowing term events to ha…

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -237,7 +237,7 @@ function setRenderers(self) {
 					// summary/survival/cuminc all expect config.term{} to be a termsetting object, but not term (which is confusing)
 					// thus convert term into a termwrapper (termsetting obj)
 					// tw.q{} is missing and will be fill in with default settings
-					const tw = { id: term.id, term }
+					const tw = term.q ? term : { id: term.id, term }
 					action.config[chart.usecase.detail] = tw
 					self.dom.tip.hide()
 					self.app.dispatch(action)

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -4,7 +4,7 @@ import { filterInit, getNormalRoot, filterPromptInit, getFilterItemByTag } from 
 import { select } from 'd3-selection'
 import { appInit } from '#termdb/app'
 import { renderTable } from '#dom/table'
-import { getSamplelstTW } from '../plots/sampleScatter.interactivity'
+import { getSamplelstTW } from '#termsetting/handlers/samplelst'
 
 /*
 this
@@ -85,7 +85,11 @@ class MassGroups {
 		for (const g of groups) {
 			const samples = await this.app.vocabApi.getFilteredSampleCount(g.filter, 'list')
 			const items = []
-			for (const sample of samples) items.push({ sampleId: sample.id, sample: sample.name })
+			for (const sample of samples) {
+				const item = { sampleId: sample.id }
+				if ('name' in sample) item.sample = sample.name
+				items.push(item)
+			}
 			samplelstGroups.push({ name: g.name, items })
 		}
 		const name = samplelstGroups.length == 1 ? samplelstGroups[0].name : 'Sample groups'
@@ -359,7 +363,7 @@ async function clickLaunchBtn(self) {
 	const tw = await self.groups2samplelst(groups)
 	tw.term.name = name
 
-	self.app.vocabApi.addCustomTerm({ name, term: tw.term })
+	self.app.vocabApi.addCustomTerm({ name, tw })
 
 	self.dom.newTermSpan.style('display', 'none')
 }

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -4,6 +4,7 @@ import { dofetch3 } from '#common/dofetch'
 import { mclass, morigin, dt2label } from '#shared/common'
 import { Menu } from '#dom/menu'
 import { rgb } from 'd3-color'
+import { getSamplelstTW } from '#termsetting/handlers/samplelst'
 
 export function setInteractivity(self) {
 	self.mouseover = function(event) {
@@ -665,48 +666,4 @@ function distance(x1, y1, x2, y2) {
 	const y = y2 - y1
 	const distance = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2))
 	return distance
-}
-
-export function getSamplelstTW(groups, name = 'groups', groupsetting = {}) {
-	const values = {}
-	const qgroups = []
-	let samples
-	for (const group of groups) {
-		values[group.name] = { key: group.name, label: group.name }
-		samples = getGroupSamples(group)
-		const qgroup = {
-			name: group.name,
-			in: true,
-			values: samples
-		}
-		qgroups.push(qgroup)
-	}
-	if (groups.length == 1) {
-		const name2 = 'Not in ' + groups[0].name
-		values[name2] = { key: name2, label: name2 }
-		qgroups.push({
-			name: name2,
-			in: false,
-			values: samples
-		})
-	}
-	const tw = {
-		term: { name, type: 'samplelst', values },
-		q: {
-			mode: 'custom-groupsetting',
-			groups: qgroups,
-			groupsetting
-		}
-	}
-	return tw
-
-	function getGroupSamples(group) {
-		const values = []
-		for (const item of group.items) {
-			const value = { sampleId: item.sampleId }
-			if ('sample' in item) value.sample = item.sample
-			values.push(value)
-		}
-		return values
-	}
 }

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -167,6 +167,6 @@ export class Vocab {
 	async getCustomTerms() {
 		if (!Array.isArray(this.state.customTerms)) return [] // only mass state has this, here this instance is missing it. do not crash
 		// return list of term{}; do not return whole object
-		return this.state.customTerms.map(i => i.term)
+		return this.state.customTerms.map(i => i.tw)
 	}
 }

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -98,6 +98,7 @@ class TdbApp {
 				// no need to create extra on
 
 				o.tree.click_term_wrapper = async term => {
+					console.log('term', term)
 					// this function wraps user-defined click_term, to encapsulate some logic
 
 					if (this.state.termdbConfig.termMatch2geneSet) {
@@ -210,14 +211,15 @@ class TdbApp {
 
 	async mayShowCustomTerms() {
 		// only run once, upon initiating this tree ui
-		const terms = await this.api.vocabApi.getCustomTerms()
-		if (!Array.isArray(terms) || terms.length == 0) return this.dom.customTermDiv.style('display', 'none')
+		const tws = await this.api.vocabApi.getCustomTerms()
+
+		if (!Array.isArray(tws) || tws.length == 0) return this.dom.customTermDiv.style('display', 'none')
 
 		// filter for display terms with usecase
 		const useTerms = []
-		for (const t of terms) {
-			const uses = isUsableTerm(t, this.state.tree.usecase)
-			if (uses.has('plot')) useTerms.push(t)
+		for (const tw of tws) {
+			const uses = isUsableTerm(tw.term, this.state.tree.usecase)
+			if (uses.has('plot')) useTerms.push(tw)
 		}
 		if (useTerms.length == 0) return this.dom.customTermDiv.style('display', 'none')
 
@@ -227,25 +229,25 @@ class TdbApp {
 			.append('div')
 			.text('CUSTOM VARIABLES')
 			.style('font-size', '.7em')
-		for (const term of useTerms) {
+		for (const tw of useTerms) {
 			this.dom.customTermDiv
 				.append('div')
 				.style('margin-bottom', '3px')
 				.append('div')
-				.text(term.name)
+				.text(tw.term.name)
 				.attr('class', 'sja_filter_tag_btn')
 				.style('padding', '3px 6px')
 				.style('border-radius', '6px')
 				.on('click', () => {
 					if (!this.opts.tree) return // click callbacks are all under tree{}
 					if (this.opts.tree.click_term) {
-						this.opts.tree.click_term(term)
+						this.opts.tree.click_term(tw)
 						return
 					}
 					if (this.opts.tree.click_term2select_tvs) {
 						this.api.dispatch({
 							type: 'submenu_set',
-							submenu: { term: term, type: 'tvs' }
+							submenu: { term: tw.term, type: 'tvs' }
 						})
 						return
 					}

--- a/client/termsetting/handlers/samplelst.js
+++ b/client/termsetting/handlers/samplelst.js
@@ -1,4 +1,4 @@
-import { getPillNameDefault } from '#termsetting'
+import { getPillNameDefault, get$id } from '#termsetting'
 import { renderTable } from '#dom/table'
 
 export function getHandler(self) {
@@ -76,5 +76,51 @@ export function fillTW(tw, vocabApi) {
 				values: v.list
 			})
 		}
+	}
+}
+
+export function getSamplelstTW(groups, name = 'groups', groupsetting = {}) {
+	const values = {}
+	const qgroups = []
+	let samples
+	for (const group of groups) {
+		values[group.name] = { key: group.name, label: group.name }
+		samples = getGroupSamples(group)
+		const qgroup = {
+			name: group.name,
+			in: true,
+			values: samples
+		}
+		qgroups.push(qgroup)
+	}
+	if (groups.length == 1) {
+		const name2 = 'Not in ' + groups[0].name
+		values[name2] = { key: name2, label: name2 }
+		qgroups.push({
+			name: name2,
+			in: false,
+			values: samples
+		})
+	}
+	const $id = get$id()
+	const tw = {
+		$id,
+		term: { $id, name, type: 'samplelst', values },
+		q: {
+			mode: 'custom-groupsetting',
+			groups: qgroups,
+			groupsetting
+		}
+	}
+	return tw
+
+	function getGroupSamples(group) {
+		const values = []
+		for (const item of group.items) {
+			const value = { sampleId: item.sampleId }
+			if ('sample' in item) value.sample = item.sample
+			values.push(value)
+		}
+		return values
 	}
 }

--- a/client/termsetting/termsetting.js
+++ b/client/termsetting/termsetting.js
@@ -26,6 +26,10 @@ opts{}
 const idSuffix = `_ts_${(+new Date()).toString().slice(-8)}`
 let $id = 0
 
+export function get$id() {
+	return `${$id++}${idSuffix}`
+}
+
 const defaultOpts = {
 	menuOptions: '{edit,reuse}', // ['edit', 'replace', 'save', 'remove'],
 	menuLayout: 'vertical'
@@ -503,7 +507,7 @@ function setInteractivity(self) {
 				click_term: async term => {
 					self.dom.tip.hide()
 
-					const tw = { id: term.id, term, q: { isAtomic: true }, isAtomic: true }
+					const tw = term.q ? term : { id: term.id, term, q: { isAtomic: true }, isAtomic: true }
 					if (self.opts.customFillTw) self.opts.customFillTw(tw)
 					await call_fillTW(tw, self.vocabApi, self.opts.defaultQ4fillTW)
 					// tw is now furbished
@@ -777,7 +781,7 @@ defaultQ{}
 */
 export async function fillTermWrapper(tw, vocabApi, defaultQ) {
 	tw.isAtomic = true
-	if (!tw.$id) tw.$id = `${$id++}${idSuffix}`
+	if (!tw.$id) tw.$id = get$id()
 
 	if (!tw.term) {
 		if (tw.id == undefined || tw.id === '') throw 'missing both .id and .term'
@@ -806,7 +810,7 @@ export async function fillTermWrapper(tw, vocabApi, defaultQ) {
 }
 
 async function call_fillTW(tw, vocabApi, defaultQ) {
-	if (!tw.$id) tw.$id = `${$id++}${idSuffix}`
+	if (!tw.$id) tw.$id = get$id()
 	const t = tw.term.type
 	const type = t == 'float' || t == 'integer' ? 'numeric.toggle' : t
 	let _

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -58,7 +58,7 @@ export function handle_request_closure(genomes) {
 			}
 			if (q.gettermdbconfig) return termdbConfig.make(q, res, ds, genome)
 			if (q.getcohortsamplecount) return res.send({ count: ds.cohort.termdb.q.getcohortsamplecount(q.cohort) })
-			if (q.getsamplecount) return res.send(await getSampleCount(q, ds))
+			if (q.getsamplecount) return res.send(await getSampleCount(req, q, ds))
 			if (q.getsamples) return await trigger_getsamples(q, res, ds)
 			if (q.getcuminc) return await trigger_getincidence(q, res, ds)
 			if (q.getsurvival) return await trigger_getsurvival(q, res, ds)
@@ -128,8 +128,12 @@ async function trigger_getsamples(q, res, ds) {
 	res.send({ samples })
 }
 
-async function getSampleCount(q, ds) {
-	if (q.getsamplecount == 'list') return await termdbsql.get_samples(q.filter, ds)
+async function getSampleCount(req, q, ds) {
+	const canDisplay = authApi.canDisplaySampleIds(req, ds)
+	if (q.getsamplecount == 'list') {
+		const samples = await termdbsql.get_samples(q.filter, ds, canDisplay)
+		return samples
+	}
 	return await termdbsql.get_samplecount(q, ds)
 }
 

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -43,7 +43,7 @@ get_label4key
 
 */
 
-export async function get_samples(qfilter, ds) {
+export async function get_samples(qfilter, ds, canDisplay = false) {
 	/*
 must have qfilter[]
 as the actual query is embedded in qfilter
@@ -60,6 +60,8 @@ return an array of sample names passing through the filter
 	let re
 	if (filter) re = sql.all(filter.values)
 	else re = sql.all()
+	if (canDisplay) return re
+	for (const item of re) delete item.name
 	return re
 }
 


### PR DESCRIPTION
@siosonel  and I worked in this branch to: pass sample names when possible. Use termwrappers in the custom terms and allow term events in the charts or the tree to handle term wrappers. These changes were needed to pass the original termwrapper that contains q settings to, for example,  hide sample names. So far our tests worked and all the tests are passing, but please test more to cover all the use cases where a term is passed and may need a term wrapper.