### PR TITLE
prototype a session tracking feature with clearer options

### DIFF
--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -65,6 +65,7 @@ class MassSessionBtn {
 		const select = tr0
 			.append('td')
 			.append('select')
+			.style('min-width', '180px')
 			.on('change', event => {
 				const name = select.property('value')
 				if (!name) return
@@ -125,6 +126,7 @@ class MassSessionBtn {
 				const select = tr2
 					.append('td')
 					.append('select')
+					.style('min-width', '180px')
 					.on('change', async event => {
 						const id = select.property('value')
 						if (!id) return
@@ -198,7 +200,7 @@ class MassSessionBtn {
 				this.sessionName = input.property('value') || placeholder
 				this.savedSessions[this.sessionName] = this.app.getState()
 				localStorage.setItem('savedMassSessions', JSON.stringify(this.savedSessions))
-				this.confirmAction(`Cached '<b>${this.sessionName}</b>'`)
+				this.confirmAction(`Cached '<b>${this.sessionName}</b>' in browser`)
 			})
 
 		submitDiv
@@ -229,7 +231,7 @@ class MassSessionBtn {
 					const res = await this.getSessionUrl(name)
 					if (res.id != name) throw `error saving ${name}`
 					// this.download(name)
-					this.confirmAction(`Saved '<b>${name}</b>'`)
+					this.confirmAction(`Saved '<b>${name}</b>' on the server`)
 				})
 		}
 	}

--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -1,0 +1,334 @@
+import { getCompInit } from '#rx'
+import { Menu } from '#dom/menu'
+import { to_textfile } from '#dom/downloadTextfile'
+import { dofetch3 } from '#common/dofetch'
+
+class MassSessionBtn {
+	constructor() {
+		this.type = 'sessionBtn'
+		this.route = 'termdb'
+		this.embedderOrigin = window.location.origin
+		this.hostURL = sessionStorage.getItem('hostURL') || this.embedderOrigin
+	}
+
+	async init(appState) {
+		const tip = new Menu({ padding: '0px' })
+		this.dom = {
+			button: this.opts.button,
+			tip
+		}
+
+		this.dom.button.on('click', () => {
+			this.dom.tip.clear()
+			this.showMenu()
+		})
+
+		this.savedSessions = JSON.parse(localStorage.getItem('savedMassSessions') || `{}`)
+		this.requiredAuth = appState.termdbConfig?.requiredAuth?.find(a => a.route == this.route && a.type == 'jwt')
+	}
+
+	showMenu() {
+		this.dom.tip.clear().d.style('padding', 0)
+		const gt = `<span style='margin-left: 24px; float: right'>&gt;</span>`
+		const options = [
+			{ label: `Open ${gt}`, callback: this.open },
+			{ label: `Save ${gt}`, callback: this.save },
+			{ label: `Share ${gt}`, callback: this.share }
+			//{ label: 'Download', callback: this.download }
+		]
+
+		this.dom.tip
+			.clear()
+			.d.selectAll('.sja_menuoption sja_sharp_border')
+			.data(options)
+			.enter()
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.html(d => d.label)
+			.on('click', (event, d) => {
+				this.dom.tip.clear().d.style('padding', '10px')
+				this.showBackBtn()
+				d.callback.call(this)
+			})
+
+		this.dom.tip.showunder(this.dom.button.node())
+	}
+
+	async open() {
+		this.dom.tip.d.append('div').style('padding', '3px 5px').style('font-weight', 600).html('Open a session from')
+		const table = this.dom.tip.d.append('table')
+
+		const tr0 = table.append('tr')
+		tr0.append('td').style('padding', '3px 5px').html('Browser cache:')
+		const sessionNames = Object.keys(this.savedSessions)
+		if (!this.sessionName) sessionNames.unshift('')
+		const select = tr0
+			.append('td')
+			.append('select')
+			.on('change', event => {
+				const name = select.property('value')
+				if (!name) return
+				this.sessionName = name
+				const state = this.savedSessions[name]
+				this.app.dispatch({ type: 'app_refresh', state })
+				this.dom.tip.hide()
+			})
+
+		select
+			.selectAll('option')
+			.data(sessionNames)
+			.enter()
+			.append('option')
+			.html(d => d)
+			.attr('value', d => d)
+			.property('selected', d => d === this.sessionName)
+
+		const tr1 = table.append('tr')
+		tr1.append('td').style('padding', '3px 5px').html('Local file:')
+		const label = tr1.append('td').append('label')
+
+		label.append('span').style('text-decoration', 'underline').style('cursor', 'pointer').html('Choose File')
+
+		label
+			.append('input')
+			.attr('type', 'file')
+			.attr('placeholder', 'file name')
+			.style('opacity', 0)
+			.style('width', '0.1px')
+			.style('height', '0.1px')
+			.style('position', 'absolute')
+			.on('change', async () => {
+				const file = event.target.files.item(0)
+				const json = await file.text()
+				let sessionName = file.name
+				if (this.savedSessions[sessionName]) {
+					sessionName = prompt(
+						`Leave as-is to overwrite a session with the same name, or enter a different session name.`,
+						sessionName
+					)
+				}
+				this.sessionName = sessionName
+				const state = JSON.parse(json)
+				this.savedSessions[file.name] = state
+				this.app.dispatch({ type: 'app_refresh', state })
+				this.dom.tip.hide()
+			})
+
+		const state = this.app.getState()
+		this.requiredAuth = state.termdbConfig?.requiredAuth?.find(a => a.route == this.route && a.type == 'jwt')
+		if (this.requiredAuth) {
+			const tr2 = table.append('tr')
+			tr2.append('td').style('padding', '3px 5px').html('Server: ')
+			if (!this.app.vocabApi.hasVerifiedToken()) {
+				tr2.append('td').style('padding', '3px 5px').html('Requires sign-in')
+			} else {
+				const select = tr2
+					.append('td')
+					.append('select')
+					.on('change', async event => {
+						const id = select.property('value')
+						if (!id) return
+						console.log(133, id)
+						const headers = this.app.vocabApi.mayGetAuthHeaders(this.route)
+						const body = { id, route: this.route, dslabel: state.vocab.dslabel, embedder: window.location.hostname }
+						const res = await dofetch3(`/massSession?`, { headers, body })
+						if (!res.state) throw res.error || 'unable to get the cached session from the server'
+						this.savedSessions[id] = res.state
+						this.app.dispatch({ type: 'app_refresh', state: res.state })
+						this.dom.tip.hide()
+					})
+
+				if (!this.serverCachedSessions) {
+					const headers = this.app.vocabApi.mayGetAuthHeaders(this.route)
+					const body = { route: this.route, dslabel: state.vocab.dslabel, embedder: window.location.hostname }
+					const res = await dofetch3('/sessionIds', { headers, body })
+					this.serverCachedSessions = res.sessionIds
+				}
+
+				select
+					.selectAll('option')
+					.data(['', ...this.serverCachedSessions])
+					.enter()
+					.append('option')
+					.html(d => d)
+					.attr('value', d => d)
+					.property('selected', d => d === this.sessionName)
+			}
+		}
+	}
+
+	save(d) {
+		const div = this.dom.tip.d
+		const inputDiv = div.append('div')
+		inputDiv.append('span').html('Save as')
+		const sessionNames = Object.keys(this.savedSessions)
+		const placeholder = this.sessionName || 'unnamed-session'
+		const input = inputDiv
+			.append('input')
+			.attr('type', 'text')
+			.attr('placeholder', placeholder)
+			.style('width', '220px')
+			.on('input', () => {
+				searchResultDiv.selectAll('*').remove()
+				const value = input.property('value')
+				const exactMatch = sessionNames.filter(s => s === value)
+				const startsWith = sessionNames.filter(s => s.startsWith(value))
+				const includes = sessionNames.filter(s => s.includes(value) && s !== value && !startsWith.includes(s))
+				searchResultDiv
+					.selectAll('div')
+					.data([...exactMatch, ...startsWith, ...includes])
+					.enter()
+					.append('div')
+					.attr('class', 'sja_menuoption')
+					.html(d => d)
+					.on('click', (event, d) => {
+						input.property('value', d)
+						searchResultDiv.selectAll('*').remove()
+					})
+			})
+
+		const searchResultDiv = div.append('div')
+		const submitDiv = div.append('div')
+		submitDiv.append('span').html('Save to&nbsp;')
+		submitDiv
+			.append('button')
+			.style('min-width', '80px')
+			.html('Browser')
+			.on('click', () => {
+				this.sessionName = input.property('value') || placeholder
+				this.savedSessions[this.sessionName] = this.app.getState()
+				localStorage.setItem('savedMassSessions', JSON.stringify(this.savedSessions))
+				this.confirmAction(`Cached '<b>${this.sessionName}</b>'`)
+			})
+
+		submitDiv
+			.append('button')
+			.style('min-width', '80px')
+			.html('File')
+			.on('click', () => {
+				const name = input.property('value') || placeholder
+				this.savedSessions[name] = this.app.getState()
+				this.download(name)
+				this.confirmAction(`Downloaded '<b>${name}</b>'`)
+			})
+
+		// assume that a jwt-type credential will include the user email in the jwt payload,
+		// which could be trusted for saving sessions under cachedir/termdbSessions/[embedderHostName]/[email]
+		if (this.requiredAuth) {
+			submitDiv
+				.append('button')
+				.style('min-width', '80px')
+				.html('Server')
+				.on('click', async () => {
+					if (!this.app.vocabApi.hasVerifiedToken()) {
+						alert('Requires sign-in')
+						return
+					}
+					const name = input.property('value') || placeholder
+					this.savedSessions[name] = this.app.getState()
+					const res = await this.getSessionUrl(name)
+					if (res.id != name) throw `error saving ${name}`
+					// this.download(name)
+					this.confirmAction(`Saved '<b>${name}</b>'`)
+				})
+		}
+	}
+
+	download(name = '') {
+		const sessionName = name || this.sessionName
+		const ext = sessionName?.endsWith('.txt') ? '' : '.txt'
+		const filename = `${sessionName}${ext}`
+		to_textfile(filename, JSON.stringify(this.savedSessions[sessionName]))
+	}
+
+	async share() {
+		this.dom.tip.d.append('div').style('max-width', '300px').html(`<b>Share this session:</b>`)
+
+		this.dom.tip.d
+			.append('button')
+			.style('margin', '10px')
+			.html('Get URL link')
+			.on('click', () => this.getSessionUrl())
+
+		this.dom.tip.d
+			.append('div')
+			.style('max-width', '300px')
+			.html(
+				`NOTE: A recovered session may hide data or views to users that are not authorized to access the saved datasets or features.`
+			)
+
+		// TODO: should filter the targets based on various checks including signed-in status, etc;
+		// this can reuse the current /massSession route as applicable/appropriate
+		// const targets = [window.location.hostname]
+		// if (targets[0].includes('localhost')) targets.push('ppr', 'pp-irt')
+		// if (targets[0].includes('proteinpaint.stjude.org')) targets.push('proteinpaint.stjude.org')
+		// this.dom.tip.d
+		// 	.append('ul')
+		// 	.selectAll('li')
+		// 	.data(targets)
+		// 	.enter()
+		// 	.append('li')
+		// 	.style('cursor', 'pointer')
+		// 	.html(d => d)
+		// 	.on('click', () => {
+		// 		alert('TODO!!!')
+		// 	})
+	}
+
+	async getSessionUrl(filename = '') {
+		const headers = this.app.vocabApi.mayGetAuthHeaders('termdb')
+		const state = structuredClone(this.app.getState())
+		const { protocol, host, search, origin, href } = window.location
+		state.embedder = { protocol, host, search, origin, href }
+		if (filename) {
+			// a non-empty filename value implies saving by email and having auth session,
+			// since it's easy for different users to use the same non-random filename
+			state.__sessionFor__ = {
+				route: this.route,
+				filename,
+				dslabel: state.vocab.dslabel,
+				embedder: window.location.hostname
+			}
+		}
+		const res = await dofetch3('/massSession', {
+			headers,
+			method: 'POST',
+			body: JSON.stringify(state)
+		})
+
+		if (filename) {
+			return res
+		} else {
+			const url = `${this.hostURL}/?mass-session-id=${res.id}&noheader=1`
+			this.dom.tip.clear().showunder(this.dom.button.node())
+			this.dom.tip.d
+				.append('div')
+				.style('margin', '10px')
+				.html(
+					`<a href='${url}' target=_blank>${res.id}</a><br><div style="font-size:.8em;opacity:.6"><span>Click the link to recover this session. Bookmark or share this link.</span><br><span>This session will be saved for ${this.opts.massSessionDuration} days.</span></div>`
+				)
+			setTimeout(() => {
+				this.dom.button.property('disabled', false)
+			}, 1000)
+		}
+	}
+
+	showBackBtn() {
+		this.dom.tip.d
+			.append('div')
+			.style('margin-bottom', '10px')
+			.style('cursor', 'pointer')
+			.html(`&lt; Session Menu`)
+			.on('click', () => this.showMenu())
+	}
+
+	confirmAction(html) {
+		this.dom.tip.clear().d.append('div').html(html).transition().delay(3000).duration(1000).style('opacity', 0)
+
+		setTimeout(() => {
+			this.dom.tip.hide()
+		}, 3500)
+	}
+}
+
+export const sessionBtnInit = getCompInit(MassSessionBtn)

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -321,6 +321,7 @@ app.all(basepath + '/termdb-barsql', termdbbarsql.handle_request_closure(genomes
 app.post(basepath + '/singlecell', singlecell.handle_singlecell_closure(genomes))
 app.post(basepath + '/massSession', massSession.save)
 app.get(basepath + '/massSession', massSession.get)
+app.get(basepath + '/sessionIds', massSession.getSessionIdsByCred)
 app.get(basepath + '/isoformbycoord', handle_isoformbycoord)
 app.post(basepath + '/ase', handle_ase)
 app.post(basepath + '/bamnochr', handle_bamnochr)

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -616,7 +616,8 @@ function mayAddSessionFromJwt(sessions, dslabel, id, req, cred) {
 	// }
 	// the request header custom key or cookie session ID should equal the signed payload.id in the header.authorization,
 	// otherwise an expired header.auth jwt may be reused even when a user has already logged out
-	if (id && payload.id != id) return
+	if (id && payload.id != id && req.headers?.['x-sjppds-sessionid'] != payload.id) return
+
 	// do not overwrite existing
 	if (!sessions[dslabel]) sessions[dslabel] = {}
 	//if (sessions[dslabel][payload.id]) throw `session conflict`

--- a/server/src/massSession.js
+++ b/server/src/massSession.js
@@ -13,7 +13,6 @@ export async function save(req, res) {
 		if (filename) {
 			const reqExtract = { headers: req.headers, query: q } //; console.log(13, reqExtract)
 			payload = authApi.getPayloadFromHeaderAuth(reqExtract, route)
-			console.log(14, payload)
 			if (!payload.email) throw `invalid credentials: no jwt.email`
 			if (payload.dslabel != dslabel || payload.route != route || payload.embedder != embedder)
 				throw `invalid credentials: mismatched payload`
@@ -86,13 +85,10 @@ export async function getSessionIdsByCred(req, res) {
 	try {
 		const { filename, route, dslabel, embedder } = req.query
 		const payload = authApi.getPayloadFromHeaderAuth(req, route)
-		console.log(14, payload)
 		if (!payload.email) {
-			res.status(401)
 			throw `invalid credentials: no jwt.email`
 		}
 		if (payload.dslabel != dslabel || payload.route != route || payload.embedder != embedder) {
-			res.status(401)
 			throw `invalid credentials: mismatched payload`
 		}
 		const dir = getSessionPath(req.query, payload)
@@ -100,10 +96,14 @@ export async function getSessionIdsByCred(req, res) {
 			.access(dir)
 			.then(() => true)
 			.catch(() => false)
-		if (!dirExists) res.send({ status: 'ok', sessionIds: [] })
+		if (!dirExists) {
+			res.send({ status: 'ok', sessionIds: [] })
+			return
+		}
 		const files = await fs.promises.readdir(dir)
 		res.send({ status: 'ok', sessionIds: files })
 	} catch (e) {
+		res.status(401)
 		res.send({ error: e.message || e })
 	}
 }

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -127,6 +127,7 @@ tape(`initialization`, async test => {
 				'getDsAuth',
 				'getForbiddenRoutesForDsEmbedder',
 				'getJwtPayload',
+				'getPayloadFromHeaderAuth',
 				'getRequiredCredForDsEmbedder',
 				'maySetAuthRoutes',
 				'userCanAccess'

--- a/server/test/fake-jwt.js
+++ b/server/test/fake-jwt.js
@@ -5,7 +5,8 @@ const jsonwebtoken = require('jsonwebtoken')
 
 const time = Math.floor(Date.now() / 1000)
 const dslabel = process.argv[2] || 'TermdbTest'
-const secret = serverconfig.dsCredentials[dslabel].termdb.localhost.secret
+const embedder = process.argv[3] || 'localhost'
+const secret = serverconfig.dsCredentials[dslabel].termdb[embedder].secret
 //for testing only
 console.log(
 	//secret,


### PR DESCRIPTION
 ## Description
Also, prefer local cache/file storage, in addition to the option to save in the server or share. ~~This is a draft, will do more integration testing later and include release notes if this approach looks okay to pursue~~.

NOTE: The `Share` option behaves almost the same as the current `Save Session` feature, but notes around expiration may have been lost. Someone else can work on that in another PR, since there is also an open question from @creilly8 on this. 

Test Scenarios for `Open` and `Save`: for each scenario, test that you can save to/open from browser, file, and if applicable, server.

A. Unrpotected ds: comment `serverconfig.dsCredentials.SJLife` (e.g., change to `dsCredentials['#SJLife']`):
  - use [a simple SJLife URL params](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22})
  - there should be no server options in the `Open` and `Save` menus 

B. Protected ds: enable `dsCredentials.SJLife`
  - use http://localhost:3000/example.auth.html
  - there should **be** server options in the `Open` and `Save` menus: I think this matches the requirements in Xin's drawing, but using button + menus instead of tab + tray
  - test while logged in and not
  - when saving to server, you should see the file saved in `[cachedir]/sessionsByCred/...`

C. Same as B, but simulate an embedded use case
  - `sudo vim /etc/hosts` and add the entry `127.0.0.1 viz.localhost`
  - change `dsCredentials['SJLife']` to `dsCredentials['*']` - all embedders will use the same jwt secret
  - from the `sjpp` dir, run `./proteinpaint/server/test/fake-jwt.js SJLife > public/fake-jwt.json '*'`
  - use http://viz.localhost:3000/example.auth.html (different subdomain)
  - manually test like in B
  - Also test that the `Share`-generated URL opens within `viz.localhost`, and not in `localhost`

The goal is to emulate familiar behavior, such as the `File: > open | save | share | ...` options that are very typical in desktop apps.

![Screenshot 2023-10-27 at 6 14 49 PM](https://github.com/stjude/proteinpaint/assets/411031/500560b8-3280-484a-8e82-b0c120f6d9c2)
![Screenshot 2023-10-27 at 6 15 42 PM](https://github.com/stjude/proteinpaint/assets/411031/a626eb7c-3101-49b6-8b71-171af749b579)
![Screenshot 2023-10-27 at 6 16 02 PM](https://github.com/stjude/proteinpaint/assets/411031/82f6d22c-f8da-4d74-b88c-a815d6f22088)
![Screenshot 2023-10-27 at 6 16 19 PM](https://github.com/stjude/proteinpaint/assets/411031/8b454c26-7cd3-4cff-b1ce-6d251805b45a)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
