### PR TITLE
bug fix to pass string sample name when available, and quit click cal…

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -84,13 +84,21 @@ export function setInteractivity(self) {
 	}
 
 	self.mouseclick = function (event, data) {
-		const q = self.state.termdbConfig.queries || {}
-		if (!q.singleSampleGenomeQuantification && !q.singleSampleMutation) return
+		// clicking only show actions for available genomic data; can later expand to non-genomic data and custom overrides
+		const q = self.state.termdbConfig.queries
+		if (!q) return // no genomic queries
+		if (!q.singleSampleGenomeQuantification && !q.singleSampleMutation) return // only works for these queries
 
 		self.dom.mainG.on('mouseout', null)
 		const sampleData = data || event.target.__data__
-		const sample = { sample_id: sampleData._SAMPLENAME_ || sampleData.row.sample }
-		if (sampleData.row['case.case_id']) sample['case.case_id'] = sampleData.row['case.case_id']
+
+		if (!sampleData) return // !!! it's undefined when dragging on the sample names
+
+		// preliminary fix: assign string sample name for "sample_id", which is used by data queries below
+		const sample = {
+			sample_id: sampleData._SAMPLENAME_ || sampleData.row.sampleName || sampleData.row.sample
+		}
+
 		self.dom.menubody.selectAll('*').remove()
 		self.dom.menutop.selectAll('*').remove()
 		self.dom.tip.show(event.clientX, event.clientY, false, true)


### PR DESCRIPTION
…lback when no event data

test by dragging on [sample names here](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22id%22:%22Gender%22},{%22id%22:%22Age%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22TSNE%20Category%22}]}]}]}), the click callback will not run and avoids crashing

test [at this](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22CLINGEN%22,%22genome%22:%22hg19%22,%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22hoxa1%22,%22type%22:%22geneVariant%22}}]}]}]}) and disco data query will use sample name but not sample id