### PR TITLE
use localStorage to persist jwt by dataset + route

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -1,6 +1,6 @@
 import { select } from 'd3-selection'
 
-const jwtByDsRouteStr = sessionStorage.getItem('jwtByDsRoute') || `{}`
+const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
 const jwtByDsRoute = JSON.parse(jwtByDsRouteStr)
 
 /*
@@ -373,7 +373,7 @@ async function defaultAuthUi(dslabel, auth) {
 					if (res.jwt) {
 						if (!jwtByDsRoute[dslabel]) jwtByDsRoute[dslabel] = {}
 						jwtByDsRoute[dslabel][res.route] = res.jwt
-						sessionStorage.setItem('jwtByDsRoute', JSON.stringify(jwtByDsRoute))
+						localStorage.setItem('jwtByDsRoute', JSON.stringify(jwtByDsRoute))
 					}
 					resolve(dslabel)
 				})

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -71,7 +71,7 @@ export class TermdbVocab extends Vocab {
     */
 	async getNestedChartSeriesData(opts) {
 		const url = this.getTdbDataUrl(opts)
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termdb')
 		const data = await dofetch3(url, { headers }, this.opts.fetchOpts)
 		if (data.error) throw data.error
 
@@ -425,7 +425,7 @@ export class TermdbVocab extends Vocab {
 	async getViolinPlotData(arg, _body = {}) {
 		// the violin plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termdb')
 		const body = Object.assign(
 			{
 				getViolinPlotData: 1,
@@ -663,7 +663,7 @@ export class TermdbVocab extends Vocab {
     */
 	async getAnnotatedSampleData(opts) {
 		// may check against required auth credentials for the server route
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termdb')
 		// unlike scatter and violin, the matrix plot will NOT display anything
 		// if sample names are not allowed to be displayed
 		// TODO: may allow a request to proceed, but not display sampleNames???
@@ -874,7 +874,7 @@ export class TermdbVocab extends Vocab {
 	async getScatterData(opts) {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termdb')
 
 		// dofetch* mayAdjustRequest() will automatically
 		// convert to GET query params or POST body, as needed
@@ -898,7 +898,7 @@ export class TermdbVocab extends Vocab {
 	async getSingleSampleData(opts) {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termdb')
 
 		// dofetch* mayAdjustRequest() will automatically
 		// convert to GET query params or POST body, as needed
@@ -923,7 +923,7 @@ export class TermdbVocab extends Vocab {
 	async getAllSamples() {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termdb')
 
 		// dofetch* mayAdjustRequest() will automatically
 		// convert to GET query params or POST body, as needed
@@ -940,7 +940,7 @@ export class TermdbVocab extends Vocab {
 	async getAllSamplesByName() {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termb')
 
 		// dofetch* mayAdjustRequest() will automatically
 		// convert to GET query params or POST body, as needed
@@ -957,7 +957,7 @@ export class TermdbVocab extends Vocab {
 	async getProfileFacilities() {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termb')
 
 		// dofetch* mayAdjustRequest() will automatically
 		// convert to GET query params or POST body, as needed
@@ -976,7 +976,7 @@ export class TermdbVocab extends Vocab {
 	async getLowessCurve(opts) {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders()
+		const headers = this.mayGetAuthHeaders('termb')
 
 		// dofetch* mayAdjustRequest() will automatically
 		// convert to GET query params or POST body, as needed

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -56,7 +56,6 @@ export class Vocab {
 				}
 				const route = 'termdb'
 				if (this.jwtByRoute[route]) headers.authorization = `Bearer ${btoa(this.jwtByRoute[route])}`
-				console.log(58, headers)
 				const data = await dofetch3('/jwt-status', {
 					method: 'POST',
 					headers,

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -71,7 +71,9 @@ export class Vocab {
 					this.tokenVerificationPayload = data
 					throw data.error
 				} else {
-					this.sessionId = data['x-sjppds-sessionid']
+					// TODO: remove the need for legacy support of hardcoded session names
+					this.sessionId =
+						(auth.headerKey && data[auth.headerKey]) || data['x-sjppds-sessionid'] || data['x-ds-access-token']
 					delete this.tokenVerificationMessage
 					delete this.tokenVerificationPayload
 					if (data.jwt) {

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -546,7 +546,7 @@ function getSessionId(req, cred) {
 	// using all lowercase is compatible for both http 1 and 2
 	return (
 		req.cookies?.[`${cred?.cookieId}`] ||
-		//req.cookies?.[`${req.query.dslabel}SessionId`] ||
+		req.cookies?.[`${req.query.dslabel}SessionId`] ||
 		req.headers?.['x-sjppds-sessionid'] ||
 		req.query?.['x-sjppds-sessionid']
 	)
@@ -594,6 +594,7 @@ function mayAddSessionFromJwt(sessions, dslabel, id, req, cred) {
 	if (type.toLowerCase() != 'bearer') throw `unsupported authorization type='${type}', allowed: 'Bearer'`
 	const token = Buffer.from(b64token, 'base64').toString()
 	const payload = jsonwebtoken.verify(token, cred.secret)
+	//if (payload.id != id) {console.log(`---- !!! jwt payload/cookie id mismatch !!! [${payload.id}][${id}] ---`)} else console.log('--- !!! id match !!! ---')
 	if (payload.id != id) return
 	// do not overwrite existing
 	if (!sessions[dslabel]) sessions[dslabel] = {}

--- a/server/test/fake-jwt.js
+++ b/server/test/fake-jwt.js
@@ -13,7 +13,7 @@ console.log(
 		{
 			iat: time,
 			exp: time + 3600,
-			datasets: ['TermdbTest', 'SJLife', 'PNET', 'sjlife', 'ccss'],
+			datasets: ['TermdbTest', 'SJLife', 'PNET', 'sjlife', 'ccss', 'ABC', 'XYZ', 'abc', 'xyz'],
 			email: 'username@test.tld',
 			ip: '127.0.0.1'
 		},


### PR DESCRIPTION
## Description
... and process in the mayGetAuthHeaders() vocab method

Tested with the usual `npm run test:unit --workspace=server` + testrun.htnl.

Also test by logging into vizcom, then [opening vizcom from a link into a separate browser tab/window](http://survivorship.stjude.cloud/), and then try to download data.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
