### PR TITLE
update the burden route per Qi's changes

### DIFF
--- a/server/routes/burden.ts
+++ b/server/routes/burden.ts
@@ -83,11 +83,14 @@ async function getBurdenEstimates(
 	// TODO: use the dataset location
 	const { fit, surv, sample } = ds.cohort.cumburden.files
 	if (!fit || !surv || !sample) throw `missing one or more of ds.cohort.burden.files.{fit, surv, sample}`
+	if (!ageCutoffs[data.diaggrp]) throw `unkown age cutoff for diaggrp='${data.diaggrp}'`
+	const ageCutoff = ageCutoffs[data.diaggrp]
 	const args = [
 		infile,
 		`${serverconfig.tpmasterdir}/${fit}`,
 		`${serverconfig.tpmasterdir}/${surv}`,
-		`${serverconfig.tpmasterdir}/${sample}`
+		`${serverconfig.tpmasterdir}/${sample}`,
+		ageCutoff
 	]
 	const Routput = await lines2R(path.join(serverconfig.binpath, 'utils/burden.R'), [], args)
 	const estimates = JSON.parse(Routput[0])
@@ -141,3 +144,17 @@ const defaults = Object.freeze({
 	pelvis: 0,
 	abd: 0 //2.4
 })
+
+const ageCutoffs = {
+	1: 50, // "Acute lymphoblastic leukemia"
+	2: 45, // "AML"
+	3: 55, // "Hodgkin lymphoma"
+	4: 50, // "Non-Hodgkin lymphoma"
+	5: 40, // "Central nervous system"
+	6: 60, // "Bone tumor"
+	7: 50, // "STS"
+	8: 45, // "Wilms tumor"
+	9: 45, // "Neuroblastoma"
+	10: 45, // "Retinoblastoma"
+	11: 50 // "Germ cell tumor";
+}


### PR DESCRIPTION
## Description
Most obvious change is the addition of a primary diagnosis input in the UI, in the pcb repo (not visible in this PP repo).

Updates per Qi's email:
(1) The age cutoff differs from DX to DX
(2 ) In "Step3Qrev-CNS1yr-Clean_for_Edgar.R", ... some modifications were needed for specific situations. I made changes in line 156-164 and line 255-261.
(3)If users ask for the 95% CI, the below are needed. 
I had run 20 bootstraps on my side to generate input data for step 3 to use (20 folders boot1-boot20
You call "BootStep3Qrev-CNS1yr-Clean_for_Edgar.R" to run ---- this is exactly the same as "Step3Qrev-CNS1yr-Clean_for_Edgar.R", but 'cphfits2.RData' and 'surv.RData' came from the bootstrapped data. Once that was run together with "Step3Qrev-CNS1yr-Clean_for_Edgar.R", you have the burden from "Step3Qrev-CNS1yr-Clean_for_Edgar.R" and 20 burden files from the bootstrap data, then run "Step4 get95%CI.R" to get the 95% CIs.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
