### PR TITLE
Missing GT fix

### DIFF
--- a/client/termsetting/handlers/snplst.ts
+++ b/client/termsetting/handlers/snplst.ts
@@ -198,7 +198,7 @@ async function makeEditMenu(self: SnpsTermSettingInstance, div0: any) {
 			validateBtn.text('Validate variants').property('disabled', false)
 		})
 
-	const snplstTableDiv = editUIholder.append('div').style('margin-bottom', '20px')
+	const snplstTableDiv = editUIholder.append('div').style('margin-bottom', '25px')
 	const [input_AFcutoff, select_alleleType, select_geneticModel, select_missingGenotype] = makeSnpSelect(
 		editUIholder.append('div'),
 		self,
@@ -291,9 +291,7 @@ function initSnpEditTable(div: any, self: SnpsTermSettingInstance, select_allele
 		.append('p')
 		.style('opacity', 0.8)
 		.style('font-size', '.8em')
-		.html(
-			'<sup><b>*</b></sup> Number of samples with at least one valid genotype.<br><sup><b>**</b></sup>Effect alleles are highlighted in red. Click on an allele to set as the effect allele.'
-		)
+		.html('Effect alleles are highlighted in red. Click on an allele to set as the effect allele.')
 }
 
 function renderSnpEditTable(self: SnpsTermSettingInstance, select_alleleType: any) {
@@ -302,9 +300,9 @@ function renderSnpEditTable(self: SnpsTermSettingInstance, select_alleleType: an
 	const title_tr = self.dom.snplst_table.append('tr').style('opacity', 0.4)
 	const col_titles = [
 		{ title: 'Variants' },
-		{ title: 'No. samples<sup><b>*</b></sup>' },
-		{ title: 'Reference allele<sup><b>**</b></sup><br>(frequency)' },
-		{ title: 'Alternative allele(s)<sup><b>**</b></sup><br>(frequency)' },
+		{ title: '# genotyped<br>samples' },
+		{ title: 'Reference allele<br>(frequency)' },
+		{ title: 'Alternative allele(s)<br>(frequency)' },
 		{ title: 'Genotype<br>(frequency)' },
 		{ title: 'Delete' }
 	]

--- a/client/termsetting/handlers/snplst.ts
+++ b/client/termsetting/handlers/snplst.ts
@@ -554,7 +554,7 @@ function validateQ(data: any) {
 	if (data.q.AFcutoff < 0 || data.q.AFcutoff > 100) throw 'AFcutoff is not within 0 to 100'
 	if (![0, 1, 2].includes(data.q.alleleType)) throw 'alleleType value is not one of 0/1'
 	if (![0, 1, 2, 3].includes(data.q.geneticModel)) throw 'geneticModel value is not one of 0/1'
-	if (![0, 1, 2].includes(data.q.missingGenotype)) throw 'missingGenotype value is not one of 0/1'
+	if (![0, 1].includes(data.q.missingGenotype)) throw 'missingGenotype value is not one of 0/1'
 }
 
 export async function fillTW(tw: SnpsTermWrapper, vocabApi: SnpsVocabApi) {

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -1276,7 +1276,7 @@ tw{}
 		cacheid
 		alleleType: 0/1
 		geneticModel: 0/1/2/3
-		missingGenotype: 0/1/2
+		missingGenotype: 0/1
 		snp2effAle{}
 		snp2refGrp{}
 samples {Map}
@@ -1459,10 +1459,6 @@ function doImputation(snp2sample, tw, cachesampleheader, sampleinfilter) {
 		return
 	}
 	if (tw.q.missingGenotype == 1) {
-		// numerically as average value
-		throw 'not done'
-	}
-	if (tw.q.missingGenotype == 2) {
 		// drop sample
 		const incompleteSamples = new Set() // any samples with missing gt
 		for (const { samples } of snp2sample.values()) {

--- a/server/src/termdb.snp.js
+++ b/server/src/termdb.snp.js
@@ -34,7 +34,7 @@ validateInputCreateCache_by_coord
 
 const bcfformat_snplst = '%CHROM\t%POS\t%REF\t%ALT[\t%TGT]\n'
 const bcfformat_snplocus = '%POS\t%ID\t%REF\t%ALT\t%INFO[\t%TGT]\n'
-const missing_gt = '.'
+const missing_gt = './.'
 const snplocusMaxVariantCount = 1000
 
 export async function validate(q, tdb, ds, genome) {


### PR DESCRIPTION
## Description

- Fixed `missing_gt` value by changing from `.` to `./.`. Now missing genotypes are handled properly.
- Fixed handling of the `Drop samples` option for missing genotype drop-down menu. Previously this option was not getting processed in backend code.

Can test by running a snplst regression with two SNPs that have missing genotypes in the db: `rs9894227` and `rs79959593`.



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
