### PR TITLE
Disable prettier configurations in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
 	root: false,
 	parser: '@typescript-eslint/parser',
 	plugins: ['@typescript-eslint'],
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
 	rules: {
 		'@typescript-eslint/no-explicit-any': 'off',
 		'@typescript-eslint/no-non-null-assertion': 'off',

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -52,9 +52,7 @@ const defaultOpts: { menuOptions: string; menuLayout: string } = {
 	menuLayout: 'vertical',
 }
 
-type HandlerByType = {
-	[index: string]: Handler //another test
-}
+type HandlerByType = { [index: string]: Handler }
 
 class TermSetting {
 	opts: TermSettingOpts

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -53,9 +53,7 @@ const defaultOpts: { menuOptions: string; menuLayout: string } = {
 }
 
 type HandlerByType = {
-	//I'm a test comment
-
-	[index: string]: Handler
+	[index: string]: Handler //another test
 }
 
 class TermSetting {

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -52,7 +52,11 @@ const defaultOpts: { menuOptions: string; menuLayout: string } = {
 	menuLayout: 'vertical',
 }
 
-type HandlerByType = { [index: string]: Handler }
+type HandlerByType = {
+	//I'm a test comment
+
+	[index: string]: Handler
+}
 
 class TermSetting {
 	opts: TermSettingOpts

--- a/client/test/test.helpers.js
+++ b/client/test/test.helpers.js
@@ -353,7 +353,6 @@ class TestAppStore {
 	constructor(opts) {
 		;(this.type = 'store'),
 			(this.defaultState = {
-				//another prettier test, should see () and ; that have been removed
 				debug: true,
 			})
 	}

--- a/client/test/test.helpers.js
+++ b/client/test/test.helpers.js
@@ -21,7 +21,7 @@ whenVisible
 */
 
 export function sleep(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms))
+	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 //exports.sleep = sleep
@@ -63,8 +63,8 @@ export async function detectLst(_opts = {}) {
 			childList: true,
 			subtree: true,
 			attributes: true,
-			characterData: true
-		}
+			characterData: true,
+		},
 	}
 
 	if (!_opts.matcher) {
@@ -89,9 +89,9 @@ export async function detectLst(_opts = {}) {
 			}
 		}
 
-		const callback = mutations => {
+		const callback = (mutations) => {
 			const elems = opts.selector ? [...opts.target.querySelectorAll(opts.selector)] : [opts.target]
-			const mutated = mutations.filter(m => elems.includes(m.target))
+			const mutated = mutations.filter((m) => elems.includes(m.target))
 			if (!mutated.length && opts.count !== 0) return
 			const matched = opts.matcher ? opts.matcher(mutated, observer) : matchedCount(elems.length, opts)
 			const expired = Date.now() - start > opts.maxTime
@@ -156,8 +156,8 @@ export async function detectChildAttr(opts) {
 		if (opts.matcher) console.warn(`will not use opts.attr since an opts.matcher is already available`)
 		else {
 			if (!('count' in opts)) opts.count = 1
-			opts.matcher = mutations => {
-				const matched = mutations.filter(m => {
+			opts.matcher = (mutations) => {
+				const matched = mutations.filter((m) => {
 					for (const key in opts.attr) {
 						if (typeof opts.attr[key] === 'function') {
 							const value = m.target.getAttribute(key)
@@ -169,7 +169,7 @@ export async function detectChildAttr(opts) {
 					return true
 				})
 				// TODO: should accumulate matched counts???
-				if (matched.length === opts.count) return matched.map(d => d.target)
+				if (matched.length === opts.count) return matched.map((d) => d.target)
 			}
 		}
 	}
@@ -194,9 +194,9 @@ export async function detectChildStyle(opts) {
 		if (opts.matcher) console.warn(`will not use opts.style since an opts.matcher is already available`)
 		else {
 			if (!('count' in opts)) opts.count = 1
-			opts.matcher = mutations => {
+			opts.matcher = (mutations) => {
 				// need to be careful of strings
-				const matched = mutations.filter(m => {
+				const matched = mutations.filter((m) => {
 					for (const key in opts.style) {
 						const value = m.target.style[key]
 						if (typeof opts.style[key] == 'function') {
@@ -206,7 +206,7 @@ export async function detectChildStyle(opts) {
 					return true
 				})
 				// TODO: should accumulate matched counts???
-				if (matched.length === opts.count) return matched.map(d => d.target)
+				if (matched.length === opts.count) return matched.map((d) => d.target)
 			}
 		}
 	}
@@ -227,7 +227,7 @@ export async function detectChildText(opts) {
 	opts.observe.characterData = true
 	opts.observe.childList = true
 	if (!opts.matcher) {
-		opts.matcher = mutations => mutations.map(m => m.target)
+		opts.matcher = (mutations) => mutations.map((m) => m.target)
 	}
 	const lst = await detectLst(opts)
 	return lst
@@ -353,7 +353,8 @@ class TestAppStore {
 	constructor(opts) {
 		;(this.type = 'store'),
 			(this.defaultState = {
-				debug: true
+				//another prettier test, should see () and ; that have been removed
+				debug: true,
 			})
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/node": "^20.2.4",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "eslint": "^8.43.0",
+        "eslint-config-prettier": "^8.8.0",
         "typescript": "^5.1.3"
       }
     },
@@ -6276,6 +6277,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -18169,6 +18182,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/node": "^20.2.4",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "eslint": "^8.43.0",
+    "eslint-config-prettier": "^8.8.0",
     "typescript": "^5.1.3"
   }
 }


### PR DESCRIPTION
- I used `eslint-config-prettier` to disable the prettier settings. You will need to delete your proteinpaint/node_modules and run`npm install` or run `npm install eslint-config-prettier`. 
- I tested by adding or deleting formatting and committing (neither my IDE or git GUI show the change until it commits). The resulting code matched past versions in master before last week. 