### PR TITLE
Loading message now is visible

### DIFF
--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -147,7 +147,7 @@ class Matrix {
 
 			this.computeStateDiff()
 
-			this.dom.loadingDiv.html('').style('display', '')
+			this.dom.loadingDiv.html('').style('display', '').style('position', 'relative').style('left', '45%')
 			if (this.stateDiff.nonsettings) {
 				// get the data
 				const reqOpts = await this.getDataRequestOpts()


### PR DESCRIPTION
Loading message is already displayed, but to the left may be hidden by the menu/popup. Moved to the center as a quick fix. Now when grouping the samples, for example, it is visible.