### PR TITLE
Avoided rerender of plots in sampleView

### DIFF
--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -404,6 +404,7 @@ class SampleView {
 	}
 
 	showVisiblePlots() {
+		this.dom.sampleDiv.style('display', this.settings.showDictionary ? 'inline-block' : 'none')
 		for (const div of this.discoPlots)
 			if (this.settings.showDisco) div.style('display', this.state.samples.length == 1 ? 'inline-block' : 'table-cell')
 			else div.style('display', 'none')
@@ -445,13 +446,13 @@ class SampleView {
 		}
 		if (state.termdbConfig.queries.singleSampleGenomeQuantification) {
 			for (const k in state.termdbConfig.queries.singleSampleGenomeQuantification) {
-				let div = this.dom.contentDiv.append('div').style('padding', '20px').style('display', 'table-row')
+				let div = this.dom.contentDiv.append('div').style('display', 'table-row')
 				for (const sample of state.samples) {
 					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
 					let plotDiv
 					if (state.samples.length == 1)
 						plotDiv = this.dom.rightDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')
-					else plotDiv = div.insert('div').style('display', 'table-cell')
+					else plotDiv = div.insert('div').style('display', 'table-cell').style('padding', '20px')
 					this.singleSamplePlots.push(plotDiv)
 					plotDiv.insert('div').style('font-weight', 'bold').text(`${sample.sampleName} ${label}`)
 					const ssgqImport = await import('./plot.ssgq.js')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- In mass sampleview, expanding tree branch everytime no longer triggers rerendering of disco/ssgq plots


### PR DESCRIPTION
## Description

Rendering plots on init and then updating visible plots on rerender. Closes #748 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
