### PR TITLE
Avoid unnecessarily running unit test CI

### DIFF
--- a/.github/workflows/CI-merge-change-log.yml
+++ b/.github/workflows/CI-merge-change-log.yml
@@ -6,7 +6,7 @@ on:
       - closed
 
 jobs:
-  if_merged:
+  merge:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
 
@@ -43,10 +43,3 @@ jobs:
             BRANCH=$(git rev-parse --abbrev-ref HEAD)
             git push origin $BRANCH
           fi
-
-  not_merged:
-    if: github.event.pull_request.merged == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Not merged
-        run: echo "no changes were merged to the log" 

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -5,8 +5,18 @@ on:
     branches:
       - master
       - fake-master
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.**ignore'
+      - 'docs/**'
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '.**ignore'
+      - 'docs/**'
 
 jobs:
   build:
@@ -43,10 +53,15 @@ jobs:
 
       - name: Detect workspaces to test
         run: |
-          echo "WS_TO_TEST=$(./build/requiresTest.sh)" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            # NOTE: the build job filters out automated push 
+            echo "WS_TO_TEST=client server rust" >> $GITHUB_ENV
+          else 
+            echo "WS_TO_TEST=$(./build/requiresTest.sh)" >> $GITHUB_ENV
+          fi
 
       - name: 🔎 Run client tests
-        if: contains(env.WS_TO_TEST, 'client') || github.event_name == 'push'
+        if: contains(env.WS_TO_TEST, 'client')
         run: |
           sudo apt-get install xvfb
           xvfb-run --auto-servernum npm run test:unit --workspace="client"
@@ -56,7 +71,7 @@ jobs:
         run: npx tsc --esModuleInterop server/dataset/*.ts && npm run test:unit --workspace="server"
 
       - name: ⚡ Cache
-        if: contains(env.WS_TO_TEST, 'rust') || github.event_name == 'push'
+        if: contains(env.WS_TO_TEST, 'rust')
         uses: actions/cache@v2
         with:
           path: |
@@ -71,7 +86,7 @@ jobs:
           toolchain: stable
 
       - name: 🔎 Rust unit tests
-        if: contains(env.WS_TO_TEST, 'rust') || github.event_name == 'push'
+        if: contains(env.WS_TO_TEST, 'rust')
         run: |
           npm run build --workspace="rust"
           npm run test:unit --workspace="rust"

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -4,22 +4,20 @@ on:
   push:
     branches:
       - master
+      - fake-master
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    if: (github.event_name == 'push' && github.event.head_commit.author.email != 'PPTeam@STJUDE.ORG') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v3
-
-      - uses: pre-commit/action@v3.0.0
         with:
-          extra_args:
-            detect-secrets --all-files
+          fetch-depth: 10
 
       - uses: actions/setup-node@v3
         with:
@@ -40,19 +38,40 @@ jobs:
           TPMASTERDIR=$(node -p "require('./serverconfig.json').tpmasterdir")
           mv serverconfig.json ../../
 
-      - name: Create cache folder
+      - name: Create server cache folder
         run: mkdir server/cache
 
-      - name: install xvfb
-        run: sudo apt-get install xvfb
+      - name: Detect workspaces to test
+        run: |
+          echo "WS_TO_TEST=$(./build/requiresTest.sh)" >> $GITHUB_ENV
 
-      - name: Run client tests
-        run: xvfb-run --auto-servernum npm run test:unit --workspace="client"
+      - name: 🔎 Run client tests
+        if: contains(env.WS_TO_TEST, 'client') || github.event_name == 'push'
+        run: |
+          sudo apt-get install xvfb
+          xvfb-run --auto-servernum npm run test:unit --workspace="client"
 
-      - name: Server unit tests
+      - name: 🔎 Server unit tests
+        if: contains(env.WS_TO_TEST, 'server')
         run: npx tsc --esModuleInterop server/dataset/*.ts && npm run test:unit --workspace="server"
 
-      - name: Rust unit tests
+      - name: ⚡ Cache
+        if: contains(env.WS_TO_TEST, 'rust') || github.event_name == 'push'
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: actions-rs/toolchain@v1
+        if: contains(env.WS_TO_TEST, 'rust')
+        with:
+          toolchain: stable
+
+      - name: 🔎 Rust unit tests
+        if: contains(env.WS_TO_TEST, 'rust') || github.event_name == 'push'
         run: |
           npm run build --workspace="rust"
           npm run test:unit --workspace="rust"

--- a/build/ci-version-update.sh
+++ b/build/ci-version-update.sh
@@ -22,7 +22,7 @@ fi
 # CONTEXT
 ##########
 
-UPDATED=$(./build/jump.js "$@")
+UPDATED=$(./build/bump.js "$@")
 if [[ "$UPDATED" == "" ]]; then
   echo "No workspace package updates, exiting script with code 1"
   exit 1

--- a/build/requiresTest.sh
+++ b/build/requiresTest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+URLRUNS="https://api.github.com/repos/stjude/proteinpaint/actions/runs?status=success&branch=master&event=push"
+UNITRUNS=$(curl -sL -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "$URLRUNS" > ./runs.json)
+SHA_IN_COMMIT=$(git rev-list -n20 HEAD)
+SHA_TESTED_LIST=$(node -p "(require('./runs.json')).workflow_runs?.filter(r => r.display_title != 'append release notes to change log').map(r => r.head_sha).join(' ')")
+rm runs.json
+for SHA in $SHA_TESTED_LIST; do
+	if [[ "$SHA_IN_COMMIT" ==  *"$SHA"* ]]; then
+		SHATESTED=$SHA
+		break
+	fi
+done
+
+if [[ "$SHATESTED" == "" ]]; then
+	SHATESTED=$(git rev-parse HEAD~7)
+fi
+CHANGEDFILES="$(git diff --name-only HEAD $SHATESTED)"
+
+IS_CODE_OR_CONFIG="f => !f.endsWith('.md') && !f.endsWith('.txt') && !f.endsWith('ignore') && f != 'LICENSE' && f != 'DESCRIPTION'"
+RELEVANTFILES=$(node -p "(\`$CHANGEDFILES\`).split('\n').filter($IS_CODE_OR_CONFIG).join('\n')")
+# patch is used only to satisfy the version type argument, can be any other allowed value  
+CHANGEDWS="$(./build/bump.js patch -c=$SHATESTED)"
+WS_TO_TEST=""
+for ws in $CHANGEDWS; do
+	if [[ "$RELEVANTFILES" == *"$ws/"* ]]; then
+		WS_TO_TEST="$WS_TO_TEST $ws"
+	fi
+done
+echo "$WS_TO_TEST"

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+DevOps:
+- avoid unnecessarily running unit test CI, for pull requests with unaffected workspaces and on automated push


### PR DESCRIPTION
## Description
Avoid unnecessarily running the unit test CI or steps within the workflow:
- **for pull requests**: run only for workspaces with relevant changes (code/config) 
- **on push**: run every time except when pushed automatically, detected via the commit author email
- cache the Rust dependencies to decrease the test runtime.

Example tests:
- [run only on a changed workspace](https://github.com/stjude/proteinpaint/actions/runs/6065692894/job/16455482502): does not apply to a push event
- [do not run on automated push](https://github.com/stjude/proteinpaint/actions/runs/6076851008): assumes that automated pushes does not affect code and configuration, like in the `"append release notes to change log"` commit
- [run all workspace unit test on non-automated push](https://github.com/stjude/proteinpaint/actions/runs/6075744937/job/16482536112), for example after the standard push that is triggered after a PR is closed and merged. This also uses the rust toolchain cache.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
