### PR TITLE
remove redundant options in the client, server tsconfig.json's

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,6 @@
     "#plots/disco/*": "./plots/disco/*",
     "#rx": "./rx/index.js",
     "#shared/*": "@sjcrh/proteinpaint-server/shared/*",
-    "#shared/types/*": "@sjcrh/proteinpaint-server/shared/types/*",
     "#termdb/*": "./termdb/*.js",
     "#termsetting": "./termsetting/termsetting.ts",
     "#termsetting/handlers/*": "./termsetting/handlers/*.ts"

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,20 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "node16", /* Specify the latest module code is generated. */
-    "moduleResolution": "node16",/* Enables Node.js module resolution.*/
-    "allowJs": true, /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    //"types": ["node", "d3"], /* Ensures that TypeScript has access to the Node.js type definitions*/
-    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
-    "strict": true, /* Enable all strict type-checking options. */
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
-    "noImplicitAny": false,
     "baseUrl": "./"
   },
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["./**/*.ts"]
 }

--- a/server/routes/gdcMaf.ts
+++ b/server/routes/gdcMaf.ts
@@ -1,5 +1,5 @@
 import { GdcMafResponse, File } from '#shared/types/routes/gdcMaf.ts'
-import { fileSize } from '#shared/fileSize'
+import { fileSize } from '#shared/fileSize.js'
 import path from 'path'
 import got from 'got'
 

--- a/server/routes/genelookup.ts
+++ b/server/routes/genelookup.ts
@@ -1,4 +1,4 @@
-import { getResult } from '#src/gene'
+import { getResult } from '#src/gene.js'
 import { GeneLookupRequest, GeneLookupResponse } from '#shared/types/routes/genelookup.ts'
 
 function init({ genomes }) {

--- a/server/routes/healthcheck.ts
+++ b/server/routes/healthcheck.ts
@@ -1,4 +1,4 @@
-import { getStat } from '#src/health'
+import { getStat } from '#src/health.ts'
 import { HealthCheckResponse } from '#shared/types/routes/healthcheck.ts'
 
 export const api = {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,31 +1,7 @@
 {
   "extends": "../tsconfig.json",
-  "compilerOptions": { 
-    "esModuleInterop": true,
-    "module": "node16",
-    "moduleResolution": "node16",
+  "compilerOptions": {
     "baseUrl": "./",
-    "paths": {
-      "#src/*": [
-        "./src/*"
-      ],
-      "#shared/*": [
-        "./shared/*"
-      ],
-      "#routes/*": [
-        "./routes/*"
-      ]
-    },
-    "allowImportingTsExtensions": true,
-    "noEmit": true,
-    "strictNullChecks": true,
-    "skipLibCheck": true,
-    "noImplicitAny": false,
-    "resolveJsonModule": true
   },
-  "include": ["**/*.ts"],
-  "exclude": [
-    "node_modules",
-    "**/*+(.spec|.e2e).ts"
-  ]
+  "include": ["./**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,10 +106,10 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["**/*.ts"],
+  "include": ["./**/*.ts"],
   "exclude": [
     "node_modules",
-    "**/tmpbuild",
-    "**/public"
+    "./**/tmpbuild",
+    "./**/public"
   ]
 }


### PR DESCRIPTION
## Description
This branch cleans up the tsconfig options to be more minimal and easier to read. 

Tested with:
```bash
cd sjpp/proteinpaint/server
npx tsc                                      # there should be no error
cd ../client 
npx tsc                                      # there should be no error
cd ..
npx tsc                                      # there should be no error, should run from the project root
npm run doc                             # should generate a correctly-styled documentation in http://localhost:3000/server.html
cd ..
npm run dev                            #  there should be no error
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
