### PR TITLE
fix: Bug fix to allow mds3 track variant download to work again

### DIFF
--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -284,7 +284,7 @@ async function downloadVariants(tk, block) {
 
 	// FIXME for custom_variants, somehow arg requries .mlst=[]
 
-	const samples = await tk.mds.variant2samples.get(arg)
+	const samples = (await tk.mds.variant2samples.get(arg)).samples
 	/*
 	array of sample objects
 	each sample will have 1 or more variants

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Bug fix to allow mds3 track variant download to work again


### PR DESCRIPTION
## Description

bug introduced by https://github.com/stjude/proteinpaint/pull/569
test at http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC, click Variant leftlabel then Download. works now
our mds3 tests still suck and didn't catch these..

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
