### PR TITLE
fix: File name of svg downloaded from disco preserves context including sample name and gene

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -357,14 +357,10 @@ async function createDiscoInSandbox(tk, block, sample, thisMutation) {
 	}
 	sandbox.header.text(headerTexts.join(''))
 	try {
-		;(await import('#plots/plot.disco.js')).default(
-			tk.mds,
-			tk.mds.label,
-			sample,
-			sandbox.body,
-			block.genome,
-			headerTexts.join('') // file name of svg downloaded from disco
-		)
+		;(await import('#plots/plot.disco.js')).default(tk.mds, tk.mds.label, sample, sandbox.body, block.genome, {
+			downloadImgName: headerTexts.join('') + ' Disco', // file name of svg downloaded from disco
+			label: { prioritizeGeneLabelsByGeneSets: true }
+		})
 	} catch (e) {
 		sandbox.body.append('div').text('Error: ' + (e.message || e))
 		if (e.stack) console.log(e.stack)

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -357,7 +357,14 @@ async function createDiscoInSandbox(tk, block, sample, thisMutation) {
 	}
 	sandbox.header.text(headerTexts.join(''))
 	try {
-		;(await import('#plots/plot.disco.js')).default(tk.mds, tk.mds.label, sample, sandbox.body, block.genome)
+		;(await import('#plots/plot.disco.js')).default(
+			tk.mds,
+			tk.mds.label,
+			sample,
+			sandbox.body,
+			block.genome,
+			headerTexts.join('') // file name of svg downloaded from disco
+		)
 	} catch (e) {
 		sandbox.body.append('div').text('Error: ' + (e.message || e))
 		if (e.stack) console.log(e.stack)

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -359,7 +359,9 @@ async function createDiscoInSandbox(tk, block, sample, thisMutation) {
 	try {
 		;(await import('#plots/plot.disco.js')).default(tk.mds, tk.mds.label, sample, sandbox.body, block.genome, {
 			downloadImgName: headerTexts.join('') + ' Disco', // file name of svg downloaded from disco
-			label: { prioritizeGeneLabelsByGeneSets: true }
+			label: {
+				prioritizeGeneLabelsByGeneSets: true // TODO control this at dataset
+			}
 		})
 	} catch (e) {
 		sandbox.body.append('div').text('Error: ' + (e.message || e))

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -15,10 +15,11 @@ import { RingType } from './ring/RingType.ts'
 import Settings from './Settings.ts'
 
 export default class Disco {
-	private type: string // what are these and where are they used??
 	private discoInteractions: DiscoInteractions
-	private opts: any
 
+	// following attributes are required by rx
+	private type: string
+	private opts: any
 	private state: any
 	private id: any
 	private app: any
@@ -26,12 +27,16 @@ export default class Disco {
 	constructor(opts: any) {
 		this.type = 'Disco'
 		this.opts = opts
-		this.discoInteractions = new DiscoInteractions(this)
 	}
+
 	getState(appState: any) {
 		return appState.plots.find(p => p.id === this.id)
 	}
+
 	async main(): Promise<void> {
+		// run this only when this.state{} is set; cannot do this step in constructor()
+		this.discoInteractions = new DiscoInteractions(this)
+
 		const settings: Settings = this.state.settings
 		const stateViewModelMapper = new ViewModelMapper(settings)
 		const viewModel = stateViewModelMapper.map(this.app.getState())

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -15,7 +15,7 @@ import { RingType } from './ring/RingType.ts'
 import Settings from './Settings.ts'
 
 export default class Disco {
-	private type: string
+	private type: string // what are these and where are they used??
 	private discoInteractions: DiscoInteractions
 	private opts: any
 

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -2,6 +2,8 @@ export default interface Settings {
 	verticalPadding: number
 	horizontalPadding: number
 
+	downloadImgName: string // file name of downloaded svg
+
 	rings: {
 		snvRingFilters: Array<string>
 
@@ -35,7 +37,7 @@ export default interface Settings {
 		animationDuration: number
 		overlapAngleFactor: number
 		showPrioritizeGeneLabelsByGeneSets: boolean
-		prioritizeGeneLabelsByGeneSets: boolean
+		prioritizeGeneLabelsByGeneSets: boolean // set to true to prioritize by default, if applicable
 	}
 	legend: {
 		snvTitle: string

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -3,6 +3,8 @@ import { copyMerge } from '#rx'
 
 export default function discoDefaults(overrides = {}): Settings {
 	const defaults = {
+		downloadImgName: 'disco.plot',
+
 		rings: {
 			nonExonicRingWidth: 20,
 			snvRingWidth: 20,

--- a/client/plots/disco/interactions/DiscoInteractions.ts
+++ b/client/plots/disco/interactions/DiscoInteractions.ts
@@ -3,14 +3,12 @@ export class DiscoInteractions {
 	downloadClickListener: (d: any) => void
 	geneClickListener: (gene: string, mnames: Array<string>) => void
 	prioritizeGenesCheckboxListener: (checked: boolean) => void
-
-	downloadImgName: string // is this needed?
+	downloadImgName: string
 
 	constructor(app: any) {
-		console.log(app) // this shows app.opts.state.args.downloadImgName is found
-		console.log(app.app) // this gives undefined. why?
+		// note! only call this constructor then app.state{} is created
 
-		this.downloadImgName = app.opts?.state?.args?.downloadImgName || 'disco.plot'
+		this.downloadImgName = app.state.settings.downloadImgName || 'disco.plot'
 
 		this.cappingClickCallback = (d: any, t: any) => {
 			const tip = app.app.tip

--- a/client/plots/disco/interactions/DiscoInteractions.ts
+++ b/client/plots/disco/interactions/DiscoInteractions.ts
@@ -4,7 +4,14 @@ export class DiscoInteractions {
 	geneClickListener: (gene: string, mnames: Array<string>) => void
 	prioritizeGenesCheckboxListener: (checked: boolean) => void
 
+	downloadImgName: string // is this needed?
+
 	constructor(app: any) {
+		console.log(app) // this shows app.opts.state.args.downloadImgName is found
+		console.log(app.app) // this gives undefined. why?
+
+		this.downloadImgName = app.opts?.state?.args?.downloadImgName || 'disco.plot'
+
 		this.cappingClickCallback = (d: any, t: any) => {
 			const tip = app.app.tip
 			tip.clear()
@@ -41,12 +48,13 @@ export class DiscoInteractions {
 
 			a.addEventListener(
 				'click',
-				function () {
+				() => {
+					// must use arrow function but not "function()", so this.downloadImgName is accessible
 					const serializer = new XMLSerializer()
 					const svg_blob = new Blob([serializer.serializeToString(svg)], {
 						type: 'image/svg+xml'
 					})
-					a.download = 'disco' + '.svg'
+					a.download = this.downloadImgName + '.svg'
 					a.href = URL.createObjectURL(svg_blob)
 					document.body.removeChild(a)
 				},

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -186,7 +186,8 @@ export function setInteractivity(self) {
 						self.state.vocab.dslabel,
 						sample,
 						sandbox.body,
-						self.app.opts.genome
+						self.app.opts.genome,
+						{ label: { prioritizeGeneLabelsByGeneSets: true } }
 					)
 				})
 		}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -187,7 +187,11 @@ export function setInteractivity(self) {
 						sample,
 						sandbox.body,
 						self.app.opts.genome,
-						{ label: { prioritizeGeneLabelsByGeneSets: true } }
+						{
+							label: {
+								prioritizeGeneLabelsByGeneSets: true // TODO control this at dataset-level
+							}
+						}
 					)
 				})
 		}

--- a/client/plots/plot.disco.js
+++ b/client/plots/plot.disco.js
@@ -21,8 +21,11 @@ holder
 
 genomeObj={}
 	client side genome obj
+
+downloadImgName=str
+	optional file name for downloaded svg, to preserve contexts where this disco plot was originated from
 */
-export default async function (termdbConfig, dslabel, sample, holder, genomeObj) {
+export default async function (termdbConfig, dslabel, sample, holder, genomeObj, downloadImgName = 'disco.plot') {
 	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
 
 	try {
@@ -61,7 +64,8 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj)
 		const disco_arg = {
 			sampleName: sample[termdbConfig.queries.singleSampleMutation.sample_id_key],
 			data: mlst,
-			genome: genomeObj
+			genome: genomeObj,
+			downloadImgName
 		}
 
 		if (termdbConfig.queries.singleSampleMutation.discoSkipChrM) {

--- a/client/plots/plot.disco.js
+++ b/client/plots/plot.disco.js
@@ -22,10 +22,12 @@ holder
 genomeObj={}
 	client side genome obj
 
-downloadImgName=str
-	optional file name for downloaded svg, to preserve contexts where this disco plot was originated from
+_overrides={}
+	optional override parameters to pass to disco
 */
-export default async function (termdbConfig, dslabel, sample, holder, genomeObj, downloadImgName = 'disco.plot') {
+export default async function (termdbConfig, dslabel, sample, holder, genomeObj, _overrides = {}) {
+	const overrides = computeOverrides(_overrides, termdbConfig, genomeObj, sample)
+
 	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
 
 	try {
@@ -64,8 +66,7 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj,
 		const disco_arg = {
 			sampleName: sample[termdbConfig.queries.singleSampleMutation.sample_id_key],
 			data: mlst,
-			genome: genomeObj,
-			downloadImgName
+			genome: genomeObj
 		}
 
 		if (termdbConfig.queries.singleSampleMutation.discoSkipChrM) {
@@ -91,11 +92,7 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj,
 						chartType: 'Disco',
 						subfolder: 'disco',
 						extension: 'ts',
-						overrides: {
-							label: {
-								showPrioritizeGeneLabelsByGeneSets: !!genomeObj.geneset
-							}
-						}
+						overrides
 					}
 				]
 			}
@@ -106,4 +103,16 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj,
 	} catch (e) {
 		loadingDiv.text('Error: ' + (e.message || e))
 	}
+}
+
+function computeOverrides(o, termdbConfig, genomeObj, sample) {
+	// parameter is duplicated into a new object; this script computes new attributes and add to the new obj
+	const overrides = structuredClone(o)
+	if (!overrides.label) overrides.label = {}
+	overrides.label.showPrioritizeGeneLabelsByGeneSets = !!genomeObj.geneset
+	if (!overrides.downloadImgName) {
+		overrides.downloadImgName =
+			sample[termdbConfig.queries.singleSampleMutation.sample_id_key || 'sample_id'] + ' Disco'
+	}
+	return overrides
 }

--- a/release.txt
+++ b/release.txt
@@ -1,4 +1,5 @@
 Fixes:
-- File name of svg downloaded from disco preserves context including sample name and gene.
+- Disco: file name of downloaded svg preserves context including sample name and gene.
+- Disco: by default it now prioritize CGC genes in hg38.
 - Various scatterplot fixes: tooltip dot scale, divideBy bug
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,4 @@
+Fixes:
+- File name of svg downloaded from disco preserves context including sample name and gene.
+- Various scatterplot fixes: tooltip dot scale, divideBy bug
 


### PR DESCRIPTION
## Description

closes #319 
test at http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC, click a mutation and launch disco. first the "prioritize by CGC" is checked by default. click Download, the svg file name carries sample name and gene etc

launch disco from non-gdc (pnet) works

mds3 manual tests pass

all 781 CI tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
