### PR TITLE
matrix fixes

### DIFF
--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -17,7 +17,7 @@ function setNumericCellProps(cell, tw, anno, value, s, t, self, width, height, d
 	cell.order = t.ref.bins ? t.ref.bins.findIndex(bin => bin.name == key) : 0
 	if (tw.q?.mode == 'continuous') {
 		if (!tw.settings) tw.settings = {}
-		if (!tw.settings.barh) tw.settings.barh = 30
+		if (!tw.settings.barh) tw.settings.barh = s.barh
 		if (!('gap' in tw.settings)) tw.settings.gap = 0
 		// TODO: may use color scale instead of bars
 		if (s.transpose) {
@@ -76,6 +76,12 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 	} else {
 		throw `cannot set cell props for dt='${value.dt}'`
 	}
+
+	// need to distinguish between not tested or wildtype by dt: snvindel vs CNV vs SV, etc
+	if (value.class == 'Blank' || value.class == 'WT') {
+		cell.label = `${self.dt2label[value.dt]} ${cell.label}`
+	}
+	if (value.origin) cell.label = `${self.morigin[value.origin].label} ${cell.label}`
 
 	// return the corresponding legend item data
 	const order = value.class == 'CNV_loss' ? -2 : value.class.startsWith('CNV_') ? -1 : 0

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -84,7 +84,9 @@ export async function getPlotConfig(opts, app) {
 					sample: 'Sample',
 					terms: 'Variables'
 				},
-				cnvUnit: 'log2ratio'
+				cnvUnit: 'log2ratio',
+
+				barh: 16 // default bar height for continuous terms
 			}
 		}
 	}

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -11,7 +11,7 @@ import { schemeCategory10, interpolateReds, interpolateBlues } from 'd3-scale-ch
 import { schemeCategory20 } from '#common/legacy-d3-polyfill'
 import { axisLeft, axisTop, axisRight, axisBottom } from 'd3-axis'
 import svgLegend from '#dom/svg.legend'
-import { mclass } from '#shared/common'
+import { mclass, dt2label, morigin } from '#shared/common'
 import { getSampleSorter, getTermSorter } from './matrix.sort'
 import { dofetch3 } from '../common/dofetch'
 export { getPlotConfig } from './matrix.config'
@@ -66,7 +66,7 @@ class Matrix {
 		this.setPill(appState)
 
 		/*
-		Levels of mclass overrides, from more general to more specific.
+		Levels of mclass overrides, from more general to more specific. Same logic for dt2label
 
 		1. server-level:
 		  - specified as serverconfig.commonOverrides
@@ -91,7 +91,11 @@ class Matrix {
 			in the resulting merged overrides, as outputted by rx.copyMerge()
 		!!!
 		*/
-		this.mclass = copyMerge({}, mclass, appState.termdbConfig.mclass || {}, appState.termdbConfig.matrix?.mclass || {})
+		const commonKeys = { mclass, dt2label, morigin }
+		for (const k in commonKeys) {
+			const v = commonKeys[k]
+			this[k] = copyMerge({}, v, appState.termdbConfig[k] || {}, appState.termdbConfig.matrix?.[k] || {})
+		}
 	}
 
 	setControls(appState) {
@@ -633,9 +637,12 @@ class Matrix {
 			}
 
 			if (t.tw.q?.mode == 'continuous') {
+				if (!t.tw.settings) t.tw.settings = {}
+				if (!t.tw.settings.barh) t.tw.settings.barh = s.barh
+				if (!('gap' in t.tw.settings)) t.tw.settings.gap = 0
 				t.scale = scaleLinear()
 					.domain([t.counts.minval, t.counts.maxval])
-					.range([1, t.tw.settings.barh])
+					.range([1, s.barh])
 			} else if (t.tw.term.type == 'geneVariant' && ('maxLoss' in this.cnvValues || 'maxGain' in this.cnvValues)) {
 				const maxVals = []
 				if ('maxLoss' in this.cnvValues) maxVals.push(this.cnvValues.maxLoss)


### PR DESCRIPTION
- create a matrix tw.settings.barh as needed to support change to continuous mode
- also show the dt, origin label…s on mouseover to disambiguate the seemingly conflicting not tested, wildtype values on mouseover

![Screenshot 2023-06-08 at 5 17 41 PM](https://github.com/stjude/proteinpaint/assets/411031/1029f54f-3da4-48fc-bf04-2800b471ff68)


