### PR TITLE
GDC oncomatrix aligns data by case uuid but not case submitter id

### DIFF
--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -421,7 +421,7 @@ class Matrix {
 					totalIndex: total + index,
 					totalHtAdjustments: 0, // may be required when transposed???
 					grpTotals: { htAdjustment: 0 }, // may be required when transposed???
-					_SAMPLENAME_: data.refs.bySampleId[row.sample],
+					_SAMPLENAME_: row.sampleName,
 					processedLst
 				})
 			}
@@ -950,7 +950,7 @@ class Matrix {
 				const cellTemplate = {
 					s: so,
 					sample: row.sample,
-					_SAMPLENAME_: data.refs.bySampleId[row.sample],
+					_SAMPLENAME_: row.sampleName,
 					tw: t.tw,
 					term: t.tw.term,
 					termid,
@@ -1020,12 +1020,12 @@ class Matrix {
 		return serieses
 	}
 
-	sampleKey(series) {
-		return series.row.sample
+	sampleKey(s) {
+		return s.row.sample
 	}
 
-	sampleLabel(series) {
-		return series.label || series.row.label || series.row.sampleName || series.row.sample || ''
+	sampleLabel(s) {
+		return s.label || s.row.label || s.row.sampleName || s.row.sample || ''
 	}
 
 	sampleGrpKey(s) {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -709,7 +709,15 @@ export class TermdbVocab extends Vocab {
 						const row = samples[sampleId]
 						if (idn in sample) {
 							row[tw.$id] = sample[idn]
-							if ('sampleName' in sample) row.sampleName = sample.sampleName
+							if (!row.sampleName) {
+								// only assign this value once for each sample
+								if (data.refs.bySampleId?.[sampleId]) row.sampleName = data.refs.bySampleId[sampleId]
+								else if ('sampleName' in sample) row.sampleName = sample.sampleName
+								else {
+									const v = sample[idn].values?.find(v => v._SAMPLENAME_ && true)
+									if (v._SAMPLENAME_) row.sampleName = v._SAMPLENAME_
+								}
+							}
 						}
 					}
 

--- a/release.txt
+++ b/release.txt
@@ -9,3 +9,4 @@ Fixes:
 - Fix the numeric edit menu when violin plot data is requested for a GDC variable, which needs currentGeneNames
 - Bug fix to show reduced sample summaries when creating sub-track from GDC lollipop (mds3) track
 - Correctly handle special uncomputable numeric term values in a matrix row bar plot, when mode='continuous' 
+- GDC OncoMatrix has switched to use case uuid but not case submitter id to align data, while still displaying submitter ids on UI; the latter is not unique between projects.

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -1919,8 +1919,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					isoform
 					chr/pos
 					mname/class
-					_SAMPLENAME_
-					_SAMPLEID_
+					_SAMPLENAME_ // sample name for display
+					_SAMPLEID_   // sample id for computing, 
 
 	this function is diverging from mds3.load, each becoming specialized
 	1. it returns sample level data points {class/mname/sample/origin}
@@ -2015,6 +2015,18 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					_SAMPLEID_: s.sample_id,
 					_SAMPLENAME_: s.sample_id
 				}
+
+				/*
+				optional __sampleName may be returned by mds3 query, if so, assign to m2{}
+
+				*** tricky use case ***
+				mayGetGeneVariantData() is used for gdc matrix
+				in which the useCaseid4sample=true flag is set to inform mds3.gdc to return both uuid and submitter id
+				e.g. s.sample_id=uuid, and s.__sampleName=submitter id
+				as gdc matrix aligns data on case uuid (unique), while must display case submitter id (not unique)
+				later m2._SAMPLENAME_ will not be overriden because gdc has no termdb.q.id2sampleName()
+				*/
+				if (s.__sampleName) m2._SAMPLENAME_ = s.__sampleName
 
 				if ('value' in m) m2.value = m.value
 

--- a/server/src/termdb.gdc.js
+++ b/server/src/termdb.gdc.js
@@ -796,6 +796,8 @@ async function fetchIdsFromGdcApi(ds, size, from, aliquot_id) {
 		const case_submitter_id = h.submitter_id
 		if (!case_submitter_id) throw 'h.submitter_id missing'
 
+		// uncomment to detect different uuids mapping to same submitter id
+		//if(ds.map2caseid.cache.has(case_submitter_id)) console.log(case_submitter_id, case_id, ds.map2caseid.cache.get(case_submitter_id))
 		ds.map2caseid.cache.set(case_submitter_id, case_id)
 
 		if (!Array.isArray(h.samples)) continue //throw 'hit.samples[] not array'

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -305,6 +305,15 @@ async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 		const s2 = {
 			sample: s.sample_id
 		}
+
+		/* optional attribute returned by gdc dataset
+		s.sample_id: case uuid for aligning matrix columns
+		s.__sampleName: case submitter id for display
+
+		non-gdc won't return this and will display s.sample_id
+		*/
+		if (s.__sampleName) s2.sampleName = s.__sampleName
+
 		for (const tw of termWrappers) {
 			const v = s[tw.term.id]
 			////////////////////////////


### PR DESCRIPTION
## Description

This change is needed due to the fact that gdc case submitter id (human readable) is not guaranteed to be unique across gdc, and can be duplicated between projects. Thus it's replaced by case uuid (not human readable). A few examples: (col 1: case submitter id, col 2-3: two different case uuid mapped to the same submitter id):

2729 c4ebca74-309f-4ae0-9bd4-a9ff1378388c ad86832f-54a1-446a-8653-00b08eed7f38
2822 80d38510-c9c5-473b-80f7-146f18969e6e 96a8439d-409a-4795-9838-29025f9c343b
TARGET-10-PARTBP 8a735bd8-86d5-59b8-9dfc-357736e6d876 c58de843-c27d-4676-bb4b-0781230d5fe2
TARGET-10-PATFWF 00c0941a-ac70-5bb3-9777-c66e02d56138 5bbac5ff-d59a-4efd-a12d-828d88480200
TARGET-10-PARXMV 031abec9-1e5e-5650-8a1c-1f6a12c1a1b5 81851db8-e649-4142-a26c-f52832fdf583

These changes are considered WIP and will be changed again, e.g. at two places of ad-hoc data reshaping, at mds3.init.js mayAdd_mayGetGeneVariantData(), and termdb.matrix.js getSampleData_dictionaryTerms_v2s(). We will standardize the data mds3 sends to getData() and received by client (e.g. by using `ref.bySampleId{}` to collect optional identifier-to-human-readable-name mapping, while mutation objects only include identifier and no human-readable name)

No change should appear on client:
- GDC OncoMatrix should show no change
- Non-gdc dataset matrices should not be impacted. 
- GDC lollipop should still count recurrence by samples but not case, and display sample submitter id (manual tests all pass)
Congyu and Karishma, please help test thoroughly.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
