### PR TITLE
Read normalization if available

### DIFF
--- a/server/src/hicstat.ts
+++ b/server/src/hicstat.ts
@@ -37,8 +37,10 @@ export async function do_hicstat(file: string, isurl: boolean): Promise<HicstatR
 	if (version == 8 || version == 7) {
 		let vectorView = await getVectorView(file, footerPosition, shunk)
 		const nbytesV5 = vectorView.getInt32(0, true)
-		vectorView = await getVectorView(file, footerPosition + nbytesV5 + 4, shunk)
-		normalization = await getNormalization(vectorView, footerPosition + nbytesV5 + 4)
+		if (nbytesV5 > 0) {
+			vectorView = await getVectorView(file, footerPosition + nbytesV5 + 4, shunk)
+			normalization = await getNormalization(vectorView, footerPosition + nbytesV5 + 4)
+		}
 	}
 	const genomeId = getString()
 	out_data['Genome ID'] = genomeId

--- a/server/src/hicstat.ts
+++ b/server/src/hicstat.ts
@@ -46,8 +46,10 @@ export async function do_hicstat(file: string, isurl: boolean): Promise<HicstatR
 	if (version == 9) {
 		const normVectorIndexPosition = Number(getLong())
 		const normVectorIndexLength = Number(getLong())
-		const vectorView = await getVectorView(file, normVectorIndexPosition, normVectorIndexLength)
-		normalization = await getNormalization(vectorView, 0)
+		if (normVectorIndexPosition > 0 && normVectorIndexLength > 0) {
+			const vectorView = await getVectorView(file, normVectorIndexPosition, normVectorIndexLength)
+			normalization = await getNormalization(vectorView, 0)
+		}
 	}
 
 	// skip unwatnted attributes


### PR DESCRIPTION
## Description

Normalization data can only be read if available. Fixes issue with Brian files under tp/browser_files. Please check so we can merge and deploy.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
