### PR TITLE
(half fix) In mds3 track, new option allows to show/hide variant labels

### DIFF
--- a/client/mds3/leftlabel.js
+++ b/client/mds3/leftlabel.js
@@ -95,12 +95,14 @@ export function positionLeftlabelg(tk, block) {
 			// need to prevent left label from overlapping with axis
 			// use y position of last label
 			const lly = tk.leftlabels.laby + labyspace + block.labelfontsize
-			if (lly > nm.toplabelheight - 10) {
+			if (lly > nm.toplabelheight + 5) {
+				// FIXME tentatively plus 5 here! was -10!
 				tk.leftlabels.xoff = nm.axisWidth
 			}
 		}
 	}
-	tk.leftlabels.g.attr('transform', `translate(-${tk.leftlabels.xoff},${labyspace + block.labelfontsize})`)
+	// transition for nice effect when switching skewer mode
+	tk.leftlabels.g.transition().attr('transform', `translate(-${tk.leftlabels.xoff},${labyspace + block.labelfontsize})`)
 }
 
 export function makelabel(tk, block, y) {

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -10,6 +10,7 @@ import { dt2label, mclass, dtsnvindel, dtsv, dtfusionrna } from '#shared/common'
 
 /*
 the "#variants" label should always be made as it is about any content displayed in mds3 track
+(variant just refers to those dots!)
 
 for now data{} is no longer used! as mlst used for display is cached on client
 if type=skewer, cached at tk.skewer.data
@@ -40,11 +41,7 @@ export function makeVariantLabel(data, tk, block, laby) {
 	}
 
 	if (totalcount == 0) {
-		tk.leftlabels.doms.variants
-			.text('No variants')
-			.attr('class', '')
-			.style('opacity', 0.5)
-			.on('click', null)
+		tk.leftlabels.doms.variants.text('No variants').attr('class', '').style('opacity', 0.5).on('click', null)
 		return
 	}
 
@@ -141,6 +138,16 @@ function menu_variants(tk, block) {
 				})
 		}
 	}
+
+	tk.menutip.d
+		.append('div')
+		.text(tk.skewer.hideDotLabels ? 'Show all variant labels' : 'Hide all variant labels')
+		.attr('class', 'sja_menuoption')
+		.on('click', () => {
+			tk.skewer.hideDotLabels = !tk.skewer.hideDotLabels
+			tk.load()
+			tk.menutip.hide()
+		})
 
 	if (!tk.custom_variants) {
 		// FIXME enable download for custom data

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -114,7 +114,8 @@ function menu_variants(tk, block) {
 			})
 	}
 
-	if (tk.skewer.viewModes.find(n => n.inuse).type == 'skewer') {
+	const vm = tk.skewer.viewModes.find(n => n.inuse) // view mode that's in use. following menu options depends on it
+	if (vm.type == 'skewer') {
 		// showmode=1/0 means expanded/folded skewer, defined in skewer.render.js
 		const expandCount = tk.skewer.data.reduce((i, j) => i + j.showmode, 0)
 		if (expandCount > 0) {
@@ -137,17 +138,19 @@ function menu_variants(tk, block) {
 					tk.menutip.hide()
 				})
 		}
-	}
+	} else if (vm.type == 'numeric') {
+		// only show this opt in numeric mode; delete when label hiding works for skewer mode
 
-	tk.menutip.d
-		.append('div')
-		.text(tk.skewer.hideDotLabels ? 'Show all variant labels' : 'Hide all variant labels')
-		.attr('class', 'sja_menuoption')
-		.on('click', () => {
-			tk.skewer.hideDotLabels = !tk.skewer.hideDotLabels
-			tk.load()
-			tk.menutip.hide()
-		})
+		tk.menutip.d
+			.append('div')
+			.text(tk.skewer.hideDotLabels ? 'Show all variant labels' : 'Hide all variant labels')
+			.attr('class', 'sja_menuoption')
+			.on('click', () => {
+				tk.skewer.hideDotLabels = !tk.skewer.hideDotLabels
+				tk.load()
+				tk.menutip.hide()
+			})
+	}
 
 	if (!tk.custom_variants) {
 		// FIXME enable download for custom data

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -257,9 +257,10 @@ function mayInitSkewer(tk) {
 		// both skewer and numeric mode will render elements into tk.skewer.g
 		// will also attach skewer.discKickSelection
 		g: tk.glider.append('g'),
-
 		// border color of a box over a highlighted data
-		hlBoxColor: tk.mds.hlBoxColor || 'red'
+		hlBoxColor: tk.mds.hlBoxColor || 'red',
+		// default to show dot labels
+		hideDotLabels: false
 	}
 	setSkewerMode(tk) // adds skewer.viewModes[]
 }

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -199,29 +199,34 @@ function numeric_make(nm, tk, block) {
 			delete m.labatbottom
 		}
 	}
-	if (showstem) {
-		// show label for each disc, all rotated up
-		for (const d of data) {
-			if (d.mlst.length == 1) {
-				const m = d.mlst[0]
-				m.labattop = true
-			} else {
-				// cluster
-				if ((d.width - d.fixedgew) / (d.mlst.length - 1) < clustercrowdlimit) {
-					// too crowded, no label
+
+	if (!tk.skewer.hideDotLabels) {
+		// can show m label
+		if (showstem) {
+			// show label for each disc, all rotated up
+			for (const d of data) {
+				if (d.mlst.length == 1) {
+					const m = d.mlst[0]
+					m.labattop = true
 				} else {
-					// show label for all m
-					for (const m of d.mlst) {
-						m.labattop = true
+					// cluster
+					if ((d.width - d.fixedgew) / (d.mlst.length - 1) < clustercrowdlimit) {
+						// too crowded, no label
+					} else {
+						// show label for all m
+						for (const m of d.mlst) {
+							m.labattop = true
+						}
 					}
 				}
 			}
+		} else {
+			// no stem
+			// sort items by v
+			verticallabplace(data)
 		}
-	} else {
-		// no stem
-		// sort items by v
-		verticallabplace(data)
 	}
+
 	nm.toplabelheight = 0
 	nm.bottomlabelheight = 0
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- In mds3 track, new option allows to show/hide variant labels


### PR DESCRIPTION
## Description

mds3 tests work. option only works in nuermic mode, not in skewer mode yet
quick fix for sjlife figure making. can announce later when enabled for skewer

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
