### PR TITLE
fix: Indicate original value unit in termsetting UI if the term value…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Indicate original value unit in termsetting UI if the term value is converted; safety check on bin size to avoid crashes

--- a/server/shared/types/termdb.ts
+++ b/server/shared/types/termdb.ts
@@ -106,6 +106,14 @@ export type Subconditions = {
 	}
 }
 
+type ValueConversion = {
+	scaleFactor: number
+	fromUnit: string // name of unit for the original value
+	toUnit: string // name of converted unit.
+	// when converting day to year, resulting value will be `X year Y day`, that the fromUnit is used to indicate residue days from the last year; it's also printed in termsetting ui
+	// this logic does not hold if converting from year to day, should detect if scaleFactor is >1 or <1
+}
+
 export type Term = {
 	id?: string
 	type?:
@@ -132,6 +140,7 @@ export type Term = {
 	tvs?: Tvs
 	values?: TermValues
 	unit?: string
+	valueConversion?: ValueConversion
 }
 
 export type DetermineQ<T extends Term['type']> = T extends 'numeric' | 'integer' | 'float'


### PR DESCRIPTION
… is converted; safety check on bin size to avoid crashes

## Description

[test here](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22header_mode%22:%22hidden%22%7D,%22plots%22:%5B%7B%22chartType%22:%22matrix%22,%22settings%22:%7B%22matrix%22:%7B%22numGenes%22:3%7D%7D,%22termgroups%22:%5B%7B%22lst%22:%5B%7B%22term%22:%7B%22name%22:%22MYC%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22name%22:%22HOXA1%22,%22type%22:%22geneVariant%22%7D%7D,{%22id%22:%22case.demographic.year_of_death%22},%7B%22id%22:%22case.diagnoses.age_at_diagnosis%22%7D%5D%7D%5D%7D%5D%7D). Edit Age and this note shows `Note: using values by the unit of day.`
Edit Year and this note does not show.
Declared new attribute in Term type but this is not checked against by termsetting code (e.g. by using wrong value in termdb.gdc.js line 338)

all termsetting tests pass

TODO add new test to termsetting to test this

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
