### PR TITLE
allow to edit axis scale for mds3 numeric mode

### DIFF
--- a/client/dom/numericAxis.js
+++ b/client/dom/numericAxis.js
@@ -114,6 +114,10 @@ export function makeNumericAxisConfig({ holder, callback, setting, noPercentile 
 					alert('invalid min value')
 					return
 				}
+				if (min >= max) {
+					alert('Min must be smaller than max')
+					return
+				}
 				callback({ fixed: { min, max } })
 			})
 	}

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -891,7 +891,7 @@ function render_axis(tk, nm, block) {
 		.attr('font-size', nm.dotwidth)
 		.attr('dominant-baseline', 'central')
 		.attr('text-anchor', 'end')
-		.attr('class', 'sjpp-mds3-nm-axislabel') // for testing
+		.attr('class', 'sjpp-mds3-nm-axislabel sja_clbtext2') // for testing
 		.attr('y', nm.axisheight / 2)
 		.attr('x', -nm.axisWidth)
 		.text(nm.label || defaultLabel) // if too long can use ellipsis, hover to show full

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -69,10 +69,7 @@ export function renderNumericMode(nm, data, tk, block) {
 	if (!nm.axisg) nm.axisg = tk.gleft.append('g')
 	if (!nm.axisheight) nm.axisheight = 150
 
-	// skewer.g <g> is always there. will create nm plot into it
-	// new d3 group selection is registered at skewer.nmg
-	tk.skewer.g.selectAll('*').remove()
-	if (tk.skewer.nmg) tk.skewer.nmg.selectAll('*').remove()
+	clearTk(tk)
 
 	numeric_make(nm, tk, block)
 
@@ -90,9 +87,21 @@ export function renderNumericMode(nm, data, tk, block) {
 	)
 }
 
+function clearTk(tk) {
+	// skewer.g <g> is always there. will create nm plot into it
+	// new d3 group selection is registered at skewer.nmg
+	tk.skewer.g.selectAll('*').remove()
+	if (tk.skewer.nmg) tk.skewer.nmg.selectAll('*').remove()
+}
+
 function numeric_make(nm, tk, block) {
 	/*
 	 */
+
+	if (!nm.axisSetting) {
+		// should be fine to create default setting when missing
+		nm.axisSetting = { auto: 1 }
+	}
 
 	const data = nm.data
 
@@ -136,7 +145,13 @@ function numeric_make(nm, tk, block) {
 				m._y = 0
 			} else {
 				// has valid value, map to axis
-				m._y = numscale(m.__value_use)
+				if (m.__value_use < nm.minvalue) {
+					m._y = 0
+				} else if (m.__value_use > nm.maxvalue) {
+					m._y = nm.axisheight
+				} else {
+					m._y = numscale(m.__value_use)
+				}
 			}
 		}
 	}
@@ -756,23 +771,19 @@ function m_mouseout(m, tk) {
 	tk.pica.g.selectAll('*').remove()
 }
 
-function setup_axis_scale(data, nm, tk) {
-	/*
-based on the source of axis scaling,
-decide following things about the y axis:
-- scale range, by different types of scales
-- name label
+/*
+based on numeric datatype selector, determine numeric value for each m
+
+if axisSetting.auto=1, determine min/max range
 */
-
-	nm.minvalue = 0
-	nm.maxvalue = 0
-
+function setup_axis_scale(data, nm, tk) {
 	for (const g of data) {
 		for (const m of g.mlst) {
 			delete m.__value_use
 			delete m.__value_missing
 		}
 	}
+
 	if (nm.byAttribute) {
 		for (const g of data) {
 			for (const m of g.mlst) {
@@ -784,17 +795,33 @@ decide following things about the y axis:
 				}
 			}
 		}
+		// TODO info field
 	} else {
 		throw 'unknown method of getting value'
 	}
 
-	for (const g of data) {
-		for (const m of g.mlst) {
-			if ('__value_use' in m) {
-				nm.minvalue = Math.min(nm.minvalue, m.__value_use)
-				nm.maxvalue = Math.max(nm.maxvalue, m.__value_use)
+	if (nm.axisSetting.auto) {
+		nm.minvalue = null
+		nm.maxvalue = null
+
+		for (const g of data) {
+			for (const m of g.mlst) {
+				if ('__value_use' in m) {
+					if (nm.minvalue == null) {
+						nm.minvalue = m.__value_use
+						nm.maxvalue = m.__value_use
+					} else {
+						nm.minvalue = Math.min(nm.minvalue, m.__value_use)
+						nm.maxvalue = Math.max(nm.maxvalue, m.__value_use)
+					}
+				}
 			}
 		}
+	} else if (nm.axisSetting.fixed) {
+		nm.minvalue = nm.axisSetting.fixed.min
+		nm.maxvalue = nm.axisSetting.fixed.max
+	} else {
+		throw 'unknown axisSetting'
 	}
 }
 
@@ -887,17 +914,16 @@ function render_axis(tk, nm, block) {
 					tk._finish()
 				})
 
-			/*
 			makeNumericAxisConfig({
-				holder: tk.menutip.d.append('div').style('margin','10px'),
-				noPercentile:true,
-				callback:s=>{
+				holder: tk.menutip.d.append('div').style('margin', '10px'),
+				noPercentile: true,
+				callback: s => {
 					nm.axisSetting = s
-					// TODO
+					clearTk(tk)
+					numeric_make(nm, tk, block)
 				},
 				setting: nm.axisSetting
 			})
-			*/
 		})
 
 	tk.skewer.maxwidth = nm.axisWidth + w

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -372,6 +372,7 @@ tape('Numeric mode custom dataset, with mode change', test => {
 				skewerModes,
 				name: 'AA sites with numbers',
 				custom_variants,
+				axisSetting: { auto: 1 },
 				callbackOnRender
 			}
 		]
@@ -404,17 +405,31 @@ tape('Numeric mode custom dataset, with mode change', test => {
 		tk.skewer.viewModes[0].inuse = false
 		tk.skewer.viewModes[1].inuse = true
 
-		tk.callbackOnRender = viewModeChange
+		tk.callbackOnRender = changeNM_autoScale
 		tk.load()
 	}
 
-	function viewModeChange(tk, bb) {
+	function changeNM_autoScale(tk, bb) {
+		const nm = tk.skewer.viewModes.find(i => i.inuse)
 		const n = tk.g.select('.sjpp-mds3-nm-axislabel')
 		test.equal(
-			tk.skewer.viewModes.find(i => i.inuse).label,
+			nm.label,
 			n.text(),
 			`numericmode axis label "${n.text()}" matches with view mode obj after switching mode`
 		)
+		test.equal(nm.minvalue, 4, '(auto) min=4')
+		test.equal(nm.maxvalue, 6, '(auto) max=6')
+
+		// change axis to fixed, and rerender
+		nm.axisSetting = { fixed: { min: 0.5, max: 2.5 } }
+		tk.callbackOnRender = changeNM_fixedScale
+		tk.load()
+	}
+
+	function changeNM_fixedScale(tk, bb) {
+		const nm = tk.skewer.viewModes.find(i => i.inuse)
+		test.equal(nm.minvalue, 0.5, '(fixed) min=0.5')
+		test.equal(nm.maxvalue, 2.5, '(fixed) max=2.5')
 		if (test._ok) holder.remove()
 		test.end()
 	}


### PR DESCRIPTION
## Description
to test, [open this](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC), click `Variants` and select `As lollipop` this creates a Y axis for the variants. click the "Occurrence" axis label and there is the Y axis editing function.

@gavrielm same applies to p-value scale of snplocus regression block tk axis

@AstridCanal this is prepping for the clinvar AF work, will support INFO fields next!

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
