### PR TITLE
fix: skip the GDC aliquot caching when validating the server

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- when validating the server configuration, data, and startup, skip the GDC aliquot caching
+- skip the GDC aliquot caching when validating the server  configuration, data, and startup

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -178,6 +178,17 @@ if (!serverconfig.features) {
 	// mdjsonform: true, healthcheck_keys: ["w", "rs"], etc.
 	serverconfig.features = {}
 }
+if (process.argv.find(a => a == 'validate')) {
+	// issues in the GDC API (like its servers being under maintenance) should not affect
+	// the ability of the PP server to launch itself, so skip GDC-caching during validation
+	// as the GDC API may come online later (and not require a PP server restart).
+	// This allows `npx @sjcrh/proteinpaint-server validate` to finish faster.
+	//
+	// NOTE: The server validation waits for the nodejs main thread to finish, so any unfinished
+	// async methods will still block the validation. Only other async methods are not blocked
+	// by each other while executing.
+	serverconfig.features.stopGdcCacheAliquot = true
+}
 
 if (!serverconfig.backend_only && fs.existsSync(path.join(process.cwd(), './public'))) {
 	const defaultTarget = path.join(serverconfig.binpath, 'cards')


### PR DESCRIPTION
## Description
... configuration, data, and startup. This allows `npx @sjcrh/proteinpaint-server validate` to finish faster.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
