### PR TITLE
Visualizing multiple samples from scatter lasso

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -122,12 +122,11 @@ function getChartTypeList(self) {
 			}
 		},
 		{
-			label: 'Samples View',
+			label: 'Sample View',
 			clickTo: self.prepPlot,
-			chartType: 'sampleGroupView',
+			chartType: 'sampleView',
 			config: {
-				chartType: 'sampleGroupView',
-				samples: []
+				chartType: 'sampleView'
 			}
 		},
 		{

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -122,11 +122,12 @@ function getChartTypeList(self) {
 			}
 		},
 		{
-			label: 'Sample View',
+			label: 'Samples View',
 			clickTo: self.prepPlot,
-			chartType: 'sampleView',
+			chartType: 'sampleGroupView',
 			config: {
-				chartType: 'sampleView'
+				chartType: 'sampleGroupView',
+				samples: []
 			}
 		},
 		{

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -459,7 +459,7 @@ function validatePlot(p, vocabApi) {
 		} else if (p.chartType == 'Disco') {
 		} else if (p.chartType == 'profileBarchart') {
 		} else if (p.chartType == 'profilePolar' || p.chartType == 'polar') {
-		} else if (p.chartType == 'sampleView' || p.chartType == 'DEanalysis') {
+		} else if (p.chartType == 'sampleGroupView' || p.chartType == 'DEanalysis') {
 		} else {
 			validateGenericPlot(p, vocabApi)
 		}

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -459,7 +459,8 @@ function validatePlot(p, vocabApi) {
 		} else if (p.chartType == 'Disco') {
 		} else if (p.chartType == 'profileBarchart') {
 		} else if (p.chartType == 'profilePolar' || p.chartType == 'polar') {
-		} else if (p.chartType == 'sampleGroupView' || p.chartType == 'DEanalysis') {
+		} else if (p.chartType == 'DEanalysis') {
+		} else if (p.chartType == 'sampleGroupView' || p.chartType == 'sampleView') {
 		} else {
 			validateGenericPlot(p, vocabApi)
 		}

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -8,7 +8,8 @@ export class MassDict {
 		const treeDiv = mainDiv.insert('div').style('display', 'inline-block')
 		this.dom = {
 			mainDiv,
-			treeDiv
+			treeDiv,
+			header: opts.header
 		}
 	}
 

--- a/client/plots/sampleGroupView.js
+++ b/client/plots/sampleGroupView.js
@@ -41,9 +41,8 @@ class SampleGroupView extends MassDict {
 			const samples = []
 			for (const option of options)
 				if (option.selected) {
-					const sampleId = option.value
-					const sample = { sampleId, sampleName: this.sampleId2Name[this.sampleId] }
-					console.log(samples)
+					const sampleId = Number(option.value)
+					const sample = { sampleId, sampleName: this.sampleId2Name[sampleId] }
 					samples.push(sample)
 				}
 			this.app.dispatch({ type: 'plot_edit', id: this.id, config: { samples } })
@@ -59,14 +58,7 @@ class SampleGroupView extends MassDict {
 	}
 
 	getState(appState) {
-		let state = {
-			vocab: appState.vocab,
-			activeCohort: appState.activeCohort,
-			termfilter: appState.termfilter,
-			selectdTerms: appState.selectedTerms,
-			customTerms: appState.customTerms,
-			termdbConfig: appState.termdbConfig
-		}
+		let state = super.getState(appState)
 		const config = appState.plots?.find(p => p.id === this.id)
 		state.samples = config?.samples
 		state.hasVerifiedToken = this.app.vocabApi.hasVerifiedToken()
@@ -76,6 +68,7 @@ class SampleGroupView extends MassDict {
 	}
 
 	async main() {
+		super.main()
 		if (this.mayRequireToken()) return
 		if (this.dom.header) {
 			let title = 'Samples ' + this.state.samples.map(s => s.sampleName).join(', ')

--- a/client/plots/sampleGroupView.js
+++ b/client/plots/sampleGroupView.js
@@ -6,6 +6,7 @@ class SampleGroupView extends MassDict {
 	constructor(opts) {
 		super(opts)
 		this.type = 'sampleGroupView'
+		this.dom.treeDiv.style('position', 'relative')
 	}
 
 	async init(appState) {

--- a/client/plots/sampleGroupView.js
+++ b/client/plots/sampleGroupView.js
@@ -22,7 +22,7 @@ class SampleGroupView {
 		for (const sample of config.samples) {
 			const div = this.dom.mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
 			const state = this.getState(appState)
-			state.sample = { sampleId: sample.sampleId, sampleName: sample.sample }
+			state.sample = sample
 			const tree = await appInit({
 				vocabApi: this.app.vocabApi,
 				holder: div,
@@ -69,7 +69,8 @@ class SampleGroupView {
 	async main() {
 		if (this.mayRequireToken()) return
 		if (this.dom.header) {
-			let title = 'Samples ' + this.state.samples.map(s => s.sample).join(', ')
+			let title = 'Samples ' + this.state.samples.map(s => s.sampleName).join(', ')
+			if (title.length > 100) title = title.substring(0, 100) + '...'
 			this.dom.header.html(title)
 		}
 	}

--- a/client/plots/sampleGroupView.js
+++ b/client/plots/sampleGroupView.js
@@ -2,51 +2,17 @@ import { getCompInit, copyMerge } from '#rx'
 import { appInit } from '#termdb/app'
 import { MassDict } from './dictionary.js'
 
-class SampleGroupView {
+class SampleGroupView extends MassDict {
 	constructor(opts) {
+		super(opts)
 		this.type = 'sampleGroupView'
-		const mainDiv = opts.holder.append('div').style('padding', '20px')
-		const treeDiv = mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
-		this.dom = {
-			mainDiv,
-			treeDiv,
-			header: opts.header
-		}
 	}
 
 	async init(appState) {
+		await super.init(appState)
 		const config = appState.plots.find(p => p.id === this.id)
 		this.sampleId2Name = await this.app.vocabApi.getAllSamples()
-		this.trees = []
 		const allSamples = Object.entries(this.sampleId2Name)
-		for (const sample of config.samples) {
-			const div = this.dom.mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
-			const state = this.getState(appState)
-			state.sample = sample
-			const tree = await appInit({
-				vocabApi: this.app.vocabApi,
-				holder: div,
-				state,
-				tree: {
-					click_term: _term => {
-						const term = _term.term || _term
-						this.app.dispatch({
-							type: 'plot_create',
-							config: {
-								chartType: term.type == 'survival' ? 'survival' : 'summary',
-								term: _term.term ? _term : 'id' in term ? { id: term.id, term } : { term }
-							}
-						})
-
-						this.app.dispatch({
-							type: 'plot_delete',
-							id: this.id
-						})
-					}
-				}
-			})
-			this.trees.push(tree)
-		}
 	}
 
 	getState(appState) {

--- a/client/plots/sampleGroupView.js
+++ b/client/plots/sampleGroupView.js
@@ -13,10 +13,6 @@ class SampleGroupView extends MassDict {
 	async init(appState) {
 		await super.init(appState)
 		const config = appState.plots.find(p => p.id === this.id)
-		this.sampleId2Name = await this.app.vocabApi.getAllSamples()
-		const samples = Object.entries(this.sampleId2Name)
-		this.sample = config.sample || { sampleId: samples[0][0], sampleName: samples[0][1] }
-
 		const label = this.dom.sampleDiv
 			.insert('label')
 			.attr('for', 'select')
@@ -30,19 +26,19 @@ class SampleGroupView extends MassDict {
 			.attr('id', 'select')
 		this.select
 			.selectAll('option')
-			.data(samples)
+			.data(config.samples)
 			.enter()
 			.append('option')
-			.attr('value', d => d[0])
-			.property('selected', d => config.samples.find(s => s.sampleId == d[0]) != null)
-			.html((d, i) => d[1])
+			.attr('value', d => d.sampleId)
+			.html((d, i) => d.sampleName)
 		this.select.on('change', e => {
 			const options = this.select.node().options
 			const samples = []
 			for (const option of options)
 				if (option.selected) {
 					const sampleId = Number(option.value)
-					const sample = { sampleId, sampleName: this.sampleId2Name[sampleId] }
+					const sampleName = config.samples.find(s => s.sampleId == sampleId).sampleName
+					const sample = { sampleId, sampleName }
 					samples.push(sample)
 				}
 			this.app.dispatch({ type: 'plot_edit', id: this.id, config: { samples } })

--- a/client/plots/sampleGroupView.js
+++ b/client/plots/sampleGroupView.js
@@ -1,0 +1,130 @@
+import { getCompInit, copyMerge } from '#rx'
+import { appInit } from '#termdb/app'
+import { MassDict } from './dictionary.js'
+
+class SampleGroupView {
+	constructor(opts) {
+		this.type = 'sampleGroupView'
+		const mainDiv = opts.holder.append('div').style('padding', '20px')
+		const treeDiv = mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
+		this.dom = {
+			mainDiv,
+			treeDiv,
+			header: opts.header
+		}
+	}
+
+	async init(appState) {
+		const config = appState.plots.find(p => p.id === this.id)
+		this.sampleId2Name = await this.app.vocabApi.getAllSamples()
+		this.trees = []
+		const allSamples = Object.entries(this.sampleId2Name)
+		for (const sample of config.samples) {
+			const div = this.dom.mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
+			const state = this.getState(appState)
+			state.sample = { sampleId: sample.sampleId, sampleName: sample.sample }
+			const tree = await appInit({
+				vocabApi: this.app.vocabApi,
+				holder: div,
+				state,
+				tree: {
+					click_term: _term => {
+						const term = _term.term || _term
+						this.app.dispatch({
+							type: 'plot_create',
+							config: {
+								chartType: term.type == 'survival' ? 'survival' : 'summary',
+								term: _term.term ? _term : 'id' in term ? { id: term.id, term } : { term }
+							}
+						})
+
+						this.app.dispatch({
+							type: 'plot_delete',
+							id: this.id
+						})
+					}
+				}
+			})
+			this.trees.push(tree)
+		}
+	}
+
+	getState(appState) {
+		let state = {
+			vocab: appState.vocab,
+			activeCohort: appState.activeCohort,
+			termfilter: appState.termfilter,
+			selectdTerms: appState.selectedTerms,
+			customTerms: appState.customTerms,
+			termdbConfig: appState.termdbConfig
+		}
+		const config = appState.plots?.find(p => p.id === this.id)
+		state.samples = config?.samples
+		state.hasVerifiedToken = this.app.vocabApi.hasVerifiedToken()
+		state.tokenVerificationPayload = this.app.vocabApi.tokenVerificationPayload
+
+		return state
+	}
+
+	async main() {
+		if (this.mayRequireToken()) return
+		if (this.dom.header) {
+			let title = 'Samples ' + this.state.samples.map(s => s.sample).join(', ')
+			this.dom.header.html(title)
+		}
+	}
+
+	async downloadData() {
+		const filename = `${this.state.sample.sampleName}.tsv`
+		this.sampleData = await this.app.vocabApi.getSingleSampleData({ sampleId: this.state.sample.sampleId })
+		let lines = ''
+		for (const id in this.sampleData) {
+			const term = this.sampleData[id].term
+			let value = this.getTermValue(term)
+			if (value == null) continue
+			lines += `${term.name}\t${value}\n`
+		}
+		const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(lines)
+
+		const link = document.createElement('a')
+		link.setAttribute('href', dataStr)
+		// If you don't know the name or want to use
+		// the webserver default set name = ''
+		link.setAttribute('download', filename)
+		document.body.appendChild(link)
+		link.click()
+		link.remove()
+	}
+
+	mayRequireToken() {
+		if (this.state.hasVerifiedToken) {
+			this.dom.mainDiv.style('display', 'block')
+			return false
+		} else {
+			const e = this.state.tokenVerificationPayload
+			const missingAccess = e?.error == 'Missing access' && this.state.termdbConfig.dataDownloadCatch?.missingAccess
+			const message = missingAccess?.message?.replace('MISSING-ACCESS-LINK', missingAccess?.links[e?.linkKey])
+			const helpLink = this.state.termdbConfig.dataDownloadCatch?.helpLink
+			this.dom.mainDiv
+				.style('color', '#e44')
+				.html(
+					message ||
+						(this.state.tokenVerificationMessage || 'Requires sign-in') +
+							(helpLink ? ` <a href='${helpLink}' target=_blank>Tutorial</a>` : '')
+				)
+
+			return true
+		}
+	}
+}
+
+export const sampleGroupViewInit = getCompInit(SampleGroupView)
+export const componentInit = sampleGroupViewInit
+
+export function getPlotConfig(opts, app) {
+	// currently, there are no configurations options for
+	// the dictionary tree; may add appearance, styling options later
+	const config = {}
+	// may apply overrides to the default configuration
+	return copyMerge(config, opts)
+}

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -10,6 +10,7 @@ import { Menu } from '#dom/menu'
 import { getSamplelstTW } from '../termsetting/handlers/samplelst.ts'
 import { regressionLoess, regressionPoly } from 'd3-regression'
 import { line, arc } from 'd3'
+import { getId } from '#mass/nav'
 
 export function setRenderers(self) {
 	self.render = function () {
@@ -491,6 +492,7 @@ export function setRenderers(self) {
 		}
 
 		function showLassoMenu(event) {
+			const samples = self.selectedItems.map(item => item.__data__)
 			self.dom.tip.clear().hide()
 			if (self.selectedItems.length == 0) return
 			self.dom.tip.show(event.clientX, event.clientY)
@@ -505,7 +507,7 @@ export function setRenderers(self) {
 					self.showTable(
 						{
 							name: 'Group ' + (self.config.groups.length + 1),
-							items: self.selectedItems.map(item => item.__data__)
+							items: samples
 						},
 						event.clientX,
 						event.clientY,
@@ -520,7 +522,7 @@ export function setRenderers(self) {
 				.on('click', async () => {
 					const group = {
 						name: 'Group',
-						items: self.selectedItems.map(item => item.__data__)
+						items: samples
 					}
 					self.addGroup(group)
 				})
@@ -531,11 +533,27 @@ export function setRenderers(self) {
 				.on('click', () => {
 					const group = {
 						name: 'Group',
-						items: self.selectedItems.map(item => item.__data__)
+						items: samples
 					}
 					self.addGroup(group)
 					const tw = getSamplelstTW([group])
 					self.addToFilter(tw)
+				})
+
+			menuDiv
+				.append('div')
+				.attr('class', 'sja_menuoption sja_sharp_border')
+				.text('Show samples')
+				.on('click', async event => {
+					self.app.dispatch({
+						type: 'plot_create',
+						id: getId(),
+						config: {
+							chartType: 'sampleGroupView',
+							samples
+						}
+					})
+					self.dom.tip.hide()
 				})
 		}
 

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -539,24 +539,24 @@ export function setRenderers(self) {
 					const tw = getSamplelstTW([group])
 					self.addToFilter(tw)
 				})
-
-			menuDiv
-				.append('div')
-				.attr('class', 'sja_menuoption sja_sharp_border')
-				.text('Show samples')
-				.on('click', async event => {
-					const groupSamples = []
-					for (const sample of samples) groupSamples.push({ sampleId: sample.sampleId, sampleName: sample.sample })
-					self.app.dispatch({
-						type: 'plot_create',
-						id: getId(),
-						config: {
-							chartType: 'sampleGroupView',
-							samples: groupSamples
-						}
+			if ('sample' in samples[0])
+				menuDiv
+					.append('div')
+					.attr('class', 'sja_menuoption sja_sharp_border')
+					.text('Show samples')
+					.on('click', async event => {
+						const groupSamples = []
+						for (const sample of samples) groupSamples.push({ sampleId: sample.sampleId, sampleName: sample.sample })
+						self.app.dispatch({
+							type: 'plot_create',
+							id: getId(),
+							config: {
+								chartType: 'sampleGroupView',
+								samples: groupSamples
+							}
+						})
+						self.dom.tip.hide()
 					})
-					self.dom.tip.hide()
-				})
 		}
 
 		if (self.lassoOn) {

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -545,12 +545,14 @@ export function setRenderers(self) {
 				.attr('class', 'sja_menuoption sja_sharp_border')
 				.text('Show samples')
 				.on('click', async event => {
+					const groupSamples = []
+					for (const sample of samples) groupSamples.push({ sampleId: sample.sampleId, sampleName: sample.sample })
 					self.app.dispatch({
 						type: 'plot_create',
 						id: getId(),
 						config: {
 							chartType: 'sampleGroupView',
-							samples
+							samples: groupSamples
 						}
 					})
 					self.dom.tip.hide()

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -59,7 +59,7 @@ class SampleView extends MassDict {
 
 		if (showContent) {
 			this.dom.treeDiv
-				.style('min-width', '550px')
+				.style('min-width', '700px')
 				.style('overflow', 'scroll')
 				.attr('class', 'sjpp_hide_scrollbar')
 				.style('border-right', '1px solid gray')

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -90,8 +90,7 @@ class SampleView extends MassDict {
 	async main() {
 		if (this.mayRequireToken()) return
 		super.main()
-		if (this.dom.header)
-			this.dom.header.html(this.state.sample ? `${this.state.sample.sampleName} Sample View` : 'Dictionary')
+		if (this.dom.header) this.dom.header.html(`Sample View`)
 
 		if (this.state.showContent) {
 			const sample = { sample_id: this.sample.sampleName }

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -58,19 +58,13 @@ class SampleView extends MassDict {
 			appState.termdbConfig.queries?.singleSampleMutation
 
 		if (showContent) {
-			this.dom.treeDiv
-				.style('min-width', '700px')
-				.style('overflow', 'scroll')
-				.attr('class', 'sjpp_hide_scrollbar')
-				.style('border-right', '1px solid gray')
-
 			this.dom.contentDiv
 				//.style('width', '60%')
 				.style('min-height', '500px')
 				.style('flex-direction', 'column')
 				.style('justify-content', 'center')
 				.style('align-items', 'start')
-				.style('border-left', '1px solid gray')
+			//.style('border-left', '1px solid gray')
 		}
 	}
 

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -78,6 +78,7 @@ class SampleView extends MassDict {
 		let state = super.getState(appState)
 		const config = appState.plots?.find(p => p.id === this.id)
 		state.sample = config?.sample || this.sample
+		state.samples = [state.sample] //for the tree
 		state.singleSampleGenomeQuantification = state.termdbConfig.queries?.singleSampleGenomeQuantification
 		state.singleSampleMutation = state.termdbConfig.queries?.singleSampleMutation
 		state.hasVerifiedToken = this.app.vocabApi.hasVerifiedToken()

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -45,7 +45,6 @@ class TdbApp {
 			submitDiv,
 			submitBtn,
 			topbar,
-			headerDiv: topbar.append('div').style('display', 'inline-block').style('margin-left', '12px'),
 			searchDiv: topbar.append('div').style('display', 'inline-block'),
 			filterDiv: topbar.append('div').style('display', 'none'),
 			errdiv: opts.holder.append('div'),

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -224,7 +224,6 @@ class TdbTree {
 		for (const term of terms) term_ids.push(term.id)
 		for (const sample of this.state.samples) {
 			const data = await this.app.vocabApi.getSingleSampleData({ sampleId: sample.sampleId, term_ids })
-			console.log(data)
 			if ('error' in data) throw data.error
 			for (const id in data) this.sampleDataByTermId[sample.sampleId][id] = data[id]
 		}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -385,6 +385,7 @@ function setRenderers(self) {
 
 		const isSelected = self.state.selectedTerms.find(t => t.name === term.name && t.type === term.type)
 		let text = term.name
+		if (self.state.samples && text.length > 50) text = text.slice(0, 50) + '...'
 
 		const labeldiv = div
 			.insert('div')
@@ -395,12 +396,11 @@ function setRenderers(self) {
 			.text(text)
 
 		if (self.state.samples) {
-			labeldiv.style('min-width', '400px')
 			const valuesDiv = div
 				.insert('div')
 				.attr('id', term.id)
 				.style('display', 'inline-block')
-				.style('vertical-align', 'bottom')
+				.style('vertical-align', 'top')
 				.style('padding', 0)
 			self.addTermValueDiv(valuesDiv, term)
 		}
@@ -468,18 +468,17 @@ function setRenderers(self) {
 	self.addTermValueDiv = function (div, term) {
 		if (!term.isleaf && self.samplesAdded) return
 		self.samplesAdded = true
-		let values = term.isleaf ? self.getTermValues(term) : self.state.samples.map(s => s.sampleName)
+		let values = term.isleaf ? self.getTermValues(term) : self.state.samples.map(s => `<b>${s.sampleName}</b>`)
+		let i = 1
 		for (const value of values) {
 			div
 				.insert('div')
-				.style('display', 'inline-block')
-				.style('float', 'right')
-
-				.style('padding', '5px')
+				.style('position', 'absolute')
+				.style('left', 300 + 300 * i + 'px')
+				.style('padding-bottom', '30px')
 				.style('color', 'gray')
-				.style('width', '200px')
-				.style('text-align', 'right')
 				.html(value)
+			i++
 		}
 	}
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -125,12 +125,7 @@ class TdbTree {
 		this.sampleDataByTermId = {}
 		this.dom.header.selectAll('*').remove()
 		if (this.state.samples) {
-			this.dom.samplesTable.selectAll('thead').remove()
-			const thead = this.dom.samplesTable.append('thead').style('text-align', 'right').style('color', 'gray')
-
-			for (const [i, sample] of Object.entries(this.state.samples)) {
-				this.sampleDataByTermId[sample.sampleId] = {}
-			}
+			for (const sample of this.state.samples) this.sampleDataByTermId[sample.sampleId] = {}
 		}
 		if (!this.state.isVisible) {
 			this.dom.holder.style('display', 'none')
@@ -511,18 +506,6 @@ function setRenderers(self) {
 		if (!term.isleaf) {
 			div.append('div').attr('class', cls_termchilddiv).style('padding-left', childterm_indent)
 		}
-	}
-
-	self.getInsertBeforeId = function (term) {
-		const parentId = self.getId(term.parent)
-		const trs = self.dom.samplesTable.selectAll('tr').nodes()
-		const index = trs.findIndex(tr => tr.getAttribute('id') == parentId)
-		const index2 = term.parent.terms.findIndex(t => t.id == term.id)
-
-		if (index == -1 || index2 == -1) return null
-		const id = trs[index + index2 + 1]?.getAttribute('id')
-		if (id) return id
-		return null
 	}
 }
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -76,8 +76,10 @@ class TdbTree {
 	async init(appState) {
 		const holder = this.opts.holder.append('div')
 		if (appState.samples) for (const sample of appState.samples) this.sampleDataByTermId[sample.sampleId] = {}
+		const header = holder.insert('div')
 		this.dom = {
-			holder
+			holder,
+			header
 		}
 	}
 
@@ -115,6 +117,21 @@ class TdbTree {
 	}
 
 	async main() {
+		this.sampleDataByTermId = {}
+		this.dom.header.selectAll('*').remove()
+		for (const [i, sample] of Object.entries(this.state.samples)) {
+			this.dom.header
+				.insert('div')
+				.style('position', 'absolute')
+				.style('left', 450 + 300 * i + 'px')
+				.style('color', 'gray')
+				.style('width', '280px')
+				.style('background-color', '#fafafa')
+				.style('text-align', 'right')
+				.style('top', '0px')
+				.html(sample.sampleName)
+			this.sampleDataByTermId[sample.sampleId] = {}
+		}
 		if (!this.state.isVisible) {
 			this.dom.holder.style('display', 'none')
 			return
@@ -475,12 +492,13 @@ function setRenderers(self) {
 			const valueDiv = div
 				.insert('div')
 				.style('position', 'absolute')
-				.style('left', 300 + 300 * i + 'px')
+				.style('left', 150 + 300 * i + 'px')
 				.style('color', 'gray')
 				.style('width', '280px')
 				.style('background-color', '#fafafa')
+				.style('z-index', 0)
+				.style('text-align', 'right')
 				.html(value)
-			if (!self.isExpanded) valueDiv.style('top', '0px')
 			i++
 		}
 		self.isExpanded = true

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -242,7 +242,7 @@ function setRenderers(self) {
 	self.renderBranch = (term, div, button) => {
 		if (!term || !term.terms) return
 
-		if (term.terms.length >= minTermCount2scroll) {
+		if (term.terms.length >= minTermCount2scroll && !self.state.samples) {
 			// too many children. scroll
 			if (div.classed('sjpp_hide_scrollbar')) {
 				// already scrolling. the style has been applied from a previous click. do not reset
@@ -334,7 +334,7 @@ function setRenderers(self) {
 		const isExpanded = self.state.expandedTermIds.includes(term.id)
 		div.select('.' + cls_termbtn).text(isExpanded ? '-' : '+')
 		if (self.state.samples && term.isleaf) {
-			const valueDiv = div.select(`#${term.id}`)
+			const valueDiv = div.select(`#${term.id.replace(/[^a-zA-Z0-9]/g, '')}`)
 			valueDiv.selectAll('*').remove()
 			self.addTermValueDiv(valueDiv, term)
 		}
@@ -398,7 +398,7 @@ function setRenderers(self) {
 		if (self.state.samples) {
 			const valuesDiv = div
 				.insert('div')
-				.attr('id', term.id)
+				.attr('id', term.id.replace(/[^a-zA-Z0-9]/g, ''))
 				.style('display', 'inline-block')
 				.style('vertical-align', 'top')
 				.style('padding', 0)
@@ -466,20 +466,24 @@ function setRenderers(self) {
 	}
 
 	self.addTermValueDiv = function (div, term) {
-		if (!term.isleaf && self.samplesAdded) return
-		self.samplesAdded = true
-		let values = term.isleaf ? self.getTermValues(term) : self.state.samples.map(s => `<b>${s.sampleName}</b>`)
+		let values = term.isleaf
+			? self.getTermValues(term)
+			: self.state.samples.map(s => `<b>${!self.isExpanded ? s.sampleName : '&nbsp;'}</b>`)
+
 		let i = 1
 		for (const value of values) {
-			div
+			const valueDiv = div
 				.insert('div')
 				.style('position', 'absolute')
 				.style('left', 300 + 300 * i + 'px')
-				.style('padding-bottom', '30px')
 				.style('color', 'gray')
+				.style('width', '280px')
+				.style('background-color', '#fafafa')
 				.html(value)
+			if (!self.isExpanded) valueDiv.style('top', '0px')
 			i++
 		}
+		self.isExpanded = true
 	}
 
 	self.getTermValues = function (term) {

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -79,7 +79,8 @@ class TdbTree {
 		const mainDiv = this.opts.holder.append('div')
 		const left = mainDiv.insert('div').style('display', 'inline-block')
 		const right = mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
-		const samplesTable = right.append('table').style('position', `relative`).style('top', `-25px`)
+		const samplesTable = right.append('table').style('position', `relative`).style('top', `-26px`)
+
 		this.dom = {
 			holder: left.insert('div'),
 			header,
@@ -389,13 +390,14 @@ function setRenderers(self) {
 			.attr('class', cls_termdiv)
 			.style('margin', term.isleaf ? '' : '2px')
 			.style('padding', '0px 5px')
+		if (self.state.samples) div.style('margin', '0px').style('background-color', '#fafafa')
 
 		if (uses.has('branch')) {
 			div
 				.insert('div')
 				.attr('class', 'sja_menuoption ' + cls_termbtn)
 				.style('display', 'inline-block')
-				.style('padding', '4px 9px')
+				.style('padding', '5px 9px')
 				.style('font-family', 'courier')
 				.text('+')
 
@@ -415,6 +417,7 @@ function setRenderers(self) {
 			.attr('class', cls_termlabel)
 			.style('display', 'inline-block')
 			.style('padding', '5px')
+			.style('margin', '1.4px')
 			.style('opacity', termIsDisabled ? 0.4 : null)
 			.text(text)
 
@@ -435,7 +438,7 @@ function setRenderers(self) {
 				labeldiv
 					.attr('class', 'sja_tree_click_term_disabled ' + cls_termlabel)
 					.style('padding', '5px 8px')
-					.style('margin', '1px 0px')
+					.style('margin', '2px 0px')
 					.style('opacity', 0.4)
 			} else if (uses.has('plot') && !self.state.samples) {
 				labeldiv
@@ -443,7 +446,7 @@ function setRenderers(self) {
 					.style('color', 'black')
 					.style('padding', '5px 8px')
 					.style('border-radius', '6px')
-					.style('margin', '1px 0px')
+					.style('margin', '2px 0px')
 					.style('cursor', 'default')
 					.on('click', () => self.clickTerm(term))
 					.attr('class', 'ts_pill sja_filter_tag_btn sja_tree_click_term ' + cls_termlabel)
@@ -505,7 +508,8 @@ function setRenderers(self) {
 			let i = 1
 			for (const value of values) {
 				tr.append('td')
-					.style('padding', '5px 4px 4px 4px')
+					.style('padding', '5px')
+					.style('border', '1px solid white')
 					.style('color', 'gray')
 					.style('background-color', '#fafafa')
 					.style('text-align', 'right')
@@ -516,6 +520,7 @@ function setRenderers(self) {
 			tr.append('td')
 				.attr('colspan', self.state.samples.length)
 				.style('padding', '5px')
+				.style('border', '1px solid white')
 				.style('background-color', '#fafafa')
 				.html('&nbsp;')
 	}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -337,8 +337,25 @@ function setRenderers(self) {
 
 	self.renderSampleTable = function () {
 		const openBranches = [self.state.samples]
+		const closedBranches = []
 		this.dom.holder.selectAll('.termdiv').each(function (d) {
-			if (select(this).style('display') != 'none') openBranches.push(d)
+			if (select(this).style('display') == 'none') {
+				closedBranches.push(this)
+			} else {
+				const childdivs = this.querySelectorAll('.termchilddiv')
+				for (const div of childdivs) {
+					if (div.style.display == 'none') closedBranches.push(div)
+				}
+				let hasClosedAncestor = false
+				for (const closed of closedBranches) {
+					if (closed.contains(this)) {
+						hasClosedAncestor = true
+						closedBranches.push(this)
+						break
+					}
+				}
+				if (!hasClosedAncestor) openBranches.push(d)
+			}
 			select(this).style('background-color', '#fafafa')
 		})
 		const trs = this.dom.samplesTable

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -338,10 +338,20 @@ function setRenderers(self) {
 		const expand = term.id in self.termsById && self.state.expandedTermIds.includes(term.id)
 		if (!expand) select(this).style('display', 'none')
 		if (self.state.samples) {
-			const id = term.id.replace(/[^a-zA-Z]/g, '')
-			const tr = self.dom.samplesTable.select(`#${id}`)
+			const tr = self.getRow(term)
 			tr.style('display', self.state.expandedTermIds.includes(term.parent.id) ? '' : 'none')
 		}
+	}
+
+	self.getRow = function (term) {
+		const id = self.getId(term)
+		const tr = self.dom.samplesTable.select(`#${id}`)
+		return tr
+	}
+
+	self.getId = function (term) {
+		const id = 'id_' + term.id.replace(/[^A-Za-z0-9]/g, '')
+		return id
 	}
 
 	self.updateTerm = function (term) {
@@ -357,8 +367,7 @@ function setRenderers(self) {
 		const isExpanded = self.state.expandedTermIds.includes(term.id)
 		div.select('.' + cls_termbtn).text(isExpanded ? '-' : '+')
 		if (self.state.samples) {
-			const id = term.id.replace(/[^a-zA-Z]/g, '')
-			const tr = self.dom.samplesTable.select(`#${id}`)
+			const tr = self.getRow(term)
 			if (term.isleaf) {
 				tr.selectAll('*').remove()
 				self.addTermValues(tr, term)
@@ -423,9 +432,9 @@ function setRenderers(self) {
 
 		if (self.state.samples) {
 			let tr
-			const id = self.getInsertBeforeId(term)
-			if (id) tr = self.dom.samplesTable.insert('tr', `#${id}`).attr('id', term.id.replace(/[^a-zA-Z]/g, ''))
-			else tr = self.dom.samplesTable.append('tr').attr('id', term.id.replace(/[^a-zA-Z]/g, ''))
+			const beforeId = self.getInsertBeforeId(term)
+			if (beforeId) tr = self.dom.samplesTable.insert('tr', `#${beforeId}`).attr('id', self.getId(term))
+			else tr = self.dom.samplesTable.append('tr').attr('id', self.getId(term))
 
 			self.addTermValues(tr, term)
 		}
@@ -491,7 +500,7 @@ function setRenderers(self) {
 	}
 
 	self.getInsertBeforeId = function (term) {
-		const parentId = term.parent.id.replace(/[^a-zA-Z]/g, '')
+		const parentId = self.getId(term.parent)
 		const trs = self.dom.samplesTable.selectAll('tr').nodes()
 		const index = trs.findIndex(tr => tr.getAttribute('id') == parentId)
 		const index2 = term.parent.terms.findIndex(t => t.id == term.id)
@@ -513,7 +522,7 @@ function setRenderers(self) {
 					.style('color', 'gray')
 					.style('background-color', '#fafafa')
 					.style('text-align', 'right')
-					.html(value)
+					.html(value == '' ? '&nbsp;' : value)
 				i++
 			}
 		} else

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -79,7 +79,7 @@ class TdbTree {
 		const mainDiv = this.opts.holder.append('div')
 		const left = mainDiv.insert('div').style('display', 'inline-block').style('min-width', '300px')
 		const right = mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
-		const samplesTable = right.append('table').style('position', `relative`).style('top', `-26px`)
+		const samplesTable = right.append('table').style('position', `relative`).style('top', `-32px`)
 
 		this.dom = {
 			holder: left.insert('div'),
@@ -344,6 +344,7 @@ function setRenderers(self) {
 		const openBranches = [self.state.samples]
 		this.dom.holder.selectAll('.termdiv').each(function (d) {
 			if (select(this).style('display') != 'none') openBranches.push(d)
+			select(this).style('background-color', '#fafafa')
 		})
 		const trs = this.dom.samplesTable
 			.style('display', openBranches.length ? 'inline-block' : 'none')
@@ -365,8 +366,12 @@ function setRenderers(self) {
 			.enter()
 			.append('td')
 			.style('height', `${height}px`)
+			.style('color', 'gray')
+			.style('background-color', '#fafafa')
 			.style('padding', '0 16px')
 			.style('text-align', 'end')
+			.style('border', '1px solid white')
+
 			.each(self.renderTd)
 	}
 
@@ -518,38 +523,6 @@ function setRenderers(self) {
 		const id = trs[index + index2 + 1]?.getAttribute('id')
 		if (id) return id
 		return null
-	}
-
-	self.addTermValues = async function (tr, term) {
-		if (term.isleaf) {
-			let values = self.getTermValues(term)
-			let i = 1
-			for (const value of values) {
-				tr.append('td')
-					.style('padding', '5px')
-					.style('border', '1px solid white')
-					.style('color', 'gray')
-					.style('background-color', '#fafafa')
-					.style('text-align', 'right')
-					.html(value == '' ? '&nbsp;' : value)
-				i++
-			}
-		} else
-			tr.append('td')
-				.attr('colspan', self.state.samples.length)
-				.style('padding', '5px')
-				.style('border', '1px solid white')
-				.style('background-color', '#fafafa')
-				.html('&nbsp;')
-	}
-
-	self.getTermValues = function (term) {
-		let values = []
-		for (const sample of self.state.samples) {
-			const value = getTermValue(term, self.sampleDataByTermId[sample.sampleId]) || 'Missing'
-			values.push(value)
-		}
-		return values
 	}
 }
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -76,10 +76,8 @@ class TdbTree {
 	async init(opts) {
 		const holder = this.opts.holder.append('div')
 
-		const loadingDiv = this.opts.headerDiv.append('div').style('display', 'inline-block').style('margin-left', '10px')
 		this.dom = {
-			holder,
-			loadingDiv
+			holder
 		}
 	}
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -146,7 +146,7 @@ class TdbTree {
 		root.terms = await this.requestTermRecursive(root)
 		this.dom.holder.style('display', 'block')
 		this.renderBranch(root, this.dom.holder)
-		this.renderSampleTable()
+		if (this.state.samples) this.renderSampleTable()
 	}
 
 	getTermsById() {
@@ -356,7 +356,6 @@ function setRenderers(self) {
 				}
 				if (!hasClosedAncestor) openBranches.push(d)
 			}
-			select(this).style('background-color', '#fafafa')
 		})
 		const trs = this.dom.samplesTable
 			.style('display', openBranches.length ? 'inline-block' : 'none')
@@ -379,7 +378,6 @@ function setRenderers(self) {
 			.append('td')
 			.style('height', `${height}px`)
 			.style('color', 'gray')
-			.style('background-color', '#fafafa')
 			.style('padding', '0 16px')
 			.style('text-align', 'end')
 			.style('border', '1px solid white')

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -466,7 +466,6 @@ function setRenderers(self) {
 
 export function getTermValue(term, data) {
 	let value = data[term.id]?.value
-
 	if (value == null) return null
 	if (term.type == 'float' || term.type == 'integer')
 		return value % 1 == 0 ? value.toString() : value.toFixed(2).toString()
@@ -480,7 +479,7 @@ export function getTermValue(term, data) {
 	if (term.type == 'survival') {
 		const values = value.split(' ')
 		let [years, status] = values
-		status = term.values[status].label || term.values[status].key
+		status = term.values?.[status]?.label || term.values?.[status]?.key || status
 		return `${status} after ${Number(years).toFixed(1)} years`
 	}
 	return null

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -335,63 +335,6 @@ function setRenderers(self) {
 		select(this).style('display', 'none')
 	}
 
-	self.renderSampleTable = function () {
-		const openBranches = [self.state.samples]
-		const closedBranches = []
-		this.dom.holder.selectAll('.termdiv').each(function (d) {
-			if (select(this).style('display') == 'none') {
-				closedBranches.push(this)
-			} else {
-				const childdivs = this.querySelectorAll('.termchilddiv')
-				for (const div of childdivs) {
-					if (div.style.display == 'none') closedBranches.push(div)
-				}
-				let hasClosedAncestor = false
-				for (const closed of closedBranches) {
-					if (closed.contains(this)) {
-						hasClosedAncestor = true
-						closedBranches.push(this)
-						break
-					}
-				}
-				if (!hasClosedAncestor) openBranches.push(d)
-			}
-		})
-		const trs = this.dom.samplesTable
-			.style('display', openBranches.length ? 'inline-block' : 'none')
-			.selectAll('tr')
-			.data(openBranches)
-		trs.exit().remove()
-		trs.each(self.renderTr)
-		trs.enter().append('tr').each(self.renderTr)
-	}
-
-	self.renderTr = function (branchData, trIndex) {
-		const tds = select(this)
-			.selectAll('td')
-			.data(self.state.samples.map(sample => ({ sample, branchData, trIndex })))
-		tds.exit().remove()
-		tds.each(self.renderTd)
-		const height = self.dom.holder.select('.termlabel').node().getBoundingClientRect().height //; console.log(495, height)
-		tds
-			.enter()
-			.append('td')
-			.style('height', `${height}px`)
-			.style('color', 'gray')
-			.style('padding', '0 16px')
-			.style('text-align', 'end')
-			.style('border', '1px solid white')
-
-			.each(self.renderTd)
-	}
-
-	self.renderTd = function (d, i) {
-		const sampleId = Number(d.sample.sampleId)
-		const data = self.sampleDataByTermId[sampleId]
-		const term = d.branchData
-		select(this).html(d.trIndex === 0 ? d.sample.sampleName : getTermValue(term, data))
-	}
-
 	self.updateTerm = function (term) {
 		const div = select(this)
 		if (!(term.id in self.termsById)) {
@@ -521,6 +464,63 @@ function setRenderers(self) {
 		if (!term.isleaf) {
 			div.append('div').attr('class', cls_termchilddiv).style('padding-left', childterm_indent)
 		}
+	}
+
+	self.renderSampleTable = function () {
+		const openBranches = [self.state.samples]
+		const closedBranches = []
+		this.dom.holder.selectAll('.termdiv').each(function (d) {
+			if (select(this).style('display') == 'none') {
+				closedBranches.push(this)
+			} else {
+				const childdivs = this.querySelectorAll('.termchilddiv')
+				for (const div of childdivs) {
+					if (div.style.display == 'none') closedBranches.push(div)
+				}
+				let hasClosedAncestor = false
+				for (const closed of closedBranches) {
+					if (closed.contains(this)) {
+						hasClosedAncestor = true
+						closedBranches.push(this)
+						break
+					}
+				}
+				if (!hasClosedAncestor) openBranches.push(d)
+			}
+		})
+		const trs = this.dom.samplesTable
+			.style('display', openBranches.length ? 'inline-block' : 'none')
+			.selectAll('tr')
+			.data(openBranches)
+		trs.exit().remove()
+		trs.each(self.renderTr)
+		trs.enter().append('tr').each(self.renderTr)
+	}
+
+	self.renderTr = function (branchData, trIndex) {
+		const tds = select(this)
+			.selectAll('td')
+			.data(self.state.samples.map(sample => ({ sample, branchData, trIndex })))
+		tds.exit().remove()
+		tds.each(self.renderTd)
+		const height = self.dom.holder.select('.termlabel').node().getBoundingClientRect().height //; console.log(495, height)
+		tds
+			.enter()
+			.append('td')
+			.style('height', `${height}px`)
+			.style('color', 'gray')
+			.style('padding', '0 16px')
+			.style('text-align', 'end')
+			.style('border', '1px solid white')
+
+			.each(self.renderTd)
+	}
+
+	self.renderTd = function (d, i) {
+		const sampleId = Number(d.sample.sampleId)
+		const data = self.sampleDataByTermId[sampleId]
+		const term = d.branchData
+		select(this).html(d.trIndex === 0 ? d.sample.sampleName : getTermValue(term, data))
 	}
 }
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -340,7 +340,7 @@ function setRenderers(self) {
 		if (!expand) select(this).style('display', 'none')
 		if (self.state.samples) {
 			const tr = self.getRow(term)
-			tr.style('display', self.state.expandedTermIds.includes(term.parent.id) ? '' : 'none')
+			tr.style('display', expand ? '' : 'none')
 		}
 	}
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -283,7 +283,6 @@ function setRenderers(self) {
 		if (self.state.usecase) {
 			for (const t of term.terms) {
 				if (isUsableTerm(t, self.state.usecase).size) {
-					t.parent = term
 					self.included_terms.push(t)
 				}
 			}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -483,9 +483,8 @@ function setRenderers(self) {
 	}
 
 	self.addTermValueDiv = function (div, term) {
-		let values = term.isleaf
-			? self.getTermValues(term)
-			: self.state.samples.map(s => `<b>${!self.isExpanded ? s.sampleName : '&nbsp;'}</b>`)
+		if (!term.isleaf) return
+		let values = self.getTermValues(term)
 
 		let i = 1
 		for (const value of values) {

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -77,7 +77,7 @@ class TdbTree {
 		const header = this.opts.holder.append('div')
 		if (appState.samples) for (const sample of appState.samples) this.sampleDataByTermId[sample.sampleId] = {}
 		const mainDiv = this.opts.holder.append('div')
-		const left = mainDiv.insert('div').style('display', 'inline-block')
+		const left = mainDiv.insert('div').style('display', 'inline-block').style('min-width', '300px')
 		const right = mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
 		const samplesTable = right.append('table').style('position', `relative`).style('top', `-26px`)
 
@@ -224,6 +224,8 @@ class TdbTree {
 		for (const term of terms) term_ids.push(term.id)
 		for (const sample of this.state.samples) {
 			const data = await this.app.vocabApi.getSingleSampleData({ sampleId: sample.sampleId, term_ids })
+			console.log(data)
+			if ('error' in data) throw data.error
 			for (const id in data) this.sampleDataByTermId[sample.sampleId][id] = data[id]
 		}
 	}

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -84,7 +84,7 @@ export function handle_request_closure(genomes) {
 			if (q.for == 'validateToken') {
 			}
 			if (q.for == 'convertSampleId') return get_convertSampleId(q, res, tdb)
-			if (q.for == 'singleSampleData') return get_singleSampleData(q, res, tdb)
+			if (q.for == 'singleSampleData') return get_singleSampleData(q, req, res, ds, tdb)
 			if (q.for == 'getAllSamples') return get_AllSamples(q, req, res, ds)
 			if (q.for == 'DEanalysis') return await get_DEanalysis(q, res, ds)
 
@@ -604,8 +604,18 @@ async function get_matrix(q, req, res, ds, genome) {
 	res.send(data)
 }
 
-async function get_singleSampleData(q, res, tdb) {
-	res.send(tdb.q.getSingleSampleData(q.sampleId, q.term_ids))
+async function get_singleSampleData(q, req, res, ds, tdb) {
+	const canDisplay = authApi.canDisplaySampleIds(req, ds)
+	let result = []
+	if (canDisplay) {
+		try {
+			result = tdb.q.getSingleSampleData(q.sampleId, q.term_ids)
+			console.log(result)
+			res.send(result)
+		} catch (e) {
+			res.send({ error: e.message || e })
+		}
+	} else res.send({ error: 'Requires sign in to access the sample data' })
 }
 
 async function get_AllSamples(q, req, res, ds) {

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -610,7 +610,6 @@ async function get_singleSampleData(q, req, res, ds, tdb) {
 	if (canDisplay) {
 		try {
 			result = tdb.q.getSingleSampleData(q.sampleId, q.term_ids)
-			console.log(result)
 			res.send(result)
 		} catch (e) {
 			res.send({ error: e.message || e })

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -428,6 +428,7 @@ export function server_init_db_queries(ds) {
 				if (!cred || cred.embedders?.[embedder]) {
 					supportedChartTypes[r.cohort].add('dataDownload')
 					supportedChartTypes[r.cohort].add('sampleView')
+					supportedChartTypes[r.cohort].add('sampleGroupView')
 				}
 			}
 			if (serverconfig.features?.draftChartTypes) {


### PR DESCRIPTION
## Description

To test it please open a scatter plot, select a few samples and click on `Show samples`. A samples table is now dynamically built and autoaligned. I display on top the samples selected instead of all the samples as I think it may be of use( selecting samples allows the user to focus on specific samples). I discussed with @siosonel details about the implementation. 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
