### PR TITLE
round 4 of server-side esm migration, for the remaining src/ code

### DIFF
--- a/server/src/aicheck.js
+++ b/server/src/aicheck.js
@@ -1,11 +1,10 @@
-const app = require('./app')
-const path = require('path')
-const fs = require('fs')
-const utils = require('./utils')
-const createCanvas = require('canvas').createCanvas
-const serverconfig = require('./serverconfig')
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { createCanvas } from 'canvas'
 
-module.exports = genomes => {
+export default function (genomes) {
 	return async (req, res) => {
 		try {
 			res.send(await do_query(req))
@@ -22,7 +21,7 @@ async function do_query(req) {
 	do not try to estimate marker size, determined by client
 	*/
 
-	const [e, file, isurl] = app.fileurl(req)
+	const [e, file, isurl] = utils.fileurl(req)
 	if (e) throw e
 	const coveragemax = Number(req.query.coveragemax) || 100
 	if (!Number.isInteger(coveragemax)) throw 'invalid coveragemax'

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -1,8 +1,7 @@
-const fs = require('fs').promises
-const existsSync = require('fs').existsSync
-const path = require('path')
-const jsonwebtoken = require('jsonwebtoken')
-const { isMatch } = require('micromatch')
+import { existsSync, promises as fs } from 'fs'
+import path from 'path'
+import jsonwebtoken from 'jsonwebtoken'
+import { isMatch } from 'micromatch'
 // TODO: may use this once babel is configured to transpile es6 node_modules
 //const sleep = require('./utils').sleep
 
@@ -616,7 +615,7 @@ function checkIPaddress(req, ip) {
 		throw `Your connection has changed, please refresh your page or sign in again.`
 }
 
-const authApi = {
+export const authApi = {
 	maySetAuthRoutes,
 	getJwtPayload,
 	canDisplaySampleIds: (req, ds) => {
@@ -629,4 +628,3 @@ const authApi = {
 	userCanAccess: () => true,
 	getRequiredCredForDsEmbedder: () => undefined
 }
-module.exports = authApi

--- a/server/src/bam.gdc.js
+++ b/server/src/bam.gdc.js
@@ -1,5 +1,5 @@
-const got = require('got')
-const path = require('path')
+import got from 'got'
+import path from 'path'
 import { fileSize } from '../shared/fileSize'
 
 /*

--- a/server/src/bam.kmer.indel.js
+++ b/server/src/bam.kmer.indel.js
@@ -1,14 +1,15 @@
-const jStat = require('jstat').jStat
-const path = require('path')
-const features = require('./app').features
-const utils = require('./utils')
-const run_rust = require('@sjcrh/proteinpaint-rust').run_rust
-const spawn = require('child_process').spawn
-const Readable = require('stream').Readable
-const readline = require('readline')
-const bamcommon = require('./bam.common')
-const fs = require('fs')
-const serverconfig = require('./serverconfig')
+import { jStat } from 'jstat'
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { spawn } from 'child_process'
+import { Readable } from 'stream'
+import { readline } from 'readline'
+import * as bamcommon from './bam.common'
+import { run_rust } from '@sjcrh/proteinpaint-rust'
+
+const features = serverconfig.features
 const clustalo_read_alignment = serverconfig.clustalo
 
 export async function match_complexvariant_rust(q, templates_info, region_widths) {
@@ -92,23 +93,24 @@ export async function match_complexvariant_rust(q, templates_info, region_widths
 		}
 		variant_idx = 0
 		for (const variant of q.variant) {
-			const leftflankseq = (await utils.get_fasta(
-				q.genome,
-				variant.chr + ':' + variant_start_global + '-' + ref_positions[variant_idx]
-			))
+			const leftflankseq = (
+				await utils.get_fasta(q.genome, variant.chr + ':' + variant_start_global + '-' + ref_positions[variant_idx])
+			)
 
 				.split('\n')
 				.slice(1)
 				.join('')
 				.toUpperCase()
-			const rightflankseq = (await utils.get_fasta(
-				q.genome,
-				variant.chr +
-					':' +
-					(ref_positions[variant_idx] + refalleles[variant_idx].length + 1) +
-					'-' +
-					variant_stop_global
-			))
+			const rightflankseq = (
+				await utils.get_fasta(
+					q.genome,
+					variant.chr +
+						':' +
+						(ref_positions[variant_idx] + refalleles[variant_idx].length + 1) +
+						'-' +
+						variant_stop_global
+				)
+			)
 				.split('\n')
 				.slice(1)
 				.join('')

--- a/server/src/bampile.js
+++ b/server/src/bampile.js
@@ -1,11 +1,10 @@
-const app = require('./app')
-const utils = require('./utils')
-const createCanvas = require('canvas').createCanvas
-const basecolor = require('#shared/common').basecolor
+import * as utils from './utils'
+import { createCanvas } from 'canvas'
+import { basecolor } from '#shared/common'
 
-module.exports = async (req, res) => {
+export default async function (req, res) {
 	try {
-		const [e, tkfile, isurl] = app.fileurl(req)
+		const [e, tkfile, isurl] = utils.fileurl(req)
 		if (e) throw e
 		let usegrade = req.query.usegrade
 		const allheight = Number(req.query.allheight),

--- a/server/src/bedgraphdot.js
+++ b/server/src/bedgraphdot.js
@@ -1,16 +1,15 @@
-const app = require('./app')
-const path = require('path')
-const fs = require('fs')
-const utils = require('./utils')
-const createCanvas = require('canvas').createCanvas
-const serverconfig = require('./serverconfig')
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { createCanvas } from 'canvas'
 
 /*
  ********************** EXPORTED
  ********************** INTERNAL
  */
 
-module.exports = genomes => {
+export default function (genomes) {
 	return async (req, res) => {
 		try {
 			const q = req.query
@@ -68,11 +67,7 @@ async function run_request(q, dir, nochr) {
 		maxv = q.maxv
 	}
 
-	const hscale = app
-		.makeyscale()
-		.height(q.barheight)
-		.min(minv)
-		.max(maxv)
+	const hscale = app.makeyscale().height(q.barheight).min(minv).max(maxv)
 
 	for (const r of q.rglst) {
 		const r2 = {

--- a/server/src/bedj.js
+++ b/server/src/bedj.js
@@ -1,10 +1,9 @@
-const app = require('./app')
-const path = require('path')
-const fs = require('fs')
-const utils = require('./utils')
-const createCanvas = require('canvas').createCanvas
-const nt2aa = require('#shared/common').nt2aa
-const parseBedLine = require('./bedj.parseBed').parseBedLine
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import { nt2aa } from '#shared/common'
+import { createCanvas } from 'canvas'
+import { parseBedLine } from './bedj.parseBed'
 
 /*
 should guard against file content error e.g. two tabs separating columns
@@ -118,7 +117,7 @@ const altcolor = 'rgba(122,103,44,.7)',
 	stopcolor = 'rgba(255,0,0,.5)',
 	skippedBpColor = '#ccc'
 
-module.exports = genomes => {
+export default function (genomes) {
 	return async (req, res) => {
 		try {
 			res.send(await do_query(req, genomes))
@@ -130,7 +129,7 @@ module.exports = genomes => {
 }
 
 async function do_query(req, genomes) {
-	const [e, tkfile, isurl] = app.fileurl(req)
+	const [e, tkfile, isurl] = utils.fileurl(req)
 	if (e) throw e
 
 	// append new boolean flag to req.query{}

--- a/server/src/bedj.parseBed.js
+++ b/server/src/bedj.parseBed.js
@@ -69,12 +69,12 @@ to parse line as gene file, require following:
 
 */
 
-const checkReadingFrame = require('./checkReadingFrame')
+import checkReadingFrame from './checkReadingFrame'
 
 //a valid exonFrames field can only contain members of validFrames, names -1, 0, 1, or 2
 const validFrames = new Set(['-1', '0', '1', '2'])
 
-exports.parseBedLine = function parseBedLine(l, enst2desc) {
+export function parseBedLine(l, enst2desc) {
 	const chr = l[0],
 		chromstart = Number(l[2 - 1]),
 		chromstop = l[3 - 1],
@@ -264,7 +264,7 @@ exports.parseBedLine = function parseBedLine(l, enst2desc) {
 	}
 	if (!tmp3.some(i => !validFrames.has(i))) {
 		/* all fields are valid frames, reject values that are not -1, 0, 1, or 2 */
-		checkReadingFrame.default(obj, exonframes)
+		checkReadingFrame(obj, exonframes)
 	}
 	return obj
 }

--- a/server/src/blat.js
+++ b/server/src/blat.js
@@ -1,15 +1,14 @@
-const fs = require('fs'),
-	path = require('path'),
-	spawn = require('child_process').spawn,
-	utils = require('./utils'),
-	app = require('./app')
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { spawn } from 'child_process'
 
-const serverconfig = require('./serverconfig')
 const tabix = serverconfig.tabix || 'tabix'
 const gfClient = serverconfig.gfClient || 'gfClient'
 const gfServer = serverconfig.gfServer || 'gfServer'
 
-exports.request_closure = genomes => {
+export function request_closure(genomes) {
 	return async (req, res) => {
 		try {
 			if (req.query.serverstat) {
@@ -49,10 +48,7 @@ function server_stat(name, g) {
 			if (e) {
 				resolve(name + ' OFF')
 			}
-			const lines = out
-				.join('')
-				.trim()
-				.split('\n')
+			const lines = out.join('').trim().split('\n')
 			let c = 0
 			for (const line of lines) {
 				if (line.startsWith('blat requests')) c = line.split(' ')[2]
@@ -72,7 +68,7 @@ async function do_blat(genome, seq, soft_starts, soft_stops) {
 	const lines = outputstr.split('\n')
 	const hits = []
 	for (const line of lines) {
-		const l = line.split(' ').filter(function(el) {
+		const l = line.split(' ').filter(function (el) {
 			return el != ''
 		})
 		const h = {}
@@ -110,7 +106,7 @@ async function do_blat2(genome, seq, soft_starts, soft_stops) {
 	const hits = []
 	let h = {}
 	for (const line of lines) {
-		const l = line.split(' ').filter(function(el) {
+		const l = line.split(' ').filter(function (el) {
 			return el != ''
 		})
 		//console.log(l)

--- a/server/src/bulk.mset.js
+++ b/server/src/bulk.mset.js
@@ -1,15 +1,16 @@
-const bulk = require('#shared/bulk'),
-	bulksnv = require('#shared/bulk.snv'),
-	bulkcnv = require('#shared/bulk.cnv'),
-	bulkdel = require('#shared/bulk.del'),
-	bulkitd = require('#shared/bulk.itd'),
-	bulksv = require('#shared/bulk.sv'),
-	bulksvjson = require('#shared/bulk.svjson'),
-	bulktrunc = require('#shared/bulk.trunc'),
-	path = require('path'),
-	fs = require('fs'),
-	serverconfig = require('./serverconfig')
-const { get_samples } = require('./termdb.sql')
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { get_samples } from './termdb.sql'
+import * as bulk from '#shared/bulk'
+import * as bulksnv from '#shared/bulk.snv'
+import * as bulkcnv from '#shared/bulk.cnv'
+import * as bulkdel from '#shared/bulk.del'
+import * as bulkitd from '#shared/bulk.itd'
+import * as bulksv from '#shared/bulk.sv'
+import * as bulksvjson from '#shared/bulk.svjson'
+import * as bulktrunc from '#shared/bulk.trunc'
 
 const handlers = {
 	snvindel: bulksnv,
@@ -37,7 +38,7 @@ const handlers = {
 
 
 */
-exports.mayGetGeneVariantData = async function(tw, q) {
+exports.mayGetGeneVariantData = async function (tw, q) {
 	// assumes this function will get attached as a method of a dataset bootstrap object
 	//console.log('what is tw in mayGetGeneVariantData', tw)
 	//console.log('what is q in mayGetGeneVariantData', q)
@@ -171,7 +172,7 @@ exports.getTermTypes = async function getData(q) {
 
 	maxGeneNameLength: optional, useful to avoid long fused gene strings
 */
-exports.mayGetMatchingGeneNames = async function(matches, str, q, maxGeneNameLength = 25) {
+exports.mayGetMatchingGeneNames = async function (matches, str, q, maxGeneNameLength = 25) {
 	// assumes this function will get attached as a method of a dataset bootstrap object
 	const ds = this
 	let unmatched = 0

--- a/server/src/bw.js
+++ b/server/src/bw.js
@@ -1,10 +1,9 @@
-const app = require('./app')
-const createCanvas = require('canvas').createCanvas
-const utils = require('./utils')
-const run_rust = require('@sjcrh/proteinpaint-rust').run_rust
-const serverconfig = require('./serverconfig')
-const spawn = require('child_process').spawn
-const { rgb } = require('d3-color')
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { spawn } from 'child_process'
+import { createCanvas } from 'canvas'
+import { run_rust } from '@sjcrh/proteinpaint-rust'
+import { rgb } from 'd3-color'
 
 /*
 
@@ -25,7 +24,7 @@ export async function handle_tkbigwig(req, res) {
 			isbedgraph = false,
 			bedgraphdir
 
-		const [e, file, isurl] = app.fileurl(req)
+		const [e, file, isurl] = utils.fileurl(req)
 		if (e) throw e
 
 		if (file.endsWith('.gz')) {
@@ -74,10 +73,7 @@ export async function handle_tkbigwig(req, res) {
 			}
 
 			if (out) {
-				r.values = out
-					.trim()
-					.split('\t')
-					.map(Number.parseFloat)
+				r.values = out.trim().split('\t').map(Number.parseFloat)
 				if (req.query.dividefactor) {
 					r.values = r.values.map(i => i / req.query.dividefactor)
 				}
@@ -182,10 +178,7 @@ export async function handle_tkbigwig(req, res) {
 			/*
 			barplot
 			*/
-			const hscale = makeyscale()
-				.height(req.query.barheight)
-				.min(minv)
-				.max(maxv)
+			const hscale = makeyscale().height(req.query.barheight).min(minv).max(maxv)
 			let x = 0
 			for (const r of req.query.rglst) {
 				if (r.values) {
@@ -247,10 +240,7 @@ async function getBedgraph(req, res, minv, maxv, file, bedgraphdir) {
 }
 
 async function bedgraphRegion(req, r, xoff, minv, maxv, file, bedgraphdir, ctx) {
-	const hscale = makeyscale()
-		.height(req.query.barheight)
-		.min(minv)
-		.max(maxv)
+	const hscale = makeyscale().height(req.query.barheight).min(minv).max(maxv)
 	const sf = r.width / (r.stop - r.start)
 
 	await utils.get_lines_bigfile({
@@ -312,15 +302,15 @@ function makeyscale() {
 		var h = (barheight * (v - minv)) / (maxv - minv)
 		return { y: barheight - h, h: h }
 	}
-	yscale.height = function(h) {
+	yscale.height = function (h) {
 		barheight = h
 		return yscale
 	}
-	yscale.min = function(v) {
+	yscale.min = function (v) {
 		minv = v
 		return yscale
 	}
-	yscale.max = function(v) {
+	yscale.max = function (v) {
 		maxv = v
 		return yscale
 	}

--- a/server/src/checkReadingFrame.js
+++ b/server/src/checkReadingFrame.js
@@ -16,7 +16,7 @@ str:
 if the first coding exon has a frame of 1/2 but not 0, the "startCodonFrame" attribute will be added to obj
 so that it can be properly translatec
 */
-exports.default = (obj, str) => {
+export default function (obj, str) {
 	if (!obj.codingstart) {
 		// not coding
 		return

--- a/server/src/dsUpdateAttr.js
+++ b/server/src/dsUpdateAttr.js
@@ -1,9 +1,9 @@
-const path = require('path')
-const fs = require('fs').promises
-const serverconfig = require('./serverconfig')
-const validate_termdb = require('./mds3.init').validate_termdb
+import fs from 'fs'
+import path from 'path'
+import serverconfig from './serverconfig'
+import { validate_termdb } from './mds3.init'
 
-exports.server_updateAttr = function(ds, sds) {
+export function server_updateAttr(ds, sds) {
 	/*
 	ds: 
 		an entry in genomes[{datasets:[ ... ]}]
@@ -48,7 +48,7 @@ exports.server_updateAttr = function(ds, sds) {
 			  http://sub.domain.ext:port/termdb-refresh.html?route=pnet-refresh-r4Nd0m-5tr1n8
 */
 
-exports.setDbRefreshRoute = function(ds, app, basepath) {
+export function setDbRefreshRoute(ds, app, basepath) {
 	if (!ds.cohort?.db?.refresh) return
 	const r = ds.cohort.db.refresh
 	// delete the optional 'refresh' attribute
@@ -82,8 +82,10 @@ exports.setDbRefreshRoute = function(ds, app, basepath) {
 				console.log(`copying ${source} to ${target}`)
 				await fs.copyFile(source, target)
 			} else {
-				throw `Updating input text files via the termdb-refresh page has been deprecated.` +
+				throw (
+					`Updating input text files via the termdb-refresh page has been deprecated.` +
 					`Please use the buildTermdb.bundle.js. pipeline before triggering this route to replace the db file.`
+				)
 			}
 			await validate_termdb(ds)
 			res.send({ status: 'ok' })

--- a/server/src/fimo.js
+++ b/server/src/fimo.js
@@ -1,12 +1,12 @@
-const app = require('./app')
-const fs = require('fs')
-const utils = require('./utils')
-const spawn = require('child_process').spawn
-const path = require('path')
-const serverconfig = require('./serverconfig')
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { spawn } from 'child_process'
+
 const fimo = serverconfig.fimo || 'fimo'
 
-exports.handle_closure = genomes => {
+export function handle_closure(genomes) {
 	return async (req, res) => {
 		try {
 			const q = req.query
@@ -36,11 +36,7 @@ function fimo_may_updateallele(q, start, ref_fasta) {
 	if (q.m.ref == '-') return
 
 	// remove fasta header
-	const seq = ref_fasta
-		.split('\n')
-		.slice(1)
-		.join('')
-		.toUpperCase()
+	const seq = ref_fasta.split('\n').slice(1).join('').toUpperCase()
 
 	// nt string at m.pos matching length of m.ref
 	const forward = seq.substring(q.m.pos - start, q.m.pos - start + q.m.ref.length)
@@ -184,10 +180,7 @@ then find motif change
 		valuemax,
 		refstart,
 		refstop,
-		refseq: ref_fasta
-			.split('\n')
-			.slice(1)
-			.join('')
+		refseq: ref_fasta.split('\n').slice(1).join('')
 	}
 }
 

--- a/server/src/hicstat.js
+++ b/server/src/hicstat.js
@@ -1,6 +1,7 @@
-const fs = require('fs')
-const util = require('util')
-const got = require('got')
+import fs from 'fs'
+import util from 'util'
+import got from 'got'
+
 /**
  * 
  * @param {*} file 

--- a/server/src/junction.js
+++ b/server/src/junction.js
@@ -1,11 +1,11 @@
-const app = require('./app')
-const utils = require('./utils')
-const fs = require('fs')
-const readline = require('readline')
+import fs from 'fs'
+import * as utils from './utils'
+import readline from 'readline'
+import serverconfig from './serverconfig'
 
-module.exports = async (req, res) => {
+export default async function (req, res) {
 	try {
-		const [e, file, isurl] = app.fileurl(req)
+		const [e, file, isurl] = utils.fileurl(req)
 		if (e) throw e
 		if (!req.query.rglst) throw 'rglst[] missing'
 		if (typeof req.query.rglst == 'string') req.query.rglst = JSON.parse(req.query.rglst)
@@ -16,7 +16,7 @@ module.exports = async (req, res) => {
 
 		let lst // list of junctions
 		if (req.query.isrnapeg) {
-			if (!app.features.junctionrnapeg) throw 'rnapeg not supported on this server'
+			if (!serverconfig.features.junctionrnapeg) throw 'rnapeg not supported on this server'
 			if (isurl) throw 'rnapeg file from url is not supported'
 			lst = await get_rnapeg(req.query, file)
 		} else {

--- a/server/src/km.js
+++ b/server/src/km.js
@@ -1,13 +1,12 @@
-const fs = require('fs'),
-	path = require('path'),
-	spawn = require('child_process').spawn,
-	readline = require('readline'),
-	app = require('./app'),
-	utils = require('./utils'),
-	common = require('#shared/common'),
-	serverconfig = require('./serverconfig'),
-	vcf = require('#shared/vcf'),
-	lines2R = require('./lines2R')
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { spawn } from 'child_process'
+import readline from 'readline'
+import * as common from '#shared/common'
+import * as vcf from '#shared/vcf'
+import lines2R from './lines2R'
 
 /*
 function cascade
@@ -27,7 +26,7 @@ pvalue_may4expquartile
 do_plot
 */
 
-exports.handle_mdssurvivalplot = genomes => {
+export function handle_mdssurvivalplot(genomes) {
 	return async (req, res) => {
 		try {
 			const q = req.query

--- a/server/src/ld.js
+++ b/server/src/ld.js
@@ -1,10 +1,10 @@
-const app = require('./app')
-const fs = require('fs')
-const path = require('path')
-const spawn = require('child_process').spawn
-const utils = require('./utils')
-const createCanvas = require('canvas').createCanvas
-const bplen = require('#shared/common').bplen
+import fs from 'fs'
+import path from 'path'
+import * as utils from './utils'
+import serverconfig from './serverconfig'
+import { spawn } from 'child_process'
+import { createCanvas } from 'canvas'
+import { bplen } from '#shared/common'
 
 /*
 req.query{}
@@ -27,7 +27,7 @@ export function handle_tkld(genomes) {
 }
 
 async function loadTk(req, genome) {
-	const [e, tkfile, isurl] = app.fileurl(req)
+	const [e, tkfile, isurl] = utils.fileurl(req)
 	if (e) throw e
 	let dir
 	if (isurl) {

--- a/server/src/lines2R.js
+++ b/server/src/lines2R.js
@@ -9,13 +9,13 @@ Arguments:
 Given an R script and a JavaScript array of input data lines, the data lines are streamed into the standard input of the R script. The standard output of the R script is then returned as a JavaScript array of output data lines.
 */
 
-const path = require('path')
-const fs = require('fs')
-const spawn = require('child_process').spawn
-const Readable = require('stream').Readable
-const serverconfig = require('./serverconfig')
+import fs from 'fs'
+import path from 'path'
+import serverconfig from './serverconfig'
+import { spawn } from 'child_process'
+import { Readable } from 'stream'
 
-module.exports = async function lines2R(Rscript, lines, args = []) {
+export default async function lines2R(Rscript, lines, args = []) {
 	try {
 		await fs.promises.stat(Rscript)
 	} catch (e) {
@@ -55,10 +55,7 @@ module.exports = async function lines2R(Rscript, lines, args = []) {
 				const errmsg = `R process emitted standard error\nR stderr: ${err}`
 				reject(errmsg)
 			}
-			const out = stdout
-				.join('')
-				.trim()
-				.split('\n')
+			const out = stdout.join('').trim().split('\n')
 			resolve(out)
 		})
 	})

--- a/server/src/termdb.config.js
+++ b/server/src/termdb.config.js
@@ -1,7 +1,7 @@
 import serverconfig from './serverconfig.js'
 import { mayComputeTermtypeByCohort } from './termdb.server.init'
 import { isMatch } from 'micromatch'
-import auth from './auth'
+import { authApi } from './auth'
 
 /*
 the "termdbConfig" object is returned to client side that uses vocabApi
@@ -65,7 +65,7 @@ export function make(q, res, ds, genome) {
 
 	if (ds.assayAvailability) c.assayAvailability = ds.assayAvailability
 	if (ds.customTwQByType) c.customTwQByType = ds.customTwQByType
-	c.requiredAuth = auth.getRequiredCredForDsEmbedder(q.dslabel, q.embedder)
+	c.requiredAuth = authApi.getRequiredCredForDsEmbedder(q.dslabel, q.embedder)
 	addRestrictAncestries(c, tdb)
 	addScatterplots(c, ds)
 	addMatrixplots(c, ds)

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -16,7 +16,7 @@ import { get_mds3variantData } from './mds3.variant'
 import roundValue from '#shared/roundValue'
 import computePercentile from '../shared/compute.percentile.js'
 import { get_lines_bigfile, mayCopyFromCookie } from './utils'
-import authApi from './auth'
+import { authApi } from './auth'
 import { getResult as geneSearch } from './gene'
 import { searchSNP } from './app'
 

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -6,7 +6,7 @@ import { schemeCategory20, getColors } from '#shared/common'
 import { interpolateSqlValues } from './termdb.sql'
 import { mclass, dt2label, morigin } from '#shared/common'
 import { getFilterCTEs } from './termdb.filter'
-import authApi from './auth'
+import { authApi } from './auth'
 import lines2R from './lines2R'
 import { write_file, read_file } from './utils'
 

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -1,7 +1,7 @@
 import serverconfig from './serverconfig'
 import { connect_db } from './utils'
 import { isUsableTerm } from '../shared/termdb.usecase'
-import auth from './auth'
+import { authApi } from './auth'
 
 /*
 server_init_db_queries()
@@ -425,7 +425,7 @@ export function server_init_db_queries(ds) {
 				if (ds.cohort.scatterplots) supportedChartTypes[r.cohort].add('sampleScatter')
 				numericTypeCount[r.cohort] = 0
 				if (ds.cohort.allowedChartTypes?.includes('matrix')) supportedChartTypes[r.cohort].add('matrix')
-				const forbiddenRoutes = auth.getForbiddenRoutesForDsEmbedder(ds.label, embedder)
+				const forbiddenRoutes = authApi.getForbiddenRoutesForDsEmbedder(ds.label, embedder)
 				if (!forbiddenRoutes.includes('termdb') && !forbiddenRoutes.includes('*')) {
 					supportedChartTypes[r.cohort].add('dataDownload')
 					supportedChartTypes[r.cohort].add('sampleView')

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -1,7 +1,7 @@
-const tape = require('tape')
-const auth = require('../auth')
-const jsonwebtoken = require('jsonwebtoken')
-const serverconfig = require('../serverconfig')
+import tape from 'tape'
+import { authApi } from '../auth'
+import jsonwebtoken from 'jsonwebtoken'
+import serverconfig from '../serverconfig'
 
 /*************************
  reusable constants and helper functions
@@ -68,7 +68,7 @@ tape('\n', function (test) {
 tape(`initialization`, async test => {
 	{
 		const app = appInit()
-		await auth.maySetAuthRoutes(app, '', { cachedir })
+		await authApi.maySetAuthRoutes(app, '', { cachedir })
 		const middlewares = Object.keys(app.middlewares)
 		test.deepEqual(
 			[],
@@ -82,7 +82,7 @@ tape(`initialization`, async test => {
 
 	{
 		const app = appInit()
-		await auth.maySetAuthRoutes(app, '', { cachedir, dsCredentials: {}, secrets })
+		await authApi.maySetAuthRoutes(app, '', { cachedir, dsCredentials: {}, secrets })
 		const middlewares = Object.keys(app.middlewares)
 		test.deepEqual([], middlewares, 'should NOT set a global middleware when dsCredentials is empty')
 		const routes = Object.keys(app.routes)
@@ -102,7 +102,7 @@ tape(`initialization`, async test => {
 				}
 			}
 		}
-		await auth.maySetAuthRoutes(app, '', { cachedir, dsCredentials, secrets })
+		await authApi.maySetAuthRoutes(app, '', { cachedir, dsCredentials, secrets })
 		const middlewares = Object.keys(app.middlewares)
 		test.deepEqual(
 			['*'],
@@ -120,7 +120,7 @@ tape(`initialization`, async test => {
 
 	{
 		const app = appInit()
-		await auth.maySetAuthRoutes(app, '', { cachedir })
+		await authApi.maySetAuthRoutes(app, '', { cachedir })
 		test.deepEqual(
 			[
 				'canDisplaySampleIds',
@@ -131,26 +131,26 @@ tape(`initialization`, async test => {
 				'maySetAuthRoutes',
 				'userCanAccess'
 			],
-			Object.keys(auth).sort(),
+			Object.keys(authApi).sort(),
 			'should set the expected methods with an empty dsCredentials'
 		)
 		test.deepEqual(
-			auth.getDsAuth({ query: {}, get() {} }),
+			authApi.getDsAuth({ query: {}, get() {} }),
 			[],
 			'should return open-access dsAuth with an empty dsCredentials'
 		)
 		test.deepEqual(
-			auth.getForbiddenRoutesForDsEmbedder(),
+			authApi.getForbiddenRoutesForDsEmbedder(),
 			[],
 			'should return open-access getForbiddenRoutesForDsEmbedder with an empty dsCredentials'
 		)
 		test.deepEqual(
-			auth.getRequiredCredForDsEmbedder(),
+			authApi.getRequiredCredForDsEmbedder(),
 			undefined,
 			'should return open-access getRequiredCredForDsEmbedder with an empty dsCredentials'
 		)
 		test.deepEqual(
-			auth.userCanAccess({ query: {} }),
+			authApi.userCanAccess({ query: {} }),
 			true,
 			'should return open-access userCanAccess with an empty dsCredentials'
 		)
@@ -185,7 +185,7 @@ tape('legacy reshape', async test => {
 		cachedir
 	}
 
-	await auth.maySetAuthRoutes(app, '', serverconfig)
+	await authApi.maySetAuthRoutes(app, '', serverconfig)
 	test.deepEqual(
 		JSON.parse(JSON.stringify(dsCredentials)),
 		{
@@ -246,24 +246,24 @@ tape(`auth methods`, async test => {
 		cachedir
 	}
 
-	await auth.maySetAuthRoutes(app, '', serverconfig)
+	await authApi.maySetAuthRoutes(app, '', serverconfig)
 	test.deepEqual(
-		auth.getDsAuth({ query: { embedder: 'some.domain' }, get: () => 'localhost' }),
+		authApi.getDsAuth({ query: { embedder: 'some.domain' }, get: () => 'localhost' }),
 		[{ dslabel: 'ds100', route: 'burden', type: 'forbidden', insession: false }],
 		`should return the expected dsAuth array for a specified embedder`
 	)
 	test.deepEqual(
-		auth.getForbiddenRoutesForDsEmbedder('ds100', 'localhost'),
+		authApi.getForbiddenRoutesForDsEmbedder('ds100', 'localhost'),
 		['burden'],
 		`should return the expected forbidden routes for a wildcard embedder with cred.type='forbidden'`
 	)
 	test.deepEqual(
-		auth.getForbiddenRoutesForDsEmbedder('ds100', 'notlocalhost'),
+		authApi.getForbiddenRoutesForDsEmbedder('ds100', 'notlocalhost'),
 		[],
 		`should return the expected forbidden routes for a non-wildcard embedder`
 	)
 	test.deepEqual(
-		auth.userCanAccess({ query: { embedder: 'localhost' } }, { label: 'ds100' }),
+		authApi.userCanAccess({ query: { embedder: 'localhost' } }, { label: 'ds100' }),
 		true,
 		`should return false for userCanAccess() for a non-logged in user`
 	)
@@ -289,7 +289,7 @@ tape(`a valid request`, async test => {
 		cachedir
 	}
 
-	await auth.maySetAuthRoutes(app, '', serverconfig) //; console.log(app.routes)
+	await authApi.maySetAuthRoutes(app, '', serverconfig) //; console.log(app.routes)
 	{
 		const req = {
 			query: { embedder: 'localhost', dslabel: 'ds0' },
@@ -336,7 +336,7 @@ tape(`mismatched ip address in /jwt-status`, async test => {
 		cachedir
 	}
 
-	await auth.maySetAuthRoutes(app, '', serverconfig) //; console.log(app.routes)
+	await authApi.maySetAuthRoutes(app, '', serverconfig) //; console.log(app.routes)
 	{
 		const req = {
 			query: { embedder: 'localhost', dslabel: 'ds0' },
@@ -392,7 +392,7 @@ tape(`invalid embedder`, async test => {
 		cachedir
 	}
 
-	await auth.maySetAuthRoutes(app, '', serverconfig) //; console.log(308, app.routes)
+	await authApi.maySetAuthRoutes(app, '', serverconfig) //; console.log(308, app.routes)
 
 	{
 		const req = {
@@ -446,7 +446,7 @@ tape(`invalid dataset access`, async test => {
 		cachedir
 	}
 
-	await auth.maySetAuthRoutes(app, '', serverconfig)
+	await authApi.maySetAuthRoutes(app, '', serverconfig)
 	{
 		const req = {
 			query: { embedder: 'localhost', dslabel: 'ds0' },
@@ -499,7 +499,7 @@ tape(`invalid jwt`, async test => {
 		cachedir
 	}
 
-	await auth.maySetAuthRoutes(app, '', serverconfig) //; console.log(app.routes)
+	await authApi.maySetAuthRoutes(app, '', serverconfig) //; console.log(app.routes)
 
 	{
 		const req = {
@@ -608,7 +608,7 @@ tape(`session-handling by the middleware`, async test => {
 	}
 
 	const app = appInit()
-	await auth.maySetAuthRoutes(app, '', serverconfig)
+	await authApi.maySetAuthRoutes(app, '', serverconfig)
 	{
 		const message = 'should call the next function on a non-protected route'
 		const req = {
@@ -774,5 +774,5 @@ tape.skip(`/dslogin`, async test => {
 	}
 
 	const app = appInit()
-	await auth.maySetAuthRoutes(app, '', serverconfig)
+	await authApi.maySetAuthRoutes(app, '', serverconfig)
 })


### PR DESCRIPTION
## Description
Round 4 of migration to esm syntax, tested with `npm run test:unit --workspace=server` from the pp dir, and also all unit and integration links in http://localhost:3000/testrun.html?name=*.integration.

The bam-related features are some of the most affected code in this round of migration, please test.

Todo later:
- migrate server/src/serverconfig.js separately, it affects many files that import it
- scan for and replace __dirname
- replace dynamic require() with await import()

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
