### PR TITLE
when somatic/germline exist should have different legend

### DIFF
--- a/client/plots/matrix.legend.js
+++ b/client/plots/matrix.legend.js
@@ -21,7 +21,7 @@ export function getLegendData(legendGroups, refs) {
 					const count = item.samples.size
 					return {
 						termid: 'Consequences',
-						key,
+						key: item.key,
 						text: this.getLegendItemText(item, count, {}, s),
 						color: item.fill,
 						order: i,
@@ -60,7 +60,7 @@ export function getLegendData(legendGroups, refs) {
 					if (item.scale) {
 						return {
 							termid: $id,
-							key,
+							key: item.key,
 							text: this.getLegendItemText(item, count, t, s),
 							width: 100,
 							scale: item.scale,
@@ -77,7 +77,7 @@ export function getLegendData(legendGroups, refs) {
 					} else {
 						return {
 							termid: $id,
-							key,
+							key: item.key,
 							text: this.getLegendItemText(item, count, t, s),
 							color: item.fill || this.colorScaleByTermId[$id](key),
 							order: 'order' in item ? item.order : i,
@@ -113,7 +113,7 @@ export function getLegendData(legendGroups, refs) {
 					return {
 						$id,
 						termid: term.id,
-						key,
+						key: item.key,
 						text: this.getLegendItemText(item, count, t, s),
 						color: t.scale || item.fill || this.colorScaleByTermId[grp](key),
 						order: 'order' in item ? item.order : i,

--- a/client/plots/matrix.serieses.js
+++ b/client/plots/matrix.serieses.js
@@ -74,13 +74,16 @@ export function getSerieses(data) {
 						if (!l) continue
 						if (!l[legend.group]) l[legend.group] = { ref: legend.ref, values: {}, order: legend.order, $id }
 						const lg = l[legend.group]
-						if (!lg.values[legend.value]) {
-							lg.values[legend.value] = JSON.parse(JSON.stringify(legend.entry))
-							lg.values[legend.value].samples = new Set()
-							if (legend.entry.scale) lg.values[legend.value].scale = legend.entry.scale
+						const legendK = legend.entry.origin ? legend.entry.origin + legend.value : legend.value
+
+						if (!lg.values[legendK]) {
+							lg.values[legendK] = JSON.parse(JSON.stringify(legend.entry))
+							lg.values[legendK].samples = new Set()
+							if (legend.entry.scale) lg.values[legendK].scale = legend.entry.scale
 						}
-						//if (!lg.values[legend.value].samples) lg.values[legend.value].samples = new Set()
-						lg.values[legend.value].samples.add(row.sample)
+						if (!lg.values[legendK].samples) lg.values[legendK].samples = new Set()
+						lg.values[legendK].samples.add(row.sample)
+
 						if (isDivideByTerm) {
 							lg.values[legend.value].isExcluded = so.grp.isExcluded
 						}
@@ -108,12 +111,15 @@ export function getSerieses(data) {
 						if (!l) continue
 						if (!l[legend.group]) l[legend.group] = { ref: legend.ref, values: {}, order: legend.order, $id }
 						const lg = l[legend.group]
-						if (!lg.values[legend.value]) {
-							lg.values[legend.value] = JSON.parse(JSON.stringify(legend.entry))
-							if (legend.entry.scale) lg.values[legend.value].scale = legend.entry.scale
+						const legendK = legend.entry.origin ? legend.entry.origin + legend.value : legend.value
+
+						if (!lg.values[legendK]) {
+							lg.values[legendK] = JSON.parse(JSON.stringify(legend.entry))
+							if (legend.entry.scale) lg.values[legendK].scale = legend.entry.scale
 						}
-						if (!lg.values[legend.value].samples) lg.values[legend.value].samples = new Set()
-						lg.values[legend.value].samples.add(row.sample)
+						if (!lg.values[legendK].samples) lg.values[legendK].samples = new Set()
+						lg.values[legendK].samples.add(row.sample)
+
 						if (isDivideByTerm) {
 							lg.values[legend.value].isExcluded = so.grp.isExcluded
 						}


### PR DESCRIPTION
## Description
fix the issue for matrix plot: for some of mclass exist as both somatic and germline, only one of somatic/germline legend created. 

MBMETA consequences before:
<img width="1377" alt="Screenshot 2023-10-06 at 16 54 38" src="https://github.com/stjude/proteinpaint/assets/111394589/e8452180-1580-4e8e-9aab-0bee1f29ec82">

After:
<img width="1377" alt="Screenshot 2023-10-06 at 16 58 05" src="https://github.com/stjude/proteinpaint/assets/111394589/23be8806-92ea-48c1-8b63-083b7cf1cc54">


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
