### PR TITLE
fix and improve the common URL parameter parsing function

### DIFF
--- a/client/common/test/urlmap.unit.spec.js
+++ b/client/common/test/urlmap.unit.spec.js
@@ -1,0 +1,62 @@
+const tape = require('tape')
+const urlmap = require('../urlmap').default
+
+/*************************
+ reusable helper functions
+**************************/
+
+/**************
+ test sections
+***************/
+
+tape('\n', test => {
+	test.pass('-***- common/urlmap -***-')
+	test.end()
+})
+
+tape('valid URL parameters', test => {
+	test.deepEqual(
+		Object.fromEntries(urlmap('?a=1&b=2')),
+		{ a: 1, b: 2 },
+		'should correctly parse non-JSON-encoded numeric URL parameters'
+	)
+	test.deepEqual(
+		Object.fromEntries(urlmap('?a="1"&b="2"')),
+		{ a: '1', b: '2' },
+		'should correctly parse a non-nested, but JSON encoded URL parameters'
+	)
+	test.deepEqual(
+		Object.fromEntries(urlmap(`?a="1"&b=${encodeURIComponent('{"c":[5,6]}')}`)),
+		{ a: '1', b: { c: [5, 6] } },
+		'should correctly parse a nested, JSON encoded URL parameters'
+	)
+	test.deepEqual(Object.fromEntries(urlmap('?a=1&&b=2&')), { a: 1, b: 2 }, 'should ignore empty URL parameters')
+	test.end()
+})
+
+tape('invalid URL parameters', test => {
+	{
+		let warn
+		urlmap('?a="1"&b="2=1"', str => {
+			warn = str
+		})
+		test.equal(
+			warn,
+			"unexpected '=' character in the URL parameter value for 'b'",
+			`should detect invalid an '=' character`
+		)
+	}
+	{
+		const message = 'should detect invalid json'
+		try {
+			urlmap(`?a="1"&b=${encodeURIComponent('{"c":[5,]}')}`, e => {
+				throw e
+			})
+			test.fail(message)
+		} catch (e) {
+			test.true(e.toString().includes('Unexpected token'), message + ': ' + e.toString())
+		}
+	}
+
+	test.end()
+})

--- a/client/common/urlmap.js
+++ b/client/common/urlmap.js
@@ -1,11 +1,45 @@
-// keys are case insensitive and are converted to lower case in the map
-export default function() {
+/*
+	Arguments
+	search: optional string, defaults to window.location.search
+	log: optional function to handle warnings/errors, defaults to console.warn
+
+	returns
+	a Map() of URL parameter key-values 
+*/
+// keys are case insensitive and will be converted to lower case in the map
+export default function(search = '', log = console.warn) {
+	const location = search ? { search } : window.location
 	const urlp = new Map()
-	for (const s of decodeURIComponent(location.search.substr(1)).split('&')) {
+	for (const s of location.search.substr(1).split('&')) {
+		if (!s) continue
 		const l = s.split('=')
-		if (l.length == 2 && l[0]!='' && l[1]!='') {
-			urlp.set(l[0].toLowerCase(), l[1])
+		if (l.length == 2 && l[0] != '' && l[1] != '') {
+			let value = decodeURIComponent(l[1])
+			if (
+				// assume JSON encoding when the string is enclosed by matching characters below
+				(value.startsWith('"') && value.endsWith('"')) ||
+				(value.startsWith('{') && value.endsWith('}')) ||
+				(value.startsWith('[') && value.endsWith(']'))
+			) {
+				try {
+					value = JSON.parse(value)
+				} catch (e) {
+					log(e)
+				}
+			} else if (isNumeric(value)) {
+				value = Number(value)
+			}
+			// keys are case insensitive and are converted to lower case in the map
+			urlp.set(l[0].toLowerCase(), value)
+		} else if (l.length > 2) {
+			log(`unexpected '=' character in the URL parameter value for '${l[0]}'`)
+		} else {
+			log(`Invalid url parameter: '${s}'`)
 		}
 	}
 	return urlp
+}
+
+function isNumeric(n) {
+	return !isNaN(parseFloat(n)) && isFinite(n)
 }

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -75,8 +75,8 @@ upon error, throw err message as a string
 	}
 
 	if (urlp.has('termdb')) {
-		const str = urlp.get('termdb')
-		const state = JSON.parse(str)
+		const value = urlp.get('termdb')
+		const state = typeof value === 'string' ? JSON.parse(value) : value
 		const opts = {
 			holder: arg.holder,
 			state
@@ -87,8 +87,8 @@ upon error, throw err message as a string
 	}
 
 	if (urlp.has('mass')) {
-		const str = urlp.get('mass')
-		const state = JSON.parse(str)
+		const value = urlp.get('mass')
+		const state = typeof value === 'string' ? JSON.parse(value) : value
 		const opts = {
 			holder: arg.holder,
 			state


### PR DESCRIPTION
@xzhou82 note that the urlmap will automatically parse json-encoded parameter values. I checked the code to make sure `JSON.parse()` will not be used when the parameter value is already an object 

tested with 
1. http://localhost:3000/testrun.html?name=urlmap.unit
2. [invalid url](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:3%7D,%22termfilter%22:%7B%22filter%22:%7B%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22and%22,%22lst%22:%5B%7B%22tag%22:%22cohortFilter%22,%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22subcohort%22,%22type%22:%22categorical%22%7D,%22values%22:%5B%7B%22key%22:%22SJLIFE%22,%22label%22:%22SJLIFE%22%7D%5D%7D%7D,%7B%22tag%22:%22filterUiRoot%22,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22genetic_race%22%7D,%22values%22:%5B%7B%22key%22:%22African%20Ancestry%22,%22label%22:%22African%20Ancestry%22%7D%5D%7D,%22$id%22:3%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22anthracyclines_cog_5%22%7D,%22ranges%22:%5B%7B%22value%22:0,%22label%22:%22x%20=%200%22%7D%5D%7D,%22$id%22:4%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22hrtavg%22%7D,%22ranges%22:%5B%7B%22value%22:0,%22label%22:%22x%20=%200%22%7D%5D%7D%7D%5D,%22$id%22:2,%22in%22:true%7D%5D%7D%7D%7D)