### PR TITLE
Burden auth

### DIFF
--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -54,6 +54,7 @@ export class Vocab {
 					},
 					body: {
 						dslabel,
+						route: 'termdb',
 						embedder: location.hostname
 					}
 				})

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -25,7 +25,7 @@ export class Vocab {
 		if (this.state.vocab) this.vocab = this.state.vocab
 		// may or may not need a verified token for a dslabel, based on genome response.dsAuth
 		const dslabel = this.state.dslabel || this.state.vocab.dslabel
-		this.verifiedToken = !this.state.termdbConfig?.requiredAuth || isInSession(dslabel)
+		this.verifiedToken = !this.state.termdbConfig?.requiredAuth?.length || isInSession(dslabel, 'termdb')
 		// secured plots need to confirm that a verified token exists
 		if (dslabel) await this.maySetVerifiedToken(dslabel)
 	}
@@ -36,7 +36,8 @@ export class Vocab {
 		const token = this.opts.getDatasetAccessToken?.()
 		if (this.verifedToken && token === this.verifiedToken) return this.verifiedToken
 		try {
-			const auth = this.state.termdbConfig?.requiredAuth
+			// TODO: do not hardcode 'termdb' here, assume that Vocab is only called within a termdb or mass app
+			const auth = this.state.termdbConfig?.requiredAuth.find(a => a.route == 'termdb')
 			if (!auth) {
 				this.verifiedToken = true
 				return

--- a/package-lock.json
+++ b/package-lock.json
@@ -4221,7 +4221,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -7201,7 +7200,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -8766,7 +8764,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -9476,7 +9473,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -10407,7 +10403,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -13042,7 +13037,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -14229,6 +14223,7 @@
         "jsonwebtoken": "^9.0.0",
         "jstat": "^1.9.3",
         "lazy": "^1.0.11",
+        "micromatch": "^4.0.5",
         "minimatch": "^3.1.2",
         "node-fetch": "^2.6.1",
         "partjson": "^0.58.1",
@@ -16108,6 +16103,7 @@
         "jsonwebtoken": "^9.0.0",
         "jstat": "^1.9.3",
         "lazy": "^1.0.11",
+        "micromatch": "^4.0.5",
         "minimatch": "^3.1.2",
         "node-fetch": "^2.6.1",
         "node-watch": "^0.7.1",
@@ -17407,7 +17403,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -19688,7 +19683,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -20857,8 +20851,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -21401,7 +21394,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -22103,8 +22095,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "4.0.1",
@@ -24059,7 +24050,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- Support different auth methods for the same dataset, by server route and app embedder.

--- a/server/package.json
+++ b/server/package.json
@@ -71,6 +71,7 @@
     "jsonwebtoken": "^9.0.0",
     "jstat": "^1.9.3",
     "lazy": "^1.0.11",
+    "micromatch": "^4.0.5",
     "minimatch": "^3.1.2",
     "node-fetch": "^2.6.1",
     "partjson": "^0.58.1",

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -412,7 +412,6 @@ export function server_init_db_queries(ds) {
 		// ds.cohort.termdb.termtypeByCohort[] is set
 
 		const cred = serverconfig.dsCredentials?.[ds.label]
-
 		const supportedChartTypes = {}
 		const numericTypeCount = {}
 		// key: subcohort combinations, comma-joined, alphabetically sorted, as in the subcohort_terms table
@@ -425,7 +424,8 @@ export function server_init_db_queries(ds) {
 				if (ds.cohort.scatterplots) supportedChartTypes[r.cohort].add('sampleScatter')
 				numericTypeCount[r.cohort] = 0
 				if (ds.cohort.allowedChartTypes?.includes('matrix')) supportedChartTypes[r.cohort].add('matrix')
-				if (!cred || cred.embedders?.[embedder]) {
+				// TODO: should use an embedderHostPattern
+				if (!cred || cred.termdb?.[embedder] || cred.termdb?.['*']) {
 					supportedChartTypes[r.cohort].add('dataDownload')
 					supportedChartTypes[r.cohort].add('sampleView')
 				}

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -158,7 +158,8 @@ tape('legacy reshape', async test => {
 						dsnames: [{ id: 'ds0', label: 'Dataset 0' }],
 						headerKey: 'x-ds-token',
 						route: 'termdb',
-						authRoute: '/jwt-status'
+						authRoute: '/jwt-status',
+						cookieId: 'x-ds-token'
 					}
 				}
 			},
@@ -168,7 +169,8 @@ tape('legacy reshape', async test => {
 						type: 'basic',
 						password: '...',
 						route: '/**',
-						authRoute: '/dslogin'
+						authRoute: '/dslogin',
+						cookieId: 'ds1-/**-*-Id'
 					}
 				}
 			}

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -112,7 +112,7 @@ tape(`initialization`, async test => {
 		const routes = Object.keys(app.routes)
 		routes.sort()
 		test.deepEqual(
-			['/authorizedActions', '/dslogin', '/jwt-status'],
+			['/authorizedActions', '/dslogin', '/dslogout', '/jwt-status'],
 			routes,
 			'should set the expected routes when there is a non-empty dsCredentials entry in serverconfig'
 		)

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -159,10 +159,8 @@ tape('legacy reshape', async test => {
 						headerKey: 'x-ds-token',
 						route: 'termdb',
 						authRoute: '/jwt-status'
-					},
-					__embedders__: ['localhost']
-				},
-				__routes__: ['termdb']
+					}
+				}
 			},
 			ds1: {
 				'/**': {
@@ -171,12 +169,9 @@ tape('legacy reshape', async test => {
 						password: '...',
 						route: '/**',
 						authRoute: '/dslogin'
-					},
-					__embedders__: ['*']
-				},
-				__routes__: ['/**']
-			},
-			__dslabels__: ['ds0', 'ds1']
+					}
+				}
+			}
 		},
 		`should transform a legacy dsCredentials format to the current shape`
 	)

--- a/server/test/fake-jwt.js
+++ b/server/test/fake-jwt.js
@@ -5,7 +5,7 @@ const jsonwebtoken = require('jsonwebtoken')
 
 const time = Math.floor(Date.now() / 1000)
 const dslabel = process.argv[2] || 'TermdbTest'
-const secret = serverconfig.dsCredentials[dslabel].embedders.localhost.secret
+const secret = serverconfig.dsCredentials[dslabel].termdb.localhost.secret
 //for testing only
 console.log(
 	//secret,


### PR DESCRIPTION
## Description
This update supports different auth methods for the same dataset. For example, use jwt for SJLIFE termdb routes and password login for burden routes.

Testing steps:
1. Pull and install updated deps, code
```bash
cd proteinpaint
git checkout master
git pull
git checkout burden-auth

cd sjpp
git checkout master
git pull // master
npm install 
```

2. Unit tests from the proteinpaint dir: `npm run test:unit --workspace=server`

3. Manual tests:
a. add this to `sjpp/serverconfig.json`
```json
"dsCredentials": {
      "SJLife": {
         "burden": {
            "*": {
               "type": "basic",
               "password": "..."
            }
         },
         "termdb": {
            "localhost": {
               "type": "jwt",
               "secret": "my-secret",
               "dsnames": [
                  {
                     "id": "sjlife",
                     "label": "SJLIFE"
                  },
                  {
                     "id": "ccss",
                     "label": "CCSS"
                  }
               ],
               "headerKey": "x-ds-access-token"
            }
         }
      },

      "PNET": {
         "type": "login",
         "password": "cb"
      }
 }
```
b. then `npm run dev`
c. in another terminal window, `./proteinpaint/server/test/fake-jwt.js TermdbTest > public/fake-jwt.json`
d. open http://localhost:3000/example.auth.html?dslabel=SJLife
- should see `Requires sign-in`
- click Login // should display the Data Download UI
- do a data download
- click Logout // should log you out and display `Requires sign-in` again

NOTE: The testing of the burden route protection will come after this, since it's still only in demo mode and will require cloning the pcb repo.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
