### PR TITLE
fix: add safety check for first bin stop and last bin start in numeri…

### DIFF
--- a/client/termsetting/handlers/density.ts
+++ b/client/termsetting/handlers/density.ts
@@ -243,7 +243,6 @@ function renderBinLines(self: NumericTermSettingInstance, data: any) {
 			//d.scaledX = Math.round(o.xscale(value))
 			if (d.index === 0) {
 				self.dom.first_stop_input.property('value', value)
-				self.dom.first_stop_input.restyle()
 				const maxX = self.q.last_bin ? lastScaledX : scaledMaxX
 				const diff = d.draggedX - d.scaledX
 				middleLines.each(function (this: Element, c: LineData) {
@@ -258,7 +257,6 @@ function renderBinLines(self: NumericTermSettingInstance, data: any) {
 				self.q.first_bin!.stop = value as number
 			} else {
 				self.dom.last_start_input.property('value', value)
-				self.dom.last_start_input.restyle()
 				self.q.last_bin!.start = value as number
 				middleLines.style('display', (c: any) => (d.draggedX && c.scaledX >= d.draggedX ? 'none' : ''))
 			}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- add safety check for first bin stop and last bin start in numeric discrete termsetting, make the ui actually usable

--- a/server/shared/types/terms/numeric.ts
+++ b/server/shared/types/terms/numeric.ts
@@ -14,32 +14,38 @@ NumericTermSettingInstance
 
 /**
  * .q{} for numeric terms
+ FIXME regular-sized bin and knots (spline) are mixed in this definition and they shouldn't
+ 	e.g. first_bin is only required for regular-sized, and knots[] is only required for the other
  */
 export type NumericQ = BaseQ & {
 	// termType: 'float' | 'integer' -- converts to 'numeric'
 	preferredBins?: 'median' | 'less' | 'default'
+
 	//regular-sized bins
 	bin_size: number
 	startinclusive?: boolean
 	stopinclusive?: boolean
-	first_bin?: {
-		start?: number
-		start_percentile?: number
+
+	// first_bin.stop is always required
+	first_bin: {
 		startunbounded?: boolean
-		stop?: number
-		stop_percentile?: number
+		stop: number
+		//stop_percentile?: number // percentile value is not used right now
 	}
+
+	// if last_bin?.start is set, then fixed last bin is used; otherwise it's not fixed and automatic
 	last_bin?: {
 		start?: number
 		stopunbounded?: boolean
 	}
+
 	modeBinaryCutoffType: 'normal' | 'percentile'
 	modeBinaryCutoffPercentile?: number
-	//density
-	knots: any //[]?
-	//binary
+
+	knots?: any //[]?
+
 	scale?: number //0.1 | 0.01 | 0.001
-	//discrete
+
 	rounding: string
 }
 


### PR DESCRIPTION
…c discrete termsetting, make the ui actually usable

## Description

closes [one issue](https://github.com/stjude/sjpp/issues/129#issuecomment-1716302275) pointed out in sjpp
all tests pass; works for gdc and sjlife

i realized it's not checked against types/terms/numeric.ts due to bundling. we can do additional debugging when the checks are enabled

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
