### PR TITLE
Fix the numeric edit menu when violin plot data is requested for a GD…

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -215,6 +215,17 @@ function setTermActions(self) {
 			vocab: appState.vocab,
 			activeCohort: appState.activeCohort,
 			numericEditMenuVersion: ['discrete', 'continuous'],
+			getCurrentGeneNames: () => {
+				const tws = []
+				for (const grp of self.config.termgroups) {
+					tws.push(...grp.lst)
+				}
+				const termNames = tws
+					.filter(tw => tw.term.type === 'geneVariant')
+					.map(tw => tw.term.name)
+					.sort()
+				return termNames.length ? termNames : undefined
+			},
 			//holder: {}, //self.dom.inputTd.append('div'),
 			//debug: opts.debug,
 			renderAs: 'none',

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -98,8 +98,6 @@ export async function init(arg, holder, genomes) {
 	if (!settings.matrix) settings.matrix = {}
 	settings.matrix.geneFilter = geneFilter
 	settings.matrix.maxGenes = maxGenes
-	//const term = { id: 'case.disease_type', name: 'Disease Type', type: 'categorical' }
-	const term = { id: 'case.primary_site', name: 'Primary Site', type: 'categorical' }
 	const opts = {
 		holder,
 		genome,
@@ -110,11 +108,8 @@ export async function init(arg, holder, genomes) {
 			plots: [
 				{
 					chartType: 'matrix',
-					termgroups: [
-						//{ lst: [{term}] },
-						{ lst: genes }
-					],
-					// divideBy: { term }, // testing only
+					termgroups: [...(arg.termgroups || []), { lst: genes }],
+					divideBy: arg.divideBy || undefined,
 					// moved default settings to gdc.hg38.js termdb.matrix.settings
 					// but can still override in the runpp() argument
 					settings

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -412,7 +412,8 @@ export class TermdbVocab extends Vocab {
 				embedder: window.location.hostname,
 				devicePixelRatio: window.devicePixelRatio,
 				maxThickness: 150,
-				screenThickness: arg.screenThickness
+				screenThickness: arg.screenThickness,
+				currentGeneNames: arg.currentGeneNames
 			},
 			arg,
 			_body

--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -44,6 +44,13 @@ export function getHandler(self: NumericTermSettingInstance) {
 				xpad: 10,
 				ypad: 20
 			}
+
+			div.selectAll('*').remove()
+			div
+				.append('div')
+				.style('padding', '10px')
+				.style('text-align', 'center')
+				.html('Getting distribution data ...<br/>')
 			// try {
 			const d = await self.vocabApi.getViolinPlotData({
 				termid: self.term.id,
@@ -52,7 +59,8 @@ export function getHandler(self: NumericTermSettingInstance) {
 				orientation: 'horizontal',
 				datasymbol: 'bean',
 				radius: 5,
-				strokeWidth: 0.2
+				strokeWidth: 0.2,
+				currentGeneNames: self.opts.getCurrentGeneNames?.()
 			})
 			self.num_obj.density_data = convertViolinData(d)
 			// } catch (e) {

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -70,6 +70,8 @@ async function showBinsMenu(self: NumericTermSettingInstance, div: any) {
 		xpad: 10,
 		ypad: 20
 	}
+	div.selectAll('*').remove()
+	div.append('div').style('padding', '10px').style('text-align', 'center').html('Getting distribution data ...<br/>')
 	try {
 		if (!self.vocabApi) throw `Missing .vocabApi{} [numeric.discrete showBinsMenu()]`
 		const d = await self.vocabApi.getViolinPlotData({
@@ -79,7 +81,8 @@ async function showBinsMenu(self: NumericTermSettingInstance, div: any) {
 			orientation: 'horizontal',
 			datasymbol: 'bean',
 			radius: 5,
-			strokeWidth: 0.2
+			strokeWidth: 0.2,
+			currentGeneNames: self.opts.getCurrentGeneNames?.()
 		})
 		self.num_obj.density_data = convertViolinData(d)
 	} catch (err) {

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -47,6 +47,12 @@ export function getHandler(self: NumericTermSettingInstance) {
 				xpad: 10,
 				ypad: 20
 			}
+			div.selectAll('*').remove()
+			div
+				.append('div')
+				.style('padding', '10px')
+				.style('text-align', 'center')
+				.html('Getting distribution data ...<br/>')
 			try {
 				const d = await self.vocabApi.getViolinPlotData({
 					termid: self.term.id,
@@ -55,7 +61,8 @@ export function getHandler(self: NumericTermSettingInstance) {
 					orientation: 'horizontal',
 					datasymbol: 'bean',
 					radius: 5,
-					strokeWidth: 0.2
+					strokeWidth: 0.2,
+					currentGeneNames: self.opts.getCurrentGeneNames?.()
 				})
 				self.num_obj.density_data = convertViolinData(d)
 			} catch (err) {

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - Selecting hundreds of samples from GDC lollipop no longer hangs or crashes (using a cached mapping to case uuid)
+- Fix the numeric edit menu when violin plot data is requested for a GDC variable, which needs currentGeneNames

--- a/server/shared/types/termsetting.ts
+++ b/server/shared/types/termsetting.ts
@@ -121,6 +121,10 @@ export type TermSettingOpts = BaseTermSettingOpts & {
 	//getBodyParams used but not documented??
 	//vocab??
 	//Methods
+
+	// optional method supplied by matrix, to work with geneVariant terms with gdc api
+	getCurrentGeneNames?: () => void
+
 	callback?: (f: TermWrapper | null) => void
 	customFillTw?: (f: TermWrapper) => void
 	getBodyParams: () => any
@@ -166,6 +170,7 @@ export type TermSettingInstance = {
 	term: Term
 	usecase?: UseCase
 	vocabApi: VocabApi
+
 	//Methods
 	/*
 	TODOs: 


### PR DESCRIPTION
## Description

The numeric edit menu errored for a GDC variable like "Days to birth", which was caused by getViolinPlotData needing to be supplied a currentGeneNames option if applicable.

To test, pull the `sjpp` master branch. Then, open http://localhost:3000/example.gdc.matrix.html?maxGenes=3, click on the `Days to birth` label and the Edit menu in the pop up. There should be no error, and a density plot should be rendered, the server may take a few seconds to respond with data.

![Screenshot 2023-07-22 at 10 03 16 PM](https://github.com/stjude/proteinpaint/assets/411031/780d0ce6-0849-45f8-bf37-0025a1f55995)

![Screenshot 2023-07-22 at 10 34 24 PM](https://github.com/stjude/proteinpaint/assets/411031/ef1083bc-9e9d-49bb-af41-8340c2f36a9d)



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
