### PR TITLE
fix: In lollipop tk, upon creating a subtk with a filtering criteria,…

### DIFF
--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2,7 +2,7 @@ import * as common from '#shared/common'
 import { compute_bins } from '#shared/termdb.bins'
 import got from 'got'
 import path from 'path'
-import { get_crosstabCombinations, combineSamplesById } from './mds3.variant2samples'
+import { combineSamplesById } from './mds3.variant2samples'
 import { filter2GDCfilter } from './mds3.gdc.filter'
 
 /*
@@ -1527,6 +1527,7 @@ input:
 	q{}
 		.tid2value={ termid: v}
 		.ssm_id_lst=str
+		.filterObj={}
 	combination={}
 		if provided, return alongside map; needed for sunburst, see get_crosstabCombinations()
 	ds


### PR DESCRIPTION
… sunburst generated from subtk will show correct total sample count for sunburst wedges by accounting for subtk filtering criteria. this fix works for both GDC and local TK

## Description

fixes #368 
works for both [gdc](http://localhost:3000/?genome=hg38&gene=ENST00000256078&mds3=GDC&filterObj=%7B%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22case.demographic.gender%22,%22name%22:%22Gender%22,%22isleaf%22:true,%22type%22:%22categorical%22,%22parent_id%22:%22case.demographic%22,%22included_types%22:%5B%22categorical%22%5D,%22child_types%22:%5B%5D,%22values%22:%7B%22male%22:%7B%22label%22:%22male%22,%22samplecount%22:735%7D,%22female%22:%7B%22label%22:%22female%22,%22samplecount%22:729%7D%7D,%22samplecount%22:%7B%7D%7D,%22values%22:%5B%7B%22key%22:%22female%22%7D%5D%7D%7D%5D%7D) and [non-gdc tk](http://localhost:3000/?genome=hg38&gene=bcr&mds3=ASH).

way to test it is in a subtk, click a big dot to launch sunburst, at the sunburst wedges it should show a total number smaller than what's shown in main tk, due to filtering of subtk

hope the commit msg can be auto added to release.txt

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
