### PR TITLE
Scatter legend fix

### DIFF
--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -178,9 +178,9 @@ export function setRenderers(self) {
 
 			axisG.style('opacity', 1)
 			if (self.config.term) {
-				let term2name = self.config.term.term.name
+				let termName = self.config.term.term.name
 				if (!self.config.colorTW && !self.config.shapeTW && !self.config.term0)
-					term2name = `${term2name}, n=${chart.cohortSamples.length}`
+					termName = `${termName}, n=${chart.cohortSamples.length}`
 
 				labelsG.selectAll('*').remove()
 				labelsG
@@ -190,8 +190,10 @@ export function setRenderers(self) {
 						`translate(${self.axisOffset.x + self.settings.svgw / 2}, ${self.settings.svgh + self.axisOffset.y + 40})`
 					)
 					.attr('text-anchor', 'middle')
-					.text(term2name)
-				if (self.config.term0) {
+					.text(termName)
+				if (self.config.term0 && !self.config.colorTW && !self.config.shapeTW) {
+					const term0Name = `${chart.id}, n=${chart.cohortSamples.length}`
+
 					labelsG
 						.append('text')
 						.attr(
@@ -199,7 +201,7 @@ export function setRenderers(self) {
 							`translate(${self.axisOffset.x + self.settings.svgw / 2}, ${self.settings.svgh + self.axisOffset.y + 65})`
 						)
 						.attr('text-anchor', 'middle')
-						.text(`${chart.id}, n=${chart.cohortSamples.length}`)
+						.text(term0Name)
 				}
 				labelsG
 					.append('text')

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -636,6 +636,7 @@ export function setRenderers(self) {
 			.attr('x', 0)
 			.attr('y', offsetY)
 			.text(title0)
+			.style('font-size', '0.9em')
 			.style('font-weight', 'bold')
 		offsetY += step + 10
 		if (self.config.colorTW) {

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -85,7 +85,7 @@ export function setRenderers(self) {
 		svg
 			.transition()
 			.duration(s.duration)
-			.attr('width', s.svgw + (self.config.shapeTW ? 500 : 300))
+			.attr('width', s.svgw + (self.config.shapeTW ? 600 : 350))
 			.attr('height', Math.max(s.svgh + 100, legendHeight)) //leaving some space for top/bottom padding and y axis
 
 		/* eslint-disable */
@@ -614,18 +614,13 @@ export function setRenderers(self) {
 	self.renderLegend = function(chart) {
 		const legendG = chart.legendG
 		legendG.selectAll('*').remove()
-		if (!self.config.colorTW) return
 
 		const step = 25
 		let offsetX = 0
 		let offsetY = 25
-		const name =
-			self.config.colorTW.term.name.length > 25
-				? self.config.colorTW.term.name.slice(0, 25) + '...'
-				: self.config.colorTW.term.name
-		let title = `${name}, n=${chart.cohortSamples.length}`
-		const colorRefCategory = chart.colorLegend.get('Ref')
+		let title
 		const colorG = legendG.append('g')
+
 		if (self.config.term0) {
 			colorG
 				.append('text')
@@ -635,137 +630,150 @@ export function setRenderers(self) {
 				.style('font-weight', 'bold')
 			offsetY += step + 10
 		}
-		if (self.config.colorTW.term.type == 'geneVariant')
-			offsetY = self.renderGeneVariantLegend(
-				chart,
-				offsetX,
-				offsetY,
-				legendG,
-				self.config.colorTW,
-				'category',
-				chart.colorLegend
-			)
-		else {
-			colorG
-				.append('text')
-				.attr('id', 'legendTitle')
-				.attr('x', offsetX)
-				.attr('y', offsetY)
-				.text(title)
-				.style('font-weight', 'bold')
-				.style('font-size', '0.8em')
-			offsetY += step
+		if (self.config.colorTW) {
+			const name =
+				self.config.colorTW.term.name.length > 20
+					? self.config.colorTW.term.name.slice(0, 20) + '...'
+					: self.config.colorTW.term.name
+			title = `${name}, n=${chart.cohortSamples.length}`
+			const colorRefCategory = chart.colorLegend.get('Ref')
 
-			if (self.config.colorTW.q.mode === 'continuous') {
-				const [min, max] = chart.colorGenerator.domain()
-				const gradientScale = d3Linear()
-					.domain([min, max])
-					.range([0, 130])
-				const axis = axisBottom(gradientScale).ticks(3)
-				const axisG = colorG
-					.append('g')
-					.attr('transform', `translate(0, 70)`)
-					.call(axis)
-
-				const rect = colorG
-					.append('rect')
-					.attr('x', 0)
-					.attr('y', 50)
-					.attr('width', 130)
-					.attr('height', 20)
-					.style('fill', `url(#linear-gradient-${self.id})`)
-					.on('click', e => {
-						const menu = new Menu()
-						const input = menu.d
-							.append('input')
-							.attr('type', 'color')
-							.attr('value', self.config.gradientColor[chart.id])
-							.on('change', () => {
-								self.config.gradientColor[chart.id] = input.node().value
-								chart.startColor = rgb(self.config.gradientColor[chart.id])
-									.brighter()
-									.brighter()
-								chart.stopColor = rgb(self.config.gradientColor[chart.id])
-									.darker()
-									.darker()
-								chart.colorGenerator = d3Linear().range([chart.startColor, chart.stopColor])
-
-								self.startGradient.attr('stop-color', chart.startColor)
-								self.stopGradient.attr('stop-color', chart.stopColor)
-								self.app.dispatch({
-									type: 'plot_edit',
-									id: self.id,
-									config: self.config
-								})
-								menu.hide()
-							})
-						menu.show(e.clientX, e.clientY, false)
-					})
-
+			if (self.config.colorTW.term.type == 'geneVariant')
+				offsetY = self.renderGeneVariantLegend(
+					chart,
+					offsetX,
+					offsetY,
+					legendG,
+					self.config.colorTW,
+					'category',
+					chart.colorLegend
+				)
+			else {
+				colorG
+					.append('text')
+					.attr('id', 'legendTitle')
+					.attr('x', offsetX)
+					.attr('y', offsetY)
+					.text(title)
+					.style('font-weight', 'bold')
+					.style('font-size', '0.8em')
 				offsetY += step
-			} else {
-				for (const [key, category] of chart.colorLegend) {
-					if (key == 'Ref') continue
-					const name = key
-					const hidden = self.config.colorTW.q.hiddenValues ? key in self.config.colorTW.q.hiddenValues : false
-					const [circleG, itemG] = addLegendItem(colorG, category, name, offsetX, offsetY, hidden)
-					circleG.on('click', e => self.onColorClick(e, key, category))
+
+				if (self.config.colorTW.q.mode === 'continuous') {
+					const [min, max] = chart.colorGenerator.domain()
+					const gradientScale = d3Linear()
+						.domain([min, max])
+						.range([0, 130])
+					const axis = axisBottom(gradientScale).ticks(3)
+					const axisG = colorG
+						.append('g')
+						.attr('transform', `translate(0, 70)`)
+						.call(axis)
+
+					const rect = colorG
+						.append('rect')
+						.attr('x', 0)
+						.attr('y', 50)
+						.attr('width', 130)
+						.attr('height', 20)
+						.style('fill', `url(#linear-gradient-${self.id})`)
+						.on('click', e => {
+							const menu = new Menu()
+							const input = menu.d
+								.append('input')
+								.attr('type', 'color')
+								.attr('value', self.config.gradientColor[chart.id])
+								.on('change', () => {
+									self.config.gradientColor[chart.id] = input.node().value
+									chart.startColor = rgb(self.config.gradientColor[chart.id])
+										.brighter()
+										.brighter()
+									chart.stopColor = rgb(self.config.gradientColor[chart.id])
+										.darker()
+										.darker()
+									chart.colorGenerator = d3Linear().range([chart.startColor, chart.stopColor])
+
+									self.startGradient.attr('stop-color', chart.startColor)
+									self.stopGradient.attr('stop-color', chart.stopColor)
+									self.app.dispatch({
+										type: 'plot_edit',
+										id: self.id,
+										config: self.config
+									})
+									menu.hide()
+								})
+							menu.show(e.clientX, e.clientY, false)
+						})
+
 					offsetY += step
-					itemG.on('click', event => self.onLegendClick(chart, legendG, 'colorTW', key, event))
+				} else {
+					for (const [key, category] of chart.colorLegend) {
+						if (key == 'Ref') continue
+						const name = key
+						const hidden = self.config.colorTW.q.hiddenValues ? key in self.config.colorTW.q.hiddenValues : false
+						const [circleG, itemG] = addLegendItem(colorG, category, name, offsetX, offsetY, hidden)
+						circleG.on('click', e => self.onColorClick(e, key, category))
+						offsetY += step
+						itemG.on('click', event => self.onLegendClick(chart, legendG, 'colorTW', key, event))
+					}
 				}
 			}
-		}
-		if (colorRefCategory.sampleCount > 0) {
-			offsetY = offsetY + step
-			const titleG = legendG.append('g')
-			titleG
-				.append('text')
-				.attr('x', offsetX)
-				.attr('y', offsetY)
-				.text('Reference')
-				.style('font-weight', 'bold')
-				.style('font-size', '0.8em')
+			if (colorRefCategory.sampleCount > 0) {
+				offsetY = offsetY + step
+				const titleG = legendG.append('g')
+				titleG
+					.append('text')
+					.attr('x', offsetX)
+					.attr('y', offsetY)
+					.text('Reference')
+					.style('font-weight', 'bold')
+					.style('font-size', '0.8em')
 
-			offsetY = offsetY + step
+				offsetY = offsetY + step
 
-			let symbol = self.symbols[0].size(64)()
-			const refColorG = legendG.append('g')
-			refColorG
-				.append('path')
-				.attr('transform', c => `translate(${offsetX}, ${offsetY})`)
-				.style('fill', colorRefCategory.color)
-				.attr('d', symbol)
-				.style('stroke', rgb(colorRefCategory.color).darker())
+				let symbol = self.symbols[0].size(64)()
+				const refColorG = legendG.append('g')
+				refColorG
+					.append('path')
+					.attr('transform', c => `translate(${offsetX}, ${offsetY})`)
+					.style('fill', colorRefCategory.color)
+					.attr('d', symbol)
+					.style('stroke', rgb(colorRefCategory.color).darker())
 
-			refColorG.on('click', e => self.onColorClick(e, 'Ref', colorRefCategory))
-			const refText = legendG
-				.append('g')
-				.append('text')
-				.attr('x', offsetX + 10)
-				.attr('y', offsetY)
-				.text(`n=${colorRefCategory.sampleCount}`)
-				.style('text-decoration', !self.settings.showRef ? 'line-through' : 'none')
-				.style('font-size', '15px')
-				.attr('alignment-baseline', 'middle')
-				.style('font-size', '0.8em')
+				refColorG.on('click', e => self.onColorClick(e, 'Ref', colorRefCategory))
+				const refText = legendG
+					.append('g')
+					.append('text')
+					.attr('x', offsetX + 10)
+					.attr('y', offsetY)
+					.text(`n=${colorRefCategory.sampleCount}`)
+					.style('text-decoration', !self.settings.showRef ? 'line-through' : 'none')
+					.style('font-size', '15px')
+					.attr('alignment-baseline', 'middle')
+					.style('font-size', '0.8em')
 
-			refText.on('click', () => {
-				refText.style('text-decoration', !self.settings.showRef ? 'none' : 'line-through')
-				self.settings.showRef = !self.settings.showRef
+				refText.on('click', () => {
+					refText.style('text-decoration', !self.settings.showRef ? 'none' : 'line-through')
+					self.settings.showRef = !self.settings.showRef
 
-				self.app.dispatch({
-					type: 'plot_edit',
-					id: self.id,
-					config: {
-						settings: { sampleScatter: self.settings }
-					}
+					self.app.dispatch({
+						type: 'plot_edit',
+						id: self.id,
+						config: {
+							settings: { sampleScatter: self.settings }
+						}
+					})
 				})
-			})
+			}
 		}
 		if (self.config.shapeTW) {
-			offsetX = self.config.colorTW.term.type == 'geneVariant' ? 300 : 200
+			offsetX = !self.config.colorTW ? 0 : self.config.colorTW.term.type == 'geneVariant' ? 300 : 200
 			offsetY = self.config.term0 ? 50 : 25
-			title = `${self.config.shapeTW.term.name}, n=${chart.cohortSamples.length}`
+			const name =
+				self.config.shapeTW.term.name.length > 20
+					? self.config.shapeTW.term.name.slice(0, 20) + '...'
+					: self.config.shapeTW.term.name
+			title = `${name}, n=${chart.cohortSamples.length}`
 			if (self.config.shapeTW.term.type == 'geneVariant')
 				self.renderGeneVariantLegend(chart, offsetX, offsetY, legendG, self.config.shapeTW, 'shape', chart.shapeLegend)
 			else {

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -614,6 +614,7 @@ export function setRenderers(self) {
 	self.renderLegend = function(chart) {
 		const legendG = chart.legendG
 		legendG.selectAll('*').remove()
+		if (!self.config.colorTW && !self.config.shapeTW) return
 
 		const step = 25
 		let offsetX = 0
@@ -623,7 +624,7 @@ export function setRenderers(self) {
 
 		const title0 = self.config.term0
 			? `${chart.id}, n=${chart.cohortSamples.length}`
-			: `n=${chart.cohortSamples.length}`
+			: `${chart.cohortSamples.length} samples`
 		colorG
 			.append('text')
 			.attr('x', 0)

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -621,21 +621,18 @@ export function setRenderers(self) {
 		let title
 		const colorG = legendG.append('g')
 
-		if (self.config.term0) {
-			colorG
-				.append('text')
-				.attr('x', 0)
-				.attr('y', offsetY)
-				.text(chart.id)
-				.style('font-weight', 'bold')
-			offsetY += step + 10
-		}
+		const title0 = self.config.term0
+			? `${chart.id}, n=${chart.cohortSamples.length}`
+			: `n=${chart.cohortSamples.length}`
+		colorG
+			.append('text')
+			.attr('x', 0)
+			.attr('y', offsetY)
+			.text(title0)
+			.style('font-weight', 'bold')
+		offsetY += step + 10
 		if (self.config.colorTW) {
-			const name =
-				self.config.colorTW.term.name.length > 20
-					? self.config.colorTW.term.name.slice(0, 20) + '...'
-					: self.config.colorTW.term.name
-			title = `${name}, n=${chart.cohortSamples.length}`
+			title = `${getTitle(self.config.colorTW)}`
 			const colorRefCategory = chart.colorLegend.get('Ref')
 
 			if (self.config.colorTW.term.type == 'geneVariant')
@@ -768,12 +765,8 @@ export function setRenderers(self) {
 		}
 		if (self.config.shapeTW) {
 			offsetX = !self.config.colorTW ? 0 : self.config.colorTW.term.type == 'geneVariant' ? 300 : 200
-			offsetY = self.config.term0 ? 60 : 25
-			const name =
-				self.config.shapeTW.term.name.length > 20
-					? self.config.shapeTW.term.name.slice(0, 20) + '...'
-					: self.config.shapeTW.term.name
-			title = `${name}, n=${chart.cohortSamples.length}`
+			offsetY = 60
+			title = `${getTitle(self.config.shapeTW)}`
 			if (self.config.shapeTW.term.type == 'geneVariant')
 				self.renderGeneVariantLegend(chart, offsetX, offsetY, legendG, self.config.shapeTW, 'shape', chart.shapeLegend)
 			else {
@@ -816,6 +809,12 @@ export function setRenderers(self) {
 					itemG.on('click', event => self.onLegendClick(chart, legendG, 'shapeTW', key, event))
 				}
 			}
+		}
+
+		function getTitle(tw) {
+			let name = tw.term.name
+			if (name.length > 25) name = name.slice(0, 25) + '...'
+			return name
 		}
 
 		function addLegendItem(g, category, name, x, y, hidden = false) {

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -768,7 +768,7 @@ export function setRenderers(self) {
 		}
 		if (self.config.shapeTW) {
 			offsetX = !self.config.colorTW ? 0 : self.config.colorTW.term.type == 'geneVariant' ? 300 : 200
-			offsetY = self.config.term0 ? 50 : 25
+			offsetY = self.config.term0 ? 60 : 25
 			const name =
 				self.config.shapeTW.term.name.length > 20
 					? self.config.shapeTW.term.name.slice(0, 20) + '...'

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -178,6 +178,10 @@ export function setRenderers(self) {
 
 			axisG.style('opacity', 1)
 			if (self.config.term) {
+				let term2name = self.config.term.term.name
+				if (!self.config.colorTW && !self.config.shapeTW && !self.config.term0)
+					term2name = `${term2name}, n=${chart.cohortSamples.length}`
+
 				labelsG.selectAll('*').remove()
 				labelsG
 					.append('text')
@@ -186,7 +190,7 @@ export function setRenderers(self) {
 						`translate(${self.axisOffset.x + self.settings.svgw / 2}, ${self.settings.svgh + self.axisOffset.y + 40})`
 					)
 					.attr('text-anchor', 'middle')
-					.text(self.config.term.term.name)
+					.text(term2name)
 				if (self.config.term0) {
 					labelsG
 						.append('text')

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -271,6 +271,7 @@ function processSample(dbSample, sample, tw, categoryMap, category) {
 	if (tw.term.type == 'geneVariant') assignGeneVariantValue(dbSample, sample, tw, categoryMap, category)
 	else {
 		value = dbSample?.[tw.id || tw.term.name]?.key
+		if (tw.term.values?.[value]?.label) value = tw.term.values?.[value]?.label
 		sample.hidden[category] = tw.q.hiddenValues ? dbSample?.[tw.id]?.key in tw.q.hiddenValues : false
 		if (value) {
 			sample[category] = value.toString()


### PR DESCRIPTION
Allowed to use shape when no term for coloring set. Displayed always term label if provided. Other small fixes in legend. Always displaying number of samples now, either on legend top or on the axes labels.