### PR TITLE
fix: GDC BAM slicing UI will reject non-BAM files.

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC BAM slicing UI will reject non-BAM files.


### PR DESCRIPTION
## Description

closes #921
also https://gdc-ctds.atlassian.net/browse/SV-2324

it now prints error if given a non-bam file ID: http://localhost:3000/?gdcbamslice=1&gdc_id=747317d4-bc1b-4371-8ddf-0a37a3380440

or a non-bam file name: http://localhost:3000/?gdcbamslice=1&gdc_id=b76fc0c0-ae54-41ea-baaf-0ecdc3488e8a.wxs.VarScan2.aliquot.maf.gz

haven't tested other kinds of non-bam files on gdc but it should work (due to use of `data_type` field)

adding `&stream2download=1` to url works. all existing examples work

existing non-CI ui tests work, but should add in this extra test of non-bam id

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
