### PR TITLE
Matrix sort improvements

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -44,6 +44,7 @@ export async function getPlotConfig(opts = {}, app) {
 				sampleNameFilter: '',
 				sortSamplesBy: 'a',
 				sortOptions: getSortOptions(app.vocabApi.termdbConfig, controlLabels),
+				sortSampleGrpsBy: 'name', // 'hits' | 'name' | 'sampleCount'
 				sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: {} /*split: {char: '', index: 0}*/ }],
 				sortTermsBy: 'sampleCount', // or 'as listed'
 				samplecount4gene: 'abs', //true, // 'abs' (default, previously true), 'pct', ''  (previously false)
@@ -133,7 +134,7 @@ export async function getPlotConfig(opts = {}, app) {
 		}
 		if (os.sortOptions) {
 			delete os.sortOptions.custom
-			delete os.sortOptions.asListedr
+			delete os.sortOptions.asListed
 		}
 	}
 
@@ -146,7 +147,8 @@ export async function getPlotConfig(opts = {}, app) {
 	// force auto-dimensions for colw
 	m.colw = 0
 	// support deprecated sortSamplesBy value from a saved session
-	if (['selectedTerms', 'class', 'dt', 'hits'].includes(m.sortSamplesBy)) m.sortSamplesBy = 'a'
+	if (!m.sortOptions?.[m.sortSamplesBy]) m.sortSamplesBy = 'a'
+	else if (['selectedTerms', 'class', 'dt', 'hits'].includes(m.sortSamplesBy)) m.sortSamplesBy = 'a'
 	if (m.samplecount4gene === true || m.samplecount4gene === 1) m.samplecount4gene = 'abs'
 	// support overrides in localhost
 	if (window.location.hostname == 'localhost') {

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -82,6 +82,33 @@ export class MatrixControls {
 						}
 					},
 					{
+						label: `Sort ${l.Sample} Groups`,
+						title: `Set how to sort ${l.sample} groups`,
+						type: 'radio',
+						chartType: 'matrix',
+						settingsKey: 'sortSampleGrpsBy',
+						options: [
+							{
+								label: 'Group Name',
+								value: 'name',
+								title: `Sort by group name`
+							},
+							{
+								label: `${l.Sample} Count`,
+								value: 'sampleCount',
+								title: `Sort by the number of samples in the group`
+							},
+							{
+								label: `Hits`,
+								value: 'hits',
+								title: `Sort by the total number of variants for every sample in the group`
+							}
+						],
+						getDisplayStyle(plot) {
+							return plot.divideBy ? 'block' : 'none'
+						}
+					},
+					{
 						label: `${l.Sample} Group Label Max Length`,
 						title: `Truncate the ${l.sample} group label if it exceeds this maximum number of characters`,
 						type: 'number',

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -305,7 +305,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}) {
 			if (d.order >= order) d.order += 1
 		})
 		sortOptions.custom = {
-			label: sortPriority.label || 'Custom sort',
+			label: s.sortPriority.label || 'Custom sort',
 			value: 'custom',
 			order,
 			sortPriority: s.sortPriority

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -314,7 +314,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}) {
 
 	// Similar to Oncoprint sorting
 	sortOptions.a = {
-		label: 'SV+Fusion > CNV+SSM > SSM-only > CNV-only',
+		label: 'CNV+SSM > SSM-only > CNV-only',
 		value: 'a',
 		order: 1,
 		sortPriority: [
@@ -381,7 +381,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}) {
 	}
 
 	sortOptions.b = {
-		label: 'SV+Fusion > CNV+SSM > SSM-only',
+		label: 'CNV+SSM > SSM-only',
 		value: 'b',
 		order: 1,
 		sortPriority: [

--- a/client/plots/test/matrix.sort.unit.spec.js
+++ b/client/plots/test/matrix.sort.unit.spec.js
@@ -212,9 +212,9 @@ tape('sortSamplesBy = asListed', test => {
 	test.end()
 })
 
-tape('sortPriority by default custom that uses a filter', test => {
+tape('sortPriority by CNV+SSM > SSM-only > CNV-only that uses a filter', test => {
 	const { self, settings, rows } = getArgs({
-		sortSamplesBy: 'custom'
+		sortSamplesBy: 'a'
 	})
 	const sorter = ms.getSampleSorter(self, settings, rows)
 	const sampleNames = self.sampleGroups.map(g => g.lst.sort(sorter).map(s => s.sample))
@@ -239,7 +239,7 @@ tape('sortPriority by default custom that uses a filter', test => {
 	test.end()
 })
 
-tape('sortPriority by custom, without filter', test => {
+tape('custom sortPriority, without filter', test => {
 	const { self, settings, rows } = getArgs({
 		sortSamplesBy: 'custom',
 		sortOptions: {
@@ -330,6 +330,7 @@ tape('sortPriority by custom, without filter', test => {
 tape('sort against selectedTerms', test => {
 	const { self, settings, rows } = getArgs({ sortSamplesBy: 'dt' })
 	self.termGroups[0].lst[1].sortSamples = {}
+	settings.sortSamplesBy = 'a'
 	const sorter = ms.getSampleSorter(self, settings, rows)
 	const sampleNames = self.sampleGroups.map(g => g.lst.sort(sorter).map(s => s.sample))
 	test.deepEqual(


### PR DESCRIPTION
- removed the asListed sample option: will require a `setting.sampleOrder` option to be easy to understand and implement
- relabeled the sample sorting options: will edit the gdc dataset file later to remove the duplicate "custom" option
- add sample grouping options

To test, just click around the new/improved sample sorting options.

![Screenshot 2023-07-17 at 1 14 10 PM](https://github.com/stjude/proteinpaint/assets/411031/cb32ef14-d924-48f3-bd2a-f3986a202719)
