### PR TITLE
optimize matrix legend filter so that filter work faster when #cases …

### DIFF
--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -124,7 +124,8 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 					minLabel: value.class == 'CNV_loss' ? -max : 0,
 					maxLabel: value.class == 'CNV_loss' ? 0 : max,
 					order,
-					dt: value.dt
+					dt: value.dt,
+					origin: value.origin
 				}
 			}
 		} else {
@@ -134,7 +135,7 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 				group,
 				value: value.class,
 				order: -1,
-				entry: { key: value.class, label: cell.label, fill: cell.fill, order, dt: value.dt }
+				entry: { key: value.class, label: cell.label, fill: cell.fill, order, dt: value.dt, origin: value.origin }
 			}
 		}
 	} else if (value.dt == 3) {
@@ -151,7 +152,8 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 				minLabel: self.geneExpValues.min,
 				maxLabel: self.geneExpValues.max,
 				order,
-				dt: value.dt
+				dt: value.dt,
+				origin: value.origin
 			}
 		}
 	} else {
@@ -161,7 +163,7 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 			group,
 			value: value.class,
 			order: -2,
-			entry: { key: value.class, label: cell.label, fill: cell.fill, order, dt: value.dt }
+			entry: { key: value.class, label: cell.label, fill: cell.fill, order, dt: value.dt, origin: value.origin }
 		}
 	}
 }

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -1144,7 +1144,7 @@ export class Matrix {
 						legend.entry.crossedOut = true
 						for (const l of [legendGroups, so.grp.legendGroups]) {
 							if (!l) continue
-							if (!l[legend.group]) l[legend.group] = { ref: legend.ref, values: {}, order: legend.order }
+							if (!l[legend.group]) l[legend.group] = { ref: legend.ref, values: {}, order: legend.order, $id }
 							const lg = l[legend.group]
 							if (!lg.values[legend.value]) {
 								lg.values[legend.value] = JSON.parse(JSON.stringify(legend.entry))
@@ -1178,7 +1178,7 @@ export class Matrix {
 					if (legend) {
 						for (const l of [legendGroups, so.grp.legendGroups]) {
 							if (!l) continue
-							if (!l[legend.group]) l[legend.group] = { ref: legend.ref, values: {}, order: legend.order }
+							if (!l[legend.group]) l[legend.group] = { ref: legend.ref, values: {}, order: legend.order, $id }
 							const lg = l[legend.group]
 							if (!lg.values[legend.value]) {
 								lg.values[legend.value] = JSON.parse(JSON.stringify(legend.entry))
@@ -1259,6 +1259,7 @@ export class Matrix {
 				legendData.unshift({
 					name: 'Consequences',
 					order: legend.order,
+					$id: legend.$id,
 					items: keys.map((key, i) => {
 						const item = legend.values[key]
 						const count = item.samples.size
@@ -1272,7 +1273,8 @@ export class Matrix {
 							count,
 							isLegendItem: true,
 							dt: item.dt,
-							crossedOut: item.crossedOut
+							crossedOut: item.crossedOut,
+							origin: item.origin
 						}
 					})
 				})
@@ -1294,6 +1296,7 @@ export class Matrix {
 				legendData.push({
 					name: $id,
 					order: legend.order,
+					$id: legend.$id,
 					hasScale,
 					items: keys.map((key, i) => {
 						const item = legend.values[key]
@@ -1312,7 +1315,8 @@ export class Matrix {
 								count,
 								isLegendItem: true,
 								dt: item.dt,
-								crossedOut: item.crossedOut
+								crossedOut: item.crossedOut,
+								origin: item.origin
 							}
 						} else {
 							return {
@@ -1324,7 +1328,8 @@ export class Matrix {
 								count,
 								isLegendItem: true,
 								dt: item.dt,
-								crossedOut: item.crossedOut
+								crossedOut: item.crossedOut,
+								origin: item.origin
 							}
 						}
 					})
@@ -1345,6 +1350,7 @@ export class Matrix {
 				legendData.push({
 					name: name.length < s.rowlabelmaxchars ? name : name.slice(0, s.rowlabelmaxchars) + '...',
 					order: legend.order,
+					$id: legend.$id,
 					items: keys.map((key, i) => {
 						const item = legend.values[key]
 						const count = item.samples?.size
@@ -1360,7 +1366,8 @@ export class Matrix {
 							//onClickCallback: this.handleLegendItemClick,
 							isLegendItem: true,
 							dt: item.dt,
-							crossedOut: item.crossedOut
+							crossedOut: item.crossedOut,
+							origin: item.origin
 						}
 					})
 				})


### PR DESCRIPTION
…and #categoriesis is large

## Description
Test by http://localhost:3000/example.gdc.matrix.html, use tp53 and primary diagnosis, increase cases#, All GDC,

<img width="1078" alt="Screenshot 2023-10-04 at 09 24 22" src="https://github.com/stjude/proteinpaint/assets/111394589/ea733f46-fd9f-4c73-a8a3-c22770c5638b">

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
