### PR TITLE
reactivate the matrix allow2selectSamples 

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1641,18 +1641,20 @@ function setZoomPanActions(self) {
 								.map(Number)
 							const xMin = xy[0]
 							const xMax = xMin + self.zoomWidth
+							const processed = new Set()
 							const filter = c => c.row && c.x >= xMin && c.x <= xMax
 							const samples = []
 							for (const series of self.serieses) {
-								samples.push(
-									...series.cells.filter(filter).map(d => {
-										const obj = {}
-										for (const a of ss.attributes) {
-											obj[a] = d.row[a]
-										}
-										return obj
-									})
-								)
+								series.cells.filter(filter).forEach(d => {
+									const obj = {}
+									for (const a of ss.attributes) {
+										obj[a] = d.row[a]
+									}
+									const sid = Object.values(obj).join(';;')
+									if (processed.has(sid)) return
+									processed.add(sid)
+									samples.push(obj)
+								})
 							}
 							ss.callback({
 								samples,

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -63,6 +63,7 @@ export async function init(arg, holder, genomes) {
 	const settings = arg.settings || {}
 	if (!settings.matrix) settings.matrix = {}
 	settings.matrix.geneFilter = geneFilter
+	settings.matrix.maxGenes = maxGenes
 	const opts = {
 		holder,
 		genome,
@@ -88,7 +89,7 @@ export async function init(arg, holder, genomes) {
 			redoHtml: 'redo'
 		},
 		matrix: {
-			// allow2selectSamples: arg.allow2selectSamples,
+			allow2selectSamples: arg.allow2selectSamples,
 			// these will display the inputs together in the Genes menu,
 			// instead of being rendered outside of the matrix holder
 			customInputs: {
@@ -208,7 +209,7 @@ async function getGenes(arg, gdcCohort, CGConly, maxGenes = 50) {
 	const body = {
 		genome: gdcGenome,
 		filter0: gdcCohort,
-		maxGenes: maxGenes
+		maxGenes
 	}
 	if (CGConly) body.CGConly = 1
 	const data = await dofetch3('gdc_filter2topGenes', { body })


### PR DESCRIPTION
and fix the cell data filtering for unique cohort case data. Previously, the allow2selectSamples was waiting for the `Update Cohort` support, but for now should be able to create a cohort from the matrix plot selection.