### PR TITLE
Cuminc cut atrisk

### DIFF
--- a/client/mass/test/cuminc.integration.spec.js
+++ b/client/mass/test/cuminc.integration.spec.js
@@ -158,7 +158,7 @@ tape('term1=Cardiovascular System, term2=agedx', function (test) {
 	async function runTests(cuminc) {
 		const div = cuminc.Inner.dom.chartsDiv
 		test.equal(div.selectAll('.sjpcb-cuminc-series').size(), 2, 'should render 2 cuminc series <g>')
-		/*test.equal(
+		test.equal(
 			div.selectAll('.sjpcb-cuminc-series path').size(),
 			4,
 			'should render 4 cuminc series paths for estimate line and 95% CI area'
@@ -185,7 +185,7 @@ tape('term1=Cardiovascular System, term2=agedx', function (test) {
 			else test.pass(`Should display series = '${d.seriesId}' in both legend and 'Number at risk' table`)
 		}
 
-		if (test._ok) cuminc.Inner.app.destroy()*/
+		if (test._ok) cuminc.Inner.app.destroy()
 		test.end()
 	}
 })

--- a/client/mass/test/cuminc.integration.spec.js
+++ b/client/mass/test/cuminc.integration.spec.js
@@ -43,24 +43,27 @@ const runpp = helpers.getRunPp('mass', {
  test sections
  ***************/
 
-tape('\n', function(test) {
+tape('\n', function (test) {
 	test.pass('-***- plots/cuminc -***-')
 	test.end()
 })
 
-tape('term1=Cardiac dysrhythmia', function(test) {
+const plot = {
+	chartType: 'cuminc',
+	settings: {
+		cuminc: {
+			minSampleSize: 1,
+			minAtRisk: 0
+		}
+	}
+}
+
+tape('term1=Cardiac dysrhythmia', function (test) {
 	test.timeoutAfter(10000)
+	plot.term = { id: 'Cardiac dysrhythmia' }
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiac dysrhythmia',
-						q: { bar_by_grade: true, value_by_max_grade: true }
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -87,20 +90,13 @@ tape('term1=Cardiac dysrhythmia', function(test) {
 	}
 })
 
-tape('term1=Cardiovascular System, filter=ALL', function(test) {
+tape('term1=Cardiovascular System, filter=ALL', function (test) {
 	// this test breaks due to the "missing minSampleSize" err
 	test.timeoutAfter(10000)
+	plot.term = { id: 'Cardiovascular System' }
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiovascular System',
-						q: { bar_by_grade: true, value_by_max_grade: true }
-					}
-				}
-			],
+			plots: [plot],
 			termfilter: {
 				filter: {
 					type: 'tvslst',
@@ -139,20 +135,13 @@ tape('term1=Cardiovascular System, filter=ALL', function(test) {
 	}
 })
 
-tape('term1=Cardiovascular System, term2=agedx', function(test) {
+tape('term1=Cardiovascular System, term2=agedx', function (test) {
 	test.timeoutAfter(10000)
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term2 = { id: 'agedx' }
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiovascular System',
-						q: { bar_by_grade: true, value_by_max_grade: true }
-					},
-					term2: { id: 'agedx' }
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -164,7 +153,7 @@ tape('term1=Cardiovascular System, term2=agedx', function(test) {
 	async function runTests(cuminc) {
 		const div = cuminc.Inner.dom.chartsDiv
 		test.equal(div.selectAll('.sjpcb-cuminc-series').size(), 2, 'should render 2 cuminc series <g>')
-		test.equal(
+		/*test.equal(
 			div.selectAll('.sjpcb-cuminc-series path').size(),
 			4,
 			'should render 4 cuminc series paths for estimate line and 95% CI area'
@@ -191,22 +180,18 @@ tape('term1=Cardiovascular System, term2=agedx', function(test) {
 			else test.pass(`Should display series = '${d.seriesId}' in both legend and 'Number at risk' table`)
 		}
 
-		if (test._ok) cuminc.Inner.app.destroy()
+		if (test._ok) cuminc.Inner.app.destroy()*/
 		test.end()
 	}
 })
 
 tape('term1=Cardiovascular System, term0=sex', test => {
 	test.timeoutAfter(5000)
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term0 = { id: 'sex' }
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: { id: 'Cardiovascular System' },
-					term0: { id: 'sex' }
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -245,42 +230,31 @@ tape('term1=Cardiovascular System, term0=sex', test => {
 
 tape('term1 = Cardiovascular System, term2 = agedx, numeric regular bins', test => {
 	test.timeoutAfter(10000)
-
 	const testBinSize = 5
 	const testStop = 5
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term2 = {
+		id: 'agedx',
+		name: 'Age (years) at Cancer Diagnosis',
+		type: 'float',
+		bins: {
+			default: {
+				type: 'regular-bin',
+				bin_size: testBinSize,
+				startinclusive: true,
+				first_bin: {
+					startunbounded: true,
+					stop: testStop
+				}
+			},
+			label_offset: 1
+		}
+	}
+	plot.settings.controls = { isOpen: true }
+
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiovascular System',
-						q: { bar_by_grade: true, value_by_max_grade: true }
-					},
-					term2: {
-						id: 'agedx',
-						name: 'Age (years) at Cancer Diagnosis',
-						type: 'float',
-						bins: {
-							default: {
-								type: 'regular-bin',
-								bin_size: testBinSize,
-								startinclusive: true,
-								first_bin: {
-									startunbounded: true,
-									stop: testStop
-								}
-							},
-							label_offset: 1
-						}
-					},
-					settings: {
-						controls: {
-							isOpen: true
-						}
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -350,68 +324,62 @@ tape('term1 = Cardiovascular System, term2 = agedx, numeric regular bins', test 
 
 tape('term1 = Cardiovascular System, term0 = agedx, numeric regular bins', test => {
 	test.timeoutAfter(5000)
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term0 = {
+		id: 'agedx',
+		term: {
+			type: 'float',
+			bins: {
+				default: {
+					type: 'regular-bin',
+					bin_size: 5,
+					startinclusive: true,
+					first_bin: {
+						startunbounded: true,
+						stop: 5
+					},
+					label_offset: 1
+				},
+				label_offset: 1
+			},
+			name: 'Age (years) at Cancer Diagnosis',
+			id: 'agedx'
+			// isleaf: true,
+			// values: {},
+			// included_types: [
+			// 	'float'
+			// ],
+			// child_types: []
+		},
+		q: {
+			isAtomic: true,
+			mode: 'discrete',
+			type: 'regular-bin'
+			// type: 'custom-bin',
+			// lst: [
+			// 	{
+			// 		startunbounded: true,
+			// 		stop: 8.164619357749999,
+			// 		stopinclusive: false,
+			// 		label: '<8.164619357749999'
+			// 	},
+			// 	{
+			// 		start: 8.164619357749999,
+			// 		startinclusive: true,
+			// 		stopunbounded: true,
+			// 		label: '≥8.164619357749999'
+			// 	}
+			// ],
+			// hiddenValues: {}
+		}
+	}
+	plot.settings.controls = {
+		term0: { id: 'agedx', term: termjson['agedx'] }
+	}
 
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: { id: 'Cardiovascular System' },
-					term0: {
-						id: 'agedx',
-						term: {
-							type: 'float',
-							bins: {
-								default: {
-									type: 'regular-bin',
-									bin_size: 5,
-									startinclusive: true,
-									first_bin: {
-										startunbounded: true,
-										stop: 5
-									},
-									label_offset: 1
-								},
-								label_offset: 1
-							},
-							name: 'Age (years) at Cancer Diagnosis',
-							id: 'agedx'
-							// isleaf: true,
-							// values: {},
-							// included_types: [
-							// 	'float'
-							// ],
-							// child_types: []
-						},
-						q: {
-							isAtomic: true,
-							mode: 'discrete',
-							type: 'regular-bin'
-							// type: 'custom-bin',
-							// lst: [
-							// 	{
-							// 		startunbounded: true,
-							// 		stop: 8.164619357749999,
-							// 		stopinclusive: false,
-							// 		label: '<8.164619357749999'
-							// 	},
-							// 	{
-							// 		start: 8.164619357749999,
-							// 		startinclusive: true,
-							// 		stopunbounded: true,
-							// 		label: '≥8.164619357749999'
-							// 	}
-							// ],
-							// hiddenValues: {}
-						}
-					},
-					settings: {
-						controls: {
-							term0: { id: 'agedx', term: termjson['agedx'] }
-						}
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -432,36 +400,24 @@ tape('term1 = Cardiovascular System, term0 = agedx, numeric regular bins', test 
 
 tape('term1 = Cardiovascular System, term2 = agedx, numeric custom bins', test => {
 	test.timeoutAfter(10000)
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term2 = {
+		id: 'agedx',
+		q: {
+			type: 'custom-bin',
+			mode: 'discrete',
+			lst: [
+				{ startunbounded: true, stop: 7, stopinclusive: false, label: '<7' },
+				{ startinclusive: true, stopinclusive: true, start: 7, stop: 12, label: '7 to 12' },
+				{ start: 12, startinclusive: false, stopunbounded: true, label: '>12' }
+			]
+		}
+	}
+	plot.settings.controls = { isOpen: true }
 
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiovascular System',
-						q: { bar_by_grade: true, value_by_max_grade: true }
-					},
-					term2: {
-						id: 'agedx',
-						q: {
-							type: 'custom-bin',
-							mode: 'discrete',
-							lst: [
-								{ startunbounded: true, stop: 7, stopinclusive: false, label: '<7' },
-								{ startinclusive: true, stopinclusive: true, start: 7, stop: 12, label: '7 to 12' },
-								{ start: 12, startinclusive: false, stopunbounded: true, label: '>12' }
-							]
-						}
-					},
-					settings: {
-						cuminc: {},
-						controls: {
-							isOpen: true
-						}
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -529,61 +485,53 @@ tape('term1 = Cardiovascular System, term2 = agedx, numeric custom bins', test =
 
 tape('term1 = Cardiovascular System, term0 = agedx, numeric custom bins', test => {
 	test.timeoutAfter(10000)
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term0 = {
+		id: 'agedx',
+		term: {
+			type: 'float',
+			// bins: {
+			// 	default: {
+			// 		type: 'regular-bin',
+			// 		bin_size: 5,
+			// 		startinclusive: true,
+			// 		first_bin: {
+			// 			startunbounded: true,
+			// 			stop: 5
+			// 		},
+			// 		label_offset: 1
+			// 	},
+			// 	label_offset: 1
+			// },
+			name: 'Age (years) at Cancer Diagnosis',
+			id: 'agedx'
+		},
+		q: {
+			isAtomic: true,
+			mode: 'discrete',
+			type: 'custom-bin',
+			lst: [
+				{
+					startunbounded: true,
+					stop: 12,
+					stopinclusive: false,
+					label: '<12'
+				},
+				{
+					start: 12,
+					startinclusive: true,
+					stopunbounded: true,
+					label: '≥12'
+				}
+			],
+			hiddenValues: {}
+		}
+	}
+	plot.settings.controls = { isOpen: true }
 
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: { id: 'Cardiovascular System' },
-					term0: {
-						id: 'agedx',
-						term: {
-							type: 'float',
-							// bins: {
-							// 	default: {
-							// 		type: 'regular-bin',
-							// 		bin_size: 5,
-							// 		startinclusive: true,
-							// 		first_bin: {
-							// 			startunbounded: true,
-							// 			stop: 5
-							// 		},
-							// 		label_offset: 1
-							// 	},
-							// 	label_offset: 1
-							// },
-							name: 'Age (years) at Cancer Diagnosis',
-							id: 'agedx'
-						},
-						q: {
-							isAtomic: true,
-							mode: 'discrete',
-							type: 'custom-bin',
-							lst: [
-								{
-									startunbounded: true,
-									stop: 12,
-									stopinclusive: false,
-									label: '<12'
-								},
-								{
-									start: 12,
-									startinclusive: true,
-									stopunbounded: true,
-									label: '≥12'
-								}
-							],
-							hiddenValues: {}
-						}
-					},
-					settings: {
-						controls: {
-							isOpen: true
-						}
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -640,26 +588,13 @@ tape('term1 = Cardiovascular System, term0 = agedx, numeric custom bins', test =
 	}
 })
 
-tape('hidden uncomputable', function(test) {
+tape('hidden uncomputable', function (test) {
 	test.timeoutAfter(10000)
+	plot.term = { id: 'Cardiac dysrhythmia' }
+	plot.term2 = { id: 'cisplateq_5' }
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiac dysrhythmia'
-					},
-					term2: {
-						id: 'cisplateq_5'
-					},
-					settings: {
-						cuminc: {
-							minSampleSize: 1
-						}
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -677,27 +612,15 @@ tape('hidden uncomputable', function(test) {
 	}
 })
 
-tape('skipped series', function(test) {
+tape.only('skipped series', function (test) {
 	test.timeoutAfter(10000)
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term2 = { id: 'genetic_race' }
+	plot.settings.cuminc.minSampleSize = 10
+
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiovascular System',
-						q: { bar_by_grade: true, value_by_max_grade: true }
-					},
-					term2: {
-						id: 'genetic_race'
-					},
-					settings: {
-						cuminc: {
-							minSampleSize: 5
-						}
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {
@@ -717,59 +640,67 @@ tape('skipped series', function(test) {
 	}
 })
 
-tape('term1 = Cardiovascular System, term2 = samplelst', function(test) {
+tape('term1 = Cardiovascular System, term2 = samplelst', function (test) {
 	test.timeoutAfter(5000)
+	plot.term = { id: 'Cardiovascular System' }
+	plot.term2 = {
+		term: {
+			name: 'Samplelst term',
+			type: 'samplelst',
+			values: {
+				'Group 1': {
+					key: 'Group 1',
+					label: 'Test 1',
+					inuse: false,
+					list: [
+						{ sampleId: 1, sample: 1 },
+						{ sampleId: 2, sample: 2 }
+					]
+				},
+				'Group 2': {
+					key: 'Group 2',
+					label: 'Test 2',
+					inuse: false,
+					list: [
+						{ sampleId: 3, sample: 3 },
+						{ sampleId: 4, sample: 4 },
+						{ sampleId: 5, sample: 5 }
+					]
+				},
+				'Group 3': { key: 'Group 3', label: 'Test 3', inuse: false, list: [{ sampleId: 6, sample: 6 }] }
+			}
+		},
+		q: {
+			groups: [
+				{
+					name: 'Group 1',
+					in: false,
+					values: [
+						{ sampleId: 1, sample: 1 },
+						{ sampleId: 2, sample: 2 }
+					]
+				},
+				{
+					name: 'Group 2',
+					in: false,
+					values: [
+						{ sampleId: 3, sample: 3 },
+						{ sampleId: 4, sample: 4 },
+						{ sampleId: 5, sample: 5 }
+					]
+				},
+				{
+					name: 'Group 3',
+					in: false,
+					values: [{ sampleId: 6, sample: 6 }]
+				}
+			]
+		}
+	}
 
 	runpp({
 		state: {
-			plots: [
-				{
-					chartType: 'cuminc',
-					term: {
-						id: 'Cardiovascular System'
-					},
-					term2: {
-						term: {
-							name: 'Samplelst term',
-							type: 'samplelst',
-							values: {
-								'Group 1': {
-									key: 'Group 1',
-									label: 'Test 1',
-									inuse: false,
-									list: [{ sampleId: 1, sample: 1 }, { sampleId: 2, sample: 2 }]
-								},
-								'Group 2': {
-									key: 'Group 2',
-									label: 'Test 2',
-									inuse: false,
-									list: [{ sampleId: 3, sample: 3 }, { sampleId: 4, sample: 4 }, { sampleId: 5, sample: 5 }]
-								},
-								'Group 3': { key: 'Group 3', label: 'Test 3', inuse: false, list: [{ sampleId: 6, sample: 6 }] }
-							}
-						},
-						q: {
-							groups: [
-								{
-									name: 'Group 1',
-									in: false,
-									values: [{ sampleId: 1, sample: 1 }, { sampleId: 2, sample: 2 }]
-								},
-								{
-									name: 'Group 2',
-									in: false,
-									values: [{ sampleId: 3, sample: 3 }, { sampleId: 4, sample: 4 }, { sampleId: 5, sample: 5 }]
-								},
-								{
-									name: 'Group 3',
-									in: false,
-									values: [{ sampleId: 6, sample: 6 }]
-								}
-							]
-						}
-					}
-				}
-			]
+			plots: [plot]
 		},
 		cuminc: {
 			callbacks: {

--- a/client/mass/test/cuminc.integration.spec.js
+++ b/client/mass/test/cuminc.integration.spec.js
@@ -48,22 +48,17 @@ tape('\n', function (test) {
 	test.end()
 })
 
-const plot = {
-	chartType: 'cuminc',
-	settings: {
-		cuminc: {
-			minSampleSize: 1,
-			minAtRisk: 0
-		}
-	}
-}
-
 tape('term1=Cardiac dysrhythmia', function (test) {
 	test.timeoutAfter(10000)
-	plot.term = { id: 'Cardiac dysrhythmia' }
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiac dysrhythmia' },
+					settings: { cuminc: { minSampleSize: 1, minAtRisk: 0 } }
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -93,10 +88,15 @@ tape('term1=Cardiac dysrhythmia', function (test) {
 tape('term1=Cardiovascular System, filter=ALL', function (test) {
 	// this test breaks due to the "missing minSampleSize" err
 	test.timeoutAfter(10000)
-	plot.term = { id: 'Cardiovascular System' }
 	runpp({
 		state: {
-			plots: [plot],
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					settings: { cuminc: { minSampleSize: 1, minAtRisk: 0 } }
+				}
+			],
 			termfilter: {
 				filter: {
 					type: 'tvslst',
@@ -137,11 +137,16 @@ tape('term1=Cardiovascular System, filter=ALL', function (test) {
 
 tape('term1=Cardiovascular System, term2=agedx', function (test) {
 	test.timeoutAfter(10000)
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term2 = { id: 'agedx' }
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term2: { id: 'agedx' },
+					settings: { cuminc: { minSampleSize: 1, minAtRisk: 0 } }
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -187,11 +192,16 @@ tape('term1=Cardiovascular System, term2=agedx', function (test) {
 
 tape('term1=Cardiovascular System, term0=sex', test => {
 	test.timeoutAfter(5000)
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term0 = { id: 'sex' }
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term0: { id: 'sex' },
+					settings: { cuminc: { minSampleSize: 1, minAtRisk: 0 } }
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -232,29 +242,36 @@ tape('term1 = Cardiovascular System, term2 = agedx, numeric regular bins', test 
 	test.timeoutAfter(10000)
 	const testBinSize = 5
 	const testStop = 5
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term2 = {
-		id: 'agedx',
-		name: 'Age (years) at Cancer Diagnosis',
-		type: 'float',
-		bins: {
-			default: {
-				type: 'regular-bin',
-				bin_size: testBinSize,
-				startinclusive: true,
-				first_bin: {
-					startunbounded: true,
-					stop: testStop
-				}
-			},
-			label_offset: 1
-		}
-	}
-	plot.settings.controls = { isOpen: true }
 
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term2: {
+						id: 'agedx',
+						name: 'Age (years) at Cancer Diagnosis',
+						type: 'float',
+						bins: {
+							default: {
+								type: 'regular-bin',
+								bin_size: testBinSize,
+								startinclusive: true,
+								first_bin: {
+									startunbounded: true,
+									stop: testStop
+								}
+							},
+							label_offset: 1
+						}
+					},
+					settings: {
+						cuminc: { minSampleSize: 1, minAtRisk: 0 },
+						controls: { isOpen: true }
+					}
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -324,62 +341,68 @@ tape('term1 = Cardiovascular System, term2 = agedx, numeric regular bins', test 
 
 tape('term1 = Cardiovascular System, term0 = agedx, numeric regular bins', test => {
 	test.timeoutAfter(5000)
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term0 = {
-		id: 'agedx',
-		term: {
-			type: 'float',
-			bins: {
-				default: {
-					type: 'regular-bin',
-					bin_size: 5,
-					startinclusive: true,
-					first_bin: {
-						startunbounded: true,
-						stop: 5
-					},
-					label_offset: 1
-				},
-				label_offset: 1
-			},
-			name: 'Age (years) at Cancer Diagnosis',
-			id: 'agedx'
-			// isleaf: true,
-			// values: {},
-			// included_types: [
-			// 	'float'
-			// ],
-			// child_types: []
-		},
-		q: {
-			isAtomic: true,
-			mode: 'discrete',
-			type: 'regular-bin'
-			// type: 'custom-bin',
-			// lst: [
-			// 	{
-			// 		startunbounded: true,
-			// 		stop: 8.164619357749999,
-			// 		stopinclusive: false,
-			// 		label: '<8.164619357749999'
-			// 	},
-			// 	{
-			// 		start: 8.164619357749999,
-			// 		startinclusive: true,
-			// 		stopunbounded: true,
-			// 		label: '≥8.164619357749999'
-			// 	}
-			// ],
-			// hiddenValues: {}
-		}
-	}
-	plot.settings.controls = {
-		term0: { id: 'agedx', term: termjson['agedx'] }
-	}
-
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term0: {
+						id: 'agedx',
+						term: {
+							type: 'float',
+							bins: {
+								default: {
+									type: 'regular-bin',
+									bin_size: 5,
+									startinclusive: true,
+									first_bin: {
+										startunbounded: true,
+										stop: 5
+									},
+									label_offset: 1
+								},
+								label_offset: 1
+							},
+							name: 'Age (years) at Cancer Diagnosis',
+							id: 'agedx'
+							// isleaf: true,
+							// values: {},
+							// included_types: [
+							// 	'float'
+							// ],
+							// child_types: []
+						},
+						q: {
+							isAtomic: true,
+							mode: 'discrete',
+							type: 'regular-bin'
+							// type: 'custom-bin',
+							// lst: [
+							// 	{
+							// 		startunbounded: true,
+							// 		stop: 8.164619357749999,
+							// 		stopinclusive: false,
+							// 		label: '<8.164619357749999'
+							// 	},
+							// 	{
+							// 		start: 8.164619357749999,
+							// 		startinclusive: true,
+							// 		stopunbounded: true,
+							// 		label: '≥8.164619357749999'
+							// 	}
+							// ],
+							// hiddenValues: {}
+						}
+					},
+					settings: {
+						cuminc: { minSampleSize: 1, minAtRisk: 0 },
+						controls: {
+							term0: { id: 'agedx', term: termjson['agedx'] }
+						}
+					}
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -400,24 +423,30 @@ tape('term1 = Cardiovascular System, term0 = agedx, numeric regular bins', test 
 
 tape('term1 = Cardiovascular System, term2 = agedx, numeric custom bins', test => {
 	test.timeoutAfter(10000)
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term2 = {
-		id: 'agedx',
-		q: {
-			type: 'custom-bin',
-			mode: 'discrete',
-			lst: [
-				{ startunbounded: true, stop: 7, stopinclusive: false, label: '<7' },
-				{ startinclusive: true, stopinclusive: true, start: 7, stop: 12, label: '7 to 12' },
-				{ start: 12, startinclusive: false, stopunbounded: true, label: '>12' }
-			]
-		}
-	}
-	plot.settings.controls = { isOpen: true }
-
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term2: {
+						id: 'agedx',
+						q: {
+							type: 'custom-bin',
+							mode: 'discrete',
+							lst: [
+								{ startunbounded: true, stop: 7, stopinclusive: false, label: '<7' },
+								{ startinclusive: true, stopinclusive: true, start: 7, stop: 12, label: '7 to 12' },
+								{ start: 12, startinclusive: false, stopunbounded: true, label: '>12' }
+							]
+						}
+					},
+					settings: {
+						cuminc: { minSampleSize: 1, minAtRisk: 0 },
+						controls: { isOpen: true }
+					}
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -485,53 +514,59 @@ tape('term1 = Cardiovascular System, term2 = agedx, numeric custom bins', test =
 
 tape('term1 = Cardiovascular System, term0 = agedx, numeric custom bins', test => {
 	test.timeoutAfter(10000)
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term0 = {
-		id: 'agedx',
-		term: {
-			type: 'float',
-			// bins: {
-			// 	default: {
-			// 		type: 'regular-bin',
-			// 		bin_size: 5,
-			// 		startinclusive: true,
-			// 		first_bin: {
-			// 			startunbounded: true,
-			// 			stop: 5
-			// 		},
-			// 		label_offset: 1
-			// 	},
-			// 	label_offset: 1
-			// },
-			name: 'Age (years) at Cancer Diagnosis',
-			id: 'agedx'
-		},
-		q: {
-			isAtomic: true,
-			mode: 'discrete',
-			type: 'custom-bin',
-			lst: [
-				{
-					startunbounded: true,
-					stop: 12,
-					stopinclusive: false,
-					label: '<12'
-				},
-				{
-					start: 12,
-					startinclusive: true,
-					stopunbounded: true,
-					label: '≥12'
-				}
-			],
-			hiddenValues: {}
-		}
-	}
-	plot.settings.controls = { isOpen: true }
-
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term0: {
+						id: 'agedx',
+						term: {
+							type: 'float',
+							// bins: {
+							// 	default: {
+							// 		type: 'regular-bin',
+							// 		bin_size: 5,
+							// 		startinclusive: true,
+							// 		first_bin: {
+							// 			startunbounded: true,
+							// 			stop: 5
+							// 		},
+							// 		label_offset: 1
+							// 	},
+							// 	label_offset: 1
+							// },
+							name: 'Age (years) at Cancer Diagnosis',
+							id: 'agedx'
+						},
+						q: {
+							isAtomic: true,
+							mode: 'discrete',
+							type: 'custom-bin',
+							lst: [
+								{
+									startunbounded: true,
+									stop: 12,
+									stopinclusive: false,
+									label: '<12'
+								},
+								{
+									start: 12,
+									startinclusive: true,
+									stopunbounded: true,
+									label: '≥12'
+								}
+							],
+							hiddenValues: {}
+						}
+					},
+					settings: {
+						cuminc: { minSampleSize: 1, minAtRisk: 0 },
+						controls: { isOpen: true }
+					}
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -590,11 +625,18 @@ tape('term1 = Cardiovascular System, term0 = agedx, numeric custom bins', test =
 
 tape('hidden uncomputable', function (test) {
 	test.timeoutAfter(10000)
-	plot.term = { id: 'Cardiac dysrhythmia' }
-	plot.term2 = { id: 'cisplateq_5' }
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiac dysrhythmia' },
+					term2: { id: 'cisplateq_5' },
+					settings: {
+						cuminc: { minSampleSize: 1, minAtRisk: 0 }
+					}
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -612,15 +654,20 @@ tape('hidden uncomputable', function (test) {
 	}
 })
 
-tape.only('skipped series', function (test) {
+tape('skipped series', function (test) {
 	test.timeoutAfter(10000)
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term2 = { id: 'genetic_race' }
-	plot.settings.cuminc.minSampleSize = 10
-
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term2: { id: 'genetic_race' },
+					settings: {
+						cuminc: { minSampleSize: 10, minAtRisk: 0 }
+					}
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {
@@ -642,65 +689,71 @@ tape.only('skipped series', function (test) {
 
 tape('term1 = Cardiovascular System, term2 = samplelst', function (test) {
 	test.timeoutAfter(5000)
-	plot.term = { id: 'Cardiovascular System' }
-	plot.term2 = {
-		term: {
-			name: 'Samplelst term',
-			type: 'samplelst',
-			values: {
-				'Group 1': {
-					key: 'Group 1',
-					label: 'Test 1',
-					inuse: false,
-					list: [
-						{ sampleId: 1, sample: 1 },
-						{ sampleId: 2, sample: 2 }
-					]
-				},
-				'Group 2': {
-					key: 'Group 2',
-					label: 'Test 2',
-					inuse: false,
-					list: [
-						{ sampleId: 3, sample: 3 },
-						{ sampleId: 4, sample: 4 },
-						{ sampleId: 5, sample: 5 }
-					]
-				},
-				'Group 3': { key: 'Group 3', label: 'Test 3', inuse: false, list: [{ sampleId: 6, sample: 6 }] }
-			}
-		},
-		q: {
-			groups: [
-				{
-					name: 'Group 1',
-					in: false,
-					values: [
-						{ sampleId: 1, sample: 1 },
-						{ sampleId: 2, sample: 2 }
-					]
-				},
-				{
-					name: 'Group 2',
-					in: false,
-					values: [
-						{ sampleId: 3, sample: 3 },
-						{ sampleId: 4, sample: 4 },
-						{ sampleId: 5, sample: 5 }
-					]
-				},
-				{
-					name: 'Group 3',
-					in: false,
-					values: [{ sampleId: 6, sample: 6 }]
-				}
-			]
-		}
-	}
-
 	runpp({
 		state: {
-			plots: [plot]
+			plots: [
+				{
+					chartType: 'cuminc',
+					term: { id: 'Cardiovascular System' },
+					term2: {
+						term: {
+							name: 'Samplelst term',
+							type: 'samplelst',
+							values: {
+								'Group 1': {
+									key: 'Group 1',
+									label: 'Test 1',
+									inuse: false,
+									list: [
+										{ sampleId: 1, sample: 1 },
+										{ sampleId: 2, sample: 2 }
+									]
+								},
+								'Group 2': {
+									key: 'Group 2',
+									label: 'Test 2',
+									inuse: false,
+									list: [
+										{ sampleId: 3, sample: 3 },
+										{ sampleId: 4, sample: 4 },
+										{ sampleId: 5, sample: 5 }
+									]
+								},
+								'Group 3': { key: 'Group 3', label: 'Test 3', inuse: false, list: [{ sampleId: 6, sample: 6 }] }
+							}
+						},
+						q: {
+							groups: [
+								{
+									name: 'Group 1',
+									in: false,
+									values: [
+										{ sampleId: 1, sample: 1 },
+										{ sampleId: 2, sample: 2 }
+									]
+								},
+								{
+									name: 'Group 2',
+									in: false,
+									values: [
+										{ sampleId: 3, sample: 3 },
+										{ sampleId: 4, sample: 4 },
+										{ sampleId: 5, sample: 5 }
+									]
+								},
+								{
+									name: 'Group 3',
+									in: false,
+									values: [{ sampleId: 6, sample: 6 }]
+								}
+							]
+						}
+					},
+					settings: {
+						cuminc: { minSampleSize: 1, minAtRisk: 0 }
+					}
+				}
+			]
 		},
 		cuminc: {
 			callbacks: {

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -290,6 +290,7 @@ function setTextInput(opts) {
 	self.dom.input = self.dom.inputTd
 		.append('input')
 		.attr('type', 'text')
+		.attr('placeholder', opts.placeholder)
 		.style('width', (opts.width || 100) + 'px')
 		.on('change', () => {
 			const value = self.dom.input.property('value')

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -344,7 +344,7 @@ class MassCumInc {
 							title: 'Display the at-risk counts'
 						},
 						{
-							label: '95% CI',
+							label: '95% confidence interval',
 							boxLabel: 'Visible',
 							type: 'checkbox',
 							chartType: 'cuminc',
@@ -1228,10 +1228,10 @@ function getPj(self) {
 				return seriesId == 'CI' ? [row.low, row.high] : row[seriesId]
 			},
 			yMin(row) {
-				return row.cuminc
+				return self.settings.ciVisible ? row.low : row.cuminc
 			},
 			yMax(row) {
-				return row.cuminc
+				return self.settings.ciVisible ? row.high : row.cuminc
 			},
 			xTickValues(row, context) {
 				const s = self.settings

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -1258,7 +1258,8 @@ function getPj(self) {
 					.range([0, s.svgw - s.svgPadding.left - s.svgPadding.right])
 			},
 			scaledX(row, context) {
-				return context.context.context.context.parent.xScale(context.self.x)
+				const xScale = context.context.context.context.parent.xScale.clamp(true)
+				return xScale(context.self.x)
 			},
 			yTickValues(row, context) {
 				const s = self.settings

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -81,11 +81,10 @@ export class Cuminc {
 		data.keys = ['chartId', 'seriesId', 'time', 'cuminc', 'low', 'high']
 		this.uniqueSeriesIds = new Set()
 		this.currData = []
-		const estKeys = ['cuminc', 'low', 'high']
 		for (const d of data.case) {
 			const obj = {}
 			data.keys.forEach((k, i) => {
-				obj[k] = estKeys.includes(k) ? 100 * d[i] : d[i]
+				obj[k] = d[i]
 			})
 			this.currData.push(obj)
 			this.uniqueSeriesIds.add(obj.seriesId)
@@ -430,35 +429,16 @@ class MassCumInc {
 	}
 
 	processData(data) {
-		// restructure case data
-		const casedata = []
+		// process case data
+		this.uniqueSeriesIds = new Set()
+		this.currData = []
 		for (const d of data.case) {
 			const obj = {}
 			data.keys.forEach((k, i) => {
 				obj[k] = d[i]
 			})
-			casedata.push(obj)
-		}
-
-		// process case data
-		const nriskCutoff = 20 // at-risk count cutoff
-		this.currData = []
-		this.uniqueSeriesIds = new Set()
-		for (const d of casedata) {
-			// convert cuminc estimates to percentages
-			d.cuminc = 100 * d.cuminc
-			d.low = 100 * d.low
-			d.high = 100 * d.high
-			if (d.nrisk < nriskCutoff) {
-				// keep the first timepoint with a low at-risk count and
-				// drop the remaining timepoints
-				// this will allow the curve to extend horizontally up to
-				// this timepoint
-				this.currData.push(d)
-				break
-			}
-			this.currData.push(d)
-			this.uniqueSeriesIds.add(d.seriesId)
+			this.currData.push(obj)
+			this.uniqueSeriesIds.add(obj.seriesId)
 		}
 
 		this.refs = data.refs

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -280,15 +280,9 @@ function setRenderers(self) {
 			.style('margin', '20px 0px 10px 0px')
 			.attr('name', label) //For integration testing
 		const row = div.append('div')
-		row
-			.append('span')
-			.style('text-decoration', 'underline')
-			.text(label)
+		row.append('span').style('text-decoration', 'underline').text(label)
 		if (label2) {
-			row
-				.append('span')
-				.html(label2)
-				.style('margin-left', '5px')
+			row.append('span').html(label2).style('margin-left', '5px')
 		}
 		return div.append('div').style('margin-left', '20px')
 	}
@@ -298,10 +292,7 @@ function setRenderers(self) {
 		const div = self.newDiv('Warnings')
 		const warnings = new Set(result.warnings)
 		for (const line of warnings) {
-			div
-				.append('p')
-				.style('margin', '5px')
-				.text(line)
+			div.append('p').style('margin', '5px').text(line)
 		}
 	}
 
@@ -309,21 +300,14 @@ function setRenderers(self) {
 		if (!result.splinePlots) return
 		const div = self.newDiv('Cubic spline plots')
 		for (const plot of result.splinePlots) {
-			div
-				.append('img')
-				.attr('src', plot.src)
-				.style('width', plot.size.width)
-				.style('height', plot.size.height)
+			div.append('img').attr('src', plot.src).style('width', plot.size.width).style('height', plot.size.height)
 		}
 	}
 
 	self.mayshow_residuals = result => {
 		if (!result.residuals) return
 		const div = self.newDiv(result.residuals.label)
-		const table = div
-			.append('table')
-			.style('border-spacing', '8px')
-			.attr('name', 'sjpp-residuals-table') //For integration tests
+		const table = div.append('table').style('border-spacing', '8px').attr('name', 'sjpp-residuals-table') //For integration tests
 		const tr1 = table.append('tr').style('opacity', 0.4)
 		const tr2 = table.append('tr')
 		for (let i = 0; i < result.residuals.header.length; i++) {
@@ -352,13 +336,10 @@ function setRenderers(self) {
 			}
 		})
 
-		if (result.cuminc.final_data) {
-			plotter.main(result.cuminc.final_data)
+		if (result.cuminc.ci_data) {
+			plotter.main(result.cuminc.ci_data)
 		} else {
-			holder
-				.append('div')
-				.style('margin', '20px')
-				.text(result.cuminc.msg)
+			holder.append('div').style('margin', '20px').text(result.cuminc.msg)
 		}
 	}
 
@@ -376,9 +357,7 @@ function setRenderers(self) {
 				labpad = 20,
 				vpad = 10
 
-			const scale = scaleLinear()
-				.domain([bs.minv, bs.maxv])
-				.range([0, boxplotWidth])
+			const scale = scaleLinear().domain([bs.minv, bs.maxv]).range([0, boxplotWidth])
 
 			const svg = div
 				.append('svg')
@@ -454,9 +433,7 @@ function setRenderers(self) {
 		{
 			const tr = table.append('tr').style('opacity', 0.4)
 			result.coefficients.header.forEach((v, i) => {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 				if (i === 1) tr.append('td') // column 3 will be for forest plot
 			})
 		}
@@ -465,9 +442,7 @@ function setRenderers(self) {
 		if (self.config.regressionType != 'cox') {
 			const tr = table.append('tr').style('background', '#eee')
 			result.coefficients.intercept.forEach((v, i) => {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 				if (i === 1) tr.append('td') // column 3 will be for forest plot
 			})
 		}
@@ -505,9 +480,7 @@ function setRenderers(self) {
 				forestPlotter(tr.append('td'), termdata.fields)
 				// rest of columns
 				for (const v of termdata.fields) {
-					tr.append('td')
-						.text(v)
-						.style('padding', '8px')
+					tr.append('td').text(v).style('padding', '8px')
 				}
 			} else if (termdata.categories) {
 				// term has categories, create one sub-row for each category in coefficient tables
@@ -546,9 +519,7 @@ function setRenderers(self) {
 
 					// rest of columns
 					for (const v of termdata.categories[k]) {
-						tr.append('td')
-							.text(v)
-							.style('padding', '8px')
+						tr.append('td').text(v).style('padding', '8px')
 					}
 				}
 			} else {
@@ -579,9 +550,7 @@ function setRenderers(self) {
 			forestPlotter(tr.append('td'), row.lst)
 			// rest of columns
 			for (const v of row.lst) {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 			}
 		}
 
@@ -602,18 +571,14 @@ function setRenderers(self) {
 		{
 			const tr = table.append('tr').style('opacity', 0.4)
 			for (const v of result.totalSnpEffect.header) {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 			}
 		}
 
 		// total snp effect row
 		const tr = table.append('tr').style('background', '#eee')
 		for (const v of result.totalSnpEffect.lst) {
-			tr.append('td')
-				.text(v)
-				.style('padding', '8px')
+			tr.append('td').text(v).style('padding', '8px')
 		}
 		const snp = self.getIndependentInput(result.totalSnpEffect.snp).term
 		const interactions = result.totalSnpEffect.interactions.map(interaction => {
@@ -622,9 +587,7 @@ function setRenderers(self) {
 				t2: self.getIndependentInput(interaction.term2).term
 			}
 		})
-		const bottomInfo = `Total: total effect of removing the snp (${
-			snp.term.name
-		}) and its interactions (${interactions
+		const bottomInfo = `Total: total effect of removing the snp (${snp.term.name}) and its interactions (${interactions
 			.map(interaction => interaction.t1.term.name + ' : ' + interaction.t2.term.name)
 			.join(' ; ')}) from the model`
 		div
@@ -645,9 +608,7 @@ function setRenderers(self) {
 		{
 			const tr = table.append('tr').style('opacity', 0.4)
 			for (const v of result.type3.header) {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 			}
 		}
 
@@ -655,9 +616,7 @@ function setRenderers(self) {
 		if (self.config.regressionType != 'cox') {
 			const tr = table.append('tr').style('background', '#eee')
 			for (const v of result.type3.intercept) {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 			}
 		}
 
@@ -674,9 +633,7 @@ function setRenderers(self) {
 			fillTdName(termNameTd, tw.term.name)
 			// rest of columns
 			for (const v of termdata) {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 			}
 		}
 		// interactions
@@ -690,9 +647,7 @@ function setRenderers(self) {
 			fillTdName(td.append('div'), t2.term.name)
 			// rest of columns
 			for (const v of row.lst) {
-				tr.append('td')
-					.text(v)
-					.style('padding', '8px')
+				tr.append('td').text(v).style('padding', '8px')
 			}
 		}
 	}
@@ -703,18 +658,13 @@ function setRenderers(self) {
 		const table = div.append('table').style('border-spacing', '0px')
 		const header = table.append('tr').style('opacity', 0.4)
 		for (const cell of result.tests.header) {
-			header
-				.append('td')
-				.text(cell)
-				.style('padding', '8px')
+			header.append('td').text(cell).style('padding', '8px')
 		}
 		let rowcount = 0
 		for (const row of result.tests.rows) {
 			const tr = table.append('tr').style('background', rowcount++ % 2 ? 'none' : '#eee')
 			for (const cell of row) {
-				tr.append('td')
-					.text(cell)
-					.style('padding', '8px')
+				tr.append('td').text(cell).style('padding', '8px')
 			}
 		}
 	}
@@ -725,9 +675,7 @@ function setRenderers(self) {
 		const table = div.append('table').style('border-spacing', '8px')
 		for (let i = 0; i < result.other.header.length; i++) {
 			const tr = table.append('tr')
-			tr.append('td')
-				.style('opacity', 0.4)
-				.text(result.other.header[i])
+			tr.append('td').style('opacity', 0.4).text(result.other.header[i])
 			tr.append('td').text(result.other.rows[i])
 		}
 	}
@@ -846,9 +794,7 @@ function setRenderers(self) {
 				// had encountered a bug that '.1r' will print "20" at the tick of "15"
 				const tickFormat = self.config.regressionType == 'logistic' ? '.1r' : undefined
 
-				const axis = axisBottom()
-					.ticks(4, tickFormat)
-					.scale(scale)
+				const axis = axisBottom().ticks(4, tickFormat).scale(scale)
 				axisstyle({
 					axis: g.call(axis),
 					color: forestcolor,
@@ -867,12 +813,7 @@ function setRenderers(self) {
 			{
 				// vertical baseline
 				const x = scale(baselineValue)
-				g.append('line')
-					.attr('x1', x)
-					.attr('y1', 0)
-					.attr('x2', x)
-					.attr('y2', height)
-					.attr('stroke', '#ccc')
+				g.append('line').attr('x1', x).attr('y1', 0).attr('x2', x).attr('y2', height).attr('stroke', '#ccc')
 			}
 
 			const mid = Number(lst[midIdx]),
@@ -1282,25 +1223,15 @@ export function showLDlegend(div, colorScale) {
 			.attr('transform', 'translate(' + xpad + ',' + axisheight + ')')
 			.call(
 				axisTop()
-					.scale(
-						scaleLinear()
-							.domain([0, 1])
-							.range([0, axiswidth])
-					)
+					.scale(scaleLinear().domain([0, 1]).range([0, axiswidth]))
 					.ticks(4)
 			),
 		fontsize: 12
 	})
 
 	const id = 'grad' + Math.random()
-	const grad = svg
-		.append('defs')
-		.append('linearGradient')
-		.attr('id', id)
-	grad
-		.append('stop')
-		.attr('offset', '0%')
-		.attr('stop-color', colorlst[0])
+	const grad = svg.append('defs').append('linearGradient').attr('id', id)
+	grad.append('stop').attr('offset', '0%').attr('stop-color', colorlst[0])
 	grad
 		.append('stop')
 		.attr('offset', '100%')

--- a/release.txt
+++ b/release.txt
@@ -1,6 +1,7 @@
 Features:
 - Display pairlst data, if available, for a fusion event on matrix cell mouseover
 - Launch lollipop from a geneVariant row label of matrix
+- User-controllable filter for at-risk counts in cumulative incidence plot
 
 Fixes:
 - Bug fix to change cutoff grade for condition term

--- a/server/src/termdb.cuminc.js
+++ b/server/src/termdb.cuminc.js
@@ -178,23 +178,33 @@ export async function runCumincR(Rinput, final_data) {
 	}
 
 	// parse results
+	const nriskCutoff = 10 // at-risk count cutoff
 	for (const chartId in ci_data) {
 		// retrieve cumulative incidence estimates
 		for (const seriesId in ci_data[chartId].estimates) {
 			const series = ci_data[chartId].estimates[seriesId]
 			// fill in final_data.case[]
 			for (let i = 0; i < series.length; i++) {
-				final_data.case.push([
+				const d = [
 					chartId,
 					seriesId,
 					series[i].time,
-					series[i].est,
-					series[i].low,
-					series[i].up,
+					series[i].est * 100,
+					series[i].low * 100,
+					series[i].up * 100,
 					series[i].nrisk,
 					series[i].nevent,
 					series[i].ncensor
-				])
+				]
+				if (series[i].nrisk < nriskCutoff) {
+					// keep the first timepoint with a low at-risk count and
+					// drop the remaining timepoints
+					// this will allow the curve to extend horizontally up to
+					// this timepoint
+					final_data.case.push(d)
+					break
+				}
+				final_data.case.push(d)
 			}
 		}
 		// retrieve results of Gray's tests

--- a/server/src/termdb.cuminc.js
+++ b/server/src/termdb.cuminc.js
@@ -49,6 +49,7 @@ export async function get_incidence(q, ds) {
 				Rinput.data[chartId] = chart
 			}
 		}
+		if (!Object.keys(Rinput.data).length) return { data: {} }
 
 		// run cumulative incidence analysis in R
 		const ci_data = await runCumincR(Rinput)

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -395,8 +395,6 @@ rightnow only few conditional terms have grade info
 }
 
 async function trigger_getincidence(q, res, ds) {
-	if (!q.minSampleSize) throw 'missing minSampleSize'
-	q.minSampleSize = Number(q.minSampleSize)
 	const data = await cuminc.get_incidence(q, ds)
 	res.send(data)
 }

--- a/server/utils/cuminc.R
+++ b/server/utils/cuminc.R
@@ -13,13 +13,15 @@
 
 # Input JSON:
 # {
-#   chartId: [
-#     {
-#       time: time to event
-#       event: event code (0 = censored, 1 = event, 2 = competing risk event)
-#       series: series ID
-#     }
-#   ]
+#   data:
+#     chartId: [
+#       {
+#         time: time to event
+#         event: event code (0 = censored, 1 = event, 2 = competing risk event)
+#         series: series ID
+#       }
+#     ],
+#   startTime: custom start time of cuminc curve
 # }
 #
 # Output JSON:


### PR DESCRIPTION
## Description
- Implemented at-risk count filter in cuminc plot. Will filter out events that have an at-risk count below a user-controlled cutoff (10 by default).
- At-risk count, sample size, and event count filters are now all performed on client side
- Axes changes
    - Require x-axis and y-axis to end at tick marks.
    - X-axis will be adjusted depending on at-risk count filter
    - Y-axis will now end at tick mark after the max upper 95% CI (if CI is visible).
    - Custom y-axis is now supported
- Removed unnecessary NodeJS post-processing steps of cuminc R output
- Handle situation when some charts have data and some do not ([example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Bowel%20perforation%22,%22q%22:{}},%22term0%22:{%22id%22:%22genetic_race%22}}],%22nav%22:{%22activeTab%22:1}}))


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
