### PR TITLE
cache all mappings to case uuid

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- Selecting hundreds of samples from GDC lollipop no longer hangs or crashes (using a cached mapping to case uuid)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -256,7 +256,7 @@ export async function validate_termdb(ds) {
 
 	if (tdb.convertSampleId) {
 		if (tdb.convertSampleId.gdcapi) {
-			gdc.convertSampleId_addGetter(tdb)
+			gdc.convertSampleId_addGetter(tdb, ds)
 			// convertSampleId.get() added
 		} else {
 			throw 'unknown implementation of tdb.convertSampleId'

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -80,7 +80,7 @@ export function handle_request_closure(genomes) {
 			if (q.for == 'mds3variantData') return await get_mds3variantData(q, res, ds, genome)
 			if (q.for == 'validateToken') {
 			}
-			if (q.for == 'convertSampleId') return await get_convertSampleId(q, res, tdb)
+			if (q.for == 'convertSampleId') return get_convertSampleId(q, res, tdb)
 
 			throw "termdb: doesn't know what to do"
 		} catch (e) {
@@ -123,10 +123,10 @@ function get_ds_tdb(genome, q) {
 	return [ds, ds.cohort.termdb]
 }
 
-async function get_convertSampleId(q, res, tdb) {
+function get_convertSampleId(q, res, tdb) {
 	if (!tdb.convertSampleId) throw 'not supported on this ds'
-	if (!q.inputs || !Array.isArray(q.inputs)) throw 'q.inputs[] not array'
-	res.send({ mapping: await tdb.convertSampleId.get(q.inputs) })
+	if (!Array.isArray(q.inputs)) throw 'q.inputs[] not array'
+	res.send({ mapping: tdb.convertSampleId.get(q.inputs) })
 }
 
 async function trigger_getsamples(q, res, ds) {


### PR DESCRIPTION
## Description

backend now caches mapping to case uuid from 3 types of ids (case submitter, sample submitter, aliquot)
when selecting cases from gdc lollipop or oncomatrix, it will fetch case id from cache, and no longer performs on the fly api query which crashes with hundreds of input ids

this affects both lollipop and oncomatrix

please help me test that sample selection from both allows to create valid GFF cohort

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
