### PR TITLE
Commit parser

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ## [Checklist](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist)
 
-Check if you performed or verified to be not applicable.
+Check each task that has been performed or verified to be not applicable.
 - [ ] Tests: added and/or passed unit and integration tests, or N/A
 - [ ] Todos: commented or documented, or N/A
 - [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 ## Description
 
-## Checklist
+## [Checklist](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist)
 
-- [ ] Tests: added unit/integration tests and/or ran tests, or N/A.
-- [ ] Todos: added to code or documentation, or N/A.
-- [ ] Release notes: updated release.txt, prefixed a commit message with "fix:" or "feat:", or N/A.
+Check if you performed or verified to be not applicable.
+- [ ] Tests: added and/or passed unit and integration tests, or N/A
+- [ ] Todos: commented or documented, or N/A
+- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A

--- a/build/changeLogGenerator.js
+++ b/build/changeLogGenerator.js
@@ -45,12 +45,12 @@ if (generalSection) {
 }
 if (featureSection || features) {
 	notes += '\n' + EnhancementsTitle
-	if (featureSection) notes += featureSection + '\n'
+	if (featureSection) notes += featureSection.trim() + '\n'
 	if (features) notes += features.map(getListItem) + '\n'
 }
 if (fixSection || fixes) {
 	notes += '\n' + FixesTitle
-	if (fixSection) notes += fixSection + '\n'
+	if (fixSection) notes += fixSection.trim() + '\n'
 	if (fixes) notes += fixes.map(getListItem) + '\n'
 }
 

--- a/build/changeLogGenerator.js
+++ b/build/changeLogGenerator.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const execSync = require('child_process').execSync
 
 const changeLogFile = './CHANGELOG.md'
 const oldChangeLogText = fs.readFileSync(changeLogFile).toString('utf-8')
@@ -16,11 +17,63 @@ const changeLogWithoutHeader = oldChangeLogText.replace(header, '')
 
 const version = require('../package.json').version
 
-const newChangeLog = `${header} 
-## ${version}
+// commits since the last release
+const commitLog = execSync(`git log "v${version}"..HEAD --oneline`, { encoding: 'utf8' })
+const commitMessages = commitLog
+	.split('\n')
+	.filter(l => l && true)
+	.map(getStringAfter1stSpace)
+// keyword convention loosely follows https://www.conventionalcommits.org/en/v1.0.0/
+// however, breaking changes is not processed here, that would require
+// manual review, handling, coordination, and should not be automated?
+const features = commitMessages.filter(m => m.toLowerCase().startsWith('feat: ')).map(getStringAfter1stSpace)
+const fixes = commitMessages.filter(m => m.toLowerCase().startsWith('fix: ')).map(getStringAfter1stSpace)
+const EnhancementsTitle = 'Enhancements\n'
+const FixesTitle = 'Fixes\n'
+const firstSubsectionTitle = releaseLogText.includes(EnhancementsTitle) ? EnhancementsTitle : FixesTitle
+const [generalSection, subsections] = releaseLogText.split(firstSubsectionTitle)
+// okay for these subsection titles to not exist
+const featureSection = firstSubsectionTitle == EnhancementsTitle ? subsections.split(FixesTitle)[0] : ''
+const fixSection = firstSubsectionTitle == FixesTitle ? subsections?.[0] : subsections.split(FixesTitle)[1]
 
-${releaseLogText}
-${changeLogWithoutHeader}`
+let notes = ''
+if (generalSection) {
+	const GeneralTitle = `General\n`
+	if (!generalSection.includes('General')) notes += GeneralTitle
+	notes += generalSection
+}
+if (featureSection || features) {
+	notes += EnhancementsTitle
+	if (featureSection) notes += featureSection + '\n'
+	if (features) notes += features.map(getListItem) + '\n'
+}
+if (fixSection || fixes) {
+	notes += FixesTitle
+	if (fixSection) notes += fixSection + '\n'
+	if (fixes) notes += fixes.map(getListItem)
+}
 
-fs.writeFileSync(changeLogFile, newChangeLog)
-fs.writeFileSync(releaseTextFile, '')
+console.log(`## ${version}
+${notes}
+`)
+
+// ${releaseLogText}
+// ${features.map(getListItem)}
+// ${fixes.map(getListItem)}
+// `)
+// const newChangeLog = `${header}
+// ## ${version}
+
+// ${notes}
+// ${changeLogWithoutHeader}`
+
+// fs.writeFileSync(changeLogFile, newChangeLog)
+// fs.writeFileSync(releaseTextFile, '')
+
+function getStringAfter1stSpace(str) {
+	return str.slice(str.indexOf(' ') + 1)
+}
+
+function getListItem(str) {
+	return '- ' + str
+}

--- a/release.txt
+++ b/release.txt
@@ -1,3 +1,0 @@
-- test
-- abc
-- xyz

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,3 @@
+- test
+- abc
+- xyz


### PR DESCRIPTION
## Description
Auto-generate release notes from commit messages with `fix:` or `feat:` keywords. Please also see the [PR Checklist wiki.](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist)

Testing via `node build/changeLogGenerator.js`, CHANGELOG.md became
```md
# Change Log

All notable changes to this project will be documented in this file.
## 2.19.0 

General
- test
- abc
- xyz

Enhancements
- add sections to the release notes based on parsed commits and/or release.txt entries

Fixes
- parse commit messages detecting release notes; update the PR template

```

## Checklist

- [x] Tests: added unit/integration tests and/or ran tests, or N/A.
- [x] Todos: added to code or documentation, or N/A.
- [x] Release notes: updated release.txt, prefixed a commit message with "fix:" or "feat:", or N/A.
