### PR TITLE
fix the lag in the /termdb-barsql response

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -65,7 +65,7 @@
     "minimatch": "^3.1.2",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "normalize.css": "^8.0.1",
-    "partjson": "^0.58.1",
+    "partjson": "^0.58.2",
     "postcss-import": "^14.1.0",
     "prettier": "^2.8.8",
     "process": "^0.11.10",

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -493,6 +493,8 @@ function handle_click(event, self, chart) {
 }
 
 function listSamples(event, self, seriesLabel, dataLabel, chart) {
+	// TODO call vocabApi.getAnnotatedSampleData() to get list of samples
+	return
 	const names = new Set()
 	for (const sample of self.samples) {
 		if (self.config.term0 && !isLabel(sample.key0, self.config.term0.term, chart.chartId)) continue

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "minimatch": "^3.1.2",
         "node-polyfill-webpack-plugin": "^1.1.4",
         "normalize.css": "^8.0.1",
-        "partjson": "^0.58.1",
+        "partjson": "^0.58.2",
         "postcss-import": "^14.1.0",
         "prettier": "^2.8.8",
         "process": "^0.11.10",
@@ -10303,9 +10303,9 @@
       }
     },
     "node_modules/partjson": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/partjson/-/partjson-0.58.1.tgz",
-      "integrity": "sha512-jYq/iNd2U1GwRQo5YEcFXzwy1LItf+3bWKj7liIOjjVIkKsuANRd+/ZbXsfLzAzUsyk74zgJNqqf4I4g4PM2qg==",
+      "version": "0.58.2",
+      "resolved": "https://registry.npmjs.org/partjson/-/partjson-0.58.2.tgz",
+      "integrity": "sha512-LMC3R2/tDGU+EJdG51t+9/Lbu+k22mqwm7KQ4s+ed5zMYUxwluHj1J46THVAiMelYpu+PhjvcyMt/YfBWF8uaQ==",
       "bin": {
         "partjson": "src/cli.js"
       }
@@ -14226,7 +14226,7 @@
         "micromatch": "^4.0.5",
         "minimatch": "^3.1.2",
         "node-fetch": "^2.6.1",
-        "partjson": "^0.58.1",
+        "partjson": "^0.58.2",
         "tiny-async-pool": "^1.2.0",
         "typedoc-plugin-missing-exports": "^2.0.1"
       },
@@ -16041,7 +16041,7 @@
         "minimatch": "^3.1.2",
         "node-polyfill-webpack-plugin": "^1.1.4",
         "normalize.css": "^8.0.1",
-        "partjson": "^0.58.1",
+        "partjson": "^0.58.2",
         "postcss-import": "^14.1.0",
         "prettier": "^2.8.8",
         "process": "^0.11.10",
@@ -16108,7 +16108,7 @@
         "node-fetch": "^2.6.1",
         "node-watch": "^0.7.1",
         "nodemon": "^2.0.19",
-        "partjson": "^0.58.1",
+        "partjson": "^0.58.2",
         "prettier": "^2.8.8",
         "tape": "^5.2.2",
         "tiny-async-pool": "^1.2.0",
@@ -22014,9 +22014,9 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "partjson": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/partjson/-/partjson-0.58.1.tgz",
-      "integrity": "sha512-jYq/iNd2U1GwRQo5YEcFXzwy1LItf+3bWKj7liIOjjVIkKsuANRd+/ZbXsfLzAzUsyk74zgJNqqf4I4g4PM2qg=="
+      "version": "0.58.2",
+      "resolved": "https://registry.npmjs.org/partjson/-/partjson-0.58.2.tgz",
+      "integrity": "sha512-LMC3R2/tDGU+EJdG51t+9/Lbu+k22mqwm7KQ4s+ed5zMYUxwluHj1J46THVAiMelYpu+PhjvcyMt/YfBWF8uaQ=="
     },
     "pascal-case": {
       "version": "3.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -74,7 +74,7 @@
     "micromatch": "^4.0.5",
     "minimatch": "^3.1.2",
     "node-fetch": "^2.6.1",
-    "partjson": "^0.58.1",
+    "partjson": "^0.58.2",
     "tiny-async-pool": "^1.2.0",
     "typedoc-plugin-missing-exports": "^2.0.1"
   },

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -133,7 +133,7 @@ export async function barchart_data(q, ds, tdb) {
 					if (samplesMap.get(sampleId)) item = samplesMap.get(sampleId)
 					else if (!samplesMap.has(sampleId)) {
 						const intSampleId = parseInt(sampleId)
-						item = { sample: intSampleId, name: ds.sampleId2Name.get(intSampleId) }
+						item = { sample: intSampleId }
 						samplesMap.set(sampleId, item)
 					}
 					if (!item) continue
@@ -164,7 +164,7 @@ export async function barchart_data(q, ds, tdb) {
 			pj: pj.times
 		}
 	}
-	return { data: pj.tree.results, samples: q.results.lst, bins }
+	return { data: pj.tree.results, bins }
 }
 
 //used by barchart_data


### PR DESCRIPTION
## Description
- update the partjson version to fix the lag when computing minimal valuesues
- do not always include a sample id-map object in the /termdb-barsql response payload

To test:
```bash
cd ~/dev/sjpp
npm update partjson --workspace=proteinpaint/server
# may need to type `rs` or stop/restart in the terminal process that is running `npm run dev`
```
Then open the [termdb-barsql request for BALL-scrna](http://localhost:3000/termdb-barsql?embedder=localhost&term1_id=cellType&term1_q=%7B%22isAtomic%22%3Atrue%2C%22type%22%3A%22values%22%2C%22groupsetting%22%3A%7B%22inuse%22%3Afalse%7D%7D&genome=hg38&dslabel=BALL-scrna), should be faster, about 2.5 seconds for sql, 4.5 seconds for partjson instead of 20+ seconds. If not, may also need to re-index the anno_categorical table (and later all the other anno_* tables) to include an index on `term_id`
```bash
$ cd ~/data/tp/files/hg38/BALL-scrna/
$ sqlite3 db
SQLite version 3.39.5 2022-10-14 20:58:05
Enter ".help" for usage hints.
sqlite>

# drop index anno_cat_term_id;
drop index anno_cat_sample;
drop index anno_cat_value;
create index anno_cat_term_id on anno_categorical(term_id);
create index anno_cat_sample on anno_categorical(sample);
create index anno_cat_value on anno_categorical(value);
```

Then open the test URL again.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
