### PR TITLE
Display average admix coefficient for filter-vs-population comp…

### DIFF
--- a/client/plots/genomeBrowser.js
+++ b/client/plots/genomeBrowser.js
@@ -40,9 +40,9 @@ this{}
 					groupTypes[]
 					groups:[]
 						// each element is a group object
-						{type=info, infoKey=str}
-						{type=filter, filter={}}
-						{type=population, key, label, ..}
+						{type='info', infoKey=str}
+						{type='filter', filter={}}
+						{type='population', key, label, ..}
 					groupTestMethod{}
 					groupTestMethodsIdx
 				populations [{key,label}] // might not be part of state
@@ -162,7 +162,10 @@ class genomeBrowser {
 			t2.custom_variants = data.mlst
 
 			// details.groups[] may have changed. update label and tooltip callback etc, of tk numeric axis view mode object
-			furbishViewModeWithSnvindelComputeDetails(this, t2.skewer.viewModes.find(i => i.type == 'numeric'))
+			furbishViewModeWithSnvindelComputeDetails(
+				this,
+				t2.skewer.viewModes.find(i => i.type == 'numeric')
+			)
 
 			t2.load()
 			return
@@ -199,7 +202,8 @@ class genomeBrowser {
 						{
 							id: this.components.gbControls.id,
 							_partialData: {
-								groupSampleCounts: [data.totalSampleCount_group1, data.totalSampleCount_group2]
+								groupSampleCounts: [data.totalSampleCount_group1, data.totalSampleCount_group2],
+								pop2average: data.pop2average
 							}
 						}
 					]

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Display average admix coefficient for filter-vs-population comparison in genome browser


### PR DESCRIPTION
…arison in genome browser

## Description

this info is now indicated on the group selector ui, as it was done when it was initially prototyped back then
all genomeBrowser tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
