### PR TITLE
Set categorical logistic outcome to q.mode=binary

### DIFF
--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -181,6 +181,10 @@ export function get_defaultQ4fillTW(regressionType, useCase = '') {
 	// numeric term
 	defaultQ['numeric'] = regressionType == 'logistic' && useCase == 'outcome' ? { mode: 'binary' } : { mode: 'discrete' }
 
+	// categorical term
+	defaultQ['categorical'] =
+		regressionType == 'logistic' && useCase == 'outcome' ? { mode: 'binary' } : { mode: 'discrete' }
+
 	// condition term
 	if (useCase == 'outcome') {
 		if (regressionType == 'cox') {


### PR DESCRIPTION
## Description

Can test by going [here](http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22regression%22,%22regressionType%22:%22logistic%22,%22outcome%22:%7B%22id%22:%22diaggrp%22%7D%7D%5D%7D) -> opening network tab -> verify term has `q.mode=binary`

Closes [#692
](https://github.com/stjude/proteinpaint/issues/692)

Can now re-open the PR: https://github.com/stjude/proteinpaint/pull/701/files


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
