### PR TITLE
fix: bug fix to not to print text when average admix value is missing…

### DIFF
--- a/client/plots/genomeBrowser.controls.js
+++ b/client/plots/genomeBrowser.controls.js
@@ -336,7 +336,7 @@ function render1group_population(self, groupIdx, group, div) {
 						They are used to adjust variant allele counts of matching ancestries from <span class=sja_menuoption style="padding:2px 5px">${
 							group.label
 						}</span>,
-						so that the adjusted allele counts are compared against Group ${groupIdx == 1 ? 1 : 2} allele counts.
+						so that the adjusted allele counts can be compared against Group ${groupIdx == 1 ? 1 : 2} allele counts.
 						This allows to account for ancestry composition difference between the two groups.
 						`)
 					})

--- a/client/plots/genomeBrowser.controls.js
+++ b/client/plots/genomeBrowser.controls.js
@@ -331,8 +331,8 @@ function render1group_population(self, groupIdx, group, div) {
 					.style('margin-left', '20px')
 					.attr('class', 'sja_clbtext')
 					.on('click', event => {
-						groupTip.clear().showunder(event.target).d.append('div').style('margin', '10px').style('width', '400px')
-							.html(`These are average of admix coefficients based on current Group ${groupIdx == 1 ? 1 : 2} samples.
+						groupTip.clear().showunder(event.target).d.append('div').style('margin', '10px').style('width', '500px')
+							.html(`These are average admixture coefficients based on current Group ${groupIdx == 1 ? 1 : 2} samples.
 						They are used to adjust variant allele counts of matching ancestries from <span class=sja_menuoption style="padding:2px 5px">${
 							group.label
 						}</span>,

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- bug fix to not to print text when average admix value is missing; improve population item UI in genomebrowser controls


### PR DESCRIPTION
…; improve population item UI in genomebrowser controls

## Description

[test link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22chr%22:%22chr17%22,%22start%22:7666657,%22stop%22:7688274}}]}), search by `rs1642785` which is filtered out by INFO filter in genomebrowser and it should not break; also the population UI is improved

the CEU/YRI/ASA names will be fixed separately by a data update

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
