### PR TITLE
Corrected matrix sorting

### DIFF
--- a/client/plots/test/matrix.sort.unit.spec.js
+++ b/client/plots/test/matrix.sort.unit.spec.js
@@ -353,3 +353,32 @@ tape('sort against selectedTerms', test => {
 	)
 	test.end()
 })
+
+tape('getSampleSorter() should apply an opts.skipSorter() argument', test => {
+	const { self, settings, rows } = getArgs({
+		sortSamplesBy: 'a'
+	})
+	const sorter = ms.getSampleSorter(self, settings, rows, {
+		skipSorter: (p, tw) => tw.term.name == 'aaa'
+	})
+	const sampleNames = self.sampleGroups.map(g => g.lst.sort(sorter).map(s => s.sample))
+	test.deepEqual(
+		sampleNames,
+		[
+			[1, 2, 3],
+			[5, 4]
+		],
+		'should sort the samples by dt then value'
+	)
+	test.deepEqual(
+		simpleMatrix(sampleNames, self.termOrder, rows),
+		// prettier-ignore
+		[ 
+			[ ' ', '2', '3', '5', ' ' ], 
+			[ '1', '2', ' ', '5', ' ' ], 
+			[ '1', ' ', '3', ' ', '4' ] 
+		],
+		'should sort sample and rows in the expected order'
+	)
+	test.end()
+})

--- a/release.txt
+++ b/release.txt
@@ -2,3 +2,4 @@ Fixes
 - Process commit-based release notes on commit instead of in CI; revert changelog generator.
 - Cohort creation in the matrix plot, where sample atttribute mapping is required.
 - Allow continuous variables to be added to GDC matrix without breaking. Next will support query of graphql API to retrieve min/max of the variables.
+- Sort matrix samples by gene variant hits before grouping, then sort again within each group


### PR DESCRIPTION
## Description

Sort matrix samples by gene variant hits before grouping, then sort again within each group. Previously, the sample grouping was being applied before sorting by gene variant hits.

This fix reverts code that was accidentally removed, but also reorganized and simplified the termOrder and sampleOrder computation.

To test, http://localhost:3000/example.gdc.matrix.html?maxGenes=3, cut down the max # samples to  ~100, then group by gender. There should be >1 groups.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [X] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
