### PR TITLE
fix: search term with space character for genomic-equipped dataset sh…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- search term with space character for genomic-equipped dataset should not break by gene search msg

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -239,18 +239,26 @@ async function trigger_findterm(q, res, termdb, ds, genome) {
 			}
 
 			if (ds.queries?.defaultBlock2GeneMode && mayUseGeneVariant) {
-				/* has queries for genomic data types, search gene from whole genome
+				/*
+				has queries for genomic data types, search gene from whole genome
 				not checking on presence of queries.snvindel{} as it's used for both wgs/germline and somatic data,
 				for now do not show gene search for wgs data
 				checking on this flag as it's enabled for ds with somatic data
 				same logic applied in termdb.config.js
+
+				must enclose in try/catch as term match allows characters including space, that are prohibited in gene search
+				when exception is thrown because of that, ignore and continue term match
 				*/
-				const re = geneSearch(genome, { input: str })
-				if (Array.isArray(re.hits)) {
-					for (let i = 0; i < 7; i++) {
-						if (!re.hits[i]) break
-						terms.push({ name: re.hits[i], type: 'geneVariant' })
+				try {
+					const re = geneSearch(genome, { input: str })
+					if (Array.isArray(re.hits)) {
+						for (let i = 0; i < 7; i++) {
+							if (!re.hits[i]) break
+							terms.push({ name: re.hits[i], type: 'geneVariant' })
+						}
 					}
+				} catch (e) {
+					// err is likely "invalid character in gene name". ignore and continue
 				}
 			}
 		}


### PR DESCRIPTION
…ould not break by gene search msg

## Description

please test at http://localhost:3000/?termdb={%22vocab%22:{%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22}}, type in "age " or just a space. it no longer breaks

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
