### PR TITLE
return blank data when filtering results in 0 samples

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -10,3 +10,4 @@ Fixes:
 - Fix the matrux sample group sorting by group name, to use predefined or group name as applicable
 - In lollipop tk, upon creating a subtk with a filtering criteria, sunburst generated from subtk will show correct total sample count for sunburst wedges by accounting for subtk filtering criteria. this fix works for both GDC and local TK
 - Scatterplot bug fix to improve behavior upon filtering by gene mutation
+- When filtering results in 0 eligible sample, big file query will not happen.

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -810,6 +810,13 @@ export async function snvindelByRangeGetter_bcf(ds, genome) {
 
 		const limitSamples = await mayLimitSamples(param, q._tk.samples, ds)
 		if (limitSamples) {
+			// is a valid set, parameter asks to filter samples
+
+			if (limitSamples.size == 0) {
+				// got 0 sample after filtering, return blank array for no data
+				return []
+			}
+
 			bcfArgs.push('-s', [...limitSamples].join(','))
 		}
 
@@ -1240,6 +1247,10 @@ async function validate_query_geneExpression(ds, genome) {
 	*/
 	q.get = async param => {
 		const limitSamples = await mayLimitSamples(param, null, ds)
+		if (limitSamples?.size == 0) {
+			// got 0 sample after filtering, return blank array for no data
+			return new Map()
+		}
 
 		const gene2sample2value = new Map() // k: gene symbol, v: { sampleId : value }
 
@@ -1341,6 +1352,7 @@ async function validate_query_probe2cnv(ds, genome) {
 		{
 			const limitSamples = await mayLimitSamples(param, q.samples, ds) // optional set of sample integer ids
 			if (limitSamples) {
+				if (limitSamples.size == 0) return []
 				for (const [i, s] of q.samples.entries()) {
 					if (limitSamples.has(s.name)) sampleCollectValues.push([])
 					else sampleCollectValues.push(null)
@@ -1630,6 +1642,10 @@ export async function svfusionByRangeGetter_file(ds, genome) {
 		const formatFilter = getFormatFilter(param)
 
 		const limitSamples = await mayLimitSamples(param, q.samples, ds)
+		if (limitSamples?.size == 0) {
+			// got 0 sample after filtering, return blank array for no data
+			return []
+		}
 
 		const key2variants = new Map()
 		/*
@@ -1820,6 +1836,10 @@ export async function cnvByRangeGetter_file(ds, genome) {
 		const formatFilter = getFormatFilter(param)
 
 		const limitSamples = await mayLimitSamples(param, q.samples, ds)
+		if (limitSamples?.size == 0) {
+			// got 0 sample after filtering, return blank array for no data
+			return []
+		}
 
 		const cnvs = []
 		const promises = []


### PR DESCRIPTION
## Description

[test here](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22nav%22:{%22activeTab%22:2},%22termfilter%22:{%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22chr10p%22},%22values%22:[{%22key%22:%22Loss%22}]}}]}}}), at filter, click AND and add MYC, it will not error out

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
