### PR TITLE
fix: cohort creation in the matrix plot

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1607,7 +1607,9 @@ function setZoomPanActions(self) {
 								series.cells.filter(filter).forEach(d => {
 									const obj = {}
 									for (const a of ss.attributes) {
-										obj[a] = d.row[a]
+										if (!('to' in a)) a.to = a.from
+										// TODO: may need to support a.convert later, not supported right now
+										obj[a.to] = d.row[a.from]
 									}
 									const sid = Object.values(obj).join(';;')
 									if (processed.has(sid)) return

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes
 - process commit-based release notes on commit instead of in CI; revert changelog generator
+- cohort creation in the matrix plot, where sample atttribute mapping is required


### PR DESCRIPTION
## Description
This fix supports embedders that require sample atttribute mapping when creating a sample/case list for cohort creation.

## [Checklist](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist)

Check each task that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
