### PR TITLE
Removed shifting in x and y

### DIFF
--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -282,8 +282,8 @@ export function setRenderers(self) {
 		scene.add(light)
 
 		for (const sample of chart.data.samples) {
-			let x = -0.5 + (chart.xAxisScale(sample.x) - chart.xScaleMin) / self.canvas.width
-			let y = 0.5 - (chart.yAxisScale(sample.y) - chart.yScaleMax) / self.canvas.height
+			let x = (chart.xAxisScale(sample.x) - chart.xScaleMin) / self.canvas.width
+			let y = (chart.yAxisScale(sample.y) - chart.yScaleMax) / self.canvas.height
 			let z = (chart.zAxisScale(sample.z) - chart.zScaleMin) / self.settings.svgd
 			const color = new THREE.Color(rgb(self.getColor(sample, chart)).toString())
 			const geometry = new THREE.SphereGeometry(0.015, 32)


### PR DESCRIPTION
Removed left over of x and y shifting that was moving the particles out of their original place. When looking at the particles now from the front side looks like the 2D plot without adding Z.
<img width="561" alt="Screenshot 2023-07-14 at 3 59 17 PM" src="https://github.com/stjude/proteinpaint/assets/12271391/fe43f6a3-69ec-49e9-94f9-b6ea8aa1004c">
