### PR TITLE
Fix disco plot download issue.

### DIFF
--- a/client/plots/disco/DiscoRenderer.ts
+++ b/client/plots/disco/DiscoRenderer.ts
@@ -32,7 +32,7 @@ export class DiscoRenderer {
 		const svgDiv = rootDiv.append('div').style('display', 'inline-block').style('font-family', 'Arial')
 		const controlsDiv = svgDiv.append('div')
 
-		this.downloadButtonRenderer.render(controlsDiv)
+		this.downloadButtonRenderer.render(controlsDiv, svgDiv)
 		this.prioritizeGenesCheckboxRenderer.render(
 			controlsDiv,
 			viewModel.settings.label.prioritizeGeneLabelsByGeneSets,

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -52,7 +52,7 @@ export default function discoDefaults(overrides = {}): Settings {
 			fusionTitle: 'SV', // Structural Variants (color by co-location)
 			lohLegendEnabled: true,
 			fontSize: 12,
-			rowHeight: 40
+			rowHeight: 48
 		},
 
 		menu: {

--- a/client/plots/disco/download/DownloadButtonRenderer.ts
+++ b/client/plots/disco/download/DownloadButtonRenderer.ts
@@ -5,14 +5,14 @@ export default class DownloadButtonRenderer {
 		this.downloadClickListener = downloadClickListener
 	}
 
-	render(holder: any) {
+	render(holder: any, svgDiv: any) {
 		holder
 			.append('span')
 			.append('button')
 			.style('margin', '2px 0 2px 30px')
 			.text('Download image')
 			.on('click', () => {
-				const svg = holder.selectAll('svg').node()
+				const svg = svgDiv.select('svg').node()
 				this.downloadClickListener(svg)
 			})
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Supply the svg element as argument to the disco plot download handler


### PR DESCRIPTION
## Description

This PR fixes an issue that the download button doesn't work. 
The problem was that instead of the svg node, the download button node ifself was passed to SVG to XMLSerializer.  

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
