### PR TITLE
Sample view validation if samples returned are empty

### DIFF
--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -78,7 +78,6 @@ class SampleView {
 		}
 		await this.setSampleSelect(config, div)
 		const state = this.getState(appState)
-		console.log(state)
 		const q = state.termdbConfig.queries
 		const hasPlots = q ? q.singleSampleGenomeQuantification || q.singleSampleMutation : false
 		if (hasPlots) await this.renderPlots(state)
@@ -386,7 +385,6 @@ class SampleView {
 	}
 
 	mayRequireToken() {
-		console.log(this.state.hasVerifiedToken)
 		if (this.state.hasVerifiedToken) {
 			this.dom.holder.style('display', 'block')
 			return false

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -121,6 +121,9 @@ class SampleView {
 		} else {
 			this.sampleId2Name = await this.app.vocabApi.getAllSamples()
 			const samples = Object.entries(this.sampleId2Name)
+			if (samples.length == 0)
+				//Happens if it requires sign in first
+				return
 			this.sample = config.sample || { sampleId: samples[0][0], sampleName: samples[0][1] }
 			this.dom.select
 				.selectAll('option')
@@ -383,6 +386,7 @@ class SampleView {
 	}
 
 	mayRequireToken() {
+		console.log(this.state.hasVerifiedToken)
 		if (this.state.hasVerifiedToken) {
 			this.dom.holder.style('display', 'block')
 			return false
@@ -393,6 +397,7 @@ class SampleView {
 			const helpLink = this.state.termdbConfig.dataDownloadCatch?.helpLink
 			this.dom.mainDiv
 				.style('color', '#e44')
+				.style('padding', '10px')
 				.html(
 					message ||
 						(this.state.tokenVerificationMessage || 'Requires sign-in') +


### PR DESCRIPTION
## Description

It can be tested adding sampleView to the allowed charts in SJLife and opening it. Before it would cause an error. Now it showns a sign in message.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
