### PR TITLE
show genome browser below methylationArrayPlot when clicking gene cell

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -107,12 +107,6 @@ export async function displaySampleTable(samples, args) {
 					const sandbox = newSandboxDiv(args.tk.newChartHolder || args.block.holder0)
 					sandbox.header.text(samples[i].sample_id)
 
-					let thisMutation
-					if (samples[i].ssm_id_lst?.[0]) {
-						thisMutation = (args.tk.skewer.rawmlst || args.tk.custom_variants).find(
-							m => m.ssm_id == samples[i].ssm_id_lst[0]
-						)
-					}
 					await (
 						await import('#plots/plot.ssgq.js')
 					).plotSingleSampleGenomeQuantification(
@@ -122,7 +116,7 @@ export async function displaySampleTable(samples, args) {
 						samples[i],
 						sandbox.body.append('div').style('margin', '20px'),
 						args.block.genome,
-						thisMutation.gene
+						args.block.usegm?.name
 					)
 				}
 			}
@@ -331,7 +325,10 @@ function printSampleName(sample, tk, div, block, thisMutation) {
 						sample,
 						sandbox.body.append('div').style('margin', '20px'),
 						block.genome,
-						thisMutation.gene
+						block.usegm?.name
+						/* to pass current gene name to launch ssgb at that gene
+						do not use thisMutation.gene, as "gene" is not guaranteed attribute on mutations
+						*/
 					)
 				})
 		}

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -106,6 +106,13 @@ export async function displaySampleTable(samples, args) {
 				callback: async (event, i) => {
 					const sandbox = newSandboxDiv(args.tk.newChartHolder || args.block.holder0)
 					sandbox.header.text(samples[i].sample_id)
+
+					let thisMutation
+					if (samples[i].ssm_id_lst?.[0]) {
+						thisMutation = (args.tk.skewer.rawmlst || args.tk.custom_variants).find(
+							m => m.ssm_id == samples[i].ssm_id_lst[0]
+						)
+					}
 					await (
 						await import('#plots/plot.ssgq.js')
 					).plotSingleSampleGenomeQuantification(
@@ -114,7 +121,8 @@ export async function displaySampleTable(samples, args) {
 						k,
 						samples[i],
 						sandbox.body.append('div').style('margin', '20px'),
-						args.block.genome
+						args.block.genome,
+						thisMutation.gene
 					)
 				}
 			}
@@ -322,7 +330,8 @@ function printSampleName(sample, tk, div, block, thisMutation) {
 						k,
 						sample,
 						sandbox.body.append('div').style('margin', '20px'),
-						block.genome
+						block.genome,
+						thisMutation.gene
 					)
 				})
 		}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -110,6 +110,8 @@ export function setInteractivity(self) {
 		const sample = {
 			sample_id: sampleData._SAMPLENAME_ || sampleData.row.sampleName || sampleData.row.sample
 		}
+		//when clicking a cell in SV, CNV, mutation panels
+		const geneName = sampleData.term?.type == 'geneVariant' ? sampleData.term.name : null
 
 		self.dom.menubody.selectAll('*').remove()
 		self.dom.menutop.selectAll('*').remove()
@@ -131,7 +133,8 @@ export function setInteractivity(self) {
 							k,
 							sample,
 							sandbox.body.append('div').style('margin', '20px'),
-							self.app.opts.genome
+							self.app.opts.genome,
+							geneName
 						)
 						self.dom.tip.hide()
 						menuDiv.remove()

--- a/client/plots/plot.ssgq.js
+++ b/client/plots/plot.ssgq.js
@@ -1,6 +1,6 @@
 import { first_genetrack_tolist } from '#common/1stGenetk'
 import { dofetch3 } from '#common/dofetch'
-import { gmlst2loci } from '../src/client'
+import { gmlst2loci } from '#src/client'
 
 /*
 for lack of better name, this script is called "ssgq", after singleSampleGenomeQuantification
@@ -157,7 +157,7 @@ async function plotSingleSampleGbtk(dslabel, sample, holder, genomeObj, q, q2, c
 	]
 	first_genetrack_tolist(genomeObj, tklst)
 
-	const bb = new (await import('../src/block')).Block({
+	const bb = new (await import('#src/block')).Block({
 		genome: genomeObj,
 		holder: holder.append('div'),
 		nobox: true,

--- a/client/plots/plot.ssgq.js
+++ b/client/plots/plot.ssgq.js
@@ -1,5 +1,6 @@
 import { first_genetrack_tolist } from '#common/1stGenetk'
 import { dofetch3 } from '#common/dofetch'
+import { gmlst2loci } from '../src/client'
 
 /*
 for lack of better name, this script is called "ssgq", after singleSampleGenomeQuantification
@@ -27,8 +28,19 @@ holder
 
 genomeObj={}
 	client side genome obj
+
+geneName
+	optional, if provided,show a genome browser view around the gene under the methylationArrayPlot when its launched
 */
-export async function plotSingleSampleGenomeQuantification(termdbConfig, dslabel, queryKey, sample, holder, genomeObj) {
+export async function plotSingleSampleGenomeQuantification(
+	termdbConfig,
+	dslabel,
+	queryKey,
+	sample,
+	holder,
+	genomeObj,
+	geneName
+) {
 	const loadingDiv = holder.append('div').text('Loading...')
 	try {
 		// verify this dataset supports this plot
@@ -73,6 +85,22 @@ export async function plotSingleSampleGenomeQuantification(termdbConfig, dslabel
 		// !!
 
 		let bb // so as to only load block once, later clicks all update existing block
+		if (geneName) {
+			const geneData = await dofetch3('genelookup', {
+				body: { genome: genomeObj.name, input: geneName, deep: 1 }
+			})
+			if (geneData.error) throw geneData.error
+			if (geneData.gmlst && geneData.gmlst.length) {
+				const locs = gmlst2loci(geneData.gmlst)
+				const chr = locs[0].chr
+				const start = Math.max(0, locs[0].start - (locs[0].stop - locs[0].start))
+				const chrLen = data.chrLst.filter(c => c.chr == chr)[0].chrLen
+				const stop = Math.min(chrLen, locs[0].stop + (locs[0].stop - locs[0].start))
+
+				// block is not present yet. load block
+				bb = await plotSingleSampleGbtk(dslabel, sample, holder, genomeObj, q, q2, chr, start, stop)
+			}
+		}
 
 		img.on('click', async event => {
 			const x = event.offsetX - data.xoff
@@ -99,40 +127,44 @@ export async function plotSingleSampleGenomeQuantification(termdbConfig, dslabel
 			}
 
 			// block is not present yet. load block
-
-			const body = {
-				genome: genomeObj.name,
-				dslabel,
-				singleSampleGbtk: { dataType: q.singleSampleGbtk, sample: sample[q2.sample_id_key] }
-			}
-			const d2 = await dofetch3('mds3', { body })
-			// d2={path:str}
-			if (!d2.path) return // no file
-			// has bedgraph file, load block
-			const tklst = [
-				{
-					type: 'bigwig',
-					name: sample[q2.sample_id_key],
-					file: d2.path,
-					height: 100,
-					scale: { min: q2.min, max: q2.max },
-					pcolor: q.positiveColor,
-					ncolor: q.negativeColor
-				}
-			]
-			first_genetrack_tolist(genomeObj, tklst)
-
-			bb = new (await import('../src/block')).Block({
-				genome: genomeObj,
-				holder: holder.append('div'),
-				nobox: true,
-				tklst,
-				chr,
-				start,
-				stop
-			})
+			bb = await plotSingleSampleGbtk(dslabel, sample, holder, genomeObj, q, q2, chr, start, stop)
 		})
 	} catch (e) {
 		loadingDiv.text('Error: ' + (e.message || e))
 	}
+}
+
+async function plotSingleSampleGbtk(dslabel, sample, holder, genomeObj, q, q2, chr, start, stop) {
+	const body = {
+		genome: genomeObj.name,
+		dslabel,
+		singleSampleGbtk: { dataType: q.singleSampleGbtk, sample: sample[q2.sample_id_key] }
+	}
+	const d2 = await dofetch3('mds3', { body })
+	// d2={path:str}
+	if (!d2.path) return // no file
+	// has bedgraph file, load block
+	const tklst = [
+		{
+			type: 'bigwig',
+			name: sample[q2.sample_id_key],
+			file: d2.path,
+			height: 100,
+			scale: { min: q2.min, max: q2.max },
+			pcolor: q.positiveColor,
+			ncolor: q.negativeColor
+		}
+	]
+	first_genetrack_tolist(genomeObj, tklst)
+
+	const bb = new (await import('../src/block')).Block({
+		genome: genomeObj,
+		holder: holder.append('div'),
+		nobox: true,
+		tklst,
+		chr,
+		start,
+		stop
+	})
+	return bb
 }


### PR DESCRIPTION
## Description
When clicking on a gene cell on the matrix plot or clicking a lollipop to launch the methylationArrayPlot, show a genome browser view around the gene under the methylationArrayPlot.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
