### PR TITLE
fix the ordering of condition term values in the barchart

### DIFF
--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -319,7 +319,7 @@ tape('series visibility - numeric', function(test) {
 	function runNumericExcludedTests(barchart) {
 		helpers
 			.rideInit({ arg: barchart, bus: barchart, eventType: 'postRender.test' })
-			.run(testHiddenByValues)
+			.run(testHiddenByValuesAndOrder)
 			.use(triggerHiddenLegendClick, { wait: 800 })
 			.to(testRevealedBar, { wait: 100 })
 			.use(triggerMenuClickToHide, { wait: 100 })
@@ -327,7 +327,7 @@ tape('series visibility - numeric', function(test) {
 			.done(test)
 	}
 
-	function testHiddenByValues(barchart) {
+	function testHiddenByValuesAndOrder(barchart) {
 		const bar = barchart.Inner
 		const excluded = bar.settings.exclude.cols
 		test.true(
@@ -344,6 +344,15 @@ tape('series visibility - numeric', function(test) {
 			foundHiddenLabels.length + 1,
 			excluded.length,
 			'should display the correct number of hidden legend labels'
+		)
+
+		const barOrder = [...bar.dom.holder.node().querySelectorAll('.bars-cell-grp')].sort(
+			(a, b) => a.__data__.data[0].y - b.__data__.data[0].y
+		)
+		test.deepEqual(
+			barOrder.map(d => d.__data__.seriesId),
+			['<5000', '5000 to <10000', '10000 to <15000', '15000 to <20000', '20000 to <25000', '≥25000'],
+			'should render the bars in the expected order'
 		)
 	}
 
@@ -401,7 +410,7 @@ tape('series visibility - numeric', function(test) {
 	}
 })
 
-tape('series visibility - condition', function(test) {
+tape('series visibility and order - condition', function(test) {
 	test.timeoutAfter(5000)
 
 	const conditionHiddenValues = { '1: Mild': 1 }
@@ -431,6 +440,14 @@ tape('series visibility - condition', function(test) {
 		const excluded = bar.settings.exclude.cols
 		// exclude "Unknown status" and "1: Mild"
 		test.equal(excluded.length, 1, 'should have the correct number of hidden condition bars by q.hiddenValues')
+		const barOrder = [...bar.dom.holder.node().querySelectorAll('.bars-cell-grp')].sort(
+			(a, b) => a.__data__.data[0].y - b.__data__.data[0].y
+		)
+		test.deepEqual(
+			barOrder.map(d => d.__data__.seriesId),
+			['0: No condition', '2: Moderate', '3: Severe', '4: Life-threatening'],
+			'should render the bars in the expected order'
+		)
 		if (test._ok) bar.app.destroy()
 		test.end()
 	}
@@ -883,48 +900,6 @@ tape.skip('click custom subcondition group bar to add filter', function(test) {
 	}
 })
 */
-
-tape.skip('single chart, genotype overlay', function(test) {
-	test.timeoutAfter(3000)
-
-	runpp({
-		state: {
-			plots: [
-				{
-					chartType: 'barchart',
-					term: { id: 'diaggrp', term: termjson['diaggrp'] },
-					term2: 'genotype'
-				}
-			],
-			ssid: {
-				mutation_name: 'TEST',
-				ssid: 'genotype-test.txt',
-				groups: {
-					Heterozygous: { color: 'red' },
-					'Homozygous reference': { color: 'blue' },
-					'Homozygous alternative': { color: 'green' }
-				}
-			}
-		},
-		barchart: {
-			callbacks: {
-				'postRender.test': testBarCount
-			}
-		}
-	})
-
-	function testBarCount(barchart) {
-		const barDiv = barchart.Inner.dom.barDiv
-		const numBars = barDiv.selectAll('.bars-cell-grp').size()
-		const numOverlays = barDiv.selectAll('.bars-cell').size()
-		const minBars = 5
-		const expectedOverlays = 15
-		test.true(numBars > minBars, `should have more than ${minBars} Diagnosis Group bars`)
-		test.equal(numOverlays, expectedOverlays, `should have a total of ${expectedOverlays} overlays`)
-		if (test._ok) barchart.Inner.app.destroy()
-		test.end()
-	}
-})
 
 tape('numeric exclude range', function(test) {
 	test.timeoutAfter(3000)

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -349,15 +349,15 @@ class Barchart {
 		// a non-numeric term.id is used directly as seriesId or dataId
 		this.settings.exclude.cols = Object.keys(term.q?.hiddenValues || {})
 			.filter(id => term.q.hiddenValues[id])
-			.map(id =>
-				term.term.type == 'categorical'
+			.map(id => {
+				return term.term.type == 'categorical'
 					? id
-					: this.settings.cols && this.settings.cols.includes(term.term.id)
+					: this.settings.cols?.includes(id)
 					? id
-					: term.term.values && id in term.term.values && 'label' in term.term.values[id]
+					: term.term.values[id]?.label
 					? term.term.values[id].label
 					: id
-			)
+			})
 
 		this.settings.exclude.rows = !term2?.q?.hiddenValues
 			? []
@@ -366,9 +366,9 @@ class Barchart {
 					.map(id =>
 						term2.term.type == 'categorical'
 							? id
-							: this.settings.cols && this.settings.cols.includes(term2.term.id)
+							: this.settings.rows?.includes(id)
 							? id
-							: term2.term.values && id in term2.term.values && 'label' in term2.term.values[id]
+							: term2.term.values[id]?.label
 							? term2.term.values[id].label
 							: id
 					)

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -508,7 +508,11 @@ export function getOrderedLabels(term, bins, q) {
 function getTermDetails(q, tdb, index) {
 	const termnum_id = 'term' + index + '_id'
 	const termid = q[termnum_id]
-	const term = q[termid] ? tdb.q.termjsonByOneid(termid) : q[`term${index}`] ? q[`term${index}`] : {}
+	let term = {}
+	if (q[termid]) term = tdb.q.termjsonByOneid(termid)
+	else if (termid) term = tdb.q.termjsonByOneid(termid)
+	else if (q[`term${index}`]) term = q[`term${index}`]
+
 	const termIsNumeric = term.type == 'integer' || term.type == 'float'
 	const unannotatedValues = term.values
 		? Object.keys(term.values)


### PR DESCRIPTION
Test with condition and numeric terms. The fix had do with the backend not querying the db for `termid`, if available.
@gavrielm the fix is mostly done in the backend, no need to add the condition term when setting excludes
@xzhou82 no need to add `order` in the grade entries for condition term.values