### PR TITLE
use consequence for canonical transcript based on gdc return

### DIFF
--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1794,24 +1794,7 @@ async function getSingleSampleMutations(query, ds, genome) {
 			// for each hit, create an element
 			// from list of consequences, find one from canonical isoform
 
-			// quick code to get canonical isoform of this gene
-			let gene
-			for (const c of hit.consequence) {
-				if (c.transcript && c.transcript.gene && c.transcript.gene.symbol) {
-					gene = c.transcript.gene.symbol
-					break
-				}
-			}
-			if (!gene) {
-				// no gene?
-				continue
-			}
-			const data = genome.genedb.get_gene2canonicalisoform.get(gene)
-			if (!data?.isoform) {
-				// no canonical isoform
-				continue
-			}
-			let c = hit.consequence.find(i => i.transcript.transcript_id == data.isoform)
+			let c = hit.consequence.find(i => i.transcript.is_canonical == true)
 			if (!c) {
 				// no consequence match with given isoform, just use the first one
 				c = hit.consequence[0]
@@ -1969,7 +1952,8 @@ const isoform2ssm_query1_getvariant = {
 		'consequence.transcript.consequence_type',
 		'consequence.transcript.aa_change',
 		// gene symbol is not required for mds3 tk, but is used in gdc bam slicing ui
-		'consequence.transcript.gene.symbol'
+		'consequence.transcript.gene.symbol',
+		'consequence.transcript.is_canonical'
 	],
 
 	/*


### PR DESCRIPTION
## Description
Now the CDKN2A coding mutation is no longer shown as Intronic
test at bam slicing http://localhost:3000/?gdcbamslice=1&gdc_id=TCGA-CS-4943&gdc_pos=chr7:55153818-55156225
disco http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=14627ffd-642c-42b5-9d95-ad436c9b1d35

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
