### PR TITLE
fix: Allow a sample to be missing files for disco and singleSampleGen…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Allow a sample to be missing files for disco and singleSampleGenomeQuantification data types and do not break server


### PR DESCRIPTION
…omeQuantification data types and do not break server

## Description

at http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38-test%22,%22dslabel%22:%22TermdbTest%22}, click `Sample View` chart button it should show "no data" for disco/methyl of this sample and no longer break server

mds3 tape tests all pass


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
