### PR TITLE
allow INFO field for mds3 numeric mode y scale

### DIFF
--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -278,6 +278,7 @@ function setSkewerMode(tk) {
 			// data method
 			if (n.byAttribute) {
 				if (!n.label) n.label = n.byAttribute
+			} else if (n.byInfo) {
 			} else {
 				// support info fields etc
 				throw 'unknown data method for a type=numeric mode'

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -795,7 +795,17 @@ function setup_axis_scale(data, nm, tk) {
 				}
 			}
 		}
-		// TODO info field
+	} else if (nm.byInfo) {
+		for (const g of data) {
+			for (const m of g.mlst) {
+				const v = m?.info?.[nm.byInfo]
+				if (Number.isFinite(v)) {
+					m.__value_use = v
+				} else {
+					m.__value_missing = true
+				}
+			}
+		}
 	} else {
 		throw 'unknown method of getting value'
 	}

--- a/server/dataset/clinvar.hg38.ts
+++ b/server/dataset/clinvar.hg38.ts
@@ -1,7 +1,7 @@
 import { clinsig } from './clinvar.js'
 import { Mds3 } from '../shared/types'
 
-export default <Mds3> {
+export default <Mds3>{
 	isMds3: true,
 	dsinfo: [
 		{ k: 'Source', v: '<a href=http://www.ncbi.nlm.nih.gov/clinvar/ target=_blank>NCBI ClinVar</a>' },
@@ -10,6 +10,14 @@ export default <Mds3> {
 		{ k: 'Download date', v: 'July 2022' }
 	],
 	genome: 'hg38',
+
+	viewModes: [
+		{
+			byInfo: 'AF_EXAC',
+			inuse: true
+		}
+	],
+
 	queries: {
 		snvindel: {
 			forTrack: true,
@@ -22,6 +30,10 @@ export default <Mds3> {
 						key: 'CLNSIG',
 						categories: clinsig,
 						separator: '|'
+					},
+					{
+						name: 'AF_EXAC',
+						key: 'AF_EXAC'
 					}
 				]
 			},

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -817,6 +817,12 @@ type LocusAttribute = {
 	attributes: Attributes
 }
 
+type ViewMode = {
+	byAttribute?: string
+	byInfo?: string
+	inuse: boolean
+}
+
 /*** types supporting Mds Dataset types ***/
 type BaseMds = {
 	genome?: string //Not declared in TermdbTest
@@ -840,6 +846,7 @@ export type Mds = BaseMds & {
 
 export type Mds3 = BaseMds & {
 	isMds3: boolean
+	viewModes?: ViewMode[]
 	dsinfo?: KeyVal[]
 	queries?: Queries
 	cohort?: Cohort

--- a/server/src/vcf.mclass.js
+++ b/server/src/vcf.mclass.js
@@ -75,6 +75,15 @@ export function compute_mclass(tk, refAllele, altAlleles, variant, info_str, ID,
 				info[key] = lst
 			}
 		}
+
+		if (tk.info[key].Type == 'Float' || tk.info[key].Type == 'Integer') {
+			if (Array.isArray(info[key])) {
+				const t = info[key].map(Number)
+				info[key] = t
+			} else {
+				info[key] = Number(info[key])
+			}
+		}
 	}
 
 	variant.mlst = altAlleles.map(i => {


### PR DESCRIPTION
## Description

please test at http://localhost:3000/?genome=hg38&gene=kras&mds3=clinvar, the track uses the AF_exac as Y axis by default

once this is approved, we will switch to the new hg38 file and help Astrid create the figures

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
