### PR TITLE
fix: Revert prev change that cause hic genome view to misalign

### DIFF
--- a/client/src/hic.straw.js
+++ b/client/src/hic.straw.js
@@ -169,7 +169,7 @@ export function hicparsefile(hic, debugmode) {
 
 	// controls
 
-	const table = hic.holder.append('table').style('border-spacing', '3px').style('margin', '5px')
+	const table = hic.holder.append('table').style('border-spacing', '3px')
 	const tr1 = table.append('tr')
 	const tr2 = table.append('tr')
 
@@ -337,7 +337,7 @@ async function init_wholegenome(hic) {
 		hic.x = {}
 	}
 	hic.c = {}
-	const table = hic.holder.append('table').style('margin', '5px')
+	const table = hic.holder.append('table')
 	const tr1 = table.append('tr')
 	hic.c.td = tr1.append('td').style('vertical-align', 'top')
 	hic.y.td = tr1.append('td').style('vertical-align', 'top')
@@ -364,12 +364,11 @@ async function init_wholegenome(hic) {
 	const fontsize = 15 // chr labels
 	const borderwidth = 1
 	const spacecolor = '#ccc'
-	const headerHeight = 50
 
 	// heatmap layer underneath sv
 	const layer_map = hic.wholegenome.svg
 		.append('g')
-		.attr('transform', 'translate(' + hardcode_wholegenomechrlabwidth + ',' + (fontsize + headerHeight) + ')')
+		.attr('transform', 'translate(' + hardcode_wholegenomechrlabwidth + ',' + fontsize + ')')
 	hic.wholegenome.layer_map = layer_map
 	const layer_sv = hic.wholegenome.svg
 		.append('g')
@@ -395,17 +394,17 @@ async function init_wholegenome(hic) {
 				.append('rect')
 				.attr('x', xoff)
 				.attr('width', chrw)
-				.attr('height', fontsize + headerHeight)
-				.attr('y', -fontsize - headerHeight)
+				.attr('height', fontsize)
+				.attr('y', -fontsize)
 				.attr('fill', checker_fill)
 		}
 		checker_row = !checker_row
 		layer_map
 			.append('text')
 			.attr('font-family', client.font)
+			.attr('text-anchor', 'middle')
 			.attr('font-size', 12)
-			//.attr('x', xoff + chrw / 2)
-			.attr('transform', `translate(${xoff + chrw / 2}, -10) rotate(-90)`)
+			.attr('x', xoff + chrw / 2)
 			.text(chr)
 
 		xoff += chrw

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Revert prev change that cause hic genome view to misalign


### PR DESCRIPTION
## Description

this change https://github.com/stjude/proteinpaint/commit/84dc49aa3779de3c3927a79cef2854faf45f8c60 is reverted to restore the [hic genome view](http://localhost:3000/?genome=hg38&hicfile=proteinpaint_demo/hg38/hic/hic_demo_v8.hic&enzyme=MboI)
(please compare how it looks in master) 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
