### PR TITLE
Sample dictionary

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -36,7 +36,7 @@ const groupsTab = { top: 'GROUPS', mid: 'NONE', btm: '', subheader: 'groups' }
 const filterTab = { top: 'FILTER', mid: 'NONE', btm: '', subheader: 'filter' }
 const cartTab = { top: 'CART', mid: 'NONE', btm: '', subheader: 'cart' }
 
-function getId() {
+export function getId() {
 	return idPrefix + '_' + id++
 }
 
@@ -64,7 +64,7 @@ class TdbNav {
 				search: searchInit({
 					app: this.app,
 					holder: this.dom.searchDiv,
-					usecase: { target: 'barchart', detail: 'term' },
+					usecase: { target: 'barchart', detail: 'term' }
 				}),
 				filter: filterRxCompInit({
 					app: this.app,
@@ -72,31 +72,31 @@ class TdbNav {
 					holder: this.dom.subheader.filter.append('div'),
 					hideLabel: this.opts.header_mode === 'with_tabs',
 					emptyLabel: '+Add new filter',
-					callback: (filter) => {
+					callback: filter => {
 						this.app.dispatch({
 							type: 'filter_replace',
-							filter,
+							filter
 						})
-					},
+					}
 				}),
 				charts: chartsInit({
 					app: this.app,
 					holder: this.dom.subheader.charts,
-					vocab: this.opts.vocab,
+					vocab: this.opts.vocab
 				}),
 				groups: groupsInit({
 					app: this.app,
 					holder: this.dom.subheader.groups,
-					vocab: this.opts.vocab,
+					vocab: this.opts.vocab
 				}),
 				recover: recoverInit({
 					app: this.app,
 					holder: this.dom.recoverDiv,
 					// TODO: ???? may limit the tracked state to only the filter, activeCohort ???
-					getState: (appState) => appState,
-					reactsTo: (action) => action.type != 'plot_edit',
-					maxHistoryLen: 5,
-				}),
+					getState: appState => appState,
+					reactsTo: action => action.type != 'plot_edit',
+					maxHistoryLen: 5
+				})
 			})
 			this.mayShowMessage_sessionDaysLeft()
 		} catch (e) {
@@ -124,7 +124,7 @@ class TdbNav {
 			termdbConfig: appState.termdbConfig,
 			filter: appState.termfilter.filter,
 			plots: appState.plots,
-			groups: appState.groups,
+			groups: appState.groups
 		}
 	}
 
@@ -165,7 +165,7 @@ class TdbNav {
 export const navInit = getCompInit(TdbNav)
 
 function setRenderers(self) {
-	self.initUI = (appState) => {
+	self.initUI = appState => {
 		const header = self.opts.holder.append('div').style('white-space', 'nowrap')
 		const tabDiv = header.append('div').style('display', 'none').style('vertical-align', 'bottom')
 		const controlsDiv = header
@@ -194,7 +194,7 @@ function setRenderers(self) {
 				.style('padding-top', '5px')
 				.style('border-bottom', '1px solid #000'),
 			messageDiv: self.opts.holder.append('div').style('margin', '30px').style('display', 'none'),
-			tip: new Menu({ padding: '5px' }),
+			tip: new Menu({ padding: '5px' })
 		}
 
 		if (self.opts.header_mode === 'with_cohortHtmlSelect') {
@@ -217,7 +217,7 @@ function setRenderers(self) {
 				.append('option')
 				.attr('value', (d, i) => i)
 				.property('selected', (d, i) => i === appState.activeCohort)
-				.html((d) => d.shortLabel)
+				.html(d => d.shortLabel)
 		}
 
 		self.dom.subheader = Object.freeze({
@@ -229,7 +229,7 @@ function setRenderers(self) {
 			cart: self.dom.subheaderDiv
 				.append('div')
 				.style('display', 'none')
-				.html('<br/>Cart feature under construction - work in progress<br/>&nbsp;<br/>'),
+				.html('<br/>Cart feature under construction - work in progress<br/>&nbsp;<br/>')
 		})
 
 		self.tabs = [chartTab, groupsTab, filterTab /*, cartTab*/]
@@ -256,18 +256,18 @@ function setRenderers(self) {
 			// hide the cohort tab until there is termdbConfig.selectCohort
 			.style('display', 'none') // d => (d.colNum === 0 || self.activeCohort !== -1 ? '' : 'none'))
 			.style('width', '100px')
-			.style('padding', (d) => (d.rowNum === 0 ? '12px 12px 3px 12px' : '3px 12px'))
+			.style('padding', d => (d.rowNum === 0 ? '12px 12px 3px 12px' : '3px 12px'))
 			.style('text-align', 'center')
 			.style('border-left', '1px solid #ccc')
 			.style('border-right', '1px solid #ccc')
 			.style('color', '#aaa')
 			.style('cursor', 'pointer')
-			.html((d) => d.label)
+			.html(d => d.label)
 			.on('click', self.setTab)
 
 		self.dom.trs = table.selectAll('tr')
 		self.dom.tds = table.selectAll('td')
-		self.subheaderKeys = self.tabs.map((d) => d.subheader)
+		self.subheaderKeys = self.tabs.map(d => d.subheader)
 
 		self.dom.saveBtn = self.dom.sessionDiv
 			.append('button')
@@ -281,7 +281,7 @@ function setRenderers(self) {
 				.append('button')
 				.style('margin', '10px')
 				.text('Export Session')
-				.on('click', (event) => {
+				.on('click', event => {
 					self.getSessionFile(event)
 				})
 		}
@@ -294,7 +294,7 @@ function setRenderers(self) {
 				.append('button')
 				.style('margin', '10px')
 				.html('Help &#9660;')
-				.on('click', (event) => {
+				.on('click', event => {
 					const p = event.target.getBoundingClientRect()
 					const div = headtip
 						.clear()
@@ -349,8 +349,8 @@ function setRenderers(self) {
 		self.dom.header.style('border-bottom', self.state.nav.header_mode === 'with_tabs' ? '1px solid #000' : '')
 		self.dom.tds
 			.style('display', '')
-			.style('color', (d) => (d.colNum == self.activeTab ? '#000' : '#aaa'))
-			.style('background-color', (d) => (d.colNum == self.activeTab ? '#ececec' : 'transparent'))
+			.style('color', d => (d.colNum == self.activeTab ? '#000' : '#aaa'))
+			.style('background-color', d => (d.colNum == self.activeTab ? '#ececec' : 'transparent'))
 			.html(function (d, i) {
 				if (d.key == 'top') return this.innerHTML
 
@@ -412,7 +412,7 @@ function setRenderers(self) {
 		for (const cohort of result.cohorts) {
 			columns.push({ label: cohort.cohort ? `${cohort.name} (${cohort.cohort})` : cohort.name })
 			for (const [i, feature] of result.features.entries()) {
-				const cf = result.cfeatures.find((cf) => cf.idfeature === feature.idfeature && cf.cohort === cohort.cohort)
+				const cf = result.cfeatures.find(cf => cf.idfeature === feature.idfeature && cf.cohort === cohort.cohort)
 				if (cf) rows[i].push({ value: cf.value })
 			}
 		}
@@ -422,7 +422,7 @@ function setRenderers(self) {
 			columns,
 			div: self.dom.cohortTable,
 			showLines: false,
-			maxHeight: '60vh',
+			maxHeight: '60vh'
 		})
 
 		self.dom.cohortTable.select('table').style('border-collapse', 'collapse')
@@ -434,7 +434,7 @@ function setRenderers(self) {
 		if (combined) {
 			selector = ''
 			for (const key of keys) {
-				const i = result.cohorts.map((c) => c.cohort).indexOf(key)
+				const i = result.cohorts.map(c => c.cohort).indexOf(key)
 				if (selector !== '') selector += ','
 				selector += `tbody > tr > td:nth-child(${i + 2})`
 			}
@@ -444,11 +444,11 @@ function setRenderers(self) {
 		self.dom.cohortInputs.property('checked', (d, i) => i === self.activeCohort)
 	}
 
-	self.initCohort = async (appState) => {
+	self.initCohort = async appState => {
 		const selectCohort = appState.termdbConfig.selectCohort
 		if (!selectCohort) return
-		self.dom.tds.filter((d) => d.colNum === 0).style('display', '')
-		self.cohortNames = selectCohort.values.map((d) => d.keys.slice().sort().join(','))
+		self.dom.tds.filter(d => d.colNum === 0).style('display', '')
+		self.cohortNames = selectCohort.values.map(d => d.keys.slice().sort().join(','))
 
 		if (selectCohort.title) {
 			self.dom.cohortTitle = self.dom.subheader.cohort
@@ -508,7 +508,7 @@ function setRenderers(self) {
 					.attr('for', radioId)
 					.attr('colspan', 2)
 					.style('cursor', 'pointer')
-					.html((d) => d.label)
+					.html(d => d.label)
 
 				tr.selectAll('td')
 					.style('max-width', '600px')
@@ -551,7 +551,7 @@ function setInteractivity(self) {
 			self.app.dispatch({
 				type: 'plot_create',
 				id: getId(),
-				config: { chartType: 'dictionary' },
+				config: { chartType: 'dictionary' }
 			})
 		}
 	}
@@ -560,7 +560,7 @@ function setInteractivity(self) {
 		self.dom.saveBtn.property('disabled', true)
 		const res = await dofetch3('/massSession', {
 			method: 'POST',
-			body: JSON.stringify(self.app.getState()),
+			body: JSON.stringify(self.app.getState())
 		})
 		const host = sessionStorage.getItem('hostURL') || `${window.location.protocol}//${window.location.host}`
 		const url = `${host}/?mass-session-id=${res.id}&noheader=1`
@@ -576,7 +576,7 @@ function setInteractivity(self) {
 		}, 1000)
 	}
 
-	self.getSessionFile = async (event) => {
+	self.getSessionFile = async event => {
 		//Download mass-session-id file
 		const res = await dofetch3(`/massSession?id=${self.sessionId}`)
 		const a = document.createElement('a')

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -5,7 +5,7 @@ class MassDict {
 	constructor(opts) {
 		this.type = 'tree'
 		const div = opts.holder.append('div').style('display', 'flex')
-		const holder = div.append('div').style('padding', '20px').style('width', '30%')
+		const holder = div.append('div').style('padding', '20px')
 		const contentDiv = div.append('div')
 		this.dom = {
 			holder,
@@ -44,10 +44,11 @@ class MassDict {
 		if (this.sample && this.showContent) {
 			this.dom.holder
 				.style('border-right', '1px solid gray')
+				.style('min-width', '500px')
 				.style('overflow', 'scroll')
 				.attr('class', 'sjpp_hide_scrollbar')
 			this.dom.contentDiv
-				.style('width', '50%')
+				.style('width', '60%')
 				.style('min-height', '500px')
 				.style('display', 'flex')
 				.style('flex-direction', 'column')

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -89,7 +89,7 @@ class MassDict {
 				for (const k in this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
 					const div = this.dom.contentDiv.append('div').style('padding', '20px')
 					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
-					div.append('div').style('font-weight', 'bold').text(label)
+					div.append('div').style('padding-bottom', '20px').style('font-weight', 'bold').text(label)
 
 					const ssgqImport = await import('./plot.ssgq.js')
 					await ssgqImport.plotSingleSampleGenomeQuantification(
@@ -97,7 +97,7 @@ class MassDict {
 						this.state.vocab.dslabel,
 						k,
 						this.sample,
-						div,
+						div.append('div'),
 						this.app.opts.genome
 					)
 				}

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -4,7 +4,7 @@ import { appInit } from '#termdb/app'
 class MassDict {
 	constructor(opts) {
 		this.type = 'tree'
-		const div = opts.holder.append('div').style('display', 'flex')
+		const div = opts.holder.append('div').style('display', 'flex').style('align-items', 'start')
 		const holder = div.append('div').style('padding', '20px')
 		const contentDiv = div.append('div')
 		this.dom = {
@@ -43,16 +43,18 @@ class MassDict {
 
 		if (this.sample && this.showContent) {
 			this.dom.holder
-				.style('border-right', '1px solid gray')
 				.style('min-width', '500px')
 				.style('overflow', 'scroll')
 				.attr('class', 'sjpp_hide_scrollbar')
+				.style('border-right', '1px solid gray')
+
 			this.dom.contentDiv
 				.style('width', '60%')
 				.style('min-height', '500px')
 				.style('display', 'flex')
 				.style('flex-direction', 'column')
 				.style('justify-content', 'center')
+				.style('border-left', '1px solid gray')
 		}
 	}
 

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -12,7 +12,7 @@ class MassDict {
 
 	async init(appState) {
 		const config = appState.plots.find(p => p.id === this.id)
-		this.sampleId = config.sampleId
+		this.sample = config.sample
 		this.tree = await appInit({
 			vocabApi: this.app.vocabApi,
 			holder: this.dom.holder,
@@ -44,12 +44,12 @@ class MassDict {
 			termfilter: appState.termfilter,
 			selectdTerms: appState.selectedTerms,
 			customTerms: appState.customTerms,
-			sampleId: this.sampleId
+			sampleId: this.sample?.sampleId
 		}
 	}
 
 	main() {
-		if (this.dom.header) this.dom.header.html('Dictionary')
+		if (this.dom.header) this.dom.header.html(this.sample ? `${this.sample.sample} Dictionary` : 'Dictionary')
 		this.tree.dispatch({
 			type: 'app_refresh',
 			state: this.state

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -40,6 +40,7 @@ class MassDict {
 				}
 			}
 		})
+
 		if (this.sample && this.showContent) {
 			this.dom.holder
 				.style('border-right', '1px solid gray')

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -47,7 +47,7 @@ class MassDict {
 				.style('overflow', 'scroll')
 				.attr('class', 'sjpp_hide_scrollbar')
 			this.dom.contentDiv
-				.style('width', '60%')
+				.style('width', '50%')
 				.style('min-height', '500px')
 				.style('display', 'flex')
 				.style('flex-direction', 'column')

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -66,12 +66,13 @@ class MassDict {
 			selectdTerms: appState.selectedTerms,
 			customTerms: appState.customTerms,
 			termdbConfig: appState.termdbConfig,
-			sampleId: this.sample?.sampleId
+			sampleId: this.sample?.sampleId,
+			sampleName: this.sample?.sample
 		}
 	}
 
 	async main() {
-		if (this.dom.header) this.dom.header.html(this.sample ? `${this.sample.sample} Dictionary` : 'Dictionary')
+		if (this.dom.header) this.dom.header.html(this.sample ? `${this.sample.sample} Sample View` : 'Dictionary')
 		this.tree.dispatch({
 			type: 'app_refresh',
 			state: this.state

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -11,6 +11,8 @@ class MassDict {
 	}
 
 	async init(appState) {
+		const config = appState.plots.find(p => p.id === this.id)
+		this.sampleId = config.sampleId
 		this.tree = await appInit({
 			vocabApi: this.app.vocabApi,
 			holder: this.dom.holder,
@@ -41,7 +43,8 @@ class MassDict {
 			activeCohort: appState.activeCohort,
 			termfilter: appState.termfilter,
 			selectdTerms: appState.selectedTerms,
-			customTerms: appState.customTerms
+			customTerms: appState.customTerms,
+			sampleId: this.sampleId
 		}
 	}
 

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -5,8 +5,8 @@ class MassDict {
 	constructor(opts) {
 		this.type = 'tree'
 		const div = opts.holder.append('div').style('display', 'flex')
-		const holder = div.append('div').style('padding', '20px')
-		const contentDiv = div.append('div').style('width', '70%').style('min-height', '500px')
+		const holder = div.append('div').style('padding', '20px').style('width', '30%')
+		const contentDiv = div.append('div')
 		this.dom = {
 			holder,
 			contentDiv,
@@ -17,6 +17,7 @@ class MassDict {
 	async init(appState) {
 		const config = appState.plots.find(p => p.id === this.id)
 		this.sample = config.sample
+		this.showContent = config.showContent
 		this.tree = await appInit({
 			vocabApi: this.app.vocabApi,
 			holder: this.dom.holder,
@@ -39,8 +40,12 @@ class MassDict {
 				}
 			}
 		})
-		if (this.sample) {
-			this.dom.holder.style('width', '30%').style('border-right', '1px solid gray')
+		if (this.sample && this.showContent) {
+			this.dom.holder
+				.style('border-right', '1px solid gray')
+				.style('overflow', 'scroll')
+				.attr('class', 'sjpp_hide_scrollbar')
+			this.dom.contentDiv.style('width', '60%').style('min-height', '500px')
 		}
 	}
 
@@ -62,7 +67,7 @@ class MassDict {
 			type: 'app_refresh',
 			state: this.state
 		})
-		if (this.sample) {
+		if (this.sample && this.showContent) {
 			if (this.state.termdbConfig.queries?.singleSampleMutation) {
 				const discoPlotImport = await import('./plot.disco.js')
 				discoPlotImport.default(

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -45,7 +45,12 @@ class MassDict {
 				.style('border-right', '1px solid gray')
 				.style('overflow', 'scroll')
 				.attr('class', 'sjpp_hide_scrollbar')
-			this.dom.contentDiv.style('width', '60%').style('min-height', '500px')
+			this.dom.contentDiv
+				.style('width', '60%')
+				.style('min-height', '500px')
+				.style('display', 'flex')
+				.style('flex-direction', 'column')
+				.style('justify-content', 'center')
 		}
 	}
 
@@ -69,14 +74,33 @@ class MassDict {
 		})
 		if (this.sample && this.showContent) {
 			if (this.state.termdbConfig.queries?.singleSampleMutation) {
+				const div = this.dom.contentDiv.append('div')
+				div.style('font-weight', 'bold').style('padding', '20px').text('Disco plot')
 				const discoPlotImport = await import('./plot.disco.js')
 				discoPlotImport.default(
 					this.state.termdbConfig,
 					this.state.vocab.dslabel,
 					this.sample,
-					this.dom.contentDiv,
+					this.dom.contentDiv.append('div'),
 					this.app.opts.genome
 				)
+			}
+			if (this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
+				for (const k in this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
+					const div = this.dom.contentDiv.append('div').style('padding', '20px')
+					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
+					div.append('div').style('font-weight', 'bold').text(label)
+
+					const ssgqImport = await import('./plot.ssgq.js')
+					await ssgqImport.plotSingleSampleGenomeQuantification(
+						this.state.termdbConfig,
+						this.state.vocab.dslabel,
+						k,
+						this.sample,
+						div,
+						this.app.opts.genome
+					)
+				}
 			}
 		}
 	}

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -6,7 +6,7 @@ class MassDict {
 		this.type = 'tree'
 		const div = opts.holder.append('div').style('display', 'flex')
 		const holder = div.append('div').style('padding', '20px')
-		const contentDiv = div.append('div').style('width', '70%')
+		const contentDiv = div.append('div').style('width', '70%').style('min-height', '500px')
 		this.dom = {
 			holder,
 			contentDiv,

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -43,7 +43,7 @@ class MassDict {
 
 		if (this.sample && this.showContent) {
 			this.dom.holder
-				.style('min-width', '500px')
+				.style('min-width', '550px')
 				.style('overflow', 'scroll')
 				.attr('class', 'sjpp_hide_scrollbar')
 				.style('border-right', '1px solid gray')

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -4,8 +4,12 @@ import { appInit } from '#termdb/app'
 class MassDict {
 	constructor(opts) {
 		this.type = 'tree'
+		const div = opts.holder.append('div').style('display', 'flex')
+		const holder = div.append('div').style('padding', '20px')
+		const contentDiv = div.append('div').style('width', '70%')
 		this.dom = {
-			holder: opts.holder.style('padding', '20px'),
+			holder,
+			contentDiv,
 			header: opts.header
 		}
 	}
@@ -35,6 +39,9 @@ class MassDict {
 				}
 			}
 		})
+		if (this.sample) {
+			this.dom.holder.style('width', '30%').style('border-right', '1px solid gray')
+		}
 	}
 
 	getState(appState) {
@@ -44,16 +51,29 @@ class MassDict {
 			termfilter: appState.termfilter,
 			selectdTerms: appState.selectedTerms,
 			customTerms: appState.customTerms,
+			termdbConfig: appState.termdbConfig,
 			sampleId: this.sample?.sampleId
 		}
 	}
 
-	main() {
+	async main() {
 		if (this.dom.header) this.dom.header.html(this.sample ? `${this.sample.sample} Dictionary` : 'Dictionary')
 		this.tree.dispatch({
 			type: 'app_refresh',
 			state: this.state
 		})
+		if (this.sample) {
+			if (this.state.termdbConfig.queries?.singleSampleMutation) {
+				const discoPlotImport = await import('./plot.disco.js')
+				discoPlotImport.default(
+					this.state.termdbConfig,
+					this.state.vocab.dslabel,
+					this.sample,
+					this.dom.contentDiv,
+					this.app.opts.genome
+				)
+			}
+		}
 	}
 }
 

--- a/client/plots/disco/DiscoRenderer.ts
+++ b/client/plots/disco/DiscoRenderer.ts
@@ -28,9 +28,8 @@ export class DiscoRenderer {
 
 	render(holder: any, viewModel: ViewModel) {
 		const rootDiv = holder.append('div')
-
+		const headerDiv = rootDiv.append('div')
 		const svgDiv = rootDiv.append('div').style('display', 'inline-block').style('font-family', 'Arial')
-
 		const controlsDiv = svgDiv.append('div')
 
 		this.downloadButtonRenderer.render(controlsDiv)

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -129,7 +129,7 @@ export function setInteractivity(self) {
 		self.dom.tip.clear()
 		let show = false
 		if ('sample' in sample) {
-			self.dom.tip.d.append('div').style('padding', '4px').html(`<b>${sample.sample}</b>`)
+			self.dom.tip.d.append('div').style('padding', '4px').html(`<b>&nbsp;${sample.sample}</b>`)
 
 			self.dom.tip.d
 				.append('div')

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -115,6 +115,7 @@ export function setInteractivity(self) {
 		tip2.hide()
 		const target = event.target
 		const sample = target.__data__
+
 		sample.sample_id = sample.sample
 		const drawMethylationArrayPlot =
 			self.state.termdbConfig.queries?.singleSampleGenomeQuantification &&
@@ -124,12 +125,10 @@ export function setInteractivity(self) {
 			self.state.termdbConfig.queries?.singleSampleMutation &&
 			target.tagName == 'path' &&
 			target.getAttribute('name') == 'serie'
-
+		self.dom.tooltip.hide()
+		self.dom.tip.clear()
+		self.dom.tip.show(event.clientX, event.clientY, true, true)
 		if (drawMethylationArrayPlot || drawDiscoPlot) {
-			self.dom.tooltip.hide()
-
-			self.dom.tip.clear()
-			self.dom.tip.show(event.clientX, event.clientY, true, true)
 			if ('sample' in sample) self.dom.tip.d.append('div').style('padding', '4px').html(`<b>${sample.sample}</b>`)
 			if (drawMethylationArrayPlot) {
 				for (const k in self.state.termdbConfig.queries.singleSampleGenomeQuantification) {
@@ -174,19 +173,19 @@ export function setInteractivity(self) {
 						self.dom.tip.hide()
 					})
 			}
-			self.dom.tip.d
-				.append('div')
-				.attr('class', 'sja_menuoption sja_sharp_border')
-				.text('Open dictionary')
-				.on('click', async event => {
-					self.app.dispatch({
-						type: 'plot_create',
-						id: getId(),
-						config: { chartType: 'dictionary', sampleId: sample.sampleId }
-					})
-					self.dom.tip.hide()
-				})
 		}
+		self.dom.tip.d
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.text('Open dictionary')
+			.on('click', async event => {
+				self.app.dispatch({
+					type: 'plot_create',
+					id: getId(),
+					config: { chartType: 'dictionary', sampleId: sample.sampleId }
+				})
+				self.dom.tip.hide()
+			})
 	}
 
 	self.onLegendClick = function (chart, legendG, name, key, e, category) {

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -139,7 +139,7 @@ export function setInteractivity(self) {
 					self.app.dispatch({
 						type: 'plot_create',
 						id: getId(),
-						config: { chartType: 'dictionary', sampleId: sample.sampleId }
+						config: { chartType: 'dictionary', sample }
 					})
 					self.dom.tip.hide()
 					show = true

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -142,8 +142,8 @@ export function setInteractivity(self) {
 						config: { chartType: 'dictionary', sample }
 					})
 					self.dom.tip.hide()
-					show = true
 				})
+			show = true
 		}
 		if (drawMethylationArrayPlot || drawDiscoPlot) {
 			if (drawMethylationArrayPlot) {

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -182,7 +182,7 @@ export function setInteractivity(self) {
 					self.app.dispatch({
 						type: 'plot_create',
 						id: getId(),
-						config: { chartType: 'dictionary', sampleId: sample.sample_id }
+						config: { chartType: 'dictionary', sampleId: sample.sampleId }
 					})
 					self.dom.tip.hide()
 				})

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -134,7 +134,7 @@ export function setInteractivity(self) {
 			self.dom.tip.d
 				.append('div')
 				.attr('class', 'sja_menuoption sja_sharp_border')
-				.text('Open dictionary')
+				.text('Show sample')
 				.on('click', async event => {
 					self.app.dispatch({
 						type: 'plot_create',

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -6,6 +6,7 @@ import { rgb } from 'd3-color'
 import { getSamplelstTW, getFilter } from '../termsetting/handlers/samplelst.ts'
 import { addPlotMenuItem, showTermsTree, addMatrixMenuItems, openSummaryPlot, tip2 } from '../mass/groups'
 import { newSandboxDiv } from '#dom/sandbox'
+import { getId } from '#mass/nav'
 
 export function setInteractivity(self) {
 	self.mouseover = function (event, chart) {
@@ -113,7 +114,8 @@ export function setInteractivity(self) {
 		if (!self.lassoOn) self.dom.tip.hide()
 		tip2.hide()
 		const target = event.target
-
+		const sample = target.__data__
+		sample.sample_id = sample.sample
 		const drawMethylationArrayPlot =
 			self.state.termdbConfig.queries?.singleSampleGenomeQuantification &&
 			target.tagName == 'path' &&
@@ -125,8 +127,7 @@ export function setInteractivity(self) {
 
 		if (drawMethylationArrayPlot || drawDiscoPlot) {
 			self.dom.tooltip.hide()
-			const sample = event.target.__data__
-			sample.sample_id = sample.sample
+
 			self.dom.tip.clear()
 			self.dom.tip.show(event.clientX, event.clientY, true, true)
 			if ('sample' in sample) self.dom.tip.d.append('div').style('padding', '4px').html(`<b>${sample.sample}</b>`)
@@ -173,6 +174,18 @@ export function setInteractivity(self) {
 						self.dom.tip.hide()
 					})
 			}
+			self.dom.tip.d
+				.append('div')
+				.attr('class', 'sja_menuoption sja_sharp_border')
+				.text('Open dictionary')
+				.on('click', async event => {
+					self.app.dispatch({
+						type: 'plot_create',
+						id: getId(),
+						config: { chartType: 'dictionary', sampleId: sample.sample_id }
+					})
+					self.dom.tip.hide()
+				})
 		}
 	}
 

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -139,7 +139,7 @@ export function setInteractivity(self) {
 					self.app.dispatch({
 						type: 'plot_create',
 						id: getId(),
-						config: { chartType: 'dictionary', sample }
+						config: { chartType: 'dictionary', sample, showContent: drawMethylationArrayPlot || drawDiscoPlot }
 					})
 					self.dom.tip.hide()
 				})

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -128,21 +128,23 @@ export function setInteractivity(self) {
 		self.dom.tooltip.hide()
 		self.dom.tip.clear()
 		let show = false
-		if ('sample' in sample) self.dom.tip.d.append('div').style('padding', '4px').html(`<b>${sample.sample}</b>`)
+		if ('sample' in sample) {
+			self.dom.tip.d.append('div').style('padding', '4px').html(`<b>${sample.sample}</b>`)
 
-		self.dom.tip.d
-			.append('div')
-			.attr('class', 'sja_menuoption sja_sharp_border')
-			.text('Open dictionary')
-			.on('click', async event => {
-				self.app.dispatch({
-					type: 'plot_create',
-					id: getId(),
-					config: { chartType: 'dictionary', sampleId: sample.sampleId }
+			self.dom.tip.d
+				.append('div')
+				.attr('class', 'sja_menuoption sja_sharp_border')
+				.text('Open dictionary')
+				.on('click', async event => {
+					self.app.dispatch({
+						type: 'plot_create',
+						id: getId(),
+						config: { chartType: 'dictionary', sampleId: sample.sampleId }
+					})
+					self.dom.tip.hide()
+					show = true
 				})
-				self.dom.tip.hide()
-				show = true
-			})
+		}
 		if (drawMethylationArrayPlot || drawDiscoPlot) {
 			if (drawMethylationArrayPlot) {
 				for (const k in self.state.termdbConfig.queries.singleSampleGenomeQuantification) {

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -127,9 +127,23 @@ export function setInteractivity(self) {
 			target.getAttribute('name') == 'serie'
 		self.dom.tooltip.hide()
 		self.dom.tip.clear()
-		self.dom.tip.show(event.clientX, event.clientY, true, true)
+		let show = false
+		if ('sample' in sample) self.dom.tip.d.append('div').style('padding', '4px').html(`<b>${sample.sample}</b>`)
+
+		self.dom.tip.d
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.text('Open dictionary')
+			.on('click', async event => {
+				self.app.dispatch({
+					type: 'plot_create',
+					id: getId(),
+					config: { chartType: 'dictionary', sampleId: sample.sampleId }
+				})
+				self.dom.tip.hide()
+				show = true
+			})
 		if (drawMethylationArrayPlot || drawDiscoPlot) {
-			if ('sample' in sample) self.dom.tip.d.append('div').style('padding', '4px').html(`<b>${sample.sample}</b>`)
 			if (drawMethylationArrayPlot) {
 				for (const k in self.state.termdbConfig.queries.singleSampleGenomeQuantification) {
 					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
@@ -173,19 +187,9 @@ export function setInteractivity(self) {
 						self.dom.tip.hide()
 					})
 			}
+			show = true
 		}
-		self.dom.tip.d
-			.append('div')
-			.attr('class', 'sja_menuoption sja_sharp_border')
-			.text('Open dictionary')
-			.on('click', async event => {
-				self.app.dispatch({
-					type: 'plot_create',
-					id: getId(),
-					config: { chartType: 'dictionary', sampleId: sample.sampleId }
-				})
-				self.dom.tip.hide()
-			})
+		if (show) self.dom.tip.show(event.clientX, event.clientY, true, true)
 	}
 
 	self.onLegendClick = function (chart, legendG, name, key, e, category) {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -889,6 +889,7 @@ export class TermdbVocab extends Vocab {
 		const body = {
 			for: 'singleSampleData',
 			sampleId: opts.sampleId,
+			term_ids: opts.term_ids,
 			genome: this.state.vocab.genome,
 			dslabel: this.state.vocab.dslabel,
 			embedder: window.location.hostname

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -879,6 +879,26 @@ export class TermdbVocab extends Vocab {
 		return await dofetch3('termdb', { headers, body })
 	}
 
+	async getSingleSampleData(opts) {
+		// the scatter plot may still render when not in session,
+		// but not have an option to list samples
+		const headers = this.mayGetAuthHeaders()
+
+		// dofetch* mayAdjustRequest() will automatically
+		// convert to GET query params or POST body, as needed
+		const body = {
+			for: 'singleSampleData',
+			sampleId: opts.sampleId,
+			genome: this.state.vocab.genome,
+			dslabel: this.state.vocab.dslabel,
+			embedder: window.location.hostname
+		}
+		const data = await dofetch3('termdb', { headers, body })
+		const byTermId = {}
+		for (const row of data) byTermId[row.term_id] = row.value
+		return byTermId
+	}
+
 	async getLowessCurve(opts) {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -159,6 +159,7 @@ class TdbApp {
 	async setComponents() {
 		try {
 			const header_mode = this.state.nav?.header_mode
+			const headerDiv = this.dom.searchDiv.append('div').style('display', 'inline-block').style('float', 'right')
 			const compPromises = {
 				/*
 			 	TODO: may need to handle a cohort filter option as an OPTIONAL component 
@@ -175,6 +176,7 @@ class TdbApp {
 				tree: treeInit({
 					app: this.api,
 					holder: this.dom.treeDiv,
+					headerDiv,
 					expandAll: header_mode == 'hide_search'
 				})
 			}

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -45,6 +45,7 @@ class TdbApp {
 			submitDiv,
 			submitBtn,
 			topbar,
+			headerDiv: topbar.append('div').style('display', 'inline-block').style('margin-left', '12px'),
 			searchDiv: topbar.append('div').style('display', 'inline-block'),
 			filterDiv: topbar.append('div').style('display', 'none'),
 			errdiv: opts.holder.append('div'),
@@ -159,7 +160,6 @@ class TdbApp {
 	async setComponents() {
 		try {
 			const header_mode = this.state.nav?.header_mode
-			const headerDiv = this.dom.searchDiv.append('div').style('display', 'inline-block').style('float', 'right')
 			const compPromises = {
 				/*
 			 	TODO: may need to handle a cohort filter option as an OPTIONAL component 
@@ -176,7 +176,7 @@ class TdbApp {
 				tree: treeInit({
 					app: this.api,
 					holder: this.dom.treeDiv,
-					headerDiv,
+					headerDiv: this.dom.headerDiv,
 					expandAll: header_mode == 'hide_search'
 				})
 			}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -77,12 +77,13 @@ class TdbTree {
 
 	async init(opts) {
 		const holder = this.opts.holder.append('div')
-		this.opts.holder
-			.insert('button')
-			.text('Download data')
-			.on('click', e => {
-				this.downloadData()
-			})
+		if (opts.sampleId)
+			this.opts.headerDiv
+				.insert('button')
+				.text('Download data')
+				.on('click', e => {
+					this.downloadData()
+				})
 		this.dom = {
 			holder
 		}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -224,8 +224,14 @@ class TdbTree {
 		for (const tw of twLst) {
 			const key = sampleData[tw.$id].key
 			let value = sampleData[tw.$id].value
-			if (value == undefined) value = tw.term.values[key].label || tw.term.values[key].key
-			else if (typeof value == 'number' && value % 1 != 0) value = value.toFixed(2)
+			if (tw.term.values) {
+				for (const key2 in tw.term.values) {
+					const value2 = tw.term.values[key2]
+					if (value2.label && key == key2) value = value2.label
+				}
+			}
+			if (!value) value = key
+			if (typeof value == 'number' && value % 1 != 0) value = value.toFixed(2)
 			this.sampleData[tw.id || tw.term.name] = value
 		}
 	}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -507,7 +507,7 @@ function setInteractivity(self) {
 	// !!! no free-floating variable declarations here !!!
 	// use self in TdbTree constructor to create properties
 
-	self.toggleBranch = async function (term) {
+	self.toggleBranch = function (term) {
 		//event.stopPropagation()
 		if (term.isleaf) return
 		const t0 = self.termsById[term.id]

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -76,8 +76,15 @@ class TdbTree {
 	}
 
 	init(opts) {
+		const holder = this.opts.holder.append('div')
+		this.opts.holder
+			.insert('button')
+			.text('Download')
+			.on('click', e => {
+				self.downloadData()
+			})
 		this.dom = {
-			holder: this.opts.holder.append('div')
+			holder
 		}
 	}
 
@@ -352,14 +359,6 @@ function setRenderers(self) {
 				)
 			}
 		}
-		self.dom.holder
-			.append('div')
-			.style('margin-top', '20px')
-			.append('button')
-			.text('Download')
-			.on('click', e => {
-				self.downloadData()
-			})
 	}
 
 	// this == the d3 selected DOM node

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -362,8 +362,15 @@ function setRenderers(self) {
 			.style('display', uses.has('plot') && isSelected && !termIsDisabled ? 'inline-block' : 'none')
 	}
 
+	self.getTermValue = function (term) {
+		let value = self.sampleByTermId[term.id]
+		if (term.type == 'float' || term.type == 'integer') return value
+		if (term.type == 'categorical') return term.values[value].label || term.values[value].key
+		return null
+	}
+
 	self.addTerm = async function (term) {
-		const termIsDisabled = self.opts.disable_terms?.includes(term.id)
+		const termIsDisabled = self.opts.disable_terms?.includes(term.id) || (term.isleaf && self.sampleId)
 		const uses = isUsableTerm(term, self.state.usecase)
 
 		const div = select(this)
@@ -389,7 +396,10 @@ function setRenderers(self) {
 
 		const isSelected = self.state.selectedTerms.find(t => t.name === term.name && t.type === term.type)
 		let text = term.name
-		if (term.isleaf && self.sampleByTermId[term.id]) text += ` (${self.sampleByTermId[term.id]})`
+		if (term.isleaf && self.sampleId) {
+			const value = self.getTermValue(term)
+			text += `..........${value || 'Missing'}`
+		}
 		const labeldiv = div
 			.append('div')
 			.attr('class', cls_termlabel)
@@ -402,7 +412,6 @@ function setRenderers(self) {
 		if (term.hashtmldetail) {
 			infoIcon_div = div.append('div').style('display', 'inline-block')
 		}
-
 		if (uses.size > 0) {
 			if (termIsDisabled) {
 				labeldiv
@@ -413,14 +422,14 @@ function setRenderers(self) {
 			} else if (uses.has('plot')) {
 				labeldiv
 					// need better css class
-					.attr('class', 'ts_pill sja_filter_tag_btn sja_tree_click_term ' + cls_termlabel)
 					.style('color', 'black')
 					.style('padding', '5px 8px')
 					.style('border-radius', '6px')
-					.style('background-color', isSelected ? 'rgba(255, 194, 10,0.5)' : '#cfe2f3')
 					.style('margin', '1px 0px')
 					.style('cursor', 'default')
 					.on('click', () => self.clickTerm(term))
+					.attr('class', 'ts_pill sja_filter_tag_btn sja_tree_click_term ' + cls_termlabel)
+					.style('background-color', isSelected ? 'rgba(255, 194, 10,0.5)' : '#cfe2f3')
 			}
 
 			//show sample count for a term

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -223,8 +223,9 @@ class TdbTree {
 		sampleData = sampleData.lst[0]
 
 		for (const tw of twLst) {
-			const key = sampleData[tw.$id].key
-			let value = sampleData[tw.$id].value
+			const key = sampleData?.[tw.$id].key
+			if (!key) continue
+			let value = sampleData?.[tw.$id].value
 			if (tw.term.values) {
 				for (const key2 in tw.term.values) {
 					const value2 = tw.term.values[key2]

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -202,6 +202,8 @@ class TdbTree {
 				// if it's collapsing this term, must add back its children terms for toggle button to work
 				// see flag TERMS_ADD_BACK
 				const t0 = this.termsById[copy.id]
+				if (this.sampleId) await this.fillSampleData([copy])
+
 				if (t0 && t0.terms) {
 					copy.terms = t0.terms
 				}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -13,7 +13,7 @@ export const root_ID = 'root'
 // this only count immediate children, not counting grandchildren
 const minTermCount2scroll = 20
 // max height of aforementioned scrolling <div>
-const scrollDivMaxHeight = '400px'
+let scrollDivMaxHeight = '400px'
 
 // class names TODO they should be shared between test/tree.spec.js
 const cls_termdiv = 'termdiv',
@@ -121,6 +121,7 @@ class TdbTree {
 			return
 		}
 		this.sampleId = this.state.sampleId
+
 		if (this.state.toSelectCohort) {
 			// dataset requires a cohort to be selected
 			if (!this.state.cohortValuelst) {
@@ -223,7 +224,7 @@ class TdbTree {
 		sampleData = sampleData.lst[0]
 
 		for (const tw of twLst) {
-			const key = sampleData?.[tw.$id].key
+			const key = sampleData?.[tw.$id]?.key
 			if (!key) continue
 			let value = sampleData?.[tw.$id].value
 			if (tw.term.values) {
@@ -236,6 +237,20 @@ class TdbTree {
 			if (typeof value == 'number' && value % 1 != 0) value = value.toFixed(2)
 			this.sampleData[tw.id || tw.term.name] = value
 		}
+	}
+
+	downloadData() {
+		const filename = `${this.sampleId}.json`
+		const dataStr = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(this.sampleData))
+
+		const link = document.createElement('a')
+		link.setAttribute('href', dataStr)
+		// If you don't know the name or want to use
+		// the webserver default set name = ''
+		link.setAttribute('download', filename)
+		document.body.appendChild(link)
+		link.click()
+		link.remove()
 	}
 }
 
@@ -271,11 +286,9 @@ function setRenderers(self) {
 			if (div.classed('sjpp_hide_scrollbar')) {
 				// already scrolling. the style has been applied from a previous click. do not reset
 			} else {
-				div
-					.style('max-height', scrollDivMaxHeight)
-					.style('padding', '10px')
-					.style('resize', 'vertical')
-					.classed('sjpp_hide_scrollbar', true)
+				if (!self.sampleId) div.style('max-height', scrollDivMaxHeight)
+
+				div.style('padding', '10px').style('resize', 'vertical').classed('sjpp_hide_scrollbar', true)
 
 				/***************************
 				remaining issues
@@ -339,6 +352,14 @@ function setRenderers(self) {
 				)
 			}
 		}
+		self.dom.holder
+			.append('div')
+			.style('margin-top', '20px')
+			.append('button')
+			.text('Download')
+			.on('click', e => {
+				self.downloadData()
+			})
 	}
 
 	// this == the d3 selected DOM node

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -209,6 +209,7 @@ class TdbTree {
 
 		for (const term of terms) {
 			let tw = { id: term.id }
+			if (!term.isleaf) continue
 			tw = await fillTermWrapper(tw, this.app.vocabApi)
 			twLst.push(tw)
 		}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -83,13 +83,23 @@ class TdbTree {
 			headerDiv: opts.headerDiv
 		}
 		if (opts.sampleId) {
+			this.opts.headerDiv.insert('label').text('Sample:')
+			const input = this.opts.headerDiv
+				.insert('input')
+				.property('disabled', true)
+				.attr('value', opts.sampleName)
+				.on('change', e => {
+					const sampleId = Number(input.node.value)
+					this.sampleDataByTermId = {}
+					//do something
+				})
 			this.opts.headerDiv
 				.insert('button')
 				.text('Download data')
 				.on('click', e => {
 					this.downloadData()
 				})
-		}
+		} else this.opts.headerDiv.style('display', 'none')
 	}
 
 	reactsTo(action) {
@@ -110,7 +120,8 @@ class TdbTree {
 			selectedTerms: appState.selectedTerms,
 			termfilter: { filter },
 			usecase: appState.tree.usecase,
-			sampleId: appState.sampleId
+			sampleId: appState.sampleId,
+			sampleName: appState.sampleName
 		}
 
 		// if cohort selection is enabled for the dataset, tree component needs to know which cohort is selected
@@ -132,6 +143,7 @@ class TdbTree {
 			return
 		}
 		this.sampleId = this.state.sampleId
+		this.sampleName = this.state.sampleName
 
 		if (this.state.toSelectCohort) {
 			// dataset requires a cohort to be selected
@@ -226,7 +238,7 @@ class TdbTree {
 	}
 
 	downloadData() {
-		const filename = `${this.sampleId}.tsv`
+		const filename = `${this.sampleName}.tsv`
 		let data = ''
 		for (const field in this.sampleDataByTermId) {
 			const term = this.termsById[field]

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -364,7 +364,8 @@ function setRenderers(self) {
 
 	self.getTermValue = function (term) {
 		let value = self.sampleByTermId[term.id]
-		if (term.type == 'float' || term.type == 'integer') return value
+		if (term.type == 'float' || term.type == 'integer')
+			return value % 1 == 0 ? value.toString() : value.toFixed(2).toString()
 		if (term.type == 'categorical') return term.values[value].label || term.values[value].key
 		return null
 	}
@@ -396,10 +397,7 @@ function setRenderers(self) {
 
 		const isSelected = self.state.selectedTerms.find(t => t.name === term.name && t.type === term.type)
 		let text = term.name
-		if (term.isleaf && self.sampleId) {
-			const value = self.getTermValue(term)
-			text += `..........${value || 'Missing'}`
-		}
+
 		const labeldiv = div
 			.append('div')
 			.attr('class', cls_termlabel)
@@ -407,7 +405,16 @@ function setRenderers(self) {
 			.style('padding', '5px')
 			.style('opacity', termIsDisabled ? 0.4 : null)
 			.text(text)
-
+		if (term.isleaf && self.sampleId) {
+			let value = self.getTermValue(term) || 'Missing'
+			div
+				.append('div')
+				.style('display', 'inline-block')
+				.style('float', 'right')
+				.style('padding', '5px')
+				.style('opacity', termIsDisabled ? 0.4 : null)
+				.text(value)
+		}
 		let infoIcon_div //Empty div for info icon if termInfoInit is called
 		if (term.hashtmldetail) {
 			infoIcon_div = div.append('div').style('display', 'inline-block')

--- a/release.txt
+++ b/release.txt
@@ -11,6 +11,7 @@ Features:
 - New Info fields from gnomAD added to clinvar datasets for mds3 track
 - CancerHotspot hg19 data added for mds3 track
 - Display sample and catergory numbers in each subgroup when hovering over term label in matrix plot
+- Added single sample viewer
 
 
 Fixes:

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -566,7 +566,7 @@ async function get_matrix(q, req, res, ds, genome) {
 }
 
 async function get_singleSampleData(q, res, tdb) {
-	res.send(tdb.q.getSingleSampleData(q.sampleId))
+	res.send(tdb.q.getSingleSampleData(q.sampleId, q.term_ids))
 }
 
 function get_mds3queryDetails(res, ds) {

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -83,6 +83,7 @@ export function handle_request_closure(genomes) {
 			if (q.for == 'validateToken') {
 			}
 			if (q.for == 'convertSampleId') return get_convertSampleId(q, res, tdb)
+			if (q.for == 'singleSampleData') return get_singleSampleData(q, res, tdb)
 
 			throw "termdb: doesn't know what to do"
 		} catch (e) {
@@ -562,6 +563,10 @@ async function get_matrix(q, req, res, ds, genome) {
 		}
 	}
 	res.send(data)
+}
+
+async function get_singleSampleData(q, res, tdb) {
+	res.send(tdb.q.getSingleSampleData(q.sampleId))
 }
 
 function get_mds3queryDetails(res, ds) {

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -456,9 +456,9 @@ export function server_init_db_queries(ds) {
 
 	q.getSingleSampleData = function (sampleId) {
 		const sql = cn.prepare(
-			`select term_id, value from anno_categorical where sample=? union all select term_id, value from anno_float where sample=?`
+			`select term_id, value from anno_categorical where sample=? union all select term_id, value from anno_float where sample=? union all  select term_id, value from anno_integer where sample=?`
 		)
-		const rows = sql.all([sampleId, sampleId])
+		const rows = sql.all([sampleId, sampleId, sampleId])
 		return rows
 	}
 	console.log(q)

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -453,6 +453,15 @@ export function server_init_db_queries(ds) {
 
 		return supportedChartTypes
 	}
+
+	q.getSingleSampleData = function (sampleId) {
+		const sql = cn.prepare(
+			`select term_id, value from anno_categorical where sample=? union all select term_id, value from anno_float where sample=?`
+		)
+		const rows = sql.all([sampleId, sampleId])
+		return rows
+	}
+	console.log(q)
 }
 
 export function listDbTables(cn) {

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -457,9 +457,6 @@ export function server_init_db_queries(ds) {
 	q.getSingleSampleData = function (sampleId, term_ids = []) {
 		const termClause = !term_ids.length ? '' : `and term_id in (${term_ids.map(t => '?').join(',')})`
 
-		let ids = '?,'.repeat(term_ids.length)
-		if (term_ids.length) ids = ids.slice(0, ids.length - 1)
-		else ids = ''
 		const query = `select term_id, value 
 		from anno_categorical 
 		where sample=? ${termClause}

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -454,7 +454,7 @@ export function server_init_db_queries(ds) {
 		return supportedChartTypes
 	}
 
-	q.getSingleSampleData = function (sampleId, term_ids) {
+	q.getSingleSampleData = function (sampleId, term_ids = []) {
 		const termClause = !term_ids.length ? '' : `and term_id in (${term_ids.map(t => '?').join(',')})`
 
 		let ids = '?,'.repeat(term_ids.length)

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -454,10 +454,14 @@ export function server_init_db_queries(ds) {
 		return supportedChartTypes
 	}
 
-	q.getSingleSampleData = function (sampleId) {
-		const sql = cn.prepare(
-			`select term_id, value from anno_categorical where sample=? union all select term_id, value from anno_float where sample=? union all  select term_id, value from anno_integer where sample=?`
-		)
+	q.getSingleSampleData = function (sampleId, term_ids) {
+		const ids = `('${term_ids.join("','")}')`
+
+		const query = `select term_id, value from anno_categorical where sample=? and term_id in ${ids}
+		union all select term_id, value from anno_float where sample=? and term_id in ${ids}
+		union all  select term_id, value from anno_integer where sample=? and term_id in ${ids} `
+
+		const sql = cn.prepare(query)
 		const rows = sql.all([sampleId, sampleId, sampleId])
 		return rows
 	}

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -455,12 +455,22 @@ export function server_init_db_queries(ds) {
 	}
 
 	q.getSingleSampleData = function (sampleId, term_ids) {
+		const termClause = !term_ids.length ? '' : `and term_id in (${term_ids.map(t => '?').join(',')})`
+
 		let ids = '?,'.repeat(term_ids.length)
 		if (term_ids.length) ids = ids.slice(0, ids.length - 1)
 		else ids = ''
-		const query = `select term_id, value from anno_categorical where sample=? and term_id in (${ids})
-		union all select term_id, value from anno_float where sample=? and term_id in (${ids})
-		union all  select term_id, value from anno_integer where sample=? and term_id in (${ids}) `
+		const query = `select term_id, value 
+		from anno_categorical 
+		where sample=? ${termClause}
+		union all 
+		select term_id, 
+		value from anno_float 
+		where sample=? ${termClause}
+		union all  
+		select term_id, value 
+		from anno_integer 
+		where sample=? ${termClause}`
 		const sql = cn.prepare(query)
 		const rows = sql.all([sampleId, ...term_ids, sampleId, ...term_ids, sampleId, ...term_ids])
 		return rows

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -455,14 +455,14 @@ export function server_init_db_queries(ds) {
 	}
 
 	q.getSingleSampleData = function (sampleId, term_ids) {
-		const ids = `('${term_ids.join("','")}')`
-
-		const query = `select term_id, value from anno_categorical where sample=? and term_id in ${ids}
-		union all select term_id, value from anno_float where sample=? and term_id in ${ids}
-		union all  select term_id, value from anno_integer where sample=? and term_id in ${ids} `
-
+		let ids = '?,'.repeat(term_ids.length)
+		if (term_ids.length) ids = ids.slice(0, ids.length - 1)
+		else ids = ''
+		const query = `select term_id, value from anno_categorical where sample=? and term_id in (${ids})
+		union all select term_id, value from anno_float where sample=? and term_id in (${ids})
+		union all  select term_id, value from anno_integer where sample=? and term_id in (${ids}) `
 		const sql = cn.prepare(query)
-		const rows = sql.all([sampleId, sampleId, sampleId])
+		const rows = sql.all([sampleId, ...term_ids, sampleId, ...term_ids, sampleId, ...term_ids])
 		return rows
 	}
 	console.log(q)


### PR DESCRIPTION
## Description

This is a first draft to show sample data in the dictionary. It can be tested clicking on a sample from a scatter plot.  When the user has access to the data a menu option is added upon click to open the dictionary. If possible shows the disco plot and the methylation arrays to the right. It also allows to download all the data in tsv format.
I have tested it with several datasets. Testing the SJLife dataset is possible if a # is added to the SJLife credentials in the server config and a dynamic scatter is built to click on a sample.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
