### PR TITLE
fix: After creating mds3 subtrack via filtering, term name may be pri…

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -99,15 +99,20 @@ export function getFilterName(f) {
 			if (!Array.isArray(tvs.values)) throw 'f.lst[0].tvs.values not array'
 			if (tvs.values.length == 1) {
 				// tvs uses only 1 category
-				// set label as key of first category
-				const str = tvs.values[0].key
+				const catValue = tvs.values[0].key
+				if ((tvs.term.name + catValue).length < 20) {
+					// term name plus category value has short length, show both
+					return tvs.term.name + ': ' + catValue
+				}
+				// only show cat value
 				return str.length < 15 ? str : str.substring(0, 13) + '...'
 			}
 			// tvs uses more than 1 category
 			// set label of first category + (3)
 			const str = tvs.values[0].key
 			return `${str.length < 12 ? str : str.substring(0, 10) + '...'} (${tvs.values.length})`
-		} else if (ttype == 'integer' || ttype == 'float') {
+		}
+		if (ttype == 'integer' || ttype == 'float') {
 			// if tvs is numeric, may show numeric range
 			if (!Array.isArray(tvs.ranges)) throw 'tvs.ranges not array'
 			if (tvs.ranges.length == 1) {

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
-
-Feature: Sample view uses input with autocomplete to search samples instead of displaying the list of all the samples to select
+Fixes:
+- After creating mds3 subtrack via filtering, term name may be printed with value if short enough


### PR DESCRIPTION
…nted with value if short enough

## Description

[test here](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.demographic.gender%22,%22name%22:%22Gender%22,%22isleaf%22:true,%22type%22:%22categorical%22,%22parent_id%22:%22case.demographic%22,%22included_types%22:[%22categorical%22],%22child_types%22:[],%22values%22:{%22female%22:{%22label%22:%22female%22,%22samplecount%22:115},%22male%22:{%22label%22:%22male%22,%22samplecount%22:49},%22not%20reported%22:{%22label%22:%22not%20reported%22,%22samplecount%22:1}},%22samplecount%22:{}},%22values%22:[{%22key%22:%22female%22}]}}]})

the left label shows `Gender: female`. was only `female` before
this allows to work better e.g. for mbmeta to show `Subtype: what`
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
