### PR TITLE
round 5 of esm migration, for src/app.js and its importers

### DIFF
--- a/server/src/handle_mdssvcnv_expression.js
+++ b/server/src/handle_mdssvcnv_expression.js
@@ -1,0 +1,120 @@
+import { tabixnoterror, cache_index } from './utils'
+
+export function handle_mdssvcnv_expression(ds, dsquery, req, data_cnv) {
+	if (req.query.singlesample) {
+		// no expression rank check in single-sample: will be handled in a separate track
+		return []
+	}
+
+	// multi-sample
+	// expression data?
+	let expressionquery
+	if (dsquery.iscustom) {
+		expressionquery = dsquery.checkexpressionrank
+	} else {
+		// official
+		if (dsquery.expressionrank_querykey) {
+			if (ds.queries[dsquery.expressionrank_querykey]) {
+				expressionquery = ds.queries[dsquery.expressionrank_querykey]
+			}
+		}
+	}
+	if (!expressionquery) {
+		// no expression query
+		return []
+	}
+
+	let viewrangeupperlimit = expressionquery.viewrangeupperlimit
+	if (!viewrangeupperlimit && dsquery.iscustom) {
+		// no limit set for custom track, set a hard limit
+		viewrangeupperlimit = 5000000
+	}
+	if (viewrangeupperlimit) {
+		const len = req.query.rglst.reduce((i, j) => i + j.stop - j.start, 0)
+		if (len >= viewrangeupperlimit) {
+			return [viewrangeupperlimit]
+		}
+	}
+
+	return Promise.resolve()
+		.then(() => {
+			// cache expression index
+
+			if (expressionquery.file) return ''
+			return cache_index(expressionquery.url, expressionquery.indexURL)
+		})
+		.then(dir => {
+			// get expression data
+
+			const gene2sample2obj = new Map()
+			// k: gene
+			// v: { chr, start, stop, samples:Map }
+			//    sample : { value:V, outlier:{}, ase:{} }
+
+			const tasks = []
+			for (const r of req.query.rglst) {
+				const task = new Promise((resolve, reject) => {
+					const data = []
+					const ps = spawn(
+						tabix,
+						[
+							expressionquery.file ? path.join(serverconfig.tpmasterdir, expressionquery.file) : expressionquery.url,
+							r.chr + ':' + r.start + '-' + r.stop
+						],
+						{ cwd: dir }
+					)
+					const rl = readline.createInterface({
+						input: ps.stdout
+					})
+					rl.on('line', line => {
+						const l = line.split('\t')
+						let j
+						try {
+							j = JSON.parse(l[3])
+						} catch (e) {
+							// invalid json
+							return
+						}
+						if (!j.gene) return
+						if (!j.sample) return
+						if (!Number.isFinite(j.value)) return
+
+						/* hiddenmattr hiddensampleattr are not applied here
+					cnv/vcf data from those samples will be dropped, so their expression won't show
+					but their expression will still be used in calculating rank of visible samples
+					*/
+
+						if (!gene2sample2obj.has(j.gene)) {
+							gene2sample2obj.set(j.gene, {
+								chr: l[0],
+								start: Number.parseInt(l[1]),
+								stop: Number.parseInt(l[2]),
+								samples: new Map()
+							})
+						}
+						gene2sample2obj.get(j.gene).samples.set(j.sample, {
+							value: j.value,
+							ase: j.ase
+							// XXX OHE is temporarily disabled!!!
+							//outlier: j.outlier
+						})
+					})
+					const errout = []
+					ps.stderr.on('data', i => errout.push(i))
+					ps.on('close', code => {
+						const e = errout.join('')
+						if (e && !tabixnoterror(e)) {
+							reject(e)
+							return
+						}
+						resolve()
+					})
+				})
+				tasks.push(task)
+			}
+
+			return Promise.all(tasks).then(() => {
+				return [false, gene2sample2obj]
+			})
+		})
+}

--- a/server/src/handle_study.js
+++ b/server/src/handle_study.js
@@ -1,0 +1,138 @@
+import path from 'path'
+import serverconfig from './serverconfig'
+import * as common from '#shared/common'
+import * as vcf from '#shared/vcf'
+import * as bulk from '#shared/bulk'
+import * as bulksnv from '#shared/bulk.snv'
+import * as bulkcnv from '#shared/bulk.cnv'
+import * as bulkdel from '#shared/bulk.del'
+import * as bulkitd from '#shared/bulk.itd'
+import * as bulksv from '#shared/bulk.sv'
+import * as bulksvjson from '#shared/bulk.svjson'
+import * as bulktrunc from '#shared/bulk.trunc'
+
+export default async function handle_study(req, res) {
+	try {
+		if (utils.illegalpath(req.query.file)) throw 'invalid file path'
+		const file = path.join(
+			serverconfig.tpmasterdir,
+			req.query.file.endsWith('.json') ? req.query.file : req.query.file + '.json'
+		)
+
+		const cohort = JSON.parse(await utils.read_file(file))
+		if (!cohort.genome) throw 'genome missing'
+		const flagset = {}
+		let nameless = 0
+		for (const mset of cohort.mutationset || []) {
+			const flag = bulk.init_bulk_flag(cohort.genome)
+			if (!flag) throw 'init_bulk_flag() failed'
+			if (cohort.mutationset.length > 1) {
+				flag.tpsetname = mset.name ? mset.name : 'set' + ++nameless
+			}
+			flagset[Math.random()] = flag
+			if (mset.snvindel) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.snvindel))
+				const lines = text.trim().split(/\r?\n/)
+				const herr = bulksnv.parseheader(lines[0], flag)
+				if (herr) throw 'snvindel header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulksnv.parseline(i, lines[i], flag)
+				}
+			}
+			if (mset.sv) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.sv))
+				const lines = text.trim().split(/\r?\n/)
+				const herr = bulksv.parseheader(lines[0], flag, true)
+				if (herr) throw 'sv header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulksv.parseline(i, lines[i], flag, true)
+				}
+			}
+			if (mset.fusion) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.fusion))
+				const lines = text.trim().split(/\r?\n/)
+				const herr = bulksv.parseheader(lines[0], flag, false)
+				if (herr) throw 'fusion header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulksv.parseline(i, lines[i], flag, false)
+				}
+			}
+			if (mset.svjson) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.svjson))
+				const lines = text.trim().split(/\r?\n/)
+				const [herr, header] = bulksvjson.parseheader(lines[0], flag)
+				if (herr) throw 'svjson header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulksvjson.parseline(i, lines[i], flag, header)
+				}
+			}
+			if (mset.cnv) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.cnv))
+				const lines = text.trim().split(/\r?\n/)
+				const herr = bulkcnv.parseheader(lines[0], flag)
+				if (herr) throw 'cnv header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulkcnv.parseline(i, lines[i], flag)
+				}
+			}
+			if (mset.itd) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.itd))
+				const lines = text.trim().split(/\r?\n/)
+				const herr = bulkitd.parseheader(lines[0], flag)
+				if (herr) throw 'itd header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulkitd.parseline(i, lines[i], flag)
+				}
+			}
+			if (mset.deletion) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.deletion))
+				const lines = text.trim().split(/\r?\n/)
+				const herr = bulkdel.parseheader(lines[0], flag)
+				if (herr) throw 'deletion header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulkdel.parseline(i, lines[i], flag)
+				}
+			}
+			if (mset.truncation) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, mset.truncation))
+				const lines = text.trim().split(/\r?\n/)
+				const herr = bulktrunc.parseheader(lines[0], flag)
+				if (herr) throw 'Truncation header line error: ' + herr
+				for (let i = 1; i < lines.length; i++) {
+					bulktrunc.parseline(i, lines[i], flag)
+				}
+			}
+		}
+		if (cohort.annotations) {
+			const idkey = cohort.annotations.idkey ? cohort.annotations.idkey : 'sample'
+			cohort.annotations.data = {}
+			for (const filename of cohort.annotations.files) {
+				const text = await utils.read_file(path.join(serverconfig.tpmasterdir, filename))
+				d3dsv.tsvParse(text).forEach(d => {
+					const id = d[idkey].trim()
+					if (!cohort.annotations.data[id]) {
+						cohort.annotations.data[id] = []
+					}
+					cohort.annotations.data[id].push(d)
+				})
+			}
+		}
+		for (const k in flagset) {
+			local_end_flag(flagset[k])
+		}
+		delete cohort.mutationset
+		res.send({
+			cohort: cohort,
+			flagset: flagset
+		})
+	} catch (e) {
+		res.send({ error: e.message || e })
+		return
+	}
+}
+
+function local_end_flag(flag) {
+	delete flag.mclasslabel2key
+	delete flag.sample2disease
+	delete flag.patient2ori2sample
+}

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -1,8 +1,7 @@
-import app from './app'
 import fs from 'fs'
 import path from 'path'
 import { spawn } from 'child_process'
-import { write_file, mayCopyFromCookie } from './utils'
+import { write_file, mayCopyFromCookie, fileurl } from './utils'
 import serverconfig from './serverconfig'
 import { snvindelByRangeGetter_bcf } from './mds3.init'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
@@ -157,7 +156,7 @@ async function get_ds(q, genome) {
 	// may cache index files from url, thus the await
 	const ds = { queries: {} }
 	if (q.bcffile || q.bcfurl) {
-		const [e, file, isurl] = app.fileurl({ query: { file: q.bcffile, url: q.bcfurl } })
+		const [e, file, isurl] = fileurl({ query: { file: q.bcffile, url: q.bcfurl } })
 		if (e) throw e
 		const _tk = {}
 		if (isurl) {

--- a/server/src/singlecell.js
+++ b/server/src/singlecell.js
@@ -1,4 +1,3 @@
-import app from './app'
 import fs from 'fs'
 import readline from 'readline'
 import * as d3scale from 'd3-scale'
@@ -88,7 +87,7 @@ may attach coloring scheme to result{} for returning to client
 
 	if (!q.textfile) throw '.textfile missing'
 	{
-		const [e, file, isurl] = app.fileurl({ query: { file: q.textfile } })
+		const [e, file, isurl] = utils.fileurl({ query: { file: q.textfile } })
 		if (e) throw '.textfile error: ' + e
 
 		if (!isurl) {
@@ -124,7 +123,7 @@ may attach coloring scheme to result{} for returning to client
 		const ge = q.getpcd.gene_expression
 		if (!ge.file) throw 'gene_expression.file missing'
 		{
-			const [e, file, isurl] = app.fileurl({ query: { file: ge.file } })
+			const [e, file, isurl] = utils.fileurl({ query: { file: ge.file } })
 			if (e) throw e
 			ge.file = file
 		}
@@ -333,7 +332,7 @@ async function get_geneboxplot(q, gn, res) {
 
 	if (!ge.expfile) throw 'getgeneboxplot.expfile missing'
 	{
-		const [e, file, isurl] = app.fileurl({ query: { file: ge.expfile } })
+		const [e, file, isurl] = utils.fileurl({ query: { file: ge.expfile } })
 		if (e) throw 'getgeneboxplot.expfile error: ' + e
 		ge.expfile = file
 	}
@@ -390,7 +389,7 @@ async function get_geneboxplot(q, gn, res) {
 	for (const [category, values] of category2values) {
 		values.sort((i, j) => i.value - j.value)
 
-		const b = app.boxplot_getvalue(values)
+		const b = utils.boxplot_getvalue(values)
 		delete b.out // remove outliers
 		const co = categorical_color_function(category)
 
@@ -464,7 +463,7 @@ async function get_heatmap(q, gn, res) {
 
 	if (!ge.expfile) throw 'getgeneboxplot.expfile missing'
 	{
-		const [e, file, isurl] = app.fileurl({ query: { file: ge.expfile } })
+		const [e, file, isurl] = utils.fileurl({ query: { file: ge.expfile } })
 		if (e) throw 'getgeneboxplot.expfile error: ' + e
 		ge.expfile = file
 	}
@@ -546,7 +545,7 @@ v: { category, expvalue }
 */
 	if (!p.cellfile) throw 'cellfile missing'
 	{
-		const [e, file, isurl] = app.fileurl({ query: { file: p.cellfile } })
+		const [e, file, isurl] = utils.fileurl({ query: { file: p.cellfile } })
 		if (e) throw 'cellfile error: ' + e
 		p.cellfile = file
 	}

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -560,7 +560,7 @@ export function query_bigbed_by_name(bigbed, name) {
 	})
 }
 
-function tabixnoterror(s) {
+export function tabixnoterror(s) {
 	return s.startsWith('[E::idx_test_and_fetch]') // got this with htslib 1.15.1
 }
 

--- a/server/src/validator.js
+++ b/server/src/validator.js
@@ -1,8 +1,6 @@
-import app from './app'
-
 const byIpAddr = {}
 
-app.catch = function (req, res, error) {
+export function floodCatch(req, res, error) {
 	const time = +new Date()
 	if (!(req.ip in byIpAddr)) {
 		byIpAddr[req.ip] = { time, count: 0 }
@@ -32,7 +30,7 @@ export function middleware(req, res, next) {
 		// TODO log out request here to eliminate repeating log(req) in handlers; may skip the bundle-loading lines?
 		next()
 	} catch (e) {
-		app.catch(req, res, e.message || e)
+		floodCatch(req, res, e.message || e)
 	}
 }
 


### PR DESCRIPTION
## Description

Round 5 of migration to esm syntax, tested with `npm run test:unit --workspace=server` from the pp dir, and also all unit and integration links in http://localhost:3000/testrun.html?name=*.integration.

The main src/app.js code is the most affected code in this round of migration, please test including feature flags.

Todo later:
- migrate server/src/serverconfig.js separately
- scan for and replace __dirname
- replace dynamic require() with await import()


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
