### PR TITLE
Migrate remaining hic files to typescript and create test file

### DIFF
--- a/client/src/block.js
+++ b/client/src/block.js
@@ -33,7 +33,7 @@ import {
 } from './block.tk.bigwigstranded'
 import { bedjfromtemplate, bedjmaketk, bedjload, bedjloadsubpanel } from './block.tk.bedj'
 import { gmtkfromtemplate, gmtkmaketk, gmtkrender } from './block.tk.usegm'
-import { hicstrawfromtemplate, hicstrawmaketk, hicstrawload } from './block.tk.hicstraw.adaptor'
+import { hicstrawfromtemplate, hicstrawmaketk, hicstrawload } from './block.tk.hicstraw.adaptor.ts'
 import { asefromtemplate, asemaketk, aseload } from './block.tk.ase.adaptor'
 
 import { mdsjunctionfromtemplate, mdsjunctionmaketk, mdsjunctionload } from './block.mds.junction.adaptor'

--- a/client/src/block.tk.hicstraw.adaptor.ts
+++ b/client/src/block.tk.hicstraw.adaptor.ts
@@ -1,4 +1,4 @@
-export function hicstrawfromtemplate(tk,template) {
+export function hicstrawfromtemplate(tk: any, template: any) {
 	if(tk.textdata) {
 
 		if(!tk.textdata.raw) return '.textdata.raw missing'
@@ -30,13 +30,13 @@ export function hicstrawfromtemplate(tk,template) {
 }
 
 
-export function hicstrawmaketk(tk,block) {
+export function hicstrawmaketk(tk: any) {
 	tk.uninitialized=true
 }
 
 
-export function hicstrawload(tk,block) {
-	import('./block.tk.hicstraw').then(module=>{
+export function hicstrawload(tk: any, block: any) {
+	import('./block.tk.hicstraw.ts').then(module=>{
 		module.loadTk(tk,block)
 	})
 }

--- a/client/src/block.tk.hicstraw.adaptor.ts
+++ b/client/src/block.tk.hicstraw.adaptor.ts
@@ -1,42 +1,36 @@
 export function hicstrawfromtemplate(tk: any, template: any) {
-	if(tk.textdata) {
-
-		if(!tk.textdata.raw) return '.textdata.raw missing'
-		if(typeof(tk.textdata.raw)!='string') return '.textdata.raw should be string'
+	if (tk.textdata) {
+		if (!tk.textdata.raw) return '.textdata.raw missing'
+		if (typeof tk.textdata.raw != 'string') return '.textdata.raw should be string'
 		delete template.enzyme
-
-	} else if(tk.bedfile || tk.bedurl) {
-
+	} else if (tk.bedfile || tk.bedurl) {
 		// bed file
-
 	} else {
-
 		// by hic straw file
-		if(!template.file && !template.url) return 'none of the data sources available: text data, bedj file, or juicebox file'
+		if (!template.file && !template.url)
+			return 'none of the data sources available: text data, bedj file, or juicebox file'
 	}
-	if(template.domainoverlay) {
-		if(!template.domainoverlay.file && !template.domainoverlay.url) return 'file or url missing for domainoverlay'
+	if (template.domainoverlay) {
+		if (!template.domainoverlay.file && !template.domainoverlay.url) return 'file or url missing for domainoverlay'
 		tk.domainoverlay = {}
-		for(const k in template.domainoverlay) {
+		for (const k in template.domainoverlay) {
 			tk.domainoverlay[k] = template.domainoverlay[k]
 		}
 	}
-	// the "hic" object to work with hic.straw.js
+	// the "hic" object to work with hic.straw.ts
 	tk.hic = {
-		enzyme:template.enzyme
+		enzyme: template.enzyme
 	}
 	delete tk.enzyme
 	return null
 }
 
-
 export function hicstrawmaketk(tk: any) {
-	tk.uninitialized=true
+	tk.uninitialized = true
 }
 
-
 export function hicstrawload(tk: any, block: any) {
-	import('./block.tk.hicstraw.ts').then(module=>{
-		module.loadTk(tk,block)
+	import('./block.tk.hicstraw.ts').then(module => {
+		module.loadTk(tk, block)
 	})
 }

--- a/client/src/block.tk.hicstraw.ts
+++ b/client/src/block.tk.hicstraw.ts
@@ -686,7 +686,7 @@ function drawCanvas(tk: any, block: any) {
 	canvas.width = canvaswidth
 	canvas.height = canvasheight
 
-	let ctx = canvas.getContext('2d')
+	const ctx = canvas.getContext('2d')
 	if (window.devicePixelRatio > 1) {
 		canvas.width = canvaswidth * window.devicePixelRatio
 		canvas.height = canvasheight * window.devicePixelRatio

--- a/client/src/block.tk.hicstraw.ts
+++ b/client/src/block.tk.hicstraw.ts
@@ -46,13 +46,13 @@ const docurl_text =
 
 let hicstraw // loaded on the fly, will result in bundle duplication
 
-export function loadTk(tk, block) {
+export function loadTk(tk: any, block: any) {
 	block.tkcloakon(tk)
 	block.block_setheight()
 
 	Promise.resolve()
 		.then(() => {
-			return import('./hic.straw').then(p => {
+			return import('./hic.straw.js').then(p => {
 				hicstraw = p
 			})
 		})
@@ -82,10 +82,10 @@ export function loadTk(tk, block) {
 		})
 
 		.then(() => {
-			return mayLoadDomainoverlay(tk, block)
+			return mayLoadDomainoverlay(tk)
 		})
 
-		.then(() => {
+		.then((): any => {
 			if (tk.textdata) return textdata_load(tk, block)
 
 			if (tk.bedfile || tk.bedurl) return bedfile_load(tk, block)
@@ -113,14 +113,14 @@ export function loadTk(tk, block) {
 		})
 }
 
-function setResolution(tk, block) {
+function setResolution(tk: any, block: any) {
 	/*
 	when using text data, no need to set resolution but still need .regions[]
 	determine what resolution, if using fragment, will load fragment index
 	*/
 
 	// list of regions to load data from, including bb.rglst[], and bb.subpanels[]
-	const regions = []
+	const regions = [] as any
 
 	let x = 0
 
@@ -176,7 +176,7 @@ function setResolution(tk, block) {
 				return
 			}
 			// cannot find bp resolution
-			if (!tk.hic.enzymefile || !tk.hic.fragresolution?.length > 0) {
+			if (!tk.hic.enzymefile || !tk.hic.fragresolution?.length || tk.hic.fragresolution.length > 0) {
 				// no enzyme fragment data (missing enzyme, or fragresolution array is blank)
 				// just use finest bp resolution
 				resolution_bp = tk.hic.bpresolution[tk.hic.bpresolution.length - 1]
@@ -188,7 +188,7 @@ function setResolution(tk, block) {
 		retrieve fragments in each regions, then use the fragment index to determine the resolution (# of fragments)
 		*/
 
-			const tasks = []
+			const tasks = [] as any
 
 			// fetch fragments for each region
 			for (const r of regions) {
@@ -241,16 +241,16 @@ function setResolution(tk, block) {
 		})
 }
 
-function mayLoadDomainoverlay(tk, block) {
+function mayLoadDomainoverlay(tk: any) {
 	// must already have tk.regions[]
 
 	if (!tk.domainoverlay || !tk.domainoverlay.inuse) return
 
 	return Promise.resolve().then(() => {
 		// fetch domains for each region
-		const tasks = []
+		const tasks = [] as any
 		for (const r of tk.regions) {
-			const arg = { getdata: 1, getBED: 1, rglst: [{ chr: r.chr, start: r.start, stop: r.stop }] }
+			const arg: any = { getdata: 1, getBED: 1, rglst: [{ chr: r.chr, start: r.start, stop: r.stop }] }
 			if (tk.domainoverlay.file) {
 				arg.file = tk.domainoverlay.file
 			} else {
@@ -269,7 +269,7 @@ function mayLoadDomainoverlay(tk, block) {
 	})
 }
 
-function textdata_load(tk, block) {
+function textdata_load(tk: any, block: any) {
 	/*
 	at the end, set tk.data[]
 	*/
@@ -283,7 +283,7 @@ function textdata_load(tk, block) {
 	}
 }
 
-function coordpair2plotpoint(chr1, start1, stop1, chr2, start2, stop2, block) {
+function coordpair2plotpoint(chr1: string, start1: number, stop1: number, chr2: string, start2: number, stop2: number, block: any) {
 	let left1 = map_point(chr1, start1, block)
 	let left2 = map_point(chr1, stop1, block)
 	if (left1 == -1 && left2 == -1) return
@@ -302,7 +302,7 @@ function coordpair2plotpoint(chr1, start1, stop1, chr2, start2, stop2, block) {
 	return [right1, right2, left1, left2]
 }
 
-function map_point(chr, pos, block) {
+function map_point(chr: string, pos: number, block: any) {
 	const lst = block.seekcoord(chr, pos)
 	for (const r of lst) {
 		if (r.ridx != undefined) {
@@ -314,11 +314,11 @@ function map_point(chr, pos, block) {
 	return -1
 }
 
-function bedfile_load(tk, block) {
+function bedfile_load(tk: any, block: any) {
 	/*
 	at end, set tk.data[]
 	*/
-	const arg = {
+	const arg: any = {
 		getdata: 1,
 		getBED: 1,
 		rglst: tk.regions.map(i => {
@@ -371,7 +371,7 @@ function bedfile_load(tk, block) {
 	})
 }
 
-function loadStrawdata(tk, block) {
+function loadStrawdata(tk: any, block: any): Promise<string | undefined> {
 	/*
 	at the end, set tk.data[]
 	*/
@@ -387,12 +387,24 @@ function loadStrawdata(tk, block) {
 			(resolution_bp ? r.start + ':' + r.stop : r.frag.startidx + ':' + r.frag.stopidx)
 	}
 
-	const tasks = []
+	const tasks = [] as any
+
+	type RegionPar = {
+		jwt: any,
+		file?: string
+		url?:  string
+		pos1: number
+		pos2: number
+		nmeth: string
+		mincutoff: number
+		resolution?: number
+		isfrag?: boolean
+	}
 
 	// 1: load data within each region
 
 	for (const [i, r] of tk.regions.entries()) {
-		const par = {
+		const par: RegionPar = {
 			jwt: block.jwt,
 			file: tk.file,
 			url: tk.url,
@@ -431,7 +443,7 @@ function loadStrawdata(tk, block) {
 
 	for (let i = 0; i < tk.regions.length - 1; i++) {
 		for (let j = i + 1; j < tk.regions.length; j++) {
-			const par = {
+			const par: RegionPar = {
 				jwt: block.jwt,
 				file: tk.file,
 				url: tk.url,
@@ -472,7 +484,7 @@ function loadStrawdata(tk, block) {
 	})
 }
 
-function parseStrawData(datalst, resolution_bp, resolution_frag, tk, block) {
+function parseStrawData(datalst: any, resolution_bp: number, resolution_frag: number, tk: any, block: any) {
 	tk.data = []
 
 	for (const data of datalst) {
@@ -627,7 +639,7 @@ function parseStrawData(datalst, resolution_bp, resolution_frag, tk, block) {
 	return
 }
 
-function drawCanvas(tk, block) {
+function drawCanvas(tk: any, block: any) {
 	/* call when:
 		finish loading data
 		changing max value, min cutoff, color
@@ -788,7 +800,7 @@ function drawCanvas(tk, block) {
 		tk.colorscale.label_mincutoff.text('')
 	}
 	client.axisstyle({
-		axis: tk.colorscale.axisg.call(axisBottom().scale(tk.colorscale.scale).tickValues([0, maxv])),
+		axis: tk.colorscale.axisg.call(axisBottom(tk.colorscale.scale).tickValues([0, maxv])),
 		showline: 1,
 		color: 'black'
 	})
@@ -796,20 +808,20 @@ function drawCanvas(tk, block) {
 	tk.height_main = tk.toppad + Math.max(tk.left_labelheight, canvasheight) + tk.bottompad
 }
 
-function resize_label(tk, block) {
+function resize_label(tk: any, block: any) {
 	tk.leftLabelMaxwidth = tk.colorscale.barwidth
-	tk.tklabel.each(function () {
+	tk.tklabel.each(function (this: any) {
 		tk.leftLabelMaxwidth = Math.max(tk.leftLabelMaxwidth, this.getBBox().width)
 	})
 	if (tk.label_resolution) {
-		tk.label_resolution.each(function () {
+		tk.label_resolution.each(function (this: any) {
 			tk.leftLabelMaxwidth = Math.max(tk.leftLabelMaxwidth, this.getBBox().width)
 		})
 	}
 	block.setllabel()
 }
 
-function makeTk(tk, block) {
+function makeTk(tk: any, block: any) {
 	/*
 	call only once to initialize
 	also parse text data
@@ -929,12 +941,12 @@ function makeTk(tk, block) {
 	})
 }
 
-function updatetkcolor_client(tk) {
+function updatetkcolor_client(tk: any) {
 	// call after updating color, only on client
 	tk.colorscale.gradientstop.attr('stop-color', tk.color)
 }
 
-function configPanel(tk, block) {
+function configPanel(tk: any, block: any) {
 	tk.tkconfigtip.clear().showunder(tk.config_handle.node())
 
 	if (tk.textdata) {
@@ -1122,7 +1134,7 @@ function configPanel(tk, block) {
 	}
 }
 
-function textdata_editUI(tk, block) {
+function textdata_editUI(tk: any, block: any) {
 	tk.tkconfigtip.d.transition().style('left', Number.parseInt(tk.tkconfigtip.d.style('left')) - 500 + 'px')
 	tk.tkconfigtip.clear()
 	const d = tk.tkconfigtip.d.append('div')
@@ -1163,7 +1175,7 @@ function textdata_editUI(tk, block) {
 		.on('click', event => tk.tkconfigtip.hide())
 }
 
-function textdata_parseraw(tk, block) {
+function textdata_parseraw(tk: any, block: any) {
 	/*
 	chr1
 	start1

--- a/client/src/block.tk.hicstraw.ts
+++ b/client/src/block.tk.hicstraw.ts
@@ -52,7 +52,7 @@ export function loadTk(tk: any, block: any) {
 
 	Promise.resolve()
 		.then(() => {
-			return import('./hic.straw.js').then(p => {
+			return import('./hic.straw.ts').then(p => {
 				hicstraw = p
 			})
 		})
@@ -283,7 +283,15 @@ function textdata_load(tk: any, block: any) {
 	}
 }
 
-function coordpair2plotpoint(chr1: string, start1: number, stop1: number, chr2: string, start2: number, stop2: number, block: any) {
+function coordpair2plotpoint(
+	chr1: string,
+	start1: number,
+	stop1: number,
+	chr2: string,
+	start2: number,
+	stop2: number,
+	block: any
+) {
 	let left1 = map_point(chr1, start1, block)
 	let left2 = map_point(chr1, stop1, block)
 	if (left1 == -1 && left2 == -1) return
@@ -390,9 +398,9 @@ function loadStrawdata(tk: any, block: any): Promise<string | undefined> {
 	const tasks = [] as any
 
 	type RegionPar = {
-		jwt: any,
+		jwt: any
 		file?: string
-		url?:  string
+		url?: string
 		pos1: number
 		pos2: number
 		nmeth: string
@@ -498,7 +506,7 @@ function parseStrawData(datalst: any, resolution_bp: number, resolution_frag: nu
 			fs_left, // # pixel per bp
 			fs_right
 
-		// using the same logic in hic.straw.js, inherently related to how straw generates data
+		// using the same logic in hic.straw.ts, inherently related to how straw generates data
 		let firstisleft = false
 
 		if (data.regionidx != undefined) {

--- a/client/src/hic.straw.ts
+++ b/client/src/hic.straw.ts
@@ -68,8 +68,8 @@ const subpanel_bordercolor = 'rgba(200,0,0,.1)'
 
 type Pane = {
 	pain: Selection<HTMLDivElement, any, any, any>
-	mini: boolean;
-	header: Selection<HTMLDivElement, any, any, any>;
+	mini: boolean
+	header: Selection<HTMLDivElement, any, any, any>
 	body: Selection<any, any, any, any>
 }
 
@@ -96,7 +96,7 @@ export function hicparsefile(hic: any, debugmode: boolean) {
 	*/
 
 	if (debugmode) {
-		window["hic"] = hic
+		window['hic'] = hic
 	}
 
 	{
@@ -371,7 +371,7 @@ async function init_wholegenome(hic: any) {
 	hic.ressays.text(common.bplen(resolution) + ' bp')
 
 	// # pixel per bin, may set according to resolution
-	let binpx = 1
+	const binpx = 1
 
 	// for each chr, a row as canvas container
 	hic.wholegenome.svg = hic.c.td.append('svg')
@@ -714,7 +714,7 @@ function tooltip_sv(event: any, hic: any, item: any): void {
 
 function click_sv(hic: any, item: any): void {
 	const pane = client.newpane({ x: 100, y: 100 }) as Partial<Pane>
-	(pane.header as Pane["header"]).text(
+	;(pane.header as Pane['header']).text(
 		hic.name +
 			' ' +
 			(item.chr1 == item.chr2
@@ -841,10 +841,7 @@ function init_chrpair(hic: any, chrx: any, chry: any) {
 			axis: svg
 				.append('g')
 				.attr('transform', 'translate(1,' + axispad + ')')
-				.call(
-					axisRight(scaleLinear().domain([0, chrylen]).range([0, h]))
-						.tickFormat(d3format('.2s'))
-				),
+				.call(axisRight(scaleLinear().domain([0, chrylen]).range([0, h])).tickFormat(d3format('.2s'))),
 			showline: true
 		})
 		hic.chrpairview.axisy = svg
@@ -868,10 +865,7 @@ function init_chrpair(hic: any, chrx: any, chry: any) {
 			axis: svg
 				.append('g')
 				.attr('transform', 'translate(' + axispad + ',1)')
-				.call(
-					axisBottom(scaleLinear().domain([0, chrxlen]).range([0, w]))
-						.tickFormat(d3format('.2s'))
-				),
+				.call(axisBottom(scaleLinear().domain([0, chrxlen]).range([0, w])).tickFormat(d3format('.2s'))),
 			showline: true
 		})
 		hic.chrpairview.axisx = svg
@@ -883,7 +877,7 @@ function init_chrpair(hic: any, chrx: any, chry: any) {
 	const canvas = hic.c.td
 		.append('canvas')
 		.style('margin', axispad + 'px')
-		.on('click', function(this: any, event: any) {
+		.on('click', function (this: any, event: any) {
 			const [x, y] = pointer(event, this)
 			init_detail(hic, chrx, chry, x, y)
 		})
@@ -942,7 +936,7 @@ function getdata_chrpair(hic: any) {
 				return
 			}
 
-			let err = 0
+			const err = 0
 
 			hic.chrpairview.isintrachr = isintrachr
 			hic.chrpairview.data = []
@@ -1248,7 +1242,7 @@ function init_detail(hic: any, chrx: any, chry: any, x: any, y: any) {
 				const regiony = hic.detailview.yb.rglst[0]
 
 				const pane = client.newpane({ x: 100, y: 100 }) as Partial<Pane>
-				(pane.header as Pane["header"]).text(hic.name + ' ' + regionx.chr + ' : ' + regiony.chr)
+				;(pane.header as Pane['header']).text(hic.name + ' ' + regionx.chr + ' : ' + regiony.chr)
 
 				const tracks = [
 					{

--- a/client/tracks/hic/test/hic.spec.ts
+++ b/client/tracks/hic/test/hic.spec.ts
@@ -1,0 +1,52 @@
+import tape from 'tape'
+import { HicRunProteinPaintTrackArgs } from '../../../types/hic.ts'
+import * as d3s from 'd3-selection'
+import { runproteinpaint } from '../../../test/front.helpers.js'
+//import { sleep, detectOne, detectGte } from '../../../test/test.helpers.js'
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+		.node()
+}
+
+tape('\n', function (test) {
+	test.pass('-***- tracks/hic -***-')
+	test.end()
+})
+
+tape('Render Hi-C track', function (test) {
+	// test.plan(1)
+	test.timeoutAfter(3000)
+	const holder = getHolder() as HTMLDivElement
+
+	runproteinpaint({
+		holder,
+		block: true,
+		nobox: 1,
+		noheader: 1,
+		genome: 'hg19',
+		position: 'chr7:13749862-20841903',
+		nativetracks: 'RefGene',
+		tracks: [
+			{
+				type: 'hicstraw',
+				file: 'proteinpaint_demo/hg19/hic/hic_demo.hic',
+				name: 'Hi-C Demo',
+				percentile_max: 95,
+				mincutoff: 1,
+				pyramidup: 1,
+				enzyme: 'MboI',
+				normalizationmethod: 'VC'
+			} as HicRunProteinPaintTrackArgs
+		]
+	})
+	test.pass('Rendered Hi-C track')
+
+	// if (test._ok) holder.remove()
+	test.end()
+})

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -1,0 +1,15 @@
+import { Normalization } from '#shared/types/routes/hicstat.ts'
+
+export type HicstrawArgs = {
+	jwt: any
+	/** HiC file path from tp/ */
+	file?: string
+	/** Remote HiC file URL */
+	url?: string
+	pos1: string
+	pos2: string
+	/** Normalization method for the queried data */
+	nmeth: Normalization
+	resolution: number
+	isfrag?: boolean
+}

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -1,11 +1,33 @@
+import { BaseTrackArgs } from './tracks.ts'
 import { Normalization } from '#shared/types/routes/hicstat.ts'
 
-export type HicstrawArgs = {
-	jwt: any
+type SharedArgs = {
 	/** HiC file path from tp/ */
 	file?: string
 	/** Remote HiC file URL */
 	url?: string
+}
+
+type RestrictionEnzyme = 'Dpnll' | 'EcoRl' | 'Hindlll' | 'MboI' | 'Ncol'
+
+export type HicRunProteinPaintTrackArgs = BaseTrackArgs &
+	SharedArgs & {
+		/** Specifies the track type
+		 * TODO: maybe move 'type' to BaseBlockArgs
+		 */
+		type: 'hicstraw'
+		name: string
+		percentile_max: number
+		mincutoff: number
+		/** Indicates whether the tip of the track points up or down */
+		pyramidup: number | boolean
+		enzyme: RestrictionEnzyme
+		/** Normalization method for the queried data */
+		normalizationmethod: Normalization
+	}
+
+export type HicstrawArgs = SharedArgs & {
+	jwt: any
 	pos1: string
 	pos2: string
 	/** Normalization method for the queried data */

--- a/client/types/tracks.ts
+++ b/client/types/tracks.ts
@@ -5,7 +5,13 @@ export type BaseRunProteinPaintArgs = {
 	genome: string
 }
 
-/** The bare minimum args required to create the track in the block */
-export type BaseTrackArgs = {
+/** The bare minimum args required to create the track in the block code
+ * TODO: name is ambigious. Suggestions to rename?
+ */
+export type BaseBlockArgs = {
 	genome: string
+}
+
+export type BaseTrackArgs = {
+	callbackOnRender?: (tk?: any, bb?: any) => void
 }

--- a/client/types/tracks.ts
+++ b/client/types/tracks.ts
@@ -1,0 +1,11 @@
+/** The bare minimum arguments required for runproteinpaint() */
+export type BaseRunProteinPaintArgs = {
+	holder: string
+	hostURL: string
+	genome: string
+}
+
+/** The bare minimum args required to create the track in the block */
+export type BaseTrackArgs = {
+	genome: string
+}

--- a/server/shared/types/routes/hicstat.ts
+++ b/server/shared/types/routes/hicstat.ts
@@ -22,7 +22,7 @@ type RequireFileOrUrl<T> = T extends HicstatRequestWithFile | HicstatRequestWith
 export type HicstatRequestWithValidation = RequireFileOrUrl<HicstatRequest>
 
 /** Normalization method for the queried data */
-type Normalization = 'VC' | 'VC_SQRT' | 'KR' | 'NONE'
+export type Normalization = 'VC' | 'VC_SQRT' | 'KR' | 'NONE'
 
 export type HicstatResponse = {
 	/** Version number pulled from the header. Only hic versions 7-9 are acceptable */


### PR DESCRIPTION
## Description
- Migrated the final hic code (`client/src/hic.straw`) to typescript. This includes a new `client/types` dir with the initial types.
-  New `hic.spec.ts`, also a test run. This is an experiment to see what typing and requirements are required to create ts type files. We can add tests in separate PR. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
