### PR TITLE
Check if tp directory is writable.

### DIFF
--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -243,7 +243,9 @@ function copyDataFilesFromRepo2Tp() {
 	const targetDir = path.join(serverconfig.binpath, 'test/tp/files/hg38/TermdbTest')
 	const datadir = path.join(serverconfig.tpmasterdir, 'files/hg38/TermdbTest')
 
-	if (!targetDir.endsWith(datadir)) {
+	// no need to set the symlink when the target TermdbTest dir
+	// already equals the datadir under serverconfig.tpmasterdir
+	if (targetDir != datadir) {
 		access(datadir, constants.R_OK | constants.W_OK, err => {
 			if (!err) {
 				try {

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -1,7 +1,7 @@
 import { Mds3 } from '../shared/types'
 import * as serverconfig from '@sjcrh/proteinpaint-server/src/serverconfig.js'
 import * as path from 'path'
-import { existsSync, unlinkSync, symlinkSync } from 'fs'
+import { existsSync, unlinkSync, symlinkSync, access, constants } from 'fs'
 
 /*
 the "test mule" for the type of termdb dataset using server-side sqlite3 db
@@ -244,11 +244,17 @@ function copyDataFilesFromRepo2Tp() {
 	const datadir = path.join(serverconfig.tpmasterdir, 'files/hg38/TermdbTest')
 
 	if (!targetDir.endsWith(datadir)) {
-		try {
-			if (existsSync(datadir)) unlinkSync(datadir)
-			symlinkSync(targetDir, datadir)
-		} catch (error) {
-			console.warn('Error while coping data files from Repo to Tp: ' + error)
-		}
+		access(datadir, constants.R_OK | constants.W_OK, err => {
+			if (!err) {
+				try {
+					if (existsSync(datadir)) unlinkSync(datadir)
+					symlinkSync(targetDir, datadir)
+				} catch (error) {
+					console.warn('Error while coping data files from Repo to Tp: ' + error)
+				}
+			} else {
+				console.warn(`user doesn't have sufficient permissions for `)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

CI integration tests sometimes fail because of with this message:
Error while coping data files from Repo to Tp: Error: EROFS: read-only file system, unlink '/home/root/pp/tp/files/hg38/TermdbTest'

I've handled the case when the file is read-only and skipped the execution of the unlink command. That command is not needed for the CI execution. 

https://github.com/stjude/proteinpaint/actions/runs/6389281370/job/17340418943


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
