### PR TITLE
Fix to show labels when the only the key is saved and isn't descriptive

### DIFF
--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -137,7 +137,6 @@ export class GroupSettingMethods {
 	}
 
 	formatCustomset(grpIdxes: Set<number>, input: DataInput) {
-		let countValues = 0
 		for (const [i, group] of this.opts.q.groupsetting.customset.groups.entries()) {
 			if (group.uncomputable) return
 			this.data.groups.push({
@@ -151,7 +150,6 @@ export class GroupSettingMethods {
 				 * If missing, find the label from category2samplecout or
 				 * use the last ditch effort to use the key.
 				 */
-				++countValues
 				const label = value.label
 					? value.label
 					: this.opts.category2samplecount
@@ -167,9 +165,9 @@ export class GroupSettingMethods {
 				})
 			}
 		}
-
-		if (this.data.values.length !== countValues) {
-			//Find excluded values not returned in customset
+		console.log(this.opts)
+		//Find excluded values not returned in customset
+		if (this.data.values.length !== Object.keys(input).length && !this.opts.q.groupsetting.inuse) {
 			Object.entries(input)
 				.filter((v: any) => !this.data.values.some(d => d.key == v[1].label))
 				.forEach(v => {
@@ -182,6 +180,17 @@ export class GroupSettingMethods {
 									(d: { key: string; label?: string; samplecount: number }) => d.key == v[0]
 							  )?.samplecount
 							: 'n/a'
+					})
+				})
+		} else if (this.data.values.length !== this.opts.category2samplecount.length) {
+			this.opts.category2samplecount
+				.filter((v: ItemEntry) => !this.data.values.some(d => d.key == v.key))
+				.forEach((v: ItemEntry) => {
+					this.data.values.push({
+						key: v.key,
+						label: v.label,
+						group: 0,
+						samplecount: v.samplecount
 					})
 				})
 		}

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -165,7 +165,7 @@ export class GroupSettingMethods {
 				})
 			}
 		}
-		console.log(this.opts)
+
 		//Find excluded values not returned in customset
 		if (this.data.values.length !== Object.keys(input).length && !this.opts.q.groupsetting.inuse) {
 			Object.entries(input)


### PR DESCRIPTION
## Description
Addresses issue #690. 

Test with [logistic link from issue here.](http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22regression%22,%22regressionType%22:%22logistic%22,%22outcome%22:%7B%22id%22:%22health%22%7D%7D%5D%7D)

All tests pass locally. 


## Checklist

- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
