### PR TITLE
cache gdc case ids with exp data

### DIFF
--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -63,7 +63,7 @@ export function convertSampleId_addGetter(tdb, ds) {
 	tdb.convertSampleId.get = inputs => {
 		const old2new = {}
 		for (const old of inputs) {
-			old2new[old] = ds.map2caseid.get(old) || old
+			old2new[old] = ds.__gdc.map2caseid.get(old) || old
 		}
 		return old2new
 	}
@@ -1500,7 +1500,7 @@ async function decideSampleId(c, ds, useCaseid4sample) {
 
 	if (c?.observation?.[0]?.sample?.tumor_sample_uuid) {
 		// hardcoded logic to return sample submitter id when aliquot id is present
-		return await ds.aliquot2submitter.get(c.observation[0].sample.tumor_sample_uuid)
+		return await ds.__gdc.aliquot2submitter.get(c.observation[0].sample.tumor_sample_uuid)
 	}
 
 	return c.case_id || c.submitter_id
@@ -1725,7 +1725,7 @@ export function validate_query_singleSampleMutation(ds, genome) {
 		do the conversion here on the fly so that no need for client to manage these extra, arbitrary ids that's specific for gdc
 		beyond sample.sample_id for display
 		*/
-		q.case_id = ds.map2caseid.get(sampleName)
+		q.case_id = ds.__gdc.map2caseid.get(sampleName)
 		if (!q.case_id) {
 			// not mapped to case id
 			// this is possible when the server just started and hasn't finished caching. thus must call this method to map

--- a/server/src/termdb.gdc.js
+++ b/server/src/termdb.gdc.js
@@ -860,15 +860,16 @@ async function cacheSampleIdMapping(ds) {
 		casesWithExpData: new Set()
 	}
 
+	// caching action is fine-tuned by the feature toggle on a pp instance; log out detailed status per setting
 	if ('stopGdcCacheAliquot' in serverconfig.features) {
 		// flag is set
 		if (Number.isInteger(serverconfig.features.stopGdcCacheAliquot)) {
 			// flag value is integer (suppose to be positive integer)
-			// allow to test on dev machine
+			// allow to run a short test on dev machine
 			console.log('GDC: running limited sample ID caching')
 		} else {
 			// flag value is not integer, do not run this function at all
-			console.log('GDC sample IDs are not cached!')
+			console.log('GDC: sample IDs are not cached!')
 			return
 		}
 	} else {
@@ -899,10 +900,10 @@ async function cacheSampleIdMapping(ds) {
 
 		await checkExpressionAvailability(ds)
 
-		console.log('GDC: Done caching sample IDs', Math.ceil((new Date() - begin) / 1000), 's')
+		console.log('GDC: Done caching sample IDs. Time:', Math.ceil((new Date() - begin) / 1000), 's')
 		console.log('\t', ds.__gdc.aliquot2submitter.cache.size, 'aliquot IDs to sample submitter id')
 		console.log('\t', ds.__gdc.map2caseid.cache.size, 'different ids to case uuid.')
-		console.log('\t', ds.__gdc.casesWithExpData.size, 'cases with exp data.')
+		console.log('\t', ds.__gdc.casesWithExpData.size, 'cases with gene expression data.')
 	} catch (e) {
 		console.log('Error at caching: ' + e)
 	}


### PR DESCRIPTION
## Description

new data are silently cached on back when server launches, should not affect any mds3/matrix features. mds3 tape tests pass

the `features."stopGdcCacheAliquot":5` flag of serverconfig allows finer control of the caching behavior on your local instance:

1. set value to `true` to disable caching
3. set to integer to only cache ?x1000 cases
    this will be printed at console (depending on integer value)

> GDC: Done caching sample IDs 150 s
> 	 8207 aliquot IDs to sample submitter id
> 	 21958 different ids to case uuid.
> 	 615 cases with exp data.

3. delete the flag to cache all cases
    this will be printed at the console
> GDC: Done caching sample IDs 147 s
> 	 265088 aliquot IDs to sample submitter id
> 	 485023 different ids to case uuid.
> 	 18799 cases with exp data.




the expression api is only visible to those with IP whitelisted by gdc, if not the `checkExpressionAvailability()` function should be skipped, same should happen when it's deployed to our servers. thus i want Congyu to test it to make sure it does not break anything

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
