### PR TITLE
Fixed bugs creating groups

### DIFF
--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -373,20 +373,20 @@ export function setInteractivity(self) {
 		const tableDiv = self.dom.tip.d.append('div')
 		const buttons = []
 		if (addGroup) {
-			const addGroup = {
+			const addGroupCallback = {
 				text: 'Add to a group',
 				callback: indexes => {
 					const items = []
 					for (const i of indexes) items.push(self.selectedItems[i].__data__)
-					self.config.groups.push({
-						name: group.name,
+					const group = {
+						name: `Group ${self.config.groups.length + 1}`,
 						items,
 						index: self.config.groups.length
-					})
-					self.app.dispatch({ type: 'plot_edit', id: self.id, config: { groups: self.config.groups } })
+					}
+					self.addGroup(group)
 				}
 			}
-			buttons.push(addGroup)
+			buttons.push(addGroupCallback)
 		} else {
 			const deleteSamples = {
 				text: 'Delete samples',

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -363,19 +363,7 @@ export function setRenderers(self) {
 						items: self.selectedItems.map(item => item.__data__),
 						index: self.config.groups.length
 					}
-					self.config.groups.push(group)
-					self.app.dispatch({ type: 'plot_edit', id: self.id, config: { groups: self.config.groups } })
-					const samplelstTW = getSamplelstTW(self.config.groups)
-					const appGroup = {
-						name: group.name,
-						filter: self.getFilter(samplelstTW)
-					}
-					await self.app.vocabApi.addGroup(appGroup)
-					const appGroups = await self.app.vocabApi.getGroups()
-					self.app.dispatch({
-						type: 'app_refresh',
-						state: { groups: appGroups }
-					})
+					self.addGroup(group)
 				})
 			menuDiv
 				.append('div')
@@ -387,10 +375,9 @@ export function setRenderers(self) {
 						items: self.selectedItems.map(item => item.__data__),
 						index: self.config.groups.length
 					}
-					self.config.groups.push(group)
+					self.addGroup(group)
 					const tw = getSamplelstTW([group])
 					self.addToFilter(tw)
-					self.app.dispatch({ type: 'plot_edit', id: self.id, config: { groups: self.config.groups } })
 				})
 		}
 
@@ -403,6 +390,22 @@ export function setRenderers(self) {
 			mainG.on('mousedown.drag', null)
 			mainG.call(chart.lasso)
 		}
+	}
+
+	self.addGroup = async function(group) {
+		self.config.groups.push(group)
+		self.app.dispatch({ type: 'plot_edit', id: self.id, config: { groups: self.config.groups } })
+		const samplelstTW = getSamplelstTW([group])
+		const appGroup = {
+			name: group.name,
+			filter: self.getFilter(samplelstTW)
+		}
+		await self.app.vocabApi.addGroup(appGroup)
+		const appGroups = await self.app.vocabApi.getGroups()
+		self.app.dispatch({
+			type: 'app_refresh',
+			state: { groups: appGroups }
+		})
 	}
 
 	self.setTools = function() {


### PR DESCRIPTION
I tested a bit more the group changes from yesterday. When creating a group the filter was containing all the samples, not just the ones from the group, as it was using a samplelst created with all the groups. Fixed now. Also creating a group from the list samples was failing. Fixed now.