### PR TITLE
update tk name in legend upon filter creation/change

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -11,6 +11,8 @@ makeSampleLabel()
 	click label to view summaries about samples that have mutation data in the view range
 
 makeSampleFilterLabel()
+
+getFilterName
 */
 
 export function makeSampleLabel(data, tk, block, laby) {
@@ -78,7 +80,7 @@ export function makeSampleFilterLabel(data, tk, block, laby) {
 	})
 }
 
-function getFilterName(f) {
+export function getFilterName(f) {
 	// try to provide a meaningful name based on filter content
 
 	if (f.lst.length == 0) {

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -46,14 +46,12 @@ run only once, called by makeTk
 	if (!tk.legend) tk.legend = {}
 	tk.legend.tip = new Menu({ padding: '0px' })
 
-	const [tr, td] = legend_newrow(block, tk.name)
+	const [tr, td, td0] = legend_newrow(block, tk.name)
+	tk.legend.headTd = td0 // for updating tk name in legend when filterObj updates
 
 	tk.tr_legend = tr // to be compatible with block.tk_remove()
 
-	const table = td
-		.append('table')
-		.style('border-spacing', '5px')
-		.style('border-collapse', 'separate')
+	const table = td.append('table').style('border-spacing', '5px').style('border-collapse', 'separate')
 
 	tk.legend.table = table
 
@@ -90,10 +88,7 @@ function create_mclass(tk, block) {
 
 function may_create_variantShapeName(tk) {
 	if (!tk.variantShapeName) return
-	const holder = tk.legend.table
-		.append('tr')
-		.append('td')
-		.attr('colspan', 2)
+	const holder = tk.legend.table.append('tr').append('td').attr('colspan', 2)
 	const vl = (tk.legend.variantShapeName = {})
 	{
 		const d = holder.append('div')
@@ -178,11 +173,7 @@ function may_create_formatFilter(tk) {
 		// this row will have two columns, just like mclass
 
 		// column 1 <td>: format field name
-		row
-			.append('td')
-			.style('text-align', 'right')
-			.style('opacity', 0.3)
-			.text(tk.mds.bcf.format[key].Description)
+		row.append('td').style('text-align', 'right').style('opacity', 0.3).text(tk.mds.bcf.format[key].Description)
 
 		tk.legend.formatFilter[key] = {
 			hiddenvalues: new Set(),
@@ -277,10 +268,7 @@ function may_update_formatFilter(data, tk) {
 				.style('background', '#aaa')
 				.style('margin-right', '5px')
 				.html(count > 1 ? count : '&nbsp;')
-			cell
-				.append('div')
-				.style('display', 'inline-block')
-				.text(category)
+			cell.append('div').style('display', 'inline-block').text(category)
 		}
 
 		// hidden ones
@@ -738,10 +726,7 @@ function may_create_ld(tk, block) {
 	const R = (tk.legend.ld = {})
 	R.row = tk.legend.table.append('tr')
 	// contents are filled in dynamically
-	R.headerTd = R.row
-		.append('td')
-		.style('text-align', 'right')
-		.style('opacity', 0.3)
+	R.headerTd = R.row.append('td').style('text-align', 'right').style('opacity', 0.3)
 	R.holder = R.row.append('td')
 	R.showHolder = R.holder.append('div').style('display', 'none')
 	showLDlegend(R.showHolder, tk.mds.queries.ld.colorScale)

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -5,6 +5,7 @@ import { loadTk, rangequery_rglst } from './tk'
 import urlmap from '#common/urlmap'
 import { mclass } from '#shared/common'
 import { vcfparsemeta } from '#shared/vcf'
+import { getFilterName } from './leftlabel.sample'
 
 /*
 this script exports one function "makeTk()" that will be called just once
@@ -206,6 +207,10 @@ export async function makeTk(tk, block) {
 
 function loadTk_finish_closure(tk, block) {
 	return data => {
+		// update legend name in case filter has changed
+		// tk.legend{} is missing if tk is not initiated (wrong ds name)
+		tk.legend?.headTd.text(tk.name + (tk.filterObj ? ' - ' + getFilterName(tk.filterObj) : ''))
+
 		// derive tk height
 		tk.height_main = 0
 		for (const k in tk.subtk2height) {

--- a/client/src/block.legend.js
+++ b/client/src/block.legend.js
@@ -20,7 +20,8 @@ const tip = new client.Menu({ padding: '0px' })
 
 export function legend_newrow(block, label) {
 	const tr = block.legend.holder.append('tr')
-	tr.append('td')
+	const td0 = tr
+		.append('td')
 		.text(label)
 		.style('padding-right', '10px')
 		.style('text-align', 'right')
@@ -30,7 +31,7 @@ export function legend_newrow(block, label) {
 		.style('color', '#555')
 		.style('border-right', 'solid 1px ' + block.legend.legendcolor)
 	const td = tr.append('td')
-	return [tr, td]
+	return [tr, td, td0]
 }
 
 export function legend_mclass(block) {


### PR DESCRIPTION
## Description

test [here](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.demographic.gender%22,%22name%22:%22Gender%22,%22isleaf%22:true,%22type%22:%22categorical%22,%22parent_id%22:%22case.demographic%22,%22included_types%22:[%22categorical%22],%22child_types%22:[],%22values%22:{%22female%22:{%22label%22:%22female%22,%22samplecount%22:115},%22male%22:{%22label%22:%22male%22,%22samplecount%22:49},%22not%20reported%22:{%22label%22:%22not%20reported%22,%22samplecount%22:1}},%22samplecount%22:{}},%22values%22:[{%22key%22:%22female%22}]}}]}). change filter from female to male the legend name updates; this works for both gdc and non-gdc tk
mds3 manual tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
