### PR TITLE
Sample viewer

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -121,6 +121,15 @@ function getChartTypeList(self) {
 			}
 		},
 		{
+			label: 'Sample View',
+			clickTo: self.prepPlot,
+			chartType: 'dictionary',
+			config: {
+				chartType: 'dictionary',
+				sampleViewer: true
+			}
+		},
+		{
 			label: 'Summary Plots',
 			chartType: 'summary',
 			clickTo: self.showTree_select1term,

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -42,6 +42,7 @@ class MassCharts {
 			// TODO: may want the server to decide this, and as defined for a dataset
 			state.supportedChartTypes.push('dictionary')
 		}
+
 		return state
 	}
 
@@ -123,10 +124,9 @@ function getChartTypeList(self) {
 		{
 			label: 'Sample View',
 			clickTo: self.prepPlot,
-			chartType: 'dictionary',
+			chartType: 'sampleView',
 			config: {
-				chartType: 'dictionary',
-				showSamples: true
+				chartType: 'sampleView'
 			}
 		},
 		{

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -126,7 +126,7 @@ function getChartTypeList(self) {
 			chartType: 'dictionary',
 			config: {
 				chartType: 'dictionary',
-				sampleViewer: true
+				showSamples: true
 			}
 		},
 		{

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -459,6 +459,7 @@ function validatePlot(p, vocabApi) {
 		} else if (p.chartType == 'Disco') {
 		} else if (p.chartType == 'profileBarchart') {
 		} else if (p.chartType == 'profilePolar' || p.chartType == 'polar') {
+		} else if (p.chartType == 'dictionary') {
 		} else {
 			validateGenericPlot(p, vocabApi)
 		}

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -459,7 +459,7 @@ function validatePlot(p, vocabApi) {
 		} else if (p.chartType == 'Disco') {
 		} else if (p.chartType == 'profileBarchart') {
 		} else if (p.chartType == 'profilePolar' || p.chartType == 'polar') {
-		} else if (p.chartType == 'dictionary') {
+		} else if (p.chartType == 'sampleView') {
 		} else {
 			validateGenericPlot(p, vocabApi)
 		}

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -22,7 +22,7 @@ class MassDict {
 		const config = appState.plots.find(p => p.id === this.id)
 		this.sample = config.sample
 
-		if (this.sample.sampleId) {
+		if (this.sample) {
 			this.sampleId2Name = await this.app.vocabApi.getAllSamples()
 			const samples = Object.entries(this.sampleId2Name)
 			const div = this.dom.sampleDiv.style('display', 'block')
@@ -104,20 +104,20 @@ class MassDict {
 			selectdTerms: appState.selectedTerms,
 			customTerms: appState.customTerms,
 			termdbConfig: appState.termdbConfig,
-			sampleId: config.sample.sampleId,
-			sampleName: config.sample.sampleName
+			sample: config.sample
 		}
 	}
 
 	async main() {
 		if (this.dom.header)
-			this.dom.header.html(this.state.sampleName ? `${this.state.sampleName} Sample View` : 'Dictionary')
-		this.sample = { sampleId: this.state.sampleId, sample_id: this.state.sampleName }
+			this.dom.header.html(this.state.sample ? `${this.state.sample.sampleName} Sample View` : 'Dictionary')
 		this.tree.dispatch({
 			type: 'app_refresh',
 			state: this.state
 		})
-		if (this.sample && this.showContent) {
+		if (this.state.sample && this.showContent) {
+			const sample = { sampleId: this.state.sample.sampleId, sample_id: this.state.sample.sampleName }
+
 			this.dom.contentDiv.selectAll('*').remove()
 			if (this.state.termdbConfig.queries?.singleSampleMutation) {
 				const div = this.dom.contentDiv
@@ -126,7 +126,7 @@ class MassDict {
 				discoPlotImport.default(
 					this.state.termdbConfig,
 					this.state.vocab.dslabel,
-					this.sample,
+					sample,
 					div.append('div'),
 					this.app.opts.genome
 				)
@@ -141,7 +141,7 @@ class MassDict {
 						this.state.termdbConfig,
 						this.state.vocab.dslabel,
 						k,
-						this.sample,
+						sample,
 						div.append('div'),
 						this.app.opts.genome
 					)

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -116,7 +116,7 @@ class MassDict {
 			state: this.state
 		})
 		if (this.state.sample && this.showContent) {
-			this.sample.sample_id = this.sample.sampleName
+			const sample = { sample_id: this.sample.sampleName }
 
 			this.dom.contentDiv.selectAll('*').remove()
 			if (this.state.termdbConfig.queries?.singleSampleMutation) {
@@ -126,7 +126,7 @@ class MassDict {
 				discoPlotImport.default(
 					this.state.termdbConfig,
 					this.state.vocab.dslabel,
-					this.sample,
+					sample,
 					div.append('div'),
 					this.app.opts.genome
 				)
@@ -141,7 +141,7 @@ class MassDict {
 						this.state.termdbConfig,
 						this.state.vocab.dslabel,
 						k,
-						this.sample,
+						sample,
 						div.append('div'),
 						this.app.opts.genome
 					)
@@ -163,7 +163,6 @@ class MassDict {
 	async downloadData() {
 		const filename = `${this.state.sample.sampleName}.tsv`
 		this.sampleData = await this.app.vocabApi.getSingleSampleData({ sampleId: this.state.sample.sampleId })
-		console.log(this.sampleData)
 		let lines = ''
 		for (const id in this.sampleData) {
 			const term = this.sampleData[id].term

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -39,10 +39,10 @@ class MassDict {
 				.html((d, i) => d[1])
 			this.select.on('change', e => {
 				const sampleId = this.select.node().value
-				const sample = this.sampleId2Name[sampleId]
+				const sampleName = this.sampleId2Name[sampleId]
 				this.sampleDataByTermId = {}
 				this.dataDownloaded = false
-				this.app.dispatch({ type: 'plot_edit', id: this.id, config: { sample: { sampleId, sample } } })
+				this.app.dispatch({ type: 'plot_edit', id: this.id, config: { sample: { sampleId, sampleName } } })
 			})
 
 			div
@@ -105,14 +105,14 @@ class MassDict {
 			customTerms: appState.customTerms,
 			termdbConfig: appState.termdbConfig,
 			sampleId: config.sample.sampleId,
-			sampleName: config.sample.sample
+			sampleName: config.sample.sampleName
 		}
 	}
 
 	async main() {
 		if (this.dom.header)
 			this.dom.header.html(this.state.sampleName ? `${this.state.sampleName} Sample View` : 'Dictionary')
-		this.sample = { sample_id: this.state.sampleId, sample: this.state.sampleName }
+		this.sample = { sampleId: this.state.sampleId, sample_id: this.state.sampleName }
 		this.tree.dispatch({
 			type: 'app_refresh',
 			state: this.state
@@ -121,7 +121,7 @@ class MassDict {
 			this.dom.contentDiv.selectAll('*').remove()
 			if (this.state.termdbConfig.queries?.singleSampleMutation) {
 				const div = this.dom.contentDiv
-				div.append('div').style('font-weight', 'bold').style('padding', '20px').text('Disco plot')
+				div.append('div').style('font-weight', 'bold').style('padding-left', '20px').text('Disco plot')
 				const discoPlotImport = await import('./plot.disco.js')
 				discoPlotImport.default(
 					this.state.termdbConfig,

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -13,7 +13,6 @@ export class MassDict {
 	}
 
 	async init(appState) {
-		console.log(appState)
 		this.tree = await appInit({
 			vocabApi: this.app.vocabApi,
 			holder: this.dom.treeDiv,

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -1,24 +1,19 @@
 import { getCompInit, copyMerge } from '#rx'
 import { appInit } from '#termdb/app'
 
-class MassDict {
+export class MassDict {
 	constructor(opts) {
 		this.type = 'tree'
-		const div = opts.holder.append('div').style('padding', '20px')
-		const treeDiv = div.insert('div').style('display', 'inline-block')
-		const sampleDiv = treeDiv.insert('div').style('display', 'none')
-
-		let contentDiv = div.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
-		contentDiv = contentDiv.insert('div').style('display', 'flex')
+		const mainDiv = opts.holder.append('div').style('padding', '20px')
+		const treeDiv = mainDiv.insert('div').style('display', 'inline-block')
 		this.dom = {
-			sampleDiv,
-			treeDiv,
-			contentDiv,
-			header: opts.header
+			mainDiv,
+			treeDiv
 		}
 	}
 
 	async init(appState) {
+		console.log(appState)
 		this.tree = await appInit({
 			vocabApi: this.app.vocabApi,
 			holder: this.dom.treeDiv,
@@ -41,148 +36,25 @@ class MassDict {
 				}
 			}
 		})
-
-		const config = appState.plots.find(p => p.id === this.id)
-		if (config.showSamples || config.sample) {
-			this.sampleId2Name = await this.app.vocabApi.getAllSamples()
-			if ('error' in this.sampleId2Name) return
-			const samples = Object.entries(this.sampleId2Name)
-			if (samples.length == 0) return
-			this.sample = config.sample || { sampleId: samples[0][0], sampleName: samples[0][1] }
-			const div = this.dom.sampleDiv.style('display', 'block')
-			div.insert('label').html('&nbsp;Sample:')
-
-			this.select = div.append('select').style('margin', '0px 5px')
-			this.select
-				.selectAll('option')
-				.data(samples)
-				.enter()
-				.append('option')
-				.attr('value', d => d[0])
-				.property('selected', d => d[0] == this.sample.sampleId)
-				.html((d, i) => d[1])
-			this.select.on('change', e => {
-				const sampleId = this.select.node().value
-				const sampleName = this.sampleId2Name[sampleId]
-				this.sample = { sampleId, sampleName }
-				this.sampleDataByTermId = {}
-				this.dataDownloaded = false
-				this.app.dispatch({ type: 'plot_edit', id: this.id, config: { sample: this.sample } })
-			})
-
-			div
-				.insert('button')
-				.text('Download')
-				.on('click', e => {
-					console.log(this.tree)
-					this.downloadData()
-				})
-		}
-
-		this.showContent = config.showContent
-
-		if (this.sample && this.showContent) {
-			this.dom.treeDiv
-				.style('min-width', '550px')
-				.style('overflow', 'scroll')
-				.attr('class', 'sjpp_hide_scrollbar')
-				.style('border-right', '1px solid gray')
-
-			this.dom.contentDiv
-				//.style('width', '60%')
-				.style('min-height', '500px')
-				.style('flex-direction', 'column')
-				.style('justify-content', 'center')
-				.style('align-items', 'start')
-				.style('border-left', '1px solid gray')
-		}
 	}
 
 	getState(appState) {
-		const config = appState.plots.find(p => p.id === this.id)
 		return {
 			vocab: appState.vocab,
 			activeCohort: appState.activeCohort,
 			termfilter: appState.termfilter,
 			selectdTerms: appState.selectedTerms,
 			customTerms: appState.customTerms,
-			termdbConfig: appState.termdbConfig,
-			sample: config.sample || this.sample
+			termdbConfig: appState.termdbConfig
 		}
 	}
 
 	async main() {
-		if (this.dom.header)
-			this.dom.header.html(this.state.sample ? `${this.state.sample.sampleName} Sample View` : 'Dictionary')
+		if (this.dom.header) this.dom.header.html('Dictionary')
 		this.tree.dispatch({
 			type: 'app_refresh',
 			state: this.state
 		})
-		if (this.state.sample && this.showContent) {
-			const sample = { sample_id: this.sample.sampleName }
-
-			this.dom.contentDiv.selectAll('*').remove()
-			if (this.state.termdbConfig.queries?.singleSampleMutation) {
-				const div = this.dom.contentDiv
-				div.append('div').style('font-weight', 'bold').style('padding-left', '20px').text('Disco plot')
-				const discoPlotImport = await import('./plot.disco.js')
-				discoPlotImport.default(
-					this.state.termdbConfig,
-					this.state.vocab.dslabel,
-					sample,
-					div.append('div'),
-					this.app.opts.genome
-				)
-			}
-			if (this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
-				for (const k in this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
-					const div = this.dom.contentDiv.append('div').style('padding', '20px')
-					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
-					div.append('div').style('padding-bottom', '20px').style('font-weight', 'bold').text(label)
-					const ssgqImport = await import('./plot.ssgq.js')
-					await ssgqImport.plotSingleSampleGenomeQuantification(
-						this.state.termdbConfig,
-						this.state.vocab.dslabel,
-						k,
-						sample,
-						div.append('div'),
-						this.app.opts.genome
-					)
-				}
-			}
-		}
-	}
-
-	getTermValue(term) {
-		let value = this.sampleData[term.id]?.value
-
-		if (value == null || value == undefined) return null
-		if (term.type == 'float' || term.type == 'integer')
-			return value % 1 == 0 ? value.toString() : value.toFixed(2).toString()
-		if (term.type == 'categorical') return term.values[value].label || term.values[value].key
-		return null
-	}
-
-	async downloadData() {
-		const filename = `${this.state.sample.sampleName}.tsv`
-		this.sampleData = await this.app.vocabApi.getSingleSampleData({ sampleId: this.state.sample.sampleId })
-		let lines = ''
-		for (const id in this.sampleData) {
-			const term = this.sampleData[id].term
-			let value = this.getTermValue(term)
-			if (value == null) continue
-			lines += `${id}\t${value}\n`
-		}
-		const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(lines)
-
-		const link = document.createElement('a')
-		link.setAttribute('href', dataStr)
-		// If you don't know the name or want to use
-		// the webserver default set name = ''
-		link.setAttribute('download', filename)
-		document.body.appendChild(link)
-		link.click()
-		link.remove()
 	}
 }
 

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -139,7 +139,11 @@ export function setInteractivity(self) {
 					self.app.dispatch({
 						type: 'plot_create',
 						id: getId(),
-						config: { chartType: 'dictionary', sample, showContent: drawMethylationArrayPlot || drawDiscoPlot }
+						config: {
+							chartType: 'dictionary',
+							sample: { sampleId: sample.sampleId, sampleName: sample.sample },
+							showContent: drawMethylationArrayPlot || drawDiscoPlot
+						}
 					})
 					self.dom.tip.hide()
 				})

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -140,7 +140,7 @@ export function setInteractivity(self) {
 						type: 'plot_create',
 						id: getId(),
 						config: {
-							chartType: 'dictionary',
+							chartType: 'sampleView',
 							sample: { sampleId: sample.sampleId, sampleName: sample.sample },
 							showContent: drawMethylationArrayPlot || drawDiscoPlot
 						}

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -51,7 +51,7 @@ class SampleView extends MassDict {
 				this.downloadData()
 			})
 
-		super.init(appState)
+		await super.init(appState)
 
 		if (this.sample && this.showContent) {
 			this.dom.treeDiv

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -139,7 +139,7 @@ class SampleView extends MassDict {
 			const term = this.sampleData[id].term
 			let value = this.getTermValue(term)
 			if (value == null) continue
-			lines += `${id}\t${value}\n`
+			lines += `${term.name}\t${value}\n`
 		}
 		const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(lines)
 

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -1,0 +1,164 @@
+import { getCompInit, copyMerge } from '#rx'
+import { appInit } from '#termdb/app'
+import { MassDict } from './dictionary.js'
+
+class SampleView extends MassDict {
+	constructor(opts) {
+		super(opts)
+		this.type = 'sampleView'
+		const treeDiv = this.dom.treeDiv
+		const sampleDiv = treeDiv.insert('div').style('display', 'none')
+
+		let contentDiv = this.dom.mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
+		contentDiv = contentDiv.insert('div').style('display', 'flex')
+		this.dom = {
+			mainDiv: this.dom.mainDiv,
+			sampleDiv,
+			treeDiv,
+			contentDiv,
+			header: opts.header
+		}
+	}
+
+	async init(appState) {
+		const config = appState.plots.find(p => p.id === this.id)
+		this.sampleId2Name = await this.app.vocabApi.getAllSamples()
+		const samples = Object.entries(this.sampleId2Name)
+		this.sample = config.sample || { sampleId: samples[0][0], sampleName: samples[0][1] }
+
+		const div = this.dom.sampleDiv.style('display', 'block')
+		div.insert('label').html('&nbsp;Sample:')
+
+		this.select = div.append('select').style('margin', '0px 5px')
+		this.select
+			.selectAll('option')
+			.data(samples)
+			.enter()
+			.append('option')
+			.attr('value', d => d[0])
+			.property('selected', d => d[0] == this.sample.sampleId)
+			.html((d, i) => d[1])
+		this.select.on('change', e => {
+			const sampleId = this.select.node().value
+			const sampleName = this.sampleId2Name[sampleId]
+			this.sample = { sampleId, sampleName }
+			this.app.dispatch({ type: 'plot_edit', id: this.id, config: { sample: this.sample } })
+		})
+
+		div
+			.insert('button')
+			.text('Download')
+			.on('click', e => {
+				this.downloadData()
+			})
+
+		super.init(appState)
+
+		if (this.sample && this.showContent) {
+			this.dom.treeDiv
+				.style('min-width', '550px')
+				.style('overflow', 'scroll')
+				.attr('class', 'sjpp_hide_scrollbar')
+				.style('border-right', '1px solid gray')
+
+			this.dom.contentDiv
+				//.style('width', '60%')
+				.style('min-height', '500px')
+				.style('flex-direction', 'column')
+				.style('justify-content', 'center')
+				.style('align-items', 'start')
+				.style('border-left', '1px solid gray')
+		}
+	}
+
+	getState(appState) {
+		let state = super.getState(appState)
+		console.log(appState.plots, this.id)
+		const config = appState.plots?.find(p => p.id === this.id)
+		state.sample = config?.sample || this.sample
+		return state
+	}
+
+	async main() {
+		super.main()
+		if (this.dom.header)
+			this.dom.header.html(this.state.sample ? `${this.state.sample.sampleName} Sample View` : 'Dictionary')
+
+		if (this.state.sample && this.showContent) {
+			const sample = { sample_id: this.sample.sampleName }
+
+			this.dom.contentDiv.selectAll('*').remove()
+			if (this.state.termdbConfig.queries?.singleSampleMutation) {
+				const div = this.dom.contentDiv
+				div.append('div').style('font-weight', 'bold').style('padding-left', '20px').text('Disco plot')
+				const discoPlotImport = await import('./plot.disco.js')
+				discoPlotImport.default(
+					this.state.termdbConfig,
+					this.state.vocab.dslabel,
+					sample,
+					div.append('div'),
+					this.app.opts.genome
+				)
+			}
+			if (this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
+				for (const k in this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
+					const div = this.dom.contentDiv.append('div').style('padding', '20px')
+					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
+					div.append('div').style('padding-bottom', '20px').style('font-weight', 'bold').text(label)
+					const ssgqImport = await import('./plot.ssgq.js')
+					await ssgqImport.plotSingleSampleGenomeQuantification(
+						this.state.termdbConfig,
+						this.state.vocab.dslabel,
+						k,
+						sample,
+						div.append('div'),
+						this.app.opts.genome
+					)
+				}
+			}
+		}
+	}
+
+	getTermValue(term) {
+		let value = this.sampleData[term.id]?.value
+
+		if (value == null || value == undefined) return null
+		if (term.type == 'float' || term.type == 'integer')
+			return value % 1 == 0 ? value.toString() : value.toFixed(2).toString()
+		if (term.type == 'categorical') return term.values[value].label || term.values[value].key
+		return null
+	}
+
+	async downloadData() {
+		const filename = `${this.state.sample.sampleName}.tsv`
+		this.sampleData = await this.app.vocabApi.getSingleSampleData({ sampleId: this.state.sample.sampleId })
+		let lines = ''
+		for (const id in this.sampleData) {
+			const term = this.sampleData[id].term
+			let value = this.getTermValue(term)
+			if (value == null) continue
+			lines += `${id}\t${value}\n`
+		}
+		const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(lines)
+
+		const link = document.createElement('a')
+		link.setAttribute('href', dataStr)
+		// If you don't know the name or want to use
+		// the webserver default set name = ''
+		link.setAttribute('download', filename)
+		document.body.appendChild(link)
+		link.click()
+		link.remove()
+	}
+}
+
+export const sampleViewInit = getCompInit(SampleView)
+export const componentInit = sampleViewInit
+
+export function getPlotConfig(opts, app) {
+	// currently, there are no configurations options for
+	// the dictionary tree; may add appearance, styling options later
+	const config = {}
+	// may apply overrides to the default configuration
+	return copyMerge(config, opts)
+}

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -905,7 +905,10 @@ export class TermdbVocab extends Vocab {
 		}
 		const data = await dofetch3('termdb', { headers, body })
 		const byTermId = {}
-		for (const row of data) byTermId[row.term_id] = row.value
+		for (const row of data) {
+			const term = JSON.parse(row.jsondata)
+			byTermId[row.term_id] = { value: row.value, term }
+		}
 		return byTermId
 	}
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -909,6 +909,23 @@ export class TermdbVocab extends Vocab {
 		return byTermId
 	}
 
+	async getAllSamples() {
+		// the scatter plot may still render when not in session,
+		// but not have an option to list samples
+		const headers = this.mayGetAuthHeaders()
+
+		// dofetch* mayAdjustRequest() will automatically
+		// convert to GET query params or POST body, as needed
+		const body = {
+			for: 'getAllSamples',
+			genome: this.state.vocab.genome,
+			dslabel: this.state.vocab.dslabel,
+			embedder: window.location.hostname
+		}
+		const data = await dofetch3('termdb', { headers, body })
+		return data
+	}
+
 	async getLowessCurve(opts) {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -905,6 +905,7 @@ export class TermdbVocab extends Vocab {
 		}
 		const data = await dofetch3('termdb', { headers, body })
 		const byTermId = {}
+		if ('error' in data) return data
 		for (const row of data) {
 			const term = JSON.parse(row.jsondata)
 			byTermId[row.term_id] = { value: row.value, term }

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -3,8 +3,6 @@ import { select, selectAll } from 'd3-selection'
 import { getNormalRoot } from '#filter'
 import { isUsableTerm } from '#shared/termdb.usecase'
 import { termInfoInit } from './termInfo'
-import { getSampleFilter } from '#termsetting/handlers/samplelst'
-import { fillTermWrapper } from '#termsetting'
 
 const childterm_indent = '25px'
 export const root_ID = 'root'
@@ -249,7 +247,7 @@ function setRenderers(self) {
 			if (div.classed('sjpp_hide_scrollbar')) {
 				// already scrolling. the style has been applied from a previous click. do not reset
 			} else {
-				if (!self.sample) div.style('max-height', scrollDivMaxHeight)
+				if (!self.state.sample) div.style('max-height', scrollDivMaxHeight)
 
 				div.style('padding', '10px').style('resize', 'vertical').classed('sjpp_hide_scrollbar', true)
 
@@ -337,16 +335,19 @@ function setRenderers(self) {
 		const isExpanded = self.state.expandedTermIds.includes(term.id)
 		div.select('.' + cls_termbtn).text(isExpanded ? '-' : '+')
 		if (self.state.sample) div.select('.' + cls_termlabel + 'Value').text(self.getTermValue(term) || 'Missing')
-
 		// update other parts if needed, e.g. label
-		div.select('.' + cls_termchilddiv).style('display', isExpanded ? 'block' : 'none')
+		else div.select('.' + cls_termchilddiv).style('display', isExpanded ? 'block' : 'none')
 
 		const isSelected = self.state.selectedTerms.find(t => t.name === term.name && t.type === term.type)
 		div
 			.select('.' + cls_termlabel)
 			.style(
 				'background-color',
-				!uses.has('plot') || termIsDisabled ? '' : isSelected ? 'rgba(255, 194, 10,0.5)' : '#cfe2f3'
+				!uses.has('plot') || termIsDisabled || self.state.sample
+					? ''
+					: isSelected
+					? 'rgba(255, 194, 10,0.5)'
+					: '#cfe2f3'
 			)
 		div
 			.select('.' + cls_termcheck)
@@ -419,7 +420,7 @@ function setRenderers(self) {
 					.style('padding', '5px 8px')
 					.style('margin', '1px 0px')
 					.style('opacity', 0.4)
-			} else if (uses.has('plot') && !self.sample) {
+			} else if (uses.has('plot') && !self.state.sample) {
 				labeldiv
 					// need better css class
 					.style('color', 'black')

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -368,7 +368,6 @@ function setRenderers(self) {
 			div.style('display', 'none')
 			return
 		}
-		console.log('updateTerm')
 
 		const termIsDisabled = self.opts.disable_terms?.includes(term.id)
 		const uses = isUsableTerm(term, self.state.usecase)

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -77,24 +77,7 @@ class TdbTree {
 
 	async init(opts) {
 		const holder = this.opts.holder.append('div')
-		if (opts.sampleId) {
-			this.opts.headerDiv.insert('label').text('Sample:')
-			const input = this.opts.headerDiv
-				.insert('input')
-				.property('disabled', true)
-				.attr('value', opts.sampleName)
-				.on('change', e => {
-					const sampleId = Number(input.node.value)
-					this.sampleDataByTermId = {}
-					//do something
-				})
-			this.opts.headerDiv
-				.insert('button')
-				.text('Download')
-				.on('click', e => {
-					this.downloadData()
-				})
-		} else this.opts.headerDiv.style('display', 'none')
+
 		const loadingDiv = this.opts.headerDiv.append('div').style('display', 'inline-block').style('margin-left', '10px')
 		this.dom = {
 			holder,
@@ -123,7 +106,6 @@ class TdbTree {
 			sampleId: appState.sampleId,
 			sampleName: appState.sampleName
 		}
-
 		// if cohort selection is enabled for the dataset, tree component needs to know which cohort is selected
 		if (appState.termdbConfig.selectCohort) {
 			state.toSelectCohort = true
@@ -138,6 +120,8 @@ class TdbTree {
 	}
 
 	async main() {
+		if (this.dom.header) this.dom.header.html(this.sampleName ? `${this.sampleName} Sample View` : 'Dictionary')
+
 		if (!this.state.isVisible) {
 			this.dom.holder.style('display', 'none')
 			return
@@ -241,7 +225,7 @@ class TdbTree {
 		this.dom.loadingDiv.text('Downloading data ...')
 		for (const id in this.termsById) {
 			const term = this.termsById[id]
-			if (term.isleaf) continue
+			//if (term.isleaf) continue
 			let terms = [term]
 			while (terms.length) for (const term of terms) terms = await this.requestTermRecursive(term)
 		}
@@ -384,6 +368,7 @@ function setRenderers(self) {
 			div.style('display', 'none')
 			return
 		}
+		console.log('updateTerm')
 
 		const termIsDisabled = self.opts.disable_terms?.includes(term.id)
 		const uses = isUsableTerm(term, self.state.usecase)
@@ -391,6 +376,8 @@ function setRenderers(self) {
 		div.style('display', '')
 		const isExpanded = self.state.expandedTermIds.includes(term.id)
 		div.select('.' + cls_termbtn).text(isExpanded ? '-' : '+')
+		div.select('.' + cls_termlabel + 'Value').text(self.getTermValue(term) || 'Missing')
+
 		// update other parts if needed, e.g. label
 		div.select('.' + cls_termchilddiv).style('display', isExpanded ? 'block' : 'none')
 
@@ -454,6 +441,7 @@ function setRenderers(self) {
 			let value = self.getTermValue(term) || 'Missing'
 			div
 				.append('div')
+				.attr('class', cls_termlabel + 'Value')
 				.style('display', 'inline-block')
 				.style('float', 'right')
 				.style('padding', '5px')

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -209,45 +209,11 @@ class TdbTree {
 		const term_ids = []
 		for (const term of terms) term_ids.push(term.id)
 		const data = await this.app.vocabApi.getSingleSampleData({ sampleId: this.state.sample.sampleId, term_ids })
-		for (const id in data) this.sampleDataByTermId[id] = data[id]
+		for (const id in data) this.sampleDataByTermId[id] = data[id].value
 	}
 
 	bindKey(term) {
 		return term.id
-	}
-
-	async requestAllTerms() {
-		this.dom.loadingDiv.text('Downloading data ...')
-		for (const id in this.termsById) {
-			const term = this.termsById[id]
-			//if (term.isleaf) continue
-			let terms = [term]
-			while (terms.length) for (const term of terms) terms = await this.requestTermRecursive(term)
-		}
-		this.dataDownloaded = true
-		this.dom.loadingDiv.text('')
-	}
-
-	async downloadData() {
-		if (!this.dataDownloaded) await this.requestAllTerms()
-		const filename = `${this.state.sample.sampleName}.tsv`
-		let data = ''
-		for (const field in this.sampleDataByTermId) {
-			const term = this.termsById[field]
-			let value = this.getTermValue(term)
-			if (value == null) continue
-			data += `${field}\t${value}\n`
-		}
-		const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(data)
-
-		const link = document.createElement('a')
-		link.setAttribute('href', dataStr)
-		// If you don't know the name or want to use
-		// the webserver default set name = ''
-		link.setAttribute('download', filename)
-		document.body.appendChild(link)
-		link.click()
-		link.remove()
 	}
 }
 

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -59,7 +59,8 @@ async function maySetAuthRoutes(app, basepath = '', _serverconfig = null) {
 			// since some data may still be returned for those, except controlled access
 			// data like sample names, which should not be included in the response payload
 			// if auth is required and not in session
-			(creds[q.dslabel].type != 'jwt' || (req.path == '/termdb' && (q.for == 'matrix' || q.for == 'singleSampleData')))
+			(creds[q.dslabel].type != 'jwt' ||
+				(req.path == '/termdb' && (q.for == 'matrix' || q.for == 'singleSampleData' || q.for == 'getAllSamples')))
 		) {
 			// will do the session check below
 		} else {

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -85,6 +85,7 @@ export function handle_request_closure(genomes) {
 			}
 			if (q.for == 'convertSampleId') return get_convertSampleId(q, res, tdb)
 			if (q.for == 'singleSampleData') return get_singleSampleData(q, res, tdb)
+			if (q.for == 'getAllSamples') return get_AllSamples(q, req, res, ds)
 
 			throw "termdb: doesn't know what to do"
 		} catch (e) {
@@ -604,6 +605,13 @@ async function get_matrix(q, req, res, ds, genome) {
 
 async function get_singleSampleData(q, res, tdb) {
 	res.send(tdb.q.getSingleSampleData(q.sampleId, q.term_ids))
+}
+
+async function get_AllSamples(q, req, res, ds) {
+	const canDisplay = authApi.canDisplaySampleIds(req, ds)
+	let result = []
+	if (canDisplay) result = Object.fromEntries(ds.sampleId2Name)
+	res.send(result)
 }
 
 function get_mds3queryDetails(res, ds) {

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -431,6 +431,7 @@ export function server_init_db_queries(ds) {
 			supportedChartTypes[cohort] = [...supportedChartTypes[cohort]]
 		}
 
+		ds.cohort.allowedChartTypes.push('sampleView')
 		// may restrict the visible chart options
 		if (ds.cohort.allowedChartTypes) {
 			for (const cohort in supportedChartTypes) {

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -403,6 +403,7 @@ export function server_init_db_queries(ds) {
 				if (ds.cohort.allowedChartTypes?.includes('matrix')) supportedChartTypes[r.cohort].add('matrix')
 				if (!cred || cred.embedders?.[embedder]) {
 					supportedChartTypes[r.cohort].add('dataDownload')
+					supportedChartTypes[r.cohort].add('sampleView')
 				}
 			}
 			if (serverconfig.features?.draftChartTypes) {

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -431,7 +431,6 @@ export function server_init_db_queries(ds) {
 			supportedChartTypes[cohort] = [...supportedChartTypes[cohort]]
 		}
 
-		ds.cohort.allowedChartTypes.push('sampleView')
 		// may restrict the visible chart options
 		if (ds.cohort.allowedChartTypes) {
 			for (const cohort in supportedChartTypes) {

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -457,7 +457,7 @@ export function server_init_db_queries(ds) {
 	q.getSingleSampleData = function (sampleId, term_ids = []) {
 		const termClause = !term_ids.length ? '' : `and term_id in (${term_ids.map(t => '?').join(',')})`
 
-		const query = `select term_id, value 
+		const query = `select term_id, value, jsondata from ( select term_id, value 
 		from anno_categorical 
 		where sample=? ${termClause}
 		union all 
@@ -467,7 +467,7 @@ export function server_init_db_queries(ds) {
 		union all  
 		select term_id, value 
 		from anno_integer 
-		where sample=? ${termClause}`
+		where sample=? ${termClause} ) join terms on terms.id = term_id`
 		const sql = cn.prepare(query)
 		const rows = sql.all([sampleId, ...term_ids, sampleId, ...term_ids, sampleId, ...term_ids])
 		return rows


### PR DESCRIPTION
## Description

Sample viewer now allows to select a sample from a dropdown list and updates the content of the tree and the plots based on it. It also allows to download the sample data. The MassDict class is extended by the new plot SampleView. If the user is not logged in and it is required to see the data the same behaviour as for the dataDownload is provided, showing a message with a link to the tutorial. This plot is added by default to the allowedChartTypes.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
