### PR TITLE
Show color category with  a circle and shape category with the shape using a gray/default color

### DIFF
--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -54,7 +54,8 @@ export function setInteractivity(self) {
 					}
 				}
 
-				if (self.config.colorTW) addCategoryInfo(self.config.colorTW?.term, 'category', d, table)
+				if (self.config.colorTW)
+					addCategoryInfo(self.config.colorTW?.term, 'category', d, table, self.config.shapeTW ? false : true)
 				if (self.config.shapeTW) addCategoryInfo(self.config.shapeTW.term, 'shape', d, table, true)
 				if (self.config.term) addCategoryInfo(self.config.term.term, 'x', d, table)
 				if (self.config.term2) addCategoryInfo(self.config.term2?.term, 'y', d, table)
@@ -72,7 +73,7 @@ export function setInteractivity(self) {
 			self.dom.tooltip.show(event.clientX, event.clientY, true, true)
 		} else self.dom.tooltip.hide()
 
-		function addCategoryInfo(term, category, d, table, showShape = false) {
+		function addCategoryInfo(term, category, d, table, showColor = false) {
 			if (!term) return
 			if (d[category] == 'Ref') return
 			let row = table.append('tr')
@@ -99,7 +100,7 @@ export function setInteractivity(self) {
 				if (typeof value == 'number' && value % 1 != 0) value = value.toFixed(2)
 				const td = row.append('td')
 
-				if (showShape) {
+				if (showColor) {
 					const color = self.getColor(d, chart)
 					const width = value.length * 9 + 60
 					const svg = td.append('svg').attr('width', width).attr('height', '35px')

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -100,7 +100,7 @@ export function setInteractivity(self) {
 				const td = row.append('td')
 				if (showShape) {
 					const color = showColor ? self.getColor(d, chart) : self.config.colorTW ? 'gray' : self.settings.defaultColor
-					const shape = showColor && !showShape ? self.getShape(chart, d, 1, true) : self.getShape(chart, d)
+					const shape = showColor ? self.getShape(chart, d, 1, true) : self.getShape(chart, d)
 					const width = value.length * 9 + 60
 					const svg = td.append('svg').attr('width', width).attr('height', '35px')
 					const g = svg.append('g').attr('transform', 'translate(10, 16)')

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -54,9 +54,8 @@ export function setInteractivity(self) {
 					}
 				}
 
-				if (self.config.colorTW)
-					addCategoryInfo(self.config.colorTW?.term, 'category', d, table, self.config.shapeTW ? false : true)
-				if (self.config.shapeTW) addCategoryInfo(self.config.shapeTW.term, 'shape', d, table, true)
+				if (self.config.colorTW) addCategoryInfo(self.config.colorTW?.term, 'category', d, table, true, true)
+				if (self.config.shapeTW) addCategoryInfo(self.config.shapeTW.term, 'shape', d, table, false, true)
 				if (self.config.term) addCategoryInfo(self.config.term.term, 'x', d, table)
 				if (self.config.term2) addCategoryInfo(self.config.term2?.term, 'y', d, table)
 				if (self.config.scaleDotTW) addCategoryInfo(self.config.scaleDotTW?.term, 'scale', d, table)
@@ -73,7 +72,7 @@ export function setInteractivity(self) {
 			self.dom.tooltip.show(event.clientX, event.clientY, true, true)
 		} else self.dom.tooltip.hide()
 
-		function addCategoryInfo(term, category, d, table, showColor = false) {
+		function addCategoryInfo(term, category, d, table, showColor = false, showShape = false) {
 			if (!term) return
 			if (d[category] == 'Ref') return
 			let row = table.append('tr')
@@ -99,13 +98,13 @@ export function setInteractivity(self) {
 				let value = d[category]
 				if (typeof value == 'number' && value % 1 != 0) value = value.toFixed(2)
 				const td = row.append('td')
-
-				if (showColor) {
-					const color = self.getColor(d, chart)
+				if (showShape) {
+					const color = showColor ? self.getColor(d, chart) : self.config.colorTW ? 'gray' : self.settings.defaultColor
+					const shape = showColor && !showShape ? self.getShape(chart, d, 1, true) : self.getShape(chart, d)
 					const width = value.length * 9 + 60
 					const svg = td.append('svg').attr('width', width).attr('height', '35px')
 					const g = svg.append('g').attr('transform', 'translate(10, 16)')
-					g.append('path').attr('d', self.getShape(chart, d)).attr('fill', color)
+					g.append('path').attr('d', shape).attr('fill', color)
 					g.append('text').attr('x', 18).attr('y', 6).text(value)
 				} else td.append('span').text(value)
 			}

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -405,8 +405,10 @@ export function setRenderers(self) {
 		return refOpacity
 	}
 
-	self.getShape = function (chart, c, factor = 1) {
-		const index = chart.shapeLegend.get(c.shape).shape % self.symbols.length
+	self.getShape = function (chart, c, factor = 1, showDefault = false) {
+		let index
+		if (!showDefault) index = chart.shapeLegend.get(c.shape).shape % self.symbols.length
+		else index = chart.shapeLegend.get('Ref').shape % self.symbols.length
 		const isRef = !('sampleId' in c)
 		if (!self.config.scaleDotTW || isRef) {
 			const size = 'sampleId' in c ? self.settings.size : self.settings.refSize


### PR DESCRIPTION
## Description

Show color category with  a circle and shape category with the shape using a gray/default color. Note this PR is built on top of scatter-shape-fix. If merged it  will be merged to this branch and then scatter-shape-fix can be merged to master

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
