### PR TITLE
more reliable detection of deployed versions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,8 @@
     "examples": "node ./test/import-specs.js name=_x_.examples && npm run tape",
     "rollw": "rm -rf dist && rollup -c ./rollup.config.js -w --bundleConfigAsCjs",
     "build": "rm -rf dist && rollup -c ./rollup.config.js",
-    "prepack": "rm -rf dist && rollup -c ./rollup.config.js"
+    "prepack": "rm -rf dist && rollup -c ./rollup.config.js && npm run sedver",
+    "sedver": "node -p \"Object.values($(npm pkg get version))[0]\" | sed -i '' \"s|___current-proteinpaint-client-version___|$(</dev/stdin)|\" dist/app*.js"
   },
   "author": "",
   "license": "SEE LICENSE IN ./LICENSE",

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -65,9 +65,10 @@ headtip.d.style('z-index', 5555)
 // headtip must get a crazy high z-index so it can stay on top of all, no matter if server config has base_zindex or not
 
 export function runproteinpaint(arg) {
+	if (arg.versionOnly) return `___current-proteinpaint-client-version___`
+
 	// polyfill
 	if (!window.structuredClone) window.structuredClone = val => JSON.parse(JSON.stringify(val))
-
 	/*
 	the "app" object is the main Proteinpaint instance, unique for each runproteinpaint() call
 	NOTE: this app instance may be returned or not depending on the

--- a/server/shared/types/routes/healthcheck.ts
+++ b/server/shared/types/routes/healthcheck.ts
@@ -11,6 +11,9 @@ export type VersionInfo = {
 	pkgver: string
 	codedate: string
 	launchdate: string
+	deps?: {
+		[pkgName: string]: string
+	}
 }
 
 type BuildByGenome = {


### PR DESCRIPTION
## Description
To test (do not permanently save the following edits after testing):
1. in `sjpp/package.json`, add `"@sjcrh/proteinpaint-server": "test"` to the `dependencies` object
2. the http://localhost:3000/healthcheck response payload should display the above information in a `versionInfo.deps` object
3. For the GDC use case where the server-side package.json in the ppserver image does not include proteinpaint-client/front, the only reliable way is to detect the bundled version at runtime in the browser:
```bash
cd proteinpaint/client
npm run sedver
grep -rl 2.27.1 dist/app*.js
# dist/app-3b28d789.js, deployed bundle

# to see how this works in dev, temporarily edit the client/package.json 
# sedver script to target `src/app.js` instead of `dist/app*.js`
npm run sedver
# in the browser console, call runproteinpaint({versionOnly: true}), should log "2.27.1"
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
