### PR TITLE
prototype gdc cohort MAF app

### DIFF
--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -67,6 +67,15 @@ upon error, throw err message as a string
 		return
 	}
 
+	if (urlp.has('gdcmaf')) {
+		const _ = await import('./gdc.maf')
+		_.gdcMAFui({
+			holder: arg.holder,
+			debugmode: arg.debugmode
+		})
+		return
+	}
+
 	//////////// to delete
 	if (urlp.has('mdsjsonform')) {
 		const _ = await import('./mdsjsonform')

--- a/client/src/gdc.maf.js
+++ b/client/src/gdc.maf.js
@@ -1,0 +1,68 @@
+import { debounce } from 'debounce'
+import { dofetch3 } from '#common/dofetch'
+import { sayerror } from '#dom/error'
+import { Menu } from '#dom/menu'
+import { renderTable } from '#dom/table'
+
+/*
+generate an aggregated maf file from a cohort
+
+filter0=str
+	optional, stringified json obj as the cohort filter from gdc ATF
+	simply pass to backend to include in api queries
+
+*/
+
+const tip = new Menu({ padding: '' })
+
+const columns = [
+	{ label: 'Case' },
+	{ label: 'Samples' },
+	{ label: 'Experimental Strategy' },
+	{ label: 'Workflow Type' },
+	{ label: 'File Size' }
+]
+export async function gdcMAFui({ holder, filter0, callbackOnRender, debugmode = false }) {
+	// public api obj to be returned
+	const publicApi = {}
+
+	if (typeof callbackOnRender == 'function') {
+		// ?
+		callbackOnRender(publicApi)
+	}
+
+	try {
+		const result = await getFileList(filter0)
+		const rows = []
+		for (const f of result.files) {
+			const row = [
+				{ value: f.case_submitter_id },
+				{ value: f.sample_types },
+				{ value: f.experimental_strategy },
+				{ value: f.workflow_type },
+				{ value: f.file_size }
+			]
+			rows.push(row)
+		}
+		renderTable({
+			rows,
+			columns,
+			div: holder.append('div')
+		})
+	} catch (e) {
+		sayerror(holder, e.message || e)
+		if (e.stack) console.log(e)
+	}
+
+	return publicApi
+}
+
+async function getFileList(filter0) {
+	const body = {
+		genome: 'hg38',
+		dslabel: 'GDC',
+		gdcMaf: 1
+	}
+	if (filter0) body.filter0 = filter0
+	return await dofetch3('mds3', { body })
+}

--- a/server/shared/fileSize.js
+++ b/server/shared/fileSize.js
@@ -1,0 +1,6 @@
+export function fileSize(v) {
+	if (v > 1e9) return (v / 1e9).toFixed(2) + ' GB'
+	if (v > 1e6) return (v / 1e6).toFixed(2) + ' MB'
+	if (v > 1e3) return (v / 1e3).toFixed(2) + ' KB'
+	return v + ' Bytes'
+}

--- a/server/src/bam.gdc.js
+++ b/server/src/bam.gdc.js
@@ -1,5 +1,6 @@
 const got = require('got')
 const path = require('path')
+import { fileSize } from '../shared/fileSize'
 
 /*
 exports one function
@@ -45,6 +46,7 @@ gdc_bam_request
 export async function gdc_bam_request(req, res) {
 	try {
 		if (req.query.gdc_id) {
+			// has user input, test on which id it is and any bam file associated with it
 			const bamdata = await get_gdc_data(
 				req.query.gdc_id,
 				req.query.filter0 // optional gdc cohort filter
@@ -54,6 +56,7 @@ export async function gdc_bam_request(req, res) {
 
 			res.send(bamdata)
 		} else {
+			// no user input, list all available bam files from current cohort
 			const re = await getCaseFiles(req.query.filter0)
 			res.send(re)
 		}
@@ -143,7 +146,7 @@ async function get_gdc_data(gdc_id, filter0) {
 
 		const file = {}
 		file.file_uuid = s.id
-		file.file_size = (Number.parseFloat(s.file_size) / 10e8).toFixed(2) + ' GB'
+		file.file_size = fileSize(s.file_size)
 		file.experimental_strategy = s.experimental_strategy
 		file.entity_id = s.associated_entities[0].entity_submitter_id
 		file.case_id = s.associated_entities[0].case_id


### PR DESCRIPTION
## Description

test at http://localhost:3000/?gdcmaf=1
this ui is a proof of concept to list first 1000 MAFs from current cohort. next we can allow user to filter by assay/caller, and delete some, then press Submit to send the list of ids to backend to aggregate

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
