### PR TITLE
handle a custom callback for matrix cell click

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1511,21 +1511,37 @@ function setZoomPanActions(self) {
 			.style('user-select', '')
 
 		const c = self.clickedSeriesCell
-
-		/* TODO enable clicking matrix cell to launch /methylationArrayPlot/DIsco plot
-		if (c.startCell && !c.endCell) {
+		const endCell = self.getCellByPos(event)
+		if (!c || !c.startCell) {
 			self.dom.mainG.on('mouseout', null)
 			delete self.clickedSeriesCell
-			self.mouseclick(event)
 			return
-		}
-		*/
-
-		if (!c || !c.startCell || !c.endCell) {
+		} else if (!c.endCell || endCell === c.startCell) {
+			self.dom.mainG.on('mouseout', null)
+			self.dom.tip.hide()
 			delete self.clickedSeriesCell
+			if (self.opts.cellClick) {
+				const cell = structuredClone(self.getImgCell(event))
+				self.opts.cellClick({
+					sampleData: cell.row,
+					term: cell.term,
+					value: cell.value,
+					s: cell.s,
+					t: cell.t,
+					siblingCells: cell.siblingCells
+						.filter(c => c !== cell)
+						.map(c => ({
+							term: c.term,
+							value: c.value,
+							s: c.s,
+							t: c.t
+						}))
+				})
+			}
 			return
 		}
-		c.endCell = self.getCellByPos(event)
+
+		c.endCell = endCell
 		const ss = self.opts.allow2selectSamples
 		if (ss) {
 			self.dom.tip.hide()

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -26,6 +26,40 @@ arg = {}
 	.genes[]
 		future: list of genes to launch matrix
 
+	.opts{}
+		.matrix{}
+			.allow2selectSamples: 
+				{
+				  buttonText: "Create Cohort",
+				  attributes: ["case.case_id"],
+				  callback: console.log,
+				}
+
+			.cellClick(cell), where
+				cell = {
+					sampleData: the data.row by sample, part of the data.lst as returned by vocabApi.getAnnotatedSampleData()
+						{
+							sample: name/id string,
+							[term1_$id]: {key, label, values, renderedValues, filteredValues, countedValues, sample},
+							[....]
+						},
+
+					value: the data.row[term.id] value, data shape depends on the term.type,
+						// for gene variant
+						{	
+							dt, class, gene, pos, _SAMPLEID_, _SAMPLENAME
+						}
+						// not shown here: example values for other term types
+
+					term: the term for this matrix cell, equivalent to t.tw,
+
+					s: the matrix.sampleOrder[] entry for this matrix cell,
+
+					t: the matrix.termOrder[] entry for this matrix cell,
+
+					siblingCells: cell data for the same matrix sample/term, but excluding this cell 
+				}
+
 holder
 genomes = { hg38 : {} }
 
@@ -89,34 +123,36 @@ export async function init(arg, holder, genomes) {
 			undoHtml: 'undo',
 			redoHtml: 'redo'
 		},
-		matrix: {
-			allow2selectSamples: arg.allow2selectSamples,
-			// these will display the inputs together in the Genes menu,
-			// instead of being rendered outside of the matrix holder
-			customInputs: {
-				genes: [
-					{
-						label: `Maximum # Genes`,
-						title: 'Limit the number of displayed genes',
-						type: 'number',
-						chartType: 'matrix',
-						settingsKey: 'maxGenes',
-						callback: async value => {
-							maxGenes = value
-							const genes = await getGenes(arg, gdcCohort, CGConly, maxGenes)
-							api.update({
-								termgroups: [{ lst: genes }],
-								settings: {
-									matrix: {
-										maxGenes
+		matrix: Object.assign(
+			{
+				// these will display the inputs together in the Genes menu,
+				// instead of being rendered outside of the matrix holder
+				customInputs: {
+					genes: [
+						{
+							label: `Maximum # Genes`,
+							title: 'Limit the number of displayed genes',
+							type: 'number',
+							chartType: 'matrix',
+							settingsKey: 'maxGenes',
+							callback: async value => {
+								maxGenes = value
+								const genes = await getGenes(arg, gdcCohort, CGConly, maxGenes)
+								api.update({
+									termgroups: [{ lst: genes }],
+									settings: {
+										matrix: {
+											maxGenes
+										}
 									}
-								}
-							})
+								})
+							}
 						}
-					}
-				]
-			}
-		}
+					]
+				}
+			},
+			arg.opts?.matrix || {}
+		)
 	}
 
 	const plotAppApi = await appInit(opts)


### PR DESCRIPTION
NOTE: The callback will need to decide how to handle the cell click event, based on the `cell` argument as commented in lines 39-60 of `proteinpaint/client/src/launchGdcMatrix.js`. 

To test, edit `sjpp/public/example.gdc.matrix.js` as follows.
```js
// line 25
setTimeout(async ()=>{
	matrixApi = await runproteinpaint({
		host: `http://localhost:${ params.port || 3000}`,
		holder:document.getElementById('aaa'),
		launchGdcMatrix:true,
		filter0: filters[dropdown.property('value')],
		settings: {
			matrix: {
				maxGenes: params.maxGenes || 50,
				maxSample: 2000
			}
		},
		opts: { /**** ADD THIS ****/
			matrix: {
				allow2selectSamples: {
				  buttonText: "Create Cohort",
				  attributes: ["case.case_id"],
				  callback: console.log,
				},
				cellClick: cell => console.log('cellClick()!!!!', cell)
			}
		}
	})
}, 0)
```