### PR TITLE
Always omit the sample label counts from gene expression row labels, …

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1413,7 +1413,7 @@ function setLabelDragEvents(self, prefix) {
 		//if (!this.dragged) return
 	}
 
-	self[`${prefix}LabelMousemove`] = () => {
+	self[`${prefix}LabelMousemove`] = (event, data) => {
 		const s = self.config.settings.matrix
 		if (self.clicked && !self.dragged) {
 			self.dom[`${prefix}LabelG`]
@@ -1424,6 +1424,8 @@ function setLabelDragEvents(self, prefix) {
 				.style('user-select', 'none')
 
 			const label = self.clicked.event.target.closest('.sjpp-matrix-label')
+			const t = label.__data__
+			if (self.type == 'hierCluster' && t.tw && t.grp?.name == 'Gene Expression') return
 			// TODO: use a native or D3 transform accessor
 			const [x, y] = select(label).attr('transform').split('translate(')[1].split(')')[0].split(',').map(Number)
 			const node = label.cloneNode(true)

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -710,7 +710,7 @@ export class Matrix {
 
 			t.label = t.tw.label || t.tw.term.name
 			if (t.label.length > s.rowlabelmaxchars) t.label = t.label.slice(0, s.rowlabelmaxchars) + '...'
-			if (s.samplecount4gene && t.tw.term.type.startsWith('gene')) {
+			if (s.samplecount4gene && t.tw.term.type.startsWith('gene') && t.grp.name != 'Gene Expression') {
 				const count =
 					s.samplecount4gene === 'abs'
 						? t.counts.samples


### PR DESCRIPTION
… and do not allow these labels to be dragged to move rows

## Description
Disable more label, interactivity options that do not apply to gene expression labels.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
