### PR TITLE
try to add `type ChartConfigByType`

### DIFF
--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -508,6 +508,7 @@ interface Termdb {
 type ChartConfigByType = {
 	[index: string]: ChartConfig
 }
+
 type ChartConfig = {
 	[key: string]: any
 }
@@ -537,11 +538,7 @@ interface BaseDtEntry {
 	no: { value: string[] }
 }
 
-interface SNVByOrigin {
-	[index: string]: BaseDtEntry
-}
-
-interface SNVByOrigin {
+type SNVByOrigin = {
 	[index: string]: BaseDtEntry
 }
 

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -6,6 +6,7 @@ ClinvarAF
 Cohort
 Mds3
 
+Termdb
 */
 
 /*** General usage types and interfaces ***/
@@ -493,6 +494,7 @@ interface Termdb {
 	matrix?: Matrix
 	matrixplots?: MatrixPlots
 	logscaleBase2?: boolean
+	chartConfigByType?: ChartConfigByType
 	//Functionality
 	dataDownloadCatch?: DataDownloadCatch
 	helpPages?: URLEntry[]
@@ -501,6 +503,13 @@ interface Termdb {
 	termid2totalsize2?: GdcApi
 	dictionary?: GdcApi
 	allowCaseDetails?: AllowCaseDetails
+}
+
+type ChartConfigByType = {
+	[index: string]: ChartConfig
+}
+type ChartConfig = {
+	[key: string]: any
 }
 
 type SimpleTermEntry = {
@@ -526,6 +535,10 @@ interface BaseDtEntry {
 	term_id: string
 	yes: { value: string[] }
 	no: { value: string[] }
+}
+
+interface SNVByOrigin {
+	[index: string]: BaseDtEntry
 }
 
 interface SNVByOrigin {


### PR DESCRIPTION
i'm adding `type ChartConfigByType` to go with a change in sjpp dataset. but i get following errors, please take a look

proteinpaint/server/shared/types/dataset.ts:541:2 - error TS2374: Duplicate index signature for type 'string'.

541  [index: string]: BaseDtEntry
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

proteinpaint/server/shared/types/dataset.ts:545:2 - error TS2374: Duplicate index signature for type 'string'.

545  [index: string]: BaseDtEntry
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[3:43:05 PM] Found 2 errors. Watching for file changes.
