### PR TITLE
bug fix to show reduced sample summary in gdc mds3

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -139,6 +139,7 @@ async function mayShowSummary(tk, block) {
 
 	try {
 		const data = await tk.mds.getSamples({ isSummary: true })
+		tk.leftlabels.__samples_data = data // for testing
 		wait.remove()
 		await showSummary4terms(data, div.append('div').attr('class', 'sja_mds3samplesummarydiv'), tk, block)
 	} catch (e) {

--- a/release.txt
+++ b/release.txt
@@ -1,3 +1,4 @@
 Fixes:
 - Selecting hundreds of samples from GDC lollipop no longer hangs or crashes (using a cached mapping to case uuid)
 - Fix the numeric edit menu when violin plot data is requested for a GDC variable, which needs currentGeneNames
+- Bug fix to show reduced sample summaries when creating sub-track from GDC lollipop (mds3) track

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1566,19 +1566,12 @@ export async function get_termlst2size(twLst, q, combination, ds) {
 	for (let i = 1; i < keys.length; i++) {
 		h = h[keys[i]]
 		if (!h)
-			throw (
-				'.' +
-				keys[i] +
-				' missing from data structure of termid2totalsize2 for query :' +
-				query +
-				' and filter: ' +
-				filter
-			)
+			throw `.${keys[i]} missing from data structure of termid2totalsize2 for query :${query} and filter: ${filter}`
 	}
 	for (const term of termPaths) {
-		if (term.type == 'categorical' && !Array.isArray(h[term.path]['buckets']))
+		if (term.type == 'categorical' && !Array.isArray(h[term.path].buckets))
 			throw keys.join('.') + ' not array for query :' + query + ' and filter: ' + filter
-		if ((term.type == 'integer' || term.type == 'float') && typeof h[term.path]['stats'] != 'object') {
+		if ((term.type == 'integer' || term.type == 'float') && typeof h[term.path].stats != 'object') {
 			throw keys.join('.') + ' not object for query :' + query + ' and filter: ' + filter
 		}
 	}
@@ -1587,14 +1580,14 @@ export async function get_termlst2size(twLst, q, combination, ds) {
 
 	for (const term of termPaths) {
 		if (term.type == 'categorical') {
-			const buckets = h[term.path]['buckets']
-			let values = []
+			const buckets = h[term.path].buckets
+			const values = []
 			for (const bucket of buckets) {
 				values.push([bucket.key.replace('.', '__'), bucket.doc_count])
 			}
 			tv2counts.set(term.id, values)
 		} else if (term.type == 'integer' || term.type == 'float') {
-			const count = h[term.path]['stats']['count']
+			const count = h[term.path].stats.count
 			tv2counts.set(term.id, { total: count })
 		}
 	}
@@ -1692,6 +1685,10 @@ function termid2size_filters(p, ds) {
 			op: '=',
 			content: { field: 'cases.gene.ssm.ssm_id', value: p.ssm_id_lst.split(',') }
 		})
+	}
+
+	if (p.filterObj) {
+		f.filters.content.push(filter2GDCfilter(p.filterObj))
 	}
 	return f
 }


### PR DESCRIPTION
## Description

subtrack created from gdc mds3 now correctly shows summaries for less number of samples compared to main track; this is because the "termislst2total" graphql query did not take sample filter into account

[test at gdc tk](http://localhost:3000/?genome=hg38&gene=ENST00000345146&mds3=GDC), click `585 samples` label, then click `Gliomas` to create a subtk; verify that the sample summaries between the main and subtrack, especially for Gender, where main tk shows total of >7000 for both sexes, compared to <600 in subtk. this gives an accurate estimated on frequency of mutated samples in the subtrack.

non-gdc dataset e.g. clingen is not affected

this expected change is now covered in mds3 manual test

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
