### PR TITLE
Cross-origin session recovery in a new tab

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -209,8 +209,8 @@ function mayAdjustRequest(url, init) {
 		return url
 	}
 
-	if (method != 'GET') {
-		throw `unsupported init.method='${method}': must be undefined or GET or POST`
+	if (method != 'GET' && method != 'DELETE') {
+		throw `unsupported init.method='${method}': must be undefined or GET or POST or DELETE`
 	}
 
 	if (init.body) {

--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -1,0 +1,25 @@
+export function corsMessage(res) {
+	const embedder = res.state?.embedder
+	console.log()
+	const messageListener = event => {
+		console.log(3, event.origin === embedder.origin, event.origin, embedder.origin)
+		if (event.origin !== embedder.origin) return
+		console.log(4, event)
+		if (event.data == 'getActiveMassSession') {
+			window.removeEventListener('message', messageListener)
+			child.postMessage({ state: res.state }, embedder.origin) //; console.log()
+			setTimeout(window.close, 500)
+		}
+	}
+	window.addEventListener('message', messageListener, false)
+	setTimeout(() => window.removeEventListener('message', messageListener), 1000)
+	if (embedder.origin != window.location.origin) {
+		confirm(
+			`Another window will open to recover the saved session. When the next window opens,` +
+				`\n- You may need to allow popups.` +
+				`\n- You may have to refresh it.` +
+				`\n- After the session is recovered, this browser window will automatically close.`
+		)
+	}
+	const child = window.open(embedder.href, 'Visualization')
+}

--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -1,10 +1,7 @@
 export function corsMessage(res) {
 	const embedder = res.state?.embedder
-	console.log()
 	const messageListener = event => {
-		console.log(3, event.origin === embedder.origin, event.origin, embedder.origin)
 		if (event.origin !== embedder.origin) return
-		console.log(4, event)
 		if (event.data == 'getActiveMassSession') {
 			window.removeEventListener('message', messageListener)
 			child.postMessage({ state: res.state }, embedder.origin) //; console.log()
@@ -12,7 +9,7 @@ export function corsMessage(res) {
 		}
 	}
 	window.addEventListener('message', messageListener, false)
-	setTimeout(() => window.removeEventListener('message', messageListener), 1000)
+	setTimeout(() => window.removeEventListener('message', messageListener), 5000)
 	if (embedder.origin != window.location.origin) {
 		confirm(
 			`Another window will open to recover the saved session. When the next window opens,` +

--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -1,11 +1,18 @@
-export function corsMessage(res) {
+export function corsMessage(res, origin = '') {
 	const embedder = res.state?.embedder
 	const messageListener = event => {
 		if (event.origin !== embedder.origin) return
 		if (event.data == 'getActiveMassSession') {
 			window.removeEventListener('message', messageListener)
-			child.postMessage({ state: res.state }, embedder.origin) //; console.log()
-			setTimeout(window.close, 500)
+			child.postMessage({ state: res.state }, embedder.origin)
+			setTimeout(() => {
+				try {
+					window.close()
+				} catch (e) {
+					console.log(e)
+					window.open(window.location, '_self').close()
+				}
+			}, 500)
 		}
 	}
 	window.addEventListener('message', messageListener, false)
@@ -15,8 +22,13 @@ export function corsMessage(res) {
 			`Another window will open to recover the saved session. When the next window opens,` +
 				`\n- You may need to allow popups.` +
 				`\n- You may have to refresh it.` +
-				`\n- After the session is recovered, this browser window will automatically close.`
+				`\n- After the session is recovered, this browser window should automatically close.`
 		)
+		document.body.innerHTML = `
+			<div style='margin: 20px; padding: 20px; font-size: 24px'>
+				Please close this browser tab. The recovered session should visible in another browser tab.
+			</div>
+		`
 	}
 	const child = window.open(embedder.href, 'Visualization')
 }

--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -5,18 +5,28 @@ export function corsMessage(res, origin = '') {
 		if (event.data == 'getActiveMassSession') {
 			window.removeEventListener('message', messageListener)
 			child.postMessage({ state: res.state }, embedder.origin)
-			setTimeout(() => {
-				try {
-					window.close()
-				} catch (e) {
-					console.log(e)
-					window.open(window.location, '_self').close()
-				}
-			}, 500)
+			if (embedder.origin != window.location.origin) {
+				// An embedder site was opened using an transitory proteinpaint site URL.
+				// Try to close this transitory URL tab since it will not display any viz
+				// and is only used to open the saved embedder URL without imposing PP-related
+				// URL parameters.
+				setTimeout(() => {
+					try {
+						// Works when a shared URL is clicked from the session menu
+						window.close()
+					} catch (e) {
+						// the browser prevents the closing of an transitory tab that was opened
+						// by clicking on a bookmarked link or pasting that link directly on the browser
+						// address bar. In that case, make another attempt to close the transitory tab
+						console.log(e)
+						window.open(window.location, '_self').close()
+					}
+				}, 500)
+			}
 		}
 	}
 	window.addEventListener('message', messageListener, false)
-	setTimeout(() => window.removeEventListener('message', messageListener), 5000)
+	setTimeout(() => window.removeEventListener('message', messageListener), 6000)
 	if (embedder.origin != window.location.origin) {
 		confirm(
 			`Another window will open to recover the saved session. When the next window opens,` +
@@ -30,5 +40,5 @@ export function corsMessage(res, origin = '') {
 			</div>
 		`
 	}
-	const child = window.open(embedder.href, 'Visualization')
+	const child = window.open(embedder.href, '_blank')
 }

--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -177,7 +177,7 @@ class MassSessionBtn {
 						this.dom.tip.hide()
 					})
 
-				if (!this.serverCachedSessions) await this.setServerCachedSessions(state)
+				if (!this.serverCachedSessions) await this.setServerCachedSessions()
 
 				select
 					.selectAll('option')
@@ -191,18 +191,20 @@ class MassSessionBtn {
 		}
 	}
 
-	async setServerCachedSessions(state) {
+	async setServerCachedSessions() {
 		const headers = this.app.vocabApi.mayGetAuthHeaders(this.route)
 		const body = { route: this.route, dslabel: this.dslabel, embedder: window.location.hostname }
 		const res = await dofetch3('/sessionIds', { headers, body })
 		this.serverCachedSessions = res.sessionIds
 	}
 
-	save(d) {
+	async save(d) {
 		const div = this.dom.tip.d
 		const inputDiv = div.append('div')
 		inputDiv.append('span').html('Save as')
 		const sessionNames = Object.keys(this.savedSessions)
+		if (!this.serverCachedSessions) await this.setServerCachedSessions()
+		sessionNames.push(...this.serverCachedSessions.filter(d => !sessionNames.includes(d)))
 		const placeholder = this.sessionName || 'unnamed-session'
 		const input = inputDiv
 			.append('input')
@@ -386,7 +388,7 @@ class MassSessionBtn {
 			.html(d => d)
 
 		const sessionIds = Object.keys(this.savedSessions).map(id => ({ loc: 'browser', id }))
-		if (!this.serverCachedSessions) await this.setServerCachedSessions(this.app.getState())
+		if (!this.serverCachedSessions) await this.setServerCachedSessions()
 		sessionIds.push(...this.serverCachedSessions.map(id => ({ loc: 'server', id })))
 
 		const trs = table

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1471,7 +1471,7 @@ async function launchmass(arg, app) {
 	if (window.opener && hostURL != window.location.origin) {
 		// if this is a child window or tab, refreshing it will need previously hydrated session state,
 		// in case the window.opener has already removed its message listener
-		opts.embeddedSessionState = JSON.parse(sessionStorage.getItem('embeddedSessionState') || {})
+		opts.embeddedSessionState = JSON.parse(sessionStorage.getItem('embeddedSessionState') || `{}`)
 		const messageListener = event => {
 			if (event.origin != window.location.origin && event.origin !== hostURL) return
 			// !!! Potential race-condition
@@ -1489,7 +1489,7 @@ async function launchmass(arg, app) {
 		}
 		window.addEventListener('message', messageListener, false)
 		// limit the time to listen for the window.opener's message
-		setTimeout(() => window.removeEventListener('message', messageListener), 100)
+		setTimeout(() => window.removeEventListener('message', messageListener), 1000)
 		// the window.opener can be either
 		// - an embedder site when clicking on `Open Session`
 		// - a proteinpaint site when clicking on a shared URL link

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1495,9 +1495,19 @@ async function launchmass(arg, app) {
 		// - a proteinpaint site when clicking on a shared URL link
 		// accessing window.opener.location.origin may emit a CORS-related error,
 		// so safer to send the message twice to cover both possibilities
+		let origin
 		try {
-			window.opener.postMessage('getActiveMassSession', window.location.origin)
-			window.opener.postMessage('getActiveMassSession', hostURL)
+			if (window.opener.origin) {
+				origin = window.opener.origin
+			} else {
+				origin = hostURL
+			}
+		} catch (e) {
+			origin = hostURL
+		}
+
+		try {
+			window.opener.postMessage('getActiveMassSession', origin)
 		} catch (e) {
 			console.log(e)
 		}

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1469,9 +1469,11 @@ async function launchmass(arg, app) {
 	opts.addLoginCallback = arg.addLoginCallback
 	const hostURL = sessionStorage.getItem('hostURL')
 	if (window.opener && hostURL != window.location.origin) {
-		opts.embeddedSessionState = {}
+		// if this is a child window or tab, refreshing it will need previously hydrated session state,
+		// in case the window.opener has already removed its message listener
+		opts.embeddedSessionState = JSON.parse(sessionStorage.getItem('embeddedSessionState') || {})
 		const messageListener = event => {
-			if (event.origin !== hostURL) return
+			if (event.origin != window.location.origin && event.origin !== hostURL) return
 			// !!! Potential race-condition
 			// - assumes that the message event from the window.opener will be received
 			//   before the storeInit() is triggered within the storeInit() call in mass/app.js
@@ -1481,10 +1483,24 @@ async function launchmass(arg, app) {
 			if (event.data.state) {
 				window.removeEventListener('message', messageListener)
 				Object.assign(opts.embeddedSessionState, event.data.state)
+				// see the comment above for when this stored embeddedState may be used
+				sessionStorage.setItem('embeddedSessionState', JSON.stringify(opts.embeddedSessionState))
 			}
 		}
 		window.addEventListener('message', messageListener, false)
-		window.opener.postMessage('getActiveMassSession', hostURL)
+		// limit the time to listen for the window.opener's message
+		setTimeout(() => window.removeEventListener('message', messageListener), 100)
+		// the window.opener can be either
+		// - an embedder site when clicking on `Open Session`
+		// - a proteinpaint site when clicking on a shared URL link
+		// accessing window.opener.location.origin may emit a CORS-related error,
+		// so safer to send the message twice to cover both possibilities
+		try {
+			window.opener.postMessage('getActiveMassSession', window.location.origin)
+			window.opener.postMessage('getActiveMassSession', hostURL)
+		} catch (e) {
+			console.log(e)
+		}
 	}
 	const _ = await import('../mass/app')
 	return await _.appInit(opts)

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -159,7 +159,6 @@ upon error, throw err message as a string
 			if (src == 'cred') {
 				const dslabel = urlp.get('dslabel')
 				const route = urlp.get('route')
-				console.log(161, dslabel)
 				fetchOpts.body.dslabel = dslabel
 				fetchOpts.body.route = route
 				fetchOpts.body.route = route
@@ -167,7 +166,6 @@ upon error, throw err message as a string
 				const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
 				this.jwtByDsRoute = JSON.parse(jwtByDsRouteStr)
 				const jwt = this.jwtByDsRoute[dslabel][route]
-				console.log(168, jwt)
 				fetchOpts.headers.authorization = `Bearer ${btoa(jwt)}`
 			}
 			res = await client.dofetch3(`/massSession`, fetchOpts)

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -129,6 +129,7 @@ export const basepath = serverconfig.basepath || ''
 function setHeaders(res) {
 	res.header('Vary', 'Origin')
 	res.header('Access-Control-Allow-Origin', '*')
+	res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS, HEAD')
 	// embedder sites may use HTTP 2.0 which requires lowercased header key names
 	// must support mixed casing and all lowercased for compatibility
 	res.header(
@@ -321,6 +322,7 @@ app.all(basepath + '/termdb-barsql', termdbbarsql.handle_request_closure(genomes
 app.post(basepath + '/singlecell', singlecell.handle_singlecell_closure(genomes))
 app.post(basepath + '/massSession', massSession.save)
 app.get(basepath + '/massSession', massSession.get)
+app.delete(basepath + '/massSession', massSession._delete)
 app.get(basepath + '/sessionIds', massSession.getSessionIdsByCred)
 app.get(basepath + '/isoformbycoord', handle_isoformbycoord)
 app.post(basepath + '/ase', handle_ase)

--- a/server/src/massSession.js
+++ b/server/src/massSession.js
@@ -81,6 +81,31 @@ export async function get(req, res) {
 	}
 }
 
+// NOTE: cannot use delete as a method name, since it's a reserver js keyword
+export async function _delete(req, res) {
+	try {
+		const ids = req.query.ids
+		if (!ids) throw 'session ids[] missing'
+		const { route, dslabel, embedder } = req.query
+		const payload = req.query.route ? authApi.getPayloadFromHeaderAuth(req, req.query.route) : null
+		if (!payload) throw 'missing credentials'
+		const dir = req.query.route ? getSessionPath(req.query, payload) : serverconfig.cachedir_massSession
+		const errors = []
+		for (const id of ids) {
+			const file = path.join(dir, id)
+			fs.unlink(file, err => {
+				if (err) {
+					errors.push(err)
+					throw err
+				}
+			})
+		}
+		if (!errors.length) res.send({ status: 'ok' })
+	} catch (e) {
+		res.send({ error: e.message || e })
+	}
+}
+
 export async function getSessionIdsByCred(req, res) {
 	try {
 		const { filename, route, dslabel, embedder } = req.query


### PR DESCRIPTION
## Description
Improvements: 
- There is now a menu option to delete cached sessions.
- The open UI now has a table of session names/IDs, the table renderer is also used in the delete option
- Clicking on a newly created `Share` URL link will open a new tab with the embedder's URL, no need to open the proteinpaint host site as an intermediary browser tab 

Test Scenarios for `Open` and `Save`: for each scenario, test that you can save to/open from browser, file, and if applicable, server.

A. Unrpotected ds: comment `serverconfig.dsCredentials.SJLife` (e.g., change to `dsCredentials['#SJLife']`):
  - use [a simple SJLife URL params](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22})
  - there should be no server options in the `Open` and `Save` menus 

B. Protected ds: enable `dsCredentials.SJLife`
  - use http://localhost:3000/example.auth.html
  - there should **be** server options in the `Open` and `Save` menus
  - test while logged in and not
  - when saving to server, you should see the file saved in `[cachedir]/sessionsByCred/...`

C. Same as B, but simulate an embedded use case
  - `sudo vim /etc/hosts` and add the entry `127.0.0.1 viz.localhost`
  - change `dsCredentials['SJLife']` to `dsCredentials['*']` - all embedders will use the same jwt secret
  - from the `sjpp` dir, run `./proteinpaint/server/test/fake-jwt.js SJLife > public/fake-jwt.json '*'`
  - use http://viz.localhost:3000/example.auth.html (different subdomain)
  - manually test like in B
  - Also test that the `Share`-generated URL opens within `viz.localhost`, and not in `localhost`


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
