### PR TITLE
Singlecell supported for BALL-scrna

### DIFF
--- a/client/plots/singleCellView.js
+++ b/client/plots/singleCellView.js
@@ -129,7 +129,6 @@ class SingleCellView {
 			const body = { genome: this.state.genome, dslabel: this.state.dslabel, sample: sampleData.sample }
 			try {
 				const result = await dofetch3('termdb/singlecellData', { body })
-				console.log(result)
 				if (result.error) throw result.error
 				for (const plot of result.plots) {
 					plot.clusterMap = result.tid2cellvalue.cellType
@@ -144,13 +143,11 @@ class SingleCellView {
 	}
 
 	renderPlot(plot) {
-		console.log(plot)
-		let clusters = new Set(
-			plot.cells.map(c => {
-				c.clusterMap = plot.clusterMap
-				return plot.clusterMap[c.cellId]
-			})
-		)
+		const cells2Clusters = plot.cells.map(c => {
+			c.clusterMap = plot.clusterMap
+			return plot.clusterMap[c.cellId]
+		})
+		let clusters = new Set(cells2Clusters)
 		clusters = Array.from(clusters).sort()
 		const cat2Color = getColors(clusters.length)
 		for (const cluster of clusters) this.colorMap[cluster] = cat2Color(cluster)
@@ -188,16 +185,17 @@ class SingleCellView {
 			.attr('r', 2)
 			.attr('fill', d => cat2Color(d.clusterMap[d.cellId]))
 
-		this.renderLegend(plot)
+		this.renderLegend(plot, cells2Clusters)
 	}
 
-	renderLegend(plot) {
+	renderLegend(plot, cells2Clusters) {
 		const legendG = this.legendG
 		legendG.append('text').style('font-weight', 'bold').text(`${plot.cells.length} cells`)
 		const step = 25
 		let y = 40
 		let x = 0
 		for (const cluster in this.colorMap) {
+			const n = cells2Clusters.filter(item => item == cluster).length
 			const color = this.colorMap[cluster]
 			const itemG = legendG.append('g').attr('transform', c => `translate(${x}, ${y})`)
 			itemG.append('circle').attr('r', 3).attr('fill', color)
@@ -205,7 +203,7 @@ class SingleCellView {
 				.append('g')
 				.attr('transform', `translate(${x + 10}, ${5})`)
 				.append('text')
-				.text(cluster)
+				.text(`${cluster} n=${n}`)
 			y += step
 		}
 	}

--- a/client/plots/singleCellView.js
+++ b/client/plots/singleCellView.js
@@ -44,7 +44,7 @@ class SingleCellView {
 		try {
 			const result = await dofetch3('termdb/singlecellSamples', { body })
 			if (result.error) throw result.error
-
+			console.log(result)
 			this.samples = result.samples
 			this.samples.sort((elem1, elem2) => {
 				const result = elem1.primarySite?.localeCompare(elem2.primarySite)
@@ -109,26 +109,45 @@ class SingleCellView {
 		this.colorMap = {}
 		this.headerTr = this.table.append('tr')
 		this.tr = this.table.append('tr')
-		if (sampleData.files)
+
+		if (sampleData.files) {
 			for (const file of sampleData.files) {
 				const body = { genome: this.state.genome, dslabel: this.state.dslabel, sample: file.fileId }
 				try {
 					const result = await dofetch3('termdb/singlecellData', { body })
-
+					console.log(result)
 					if (result.error) throw result.error
 					for (const plot of result.plots) {
-						plot.clusterMap = result.tid2cellvalue.cluster
-						this.renderPlot(file, plot)
+						plot.clusterMap = result.tid2cellvalue.cellType
+						this.renderPlot(plot)
 					}
 				} catch (e) {
+					console.log(e.stack)
 					sayerror(this.mainDiv, e)
 					return
 				}
 			}
+		} else {
+			const body = { genome: this.state.genome, dslabel: this.state.dslabel, sample: sampleData.sample }
+			try {
+				const result = await dofetch3('termdb/singlecellData', { body })
+				console.log(result)
+				if (result.error) throw result.error
+				for (const plot of result.plots) {
+					plot.clusterMap = result.tid2cellvalue.cellType
+					console.log(plot.clusterMap)
+					this.renderPlot(plot)
+				}
+			} catch (e) {
+				console.log(e.stack)
+				sayerror(this.mainDiv, e)
+				return
+			}
+		}
 	}
 
-	renderPlot(file, plot) {
-		this.plotsData[file] = plot
+	renderPlot(plot) {
+		console.log(plot)
 		let clusters = new Set(
 			plot.cells.map(c => {
 				c.clusterMap = plot.clusterMap

--- a/client/plots/singleCellView.js
+++ b/client/plots/singleCellView.js
@@ -6,9 +6,6 @@ import { sayerror } from '#dom/error'
 import { dofetch3 } from '#common/dofetch'
 import { getColors } from '#shared/common'
 
-const dslabel = 'GDC',
-	genome = 'hg38'
-
 export const minDotSize = 9
 export const maxDotSize = 300
 class SingleCellView {
@@ -43,7 +40,7 @@ class SingleCellView {
 			controlsHolder
 		}
 
-		const body = { genome, dslabel }
+		const body = { genome: appState.vocab.genome, dslabel: appState.vocab.dslabel }
 		try {
 			const result = await dofetch3('termdb/singlecellSamples', { body })
 			if (result.error) throw result.error
@@ -94,7 +91,9 @@ class SingleCellView {
 		}
 		return {
 			config,
-			sample: config.sample || this.samples[0].sample
+			sample: config.sample || this.samples[0].sample,
+			dslabel: appState.vocab.dslabel,
+			genome: appState.vocab.genome
 		}
 	}
 
@@ -110,7 +109,7 @@ class SingleCellView {
 		this.headerTr = this.table.append('tr')
 		this.tr = this.table.append('tr')
 		for (const file of sampleData.files) {
-			const body = { genome, dslabel, sample: file.fileId }
+			const body = { genome: this.state.genome, dslabel: this.state.dslabel, sample: file.fileId }
 			try {
 				const result = await dofetch3('termdb/singlecellData', { body })
 
@@ -247,10 +246,8 @@ export const componentInit = scatterInit
 
 export async function getPlotConfig(opts, app) {
 	try {
-		const settings = getDefaultScatterSettings()
-		if (!opts.term && !opts.term2) settings.showAxes = false
+		const settings = getDefaultSingleCellSettings()
 		const config = {
-			groups: [],
 			settings: {
 				singleCellView: settings
 			}
@@ -264,21 +261,10 @@ export async function getPlotConfig(opts, app) {
 	}
 }
 
-export function getDefaultScatterSettings() {
+export function getDefaultSingleCellSettings() {
 	return {
-		size: 25,
-		minDotSize: 16,
-		maxDotSize: 144,
-		scaleDotOrder: 'Ascending',
-		refSize: 9,
-		svgw: 550,
-		svgh: 550,
-		svgd: 550,
-		axisTitleFontSize: 16,
-		showAxes: true,
-		showRef: true,
-		opacity: 0.8,
-		defaultColor: 'rgb(144, 23, 57)',
-		regression: 'None'
+		svgw: 800,
+		svgh: 800,
+		svgd: 800
 	}
 }

--- a/client/plots/singleCellView.js
+++ b/client/plots/singleCellView.js
@@ -44,7 +44,6 @@ class SingleCellView {
 		try {
 			const result = await dofetch3('termdb/singlecellSamples', { body })
 			if (result.error) throw result.error
-			console.log(result)
 			this.samples = result.samples
 			this.samples.sort((elem1, elem2) => {
 				const result = elem1.primarySite?.localeCompare(elem2.primarySite)
@@ -115,14 +114,13 @@ class SingleCellView {
 				const body = { genome: this.state.genome, dslabel: this.state.dslabel, sample: file.fileId }
 				try {
 					const result = await dofetch3('termdb/singlecellData', { body })
-					console.log(result)
 					if (result.error) throw result.error
 					for (const plot of result.plots) {
 						plot.clusterMap = result.tid2cellvalue.cellType
 						this.renderPlot(plot)
 					}
 				} catch (e) {
-					console.log(e.stack)
+					if (e.stack) console.log(e.stack)
 					sayerror(this.mainDiv, e)
 					return
 				}
@@ -135,11 +133,10 @@ class SingleCellView {
 				if (result.error) throw result.error
 				for (const plot of result.plots) {
 					plot.clusterMap = result.tid2cellvalue.cellType
-					console.log(plot.clusterMap)
 					this.renderPlot(plot)
 				}
 			} catch (e) {
-				console.log(e.stack)
+				if (e.stack) console.log(e.stack)
 				sayerror(this.mainDiv, e)
 				return
 			}
@@ -208,7 +205,7 @@ class SingleCellView {
 				.append('g')
 				.attr('transform', `translate(${x + 10}, ${5})`)
 				.append('text')
-				.text(`Cluster ${cluster}`)
+				.text(cluster)
 			y += step
 		}
 	}

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -112,17 +112,22 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 		const t = ds.cohort.termdb.q.termjsonByOneid(tid)
 		if (!t) throw 'invalid term id from queries.singleCell.data.termIds[]'
 		_terms.push(t)
-		_tid2cellvalue[tid] = ds.cohort.termdb.q.getAllValues4term(tid)
+		// _tid2cellvalue[tid] = {}
+		// const clusterMap = ds.cohort.termdb.q.getAllValues4term(tid)
+		// for(const [id, cluster] of clusterMap)
+		// {
+		// 	const name = ds.cohort.termdb.q.id2sampleName(id)
+		// 	_tid2cellvalue[tid][name] = cluster
+		// }
 	}
-	D.get = async sample => {
+	D.get = async q => {
 		// if sample is int, may convert to string
 		try {
 			const tid2cellvalue = {}
 			for (const tid of D.termIds) tid2cellvalue[tid] = {} // k: cell id, v: cell value for this term
-
 			const plots = [] as Plot[] // given a sample name, collect every plot data for this sample and return
 			for (const plot of D.plots) {
-				const tsvfile = path.join(serverconfig.tpmasterdir, plot.folder, sample, plot.fileSuffix)
+				const tsvfile = path.join(serverconfig.tpmasterdir, plot.folder, q.sample + plot.fileSuffix)
 				try {
 					await fs.promises.stat(tsvfile)
 				} catch (e: any) {
@@ -147,9 +152,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 					cells.push({ cellId, x, y })
 
 					for (const tid of D.termIds) {
-						if (_tid2cellvalue[tid].has(cellId)) {
-							tid2cellvalue[tid][cellId] = _tid2cellvalue[tid].get(cellId)
-						}
+						tid2cellvalue[tid][cellId] = l[1]
 					}
 				}
 				plots.push({ name: plot.name, cells })

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2181,7 +2181,7 @@ export function gdc_validate_query_singleCell_data(ds, genome) {
 			const clusterId = l[3]
 			if (!clusterId) throw 'seuratCluster missing from a line'
 			seuratClusterTerm.values[clusterId] = { label: 'Cluster ' + clusterId }
-			tid2cellvalue.cluster[cellId] = clusterId
+			tid2cellvalue.cellType[cellId] = `Cluster ${clusterId}`
 
 			const umap1 = Number(l[4]),
 				umap2 = Number(l[5]),

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2171,7 +2171,7 @@ export function gdc_validate_query_singleCell_data(ds, genome) {
 			plotTsne = { name: 'TSNE', cells: [] },
 			plotPca = { name: 'PCA', cells: [] },
 			seuratClusterTerm = { id: 'cluster', name: 'Seurat cluster', type: 'categorical', values: {} },
-			tid2cellvalue = { cluster: {} } // corresponds to above term id
+			tid2cellvalue = { cellType: {} } // corresponds to above term id
 
 		for (let i = 1; i < lines.length; i++) {
 			const line = lines[i]


### PR DESCRIPTION
## Description

Once updated the dataset the SinglecellView for the dataset BALL-scrna can be seen [here](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22BALL-scrna%22,%22plots%22:[{%22chartType%22:%22singleCellView%22}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
