### PR TITLE
Sample view controls

### DIFF
--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -248,7 +248,6 @@ TdbStore.prototype.actions = {
 
 	async plot_create(action) {
 		const _ = await import(`../plots/${action.config.chartType}.js`)
-		console.log(246, action.config)
 		const plot = await _.getPlotConfig(action.config, this.app)
 		if (!('id' in action)) action.id = getId()
 		plot.id = action.id

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -215,7 +215,6 @@ TdbStore.prototype.actions = {
 
 		for (const plot in this.state.plots) {
 			if (plot.mayAdjustConfig && !subactionPlotIds.has(plot.id)) {
-				// console.log('mayAdjustConfig() used by mass store in dispatched action=app_refresh')
 				plot.mayAdjustConfig(plot, action.config)
 			}
 		}
@@ -254,7 +253,6 @@ TdbStore.prototype.actions = {
 		if (!('id' in action)) action.id = getId()
 		plot.id = action.id
 		if (plot.mayAdjustConfig) {
-			// console.log('mayAdjustConfig() used by mass store in dispatched action=plot_create')
 			plot.mayAdjustConfig(plot, action.config)
 		}
 		this.state.plots.push(plot)
@@ -265,7 +263,6 @@ TdbStore.prototype.actions = {
 		if (!plot) throw `missing plot id='${action.id}' in store.plot_edit()`
 		this.copyMerge(plot, action.config, action.opts ? action.opts : {})
 		if (plot.mayAdjustConfig) {
-			// console.log('mayAdjustConfig() used by mass store in dispatched action=plot_edit')
 			plot.mayAdjustConfig(plot, action.config)
 		}
 		validatePlot(plot, this.app.vocabApi)

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -24,7 +24,7 @@ export default class ViewModel {
 		this.fusions = fusions
 
 		this.width =
-			2 *
+			1.5 *
 			(this.settings.horizontalPadding +
 				this.settings.rings.labelLinesInnerRadius +
 				this.settings.rings.labelsToLinesDistance)

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -24,7 +24,7 @@ export default class ViewModel {
 		this.fusions = fusions
 
 		this.width =
-			1.5 *
+			1.2 *
 			(this.settings.horizontalPadding +
 				this.settings.rings.labelLinesInnerRadius +
 				this.settings.rings.labelsToLinesDistance)

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -109,7 +109,7 @@ class SampleView {
 	getState(appState) {
 		const config = appState.plots?.find(p => p.id === this.id)
 		const q = appState.termdbConfig.queries
-		const showContent = q ? q.singleSampleGenomeQuantification || q.singleSampleMutation : false
+		const hasPlots = q ? q.singleSampleGenomeQuantification || q.singleSampleMutation : false
 		const state = {
 			config,
 			// TODO: use state.config drectly, instead of having to extract
@@ -123,7 +123,7 @@ class SampleView {
 			singleSampleMutation: q?.singleSampleMutation,
 			hasVerifiedToken: this.app.vocabApi.hasVerifiedToken(),
 			tokenVerificationPayload: this.app.vocabApi.tokenVerificationPayload,
-			showContent,
+			hasPlots,
 			termdbConfig: appState.termdbConfig,
 			vocab: appState.vocab
 		}
@@ -143,8 +143,7 @@ class SampleView {
 		if (this.mayRequireToken()) return
 		this.config = structuredClone(this.state.config)
 		this.settings = this.state.config.settings.sampleView
-
-		await this.setControls()
+		if (this.state.hasPlots) await this.setControls()
 		if (this.dom.header) this.dom.header.html(`Sample View`)
 		this.termsById = this.getTermsById(this.state)
 		this.sampleDataByTermId = {}
@@ -372,7 +371,7 @@ class SampleView {
 
 	async renderPlots() {
 		this.dom.contentDiv.selectAll('*').remove()
-		if (this.state.showContent) {
+		if (this.state.hasPlots) {
 			const table = this.dom.contentDiv.style('display', 'table')
 			if (this.settings.showDisco && this.state.termdbConfig?.queries?.singleSampleMutation) {
 				const div = this.dom.contentDiv.append('div').style('display', 'table-row')

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -17,6 +17,7 @@ class SampleView {
 		const div = opts.holder.append('div')
 		const controlsDiv = div.insert('div').style('display', 'inline-block')
 		const mainDiv = div.insert('div').style('display', 'inline-block')
+		const rightDiv = div.append('div').style('display', 'inline-block')
 		const sampleDiv = mainDiv.insert('div').style('display', 'inline-block').style('padding', '20px')
 		const sampleLabel = sampleDiv.insert('label').style('vertical-align', 'top').html('Sample:')
 
@@ -35,6 +36,7 @@ class SampleView {
 			theadrow: thead.append('tr'),
 			tbody: table.append('tbody'),
 			contentDiv: mainDiv.insert('div'),
+			rightDiv,
 			sampleLabel,
 			select: sampleDiv.insert('select').style('margin', '0px 5px')
 		}
@@ -371,13 +373,17 @@ class SampleView {
 
 	async renderPlots() {
 		this.dom.contentDiv.selectAll('*').remove()
+		this.dom.rightDiv.selectAll('*').remove()
 		if (this.state.hasPlots) {
 			const table = this.dom.contentDiv.style('display', 'table')
 			if (this.settings.showDisco && this.state.termdbConfig?.queries?.singleSampleMutation) {
 				const div = this.dom.contentDiv.append('div').style('display', 'table-row')
 
 				for (const sample of this.state.samples) {
-					const cellDiv = div.append('div').style('display', 'table-cell')
+					let cellDiv
+					if (this.state.samples.length == 1)
+						cellDiv = this.dom.rightDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')
+					else cellDiv = div.append('div').style('display', 'table-cell')
 
 					cellDiv
 						.insert('div')
@@ -399,7 +405,10 @@ class SampleView {
 					let div = this.dom.contentDiv.append('div').style('padding', '20px').style('display', 'table-row')
 					for (const sample of this.state.samples) {
 						const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
-						const plotDiv = div.insert('div').style('display', 'table-cell')
+						let plotDiv
+						if (this.state.samples.length == 1)
+							plotDiv = this.dom.rightDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')
+						else plotDiv = div.insert('div').style('display', 'table-cell')
 						plotDiv.insert('div').style('font-weight', 'bold').text(`${sample.sampleName} ${label}`)
 						const ssgqImport = await import('./plot.ssgq.js')
 						await ssgqImport.plotSingleSampleGenomeQuantification(
@@ -461,7 +470,6 @@ function setRenderers(self) {
 	}
 
 	self.renderTHead = function (data) {
-		console.log(data)
 		const trs = self.dom.theadrow.selectAll('th').data(data)
 		trs.exit().remove()
 		trs.html(self.getThHtml)

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -324,13 +324,15 @@ class SampleView {
 	async renderPlots() {
 		this.dom.contentDiv.selectAll('*').remove()
 		if (this.state.showContent) {
-			for (const stateSample of this.state.samples) {
-				let sample = JSON.parse(JSON.stringify(stateSample))
-				sample.sample_id = sample.sampleName
-				if (this.state.termdbConfig?.queries?.singleSampleMutation) {
-					const div = this.dom.contentDiv
-					div
-						.append('div')
+			const table = this.dom.contentDiv.style('display', 'table')
+			if (this.state.termdbConfig?.queries?.singleSampleMutation) {
+				const div = this.dom.contentDiv.append('div').style('display', 'table-row')
+
+				for (const sample of this.state.samples) {
+					const cellDiv = div.append('div').style('display', 'table-cell')
+
+					cellDiv
+						.insert('div')
 						.style('font-weight', 'bold')
 						.style('padding-left', '20px')
 						.text(`${sample.sampleName} Disco plot`)
@@ -338,27 +340,26 @@ class SampleView {
 					discoPlotImport.default(
 						this.state.termdbConfig,
 						this.state.vocab.dslabel,
-						sample,
-						div.append('div'),
+						{ sample_id: sample.sampleName },
+						cellDiv,
 						this.app.opts.genome
 					)
 				}
-				if (this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
-					for (const k in this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
-						const div = this.dom.contentDiv.append('div').style('padding', '20px')
+			}
+			if (this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
+				for (const k in this.state.termdbConfig.queries.singleSampleGenomeQuantification) {
+					let div = this.dom.contentDiv.append('div').style('padding', '20px').style('display', 'table-row')
+					for (const sample of this.state.samples) {
 						const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
-						div
-							.append('div')
-							.style('padding-bottom', '20px')
-							.style('font-weight', 'bold')
-							.text(`${sample.sampleName} ${label}`)
+						const plotDiv = div.insert('div').style('display', 'table-cell')
+						plotDiv.insert('div').style('font-weight', 'bold').text(`${sample.sampleName} ${label}`)
 						const ssgqImport = await import('./plot.ssgq.js')
 						await ssgqImport.plotSingleSampleGenomeQuantification(
 							this.state.termdbConfig,
 							this.state.vocab.dslabel,
 							k,
-							sample,
-							div.append('div'),
+							{ sample_id: sample.sampleName },
+							plotDiv.insert('div'),
 							this.app.opts.genome
 						)
 					}

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -74,6 +74,7 @@ class SampleView {
 				.enter()
 				.append('option')
 				.attr('value', d => d.sampleId)
+				.property('selected', (d, i) => i < 15)
 				.html((d, i) => d.sampleName)
 			select.on('change', e => {
 				const options = select.node().options
@@ -87,6 +88,12 @@ class SampleView {
 					}
 				this.app.dispatch({ type: 'plot_edit', id: this.id, config: { samples } })
 			})
+			if (config.samples.length > 15)
+				this.app.dispatch({
+					type: 'plot_edit',
+					id: this.id,
+					config: { samples: config.samples.filter((s, i) => i < 15) }
+				})
 		} else {
 			this.sampleId2Name = await this.app.vocabApi.getAllSamples()
 			const samples = Object.entries(this.sampleId2Name)

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -168,24 +168,24 @@ class SampleView {
 				holder: this.dom.controlsDiv,
 				inputs: [
 					{
-						boxLabel: 'Show dictionary',
-						label: '',
+						boxLabel: 'Visible',
+						label: 'Samples dictionary',
 						type: 'checkbox',
 						chartType: 'sampleView',
 						settingsKey: 'showDictionary',
 						title: `Option to show/hide dictionary table with sample values`
 					},
 					{
-						boxLabel: 'Show disco',
-						label: '',
+						boxLabel: 'Visible',
+						label: 'Disco plot',
 						type: 'checkbox',
 						chartType: 'sampleView',
 						settingsKey: 'showDisco',
 						title: `Option to show/hide disco plots`
 					},
 					{
-						boxLabel: 'Show single sample',
-						label: '',
+						boxLabel: 'Visible',
+						label: 'Single sample plots',
 						type: 'checkbox',
 						chartType: 'sampleView',
 						settingsKey: 'showSingleSample',

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -451,7 +451,7 @@ function setRenderers(self) {
 		// but prototyping with just one sample for now
 		const visibleSamples = Object.values(self.sampleDataByTermId)
 		// for the column names, just need the first column name + sample data
-		self.renderTHead([{ name: 'Variable' }, ...visibleSamples])
+		self.renderTHead(['', ...self.state.samples.map(s => s.sampleName)])
 		const tBodyData = self.orderedVisibleTerms.map((term, trIndex) => [
 			{ term }, // first column, no sample data
 			// create data to bind for each sample column
@@ -461,13 +461,14 @@ function setRenderers(self) {
 	}
 
 	self.renderTHead = function (data) {
+		console.log(data)
 		const trs = self.dom.theadrow.selectAll('th').data(data)
 		trs.exit().remove()
 		trs.html(self.getThHtml)
 		trs.enter().append('th').style('padding', '5px 10px').style('text-align', 'end').html(self.getThHtml)
 	}
 
-	self.getThHtml = d => d.sampleName || ''
+	self.getThHtml = d => d
 
 	self.renderTBody = function (data) {
 		const trs = self.dom.tbody.selectAll('tr').data(data)


### PR DESCRIPTION
## Description

Added controls to customize the samples view. Now you can decide if you want to show/hide the dictionary table with the sample values, the disco plots or the single sample plots. Also limited the number of samples selected to 15 and when a single sample is loaded I display the plots horizontally.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
