### PR TITLE
Matrix chromatic cnv

### DIFF
--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -90,6 +90,8 @@ export default function svgLegend(opts) {
 		if (settings.linesep) {
 			currlinex = settings.padleft
 			currliney += settings.lineh
+		} else if (d.hasScale) {
+			currlinex = leftdist - 2 * settings.padx + 2
 		} else if (settings.hangleft) {
 			currlinex = leftdist + 2 * settings.padx
 		} else {
@@ -117,7 +119,7 @@ export default function svgLegend(opts) {
 	}
 
 	function addItem(d, i) {
-		let g = select(this)
+		const g = select(this)
 			.attr('transform', 'translate(' + currlinex + ',' + currliney + ')')
 			.style('opacity', settings.itemOpacity)
 
@@ -159,25 +161,73 @@ export default function svgLegend(opts) {
 		})
 
 		const bbox = itemlabel.node().getBBox()
-		currlinex += settings.iconw + bbox.width + 2.5 * settings.padx
+		const width = d.width || settings.iconw
+		currlinex += bbox.width + width
 		if (settings.linesep || currlinex > settings.svgw - settings.padright) {
 			currliney += settings.lineh
 			const leftdist = !settings.hangleft ? settings.padleft : settings.padleft + settings.hangleft + settings.padx
 
 			g.attr('transform', 'translate(' + leftdist + ',' + currliney + ')')
-			currlinex = settings.iconw + bbox.width + 2.5 * settings.padx + settings.padleft
-			if (settings.hangleft) currlinex = settings.iconw + bbox.width + 2.5 * settings.padx + leftdist
-			else currlinex = settings.iconw + bbox.width + 2.5 * settings.padx + settings.padleft
+			currlinex = bbox.width + width + settings.padleft
+			if (settings.hangleft) currlinex = settings.iconw + bbox.width + leftdist
+			else currlinex = width + bbox.width + settings.padleft
 		}
 
-		const rect = g
-			.append('rect')
-			.attr('height', settings.iconh)
-			.attr('width', settings.iconw)
-			.attr('y', settings.fontsize - bbox.height + (bbox.height - settings.iconh) / 2)
-			.attr('fill', opts.rectFillFxn)
-			.attr('stroke', opts.iconStroke)
-			.attr('shape-rendering', 'crispEdges')
+		const y = settings.fontsize - bbox.height + (bbox.height - settings.iconh) / 2
+		let colorGradientId, minLabelBBox
+		if (d.domain) {
+			colorGradientId = `sjpp-linear-gradient-${getId()}`
+			g.append('linearGradient')
+				.attr('id', colorGradientId)
+				.attr('x1', '0%')
+				.attr('x2', '100%') //d.width)
+				.attr('y1', '0%')
+				.attr('y2', '0%')
+				.selectAll('stop')
+				.data(d.domain[0] < d.domain[1] ? [0, 1] : [1, 0])
+				.enter()
+				.append('stop')
+				.attr('offset', (c, i) => `${i * 100}%`)
+				.attr('stop-color', c => d.scale(c))
+				.attr('stop-opacity', 1)
+
+			const minLabel = g
+				.append('text')
+				.text(d.minLabel || d.domain[0])
+				.attr('x', bbox.width + 25)
+				.attr('y', 0.82 * settings.fontsize)
+				.attr('text-anchor', 'start')
+			minLabelBBox = minLabel.node().getBBox()
+			currlinex += minLabelBBox.width + 5
+
+			g.append('rect')
+				.attr('height', settings.iconh)
+				.attr('width', width)
+				.attr('x', bbox.width + minLabelBBox.width + 30)
+				.attr('y', y)
+				.attr('fill', colorGradientId ? `url(#${colorGradientId})` : opts.rectFillFxn)
+				.attr('stroke', opts.iconStroke)
+				.attr('shape-rendering', 'crispEdges')
+
+			const maxLabel = g
+				.append('text')
+				.text(d.maxLabel || d.domain[1])
+				.attr('x', bbox.width + minLabelBBox.width + 135)
+				.attr('y', 0.8 * settings.fontsize)
+				.attr('text-anchor', 'start')
+			currlinex += maxLabel.node().getBBox().width + 2.5 * settings.padx + 50
+		} else {
+			g.append('rect')
+				.attr('height', settings.iconh)
+				.attr('width', width)
+				//.attr('x', bbox.width)
+				.attr('y', y)
+				.attr('fill', colorGradientId ? `url(#${colorGradientId})` : opts.rectFillFxn)
+				.attr('stroke', opts.iconStroke)
+				.attr('shape-rendering', 'crispEdges')
+
+			currlinex += 2.5 * settings.padx
+		}
 
 		if (Math.abs(bbox.y + bbox.height / 2) > 1) {
 			// dominant-baseline is not supported, manually position
@@ -186,4 +236,13 @@ export default function svgLegend(opts) {
 	}
 
 	return render
+}
+
+let i = 0
+function getId() {
+	return `${i++}-${Date.now()
+		.toString()
+		.slice(-6)}-${Math.random()
+		.toString()
+		.slice(-6)}`
 }

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -51,6 +51,7 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 	const values = anno.renderedValues || anno.filteredValues || anno.values || [anno.value]
 	cell.label = value.label || self.mclass[value.class].label
 	const colorFromq = tw.q?.values && tw.q?.values[value.class]?.color
+	// may overriden by a color scale by dt, if applicable below
 	cell.fill = colorFromq || value.color || self.mclass[value.class]?.color
 	cell.class = value.class
 	cell.value = value
@@ -61,6 +62,11 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 		cell.width = colw
 		cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
 		cell.y = height * i
+		if (value.dt == 4 && 'value' in value) {
+			value.scaledValue = Math.abs(value.value / (value.value < 0 ? t.counts.maxLoss : t.counts.maxGain))
+			if (value.value > 0) value.scaledValue = 0.9 * value.scaledValue
+			cell.fill = value.value < 0 ? t.scales.loss(value.scaledValue) : t.scales.gain(value.scaledValue)
+		}
 	} else if (value.dt == 1) {
 		const divisor = 3
 		cell.height = s.rowh / divisor

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -62,9 +62,9 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 		cell.width = colw
 		cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
 		cell.y = height * i
-		if (value.dt == 4 && 'value' in value) {
-			value.scaledValue = Math.abs(value.value / (value.value < 0 ? t.counts.maxLoss : t.counts.maxGain))
-			if (value.value > 0) value.scaledValue = 0.9 * value.scaledValue
+		if (value.dt == 4 && 'value' in value && t.scales) {
+			value.scaledValue =
+				0.9 * Math.abs(value.value / (value.value < 0 ? self.cnvValues.maxLoss : self.cnvValues.maxGain))
 			cell.fill = value.value < 0 ? t.scales.loss(value.scaledValue) : t.scales.gain(value.scaledValue)
 		}
 	} else if (value.dt == 1) {

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -83,7 +83,8 @@ export async function getPlotConfig(opts, app) {
 					samples: 'Samples',
 					sample: 'Sample',
 					terms: 'Variables'
-				}
+				},
+				cnvUnit: 'log2ratio'
 			}
 		}
 	}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -33,6 +33,7 @@ export function setInteractivity(self) {
 				const label = v.mname ? `${v.mname} ${c.label}` : c.label
 				const info = []
 				if (v.label && v.label !== c.label) info.push(v.label)
+				if ('value' in v) info.push(`log2r=${v.value}`)
 				if (v.chr) {
 					const pos = v.pos ? `:${v.pos}` : v.start ? `:${v.start}-${v.stop}` : ''
 					info.push(`${v.chr}${pos}`)

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -33,7 +33,7 @@ export function setInteractivity(self) {
 				const label = v.mname ? `${v.mname} ${c.label}` : c.label
 				const info = []
 				if (v.label && v.label !== c.label) info.push(v.label)
-				if ('value' in v) info.push(`log2r=${v.value}`)
+				if ('value' in v) info.push(`${self.settings.matrix.cnvUnit}=${v.value}`)
 				if (v.chr) {
 					const pos = v.pos ? `:${v.pos}` : v.start ? `:${v.start}-${v.stop}` : ''
 					info.push(`${v.chr}${pos}`)
@@ -45,7 +45,14 @@ export function setInteractivity(self) {
 					: `<td style='text-align: right'>${label}</td><td>${info.map(i => `<span>${i}</span>`).join(' ')}</td>`
 
 				const color = c.fill == v.color || v.class == 'Blank' ? '' : c.fill
-				rows.push(`<tr style='color: ${color}'>${tds}</tr>`)
+				if (v.dt == 4 && 'value' in v) {
+					const textColor = Math.abs(v.value) < 0.5 ? '#000' : '#fff'
+					rows.push(
+						`<tr style='background-color: ${color}; color: ${textColor}; padding-left: 2px; padding-right: 2px'>${tds}</tr>`
+					)
+				} else {
+					rows.push(`<tr style='color: ${color}'>${tds}</tr>`)
+				}
 			}
 		}
 

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -576,7 +576,7 @@ class Matrix {
 
 	setLabelsAndScales() {
 		const s = this.settings.matrix
-
+		this.cnvValues = {}
 		// ht: standard cell dimension for term row or column
 		const ht = s.transpose ? s.colw : s.rowh
 		const grpTotals = {}
@@ -613,8 +613,8 @@ class Matrix {
 							const v = val.value
 							const minKey = v < 0 ? 'minLoss' : 'minGain'
 							const maxKey = v < 0 ? 'maxLoss' : 'maxGain'
-							if (!(minKey in t.counts) || t.counts[minKey] > v) t.counts[minKey] = v
-							if (!(maxKey in t.counts) || t.counts[maxKey] < v) t.counts[maxKey] = v
+							if (!(minKey in this.cnvValues) || this.cnvValues[minKey] > v) this.cnvValues[minKey] = v
+							if (!(maxKey in this.cnvValues) || this.cnvValues[maxKey] < v) this.cnvValues[maxKey] = v
 						}
 					}
 				}
@@ -629,7 +629,7 @@ class Matrix {
 				t.scale = scaleLinear()
 					.domain([t.counts.minval, t.counts.maxval])
 					.range([1, t.tw.settings.barh])
-			} else if (t.tw.term.type == 'geneVariant' && 'maxGain' in t.counts) {
+			} else if (t.tw.term.type == 'geneVariant' && 'maxGain' in this.cnvValues) {
 				t.scales = {
 					loss: interpolateBlues,
 					gain: interpolateReds

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -1829,6 +1829,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					_SAMPLENAME_: s.sample_id
 				}
 
+				if ('value' in m) m2.value = m.value
+
 				if (s.formatK2v) {
 					// this sample have format values, flatten those
 					for (const k in s.formatK2v) {


### PR DESCRIPTION
This branch works with the IHG_file_transition branch in the sjpp repo. 
- the tooltip will display the CNV unit based on the dataset termdb.matrix.settings.cnvUnit value, or default to log2ratio
- the chromatic scale/legend max value for loss, gain is set to the higher of the two
- The loss/gain scales are still listed separately in the legend, can work on combining into one scale later in a separate branch