### PR TITLE
Issue.648

### DIFF
--- a/client/dom/genesetEdit.ts
+++ b/client/dom/genesetEdit.ts
@@ -23,6 +23,7 @@ export function showGenesetEdit({
 	genome,
 	callback,
 	geneList = [],
+	mode,
 	vocabApi,
 	group,
 	showGroup
@@ -31,11 +32,13 @@ export function showGenesetEdit({
 	menu: Menu
 	genome: any
 	geneList: Array<Gene>
+	mode?: string
 	callback: (group, geneList) => void
 	vocabApi: any
 	group: any
 	showGroup: boolean
 }) {
+	console.log('mode', mode)
 	menu.clear()
 	const tip2 = new Menu({ padding: '0px' })
 	const div = menu.d.append('div').style('width', '850px').style('padding', '5px')

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -5,7 +5,7 @@ import { Menu } from '#dom/menu'
 import { zoom } from '#dom/zoom'
 import { icons } from '#dom/control.icons'
 import { svgScroll } from '#dom/svg.scroll'
-import { showGenesetEdit } from '../dom/genesetEdit.ts'
+import { showGenesetEdit } from '../dom/genesetEdit.ts' // cannot use '#dom/', breaks
 
 const tip = new Menu({ padding: '' })
 
@@ -793,20 +793,24 @@ export class MatrixControls {
 				const group = parent.config.termgroups[selectedGroup]
 				app.tip.clear().hide()
 
-				const geneList = []
-				for (const tw of group.lst) if (tw.term.type == 'geneVariant') geneList.push({ name: tw.term.name })
-				showGenesetEdit({
+				const gsArg = {
 					holder: event.target,
 					menu: app.tip,
 					genome: app.opts.genome,
-					geneList,
+					geneList: [],
 					callback,
 					vocabApi: this.opts.app.vocabApi,
-					// TODO later when the gene exp plot is launched via matrix, will set mode:expression
-					//mode: 'expression',
 					group,
 					showGroup: parent.config.termgroups > 1
-				})
+				}
+
+				if (this.parent.chartType == 'hierCluster' && selectedGroup == 0) {
+					// TODO comment
+					gsArg.mode = 'expression'
+				}
+
+				for (const tw of group.lst) if (tw.term.type == 'geneVariant') gsArg.geneList.push({ name: tw.term.name })
+				showGenesetEdit(gsArg)
 			})
 	}
 
@@ -833,6 +837,9 @@ export class MatrixControls {
 					overrides: false,
 					lst: []
 				}
+				/* no need to detect the condition and assign mode=expression. 
+				it is expected that a newly added gene term group will not trigger clustering analysis
+				*/
 				showGenesetEdit({
 					holder: event.target,
 					menu: app.tip,
@@ -840,8 +847,6 @@ export class MatrixControls {
 					geneList: [],
 					callback,
 					vocabApi: this.opts.app.vocabApi,
-					// TODO later when the gene exp plot is launched via matrix, will set mode:expression
-					//mode: 'expression',
 					group,
 					showGroup: true
 				})

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -996,8 +996,12 @@ export class TermdbVocab extends Vocab {
 		})
 	}
 
+	// following two methods are hardcoded at /gdc/*. TODO change to generic method to work for all datasets
 	async getTopMutatedGenes(arg) {
 		return await dofetch3('gdc/topMutatedGenes', { method: 'GET', body: arg })
+	}
+	async getTopVariablyExpressedGenes(arg) {
+		return await dofetch3('gdc/topVariablyExpressedGenes', { method: 'GET', body: arg })
 	}
 
 	/* 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- New button in geneset edit UI allowing to load top variably expressed genes in hierarchical clustering, for eligible datasets

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -225,15 +225,15 @@ type SingleSampleMutation = GdcApi & {
 	discoSkipChrM?: boolean
 }
 
-type ArgumentsEntry = {
-	id: string
-	label: string
-	type: string
-	value: string
-}
+type TopVariablyExpressedGenes = {} // to add arguments
 
 type TopMutatedGenes = {
-	arguments?: ArgumentsEntry[]
+	arguments?: {
+		id: string
+		label: string
+		type: string
+		value: string
+	}[]
 }
 
 type TklstEntry = {
@@ -289,6 +289,7 @@ type Queries = {
 	geneExpression?: GeneExpressionQuery
 	rnaseqGeneCount?: RnaseqGeneCount
 	topMutatedGenes?: TopMutatedGenes
+	topVariablyExpressedGenes?: TopVariablyExpressedGenes
 	trackLst?: TrackLstEntry[]
 	// TODO singleSampleGbtk
 }

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -61,11 +61,13 @@ type InfoFieldsEntry = {
 	separator: string
 }
 
+/*
 type GenomicPositionEntry = {
 	chr: string
 	start: number
 	stop: number
 }
+*/
 
 type Chr2bcffile = { [index: string]: string }
 
@@ -225,7 +227,9 @@ type SingleSampleMutation = GdcApi & {
 	discoSkipChrM?: boolean
 }
 
-type TopVariablyExpressedGenes = {} // to add arguments
+type TopVariablyExpressedGenes = {
+	args?: any
+}
 
 type TopMutatedGenes = {
 	arguments?: {

--- a/server/src/termdb.config.js
+++ b/server/src/termdb.config.js
@@ -137,7 +137,7 @@ function addGenomicQueries(c, ds, genome) {
 		}
 	}
 	if (q.topMutatedGenes) q2.topMutatedGenes = q.topMutatedGenes
-	if (q.topVariablyExpressedGenes) q2.topVariablyExpressedGenes = q.topVariablyExpressedGenes.arguments
+	if (q.topVariablyExpressedGenes) q2.topVariablyExpressedGenes = q.topVariablyExpressedGenes
 	if (q.singleSampleMutation) {
 		q2.singleSampleMutation = {
 			sample_id_key: q.singleSampleMutation.sample_id_key,


### PR DESCRIPTION
## Description

closes #648 
please pull sjpp master to test with this pr
when running exp cluster on gdc, at geneset edit UI, it should show button `Top variably expressed`, but not `Top mutated`


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
