### PR TITLE
detect if unable to plot density due to missing data

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -183,6 +183,11 @@ async function showSummary4terms(data, div, tk, block) {
 				.style('opacity', 0.5)
 			showSummary4oneTerm(d.termid, holder, d.numbycategory, tk, block)
 		} else if (d.density_data) {
+			if (!Number.isFinite(d.density_data.minvalue) || !Number.isFinite(d.density_data.maxvalue)) {
+				holder.append('div').text('No data')
+				continue
+			}
+
 			holder
 				.append('div')
 				.text('Select a range to create new track.')

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -504,11 +504,13 @@ export async function get_tklst(urlp, genomeobj) {
 		// official mds3 dataset; value is comma-joined dslabels
 		const lst = urlp.get('mds3').split(',')
 		for (const n of lst) {
-			tklst.push({
+			const tk = {
 				type: client.tkt.mds3,
-				dslabel: n,
-				token: urlp.get('token') // temporary
-			})
+				dslabel: n
+			}
+			if (urlp.has('token')) tk.token = urlp.get('token') // temporary
+			if (urlp.has('filterobj')) tk.filterObj = urlp.get('filterobj')
+			tklst.push(tk)
 		}
 	}
 


### PR DESCRIPTION
## Description

test [by this link](http://localhost:3000/?genome=hg38&gene=wee1&mds3=GDC&filterObj=%7B%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22case.project.project_id%22,%22name%22:%22Project%20id%22,%22isleaf%22:true,%22type%22:%22categorical%22,%22parent_id%22:%22case.project%22%7D,%22values%22:%5B%7B%22key%22:%22CPTAC-2%22%7D%5D%7D%7D%5D%7D), then click `2 samples` label on left, client should no longer crash and will show "No data" for age.

closes #363 

fix: Bug fix for mds3 lollipop track to detect when not to show density plot due to missing data.

this fix works for both gdc and non-gdc datasets

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
