### PR TITLE
fix: Bin default age ranges by 30 and 60 years for GDC age_at_diagnosis

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Bin default age ranges by 30 and 60 years for GDC age_at_diagnosis


### PR DESCRIPTION
## Description

[please test here](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22case.disease_type%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}],%22divideBy%22:{%22id%22:%22case.demographic.gender%22}}]}), where age at diagnosis with default bin is used
this change only affects gdc dataset, and mds3  non-CI tests all pass, so it should be fine

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
