### PR TITLE
Only show actual mutations from the cancer gene

### DIFF
--- a/client/plots/disco/DiscoRenderer.ts
+++ b/client/plots/disco/DiscoRenderer.ts
@@ -36,7 +36,9 @@ export class DiscoRenderer {
 		this.prioritizeGenesCheckboxRenderer.render(
 			controlsDiv,
 			viewModel.settings.label.prioritizeGeneLabelsByGeneSets,
-			viewModel.settings.label.showPrioritizeGeneLabelsByGeneSets
+			viewModel.settings.label.showPrioritizeGeneLabelsByGeneSets,
+			viewModel.filteredSnvDataLength,
+			viewModel.svnDataLength
 		)
 
 		const svg = svgDiv

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -23,6 +23,9 @@ export default interface Settings {
 
 		nonExonicFilterValues: Array<string>
 	}
+	snv: {
+		maxMutationCount: number
+	}
 	cnv: {
 		cappedAmpColor: string
 		ampColor: string

--- a/client/plots/disco/data/DataMapper.ts
+++ b/client/plots/disco/data/DataMapper.ts
@@ -75,8 +75,18 @@ export default class DataMapper {
 
 		this.nonExonicFilter = (data: Data) =>
 			settings.rings.nonExonicFilterValues.includes(ViewModelMapper.snvClassLayer[data.mClass])
-		this.snvRingFilter = (data: Data) =>
-			settings.rings.snvRingFilters.includes(ViewModelMapper.snvClassLayer[data.mClass])
+
+		this.snvRingFilter = (data: Data) => {
+			if (prioritizedGenes.length > 0 && this.settings.label.prioritizeGeneLabelsByGeneSets) {
+				return (
+					prioritizedGenes.includes(data.gene) &&
+					settings.rings.snvRingFilters.includes(ViewModelMapper.snvClassLayer[data.mClass])
+				)
+			} else {
+				return settings.rings.snvRingFilters.includes(ViewModelMapper.snvClassLayer[data.mClass])
+			}
+		}
+
 		this.dataObjectMapper = new DataObjectMapper(sample, prioritizedGenes)
 	}
 
@@ -89,7 +99,7 @@ export default class DataMapper {
 			const indexB = this.reference.chromosomesOrder.indexOf(dObject.chrB)
 
 			if (dObject.dt == MutationTypes.SNV) {
-				if (index != -1) {
+				if (index != -1 && this.snvData.length < this.settings.snv.maxMutationCount) {
 					this.addData(dObject, dataArray)
 				}
 			} else if (dObject.dt == MutationTypes.FUSION || dObject.dt == MutationTypes.SV) {

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -47,6 +47,9 @@ export default function discoDefaults(overrides = {}): Settings {
 			cappedLossColor: '#00008B',
 			unit: 'Unit'
 		},
+		snv: {
+			maxMutationCount: 10000
+		},
 		legend: {
 			snvTitle: 'SNV',
 			cnvTitle: 'CNV',

--- a/client/plots/disco/label/Labels.ts
+++ b/client/plots/disco/label/Labels.ts
@@ -9,7 +9,6 @@ export default class Labels extends Ring<Label> {
 	elementsToDisplay: Array<Label> = []
 
 	private hasPrioritizedGenes: boolean
-	private filteredPrioritizedGenesList: Array<Label> = []
 	private overlapAngle: number
 
 	constructor(settings: Settings, elements: Array<Label>, hasPrioritizedGenes: boolean) {
@@ -34,24 +33,27 @@ export default class Labels extends Ring<Label> {
 		this.collisions = []
 
 		let hasPrioritizedGenesList: Array<Label> = []
+		hasPrioritizedGenesList = this.elements.filter(label => label.isPrioritized)
 
-		if (this.hasPrioritizedGenes) {
-			hasPrioritizedGenesList = this.elements.filter(label => label.isPrioritized)
-			this.filteredPrioritizedGenesList = this.getLabelsWithoutPrioritizedGenes(hasPrioritizedGenesList)
+		if (this.settings.label.prioritizeGeneLabelsByGeneSets) {
+			this.elementsToDisplay = this.getLabelsWithPrioritizedGenes(hasPrioritizedGenesList)
+		} else if (this.hasPrioritizedGenes) {
+			const prioritizedGenesList = this.elements.filter(label => label.isPrioritized)
+			const filteredPrioritizedGenesList = this.getLabelsWithPrioritizedGenes(prioritizedGenesList)
 
-			const hasPrioritizedGenes = this.elements.filter(label => !label.isPrioritized)
+			const withoutPrioritizedGenesList = this.elements.filter(label => !label.isPrioritized)
 
-			const combinedAndSortedList = hasPrioritizedGenes.concat(this.filteredPrioritizedGenesList).sort((a, b) => {
-				return a.startAngle < b.startAngle ? -1 : a.startAngle > b.startAngle ? 1 : 0
-			})
+			const combinedAndSortedList = [...withoutPrioritizedGenesList, ...filteredPrioritizedGenesList].sort(
+				(a, b) => a.startAngle - b.startAngle
+			)
 
 			this.elementsToDisplay = this.getAllLabels(combinedAndSortedList)
 		} else {
-			this.elementsToDisplay = this.getLabelsWithoutPrioritizedGenes(this.elements)
+			this.elementsToDisplay = this.getLabelsWithPrioritizedGenes(this.elements)
 		}
 	}
 
-	private getLabelsWithoutPrioritizedGenes(elemenets: Array<Label>) {
+	private getLabelsWithPrioritizedGenes(elemenets: Array<Label>) {
 		const filteredList: Array<Label> = []
 
 		let prev = { endAngle: 0 }

--- a/client/plots/disco/prioritizegenes/PrioritizeGenesCheckboxRenderer.ts
+++ b/client/plots/disco/prioritizegenes/PrioritizeGenesCheckboxRenderer.ts
@@ -5,7 +5,13 @@ export default class PrioritizeGenesCheckboxRenderer {
 		this.checkBoxClickListener = checkBoxClickListener
 	}
 
-	render(holder: any, checked: boolean, showPrioritizeGenesCheckbox: boolean) {
+	render(
+		holder: any,
+		checked: boolean,
+		showPrioritizeGenesCheckbox: boolean,
+		displayedElementsCount: number,
+		allElementsCount: number
+	) {
 		if (showPrioritizeGenesCheckbox) {
 			const checkbox = holder
 				.append('span')
@@ -14,7 +20,10 @@ export default class PrioritizeGenesCheckboxRenderer {
 				.attr('id', 'genes-checkbox')
 				.property('checked', checked)
 
-			holder.append('label').attr('for', 'genes-checkbox').text('Prioritize Cancer Gene Census')
+			holder
+				.append('label')
+				.attr('for', 'genes-checkbox')
+				.text(`Prioritize Cancer Gene Census (${displayedElementsCount} mutations out of ${allElementsCount} total)`)
 
 			checkbox.on('change', () => {
 				this.checkBoxClickListener(checkbox.property('checked'))

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -16,8 +16,17 @@ export default class ViewModel {
 	fusions: Array<Fusion>
 
 	settings: Settings
+	svnDataLength: number
+	filteredSnvDataLength: number
 
-	constructor(settings: Settings, rings: Rings, legend: Legend, fusions: Array<Fusion>) {
+	constructor(
+		settings: Settings,
+		rings: Rings,
+		legend: Legend,
+		fusions: Array<Fusion>,
+		filteredSnvDataLength: number,
+		svnDataLength: number
+	) {
 		this.settings = settings
 		this.rings = rings
 		this.legend = legend
@@ -35,6 +44,8 @@ export default class ViewModel {
 				this.settings.verticalPadding)
 
 		this.legendHeight = this.calculateLegendHeight(legend)
+		this.svnDataLength = svnDataLength
+		this.filteredSnvDataLength = filteredSnvDataLength
 	}
 
 	getElements(ringType: RingType): Array<Arc> {

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -56,8 +56,7 @@ export class ViewModelMapper {
 
 		const genome = opts.args.genome
 
-		const prioritizedGenes =
-			genome?.geneset?.[0] && this.settings.label.prioritizeGeneLabelsByGeneSets ? genome.geneset[0].lst : []
+		const prioritizedGenes = genome?.geneset?.[0] ? genome.geneset[0].lst : []
 
 		const data: Array<any> = opts.args.data
 

--- a/client/plots/disco/viewmodel/ViewModelProvider.ts
+++ b/client/plots/disco/viewmodel/ViewModelProvider.ts
@@ -137,6 +137,13 @@ export default class ViewModelProvider {
 			this.lohArcRing
 		)
 
-		return new ViewModel(this.settings, rings, legend, fusions)
+		return new ViewModel(
+			this.settings,
+			rings,
+			legend,
+			fusions,
+			dataHolder.filteredSnvData.length,
+			dataHolder.snvData.length - dataHolder.nonExonicSnvData.length
+		)
 	}
 }


### PR DESCRIPTION
When the checkbox is selected in the Disco plot,  only show actual mutations from the cancer gene census and then increase to include other gene mutations when unchecked (max 10,000)

At the end of the Prioritize CGC label added text: add xx mutations out of yy total

When checking/unchecking CGC box, the number of mutations in legend is changed. 

## Description



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
