### PR TITLE
use the matrix.dimensions.dx, dy which includes gaps/spaces

### DIFF
--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -107,8 +107,8 @@ class HierCluster extends Matrix {
 	async renderDendrogram() {
 		const obj = this.hierClusterData.clustering
 		obj.d = {
-			rowHeight: this.settings.matrix.rowh,
-			colWidth: this.dimensions.colw,
+			rowHeight: this.dimensions.dy,
+			colWidth: this.dimensions.dx,
 			xDendrogramHeight: this.settings.hierCluster.xDendrogramHeight,
 			yDendrogramHeight: this.settings.hierCluster.yDendrogramHeight,
 			minColor: '#0c306b',


### PR DESCRIPTION
 for hierCluster rendering

## Description
Fixes the insufficient width/branches for dendrogram rendering in the hierCluster plot


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
