### PR TITLE
mds3 variant2samples.get() returns an object to wrap the optiona…

### DIFF
--- a/client/mds3/clickVariant.js
+++ b/client/mds3/clickVariant.js
@@ -66,7 +66,7 @@ async function click2sunburst(d, tk, block, tippos) {
 	})
 	tk.glider.style('cursor', 'auto')
 	const arg = {
-		nodes: data,
+		nodes: data.nodes,
 		occurrence: d.occurrence,
 		boxyoff: tk.yoff,
 		boxheight: tk.height,

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -150,10 +150,10 @@ async function mayShowSummary(tk, block) {
 	const wait = div.append('div').text('Loading...')
 
 	try {
-		const data = await tk.mds.getSamples({ isSummary: true })
-		tk.leftlabels.__samples_data = data // for testing
+		const { summary } = await tk.mds.getSamples({ isSummary: true })
+		tk.leftlabels.__samples_data = summary // for testing
 		wait.remove()
-		await showSummary4terms(data, div.append('div').attr('class', 'sja_mds3samplesummarydiv'), tk, block)
+		await showSummary4terms(summary, div.append('div').attr('class', 'sja_mds3samplesummarydiv'), tk, block)
 	} catch (e) {
 		wait.text(`Error: ${e.message || e}`)
 		if (e.stack) console.log(e.stack)
@@ -351,7 +351,7 @@ function menu_listSamples(buttonrow, data, tk, block) {
 			tk.menutip.clear()
 			const wait = tk.menutip.d.append('div').text('Loading...').style('margin', '15px')
 			try {
-				const samples = await tk.mds.getSamples()
+				const { samples } = await tk.mds.getSamples()
 				await displaySampleTable(samples, {
 					div: tk.menutip.d,
 					tk,

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -453,7 +453,7 @@ function mayaddGetter_variant2samples(tk, block) {
 						samples.push(s2)
 					}
 				}
-				return samples
+				return { samples }
 			}
 			if (arg.querytype == tk.mds.variant2samples.type_summary) {
 				throw 'todo: summary'
@@ -478,7 +478,7 @@ function mayaddGetter_variant2samples(tk, block) {
 					}
 				}
 			}
-			return [...id2sample.values()]
+			return { samples: [...id2sample.values()] }
 		}
 		return
 	}
@@ -570,8 +570,18 @@ function mayaddGetter_variant2samples(tk, block) {
 
 		const data = await dofetch3('mds3', { body: par, headers }, { serverData: tk.cache })
 		if (data.error) throw data.error
-		if (!data.variant2samples) throw 'result error'
-		return data.variant2samples
+		const r = data.variant2samples
+		if (!r) throw 'result error'
+		if (arg.querytype == tk.mds.variant2samples.type_sunburst) {
+			if (!Array.isArray(r.nodes)) throw 'nodes[] not array from return'
+		} else if (arg.querytype == tk.mds.variant2samples.type_samples) {
+			if (!Array.isArray(r.samples)) throw 'samples[] not array from return'
+		} else if (arg.querytype == tk.mds.variant2samples.type_summary) {
+			if (!Array.isArray(r.summary)) throw 'summary[] not array from return'
+		} else {
+			throw 'unknown querytype'
+		}
+		return r
 	}
 
 	/*

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -58,8 +58,8 @@ export async function init_sampletable(arg) {
 
 	try {
 		arg.querytype = arg.tk.mds.variant2samples.type_samples
-		const samples = await arg.tk.mds.variant2samples.get(arg) // returns list of samples
-		await displaySampleTable(samples, arg)
+		const out = await arg.tk.mds.variant2samples.get(arg) // returns list of samples
+		await displaySampleTable(out.samples, arg)
 		wait.remove()
 	} catch (e) {
 		wait.text('Error: ' + (e.message || e))

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- mds3 variant2samples.get() returns an object to wrap the optional bin labels

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -47,6 +47,11 @@ Returns:
 		}
 	
 	byTermId:{}
+		<term id>:
+			bins: CTE.bins
+			events: CTE.events
+				these info are not available in term object and is computed during run time, and 
+
 	bySampleId:{}
 		key: stringified integer id
 		value: sample name
@@ -282,6 +287,7 @@ async function mayQueryMutatedSamples(q) {
 
 /*
 using mds3 dataset, that's without server-side sqlite db
+only gdc runs it
 */
 async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 	const q2 = {
@@ -299,12 +305,14 @@ async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 		}
 	}
 
-	const sampleLst = await q.ds.variant2samples.get(q2)
+	const data = await q.ds.variant2samples.get(q2)
 
 	const samples = {}
-	const refs = { byTermId: {} }
+	const refs = {
+		byTermId: data.byTermId
+	}
 
-	for (const s of sampleLst) {
+	for (const s of data.samples) {
 		const s2 = {
 			sample: s.sample_id
 		}


### PR DESCRIPTION
…l bin labels

## Description

 [test by this](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22case.disease_type%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}],%22divideBy%22:{%22id%22:%22case.demographic.gender%22}}]}) Age at diagnosis legend shows correct order of bin labels.
previously gdc query did not return list of bin labels to client. now this is returned same as sql CTE query, so client can refer to this for legend rendering

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
