### PR TITLE
Run the typescript compiler in the unit test CI

### DIFF
--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -43,15 +43,15 @@ jobs:
       - name: Run ESLint
         run: npx eslint . --ext .ts
 
-      - name: Run tsc
-        run: npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions
-
       - name: Copy serverconfig.json to root
         run: |
           cd server/test/
           node -e 'const fs = require("fs"); const serverconfig = JSON.parse(fs.readFileSync("serverconfig.json")); tpmasterdir = "/home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/server/test/tp"; fs.writeFileSync("data.json", JSON.stringify(serverconfig));'
           TPMASTERDIR=$(node -p "require('./serverconfig.json').tpmasterdir")
           mv serverconfig.json ../../
+
+      - name: Run tsc
+        run: npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions
 
       - name: Create server cache folder
         run: mkdir server/cache

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -51,7 +51,9 @@ jobs:
           mv serverconfig.json ../../
 
       - name: Run tsc
-        run: npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions
+        run: |
+          cd server && npm run checkers && cd ..
+          npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions
 
       - name: Create server cache folder
         run: mkdir server/cache

--- a/augen/build.sh
+++ b/augen/build.sh
@@ -29,8 +29,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # skipping the typeChecker step since ts-node(-esm) sometimes breaks on mixed esm import/cjs require between files 
 # !!! NOTE 
-# !!! the current solution is for server/src/run.sh to call augen.setRoutes(), 
+# !!! - in dev, the current solution is for server/src/run.sh to call augen.setRoutes(), 
 # !!! which fills in checkers-raw/index.ts, as part of server startup
+# !!! - in test, `cd ../server; npm run checkers` will also generate checkers-raw/index.ts
 # !!!
 #
 # TODO: reenable the code below once the issues are fixed with running these independent of server startup

--- a/augen/build.sh
+++ b/augen/build.sh
@@ -28,15 +28,19 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # echo "SCRIPT_DIR=[$SCRIPT_DIR]"
 
 # skipping the typeChecker step since ts-node(-esm) sometimes breaks on mixed esm import/cjs require between files 
-# the current solution is to use the opts.apiJSON + types.{importDir, outputFile} to augen.setRoutes()
+# !!! NOTE 
+# !!! the current solution is for server/src/run.sh to call augen.setRoutes(), 
+# !!! which fills in checkers-raw/index.ts, as part of server startup
+# !!!
 #
-# TODO: reenable these steps once the ts-node issues abpve are fixed
+# TODO: reenable the code below once the issues are fixed with running these independent of server startup
 # rm -rf $CHECKERSRAW
 # mkdir $CHECKERSRAW
-# CHECKERSRAW_OUTPUT=$(npx ts-node-esm $SCRIPT_DIR/cli.js typeCheckers $ROUTESDIR $IMPORTRELPATH)
+# echo "npx tsx $SCRIPT_DIR/cli.js typeCheckers $PWD/$ROUTESDIR $IMPORTRELPATH"
+# CHECKERSRAW_OUTPUT=$(npx tsx $SCRIPT_DIR/cli.js typeCheckers $PWD/$ROUTESDIR $IMPORTRELPATH)
 # echo "$CHECKERSRAW_OUTPUT" > $CHECKERSRAW/index.ts
 # 
-
+echo "npx typia generate --input $CHECKERSRAW --output $CHECKERSDIR"
 npx typia generate --input $CHECKERSRAW --output $CHECKERSDIR # --project ./shared/checkers/tsconfig.json
 
 echo "building documentation at $DOCSDIR ..."

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -290,24 +290,18 @@ type GeneExpressionQuery = {
 
 export type SingleCellSamplesGdc = {
 	src: 'gdcapi'
-	// TODO: do not use this boolean
-	gdcapi?: true
 }
 export type SingleCellSamplesNative = {
+	src: 'native'
 	/*
 	a way to query anno_cat table to find those samples labeled with this term for having sc data
 	TODO change to hasScTerm:string
 	*/
-	src: 'native'
-	// TODO: do not use this boolean
-	gdcapi?: false | undefined
 	isSampleTerm: string
 	get: () => { sample: string }[]
 }
 export type SingleCellDataGdc = {
 	src: 'gdcapi'
-	// TODO: do not use this boolean
-	gdcapi?: true
 }
 type SingleCellPlot = {
 	name: string
@@ -316,8 +310,6 @@ type SingleCellPlot = {
 }
 export type SingleCellDataNative = {
 	src: 'native'
-	// TODO: do not use this boolean
-	gdcapi?: false | undefined
 	plots: SingleCellPlot[]
 	termIds: string[]
 	get: (sample: any) => any

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -291,7 +291,7 @@ type GeneExpressionQuery = {
 export type SingleCellSamplesGdc = {
 	src: 'gdcapi'
 	// TODO: do not use this boolean
-	gdcapi: true
+	gdcapi?: true
 }
 export type SingleCellSamplesNative = {
 	/*
@@ -307,7 +307,7 @@ export type SingleCellSamplesNative = {
 export type SingleCellDataGdc = {
 	src: 'gdcapi'
 	// TODO: do not use this boolean
-	gdcapi: true
+	gdcapi?: true
 }
 type SingleCellPlot = {
 	name: string

--- a/server/shared/types/filter.ts
+++ b/server/shared/types/filter.ts
@@ -1,7 +1,8 @@
-import { Term, BaseValue } from './terms/term'
+import { BaseValue } from './terms/term'
 import { NumericTerm, NumericBin } from './terms/numeric'
 import { CategoricalTerm } from './terms/categorical'
 import { GeneVariantTerm } from './terms/geneVariant'
+import { ConditionTerm } from './terms/condition'
 
 /*
 --------EXPORTED--------
@@ -36,7 +37,7 @@ export type NumericTvs = BaseTvs & {
 	}[]
 }
 
-/*type GradeAndChildEntry = {
+type GradeAndChildEntry = {
 	grade: number
 	grade_label: string
 	child_id: string | undefined
@@ -50,7 +51,7 @@ export type ConditionTvs = BaseTvs & {
 	value_by_computable_grade?: boolean
 	grade_and_child?: GradeAndChildEntry[]
 }
-*/
+
 type GeneVariantOrigin = 'somatic' | 'germline'
 
 type SNVIndelClasses =
@@ -113,7 +114,7 @@ type GeneVariantTvs = BaseTvs & {
 }
 /*** types supporting Filter type ***/
 
-export type Tvs = CategoricalTvs | NumericTvs // | ConditionTvs | GeneVariantTvs // | SampleLstTvs ...
+export type Tvs = CategoricalTvs | NumericTvs | ConditionTvs | GeneVariantTvs // | SampleLstTvs ...
 
 export type Filter = {
 	type: 'lst'

--- a/server/shared/types/terms/categorical.ts
+++ b/server/shared/types/terms/categorical.ts
@@ -9,7 +9,6 @@ import {
 	PredefinedGroupSetting,
 	CustomGroupSetting
 } from './term'
-import { TermSettingInstance } from '../termsetting'
 
 /*
 --------EXPORTED--------
@@ -56,12 +55,7 @@ export type GroupSet = {
 export type CategoricalTerm = Term & {
 	type: 'categorical'
 	values: CategoricalValuesObject
-	groupsetting:
-		| {
-				disabled: boolean
-				lst: GroupSet[]
-		  }
-		| { disabled?: boolean }
+	//groupsetting: { disabled?: boolean | undefined } //, lst?: GroupSet }
 }
 
 export type CategoricalQ = BaseQ & (CategoricalValuesObject | GroupSet)

--- a/server/shared/types/terms/condition.ts
+++ b/server/shared/types/terms/condition.ts
@@ -1,4 +1,4 @@
-import { BaseQ } from './term'
+import { Term, BaseQ, BaseValue, EmptyGroupSetting } from './term'
 import { TermWrapper } from './tw'
 
 /*
@@ -11,6 +11,16 @@ ConditionalTW
 /**
  * @category TW
  */
+
+export type ConditionValuesObject = {
+	mode: 'binary' | 'discrete'
+	type?: 'values'
+	values: {
+		[key: string]: BaseValue
+	}
+	groupsetting: EmptyGroupSetting
+}
+
 export type ConditionQ = BaseQ & {
 	// termType: 'conditional'
 	bar_by_children?: boolean // 'true' if term is not a leaf and has subconditions
@@ -33,11 +43,17 @@ export type ConditionQ = BaseQ & {
 	groups?: any // TODO: should use a defined type
 }
 
+export type ConditionTerm = Term & {
+	values: ConditionValuesObject
+	//groupsetting: { disabled?: boolean | undefined }
+}
+
 /**
  * @group Termdb
  * @category TW
  */
 export type ConditionTW = TermWrapper & {
+	term: ConditionTerm
 	q: ConditionQ //replace the generic Q with specific condition Q
 }
 

--- a/server/shared/types/terms/tw.ts
+++ b/server/shared/types/terms/tw.ts
@@ -1,7 +1,7 @@
 import { BaseQ, BaseTW } from './term'
-import { CategoricalTerm, CategoricalQ, CategoricalTW } from './categorical.ts'
-import { NumericTerm, NumericQ, NumericTW } from './numeric.ts'
-import { SnpsTerm, SnpsQ, SnpsTW } from './snps.ts'
+import { CategoricalTerm, CategoricalQ, CategoricalTW } from './categorical'
+import { NumericTerm, NumericQ, NumericTW } from './numeric'
+import { SnpsTerm, SnpsQ, SnpsTW } from './snps'
 
 export type Term = CategoricalTerm | NumericTerm | SnpsTerm
 export type Q = CategoricalQ | NumericQ | BaseQ | SnpsQ

--- a/server/shared/types/test/numeric.type.spec.ts
+++ b/server/shared/types/test/numeric.type.spec.ts
@@ -1,4 +1,4 @@
-import { StartUnboundedBin, StopUnboundedBin, FullyBoundedBin, NumericTerm } from '../terms/numeric.ts'
+import { StartUnboundedBin, StopUnboundedBin, FullyBoundedBin, NumericTerm } from '../terms/numeric'
 
 /*
 	Non-asserted type definition tests 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./",
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.type.spec.ts"]
 }


### PR DESCRIPTION
## Description
Tested locally with `npm run checkers` and `npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions`, which runs as a new step in the unit test CI.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
