### PR TITLE
Making dashed bars for subjective terms

### DIFF
--- a/client/plots/profileBarchart.js
+++ b/client/plots/profileBarchart.js
@@ -214,6 +214,8 @@ class profileBarchart {
 
 		function drawRect(x, y, row, i) {
 			const tw = row.twlst[i]
+			let subjectiveTerm = false
+			if (row.subjective) subjectiveTerm = true
 			const termColor = tw?.term?.color
 			const value = sampleData[tw.$id]?.value
 			const isFirst = i % 2 == 0
@@ -229,7 +231,7 @@ class profileBarchart {
 					.attr('y', 0)
 					.attr('width', width)
 					.attr('height', 20)
-				if (pairValue || !hasSubjectiveData) rect.attr('fill', termColor)
+				if (!subjectiveTerm && (pairValue || !hasSubjectiveData)) rect.attr('fill', termColor)
 				else {
 					const id = tw.term.name.replace(/[^a-zA-Z0-9]/g, '')
 					svg


### PR DESCRIPTION
## Description

If the term is marked as subjective by the dataset then it has a dashed bar. Should be merged with the corresponding PR from sjpp

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
