### PR TITLE
do not force a matrix barplot min scale to 0; 

### DIFF
--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -710,25 +710,28 @@ class Matrix {
 				if (!('gap' in t.tw.settings)) t.tw.settings.gap = 4
 				const barh = t.tw.settings.barh
 				const absMin = Math.abs(t.counts.minval)
+				const rangeSpansZero = t.counts.minVal < 0 && t.counts.maxval
 				const ratio = t.counts.minval >= 0 ? 1 : t.counts.maxval / (absMin + t.counts.maxval)
 				t.counts.posMaxHt = ratio * barh
-				const tickValues =
-					t.counts.minVal < 0 && t.counts.maxval > 0
+				const tickValues = //[t.counts.minval, t.counts.maxval]
+					rangeSpansZero
 						? [t.counts.minval, t.counts.maxval]
-						: t.counts.maxval <= 0
-						? [0, t.counts.minval]
-						: [t.counts.maxval, 0]
+						: t.counts.maxval > 0
+						? [t.counts.maxval, t.counts.minval]
+						: [t.counts.minval, t.counts.maxval]
 
 				t.scales = {
 					tickValues,
 					full: scaleLinear().domain(tickValues).range([1, barh])
 				}
 				if (t.counts.maxval >= 0) {
-					t.scales.pos = scaleLinear().domain([0, t.counts.maxval]).range([1, t.counts.posMaxHt])
+					const domainMin = rangeSpansZero ? 0 : t.counts.minval
+					t.scales.pos = scaleLinear().domain([domainMin, t.counts.maxval]).range([1, t.counts.posMaxHt])
 				}
 				if (t.counts.minval < 0) {
+					const domainMax = rangeSpansZero ? 0 : t.counts.maxval
 					t.scales.neg = scaleLinear()
-						.domain([0, t.counts.minval])
+						.domain([domainMax, t.counts.minval])
 						.range([1, barh - t.counts.posMaxHt - 5])
 				}
 			} else if (t.tw.term.type == 'geneVariant' && ('maxLoss' in this.cnvValues || 'maxGain' in this.cnvValues)) {
@@ -938,7 +941,7 @@ class Matrix {
 			const isDivideByTerm = termid === divideByTermId
 			const emptyGridCells = []
 			const y = !s.transpose ? t.totalIndex * dy + t.visibleGrpIndex * s.rowgspace + t.totalHtAdjustments : 0
-			const hoverY0 = t.tw.settings?.gap || y
+			const hoverY0 = (t.tw.settings?.gap || 0) + y
 			const series = {
 				t,
 				tw: t.tw,

--- a/release.txt
+++ b/release.txt
@@ -3,3 +3,5 @@ Features:
 Fixes:
 - Update gene filter to restrict filtering for multiple alteration groups.
 - Ignore hidden values when conducting association tests.
+- Do not force a matrix barplot min scale to 0;
+- Fix the missing tooltip when mousing over second+ continuous matrix barplot rows


### PR DESCRIPTION
fixes https://github.com/stjude/proteinpaint/issues/417

## Description
- do not force a matrix barplot min scale to 0;
- fix the missing tooltip when mousing over second+ continuous barplot rows

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
