### PR TITLE
Filter group

### DIFF
--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -873,7 +873,9 @@ function setRenderers(self) {
 			// assume that a cohortFilter is always joined via intersection with other filters
 			return self.filter.lst.length == 1 && d == 'and' ? 'inline-block' : 'none'
 		} else {
-			return self.filter && self.filter.lst.length > 0 && self.filter.join !== d ? 'inline-block' : 'none'
+			return self.filter && self.filter.lst.length > 0 && (self.filter.join !== d || !self.filter.in)
+				? 'inline-block'
+				: 'none'
 		}
 	}
 }
@@ -1120,7 +1122,7 @@ function setInteractivity(self) {
 		} else {
 			if (!filterUiRoot.join) filterUiRoot.join = d // 'and' || 'or'
 
-			if (filterUiRoot.join == d) {
+			if (filterUiRoot.join == d && filterUiRoot.in) {
 				if (tvslst.length < 2 || filterUiRoot.join == 'and') {
 					filterUiRoot.lst.push(...tvslst)
 				} else {

--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -505,6 +505,7 @@ function setRenderers(self) {
 		const menuOptions = [
 			{ action: 'edit', html: ['', 'Edit', '&rsaquo;'], handler: self.editTerm },
 			{ action: 'join', html: ['&#10010;', '', '&rsaquo;'], handler: self.displayTreeMenu },
+			{ action: 'switch', html: ['', 'Switch to', ''], handler: self.switchJoin },
 			{ action: 'negate', html: ['', 'Negate', ''], handler: self.negateClause },
 			{ action: 'remove', html: ['&#10006;', 'Remove', ''], handler: self.removeTransform }
 		]
@@ -920,6 +921,19 @@ function setInteractivity(self) {
 			.select('td:nth-child(2)')
 			.html(grpAction ? filter.join.toUpperCase() : filter.join == 'and' ? 'OR' : 'AND')
 
+		menuRows
+			.filter(d => d.action == 'switch')
+			.style(
+				'display',
+				self.opts.joinWith.length < 2 ||
+					(filter.$id == self.filter.$id && filter.lst.length == 1) ||
+					!cls.includes('_join_')
+					? 'none'
+					: 'table-row'
+			)
+			.select('td:nth-child(2)')
+			.html(d => (filter.join == 'and' ? 'Switch to OR' : 'Switch to AND'))
+
 		self.dom.filterContainer.selectAll('.sja_filter_grp').style('background-color', 'transparent')
 		if (grpAction) {
 			if (cls.includes('join')) elem.parentNode.parentNode.style.backgroundColor = '#ee5'
@@ -931,7 +945,7 @@ function setInteractivity(self) {
 		event.stopPropagation()
 		if (d == self.activeData.menuOpt) return
 		self.activeData.menuOpt = d
-		if (self.activeData.elem.className.includes('join') && d.action !== 'join') {
+		if (self.activeData.elem.className.includes('join') && d.action !== 'join' && d.action != 'switch') {
 			self.activeData.item = self.activeData.filter
 			self.activeData.filter = findParent(self.filter, self.activeData.item)
 		}
@@ -1369,6 +1383,14 @@ function setInteractivity(self) {
 		self.activeData = { item: filter, filter, elem }
 		self.resetBlankPill(d.action)
 		self.displayTreeMenu(elem, d)
+	}
+
+	self.switchJoin = function(event, d) {
+		const filterUiRoot = JSON.parse(JSON.stringify(self.filter))
+		const filterCopy = findItem(filterUiRoot, self.activeData.filter.$id)
+		if (filterCopy.join < 2) return
+		filterCopy.join = filterCopy.join == 'and' ? 'or' : 'and'
+		self.refresh(filterUiRoot)
 	}
 }
 

--- a/client/filter/test/filter.integration.spec.js
+++ b/client/filter/test/filter.integration.spec.js
@@ -562,6 +562,57 @@ tape('add-transformer button interaction, 2-pill', async test => {
 	test.end()
 })
 
+tape('add-transformer button interaction, NEGATED 2-pill', async test => {
+	test.timeoutAfter(3000)
+	test.plan(6)
+
+	const opts = getOpts({
+		filterData: {
+			type: 'tvslst',
+			in: false,
+			join: 'and',
+			lst: [diaggrp(), agedx()]
+		}
+	})
+
+	await opts.filter.main(opts.filterData)
+	const adder = opts.holder
+		.selectAll('.sja_filter_add_transformer')
+		.filter(function() {
+			return this.style.display !== 'none'
+		})
+		.node()
+	adder.click()
+
+	await sleep(50)
+	test.notEqual(
+		opts.filter.Inner.dom.treeTip.d.node().style.display,
+		'none',
+		'should display the tree menu when clicking the add-transformer button'
+	)
+	test.equal(
+		opts.holder.node().querySelectorAll('.sja_filter_blank_pill').length,
+		1,
+		'should create exactly 1 blank pill when clicking on a two-pill root add-transformer'
+	)
+	test.equal(
+		opts.holder.node().querySelector('.sja_filter_blank_pill').firstChild.innerHTML,
+		'AND',
+		'should correctly label the join label between the potentially subnested root and blank pill'
+	)
+
+	const origFilter = JSON.parse(JSON.stringify(opts.filterData))
+	await addDemographicSexFilter(opts, adder)
+	test.deepEqual(
+		opts.filter.Inner.filter.lst[0].lst.map(t => t.tvs.term.id),
+		origFilter.lst.map(t => t.tvs.term.id),
+		'should subnest the original filter tvslst'
+	)
+	test.equal(opts.filterData.lst[1]?.tvs.term.id, 'sex', 'should append the new term to the re-rooted filter')
+	test.equal(opts.holder.selectAll('.sja_pill_wrapper').size(), 3, 'should display 3 pills')
+	test.end()
+})
+
 tape('pill Edit interaction', async test => {
 	test.timeoutAfter(3000)
 	test.plan(4)

--- a/client/filter/test/filter.integration.spec.js
+++ b/client/filter/test/filter.integration.spec.js
@@ -308,7 +308,7 @@ tape('1-entry root filter: visible controls', async test => {
 
 tape('2-entry root filter: visible controls', async test => {
 	test.timeoutAfter(5000)
-	test.plan(19)
+	test.plan(21)
 	const opts = getOpts({
 		filterData: {
 			type: 'tvslst',
@@ -383,11 +383,9 @@ tape('2-entry root filter: visible controls', async test => {
 
 	const joinOpt = menuRows.filter(d => d.action == 'join')
 	test.equal(joinOpt.style('display'), 'table-row', 'should display a join option')
-	test.equal(
-		joinOpt.node().querySelector('td:nth-child(2)').innerHTML,
-		opts.filterData.join == 'or' ? 'AND' : 'OR',
-		'should correctly label the pill join option'
-	)
+
+	const switchOpt = menuRows.filter(d => d.action == 'switch')
+	test.equal(switchOpt.style('display'), 'none', 'should NOT display a switch option')
 
 	const negateOpt = menuRows.filter(d => d.action == 'negate')
 	test.equal(negateOpt.style('display'), 'table-row', 'should have a pill Negate option')
@@ -412,6 +410,12 @@ tape('2-entry root filter: visible controls', async test => {
 		joinOpt.node().querySelector('td:nth-child(2)').innerHTML,
 		opts.filterData.join.toUpperCase(),
 		'should correctly label the group append option'
+	)
+	test.equal(switchOpt.style('display'), 'table-row', 'should NOT display a switch option')
+	test.equal(
+		switchOpt.node().querySelector('td:nth-child(2)').innerHTML,
+		opts.filterData.join == 'or' ? 'Switch to AND' : 'Switch to OR',
+		'should correctly label the switch option'
 	)
 	test.equal(negateOpt.style('display'), 'table-row', 'should show a group Negate option')
 	test.equal(removeOpt.style('display'), 'table-row', 'should show a group Remove option')
@@ -958,6 +962,42 @@ tape('group Remove interaction', async test => {
 	test.equal(opts.holder.selectAll('.sja_pill_wrapper').size(), 0, `should remove a group's pills when clicked`)
 
 	//document.body.dispatchEvent(new Event('mousedown', { bubbles: true }))
+	test.end()
+})
+
+tape('group Switch join interaction', async test => {
+	test.timeoutAfter(3000)
+	test.plan(2)
+
+	const opts = getOpts({
+		filterData: {
+			type: 'tvslst',
+			in: true,
+			join: 'or',
+			lst: [diaggrp(), gettvs('abc')]
+		}
+	})
+
+	await opts.filter.main(opts.filterData)
+	const joinLabel = opts.filter.Inner.dom.holder.select('.sja_filter_join_label')
+	joinLabel.node().click()
+
+	const tipd = opts.filter.Inner.dom.controlsTip.d
+	const menuRows = tipd.selectAll('tr')
+	const switchOpt = menuRows.filter(d => d.action == 'switch')
+	const expectedLabel = 'Switch to AND'
+	test.equal(
+		switchOpt.select('td:nth-child(2)').text(),
+		expectedLabel,
+		`should display the menu option as ${expectedLabel}`
+	)
+	switchOpt.node().click()
+	await sleep(30)
+	test.equal(
+		opts.filter.Inner.filter.join,
+		'and',
+		`should switch a group's filter.join value after clicking ${expectedLabel}`
+	)
 	test.end()
 })
 


### PR DESCRIPTION
Full test: http://localhost:3000/testrun.html?dir=filter

Manual tests: 
1. Should now show `+AND`, previously this was hidden since it matched the group's join value. Click on `+AND` to add filters with the same join value as the negated subgroup
![Screenshot 2023-05-01 at 10 13 09 AM](https://user-images.githubusercontent.com/411031/235474777-36e262c0-26cb-4234-9ca7-dff2395f188f.png)

2. Should now have a menu option to easily switch the group's join value between 'AND' and 'OR', useful when negating a group which will require reversing the group's disjunction or conjunction
![Screenshot 2023-05-01 at 10 15 32 AM](https://user-images.githubusercontent.com/411031/235475182-af82c47e-f0f3-44d9-a868-ba3ebacfed25.png)


