### PR TITLE
Deciding decimal places on numeric filter dynamically

### DIFF
--- a/client/dom/numericRangeInput.js
+++ b/client/dom/numericRangeInput.js
@@ -4,7 +4,7 @@ export class NumericRangeInput {
 			.append('input')
 			.attr('name', 'rangeInput')
 			.attr('title', `leave blank for the allowed minimum value`)
-			.style('width', '180px')
+			.style('width', '250px')
 			.style('margin', '3px 5px')
 			//.style('font-size', '20px')
 			.on('change', () => {

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -62,6 +62,7 @@ export function addBrushes(self, new_brush_location) {
 }
 
 function applyBrush(self, elem, brush) {
+	console.log(self)
 	if (!brush.elem) brush.elem = select(elem)
 	const range = brush.range
 	const plot_size = self.num_obj.plot_size
@@ -83,10 +84,20 @@ function applyBrush(self, elem, brush) {
 				return
 			}
 			//update temp_ranges
-			range.start = roundValue(xscale.invert(s[0]), 2)
-			range.stop = roundValue(xscale.invert(s[1]), 2)
-			const min = roundValue(minvalue, 2)
-			const max = roundValue(maxvalue, 2)
+
+			range.start = Number(xscale.invert(s[0]))
+			range.stop = Number(xscale.invert(s[1]))
+			let min = Number(minvalue)
+			let max = Number(maxvalue)
+			let digits = 0
+			if (self.tvs.term.type == 'float')
+				digits = Math.max(getDecimalPlaces(range.start, min, max), getDecimalPlaces(range.stop, min, max))
+
+			range.start = range.start.toFixed(digits)
+			range.stop = range.stop.toFixed(digits)
+			min = min.toFixed(digits)
+			max = max.toFixed(digits)
+
 			range.startunbounded = min == range.start && inputRange.startunbounded //Limit by the brush, not by the user
 			range.stopunbounded = max == range.stop && inputRange.stopunbounded
 			const start = range.startunbounded ? '' : inputRange.startinclusive ? `${range.start} <=` : `${range.start} <`
@@ -116,6 +127,16 @@ function applyBrush(self, elem, brush) {
 				? '#23cba7'
 				: '#777777'
 		)
+
+	function getDecimalPlaces(value, min, max) {
+		let digits = 2
+		let round = value.toFixed(digits)
+		while (round < min || round > max) {
+			digits++
+			round = value.toFixed(digits)
+		}
+		return digits
+	}
 }
 
 //Add new blank range temporary, save after entering values

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -128,6 +128,12 @@ function applyBrush(self, elem, brush) {
 
 	function getDecimalPlaces(value, min, max) {
 		let digits = 2
+		if (Math.abs(Math.trunc(value)) == 0) {
+			//integer part is 0
+			const log = Math.floor(Math.log10(Math.abs(value)) + 1) //may be 0 or a negative value
+			digits = log * -1 + 2
+		}
+
 		let round = value.toFixed(digits)
 		while (round < min || round > max) {
 			digits++

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -62,7 +62,6 @@ export function addBrushes(self, new_brush_location) {
 }
 
 function applyBrush(self, elem, brush) {
-	console.log(self)
 	if (!brush.elem) brush.elem = select(elem)
 	const range = brush.range
 	const plot_size = self.num_obj.plot_size

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -128,7 +128,7 @@ function applyBrush(self, elem, brush) {
 
 	function getDecimalPlaces(value, min, max) {
 		let digits = 2
-		if (Math.abs(Math.trunc(value)) == 0) {
+		if (Math.trunc(value) == 0) {
 			//integer part is 0
 			const log = Math.floor(Math.log10(Math.abs(value)) + 1) //may be 0 or a negative value
 			digits = log * -1 + 2

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -1,6 +1,5 @@
 import { select } from 'd3-selection'
 import { brushX } from 'd3-brush'
-import roundValue from '#shared/roundValue'
 
 /*
 ********************** EXPORTED


### PR DESCRIPTION
## Description

Now the decimal places are chosen dynamically. If the term type is integer is set to  0, otherwise is set considering that the rounded value is still between the mix and max values.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
