### PR TITLE
Keeping font style when downloading image

### DIFF
--- a/client/common/svg.download.js
+++ b/client/common/svg.download.js
@@ -1,7 +1,13 @@
 import { select } from 'd3-selection'
 import { to_svg } from '../src/client'
 
-export function downloadSingleSVG(svg, filename) {
+export function downloadSingleSVG(svg, filename, parent) {
+	if (parent) {
+		const svgStyles = window.getComputedStyle(parent)
+		for (const prop of svgStyles) {
+			if (prop.startsWith('font')) svg.style(prop, svgStyles.getPropertyValue(prop))
+		}
+	}
 	const link = document.createElement('a')
 	// If you don't know the name or want to use
 	// the webserver default set name = ''

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -153,7 +153,7 @@ export class profilePlot {
 			})
 		}
 		this.components.controls.on(`downloadClick.${chartType}`, () =>
-			downloadSingleSVG(this.svg, this.getDownloadFilename())
+			downloadSingleSVG(this.svg, this.getDownloadFilename(), this.dom.holder.node())
 		)
 		this.components.controls.on(`helpClick.${chartType}`, () =>
 			window.open(

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -382,7 +382,7 @@ class Scatter {
 		}
 		// TODO: handle multiple chart download when there is a divide by term
 		this.components.controls.on('downloadClick.scatter', () => {
-			for (const chart of this.charts) downloadSingleSVG(chart.svg, 'scatter.svg')
+			for (const chart of this.charts) downloadSingleSVG(chart.svg, 'scatter.svg', this.opts.holder.node())
 		})
 		this.dom.toolsDiv = this.dom.controls.insert('div')
 	}


### PR DESCRIPTION
## Description

Svg downloaded keeps fontsize if the parent node is specified in downloadSingleSVG. Used to download scatter plot and profile plots

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
