### PR TITLE
Fix for `cancel grouping` button appearing in logistic regression menu

### DIFF
--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -572,7 +572,11 @@ function setInteractivity(self: TermSettingInstance) {
 		type opt = { label: string; callback: (f?: any) => void }
 		const options: opt[] = []
 
-		if (self.term?.type == 'categorical' && self.q?.groupsetting?.inuse) {
+		if (
+			self.term?.type == 'categorical' &&
+			self.q?.groupsetting?.inuse &&
+			self.opts.usecase?.regressionType != 'logistic'
+		) {
 			// this instance is using a categorical term doing groupsetting; add option to cancel it
 			// as categorical edit menu cannot do the canceling
 			options.push({ label: 'Cancel grouping', callback: self.cancelGroupsetting } as opt)


### PR DESCRIPTION
## Description

Addresses issue #691. 

Test with [issue link here](http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22regression%22,%22regressionType%22:%22logistic%22,%22outcome%22:%7B%22id%22:%22diaggrp%22%7D%7D%5D%7D).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
