### PR TITLE
Increase timeout on survival tape test to avoid future CI failures

### DIFF
--- a/client/mass/test/survival.integration.spec.js
+++ b/client/mass/test/survival.integration.spec.js
@@ -544,7 +544,7 @@ tape('survival term as term1, term2 = agedx, custom bins', function(test) {
 })
 
 tape('survival term as term1, term0 = agedx, custom bins', function(test) {
-	test.timeoutAfter(10000)
+	test.timeoutAfter(20000)
 
 	runpp({
 		state: {


### PR DESCRIPTION
CI failed last night on `survival term as term1, term0 = agedx, custom bin`. Increase time out to avoid another failure. 