### PR TITLE
Use a jwt bearer auth to propagate basic session state 

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -390,7 +390,6 @@ async function defaultAuthUi(dslabel, auth) {
 }
 
 function mayAddJwtToRequest(init, body, url) {
-	//console.log(393, 'mayAddJwtToRequest()', init.headers.authorization, body?.dslabel)
 	if (init.headers.authorization) return
 	let dslabel = body?.dslabel // || body.mass?.vocab.dslabel || body.tracks?.find(t => t.dslabel)?.dslabel
 	if (!dslabel) {
@@ -408,7 +407,8 @@ function mayAddJwtToRequest(init, body, url) {
 		}
 	}
 	if (!dslabel || !jwtByDsRoute[dslabel]) return
-	const route = window.location.pathname
+	const h = url.split('//')
+	const route = (h[1] || h[0]).split('/')[1].split('?')[0]
 	const jwt = jwtByDsRoute[dslabel][route] || jwtByDsRoute[dslabel]['/**']
 	if (jwt) init.headers.authorization = 'Bearer ' + btoa(jwt)
 }

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -742,8 +742,8 @@ export class TermdbVocab extends Vocab {
 								if (data.refs.bySampleId?.[sampleId]) row.sampleName = data.refs.bySampleId[sampleId]
 								else if ('sampleName' in sample) row.sampleName = sample.sampleName
 								else {
-									const v = sample[idn].values?.find(v => v._SAMPLENAME_ && true)
-									if (v._SAMPLENAME_) row.sampleName = v._SAMPLENAME_
+									const v = sample[idn].values?.find(v => v._SAMPLENAME_)
+									if (v?._SAMPLENAME_) row.sampleName = v._SAMPLENAME_
 								}
 							}
 						}

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,46 @@
         "ppfull": "app-full.js"
       }
     },
+    "container/node_modules/@sjcrh/proteinpaint-front": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-front/-/proteinpaint-front-2.29.0.tgz",
+      "integrity": "sha512-ZNJ6BSjmlZUTCr5z7JZp+7ml1NVrMSUlvPraglKW1r3GMsKODQ6hAVra1AnSpgLXygLJAKppCjM4Oz6Rp2/tqA==",
+      "bin": {
+        "proteinpaint-front": "init.js"
+      }
+    },
+    "container/node_modules/@sjcrh/proteinpaint-server": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-server/-/proteinpaint-server-2.29.0.tgz",
+      "integrity": "sha512-vw6N1Qzi1tzVO3mrwrcmK+gOvQESgC0/GdwyHCIsoTreive/v7fbXRzRrqLVigcnE7FkAQ07upOqjGRZULPXsg==",
+      "dependencies": {
+        "@sjcrh/augen": "2.27.0",
+        "@sjcrh/proteinpaint-rust": "2.27.0",
+        "better-sqlite3": "^7.5.3",
+        "body-parser": "^1.15.2",
+        "canvas": "~2.9.3",
+        "compression": "^1.6.2",
+        "cookie-parser": "^1.4.5",
+        "d3": "^7.6.1",
+        "deep-object-diff": "^1.1.0",
+        "express": "^4.17.1",
+        "express-basic-auth": "^1.1.5",
+        "got": "^11.5.1",
+        "image-size": "^0.5.5",
+        "jsonwebtoken": "^9.0.0",
+        "jstat": "^1.9.3",
+        "lazy": "^1.0.11",
+        "micromatch": "^4.0.5",
+        "minimatch": "^3.1.2",
+        "node-fetch": "^2.6.1",
+        "partjson": "^0.58.2",
+        "tiny-async-pool": "^1.2.0",
+        "typedoc-plugin-missing-exports": "^2.0.1"
+      },
+      "bin": {
+        "proteinpaint-server": "start.js"
+      }
+    },
     "container/server": {
       "name": "@sjcrh/ppserver",
       "version": "2.29.0",

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Use a jwt bearer auth to propagate basic session state to multiple PP server processes, beyond the server process that processed the /dslogin request

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -571,7 +571,7 @@ function mayAddSessionFromJwt(sessions, dslabel, id, req, cred) {
 	// do not overwrite existing
 	if (!sessions[dslabel]) sessions[dslabel] = {}
 	//if (sessions[dslabel][payload.id]) throw `session conflict`
-	const path = req.path[0] == '/' ? req.path.slice(1) : req.path
+	const path = req.path[0] == '/' && !cred.route.startsWith('/') ? req.path.slice(1) : req.path
 	if (isMatch(path, cred.route) || path == 'authorizedActions') {
 		sessions[dslabel][payload.id] = payload
 		return payload.id

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -45,6 +45,8 @@ export async function getFilterCTEs(filter, ds, CTEname = 'f') {
 			// .CTEs: [] list of individual CTE string
 			// .values: []
 			// .CTEname: str
+		} else if (!item.tvs) {
+			throw `filter item should have a 'tvs' or 'lst' property`
 		} else if (item.tvs.term.type == 'categorical') {
 			f = get_categorical(item.tvs, CTEname_i)
 			// .CTEs: []

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -673,7 +673,7 @@ tape(`session-handling by the middleware`, async test => {
 			},
 			path: '/termdb',
 			cookies: {
-				ds0SessionId: sessionId
+				[headerKey]: sessionId
 			},
 			ip: '127.0.0.1'
 		}
@@ -682,7 +682,8 @@ tape(`session-handling by the middleware`, async test => {
 		const res1 = {
 			send(data) {
 				if (data.error) test.fail(message1 + ': ' + data.error)
-			}
+			},
+			status() {}
 		}
 		function next1() {
 			test.pass(message1)
@@ -698,7 +699,7 @@ tape(`session-handling by the middleware`, async test => {
 			},
 			path: '/termdb',
 			cookies: {
-				ds0SessionId: 'Invalid-Session-Id'
+				[headerKey]: 'Invalid-Session-Id'
 			}
 		}
 		const res2 = {
@@ -727,7 +728,7 @@ tape(`session-handling by the middleware`, async test => {
 			},
 			path: '/termdb',
 			cookies: {
-				ds0SessionId: sessionId
+				[headerKey]: sessionId
 			},
 			ip: '127.0.0.x'
 		}


### PR DESCRIPTION
## Description
... to multiple PP server processes, beyond the server process that processed the `/dslogin` request. EDIT: Also supported the `/jwt-status` requests. 

To test:
The following were done in addition to `npm run test:unit --workspace=server` from the proteinpaint dir and all unit/integration tests from the `testrun.html` page.

Your `sjpp/pp-irt/serverconfig.json` must have the following entries:

```json
  "genomes": [  {
         "name": "hg38",
         "species": "human",
         "file": "./genome/hg38.js",
         "datasets": [
           ...
            {
               "name": "MB_meta_analysis",
               "jsfile": "./dataset/mbmeta.hg38.js"
            },...
          ]
       }
    ],
    "dsCredentials": {
        "MB_meta_analysis": {
         "*": {
            "*": {
               "type": "basic",
               "password": "...",
               "secret": "my-secret"
            }
         }
      }
    },
    
     "SJLife": {
         "termdb": {
            "localhost": {
               "type": "jwt",
               "secret": "my-secret",
               "dsnames": [
                  {
                     "id": "sjlife",
                     "label": "SJLIFE"
                  },
                  {
                     "id": "ccss",
                     "label": "CCSS"
                  }
               ]
            }
         }
        

```
Then
```bash
cd sjpp
git checkout master
git pull
# follow the instructions in the pp-irt/README.md to test with the pm2 setup
```
Then open a [blank MB_meta_analysis page](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22}). 
- You should see a password input. 
- Upon successful login, you should be able to open a sample matrix plot without errors, and see from the `pm2 logs` that the data requests for each term are being routed to different server process IDs, implying that the login was successfully propagated to other servers. 

EDIT: Should also test http://localhost:3000/example.auth.html?dslabel=SJLife, login, download, logout.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
