### PR TITLE
display pairlst data for a fusion event on matrix cell mouseover

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -44,7 +44,15 @@ export function setInteractivity(self) {
 			for (const c of d.siblingCells) {
 				if (c.$id != d.$id) continue
 				const v = c.value
-				const label = v.mname ? `${v.mname} ${c.label}` : c.label
+				const p = v.pairlst
+				// TODO: when the same label can apply to multiple values/hits in the same matrix cell,
+				// list that label only once but with a hit count, instead of listing that same label
+				// as multiple table rows in the mouseover
+				const label = p
+					? (p[0].a.name || p[0].a.chr) + '::' + (p[0].b.name || p[0].b.chr)
+					: v.mname
+					? `${v.mname} ${c.label}`
+					: c.label
 				const info = []
 				if (v.label && v.label !== c.label) info.push(v.label)
 				if ('value' in v) info.push(`${s.cnvUnit}=${v.value}`)

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,7 @@
+Features:
+- Display pairlst data, if available, for a fusion event on matrix cell mouseover
+
 Fixes:
 - Bug fix to change cutoff grade for condition term
+- Fix the matrix sample sorting by name, to use the display sampleName instead of sample ID
+- Fix the matrux sample group sorting by group name, to use predefined or group name as applicable


### PR DESCRIPTION
## Description

Resolves issue # 374

@xzhou82 I started to code this enhancement. Not sure if @congyu-lu would like to take over this branch/issue, including showing only one row with #hits for the same label, instead of showing multiple rows for the same label as in the screenshot below. 

![Screenshot 2023-08-03 at 9 44 39 PM](https://github.com/stjude/proteinpaint/assets/411031/c1852928-0687-4376-8e18-cac211a560e6)

Now the sv/fusion events passed to matrix will contain new attribute pairlst[], this allows to generate the correct fusion event label, as (pairlst[0].a.name || pairlst[0].a.chr) + '::'+(pairlst[0].b.name||pairlst[0].b.chr)
Thus, hover over a matrix cell with svfusion events should display this label in tooltip

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
