### PR TITLE
Matrix negative bar direction for continuous mode

### DIFF
--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -22,7 +22,7 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape.only('only dictionary terms', function (test) {
+tape('only dictionary terms', function (test) {
 	test.timeoutAfter(5000)
 	test.plan(5)
 	runpp({
@@ -110,7 +110,7 @@ tape.only('only dictionary terms', function (test) {
 
 		// TODO: test for matrix bar plots of continuous mode terms with allowed negative value
 
-		if (test._ok) matrix.Inner.app.destroy()
+		//if (test._ok) matrix.Inner.app.destroy()
 		test.end()
 	}
 })

--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -22,9 +22,9 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('only dictionary terms', function (test) {
+tape.only('only dictionary terms', function (test) {
 	test.timeoutAfter(5000)
-	test.plan(3)
+	test.plan(5)
 	runpp({
 		state: {
 			nav: {
@@ -44,6 +44,12 @@ tape('only dictionary terms', function (test) {
 						{
 							name: 'Demographics',
 							lst: [
+								{
+									id: 'aaclassic_5',
+									q: {
+										mode: 'continuous'
+									}
+								},
 								{
 									id: 'sex'
 									//q: { mode: 'values' } // or 'groupsetting'
@@ -78,12 +84,12 @@ tape('only dictionary terms', function (test) {
 		matrix.on('postRender.test', null)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g').size(),
-			2,
+			3,
 			`should render the expected number of serieses`
 		)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g rect').size(),
-			120,
+			180,
 			`should render the expected number of cell rects`
 		)
 		test.equal(
@@ -91,6 +97,18 @@ tape('only dictionary terms', function (test) {
 			1,
 			`should render the expected number of cluster rects`
 		)
+		// select the first series
+		const sg0rects = matrix.Inner.dom.seriesesG.select('.sjpp-mass-series-g').selectAll('rect')
+		test.equal(
+			sg0rects.filter(d => d.key <= 0 && d.fill === 'transparent').size(),
+			14,
+			`should render special values with transparent rects`
+		)
+		const uniqueHts = new Set()
+		sg0rects.each(d => uniqueHts.add(d.height))
+		test.equal(uniqueHts.size, 45, `should render different rect heights for continuous mode bar plots`)
+
+		// TODO: test for matrix bar plots of continuous mode terms with allowed negative value
 
 		if (test._ok) matrix.Inner.app.destroy()
 		test.end()
@@ -209,7 +227,7 @@ tape('long column group labels', function (test) {
 		const h = matrix.Inner.dom.clipRect.property('height').baseVal.value
 		test.true(h > 619 && h <= 620, `should adjust the clip-path height to between 595 and 596, actual=${h}`)
 
-		//if (test._ok) matrix.Inner.app.destroy()
+		if (test._ok) matrix.Inner.app.destroy()
 		test.end()
 	}
 })

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -12,13 +12,28 @@ function setNumericCellProps(cell, tw, anno, value, s, t, self, width, height, d
 	cell.label = 'label' in anno ? anno.label : values[key]?.label ? values[key].label : key
 	cell.fill = anno.color || values[anno.key]?.color
 
-	//cell.y = height * i //t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + height * i + t.totalHtAdjustments
-
 	cell.order = t.ref.bins ? t.ref.bins.findIndex(bin => bin.name == key) : 0
 	if (tw.q?.mode == 'continuous') {
 		if (!tw.settings) tw.settings = {}
 		if (!tw.settings.barh) tw.settings.barh = s.barh
-		if (!('gap' in tw.settings)) tw.settings.gap = 0
+		if (!('gap' in tw.settings)) tw.settings.gap = 4
+
+		const specialValue = tw.term.values?.[cell.key]
+
+		// handle uncomputable values
+		// TODO: the server response data should not have uncomputable values when mode='continuous'
+		// this may be implemented in getData(), but will require lots of testing since it is used
+		// by multiple charts
+		if (specialValue?.uncomputable) {
+			cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
+			cell.y = height * i
+			cell.height = tw.settings.barh
+			cell.fill = 'transparent'
+			//cell.label = specialValue.label
+			const group = tw.legend?.group || tw.$id
+			return //{ ref: t.ref, group, value: specialValue.label || specialValue.key, entry: { key, label: cell.label, fill: cell.fill } }
+		}
+
 		// TODO: may use color scale instead of bars
 		if (s.transpose) {
 			cell.height = t.scale(cell.key)

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -24,9 +24,9 @@ function setNumericCellProps(cell, tw, anno, value, s, t, self, width, height, d
 			cell.height = t.scale(cell.key)
 			cell.x = tw.settings.gap // - cell.width
 		} else {
-			cell.height = t.scale(cell.key)
+			cell.height = cell.key >= 0 ? t.scales.pos(cell.key) : t.scales.neg(cell.key)
 			cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
-			cell.y = tw.settings.barh + t.tw.settings.gap - cell.height
+			cell.y = cell.key >= 0 ? t.counts.posMaxHt + t.tw.settings.gap - cell.height : 0
 		}
 	} else {
 		cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -26,7 +26,9 @@ export function setInteractivity(self) {
 		if (d.term.type != 'geneVariant') {
 			rows.push(`<tr><td>${l.Sample}:</td><td>${d._SAMPLENAME_ || d.sample}</td></tr>`)
 			rows.push(
-				`<tr><td>${d.term.name}:</td><td style='color: ${d.fill == '#fff' ? '' : d.fill}'> ${d.label}</td></tr>`
+				`<tr><td>${d.term.name}:</td><td style='color: ${d.fill == '#fff' || d.fill == 'transparent' ? '' : d.fill}'> ${
+					d.label
+				}</td></tr>`
 			)
 		} else if (d.term.type == 'geneVariant' && d.value) {
 			rows.push(

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -17,7 +17,10 @@ export function setInteractivity(self) {
 		}
 		if (event.target.tagName !== 'rect' && !self.imgBox) self.imgBox = event.target.getBoundingClientRect()
 		const d = event.target.tagName == 'rect' ? event.target.__data__ : self.getImgCell(event)
+		// TODO: svg-rendered cell rects may be thin and hard to mouse over,
+		// but the tooltip should still display info
 		if (!d || !d.term || !d.sample || !d.siblingCells?.length) {
+			self.dom.tip.hide()
 			return
 		}
 		const s = self.settings.matrix
@@ -80,7 +83,7 @@ export function setInteractivity(self) {
 	self.getImgCell = function (event) {
 		//const [x,y] = pointer(event, event.target)
 		const y = event.clientY - self.imgBox.y - event.target.clientTop
-		const d = event.target.__data__.find(series => series.y <= y && y <= series.y + self.dimensions.dy)
+		const d = event.target.__data__.find(series => series.hoverY0 <= y && y <= series.hoverY1)
 		if (!d) return
 		const { xMin, dx } = self.dimensions
 		const x2 = event.clientX - self.imgBox.x - event.target.clientLeft + xMin

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -670,8 +670,10 @@ class Matrix {
 					t.counts.hits += anno.countedValues.length
 					if (t.tw.q?.mode == 'continuous') {
 						const v = anno.value
-						if (!('minval' in t.counts) || t.counts.minval > v) t.counts.minval = v
-						if (!('maxval' in t.counts) || t.counts.maxval < v) t.counts.maxval = v
+						if (!t.tw.term.values?.[v]?.uncomputable) {
+							if (!('minval' in t.counts) || t.counts.minval > v) t.counts.minval = v
+							if (!('maxval' in t.counts) || t.counts.maxval < v) t.counts.maxval = v
+						}
 					}
 					if (t.tw.term.type == 'geneVariant' && anno.values) {
 						for (const val of anno.values) {
@@ -716,12 +718,12 @@ class Matrix {
 					full: scaleLinear().domain(tickValues).range([1, barh])
 				}
 				if (t.counts.maxval >= 0) {
-					t.scales.pos = scaleLinear().domain([0, t.counts.maxval]).range([0, t.counts.posMaxHt])
+					t.scales.pos = scaleLinear().domain([0, t.counts.maxval]).range([1, t.counts.posMaxHt])
 				}
 				if (t.counts.minval < 0) {
 					t.scales.neg = scaleLinear()
 						.domain([0, t.counts.minval])
-						.range([0, barh - t.counts.posMaxHt - 5])
+						.range([1, barh - t.counts.posMaxHt - 5])
 				}
 			} else if (t.tw.term.type == 'geneVariant' && ('maxLoss' in this.cnvValues || 'maxGain' in this.cnvValues)) {
 				const maxVals = []

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -737,7 +737,8 @@ class Matrix {
 			}
 
 			t.totalHtAdjustments = totalHtAdjustments
-			const adjustment = (t.tw.settings ? t.tw.settings.barh + 2 * t.tw.settings.gap : ht) - ht
+			t.rowHt = t.tw.settings ? t.tw.settings.barh + 2 * t.tw.settings.gap : ht
+			const adjustment = t.rowHt - ht
 			totalHtAdjustments += adjustment
 			if (!(t.visibleGrpIndex in grpTotals)) grpTotals[t.visibleGrpIndex] = { htAdjustment: 0 }
 			grpTotals[t.visibleGrpIndex].htAdjustment += adjustment
@@ -930,11 +931,15 @@ class Matrix {
 			const termid = 'id' in t.tw.term ? t.tw.term.id : t.tw.term.name
 			const isDivideByTerm = termid === divideByTermId
 			const emptyGridCells = []
+			const y = !s.transpose ? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + t.totalHtAdjustments : 0
+			const hoverY0 = t.tw.settings?.gap || y
 			const series = {
 				t,
 				tw: t.tw,
 				cells: [],
-				y: !s.transpose ? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + t.totalHtAdjustments : 0
+				y,
+				hoverY0,
+				hoverY1: hoverY0 + (t.tw.settings?.barh || dy)
 			}
 
 			for (const so of this.unfilteredSampleOrder) {

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -699,8 +699,30 @@ class Matrix {
 			if (t.tw.q?.mode == 'continuous') {
 				if (!t.tw.settings) t.tw.settings = {}
 				if (!t.tw.settings.barh) t.tw.settings.barh = s.barh
-				if (!('gap' in t.tw.settings)) t.tw.settings.gap = 0
-				t.scale = scaleLinear().domain([t.counts.minval, t.counts.maxval]).range([1, t.tw.settings.barh])
+				if (!('gap' in t.tw.settings)) t.tw.settings.gap = 4
+				const barh = t.tw.settings.barh
+				const absMin = Math.abs(t.counts.minval)
+				const ratio = t.counts.minval >= 0 ? 1 : t.counts.maxval / (absMin + t.counts.maxval)
+				t.counts.posMaxHt = ratio * barh
+				const tickValues =
+					t.counts.minVal < 0 && t.counts.maxval > 0
+						? [t.counts.minval, t.counts.maxval]
+						: t.counts.maxval <= 0
+						? [0, t.counts.minval]
+						: [t.counts.maxval, 0]
+
+				t.scales = {
+					tickValues,
+					full: scaleLinear().domain(tickValues).range([1, barh])
+				}
+				if (t.counts.maxval >= 0) {
+					t.scales.pos = scaleLinear().domain([0, t.counts.maxval]).range([0, t.counts.posMaxHt])
+				}
+				if (t.counts.minval < 0) {
+					t.scales.neg = scaleLinear()
+						.domain([0, t.counts.minval])
+						.range([0, barh - t.counts.posMaxHt - 5])
+				}
 			} else if (t.tw.term.type == 'geneVariant' && ('maxLoss' in this.cnvValues || 'maxGain' in this.cnvValues)) {
 				const maxVals = []
 				if ('maxLoss' in this.cnvValues) maxVals.push(this.cnvValues.maxLoss)

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -204,8 +204,10 @@ export function setRenderers(self) {
 					.attr('cursor', 'pointer')
 					.attr(side.attr.textpos.coord, side.attr.textpos.factor * (showContAxis ? 30 : 0))
 
-				if (!Array.isArray(labelText)) text.text(labelText)
-				else {
+				if (!Array.isArray(labelText)) {
+					text.text(labelText)
+					if (lab.tw?.q?.mode == 'continuous') text.attr('y', 10)
+				} else {
 					const tspan = text.selectAll('tspan').data(labelText)
 					tspan.exit().remove()
 					tspan.attr('dx', getTspanDx).attr('font-size', getTspanFontSize).text(getTspanText)
@@ -237,7 +239,7 @@ export function setRenderers(self) {
 					axisg
 						.attr('shape-rendering', 'crispEdges')
 						.attr('transform', `translate(${x},${y})`)
-						.call(side.attr.axisFxn(lab.scale.domain(domain)).tickValues(domain))
+						.call(side.attr.axisFxn(lab.scales.full.domain(lab.scales.tickValues)).tickValues(lab.scales.tickValues))
 				} else if (hasAxis) {
 					g.select('.sjpp-matrix-cell-axis').remove()
 				}
@@ -387,6 +389,7 @@ function getRectFill(d) {
 	if (d.fill) return d.fill
 	/*** TODO: class should be for every values entry, as applicable ***/
 	const cls = d.class || (Array.isArray(d.values) && d.values[0].class)
+	if (!cls) console.log
 	return cls ? mclass[cls].color : '#555'
 }
 

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -134,7 +134,7 @@ export function setRenderers(self) {
 		const x = cell.x ? cell.x - d.xMin : 0
 		const y = _y ? _y + cell.y : cell.y || 0
 		const width = s.useMinPixelWidth ? Math.max(cell.width || d.colw, d.pxw) : cell.width || d.colw
-		const height = cell.height || s.rowh
+		const height = 'height' in cell ? cell.height : s.rowh
 		ctx.fillStyle = cell.fill
 		ctx.fillRect(x, y, width, height)
 
@@ -161,7 +161,7 @@ export function setRenderers(self) {
 			.attr('x', cell.x || 0)
 			.attr('y', cell.y || 0)
 			.attr('width', cell.width || self.dimensions.colw)
-			.attr('height', cell.height || s.rowh)
+			.attr('height', 'height' in cell ? cell.height : s.rowh)
 			.attr('shape-rendering', 'crispEdges')
 			//.attr('stroke', cell.fill)
 			.attr('stroke-width', 0)

--- a/release.txt
+++ b/release.txt
@@ -7,3 +7,4 @@ Fixes:
 - Selecting hundreds of samples from GDC lollipop no longer hangs or crashes (using a cached mapping to case uuid)
 - Fix the numeric edit menu when violin plot data is requested for a GDC variable, which needs currentGeneNames
 - Bug fix to show reduced sample summaries when creating sub-track from GDC lollipop (mds3) track
+- Correctly handle special uncomputable numeric term values in a matrix row bar plot, when mode='continuous' 


### PR DESCRIPTION
## Description
This update fixes the rendering of allowed negative values for a continuous mode, numeric term as a row of bar plot cells. 
To test, you can do one or more of the following: 
a. pull `sjpp` master, then in http://localhost:3000/example.gdc.matrix.html?maxGenes=3 you should see correctly rendered bar plot cells of days to birth. You can also add other numeric term and edit to continuous mode.
b. http://localhost:3000/testrun.html?name=matrix.integration: uncomment the `destroy` step in the last test, to see the rendered matrix


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
