### PR TITLE
create a workflow to append branch release notes to avoid merge conflicts

### DIFF
--- a/.github/workflows/CI-approve-pr.yml
+++ b/.github/workflows/CI-approve-pr.yml
@@ -1,15 +1,20 @@
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request_target:
+    types:
+      - closed
 
 jobs:
-  approved:
-    if: github.event.review.state == 'approved'
+  if_merged:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - run: 
-        node ./build/releaseNotesGenerator.js release.txt
-        if [[ "$(git diff --name-only release.txt)" == "release.txt" ]]; then
-          git add release.txt
-          git commit -m "append branch release notes to avoid merge conflicts"
+    - run: |
+        if [[ -f ./build/setReleaseText.js ]]; then
+          NOTES=$(node ./build/setReleaseText.js release.txt)
+          echo "$NOTES" > CHANGELOG.md
+          if [[ "$(git diff --name-only CHANGELOG.md)" == "CHANGELOG.md" ]]; then
+            echo '' > release.txt
+            git add release.txt
+            git commit -m "append branch release notes to avoid merge conflicts"
+          fi
         fi

--- a/.github/workflows/CI-approve-pr.yml
+++ b/.github/workflows/CI-approve-pr.yml
@@ -1,0 +1,15 @@
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approved:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - run: 
+        node ./build/releaseNotesGenerator.js release.txt
+        if [[ "$(git diff --name-only release.txt)" == "release.txt" ]]; then
+          git add release.txt
+          git commit -m "append branch release notes to avoid merge conflicts"
+        fi

--- a/.github/workflows/fake-merge.yml
+++ b/.github/workflows/fake-merge.yml
@@ -1,20 +1,20 @@
-name: "Detect changes"
+name: "Fake Merge"
 
 on:
-  pull_request_target:
-    types:
-      - closed
+  workflow_dispatch:
+    inputs:
+      build_secret:
+        type: string
+        description: Build secret
 
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged
+  build:
     runs-on: ubuntu-latest
     steps:
+      - name: Detect changes
       - run: |
-          if [[ -f ./build/setReleaseText.js ]]; then
-            NOTES=$(node ./build/setReleaseText.js release.txt)
-            echo "$NOTES" > CHANGELOG.md
-          fi
+          NOTES=$(node ./build/setReleaseText.js release.txt)
+          echo "$NOTES" > CHANGELOG.md
           
           if [[ "$(git diff --name-only CHANGELOG.md)" == "CHANGELOG.md" ]]; then
             echo '' > release.txt

--- a/build/changeLogGenerator.js
+++ b/build/changeLogGenerator.js
@@ -1,26 +1,45 @@
-const fs = require('fs')
+/*
+	call from the proteinpaint project dir
+	usage: node changeLogGenerator.js [-u]
+	
+	-u output only the unreleased change notes 
+*/
 
+const fs = require('fs')
+const rp = require('./releaseParser')
+
+const options = process.argv[2] || ''
+const releaseTxtFile = './release.txt'
+const releaseLogText = fs.readFileSync(releaseTxtFile).toString('utf-8')
+if (releaseLogText === '') {
+	throw Error(`Release text in ${releaseTxtFile} is empty`)
+}
+
+const version = require('../package.json').version
 const changeLogFile = './CHANGELOG.md'
 const oldChangeLogText = fs.readFileSync(changeLogFile).toString('utf-8')
 
-const releaseTextFile = './release.txt'
-const releaseLogText = fs.readFileSync(releaseTextFile).toString('utf-8')
+const start = oldChangeLogText.indexOf('Unreleased')
+const stop = oldChangeLogText.indexOf('\n##', start)
+const unreleasedText = oldChangeLogText.slice(start, stop)
 
-if (releaseLogText === '') {
-	throw Error(`Release text in ${releaseTextFile} is empty`)
+const unreleasedSections = rp.getSections(unreleasedText)
+const currSections = rp.getSections(releaseLogText, unreleasedSections)
+
+const notes = [
+	'# Change Log',
+	'',
+	'All notable changes to this project will be documented in this file.',
+	'',
+	'## Unreleased',
+	''
+]
+
+for (const title in currSections) {
+	const lines = currSections[title]
+	if (lines.length) notes.push(title, ...lines, '')
 }
 
-const header = '# Change Log\n' + '\n' + 'All notable changes to this project will be documented in this file.'
+if (!options.includes('u')) notes.push(oldChangeLogText.slice(stop))
 
-const changeLogWithoutHeader = oldChangeLogText.replace(header, '')
-
-const version = require('../package.json').version
-
-const newChangeLog = `${header} 
-## ${version}
-
-${releaseLogText}
-${changeLogWithoutHeader}`
-
-fs.writeFileSync(changeLogFile, newChangeLog)
-fs.writeFileSync(releaseTextFile, '')
+console.log(notes.join('\n'))

--- a/build/ci-version-update.sh
+++ b/build/ci-version-update.sh
@@ -29,17 +29,18 @@ if [[ "$UPDATED" == "" ]]; then
 fi
 
 
-######################
-# Generate change log
-######################
+########################
+# Update the change log
+########################
 
-node build/changeLogGenerator.js
+VERSION="$(node -p "require('./package.json').version")"
+TAG="v$VERSION"
+sed -i.bak "s|Unreleased|$VERSION|" CHANGELOG.md
 
 #################
 # COMMIT CHANGES
 #################
 
-TAG="v$(node -p "require('./package.json').version")"
 # tag first to detect conflict
 git tag $TAG
 git push origin $TAG

--- a/build/releaseParser.js
+++ b/build/releaseParser.js
@@ -1,0 +1,27 @@
+const GenTitle = 'General:'
+const FeatTitle = 'Features:'
+const FixTitle = 'Fixes:'
+
+module.exports = {
+	GenTitle,
+	FeatTitle,
+	FixTitle,
+	getSections(releaseTxt, _bySection = null) {
+		const bySection = _bySection || {
+			[GenTitle]: [],
+			[FeatTitle]: [],
+			[FixTitle]: []
+		}
+		const lines = releaseTxt.split('\n').map(l => l.trim())
+		let currSection = bySection[GenTitle]
+		for (const line of lines) {
+			if (line in bySection) {
+				// switch to the next section
+				currSection = bySection[line]
+			} else if (line?.startsWith('- ') && !currSection.includes(line)) {
+				currSection.push(line)
+			}
+		}
+		return bySection
+	}
+}

--- a/release.txt
+++ b/release.txt
@@ -4,3 +4,4 @@ Features:
 
 Fixes:
 - fix for sorting labels for custom binning on numeric terms in violin plot
+- test test test

--- a/utils/hooks/commit-msg
+++ b/utils/hooks/commit-msg
@@ -11,7 +11,8 @@ NOTES="$(cat release.txt)"
 
 if [[ "$MSG" == *"fix: "* || "$MSG" == *"feat: "* ]]; then
   echo "adding release notes ..."  
-  node ./build/releaseNotesGenerator.js release.txt "$1"
+  NOTES=$(node ./build/setReleaseText.js release.txt "$1")
+  echo -e "$NOTES" > release.txt
   if [[ "$(git diff --name-only release.txt)" == 'release.txt' ]]; then
     git add release.txt
   fi


### PR DESCRIPTION
## Description
The new workflow helps avoid having to deal with merge conflicts in release.txt. 

@xzhou82 Could you approve but NOT merge? this branch is mostly for testing the workflow, since I cannot approve my own PR. A commit should be triggered if there are differences in the release.txt between this branch and master.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
