### PR TITLE
bug fix for showing correct number of samples in mds3 subtk filter

### DIFF
--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -25,10 +25,10 @@ Incorrect dataset name: ah instead of ASH
 Launch variant table from track variant label
 
 ### via gdc api
-GDC - sample summaries table, create subtrack
+GDC - sample summaries table, create subtrack (tk.filterObj)
 
 ### via bcf and termdb
-ASH - sample summaries table, create subtrack
+ASH - sample summaries table, create subtrack (tk.filterObj)
 
 ###
 GDC - mclass filtering
@@ -367,7 +367,7 @@ tape('Launch variant table from track variant label', test => {
 	}
 })
 
-tape('GDC - sample summaries table, create subtrack', test => {
+tape('GDC - sample summaries table, create subtrack (tk.filterObj)', test => {
 	//If dispatchEvent error in browser, run again before debugging
 	test.timeoutAfter(5000)
 	const holder = getHolder()
@@ -376,7 +376,7 @@ tape('GDC - sample summaries table, create subtrack', test => {
 		holder,
 		noheader: true,
 		genome: 'hg38',
-		gene: 'kras',
+		gene: 'idh1',
 		tracks: [{ type: 'mds3', dslabel: 'GDC', callbackOnRender }]
 	})
 
@@ -400,7 +400,7 @@ tape('GDC - sample summaries table, create subtrack', test => {
 
 		// find one of the clickable label for a category
 		// attach this callback on bb (block instance) to be triggered when the subtrack is loaded
-		bb.onloadalltk_always = () => {
+		bb.onloadalltk_always = async () => {
 			test.equal(
 				bb.tklst.length,
 				3,
@@ -421,13 +421,17 @@ tape('GDC - sample summaries table, create subtrack', test => {
 			)
 
 			test.ok(subtk.leftlabels.doms.filterObj, '.leftlabels.doms.filterObj is set on subtrack')
-			// TODO trigger click on filterObj and detect filter ui
+			// click on the filterObj left label to show menu with filter UI
+			subtk.leftlabels.doms.filterObj.node().dispatchEvent(new Event('click'))
+			await whenVisible(subtk.menutip.d)
+			test.pass('subtk.menutip is shown (with filter UI), after clicking leftlabels.doms.filterObj')
 
 			test.ok(subtk.leftlabels.doms.close, '.leftlabels.doms.close is set on subtrack')
 
-			// Close orphaned popup window
-			tk.menutip.d.remove()
-			if (test._ok) holder.remove()
+			if (test._ok) {
+				holder.remove()
+				tk.menutip.d.remove() // Close orphaned popup window
+			}
 			test.end()
 		}
 
@@ -436,7 +440,7 @@ tape('GDC - sample summaries table, create subtrack', test => {
 	}
 })
 
-tape('ASH - sample summaries table, create subtrack', test => {
+tape('ASH - sample summaries table, create subtrack (tk.filterObj)', test => {
 	//If dispatchEvent error in browser, run again before debugging
 	test.timeoutAfter(5000)
 	const holder = getHolder()

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -207,6 +207,10 @@ async function getSampleData_dictionaryTerms(q, termWrappers) {
 	throw 'unknown method for dictionary terms'
 }
 
+/*
+--- XXX bug ---
+q.currentGeneNames[] is ignored and will not restrict to samples mutated for said genes
+*/
 export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	const samples = {}
 	const refs = { byTermId: {} }
@@ -260,11 +264,11 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 }
 
 /*
-using mds3 dataset
+using mds3 dataset, that's without server-side sqlite db
 */
 async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 	const q2 = {
-		filter: q.filter,
+		filterObj: q.filter, // must rename key as "filterObj" but not "filter" to go with what mds3 backend is using
 		genome: q.genome,
 		get: 'samples',
 		twLst: termWrappers,


### PR DESCRIPTION
please see if this fixes the bug of not restricting to correct number of samples in "Heme" subtk http://localhost:3000/?genome=hg38&gene=idh1&mds3=GDC

i've also identified another bug affecting datasets using sqlite db but not gdc (not using db), indicated in line 207 of termdb.matrix.js. since this does not affect gdc, i will fix it later