### PR TITLE
Pending fixes in the groups

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -237,7 +237,7 @@ function setRenderers(self) {
 					// summary/survival/cuminc all expect config.term{} to be a termsetting object, but not term (which is confusing)
 					// thus convert term into a termwrapper (termsetting obj)
 					// tw.q{} is missing and will be fill in with default settings
-					const tw = term.q ? term : { id: term.id, term }
+					const tw = term.term ? term : { id: term.id, term }
 					action.config[chart.usecase.detail] = tw
 					self.dom.tip.hide()
 					self.app.dispatch(action)

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -148,9 +148,7 @@ class MassGroups {
 		if (this.state.customTerms.length == 0) {
 			this.dom.customTermDiv
 				.append('div')
-				.text(
-					'No custom variables. Use above controls to create new ones. Custom variables are added to dictionary terms'
-				)
+				.text('No custom variables. Use above controls to create new ones. Custom variables are added to dictionary.')
 				.style('font-size', '.8em')
 			return
 		}

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -98,7 +98,6 @@ class TdbApp {
 				// no need to create extra on
 
 				o.tree.click_term_wrapper = async term => {
-					console.log('term', term)
 					// this function wraps user-defined click_term, to encapsulate some logic
 
 					if (this.state.termdbConfig.termMatch2geneSet) {

--- a/client/termsetting/termsetting.js
+++ b/client/termsetting/termsetting.js
@@ -507,7 +507,7 @@ function setInteractivity(self) {
 				click_term: async term => {
 					self.dom.tip.hide()
 
-					const tw = term.q ? term : { id: term.id, term, q: { isAtomic: true }, isAtomic: true }
+					const tw = term.term ? term : { id: term.id, term, q: { isAtomic: true }, isAtomic: true }
 					if (self.opts.customFillTw) self.opts.customFillTw(tw)
 					await call_fillTW(tw, self.vocabApi, self.opts.defaultQ4fillTW)
 					// tw is now furbished


### PR DESCRIPTION
Added some pending fixes to the PR from yesterday. Showing sample names was disabled always, fixed. Improved groups GUI as discussed previously. Used .term to check if term wrapper, as @siosonel commented out. Please check.