### PR TITLE
fix: Improve INFO field UI in genome browser group selection

### DIFF
--- a/client/plots/genomeBrowser.controls.js
+++ b/client/plots/genomeBrowser.controls.js
@@ -255,8 +255,52 @@ function render1group_info(self, groupIdx, group, div) {
 		const f = self.state.config.variantFilter.terms.find(i => i.id == group.infoKey)
 		if (f && f.name) name = f.name
 	}
-	div.append('span').text(name)
-	div.append('span').text('INFO FIELD').style('font-size', '.5em').style('margin-left', '10px')
+	div
+		.append('span')
+		.text(name)
+		.attr('class', 'sja_menuoption')
+		.on('click', event => {
+			if (self.state.config.variantFilter.terms.length <= 1) {
+				// only 1, no other option to switch to
+				return
+			}
+			// multiple options, allow to replace
+			groupTip
+				.clear()
+				.showunder(event.target)
+				.d.append('div')
+				.text('Replace with:')
+				.style('margin', '10px')
+				.style('font-size', '.8em')
+			for (const f of self.state.config.variantFilter.terms) {
+				if (f.type != 'integer' && f.type != 'float') continue // only allow numeric fields
+				if (f.id == group.infoKey) continue // same one
+
+				groupTip.d
+					.append('div')
+					.text(f.name)
+					.attr('class', 'sja_menuoption')
+					.on('click', () => {
+						/////////////////////////////////
+						// create a new group using this info field
+						groupTip.hide()
+						const groups = structuredClone(self.state.config.snvindel.details.groups)
+						groups[groupIdx].infoKey = f.id
+						groups[groupIdx].type = 'info'
+						self.app.dispatch({
+							type: 'plot_edit',
+							id: self.id,
+							config: { snvindel: { details: { groups } } }
+						})
+					})
+			}
+		})
+	div
+		.append('span')
+		.text('PER-VARIANT NUMERICAL VALUES')
+		.style('font-size', '.7em')
+		.style('opacity', 0.6)
+		.style('margin-left', '10px')
 }
 
 function render1group_population(self, groupIdx, group, div) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Improve INFO field UI in genome browser group selection


### PR DESCRIPTION
## Description

[test with this direct link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22chr%22:%22chr17%22,%22start%22:7666657,%22stop%22:7688274},%22snvindel%22:{%22details%22:{%22groups%22:[{%22type%22:%22info%22,%22infoKey%22:%22AF%22}]}}}]}) (added to sjpp master), now an INFO field is shown in consistent style as population

<img width="567" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/3a64936c-5647-4522-85c8-2a7166627389">


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
