### PR TITLE
Moved filters in barchart and polar plots to burguer menu added to the left

### DIFF
--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -463,7 +463,6 @@ function setDropdownInput(opts) {
 				}
 			})
 	})
-
 	self.dom.select
 		.selectAll('option')
 		.data(opts.options)

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -448,17 +448,20 @@ function setDropdownInput(opts) {
 	}
 
 	self.dom.select = self.dom.inputTd.append('select').on('change', () => {
-		opts.dispatch({
-			type: 'plot_edit',
-			id: opts.id,
-			config: {
-				settings: {
-					[opts.chartType]: {
-						[opts.settingsKey]: self.dom.select.property('value')
+		const value = self.dom.select.property('value')
+		if (opts.callback) opts.callback(value)
+		else
+			opts.dispatch({
+				type: 'plot_edit',
+				id: opts.id,
+				config: {
+					settings: {
+						[opts.chartType]: {
+							[opts.settingsKey]: value
+						}
 					}
 				}
-			}
-		})
+			})
 	})
 
 	self.dom.select

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -30,7 +30,6 @@ export class profilePlot {
 			plotDiv
 		}
 		const config = appState.plots.find(p => p.id === this.id)
-		this.settings = config.settings
 		this.sampleidmap = await this.app.vocabApi.getAllSamplesByName()
 		this.regions = [
 			{ value: '', label: '' },
@@ -47,6 +46,37 @@ export class profilePlot {
 			this.regions.push({ value: region.name, label: region.name })
 			for (const country of region.countries) this.regions.push({ value: country, label: `-- ${country}` })
 		}
+	}
+
+	setRegion(region) {
+		const config = this.config
+		this.settings.facility = ''
+		this.settings.region = region
+		this.settings.income = ''
+		const sampleId = parseInt(this.sampleidmap[region])
+		config.sampleName = config.region
+		config.filter = getSampleFilter(sampleId)
+		this.app.dispatch({ type: 'plot_edit', id: this.id, config })
+	}
+
+	setIncome(income) {
+		const config = this.config
+		this.settings.facility = ''
+		this.settings.income = income
+		this.settings.region = ''
+		const sampleId = parseInt(this.sampleidmap[income])
+		config.sampleName = config.income
+		config.filter = getSampleFilter(sampleId)
+		this.app.dispatch({ type: 'plot_edit', id: this.id, config })
+	}
+
+	addLegendFilter(filter, value, index) {
+		const text = this.filterG
+			.append('text')
+			.attr('transform', `translate(0, ${index * 20})`)
+			.attr('text-anchor', 'left')
+		text.append('tspan').attr('font-weight', 'bold').text(filter)
+		text.append('tspan').text(`: ${value ? value : 'None'}`)
 	}
 
 	addLegendItem(category, description, index) {

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -24,11 +24,14 @@ export class profilePlot {
 	}
 
 	async init(appState) {
-		const holder = this.opts.holder.append('div')
+		const controlsDiv = this.opts.holder.append('div').style('display', 'inline-block')
+		const holder = this.opts.holder.append('div').style('display', 'inline-block').style('display', 'inline-block')
+
 		const div = holder.append('div').style('margin-left', '50px').style('margin-top', '20px')
 		const firstDiv = div.append('div').style('display', 'inline-block')
 		const plotDiv = holder.append('div')
 		this.dom = {
+			controlsDiv,
 			holder,
 			firstDiv,
 			filterDiv: div,
@@ -36,7 +39,7 @@ export class profilePlot {
 			plotDiv
 		}
 		const config = appState.plots.find(p => p.id === this.id)
-
+		this.settings = config.settings
 		this.sampleidmap = await this.app.vocabApi.getAllSamplesByName()
 		this.regions = [
 			{ key: '', label: '' },

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -14,15 +14,6 @@ export class profilePlot {
 		}
 	}
 
-	setFilter() {
-		this.regionSelect.selectAll('option').property('selected', d => d.key == this.region)
-		this.incomeSelect.selectAll('option').property('selected', d => d == this.income)
-		if (this.facilitySelect)
-			this.facilitySelect.selectAll('option').property('selected', d => d == this.config.facility)
-
-		if (this.selectComp) this.selectComp.selectAll('option').property('selected', (d, i) => i == this.componentIndex)
-	}
-
 	async init(appState) {
 		const controlsDiv = this.opts.holder.append('div').style('display', 'inline-block')
 		const holder = this.opts.holder.append('div').style('display', 'inline-block').style('display', 'inline-block')
@@ -42,67 +33,24 @@ export class profilePlot {
 		this.settings = config.settings
 		this.sampleidmap = await this.app.vocabApi.getAllSamplesByName()
 		this.regions = [
-			{ key: '', label: '' },
-			{ key: 'Global', label: 'Global' }
+			{ value: '', label: '' },
+			{ value: 'Global', label: 'Global' }
 		]
-		this.incomes = ['']
-		this.incomes.push(...config.incomes)
+		this.incomes = [{ value: '', label: '' }]
+		this.incomes.push(
+			...config.incomes.map(elem => {
+				return { label: elem, value: elem }
+			})
+		)
 
 		for (const region of config.regions) {
-			this.regions.push({ key: region.name, label: region.name })
-			for (const country of region.countries) this.regions.push({ key: country, label: `-- ${country}` })
+			this.regions.push({ value: region.name, label: region.name })
+			for (const country of region.countries) this.regions.push({ value: country, label: `-- ${country}` })
 		}
-
-		div.append('label').style('margin-left', '15px').html('Region:').style('font-weight', 'bold')
-		this.regionSelect = div.append('select').style('margin-left', '5px')
-		this.regionSelect
-			.selectAll('option')
-			.data(this.regions)
-			.enter()
-			.append('option')
-			.attr('value', d => d.key)
-			.html((d, i) => d.label)
-
-		this.regionSelect.on('change', () => {
-			const config = this.config
-			config.facility = ''
-			config.region = this.regionSelect.node().value
-			config.income = ''
-			const sampleId = parseInt(this.sampleidmap[config.region])
-			config.sampleName = config.region
-			config.filter = getSampleFilter(sampleId)
-			this.app.dispatch({ type: 'plot_edit', id: this.id, config })
-		})
-
-		div.append('label').style('margin-left', '15px').html(' or Income Group:').style('font-weight', 'bold')
-		this.incomeSelect = div.append('select').style('margin-left', '5px')
-		this.incomeSelect
-			.selectAll('option')
-			.data(this.incomes)
-			.enter()
-			.append('option')
-			.html((d, i) => d)
-
-		this.incomeSelect.on('change', () => {
-			const config = this.config
-			config.facility = ''
-			config.income = this.incomeSelect.node().value
-			config.region = ''
-			const sampleId = parseInt(this.sampleidmap[config.income])
-			config.sampleName = config.income
-			config.filter = getSampleFilter(sampleId)
-			this.app.dispatch({ type: 'plot_edit', id: this.id, config })
-		})
-
-		div
-			.append('button')
-			.style('margin-left', '15px')
-			.text('Download Image')
-			.on('click', () => downloadSingleSVG(this.svg, this.filename))
 	}
 
-	addLegendItem(legendG, category, description, index) {
-		const text = legendG
+	addLegendItem(category, description, index) {
+		const text = this.legendG
 			.append('text')
 			.attr('transform', `translate(0, ${index * 20})`)
 			.attr('text-anchor', 'left')

--- a/client/plots/profilePolar.js
+++ b/client/plots/profilePolar.js
@@ -64,32 +64,10 @@ class profilePolar extends profilePlot {
 		this.components.controls.on('downloadClick.profilePolar', () => downloadSingleSVG(this.svg, this.filename))
 	}
 
-	setRegion(region) {
-		const config = this.config
-		config.settings.profilePolar.facility = ''
-		config.settings.profilePolar.region = region
-		config.settings.profilePolar.income = ''
-		const sampleId = parseInt(this.sampleidmap[region])
-		config.sampleName = config.region
-		config.filter = getSampleFilter(sampleId)
-		this.app.dispatch({ type: 'plot_edit', id: this.id, config })
-	}
-
-	setIncome(income) {
-		const config = this.config
-		config.settings.profilePolar.facility = ''
-		config.settings.profilePolar.income = income
-		config.settings.profilePolar.region = ''
-		const sampleId = parseInt(this.sampleidmap[income])
-		config.sampleName = config.income
-		config.filter = getSampleFilter(sampleId)
-		this.app.dispatch({ type: 'plot_edit', id: this.id, config })
-	}
-
 	async main() {
 		this.config = JSON.parse(JSON.stringify(this.state.config))
 		this.settings = this.config.settings.profilePolar
-		await this.setControls()
+		this.setControls()
 		this.twLst = []
 		for (const [i, tw] of this.config.terms.entries()) {
 			if (tw.id) this.twLst.push(tw)
@@ -252,15 +230,6 @@ class profilePolar extends profilePlot {
 					.attr('pointer-events', 'none')
 			}
 		}
-	}
-
-	addLegendFilter(filter, value, index) {
-		const text = this.filterG
-			.append('text')
-			.attr('transform', `translate(0, ${index * 20})`)
-			.attr('text-anchor', 'left')
-		text.append('tspan').attr('font-weight', 'bold').text(filter)
-		text.append('tspan').text(`: ${value ? value : 'None'}`)
 	}
 }
 


### PR DESCRIPTION
## Description

Moved filters in barchart and polar plots to burguer menu added to the left. Pending to apply it in the radar graphs. @siosonel I did a small change in the controls to use my own callback. Please check if ok. You can test these links [Barchart](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22ProfileFull%22,%22plots%22:[{%22chartType%22:%22profileBarchart%22,%22region%22:%22Global%22}]})
[Polar](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22ProfileFull%22,%22plots%22:[{%22chartType%22:%22profilePolar%22,%22region%22:%22Global%22}]})


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
