### PR TITLE
fix issues with opening sessions and saving labels

### DIFF
--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -63,14 +63,17 @@ class MassSessionBtn {
 
 	async open() {
 		const radioName = `sjpp-session-open-radio-` + Math.random().toString().slice(-6)
-		this.dom.tip.d.append('div').style('padding', '3px 9px').html(`
+		// always open in the current tab for now, to avoid the tricky part of the code
+		// that involves parent-child window messaging
+		// TODO: re-enable when the new tab option works reliably
+		this.dom.tip.d.append('div').style('display', 'none').style('padding', '3px 9px').html(`
 			<b>Open in</b>
 			<label>
-				<input type='radio' name='${radioName}' value='new' checked=checked style='margin-right: 0; vertical-align: bottom'/>
+				<input type='radio' name='${radioName}' value='new' style='margin-right: 0; vertical-align: bottom'/>
 				<span>a new tab</span>
 			</label>
 			<label style='margin-left: 5px'>
-				<input type='radio' name='${radioName}' value='current' style='margin-right: 0; vertical-align: bottom'/>
+				<input type='radio' name='${radioName}' value='current' checked=checked style='margin-right: 0; vertical-align: bottom'/>
 				<span>current tab</span>
 			</label>
 		`)
@@ -299,14 +302,16 @@ class MassSessionBtn {
 		// assume that a jwt-type credential will include the user email in the jwt payload,
 		// which could be trusted for saving sessions under cachedir/termdbSessions/[embedderHostName]/[email]
 		if (this.requiredAuth) {
+			const requiresSignIn = this.app.vocabApi.hasVerifiedToken() ? '' : 'Requires sign-in. '
 			submitDiv
 				.append('button')
 				.style('min-width', '80px')
 				.html('Server')
 				.attr(
 					'title',
-					`Save the session into a remote server. The session can be easily shared across your different devices and recovered using the 'Open from server' option.`
+					`${requiresSignIn}Save the session into a remote server. The session can be easily shared across your different devices and recovered using the 'Open from server' option.`
 				)
+				.property('disabled', !this.app.vocabApi.hasVerifiedToken())
 				.on('click', async () => {
 					if (!this.app.vocabApi.hasVerifiedToken()) {
 						alert('Requires sign-in')

--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -34,14 +34,14 @@ class MassSessionBtn {
 		this.dom.tip.clear().d.style('padding', 0)
 		const gt = `<span style='margin-left: 24px; float: right'>&gt;</span>`
 		const options = [
-			{ label: `Open ${gt}`, callback: this.open },
-			{ label: `Save ${gt}`, callback: this.save },
-			{ label: `Share ${gt}`, callback: this.getSessionUrl }
+			{ label: `Open`, title: 'Recover a saved session', callback: this.open },
+			{ label: `Save`, title: 'Save the current view', callback: this.save },
+			{ label: `Share`, title: 'Create a URL link to share this view', callback: this.getSessionUrl }
 		]
 
 		if (!this.serverCachedSessions) await this.setServerCachedSessions()
 		if (Object.keys(this.savedSessions).length || Object.keys(this.serverCachedSessions).length) {
-			options.push({ label: `Delete ${gt}`, callback: this.delete })
+			options.push({ label: `Delete`, title: 'Delete a saved session', callback: this.delete })
 		}
 
 		this.dom.tip
@@ -51,6 +51,7 @@ class MassSessionBtn {
 			.enter()
 			.append('div')
 			.attr('class', 'sja_menuoption sja_sharp_border')
+			.attr('title', d => d.title)
 			.html(d => d.label)
 			.on('click', (event, d) => {
 				this.dom.tip.clear().d.style('padding', '10px')


### PR DESCRIPTION
## Description
Fixes https://github.com/stjude/proteinpaint/issues/839.

- do not show the option to open a session in a new tab, to fix the error related to a blank child window
- disable the option to save a session to the server when the user is not yet signed-in

![Screenshot 2023-11-21 at 12 49 38 PM](https://github.com/stjude/proteinpaint/assets/411031/ee932f4c-9063-49f6-a371-95f82ae45840)
![Screenshot 2023-11-21 at 12 49 29 PM](https://github.com/stjude/proteinpaint/assets/411031/516bac14-e628-470d-b94c-79ad0c982a85)
![Screenshot 2023-11-21 at 12 49 22 PM](https://github.com/stjude/proteinpaint/assets/411031/3cad2461-92da-4910-9fa8-cabb90221ad1)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
