### PR TITLE
fix: Bug fix that creating mds3 subtrack with long filter name breaks

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -97,20 +97,20 @@ export function getFilterName(f) {
 		if (ttype == 'categorical') {
 			// tvs is categorical
 			if (!Array.isArray(tvs.values)) throw 'f.lst[0].tvs.values not array'
+
+			const catValue = tvs.values[0].key // only assess 1st category name
+
 			if (tvs.values.length == 1) {
 				// tvs uses only 1 category
-				const catValue = tvs.values[0].key
 				if ((tvs.term.name + catValue).length < 20) {
 					// term name plus category value has short length, show both
 					return tvs.term.name + ': ' + catValue
 				}
 				// only show cat value
-				return str.length < 15 ? str : str.substring(0, 13) + '...'
+				return catValue.length < 15 ? catValue : catValue.substring(0, 13) + '...'
 			}
-			// tvs uses more than 1 category
-			// set label of first category + (3)
-			const str = tvs.values[0].key
-			return `${str.length < 12 ? str : str.substring(0, 10) + '...'} (${tvs.values.length})`
+			// tvs uses more than 1 category, set label as "catValue (3)"
+			return `${catValue.length < 12 ? catValue : catValue.substring(0, 10) + '...'} (${tvs.values.length})`
 		}
 		if (ttype == 'integer' || ttype == 'float') {
 			// if tvs is numeric, may show numeric range

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,5 @@
 Features:
 - Support optional postRender and error callbacks from the embedded wrapper code
+
+Fixes:
+- Bug fix that creating mds3 subtrack with long filter name breaks


### PR DESCRIPTION
## Description

fix bug introduced in https://github.com/stjude/proteinpaint/pull/797
test at http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC, click Samples and select Adenomas, subtk can be created without crashing
all mds3 tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
