### PR TITLE
Fix for items not always appearing in groupsetting menu

### DIFF
--- a/client/termsetting/handlers/categorical.ts
+++ b/client/termsetting/handlers/categorical.ts
@@ -104,6 +104,11 @@ export async function getHandler(self: CategoricalTermSettingInstance) {
 			//for rendering groupsetting menu
 			const body = self.opts.getBodyParams?.() || {}
 			const data = await self.vocabApi.getCategories(self.term, self.filter!, body)
+			/** Original code created a separate array (self.category2samplecount) and pushed only the key and label.
+			 * The new self.category2samplecount was used to create the groupsetting menu items. That logic was removed
+			 * as groupsetting.ts handles formating the data. However category2samplecount = [] is still used
+			 * in other client side code. The data shape may differ until all the code is refactored.
+			 */
 			self.category2samplecount = data.lst
 			if (!self.term.values) {
 				self.q = {}

--- a/client/termsetting/handlers/categorical.ts
+++ b/client/termsetting/handlers/categorical.ts
@@ -101,15 +101,10 @@ export async function getHandler(self: CategoricalTermSettingInstance) {
 		},
 
 		async postMain() {
+			//for rendering groupsetting menu
 			const body = self.opts.getBodyParams?.() || {}
 			const data = await self.vocabApi.getCategories(self.term, self.filter!, body)
-			self.category2samplecount = []
-			for (const i of data.lst) {
-				//Is restructuring here necessary? If category2samplecount is only used for
-				//groupsetting, then this is unnecessary.
-				self.category2samplecount.push({ key: i.key, count: i.samplecount })
-				//
-			}
+			self.category2samplecount = data.lst
 			if (!self.term.values) {
 				self.q = {}
 			} // ...

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -187,7 +187,6 @@ export class GroupSettingMethods {
 }
 
 function setRenderers(self: any) {
-	let maxGrpNum: number
 	self.initGrpSetUI = async function () {
 		/*max num of groups rendered + excluded categories
 		Only allow adding the max feasible groups with cutoff of 5 + excluded categories*/

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -329,7 +329,6 @@ tape('Categorical term', async test => {
 	})
 
 	await opts.pill.main(opts.tsData)
-
 	const pilldiv = opts.holder.node().querySelectorAll('.ts_pill')[0]
 	pilldiv.click()
 	const tip = opts.pill.Inner.dom.tip
@@ -338,16 +337,17 @@ tape('Categorical term', async test => {
 	test.equal(tip.d.selectAll('.sja_menuoption.sja_sharp_border').size(), 2, 'Should have 2 buttons for group config')
 
 	// check menu buttons on category menu
-	const itemNum = Object.keys(opts.tsData.term.values).length
+	/** Although 27 values, annotations only available for 10. */
+	//const itemNum = Object.keys(opts.tsData.term.values).length
 	const dragItems = await detectGte({
 		elem: tip.d.node(),
 		selector: 'div > div > div > .sjpp-drag-item',
-		count: itemNum,
+		count: 10,
 		async trigger() {
 			tip.d.selectAll('.sja_menuoption.sja_sharp_border')._groups[0][0].click()
 		}
 	})
-	test.equal(dragItems.length, itemNum, `Should have rows (n=${dragItems.length}) for each category (n=${itemNum})`)
+	test.equal(dragItems.length, 10, `Should have rows (n=${dragItems.length}) for each category (n=10)`)
 	test.equal(
 		tip.d.selectAll('div > div > div > .sjpp_grpset_addGrp_btn').size(),
 		1,
@@ -358,7 +358,11 @@ tape('Categorical term', async test => {
 		1,
 		'Should have "Apply" button to apply group changes'
 	)
-	test.equal(dragItems[0].innerHTML, 'Acute lymphoblastic leukemia (n=44)', 'Should have first cateogry as "ALL"')
+	test.equal(
+		dragItems[0].innerHTML,
+		'Non-Hodgkin lymphoma (n=16)',
+		'Should have first cateogry as "Non-Hodgkin lymphoma (n=16)"'
+	)
 
 	//Test drag functionality
 	const grpInputs = await detectLst({ elem: tip.d.node(), selector: 'input', count: 2 })

--- a/server/shared/types/termdb.ts
+++ b/server/shared/types/termdb.ts
@@ -45,7 +45,8 @@ export type RangeEntry = {
 
 export type GroupEntry = {
 	name: string
-	type?: 'values' | 'filter' //filter is no longer used. Only use values
+	/** 'filter' is no longer used!! Only use values */
+	type?: 'values' | 'filter'
 	color?: string
 	values: { key: number | string; label: string }[]
 	filter?: Filter
@@ -62,24 +63,59 @@ export type GroupSetEntry = BaseGroupSet & {
 }
 
 export type GroupSetting = {
+	/** If true, apply and will require the following attributes */
 	inuse?: boolean
 	disabled?: boolean
 	useIndex?: number
+	/**Value is array index of term.groupsetting.lst[] */
 	predefined_groupset_idx?: number
 	lst?: GroupSetEntry[]
+	/** When “predefined_groupset_idx” is undefined, will use this set of groups.
+	This is a custom set of groups either copied from predefined set, or created with UI.
+	Custom set definition is the same as a predefined set. */
 	customset?: BaseGroupSet
 }
 
 export type BaseQ = {
 	groups?: any // Not documented but appears in condition and samplelst?? same as groupsetting?
 	groupsetting?: GroupSetting
+	/**Automatically set by fillTermWrapper()
+	Applies to barchart, survival plot, and cuminc plot.
+	Contains categories of a term to be hidden in its chart. This should only apply to client-side rendering, and should not be part of “dataName” when requesting data from server. Server will always provide a summary for all categories. It’s up to the client to show/hide categories.
+	This allows the key visibility to be stored in state, while toggling visibility will not trigger data re-request.
+	Currently termsetting menu does not manage this attribute. It’s managed by barchart legend.
+	*/
 	hiddenValues?: HiddenValues
+	/**indicates this object should not be extended by a copy-merge tool */
 	isAtomic?: boolean
+	/** Describes list of custom bins. */
 	lst?: RangeEntry[]
 	name?: string
-	mode?: 'discrete' | 'binary' | 'continuous' | 'spline' | 'cuminc' | 'cox'
+	mode?:
+		| 'discrete'
+		/** Binary is a special case of discrete. */
+		| 'binary'
+		| 'continuous'
+		/** Only for numeric terms in regression analysis. Requires q.knots */
+		| 'spline'
+		/** Only applies to condition term. Requires q.breaks[] to have one grade value.*/
+		| 'cuminc'
+		/** Only applies to condition term for cox regression outcome. Requires q.breaks[] to have one grade value, for event and q.timeScale.*/
+		| 'cox'
+
 	reuseId?: string
-	type?: 'values' | 'regular-bin' | 'custom-bin' | 'predefined-groupset' | 'custom-groupset' | 'custom-samplelst'
+	/** To define ways to divide up cohort based on a term, using methods specific to term types.*/
+	type?: /** Requires term.values{} to access categories for categorical term, and grade for condition term */
+	| 'values'
+		/** Applies to numeric terms */
+		| 'regular-bin'
+		/** Applies to numeric terms */
+		| 'custom-bin'
+		/** Applies to categorical and condition terms */
+		| 'predefined-groupset'
+		/** Applies to categorical and condition terms */
+		| 'custom-groupset'
+		| 'custom-samplelst'
 }
 
 export type Q = BaseQ | CategoricalQ | ConditionQ | NumericQ | GeneVariantQ | SampleLstQ | SnpsQ
@@ -101,17 +137,16 @@ export type TermValues = {
 export type Subconditions = {
 	[index: string | number]: {
 		label: string
-		group?: number //see handlers/categorical.ts
-		uncomputable?: true //Not sure if this is correct??
 	}
 }
 
 type ValueConversion = {
-	scaleFactor: number
-	fromUnit: string // name of unit for the original value
-	toUnit: string // name of converted unit.
-	// when converting day to year, resulting value will be `X year Y day`, that the fromUnit is used to indicate residue days from the last year; it's also printed in termsetting ui
-	// this logic does not hold if converting from year to day, should detect if scaleFactor is >1 or <1
+	/**name of unit for the original value */
+	fromUnit: string
+	/** name of converted unit.
+	when converting day to year, resulting value will be `X year Y day`, that the fromUnit is used to indicate residue days from the last year; it's also printed in termsetting ui
+	this logic does not hold if converting from year to day, should detect if scaleFactor is >1 or <1 */
+	toUnit: string
 }
 
 export type Term = {
@@ -128,10 +163,12 @@ export type Term = {
 		| 'snplst'
 	child_types?: string[]
 	groupsetting?: GroupSetting
+	/** Information to be displayed in the client-side UI. */
 	hashtmldetail?: boolean
 	included_types?: string[]
 	isleaf?: boolean
-	logScale?: string | number //2, 10, or e only
+	/** 2, 10, or e only */
+	logScale?: string | number
 	max?: number
 	min?: number
 	name?: string
@@ -156,49 +193,6 @@ export type DetermineQ<T extends Term['type']> = T extends 'numeric' | 'integer'
 	: T extends 'snplst' | 'snplocus'
 	? SnpsQ
 	: Q
-
-// export function matchTermType(term: Term): Q | undefined {
-// 	switch (term.type) {
-// 	  case 'categorical':
-// 		return {
-// 		  termType: 'categorical',
-// 		} as CategoricalConditionQ;
-// 	  case 'integer':
-// 		return {
-// 		  termType: 'integer',
-// 		} as NumericQ;
-// 	  case 'float':
-// 		return {
-// 		  termType: 'float',
-// 		} as NumericQ;
-// 	  case 'condition':
-// 		return {
-// 		  termType: 'conditional',
-// 		} as CategoricalConditionQ;
-// 	  case 'survival':
-// 		return {
-// 		  termType: 'survival',
-// 		} as BaseQ;
-// 	  case 'samplelst':
-// 		return {
-// 		  termType: 'samplelst',
-// 		} as BaseQ;
-// 	  case 'geneVariant':
-// 		return {
-// 		  termType: 'geneVariant',
-// 		} as GeneVariantQ;
-// 	  case 'snplocus':
-// 		return {
-// 		  termType: 'snplocus',
-// 		} as SnpLocusQ;
-// 	  case 'snplst':
-// 		return {
-// 		  termType: 'snplst',
-// 		} as SnpLstQ;
-// 	  default:
-// 		return undefined;
-// 	}
-//   }
 
 export type TermWrapper = {
 	//Term wrapper aka. term:{term:{...}, q:{...}...}


### PR DESCRIPTION
## Description
Test with: http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22hltins%22},%22settings%22:{%22controls%22:{%22isOpen%22:%22true%22}}}],%22nav%22:{%22activeTab%22:1}} -> Edit -> all categories appear

Some changes are from the subconditions work to avoid merge conflicts with others later. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
