### PR TITLE
fix barChart ranking error and add to commons.js morigin germline and…

### DIFF
--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -428,6 +428,10 @@ morigin[morigingermline] = {
 		'A constitutional variant found in a normal sample. The proportion is indicated by the span of the solid arc within the whole circle.',
 	legend: germlinelegend
 }
+
+morigin.germline = morigin[morigingermline]
+morigin.somatic = morigin[moriginsomatic]
+
 export const moriginrelapse = 'R'
 morigin[moriginrelapse] = {
 	label: 'Relapse',

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -512,7 +512,7 @@ export function getOrderedLabels(term, bins, q) {
 					? term.values[b].order
 					: 0
 			)
-			.map(i => term.values[i].label)
+			.map(i => term.values[i].key)
 	}
 	return bins.map(bin => (bin.name ? bin.name : bin.label))
 }


### PR DESCRIPTION
… somatic

Can remove morigin.germline and morigin.somatic if we revert back to 'G'/'S' in neuro onc datasets. 