### PR TITLE
Gdc.geneexp

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -748,6 +748,9 @@ async function parseEmbedThenUrl(arg, app) {
 	if (arg.launchGdcMatrix) {
 		return await launchGdcMatrix(arg, app)
 	}
+	if (arg.launchGdcHierCluster) {
+		return await launchGdcHierCluster(arg, app)
+	}
 
 	if (arg.parseurl && location.search.length) {
 		/*
@@ -1362,6 +1365,10 @@ async function launchGeneSearch4GDCmds3(arg, app) {
 }
 async function launchGdcMatrix(arg, app) {
 	const _ = await import('./launchGdcMatrix')
+	return await _.init(arg, app.holder0, app.genomes)
+}
+async function launchGdcHierCluster(arg, app) {
+	const _ = await import('./launchGdcHierCluster')
 	return await _.init(arg, app.holder0, app.genomes)
 }
 

--- a/client/src/launchGdcHierCluster.js
+++ b/client/src/launchGdcHierCluster.js
@@ -1,0 +1,181 @@
+import { dofetch3 } from '#common/dofetch'
+import { appInit } from '#plots/plot.app.js'
+import { fillTermWrapper } from '#termsetting'
+
+/*
+test with http://localhost:3000/example.gdc.exp.html
+
+designed to work for Gene Exp Visualization app in GDC Analysis Tools Framework
+
+the pp react wrapper in Gdc Frontend Framework will call this with parameters:
+runpp({ launchGdcHierCluster:true })
+
+initiates a "plot" app instance that wraps around the hierCluster component
+and returns the plot app API
+
+
+********* parameters
+
+holder
+genomes = { hg38 : {} }
+arg = {}
+	runpp() argument object
+
+	.filter0{}
+		see notes in launchGdcMatrix.js
+
+	.genes[]
+		future: list of genes to launch matrix
+
+	.termgroups[]
+		list of terms to be added to the matrix by default
+	
+	.settings{hierCluster{}}
+		.maxGenes
+
+	.opts{hierCluster{}}
+
+
+********* returns
+
+API object with following methods; pp react wrapper can call api.update() when user updates cohort in the GDC portal
+TODO revise to a simpler object
+
+{
+	type:'hierCluster'
+	id:str
+	getComponents()
+	on()
+	update()
+	destroy()
+}
+*/
+
+const gdcGenome = 'hg38'
+const gdcDslabel = 'GDC'
+
+export async function init(arg, holder, genomes) {
+	const genome = genomes[gdcGenome]
+	if (!genome) throw gdcGenome + ' missing'
+
+	// these options will allow session recovery by an embedder
+	const settings = arg.settings || {}
+	if (typeof settings != 'object') throw 'arg.settings{} not object'
+	if (!settings.hierCluster) settings.hierCluster = {}
+	if (typeof settings.hierCluster != 'object') throw 'arg.settings.hierCluster{} not object'
+	// set defaults
+	if (!Number.isInteger(settings.hierCluster.maxGenes)) settings.hierCluster.maxGenes = 100
+
+	if (arg.filter0 && typeof arg.filter0 != 'object') throw 'arg.filter0 not object'
+
+	const genes = await getGenes(arg, arg.filter0, settings.hierCluster)
+
+	const opts = {
+		holder,
+		genome,
+		state: {
+			genome: gdcGenome,
+			dslabel: gdcDslabel,
+			termfilter: { filter0: arg.filter0 },
+			plots: [
+				{
+					chartType: 'hierCluster',
+					//termgroups: [...(arg.termgroups || []), { lst: genes }],
+					genes,
+					settings
+				}
+			]
+		},
+		app: {
+			features: ['recover']
+		},
+		recover: {
+			undoHtml: 'Undo',
+			redoHtml: 'Redo',
+			resetHtml: 'Restore'
+		}
+		/*
+		matrix: Object.assign(
+			{
+				// these will display the inputs together in the Genes menu,
+				// instead of being rendered outside of the matrix holder
+				customInputs: {
+					genes: [
+						{
+							label: `Maximum # Genes`,
+							title: 'Limit the number of displayed genes',
+							type: 'number',
+							chartType: 'matrix',
+							settingsKey: 'maxGenes',
+							callback: async value => {
+								const genes = await getGenes(arg, arg.filter0, { maxGenes: value })
+								api.update({
+									termgroups: [{ lst: genes }],
+									settings: {
+										matrix: { maxGenes: value }
+									}
+								})
+							}
+						}
+					]
+				}
+			},
+			arg.opts?.matrix || {}
+		)
+		*/
+	}
+
+	const plotAppApi = await appInit(opts)
+	const thisApi = plotAppApi.getComponents('plots.0')
+
+	const api = {
+		update: arg => {
+			if ('filter0' in arg) {
+				plotAppApi.dispatch({
+					type: 'filter_replace',
+					filter0: arg.filter0
+				})
+			} else {
+				plotAppApi.dispatch({
+					type: 'plot_edit',
+					id: thisApi.id,
+					config: arg
+				})
+			}
+		}
+	}
+
+	return api
+}
+
+/*
+arg={}
+	.genes=[ str, ... ]
+filter0={}
+config{}
+*/
+async function getGenes(arg, filter0, config) {
+	if (arg.genes) {
+		// genes are predefined
+		if (!Array.isArray(arg.genes) || arg.genes.length == 0) throw '.genes[] is not non-empty array'
+		return await Promise.all(
+			arg.genes.map(async i => {
+				return await fillTermWrapper({ term: { name: i, type: 'geneVariant' } })
+			})
+		)
+	}
+
+	// genes are not predefined. query to get top genes using the current cohort
+	const body = {
+		filter0,
+		maxGenes: config.maxGenes
+	}
+	const data = await dofetch3('gdc/topVariablyExpressedGenes', { body })
+	if (data.error) throw data.error
+	if (!data.genes) throw 'no top genes found using the cohort filter'
+	return await Promise.all(
+		data.genes.map(async i => {
+			return await fillTermWrapper({ term: { name: i, type: 'geneVariant' } })
+		})
+	)
+}

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -31,15 +31,15 @@ arg = {}
 		future: list of genes to launch matrix
 
 	.termgroups[]
-		TODO 
+		list of terms to be added to the matrix by default
 	
-	.settings{}
-		.matrix{}
-			.maxGenes
-			.maxSamples
+	.settings{matrix{}}
+		any state that can be JSON-encoded/hydrated as part of getPlotConfig().settings.matrix. This is meant to hold plot-instance-specific state that only affects rendering and not data requests, but that distinction is not as clear with plots that use server-side rendering like violin plot.
+		.maxGenes
+		.maxSamples
 
-	.opts{}
-		.matrix{}
+	.opts{matrix{}}
+		any options that cannot be JSON-stringified, like callbacks. These options will also be applied to all rehydrated or new plots of the same type, so not plot-instance-specific. this way of adding callback allows to work with an external portal, e.g. a callback from gdc to collect cases
 			.allow2selectSamples: 
 				{
 				  buttonText: "Create Cohort",

--- a/server/routes/gdc.topVariablyExpressedGenes.ts
+++ b/server/routes/gdc.topVariablyExpressedGenes.ts
@@ -1,0 +1,101 @@
+import { GdcTopVariablyExpressedGenesResponse } from '#shared/types/routes/gdc.topVariablyExpressedGenes.ts'
+import { getCasesWithExressionDataFromCohort } from '../src/mds3.gdc.js'
+//import path from 'path'
+import got from 'got'
+
+//const apihost = process.env.PP_GDC_HOST || 'https://api.gdc.cancer.gov'
+const apihost = 'https://uat-portal.gdc.cancer.gov/auth/api/v0/gene_expression/gene_selection' // TODO change when api is released to prod
+
+const gdcGenome = 'hg38'
+const gdcDslabel = 'GDC'
+
+export const api = {
+	endpoint: 'gdc/topVariablyExpressedGenes',
+	methods: {
+		get: {
+			init({ genomes }) {
+				/*
+				 */
+
+				return async (req: any, res: any): Promise<void> => {
+					try {
+						// following logic requires hg38 gdc dataset
+						const genome = genomes[gdcGenome]
+						if (!genome) throw 'hg38 genome missing'
+						const ds = genome.datasets?.[gdcDslabel]
+						if (!ds) throw 'gdc dataset missing'
+						const genes = await getGenes(req.query, ds, genome)
+						const payload = { genes } as GdcTopVariablyExpressedGenesResponse
+						res.send(payload)
+					} catch (e: any) {
+						res.send({ status: 'error', error: e.message || e })
+					}
+				}
+			},
+			request: {
+				typeId: null
+				//valid: default to type checker
+			},
+			response: {
+				typeId: 'GdcTopVariablyExpressedGenesResponse'
+				// will combine this with type checker
+				//valid: (t) => {}
+			}
+		}
+	}
+}
+
+/*
+req.query {
+	filter0 // optional gdc GFF cohort filter, invisible and read only
+		FIXME should there be pp filter too?
+	maxGenes: int
+}
+
+ds { } // server-side ds object
+
+*/
+async function getGenes(q: any, ds: any, genome: any) {
+	// based on current cohort, get list of cases with exp data, as input of next api query
+	const caseLst = await getCasesWithExressionDataFromCohort(q, ds)
+	if (caseLst.length == 0) {
+		// there are no cases with gene exp data
+		return [] as string[]
+	}
+
+	// change to this when api is available on prod
+	// const url = path.join(apihost, '/gene_expression/gene_selection')
+
+	const response = await got.post(apihost, {
+		headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+		body: JSON.stringify({
+			case_ids: caseLst,
+			gene_ids: getFullGenelist(genome), // XXX should not be required
+			size: q.maxGenes || 100
+		})
+	})
+
+	const re = JSON.parse(response.body)
+	// {"gene_selection":[{"gene_id":"ENSG00000141510","log2_uqfpkm_median":3.103430497010492,"log2_uqfpkm_stddev":0.8692021350485105,"symbol":"TP53"}, ... ]}
+
+	const genes = [] as string[]
+	if (!Array.isArray(re.gene_selection)) throw 're.gene_selection[] is not array'
+	for (const i of re.gene_selection) {
+		if (i.gene_id && typeof i.gene_id == 'string') {
+			genes.push(i.gene_id) // ensg
+		} else if (i.symbol && typeof i.symbol == 'string') {
+			genes.push(i.symbol)
+		} else {
+			throw 'a return is missing both gene_id and symbol'
+		}
+	}
+	return genes
+}
+
+function getFullGenelist(genome) {
+	// just for testing only! should not be required. pending discussion with Phil
+	// cannot send all 60k ENSG to api, it errors out. can only send 200 or less
+	const re = genome.genedb.getAllENSG.all()
+	const lst = re.slice(0, 200).map(i => i.alias)
+	return lst
+}

--- a/server/shared/types/routes/gdc.topVariablyExpressedGenes.ts
+++ b/server/shared/types/routes/gdc.topVariablyExpressedGenes.ts
@@ -1,0 +1,3 @@
+export type GdcTopVariablyExpressedGenesResponse = {
+	genes: string[]
+}

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7193,8 +7193,6 @@ async function pp_init(serverconfig) {
 				g.genedb.getNameByAlias = g.genedb.db.prepare('select name from genealias where alias=?')
 				// quick fix -- convert symbol to ENSG, to be used for gdc api query
 				g.genedb.getAliasByName = g.genedb.db.prepare('select alias from genealias where name=?')
-				// quick fix -- required by gdc api /gene_expression/gene_selection, one input is all ensg
-				g.genedb.getAllENSG = g.genedb.db.prepare("select alias from genealias where alias like 'ENSG%'")
 			}
 			if (tables.has('gene2coord')) {
 				g.genedb.getCoordByGene = g.genedb.db.prepare('select * from gene2coord where name=?')

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7191,8 +7191,10 @@ async function pp_init(serverconfig) {
 			const tables = listDbTables(g.genedb.db)
 			if (tables.has('genealias')) {
 				g.genedb.getNameByAlias = g.genedb.db.prepare('select name from genealias where alias=?')
-				g.genedb.getAliasByName = g.genedb.db.prepare('select alias from genealias where name=?') // quick fix!! convert symbol to ENSG, to be used for gdc api query
-				g.genedb.tableSize = g.genedb.db.prepare('select count(*) from genealias where alias=?')
+				// quick fix -- convert symbol to ENSG, to be used for gdc api query
+				g.genedb.getAliasByName = g.genedb.db.prepare('select alias from genealias where name=?')
+				// quick fix -- required by gdc api /gene_expression/gene_selection, one input is all ensg
+				g.genedb.getAllENSG = g.genedb.db.prepare("select alias from genealias where alias like 'ENSG%'")
 			}
 			if (tables.has('gene2coord')) {
 				g.genedb.getCoordByGene = g.genedb.db.prepare('select * from gene2coord where name=?')

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -205,7 +205,7 @@ export function validate_query_geneExpression(ds, genome) {
 	}
 }
 
-async function getCasesWithExressionDataFromCohort(q, ds) {
+export async function getCasesWithExressionDataFromCohort(q, ds) {
 	const f = { op: 'and', content: [] }
 	if (q.filter0) {
 		f.content.push(q.filter0)

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -171,18 +171,19 @@ export function validate_query_geneExpression(ds, genome) {
 		const ensg2symbol = new Map()
 
 		for (const g of q.genes) {
-			if (typeof g.gene != 'string') continue
-			if (g.gene.startsWith('ENSG') && g.gene.length == 15) {
-				ensgLst.push(g.gene)
-				ensg2symbol.set(g.gene, g.gene)
+			const name = g.gene || g.name // TODO should be only g.gene
+			if (typeof name != 'string') continue // TODO report skipped ones
+			if (name.startsWith('ENSG') && name.length == 15) {
+				ensgLst.push(name)
+				ensg2symbol.set(name, name)
 				continue
 			}
-			const lst = genome.genedb.getAliasByName.all(g.gene)
+			const lst = genome.genedb.getAliasByName.all(name)
 			if (Array.isArray(lst)) {
 				for (const a of lst) {
 					if (a.alias.startsWith('ENSG')) {
 						ensgLst.push(a.alias)
-						ensg2symbol.set(a.alias, g.gene)
+						ensg2symbol.set(a.alias, name)
 						break
 					}
 				}


### PR DESCRIPTION
## Description

please pull sjpp master
must have below in your serverconfig.features{}:

>                 "stopGdcCacheAliquot":2,
>                 "gdcGenes":["MYC","ALK","GAPDH","ELP1","IDH1","CDKN2A"],

1st line is to cache some gdc cases with exp data
2nd line is to get around a known issue with /gene_selection API. when it's resolved by UC this line and some codewill be deleted

test at http://localhost:3000/example.gdc.exp.html, it should load up a map of cases cached on your instance and the hardcoded genes

should be fine to merge and no existing things should be impacted; next will work on various UI issues

one of the change solves https://github.com/stjude/proteinpaint/issues/596 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
