### PR TITLE
wip prototype gene exp clustering for gdc

### DIFF
--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -273,6 +273,12 @@ type RnaseqGeneCount = {
 	file: string
 }
 
+// the geneExpression query. if file is set, it loads data from local file; otherwise gdcapi should be set to true
+type GeneExpressionQuery = {
+	file?: string
+	gdcapi?: boolean
+}
+
 type Queries = {
 	defaultBlock2GeneMode?: boolean
 	snvindel?: SnvIndel
@@ -280,7 +286,7 @@ type Queries = {
 	probe2cnv?: Probe2Cnv // this is no longer used
 	cnv?: CnvSegment
 	singleSampleMutation?: SingleSampleMutation
-	geneExpression?: FileObj
+	geneExpression?: GeneExpressionQuery
 	rnaseqGeneCount?: RnaseqGeneCount
 	topMutatedGenes?: TopMutatedGenes
 	trackLst?: TrackLstEntry[]

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7193,6 +7193,7 @@ async function pp_init(serverconfig) {
 			const tables = listDbTables(g.genedb.db)
 			if (tables.has('genealias')) {
 				g.genedb.getNameByAlias = g.genedb.db.prepare('select name from genealias where alias=?')
+				g.genedb.getAliasByName = g.genedb.db.prepare('select alias from genealias where name=?') // quick fix!! convert symbol to ENSG, to be used for gdc api query
 				g.genedb.tableSize = g.genedb.db.prepare('select count(*) from genealias where alias=?')
 			}
 			if (tables.has('gene2coord')) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -1271,7 +1271,7 @@ async function validate_query_geneExpression(ds, genome) {
 	if (!q) return
 
 	if (q.gdcapi) {
-		gdc.validate_query_geneExpression(ds)
+		gdc.validate_query_geneExpression(ds, genome)
 		// .get() added, same behavior as below
 		return
 	}

--- a/server/src/termdb.gdc.js
+++ b/server/src/termdb.gdc.js
@@ -34,7 +34,7 @@ initGDCdictionary
   ds.__gdc {
   	aliquot2submitter{ get() }
   	map2caseid{ get() }
-	caseIds
+	casesWithExpData Set
   }
 */
 
@@ -856,6 +856,7 @@ async function cacheSampleIdMapping(ds) {
 				// NOTE if mapping is not found, do not return input, caller will call convert2caseId() to map on demand
 			}
 		},
+		caseid2submitter: new Map(), // k: case uuid, v: case submitter id
 		caseIds: new Set(), //
 		casesWithExpData: new Set()
 	}
@@ -901,8 +902,9 @@ async function cacheSampleIdMapping(ds) {
 		await checkExpressionAvailability(ds)
 
 		console.log('GDC: Done caching sample IDs. Time:', Math.ceil((new Date() - begin) / 1000), 's')
-		console.log('\t', ds.__gdc.aliquot2submitter.cache.size, 'aliquot IDs to sample submitter id')
-		console.log('\t', ds.__gdc.map2caseid.cache.size, 'different ids to case uuid.')
+		console.log('\t', ds.__gdc.aliquot2submitter.cache.size, 'aliquot IDs to sample submitter id,')
+		console.log('\t', ds.__gdc.caseid2submitter.size, 'case uuid to submitter id,')
+		console.log('\t', ds.__gdc.map2caseid.cache.size, 'different ids to case uuid,')
 		console.log('\t', ds.__gdc.casesWithExpData.size, 'cases with gene expression data.')
 	} catch (e) {
 		console.log('Error at caching: ' + e)
@@ -980,6 +982,8 @@ async function fetchIdsFromGdcApi(ds, size, from, aliquot_id) {
 
 		const case_submitter_id = h.submitter_id
 		if (!case_submitter_id) throw 'h.submitter_id missing'
+
+		ds.__gdc.caseid2submitter.set(case_id, case_submitter_id)
 
 		/*
 		below shows different uuids mapping to same submitter id


### PR DESCRIPTION
## Description

initial prototyping the gene exp clustering in gdc data. please pull same branch of sjpp to test.
[use this link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22hierCluster%22,%22genes%22:[{%22gene%22:%22GAPDH%22},{%22gene%22:%22BCR%22,%22chr%22:%22chr22%22,%22start%22:23180509,%22stop%22:23318037},{%22gene%22:%22ABL1%22,%22chr%22:%22chr9%22,%22start%22:130835254,%22stop%22:130887675},{%22gene%22:%22HOXA1%22,%22chr%22:%22chr7%22,%22start%22:27092993,%22stop%22:27096000}]}]}) which is also added to url.html
need `"stopGdcCacheAliquot":5,` in serverconfig features for the example to work. otherwise no gdc cases will be identified as having exp data
example will not work for Congyu due to api being on prod-uat, but should be safe to merge to master

all mds3 tape tests pass

next step:
1. may create launchGdcClustering.js so it calls gene_selection api to select top genes from cohort
2. extend matrix gene ui to add button to call gene_selection api

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
