### PR TITLE
Add binary logic

### DIFF
--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -257,8 +257,8 @@ function setRenderers(self: any) {
 			.classed('sjpp_grpset_addGrp_btn', true) //for integration testing
 			.style('display', 'inline-block')
 			.style('text-align', 'center')
-			.style('cursor', 'pointer')
-			.property('disabled', self.opts.q?.mode == 'binary' ? true : self.data.groups.length >= self.maxGrpNum)
+			.style('cursor', self.opts.q.mode == 'binary' ? 'default' : 'pointer')
+			.property('disabled', self.opts.q.mode == 'binary' ? true : self.data.groups.length >= self.maxGrpNum)
 			.text('Add Group')
 			.on('click', async () => {
 				newGrpNum++
@@ -572,10 +572,7 @@ function setRenderers(self: any) {
 	}
 
 	self.update = async function () {
-		self.dom.actionDiv.addGroup.property(
-			'disabled',
-			self.opts.q?.mode == 'binary' ? true : self.data.groups.length >= self.maxGrpNum
-		)
+		self.dom.actionDiv.addGroup.property('disabled', self.data.groups.length >= self.maxGrpNum)
 		for (const [i, grp] of self.data.groups.entries()) {
 			if (i === 0) continue
 			if (grp.currentIdx != i) {

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -258,12 +258,7 @@ function setRenderers(self: any) {
 			.style('display', 'inline-block')
 			.style('text-align', 'center')
 			.style('cursor', 'pointer')
-			.property(
-				'disabled',
-				self.opts.usecase?.regressionType == 'logistic' && self.opts.usecase?.detail == 'outcome'
-					? true
-					: self.data.groups.length >= self.maxGrpNum
-			)
+			.property('disabled', self.opts.q?.mode == 'binary' ? true : self.data.groups.length >= self.maxGrpNum)
 			.text('Add Group')
 			.on('click', async () => {
 				newGrpNum++
@@ -579,9 +574,7 @@ function setRenderers(self: any) {
 	self.update = async function () {
 		self.dom.actionDiv.addGroup.property(
 			'disabled',
-			self.opts.usecase?.regressionType == 'logistic' && self.opts.usecase?.detail == 'outcome'
-				? true
-				: self.data.groups.length >= self.maxGrpNum
+			self.opts.q?.mode == 'binary' ? true : self.data.groups.length >= self.maxGrpNum
 		)
 		for (const [i, grp] of self.data.groups.entries()) {
 			if (i === 0) continue

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -572,7 +572,7 @@ function setInteractivity(self: TermSettingInstance) {
 		type opt = { label: string; callback: (f?: any) => void }
 		const options: opt[] = []
 
-		if (self.term?.type == 'categorical' && self.q?.groupsetting?.inuse) {
+		if (self.q?.groupsetting?.inuse && self.q?.mode != 'binary') {
 			// this instance is using a categorical term doing groupsetting; add option to cancel it
 			// as categorical edit menu cannot do the canceling
 			options.push({ label: 'Cancel grouping', callback: self.cancelGroupsetting } as opt)

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -572,7 +572,7 @@ function setInteractivity(self: TermSettingInstance) {
 		type opt = { label: string; callback: (f?: any) => void }
 		const options: opt[] = []
 
-		if (self.q?.groupsetting?.inuse && self.q?.mode != 'binary') {
+		if (self.q.groupsetting?.inuse && self.q.mode != 'binary') {
 			// this instance is using a categorical term doing groupsetting; add option to cancel it
 			// as categorical edit menu cannot do the canceling
 			options.push({ label: 'Cancel grouping', callback: self.cancelGroupsetting } as opt)


### PR DESCRIPTION
## Description
- Update disabled logic for `Add Group` button in groupsetting to include new binary mode for categorical terms
- Rm `Cancel Grouping` option when `q.mode = 'binary'` is present. Addresses #691 . 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
