### PR TITLE
Fix to display human readable error message

### DIFF
--- a/client/src/hic.straw.ts
+++ b/client/src/hic.straw.ts
@@ -614,7 +614,7 @@ async function getdata_leadfollow(hic: any, lead: any, follow: any) {
 			method: 'POST',
 			body: JSON.stringify(arg)
 		})
-		if (data.error) throw lead + ' - ' + follow + ': ' + data.error
+		if (data.error) throw lead + ' - ' + follow + ': ' + data.error.error //Fix for error message displaying [Object object] instead of error message
 		if (!data.items || data.items.length == 0) {
 			return
 		}


### PR DESCRIPTION
## Description
The error messages in the hic track are unintelligible for the user: 
<img width="198" alt="Screenshot 2023-11-18 at 9 13 57 AM" src="https://github.com/stjude/proteinpaint/assets/20135430/a81969c5-97ac-4113-99cd-3ba91c4b5691">

This fix changes the above to: 
<img width="382" alt="Screenshot 2023-11-18 at 9 16 11 AM" src="https://github.com/stjude/proteinpaint/assets/20135430/2815046c-75b7-4356-86c2-c18c1d8c46d2">

Test by: 
```
scp hpc:~/tp/lmontefi/MLL14744.hybrid.hic ~/data/tp
```
Open http://localhost:3000/?genome=hg38&hicfile=MLL14744.hybrid.hic

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
