### PR TITLE
Minor changes to handler code

### DIFF
--- a/client/dom/toggleButtons.js
+++ b/client/dom/toggleButtons.js
@@ -9,7 +9,11 @@ opts: {
 	tabsHolder,
 		d3 DOM created by this script
 	contentHolder,
-		optional; if not provided, create new under opts.holder
+		optional: if not provided, create new under opts.holder
+	noTopContentStyle: BOOL
+		optional: removes the padding-top and margin-top required for SVGs 
+		- intented to remove the excess white space that appears for non-SVG content
+		between the tabs and content div
 	tabs[ tab{} ]
 		.label:
 			required
@@ -141,7 +145,7 @@ function setRenderers(self) {
 			.style('background-color', 'transparent')
 			.style('display', self.opts.tabsPosition == 'vertical' ? 'flex' : 'inline-grid')
 			.property('disabled', tab => (tab.disabled ? tab.disabled() : false))
-			.each(async function(tab) {
+			.each(async function (tab) {
 				/* The whole button is clickable (i.e. the white space where the blue, 'active' line
 				is not visible). The event is on the button (i.e. tab.wrapper). The style changes 
 				when the button is active/inactive are on the text (i.e. tab.tab) and line 
@@ -200,7 +204,7 @@ function setRenderers(self) {
 					Div acts as a `viewBox`.*/
 						.append('div')
 						.style('display', tab.active ? 'block' : 'none')
-					if (self.opts.tabsPosition == 'horizontal') {
+					if (self.opts.tabsPosition == 'horizontal' && !self.opts.noTopContentStyle) {
 						tab.contentHolder.style('padding-top', '10px').style('margin-top', '10px')
 					}
 				}
@@ -251,118 +255,3 @@ function setRenderers(self) {
 			})
 	}
 }
-
-/* Old implementation */
-
-// export async function init_tabs(opts) {
-// 	if (!opts.holder) throw `missing opts.holder for toggleButtons()`
-// 	if (!Array.isArray(opts.tabs)) throw `invalid opts.tabs for toggleButtons()`
-// 	const defaultTabWidth = 90
-// 	const tabs = opts.tabs
-// 	opts.tabsHolder = opts.holder
-// 		.append('div')
-// 		//add light grey border underneath the buttons
-// 		.style('border-bottom', '0.5px solid lightgrey')
-// 		.style('width', 'fit-content')
-
-// 	if (!opts.contentHolder) {
-// 		if (!opts.noContent) opts.contentHolder = opts.holder.append('div')
-// 	}
-
-// 	const has_active_tab = tabs.some(i => i.active)
-// 	if (!has_active_tab) tabs[0].active = true
-
-// 	for (const [i, tab] of tabs.entries()) {
-// 		// const toggle_btn_class = i == 0 ? ' sj-left-toggle' : i < tabs.length - 1 ? ' sj-center-toggle' : ' sj-right-toggle'
-
-// 		const linePosition = opts.linePosition || 'bottom'
-// 		const textAlign = linePosition == 'bottom' || linePosition == 'top' ? 'center' : linePosition
-
-// 		tab.wrapper = opts.tabsHolder
-// 			.append('button')
-// 			.attr('type', 'button')
-// 			.attr('class', 'sj-toggle-button')
-// 			//Padding here overrides automatic styling for all pp buttons
-// 			.style('padding', '0px')
-// 			// .attr('class', 'sj-toggle-button' + toggle_btn_class)
-// 			.classed('sjpp-active', tab.active ? true : false)
-// 			.style('border', 'none')
-// 			.style('background-color', 'transparent')
-
-// 		if (linePosition == 'top' || linePosition == 'left') {
-// 			//create the line div before the tab text
-// 			tab.line = tab.wrapper.append('div').style('display', linePosition == 'left' ? 'inline-flex' : 'block')
-// 			tab.tab = tab.wrapper.append('div').style('display', linePosition == 'left' ? 'inline-flex' : 'block')
-// 		} else {
-// 			//create the line div after the tab text
-// 			tab.tab = tab.wrapper.append('div').style('display', linePosition == 'right' ? 'inline-flex' : 'block')
-// 			tab.line = tab.wrapper.append('div').style('display', linePosition == 'right' ? 'inline-flex' : 'block')
-// 		}
-
-// 		tab.tab
-// 			.style('color', tab.active ? '#1575ad' : '#757373')
-// 			.style('text-align', textAlign)
-// 			.style('padding', '5px')
-// 			.html(tab.label)
-
-// 		tab.line
-// 			.style('color', '#1575ad')
-// 			.style('background-color', '#1575ad')
-// 			.style('visibility', tab.active ? 'visible' : 'hidden')
-
-// 		if (linePosition == 'top' || linePosition == 'bottom') {
-// 			tab.line.style('height', '8px')
-// 		} else {
-// 			tab.line
-// 				.style('width', '8px')
-// 				//Trick div into appearing the full height of the parent
-// 				.style('padding', '5px 0px')
-// 				.html('l')
-// 		}
-
-// 		if (tab.width) {
-// 			// fixed
-// 			tab.wrapper.style('width', tab.width + 'px')
-// 		} else {
-// 			// automatically decide based on default width
-// 			let width = defaultTabWidth
-// 			tab.wrapper.each(function() {
-// 				width = Math.max(width, this.getBoundingClientRect().width)
-// 			})
-// 			tab.wrapper.style('width', width + 'px')
-// 		}
-
-// 		tab.wrapper.on('click', async () => {
-// 			for (const tab_ of tabs) {
-// 				tab_.active = tab_ === tab
-// 				tab_.wrapper.classed('sjpp-active', tab_.active ? true : false)
-// 				tab_.holder.style('display', tab_.active ? 'block' : 'none')
-// 				tab_.tab.style('color', tab_.active ? '#1575ad' : '#757373')
-// 				tab_.line.style('visibility', tab_.active ? 'visible' : 'hidden')
-// 			}
-// 			if (tab.callback) await tab.callback(tab.holder)
-// 		})
-
-// 		if (opts.contentHolder) {
-// 			tab.holder = opts.contentHolder
-// 				.append('div')
-// 				.style('padding-top', '10px')
-// 				.style('margin-top', '10px')
-// 				.style('display', tab.active ? 'block' : 'none')
-// 		}
-
-// 		if (tab.active) {
-// 			if (tab.callback) await tab.callback(tab.holder)
-// 		}
-// 	}
-// }
-
-// export function update_tabs(tabs) {
-// 	const has_active_tab = tabs.some(i => i.active)
-// 	if (!has_active_tab) tabs[0].active = true
-
-// 	for (const tab of tabs) {
-// 		tab.tab.classed('sjpp-active', tab.active ? true : false)
-// 		tab.holder.style('display', tab.active ? 'block' : 'none')
-// 	}
-// }

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -1,7 +1,7 @@
 import { keyupEnter } from '#src/client'
 import { select } from 'd3-selection'
 import { filterInit } from '#filter'
-import { make_radios } from '#dom/radiobutton'
+// import { make_radios } from '#dom/radiobutton'
 import { GroupSetEntry, GroupEntry, TermValues, Subconditions } from '#shared/types'
 
 /*
@@ -24,144 +24,144 @@ type GroupArgs = { holder: any; name: string; group_idx: number; group_type?: st
 
 export function setGroupsettingMethods(self: any) {
 	self.regroupMenu = function (grp_count: number, temp_cat_grps: GroupSetEntry) {
-		if (self.q.mode == 'cutoff') {
-			self.showCutoff()
-		} else {
-			self.showDraggables(grp_count, temp_cat_grps)
-		}
+		// if (self.q.mode == 'cutoff') {
+		// 	self.showCutoff()
+		// } else {
+		self.showDraggables(grp_count, temp_cat_grps)
+		// }
 	}
-	self.showCutoff = function () {
-		// regroup menu for cutoff mode
-		// NOTE: assumes condition term. Eventually, apply to any ordinal term.
-		self.dom.tip.clear().showunder(self.dom.holder.node())
+	// self.showCutoff = function () {
+	// 	// regroup menu for cutoff mode
+	// 	// NOTE: assumes condition term. Eventually, apply to any ordinal term.
+	// 	self.dom.tip.clear().showunder(self.dom.holder.node())
 
-		// div for cutoff drop-down menu
-		const cutoff_div = self.dom.tip.d.append('div').style('margin', '10px')
+	// 	// div for cutoff drop-down menu
+	// 	const cutoff_div = self.dom.tip.d.append('div').style('margin', '10px')
 
-		// get sorted list of grades
-		const grades = Object.keys(self.term.values)
-			.filter((k: string) => !self.term.values[k].uncomputable && k !== '0')
-			.sort((a: string, b: string) => Number(a) - Number(b))
-			.map((k: string) => {
-				return { key: k, label: self.term.values[k].label }
-			})
+	// 	// get sorted list of grades
+	// 	const grades = Object.keys(self.term.values)
+	// 		.filter((k: string) => !self.term.values[k].uncomputable && k !== '0')
+	// 		.sort((a: string, b: string) => Number(a) - Number(b))
+	// 		.map((k: string) => {
+	// 			return { key: k, label: self.term.values[k].label }
+	// 		})
 
-		// build drop-down menu
-		const defaultCutoff = 'cutoff' in self.q ? self.q.cutoff : Number(grades[0].key)
+	// 	// build drop-down menu
+	// 	const defaultCutoff = 'cutoff' in self.q ? self.q.cutoff : Number(grades[0].key)
 
-		const cutoff_select = cutoff_div
-			.append('div')
-			//.style('display', 'inline')
-			.text('Minimum grade for event: ')
-			.append('select')
-			.style('margin', '5px 10px')
+	// 	const cutoff_select = cutoff_div
+	// 		.append('div')
+	// 		//.style('display', 'inline')
+	// 		.text('Minimum grade for event: ')
+	// 		.append('select')
+	// 		.style('margin', '5px 10px')
 
-		cutoff_select
-			.selectAll('option')
-			.data(grades)
-			.enter()
-			.append('option')
-			.attr('value', (d: KeyLabel) => d.key)
-			.property('selected', (d: KeyLabel) => Number(d.key) == defaultCutoff)
-			.html((d: KeyLabel) => d.label)
+	// 	cutoff_select
+	// 		.selectAll('option')
+	// 		.data(grades)
+	// 		.enter()
+	// 		.append('option')
+	// 		.attr('value', (d: KeyLabel) => d.key)
+	// 		.property('selected', (d: KeyLabel) => Number(d.key) == defaultCutoff)
+	// 		.html((d: KeyLabel) => d.label)
 
-		// div for time scale
-		const scale_select = cutoff_div
-			.append('div')
-			.style('margin', '10px 0px')
-			//.style('display', 'inline')
-			.text('Time scale: ')
-		const defaultScale: string = 'timeScale' in self.q ? self.q.timeScale : 'time'
-		self.q.timeScale = defaultScale
-		const scales: ScaleEntry[] = [
-			{
-				label: 'Time from study entry',
-				value: 1,
-				checked: defaultScale == 'time' ? true : false
-			},
-			{
-				label: 'Age',
-				value: 2,
-				checked: defaultScale == 'age' ? true : false
-			}
-		]
+	// 	// div for time scale
+	// 	const scale_select = cutoff_div
+	// 		.append('div')
+	// 		.style('margin', '10px 0px')
+	// 		//.style('display', 'inline')
+	// 		.text('Time scale: ')
+	// 	const defaultScale: string = 'timeScale' in self.q ? self.q.timeScale : 'time'
+	// 	self.q.timeScale = defaultScale
+	// 	const scales: ScaleEntry[] = [
+	// 		{
+	// 			label: 'Time from study entry',
+	// 			value: 1,
+	// 			checked: defaultScale == 'time' ? true : false
+	// 		},
+	// 		{
+	// 			label: 'Age',
+	// 			value: 2,
+	// 			checked: defaultScale == 'age' ? true : false
+	// 		}
+	// 	]
 
-		// build radio buttons for time scale
-		make_radios({
-			holder: scale_select,
-			options: scales,
-			callback: (value: number) => {
-				self.q.timeScale = value == 1 ? 'time' : 'age'
-			}
-		})
+	// 	// build radio buttons for time scale
+	// 	make_radios({
+	// 		holder: scale_select,
+	// 		options: scales,
+	// 		callback: (value: number) => {
+	// 			self.q.timeScale = value == 1 ? 'time' : 'age'
+	// 		}
+	// 	})
 
-		// 'Apply' button
-		cutoff_div
-			.append('div')
-			.attr('class', 'sjpp_apply_btn sja_filter_tag_btn')
-			.style('display', 'inline-block')
-			.style('text-align', 'center')
-			.style('font-size', '.8em')
-			.style('float', 'right')
-			.style('text-transform', 'uppercase')
-			.text('Apply')
-			.on('click', () => {
-				self.q.cutoff = Number(cutoff_select.property('value'))
-				// split grades into two groups based on cutoff value
+	// 	// 'Apply' button
+	// 	cutoff_div
+	// 		.append('div')
+	// 		.attr('class', 'sjpp_apply_btn sja_filter_tag_btn')
+	// 		.style('display', 'inline-block')
+	// 		.style('text-align', 'center')
+	// 		.style('font-size', '.8em')
+	// 		.style('float', 'right')
+	// 		.style('text-transform', 'uppercase')
+	// 		.text('Apply')
+	// 		.on('click', () => {
+	// 			self.q.cutoff = Number(cutoff_select.property('value'))
+	// 			// split grades into two groups based on cutoff value
 
-				// below cutoff group
-				// 'no condition' and 'not tested' grades are always below cutoff
-				const belowCutoff = [
-					{
-						key: '0',
-						label: 'No condition'
-					},
-					{
-						key: '-1',
-						label: 'Not tested'
-					}
-				]
-				belowCutoff.push(...grades.filter(grade => Number(grade.key) < self.q.cutoff))
+	// 			// below cutoff group
+	// 			// 'no condition' and 'not tested' grades are always below cutoff
+	// 			const belowCutoff = [
+	// 				{
+	// 					key: '0',
+	// 					label: 'No condition'
+	// 				},
+	// 				{
+	// 					key: '-1',
+	// 					label: 'Not tested'
+	// 				}
+	// 			]
+	// 			belowCutoff.push(...grades.filter(grade => Number(grade.key) < self.q.cutoff))
 
-				// above cutoff group
-				const aboveCutoff = grades.filter(grade => Number(grade.key) >= self.q.cutoff)
+	// 			// above cutoff group
+	// 			const aboveCutoff = grades.filter(grade => Number(grade.key) >= self.q.cutoff)
 
-				const groups = [
-					{
-						name: `Grade < ${self.q.cutoff}`,
-						values: belowCutoff
-					},
-					{
-						name: `Grade >= ${self.q.cutoff}`,
-						values: aboveCutoff
-					}
-				]
+	// 			const groups = [
+	// 				{
+	// 					name: `Grade < ${self.q.cutoff}`,
+	// 					values: belowCutoff
+	// 				},
+	// 				{
+	// 					name: `Grade >= ${self.q.cutoff}`,
+	// 					values: aboveCutoff
+	// 				}
+	// 			]
 
-				self.q.type = 'custom-groupset'
-				self.q.groupsetting = {
-					inuse: true,
-					customset: {
-						name: 'grade cutoff',
-						is_grade: true,
-						groups
-					}
-				}
-				self.dom.tip.hide()
-				self.runCallback()
-			})
+	// 			self.q.type = 'custom-groupset'
+	// 			self.q.groupsetting = {
+	// 				inuse: true,
+	// 				customset: {
+	// 					name: 'grade cutoff',
+	// 					is_grade: true,
+	// 					groups
+	// 				}
+	// 			}
+	// 			self.dom.tip.hide()
+	// 			self.runCallback()
+	// 		})
 
-		// for description blurb
-		// explain to user that 'no condition' and 'not tested' grades are below the grade cutoff for an event
-		/*
-		const descr_div = self.dom.tip.d.append('div').style('margin', '10px')
-		descr_div
-			.style('font-size', '0.8em')
-			.style('text-align', 'left')
-			.style('color', 'rgb(153, 153, 153)')
-			.style('display', 'block')
-			.text('')
-		*/
-	}
+	// 	// for description blurb
+	// 	// explain to user that 'no condition' and 'not tested' grades are below the grade cutoff for an event
+	// 	/*
+	// 	const descr_div = self.dom.tip.d.append('div').style('margin', '10px')
+	// 	descr_div
+	// 		.style('font-size', '0.8em')
+	// 		.style('text-align', 'left')
+	// 		.style('color', 'rgb(153, 153, 153)')
+	// 		.style('display', 'block')
+	// 		.text('')
+	// 	*/
+	// }
 
 	self.showDraggables = function (grp_count: number, temp_cat_grps: GroupSetEntry) {
 		//start with default 2 groups, extra groups can be added by user

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -19,11 +19,15 @@ other internal functions:
 */
 
 type KeyLabel = { key: string | number; label: string }
-type ScaleEntry = { label: string; value: number; checked: boolean }
+// type ScaleEntry = { label: string; value: number; checked: boolean }
 type GroupArgs = { holder: any; name: string; group_idx: number; group_type?: string }
 
 export function setGroupsettingMethods(self: any) {
 	self.regroupMenu = function (grp_count: number, temp_cat_grps: GroupSetEntry) {
+		/* q.mode='cutoff' is no longer used! Commenting out code for now until
+		 * groupsetting is refactored.
+		 */
+
 		// if (self.q.mode == 'cutoff') {
 		// 	self.showCutoff()
 		// } else {

--- a/client/termsetting/numeric.toggle.ts
+++ b/client/termsetting/numeric.toggle.ts
@@ -105,6 +105,7 @@ export async function getHandler(self: NumericTermSettingInstance) {
 			new Tabs({
 				holder: topBar.append('div').style('display', 'inline-block'),
 				contentHolder: div.append('div'),
+				noTopContentStyle: true,
 				tabs
 			}).main()
 		}


### PR DESCRIPTION
## Description
These are two minor changes pulled form the initial numeric handler plan. 
- Commenting out q.mode='cutoff' in groupsetting.ts, as it appears no longer needed. 
- Fix for the excessive white space appearing in the numeric toggle menu. Test with http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22hrtavg%22}}],%22nav%22:{%22activeTab%22:1}}. Click on the pill -> Edit -> less white space between the content and the tabs. 


## Checklist
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
