### PR TITLE
feat: Default bin configs for GDC numeric variables are determined on…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Default bin configs for GDC numeric variables are determined on the fly and no longer hardcoded


### PR DESCRIPTION
… the fly and no longer hardcoded

## Description

[please test here](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22case.disease_type%22}]}],%22divideBy%22:{%22id%22:%22case.demographic.gender%22}}]}) by adding some numeric terms e.g. Age and Year. default bin config divides to 5 bins by the size of (max-min)/5

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
