### PR TITLE
Display the active divide-by label for matrix sample columns

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1263,6 +1263,8 @@ function setLabelDragEvents(self, prefix) {
 	}
 
 	self[`${prefix}LabelMouseover`] = (event, t) => {
+		const cls = event.target.className?.baseVal || event.target.parentNode.className?.baseVal || ''
+		if (cls.includes('divide-by')) return
 		if (event.target.tagName === 'text') select(event.target).style('fill', 'blue')
 		if (!self.dragged) return
 		// TODO: why is the element-bound __data__ (t) not provided as a second argument by d3??

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -17,6 +17,7 @@ export function setRenderers(self) {
 
 		self.renderSerieses(s, l, d, duration)
 		self.renderLabels(s, l, d, duration)
+		self.renderDivideByLabel(s, l, d, duration)
 	}
 
 	self.renderSerieses = function (s, l, d, duration) {
@@ -307,6 +308,28 @@ export function setRenderers(self) {
 		const x = 0 // lab.tw?.q?.mode == 'continuous' ? -30 : 0
 		const y = lab.grpIndex * s.rowgspace + lab.totalIndex * d.dy + 0.7 * s.rowh + lab.totalHtAdjustments
 		return `translate(${x},${y})`
+	}
+
+	self.renderDivideByLabel = (s, l, d) => {
+		self.dom.mainG.selectAll('.sjpp-matrix-divide-by-label').remove()
+		if (!self.config.divideBy) return
+		const name = self.config.divideBy?.term.name || ''
+		const text = name.length < s.rowlabelmaxchars ? name : name.slice(0, s.rowlabelmaxchars) + '...'
+		const sides = !s.transpose ? [l.left, l.right] : [l.top, l.bottom]
+		const box = sides.find(d => !d.isGroup)?.box
+		const y = (s.collabelpos == 'top' ? d.mainh + s.collabelmaxchars : -s.collabelmaxchars) + 8
+		const anchor = s.rowlabelpos == 'left' ? 'end' : 'start'
+		const cl = s.controlLabels
+		const g = box.append('g').attr('class', 'sjpp-matrix-divide-by-label').attr('transform', `translate(0, ${y})`)
+		g.append('text')
+			.attr('text-anchor', anchor)
+			.attr('font-style', 'italic')
+			.attr('y', -20)
+			.text(`${cl.Samples} grouped by`)
+		g.append('text').attr('text-anchor', anchor).attr('font-weight', 600).text(text)
+		g.append('title').text(
+			`${cl.Samples} are grouped by this gene or variable. Use the Samples -> 'Group Samples By' input in the controls bar to edit.`
+		)
 	}
 
 	self.adjustSvgDimensions = async function (prevTranspose) {


### PR DESCRIPTION
Addresses JIRA # SV-2240.

The divide by label moves based on Cell Layout -> Group Label position inputs such as `s.collabelpos == 'top'`. Use the [integration test](http://localhost:3000/testrun.html?name=matrix.integration) or any dataset with matrix plots with a divide by term.
 
![Screenshot 2023-07-16 at 8 52 44 PM](https://github.com/stjude/proteinpaint/assets/411031/c20f8208-2337-49fa-8b71-f571fee7d540)


