### PR TITLE
When the brush updates the range it misses the equal

### DIFF
--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -87,9 +87,8 @@ function applyBrush(self, elem, brush) {
 			const max = Number(maxvalue.toFixed(1))
 			range.startunbounded = min == range.start && inputRange.startunbounded //Limit by the brush, not by the user
 			range.stopunbounded = max == range.stop && inputRange.stopunbounded
-
-			const start = range.startunbounded ? '' : range.startinclusive ? `${range.start} <=` : `${range.start} <`
-			const stop = range.stopunbounded ? '' : range.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
+			const start = range.startunbounded ? '' : inputRange.startinclusive ? `${range.start} <=` : `${range.start} <`
+			const stop = range.stopunbounded ? '' : inputRange.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
 			// update inputs from brush move
 			brush.rangeInput.getInput().node().value = range.value ? `x = ${range.value}` : `${start} x ${stop}`
 		})


### PR DESCRIPTION
Fixes bug reported by @gavrielm. The filter was missing the equal. 