### PR TITLE
use a type checker plugin to catch typescript errors during bundling

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,8 +13,10 @@
     "#mass/*": "./mass/*.js",
     "#plots/*": "./plots/*",
     "#plotsts/*": "./plots/*.js",
+    "#plots/disco/*": "./plots/disco/*",
     "#rx": "./rx/index.js",
-    "#shared/*": "./shared/*.js",
+    "#shared/*": "@sjcrh/proteinpaint-server/shared/*",
+    "#shared/types/*": "@sjcrh/proteinpaint-server/shared/types/*",
     "#termdb/*": "./termdb/*.js",
     "#termsetting": "./termsetting/termsetting.ts",
     "#termsetting/handlers/*": "./termsetting/handlers/*.ts"

--- a/client/plots/disco/cnv/test/CnvArcsMapperTest.unit.spec.ts
+++ b/client/plots/disco/cnv/test/CnvArcsMapperTest.unit.spec.ts
@@ -1,5 +1,5 @@
 import test from 'tape'
-import discoDefaults from '#plots/disco/defaults'
+import discoDefaults from '#plots/disco/defaults.ts'
 import Reference from '#plots/disco/chromosome/Reference.ts'
 import CnvArcsMapper from '#plots/disco/cnv/CnvArcsMapper.ts'
 import DataMapper from '#plots/disco/data/DataMapper.ts'

--- a/client/plots/disco/label/test/LabelsMapper.unit.spec.ts
+++ b/client/plots/disco/label/test/LabelsMapper.unit.spec.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
 import LabelsMapper from '#plots/disco/label/LabelsMapper.ts'
 import Reference from '#plots/disco/chromosome/Reference.ts'
-import discoDefaults from '#plots/disco/defaults'
+import discoDefaults from '#plots/disco/defaults.ts'
 import DataMapper from '#plots/disco/data/DataMapper.ts'
 
 // Create test data

--- a/client/termsetting/handlers/categorical.ts
+++ b/client/termsetting/handlers/categorical.ts
@@ -11,7 +11,7 @@ import {
 	GroupEntry,
 	CategoricalTermSettingInstance,
 	CategoricalTW
-} from '#shared/types'
+} from '#shared/types/index'
 
 /*
 ********************** EXPORTED

--- a/client/termsetting/handlers/condition.ts
+++ b/client/termsetting/handlers/condition.ts
@@ -2,7 +2,7 @@ import { getPillNameDefault, set_hiddenvalues } from '#termsetting'
 import { make_radios } from '#dom/radiobutton'
 import { copyMerge } from '#rx'
 import { sayerror } from '#dom/error'
-import { PillData, ConditionTW, ConditionQ, VocabApi } from '#shared/types'
+import { PillData, ConditionTW, ConditionQ, VocabApi } from '#shared/types/index'
 
 // grades that can be used for q.breaks, exclude uncomputable ones and 0, thus have to hardcode
 // if needed, can define from termdbConfig

--- a/client/termsetting/handlers/condition.ts
+++ b/client/termsetting/handlers/condition.ts
@@ -424,8 +424,11 @@ export function fillTW(tw: ConditionTW, vocabApi: VocabApi, defaultQ: ConditionQ
 		if (tw.q.mode == 'discrete' || tw.q.mode == 'binary') {
 			// only assign groups to discrete and binary terms
 			// for cuminc and cox terms, groups will be determined in sql query
+
+			// term.values is treated optional so tsc won't complain
+
 			const grades = Object.keys(tw.term.values)
-				.filter(g => (tw.q.mode == 'discrete' ? !tw.term.values[g].uncomputable : g))
+				.filter(g => (tw.q.mode == 'discrete' ? !tw.term.values?.[g].uncomputable : g))
 				.map(Number)
 				.sort((a, b) => a - b)
 

--- a/client/termsetting/handlers/density.ts
+++ b/client/termsetting/handlers/density.ts
@@ -2,7 +2,7 @@ import { select, pointer } from 'd3-selection'
 import { scaleLinear, drag as d3drag } from 'd3'
 import { get_bin_label, get_bin_range_equation } from '#shared/termdb.bins'
 import { makeDensityPlot } from '#filter/densityplot'
-import { BrushEntry, NumberObj, NumericTermSettingInstance } from '#shared/types'
+import { BrushEntry, NumberObj, NumericTermSettingInstance } from '#shared/types/index'
 import { BaseType } from 'd3-selection'
 /*
 ********************** IMPORTED

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -94,11 +94,13 @@ function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 	const exclude = self.q?.exclude?.slice().sort() || []
 	const origExclude = JSON.stringify(exclude)
 	const mclasses = Object.values(mclass)
-	const dtNums = [...new Set(mclasses.map(c => c.dt))].sort() as number[]
+
+	const dtNums = [...new Set(mclasses.map((c: any) => c.dt))].sort() as number[] // must add type "any" to avoid tsc err
 
 	const groups: GroupsEntry[] = []
 	for (const dt of dtNums) {
-		const items = mclasses.filter(c => c.dt === dt)
+		const items = mclasses.filter((c: any) => c.dt === dt) as MClassEntry[] // must add type "any" to avoid tsc err
+
 		if (items.length) {
 			groups.push({
 				name: dt2label[dt],

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -1,6 +1,6 @@
 import { select } from 'd3-selection'
 import { mclass, dt2label } from '#shared/common'
-import { PillData, VocabApi, GeneVariantTermSettingInstance, GeneVariantTW } from '#shared/types'
+import { PillData, VocabApi, GeneVariantTermSettingInstance, GeneVariantTW } from '#shared/types/index'
 
 /* 
 instance attributes

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -2,7 +2,7 @@ import { keyupEnter } from '#src/client'
 import { select } from 'd3-selection'
 import { filterInit } from '#filter'
 // import { make_radios } from '#dom/radiobutton'
-import { GroupSetEntry, GroupEntry, TermValues, Subconditions } from '#shared/types'
+import { GroupSetEntry, GroupEntry, TermValues, Subconditions } from '#shared/types/index'
 
 /*
 Arguments

--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -4,7 +4,7 @@ import { get_bin_label, get_bin_range_equation } from '#shared/termdb.bins'
 import { make_one_checkbox } from '#dom/checkbox'
 import { getPillNameDefault } from '#termsetting'
 import { convertViolinData } from '#filter/tvs.numeric'
-import { PillData, RangeEntry, NumericTermSettingInstance } from '#shared/types'
+import { PillData, RangeEntry, NumericTermSettingInstance } from '#shared/types/index'
 
 /*
 ********************** EXPORTED

--- a/client/termsetting/handlers/numeric.continuous.ts
+++ b/client/termsetting/handlers/numeric.continuous.ts
@@ -1,5 +1,5 @@
 import { getPillNameDefault } from '#termsetting'
-import { NumericTermSettingInstance, PillData, Term } from '#shared/types'
+import { NumericTermSettingInstance, PillData, Term } from '#shared/types/index'
 import { makeDensityPlot } from '#filter/densityplot'
 import { convertViolinData } from '#filter/tvs.numeric'
 

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -7,7 +7,7 @@ import { Tabs } from '#dom/toggleButtons'
 import { make_radios } from '#dom/radiobutton'
 import { getPillNameDefault } from '#termsetting'
 import { convertViolinData } from '#filter/tvs.numeric'
-import { NumericTermSettingInstance, PillData, RangeEntry, NumericQ, DensityData } from '#shared/types'
+import { NumericTermSettingInstance, PillData, RangeEntry, NumericQ, DensityData } from '#shared/types/index'
 
 /*
 ********************** EXPORTED

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -2,7 +2,7 @@ import { setDensityPlot } from './density'
 import { keyupEnter } from '#src/client'
 import { getPillNameDefault } from '#termsetting'
 import { convertViolinData } from '#filter/tvs.numeric'
-import { NumericTermSettingInstance, NumericQ } from '#shared/types'
+import { NumericTermSettingInstance, NumericQ } from '#shared/types/index'
 
 /*
 ********************** EXPORTED

--- a/client/termsetting/handlers/numeric.toggle.ts
+++ b/client/termsetting/handlers/numeric.toggle.ts
@@ -1,7 +1,7 @@
 import { Tabs } from '#dom/toggleButtons'
 import { getPillNameDefault, set_hiddenvalues } from '#termsetting'
 import { copyMerge } from '#rx'
-import { PillData, NumericTW, NumericTermSettingInstance, VocabApi, NumericQ } from '#shared/types'
+import { PillData, NumericTW, NumericTermSettingInstance, VocabApi, NumericQ } from '#shared/types/index'
 
 /*
 ********************** EXPORTED

--- a/client/termsetting/handlers/numeric.toggle.ts
+++ b/client/termsetting/handlers/numeric.toggle.ts
@@ -173,6 +173,8 @@ export async function fillTW(tw: NumericTW, vocabApi: VocabApi, defaultQ = null)
 	set_hiddenvalues(tw.q, tw.term)
 }
 
+// return false for failed validation
+// TODO this may not be needed as checks are auto-done by ts?
 function valid_binscheme(q: NumericQ) {
 	/*if (q.mode == 'continuous') { console.log(472, q)
 		// only expect a few keys for now "mode", "scale", "transform" keys for now
@@ -188,15 +190,7 @@ function valid_binscheme(q: NumericQ) {
 		return true
 	}
 	if (Number.isFinite(q.bin_size) && q.first_bin) {
-		if (q.first_bin.startunbounded) {
-			if (Number.isInteger(q.first_bin.stop_percentile) || Number.isFinite(q.first_bin.stop)) {
-				return true
-			}
-		} else {
-			if (Number.isInteger(q.first_bin.start_percentile) || Number.isFinite(q.first_bin.start)) {
-				return true
-			}
-		}
+		if (Number.isFinite(q.first_bin.stop)) return true
 	}
 	return false
 }

--- a/client/termsetting/handlers/numeric.ts
+++ b/client/termsetting/handlers/numeric.ts
@@ -1,4 +1,4 @@
-import { NumericQ, NumericTermSettingInstance, NumericTW, VocabApi } from '#shared/types'
+import { NumericQ, NumericTermSettingInstance, NumericTW, VocabApi } from '#shared/types/index'
 
 /*
 Routes numeric terms to their respective subhandlers. Functions follow the same naming convention as the other handler files and returns the results. 

--- a/client/termsetting/handlers/samplelst.ts
+++ b/client/termsetting/handlers/samplelst.ts
@@ -1,6 +1,6 @@
 import { getPillNameDefault, get$id } from '#termsetting'
 import { renderTable } from '#dom/table'
-import { SampleLstTermSettingInstance, PillData, SampleLstTW } from '#shared/types'
+import { SampleLstTermSettingInstance, PillData, SampleLstTW } from '#shared/types/index'
 
 export function getHandler(self: SampleLstTermSettingInstance) {
 	return {

--- a/client/termsetting/handlers/snplocus.ts
+++ b/client/termsetting/handlers/snplocus.ts
@@ -1,7 +1,7 @@
 import { makeSnpSelect, mayRestrictAncestry } from './snplst'
 import { filterInit, getNormalRoot } from '#filter'
 import { addGeneSearchbox } from '#dom/genesearch'
-import { SnpsTermSettingInstance, SnpsTermWrapper, SnpsQ, SnpsVocabApi, SnpsTerm } from '#shared/types'
+import { SnpsTermSettingInstance, SnpsTermWrapper, SnpsQ, SnpsVocabApi, SnpsTerm } from '#shared/types/index'
 
 /* 
 ***************** EXPORT

--- a/client/termsetting/handlers/snplst.sampleSum.ts
+++ b/client/termsetting/handlers/snplst.sampleSum.ts
@@ -1,4 +1,4 @@
-import { SnpsTermSettingInstance, SnpsTermWrapper, SnpsQ, SnpsVocabApi } from '#shared/types'
+import { SnpsTermSettingInstance, SnpsTermWrapper, SnpsQ, SnpsVocabApi } from '#shared/types/index'
 
 /*
 if the "effect allele" is already set for a snp (by user), return it

--- a/client/termsetting/handlers/snplst.ts
+++ b/client/termsetting/handlers/snplst.ts
@@ -1,5 +1,5 @@
 import { mayRunSnplstTask } from './snplst.sampleSum'
-import { SnpsTermSettingInstance, SnpsQ, SnpsTermWrapper, SnpsVocabApi, SnpsTerm, SnpsEntry } from '#shared/types'
+import { SnpsTermSettingInstance, SnpsQ, SnpsTermWrapper, SnpsVocabApi, SnpsTerm, SnpsEntry } from '#shared/types/index'
 
 /* 
 TODO clean up ui logic, may use table.js?

--- a/client/termsetting/handlers/survival.ts
+++ b/client/termsetting/handlers/survival.ts
@@ -1,5 +1,5 @@
 import { getPillNameDefault } from '#termsetting'
-import { TermWrapper, VocabApi, TermSettingInstance, PillData } from '#shared/types'
+import { TermWrapper, VocabApi, TermSettingInstance, PillData } from '#shared/types/index'
 
 export function getHandler(self: TermSettingInstance) {
 	return {

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -18,7 +18,7 @@ import {
 	Handler,
 	Filter,
 	SampleCountsEntry
-} from '#shared/types'
+} from '#shared/types/index'
 /*
 ********************* EXPORTED
 nonDictionaryTermTypes

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true, /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "types": ["node", "d3"], /* Ensures that TypeScript has access to the Node.js type definitions*/
-    "moduleResolution": "node",/* Enables Node.js module resolution.*/
+    "moduleResolution": "nodenext",/* Enables Node.js module resolution.*/
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "strict": true, /* Enable all strict type-checking options. */
     "allowImportingTsExtensions": true,

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -9,6 +9,7 @@
     //"types": ["node", "d3"], /* Ensures that TypeScript has access to the Node.js type definitions*/
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "strict": true, /* Enable all strict type-checking options. */
+    "noEmit": true,
     "allowImportingTsExtensions": true,
     "noImplicitAny": false,
     "baseUrl": "./"

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,56 +2,18 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "esnext", /* Specify the latest module code is generated. */
+    "module": "node16", /* Specify the latest module code is generated. */
+    "moduleResolution": "node16",/* Enables Node.js module resolution.*/
     "allowJs": true, /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "types": ["node", "d3"], /* Ensures that TypeScript has access to the Node.js type definitions*/
-    "moduleResolution": "nodenext",/* Enables Node.js module resolution.*/
+    //"types": ["node", "d3"], /* Ensures that TypeScript has access to the Node.js type definitions*/
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "strict": true, /* Enable all strict type-checking options. */
     "allowImportingTsExtensions": true,
     "noImplicitAny": false,
-      "baseUrl": "./",
-      "paths": {
-        "#src/*": [
-          "./src/*"
-        ],
-        "#common/*": [
-          "./common/*"
-        ],
-        "#dom/*": [
-          "./dom/*"
-        ],
-        "#filter": [
-          "./filter/filter.js"
-        ],
-        "#filter/*": [
-          "./filter/*"
-        ],
-        "#mass/*": [
-          "./mass/*"
-        ],
-        "#plots/*": [
-          "./plots/*"
-        ],
-        "#rx": [
-          "./rx/index.js"
-        ],
-        "#shared/*": [
-          "./shared/*"
-        ],
-        "#termdb/*": [
-          "./termdb/*"
-        ],
-        "#termsetting": [
-          "./termsetting/termsetting.js"
-        ],
-        "#termsetting/handlers/*": [
-          "./termsetting/handlers/*"
-        ]
-      }
-    },
-    "exclude": [
-      "node_modules"
-    ]
-  }
+    "baseUrl": "./"
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2971,12 +2971,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.4.tgz",
       "integrity": "sha512-ni5f8Xlf4PwnT/Z3f0HURc3ZSw8UyrqMqmM3L5ysa7VjHu8c3FOmIo1nKCcLrV/OAmtf3N4kFna/aJqxsfEtnA=="
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -5097,22 +5091,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -6411,15 +6389,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "node_modules/es-abstract": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
@@ -7333,172 +7302,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
-      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cosmiconfig": "^7.0.1",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^10.0.0",
-        "memfs": "^3.4.1",
-        "minimatch": "^3.0.4",
-        "node-abort-controller": "^3.0.1",
-        "schema-utils": "^3.1.1",
-        "semver": "^7.3.5",
-        "tapable": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=12.13.0",
-        "yarn": ">=1.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">3.6.0",
-        "webpack": "^5.11.0"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7544,12 +7347,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/fs-monkey": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
-      "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
-      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -8777,12 +8574,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
-    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -9372,12 +9163,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
-    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -9659,18 +9444,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/memfs": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
-      "dev": true,
-      "dependencies": {
-        "fs-monkey": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -9945,12 +9718,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -10529,24 +10296,6 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -14498,7 +14247,6 @@
         "@babel/register": "^7.14.5",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "babel-loader": "^8.2.2",
-        "fork-ts-checker-webpack-plugin": "^8.0.0",
         "node-watch": "^0.7.1",
         "nodemon": "^2.0.19",
         "prettier": "^2.8.8",
@@ -16355,7 +16103,6 @@
         "deep-object-diff": "^1.1.0",
         "express": "^4.17.1",
         "express-basic-auth": "^1.1.5",
-        "fork-ts-checker-webpack-plugin": "^8.0.0",
         "got": "^11.5.1",
         "image-size": "^0.5.5",
         "jsonwebtoken": "^9.0.0",
@@ -16746,12 +16493,6 @@
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.4.tgz",
       "integrity": "sha512-ni5f8Xlf4PwnT/Z3f0HURc3ZSw8UyrqMqmM3L5ysa7VjHu8c3FOmIo1nKCcLrV/OAmtf3N4kFna/aJqxsfEtnA=="
-    },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -18337,19 +18078,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "requires": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      }
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -19350,15 +19078,6 @@
       "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
       "dev": true
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "es-abstract": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
@@ -20054,124 +19773,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "fork-ts-checker-webpack-plugin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
-      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cosmiconfig": "^7.0.1",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^10.0.0",
-        "memfs": "^3.4.1",
-        "minimatch": "^3.0.4",
-        "node-abort-controller": "^3.0.1",
-        "schema-utils": "^3.1.1",
-        "semver": "^7.3.5",
-        "tapable": "^2.2.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "schema-utils": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        }
-      }
-    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -20205,12 +19806,6 @@
       "requires": {
         "minipass": "^3.0.0"
       }
-    },
-    "fs-monkey": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
-      "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -21140,12 +20735,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
-    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -21565,12 +21154,6 @@
       "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
     },
-    "lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
-    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -21792,15 +21375,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
     },
-    "memfs": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
-      "dev": true,
-      "requires": {
-        "fs-monkey": "^1.0.4"
-      }
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -22013,12 +21587,6 @@
           }
         }
       }
-    },
-    "node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "dev": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -22446,18 +22014,6 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
       }
     },
     "parseurl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2971,6 +2971,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.4.tgz",
       "integrity": "sha512-ni5f8Xlf4PwnT/Z3f0HURc3ZSw8UyrqMqmM3L5ysa7VjHu8c3FOmIo1nKCcLrV/OAmtf3N4kFna/aJqxsfEtnA=="
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -5091,6 +5097,22 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -6389,6 +6411,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
@@ -7302,6 +7333,172 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
+      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "cosmiconfig": "^7.0.1",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^10.0.0",
+        "memfs": "^3.4.1",
+        "minimatch": "^3.0.4",
+        "node-abort-controller": "^3.0.1",
+        "schema-utils": "^3.1.1",
+        "semver": "^7.3.5",
+        "tapable": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=12.13.0",
+        "yarn": ">=1.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">3.6.0",
+        "webpack": "^5.11.0"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7347,6 +7544,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/fs-monkey": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
+      "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -8574,6 +8777,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -9163,6 +9372,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -9444,6 +9659,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memfs": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+      "dev": true,
+      "dependencies": {
+        "fs-monkey": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -9718,6 +9945,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -10296,6 +10529,24 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -14247,6 +14498,7 @@
         "@babel/register": "^7.14.5",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "babel-loader": "^8.2.2",
+        "fork-ts-checker-webpack-plugin": "^8.0.0",
         "node-watch": "^0.7.1",
         "nodemon": "^2.0.19",
         "prettier": "^2.8.8",
@@ -16103,6 +16355,7 @@
         "deep-object-diff": "^1.1.0",
         "express": "^4.17.1",
         "express-basic-auth": "^1.1.5",
+        "fork-ts-checker-webpack-plugin": "^8.0.0",
         "got": "^11.5.1",
         "image-size": "^0.5.5",
         "jsonwebtoken": "^9.0.0",
@@ -16493,6 +16746,12 @@
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.4.tgz",
       "integrity": "sha512-ni5f8Xlf4PwnT/Z3f0HURc3ZSw8UyrqMqmM3L5ysa7VjHu8c3FOmIo1nKCcLrV/OAmtf3N4kFna/aJqxsfEtnA=="
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -18078,6 +18337,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -19078,6 +19350,15 @@
       "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
       "dev": true
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es-abstract": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
@@ -19773,6 +20054,124 @@
         "is-callable": "^1.1.3"
       }
     },
+    "fork-ts-checker-webpack-plugin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
+      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "cosmiconfig": "^7.0.1",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^10.0.0",
+        "memfs": "^3.4.1",
+        "minimatch": "^3.0.4",
+        "node-abort-controller": "^3.0.1",
+        "schema-utils": "^3.1.1",
+        "semver": "^7.3.5",
+        "tapable": "^2.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -19806,6 +20205,12 @@
       "requires": {
         "minipass": "^3.0.0"
       }
+    },
+    "fs-monkey": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
+      "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -20735,6 +21140,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -21154,6 +21565,12 @@
       "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
     },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -21375,6 +21792,15 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
     },
+    "memfs": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+      "dev": true,
+      "requires": {
+        "fs-monkey": "^1.0.4"
+      }
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -21587,6 +22013,12 @@
           }
         }
       }
+    },
+    "node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "dev": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -22014,6 +22446,18 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "parseurl": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sethooks": "./utils/hooks/init.sh",
     "getconf": "node -p 'JSON.stringify(require(\"./server/src/serverconfig.js\"),null,\"  \")'",
     "clean": "git add -A; git stash --staged",
-    "doc": "cd server && npm run doc && cd .."
+    "doc": "npm run doc --workspace=server"
   },
   "author": "",
   "license": "SEE LICENSE IN ./LICENSE",

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,7 @@
     "@babel/register": "^7.14.5",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "babel-loader": "^8.2.2",
+    "fork-ts-checker-webpack-plugin": "^8.0.0",
     "node-watch": "^0.7.1",
     "nodemon": "^2.0.19",
     "prettier": "^2.8.8",

--- a/server/package.json
+++ b/server/package.json
@@ -5,10 +5,10 @@
   "main": "server.js",
   "bin": "start.js",
   "imports": {
-    "#shared/*": "./shared/*.js",
+    "#shared/*": "./shared/*",
     "#shared/types/*": "./shared/types/*",
-    "#src/*": "./src/*.js",
-    "#routes/*": "./routes/*.js"
+    "#src/*": "./src/*",
+    "#routes/*": "./routes/*"
   },
   "scripts": {
     "prepare": "ts-patch install",
@@ -38,7 +38,6 @@
     "@babel/register": "^7.14.5",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "babel-loader": "^8.2.2",
-    "fork-ts-checker-webpack-plugin": "^8.0.0",
     "node-watch": "^0.7.1",
     "nodemon": "^2.0.19",
     "prettier": "^2.8.8",

--- a/server/package.json
+++ b/server/package.json
@@ -6,8 +6,9 @@
   "bin": "start.js",
   "imports": {
     "#shared/*": "./shared/*.js",
-    "#src/*": "./src/*",
-    "#routes/*": "./routes/*"
+    "#shared/types/*": "./shared/types/*",
+    "#src/*": "./src/*.js",
+    "#routes/*": "./routes/*.js"
   },
   "scripts": {
     "prepare": "ts-patch install",

--- a/server/routes/gdcMaf.ts
+++ b/server/routes/gdcMaf.ts
@@ -1,5 +1,5 @@
-import { GdcMafResponse, File } from '../shared/types/routes/gdcMaf.js'
-import { fileSize } from '../shared/fileSize'
+import { GdcMafResponse, File } from '#shared/types/routes/gdcMaf.ts'
+import { fileSize } from '#shared/fileSize'
 import path from 'path'
 import got from 'got'
 

--- a/server/routes/genelookup.ts
+++ b/server/routes/genelookup.ts
@@ -1,5 +1,5 @@
-import { getResult } from '#src/gene.js'
-import { GeneLookupRequest, GeneLookupResponse } from '#shared/types/routes/genelookup'
+import { getResult } from '#src/gene'
+import { GeneLookupRequest, GeneLookupResponse } from '#shared/types/routes/genelookup.ts'
 
 function init({ genomes }) {
 	return (req: any, res: any): void => {

--- a/server/routes/healthcheck.ts
+++ b/server/routes/healthcheck.ts
@@ -1,5 +1,5 @@
-import { getStat } from '#src/health.ts'
-import { HealthCheckResponse } from '#shared/types/routes/healthcheck.js'
+import { getStat } from '#src/health'
+import { HealthCheckResponse } from '#shared/types/routes/healthcheck.ts'
 
 export const api = {
 	endpoint: 'healthcheck',

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -1,5 +1,5 @@
 import { trigger_getViolinPlotData } from '#src/termdb.violin'
-import { Filter } from '#shared/types/filter.js'
+import { Filter } from '../shared/types/filter.js'
 // import { getViolinRequest, getViolinResponse } from '#shared/types/routes/termdb.violin'
 
 export const api: any = {

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -1,5 +1,5 @@
 import { trigger_getViolinPlotData } from '#src/termdb.violin'
-import { Filter } from '../shared/types/filter.js'
+import { Filter } from '#shared/types/filter.ts'
 // import { getViolinRequest, getViolinResponse } from '#shared/types/routes/termdb.violin'
 
 export const api: any = {

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -1,4 +1,4 @@
-import { trigger_getViolinPlotData } from '#src/termdb.violin'
+import { trigger_getViolinPlotData } from '#src/termdb.violin.js'
 import { Filter } from '#shared/types/filter.ts'
 // import { getViolinRequest, getViolinResponse } from '#shared/types/routes/termdb.violin'
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -17,6 +17,7 @@
       ]
     },
     "allowImportingTsExtensions": true,
+    "noEmit": true,
     "strictNullChecks": true,
     "skipLibCheck": true,
     "noImplicitAny": false,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -19,6 +19,7 @@
     "skipLibCheck": true,
     "noImplicitAny": false
   },
+  "include": ["**/*.ts"],
   "exclude": [
     "node_modules",
     "**/*+(.spec|.e2e).ts"

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": { 
     "esModuleInterop": true,
+    "module": "node16",
+    "moduleResolution": "node16",
     "baseUrl": "./",
     "paths": {
       "#src/*": [
@@ -17,7 +19,8 @@
     "allowImportingTsExtensions": true,
     "strictNullChecks": true,
     "skipLibCheck": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "resolveJsonModule": true
   },
   "include": ["**/*.ts"],
   "exclude": [

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -4,6 +4,7 @@ const nodeExternals = require('webpack-node-externals')
 const fs = require('fs')
 const TerserPlugin = require('terser-webpack-plugin')
 const webpack = require('webpack')
+const TsChecker = require('fork-ts-checker-webpack-plugin')
 
 let babelrc
 try {
@@ -62,6 +63,12 @@ const commonConfig = {
 	}
 }
 
+const TsCheckerOpts = {
+	typescript: {
+		memoryLimit: 8192
+	}
+}
+
 module.exports = env => {
 	const NODE_ENV = env.NODE_ENV || 'production'
 	switch (NODE_ENV) {
@@ -77,7 +84,8 @@ module.exports = env => {
 					// ignore spec files by default
 					new webpack.IgnorePlugin({
 						resourceRegExp: /\.(spec|md)$/gi
-					})
+					}),
+					new TsChecker(TsCheckerOpts)
 				],
 				optimization: {
 					minimizer: [
@@ -105,8 +113,12 @@ module.exports = env => {
 					// ignore spec files by default
 					new webpack.IgnorePlugin({
 						resourceRegExp: /\.md$/gi
-					})
+					}),
+					new TsChecker(TsCheckerOpts)
 				],
+				optimization: {
+					emitOnErrors: true
+				},
 				// see https://v4.webpack.js.org/configuration/devtool/ for option details
 				//
 				// devtool: 'eval' is fastest to build/rebuild, no files are written,

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -4,7 +4,6 @@ const nodeExternals = require('webpack-node-externals')
 const fs = require('fs')
 const TerserPlugin = require('terser-webpack-plugin')
 const webpack = require('webpack')
-const TsChecker = require('fork-ts-checker-webpack-plugin')
 
 let babelrc
 try {
@@ -63,12 +62,6 @@ const commonConfig = {
 	}
 }
 
-const TsCheckerOpts = {
-	typescript: {
-		memoryLimit: 8192
-	}
-}
-
 module.exports = env => {
 	const NODE_ENV = env.NODE_ENV || 'production'
 	switch (NODE_ENV) {
@@ -84,8 +77,7 @@ module.exports = env => {
 					// ignore spec files by default
 					new webpack.IgnorePlugin({
 						resourceRegExp: /\.(spec|md)$/gi
-					}),
-					new TsChecker(TsCheckerOpts)
+					})
 				],
 				optimization: {
 					minimizer: [
@@ -113,8 +105,7 @@ module.exports = env => {
 					// ignore spec files by default
 					new webpack.IgnorePlugin({
 						resourceRegExp: /\.md$/gi
-					}),
-					new TsChecker(TsCheckerOpts)
+					})
 				],
 				optimization: {
 					emitOnErrors: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,7 @@
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -86,7 +86,7 @@
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
@@ -110,6 +110,7 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/tmpbuild"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,12 +26,33 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "nodenext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
      "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
      "paths": {
+        "#src/*": [
+          "./server/src/*"
+        ],
+        "#shared/*": [
+          "./server/shared/*"
+        ],
         "#routes/*": [
-          "./routes/*"
-        ]
+          "./server/routes/*"
+        ],
+        //
+        "#src/*": ["./client/src/*.js"],
+        "#common/*": ["./client/common/*.js"],
+        "#dom/*": ["./client/dom/*.js"],
+        "#filter": ["./client/filter/filter.js"],
+        "#filter/*": ["./client/filter/*.js"],
+        "#mass/*": ["./client/mass/*.js"],
+        "#plots/*": ["./client/plots/*"],
+        "#plotsts/*": ["./client/plots/*.js"],
+        "#rx": ["./client/rx/index.js"],
+        "#shared/*": ["./client/shared/*.js"],
+        "#termdb/*": ["./client/termdb/*.js"],
+        "#termsetting": ["./client/termsetting/termsetting.ts"],
+        "#termsetting/handlers/*": ["./client/termsetting/handlers/*.ts"]
+
      },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -109,8 +130,10 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
+  "include": ["**/*.ts"],
   "exclude": [
     "node_modules",
-    "**/tmpbuild"
+    "**/tmpbuild",
+    "**/public"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,36 +24,12 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "node16",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "nodenext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-     "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-     "paths": {
-        "#src/*": [
-          "./server/src/*"
-        ],
-        "#shared/*": [
-          "./server/shared/*"
-        ],
-        "#routes/*": [
-          "./server/routes/*"
-        ],
-        //
-        "#src/*": ["./client/src/*.js"],
-        "#common/*": ["./client/common/*.js"],
-        "#dom/*": ["./client/dom/*.js"],
-        "#filter": ["./client/filter/filter.js"],
-        "#filter/*": ["./client/filter/*.js"],
-        "#mass/*": ["./client/mass/*.js"],
-        "#plots/*": ["./client/plots/*"],
-        "#plotsts/*": ["./client/plots/*.js"],
-        "#rx": ["./client/rx/index.js"],
-        "#shared/*": ["./client/shared/*.js"],
-        "#termdb/*": ["./client/termdb/*.js"],
-        "#termsetting": ["./client/termsetting/termsetting.ts"],
-        "#termsetting/handlers/*": ["./client/termsetting/handlers/*.ts"]
-
-     },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "moduleResolution": "node16",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations*/
+                                                         /* paths are not needed when "moduleResolution": "mode16 || nodenext" and there is package.imports
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */


### PR DESCRIPTION
## Description
The `fork-ts-checker-webpack-plugin` runs in a separate process from the webpack bundler. Marking as draft PR since it emits a lot of errors when running `npm run dev`, should clean up these typing errors first.

To test: 
```bash
cd sjpp
git checkout master
git pull  # the updated tsconfig.json excludes more folders and files
npm install
npm run dev
# should see a bunch of typescript errors after about  5 seconds.
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
