### PR TITLE
Auth fixes and improvements

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -307,6 +307,9 @@ async function mayShowAuthUi(init, path) {
 			else if (a.type == 'jwt') {
 				// assume the embedder/portal provides the login UI
 				// so do not need to do anything here
+			} else if (a.type == 'forbidden') {
+				alert('Forbidden access')
+				// don't do anything
 			} else throw `unsupported dsAuth type='${a.type}'`
 		}
 	}

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -625,7 +625,7 @@ async function get_singleSampleData(q, req, res, ds, tdb) {
 async function get_AllSamples(q, req, res, ds) {
 	const canDisplay = authApi.canDisplaySampleIds(req, ds)
 	let result = []
-	if (canDisplay) result = Object.fromEntries(ds.id2sampleName)
+	if (canDisplay) result = Object.fromEntries(ds.id2sampleName || [])
 	res.send(result)
 }
 

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -1,6 +1,7 @@
 import serverconfig from './serverconfig'
 import { connect_db } from './utils'
 import { isUsableTerm } from '../shared/termdb.usecase'
+import auth from './auth'
 
 /*
 server_init_db_queries()
@@ -424,8 +425,8 @@ export function server_init_db_queries(ds) {
 				if (ds.cohort.scatterplots) supportedChartTypes[r.cohort].add('sampleScatter')
 				numericTypeCount[r.cohort] = 0
 				if (ds.cohort.allowedChartTypes?.includes('matrix')) supportedChartTypes[r.cohort].add('matrix')
-				// TODO: should use an embedderHostPattern
-				if (!cred || cred.termdb?.[embedder] || cred.termdb?.['*']) {
+				const forbiddenRoutes = auth.getForbiddenRoutesForDsEmbedder(ds.label, embedder)
+				if (!forbiddenRoutes.includes('termdb') && !forbiddenRoutes.includes('*')) {
 					supportedChartTypes[r.cohort].add('dataDownload')
 					supportedChartTypes[r.cohort].add('sampleView')
 				}

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -126,29 +126,30 @@ tape('legacy reshape', async test => {
 	test.plan(1)
 
 	const app = appInit()
-	const serverconfig = {
-		dsCredentials: {
-			ds0: {
-				type: 'jwt',
-				embedders: {
-					localhost: {
-						secret,
-						dsnames: [{ id: 'ds0', label: 'Dataset 0' }]
-					}
-				},
-				headerKey
+	const dsCredentials = {
+		ds0: {
+			type: 'jwt',
+			embedders: {
+				localhost: {
+					secret,
+					dsnames: [{ id: 'ds0', label: 'Dataset 0' }]
+				}
 			},
-			ds1: {
-				type: 'login',
-				password: '...'
-			}
+			headerKey
 		},
+		ds1: {
+			type: 'login',
+			password: '...'
+		}
+	}
+	const serverconfig = {
+		dsCredentials,
 		cachedir
 	}
 
 	await auth.maySetAuthRoutes(app, '', serverconfig)
 	test.deepEqual(
-		JSON.parse(JSON.stringify(serverconfig.dsCredentials)),
+		JSON.parse(JSON.stringify(dsCredentials)),
 		{
 			ds0: {
 				termdb: {


### PR DESCRIPTION
## Description
- fix the auth custom headerKey handling
- limit the dsCredentials visibility

@airenzp Please test that sample ID/name handling works, I noticed an error in `get_AllSamples()` where `ds.id2sampleName` is not iterable, I'm pretty sure it's not related to my changes.

To test: 
- from the pp directory, `npm run test --workspace=server`
- have entries like the following in your `serverconfig.dsCredentials` object
```json
      "PNET": {
         "type": "login",
         "password": "..."
      },

      "TermdbTest": {
         "termdb": {
            "localhost": {
               "type": "jwt",
               "secret": "...",
               "dsnames": [
                  {
                     "id": "sjlife",
                     "label": "SJLIFE"
                  },
                  {
                     "id": "ccss",
                     "label": "CCSS"
                  }
               ],
               "headerKey": "x-ds-access-token"
            }
         }
      },
      "MB_meta_analysis": {
         "*": {
            "*": {
               "type": "basic",
               "password": "..."
            }
         }
      }
```
- manual jwt test: login, download data, log out in http://localhost:3000/example.auth.html?
- [PNET](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg19%22,%22dslabel%22:%22PNET%22}) should require a password
- [MBmeta](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22}) should require a password


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
