### PR TITLE
fix: Restore yellow highlight line when moving cursor over a genome b…

### DIFF
--- a/client/src/block.js
+++ b/client/src/block.js
@@ -5196,24 +5196,16 @@ async function maygetdna(block, tip) {
 }
 
 function init_cursorhlbar(block) {
-	// cursor highlight bar
+	// highlight bar under the cursor
+	// default fill color is registered on block, as the bar can be changed by actions in certain tracks
+	// eg hover over splice junction. this allows the style to be restored to the bar
 	block.cursorhlbarFillColor = '#FFFF99'
 	block.cursorhlbar = block.gbase.append('rect').attr('fill', block.cursorhlbarFillColor)
 
 	block.gbase
-		.on('mousemove', () => {
-			let x // cursor x distance relative to the block tkheader
-
-			if (block.rotated) {
-				// vertical, tk header at bottom
-				// as returned by pointer(), the x position (vertical offset from left end of block) is negative, absolute value increases as moving up
-				x = -pointer(event, block.gbase.node())[1]
-			} else {
-				// horizontal, tk header at left
-				x = pointer(block.gbase.node())[0]
-			}
-
-			// rest is independent of block rotation
+		.on('mousemove', event => {
+			// pointer() accounts for whether block is rotated or not
+			const x = pointer(event, block.gbase.node())[0]
 
 			let xoffset = block.leftheadw + block.lpad
 

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
-feat: In addition to genomic features, search for tracks, apps, datasets, and information from header searchbar
-fix: HiC track now supports remote files of all versions (9, 8, 7)
+Fixes:
+- Restore yellow highlight line when moving cursor over a genome browser block


### PR DESCRIPTION
…rowser block

## Description

fix a long broken feature since d3v7 upgrade
test at http://localhost:3000/?block=on&genome=hg19&position=chr17:7579564-7579618 when block is in bp zoom level, the hl bar width spans a basepair. it also works in protein view and hic x/y view

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
