### PR TITLE
Added empty region to be selected when filtering by income

### DIFF
--- a/client/plots/profileBarchart.js
+++ b/client/plots/profileBarchart.js
@@ -45,7 +45,10 @@ class profileBarchart {
 		this.data = await this.app.vocabApi.getAnnotatedSampleData({
 			terms: twLst
 		})
-		this.regions = [{ key: 'Global', label: 'Global' }]
+		this.regions = [
+			{ key: '', label: '' },
+			{ key: 'Global', label: 'Global' }
+		]
 		this.incomes = ['Any']
 		this.incomes.push(...this.config.incomes)
 
@@ -121,7 +124,7 @@ class profileBarchart {
 		incomeSelect.on('change', () => {
 			config.income = incomeSelect.node().value
 			config.sampleName = config.income
-			config.region = 'Global'
+			config.region = ''
 			this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 		})
 

--- a/client/plots/profileBarchart.js
+++ b/client/plots/profileBarchart.js
@@ -49,7 +49,7 @@ class profileBarchart {
 			{ key: '', label: '' },
 			{ key: 'Global', label: 'Global' }
 		]
-		this.incomes = ['Any']
+		this.incomes = ['']
 		this.incomes.push(...this.config.incomes)
 
 		for (const region of this.config.regions) {
@@ -108,7 +108,7 @@ class profileBarchart {
 		regionSelect.on('change', () => {
 			config.region = regionSelect.node().value
 			config.sampleName = config.region
-			config.income = 'Any'
+			config.income = ''
 			this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 		})
 		div.append('label').style('margin-left', '15px').html('Income Group:').style('font-weight', 'bold')

--- a/client/plots/profilePolar.js
+++ b/client/plots/profilePolar.js
@@ -37,7 +37,10 @@ class profilePolar {
 		this.data = await this.app.vocabApi.getAnnotatedSampleData({
 			terms: twLst
 		})
-		this.regions = [{ key: 'Global', label: 'Global' }]
+		this.regions = [
+			{ key: '', label: '' },
+			{ key: 'Global', label: 'Global' }
+		]
 		this.incomes = ['Any']
 		this.incomes.push(...this.config.incomes)
 
@@ -101,7 +104,7 @@ class profilePolar {
 		incomeSelect.on('change', () => {
 			config.income = incomeSelect.node().value
 			config.sampleName = config.income
-			config.region = 'Global'
+			config.region = ''
 			this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 		})
 

--- a/client/plots/profilePolar.js
+++ b/client/plots/profilePolar.js
@@ -41,7 +41,7 @@ class profilePolar {
 			{ key: '', label: '' },
 			{ key: 'Global', label: 'Global' }
 		]
-		this.incomes = ['Any']
+		this.incomes = ['']
 		this.incomes.push(...this.config.incomes)
 
 		for (const region of this.config.regions) {
@@ -87,7 +87,7 @@ class profilePolar {
 			config.region = regionSelect.node().value
 
 			config.sampleName = config.region
-			config.income = 'Any'
+			config.income = ''
 			this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 		})
 


### PR DESCRIPTION
## Description

When filtering by income the region cant be global. It needs to be empty/not selected. Otherwise filtering by income would not work. This PR should be merged with the corresponding PR in sjpp.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
