### PR TITLE
fix matrix legend filter issues

### DIFF
--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -121,6 +121,7 @@ export default function svgLegend(opts) {
 		const g = select(this)
 			.attr('transform', 'translate(' + currlinex + ',' + currliney + ')')
 			.style('opacity', settings.itemOpacity)
+			.style('opacity', d.greyedOut ? '0.3' : 1)
 
 		const itemlabel = g
 			.append('text')

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -181,7 +181,11 @@ export class Matrix {
 				this.sampleOrder = this.getSampleOrder(this.data)
 			}
 
-			if (!this.sampleOrder.length) {
+			if (
+				!this.sampleOrder.length &&
+				!this.config.legendGrpFilter.lst.length &&
+				!this.config.legendValueFilter.lst.length
+			) {
 				this.dom.loadingDiv.html('No matching sample data').style('display', '')
 				this.dom.svg.style('display', 'none')
 				return

--- a/client/plots/matrix.legend.js
+++ b/client/plots/matrix.legend.js
@@ -24,7 +24,8 @@ export function getLegendData(legendGroups, refs, self) {
 							label: v.label || self.mclass[key].label,
 							fill: v.color || self.mclass[key]?.color,
 							order: key == 'CNV_loss' ? -2 : key.startsWith('CNV_') ? -1 : 0,
-							crossedOut: true
+							crossedOut: f.tvs.legendFilterType == 'geneVariant_hard' ? true : false,
+							greyedOut: f.tvs.legendFilterType == 'geneVariant_soft' ? true : false
 						}
 					}
 				}
@@ -52,6 +53,7 @@ export function getLegendData(legendGroups, refs, self) {
 						isLegendItem: true,
 						dt: item.dt,
 						crossedOut: item.crossedOut,
+						greyedOut: item.greyedOut,
 						origin: item.origin
 					}
 				})
@@ -84,7 +86,8 @@ export function getLegendData(legendGroups, refs, self) {
 							label: v.label || self.mclass[key].label,
 							fill: v.color || self.mclass[key]?.color,
 							order: key == 'CNV_loss' ? -2 : key.startsWith('CNV_') ? -1 : 0,
-							crossedOut: true
+							crossedOut: f.tvs.legendFilterType == 'geneVariant_hard' ? true : false,
+							greyedOut: f.tvs.legendFilterType == 'geneVariant_soft' ? true : false
 						}
 					}
 				}
@@ -141,6 +144,7 @@ export function getLegendData(legendGroups, refs, self) {
 							isLegendItem: true,
 							dt: item.dt,
 							crossedOut: item.crossedOut,
+							greyedOut: item.greyedOut,
 							origin: item.origin
 						}
 					} else {
@@ -154,6 +158,7 @@ export function getLegendData(legendGroups, refs, self) {
 							isLegendItem: true,
 							dt: item.dt,
 							crossedOut: item.crossedOut,
+							greyedOut: item.greyedOut,
 							origin: item.origin
 						}
 					}
@@ -194,6 +199,7 @@ export function getLegendData(legendGroups, refs, self) {
 						isLegendItem: true,
 						dt: item.dt,
 						crossedOut: item.crossedOut,
+						greyedOut: item.greyedOut,
 						origin: item.origin
 					}
 				})
@@ -209,7 +215,7 @@ export function getLegendData(legendGroups, refs, self) {
 }
 
 export function getLegendItemText(item, count, t, s) {
-	if (item.crossedOut) {
+	if (item.crossedOut || item.greyedOut) {
 		// when the legend is crossed out
 		return item.label
 	}

--- a/client/plots/matrix.legend.js
+++ b/client/plots/matrix.legend.js
@@ -116,7 +116,7 @@ export function getLegendData(legendGroups, refs, self) {
 			}
 		}
 
-		const keys = Object.keys(legend.values).sort((a, b) => legend.values[a].order - legend.values[b].order)
+		const keys = Object.keys(legend.values).sort()
 		const hasScale = Object.values(legend.values).find(v => v.scale)
 		if (hasScale) {
 			legendData.push({

--- a/client/plots/matrix.serieses.js
+++ b/client/plots/matrix.serieses.js
@@ -119,9 +119,39 @@ export function getSerieses(data) {
 		if (series.cells.length) serieses.push(series)
 	}
 
+	addAllHiddenLegendGroups(legendGroups, this)
 	this.legendData = this.getLegendData(legendGroups, data.refs, this)
 	for (const grp of this.sampleGroups) {
 		grp.legendData = this.getLegendData(grp.legendGroups, data.refs, this)
 	}
 	return serieses
+}
+
+// Add a legendGroup for the a legend group whose legends are all hidden
+function addAllHiddenLegendGroups(legendGroups, self) {
+	for (const valueFilter of self.config.legendValueFilter.lst) {
+		if (valueFilter.tvs.term.type == 'categorical' && !legendGroups[valueFilter.tvs.term.$id]) {
+			legendGroups[valueFilter.tvs.term.$id] = {
+				ref: {},
+				values: {},
+				$id: valueFilter.tvs.term.$id
+			}
+		} else if (valueFilter.tvs.term.type == 'geneVariant' && !legendGroups[valueFilter.legendGrpName]) {
+			legendGroups[valueFilter.legendGrpName] = {
+				ref: {},
+				values: {},
+				dt: valueFilter.tvs.values[0].dt,
+				origin: valueFilter.tvs.values[0].origin
+			}
+		} else if (
+			(valueFilter.tvs.term.type == 'integer' || valueFilter.tvs.term.type == 'float') &&
+			!legendGroups[valueFilter.tvs.term.$id]
+		) {
+			legendGroups[valueFilter.tvs.term.$id] = {
+				ref: {},
+				values: {},
+				$id: valueFilter.tvs.term.$id
+			}
+		}
+	}
 }

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -361,7 +361,8 @@ export function getSortOptions(termdbConfig, controlLabels = {}) {
 							'Utr3',
 							'Utr5',
 							'S',
-							'Intron'
+							'Intron',
+							'noncoding'
 						]
 					},
 					// NOTE: nested CNV filter causes sorting samples by cnv+ssm > ssm-only > cnv-only


### PR DESCRIPTION
## Description

After "Hide samples with event" (hard). legends are crossed out, after "Do not show event"(soft), legends are greyed out. 

Removed "show only" for geneVariant term, but kept "show all"

Still show legends after all samples are removed or hidden

Rename "filter" to "hide" for non-genevariant legends

Legends are no longer clickable after legend groups are hidden.

will optimize tvs structure to get ride of hard/soft flag in another branch after figuring out best structure for soft filter

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
