### PR TITLE
click dendrogram to highlight and select cases underneath it

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
+Features:
+- Click dendrogram to highlight sub-branches, zoom in and select cases underneath
 


### PR DESCRIPTION
## Description
Test by [pediatricMds3](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22pediatricMds3%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22hierCluster%22,%22genes%22:[{%22gene%22:%22GAPDH%22},{%22gene%22:%22BCR%22,%22chr%22:%22chr22%22,%22start%22:23180509,%22stop%22:23318037},{%22gene%22:%22ABL1%22,%22chr%22:%22chr9%22,%22start%22:130835254,%22stop%22:130887675},{%22gene%22:%22HOXA1%22,%22chr%22:%22chr7%22,%22start%22:27092993,%22stop%22:27096000}]}]})
and http://localhost:3000/example.gdc.exp.html 

pediatricMds3 doesn't have allow2selectSamples set so clicking dendrogram only highlighting it
example.gdc.exp.html has allow2selectSamples set (need to be on sjpp branch [enable_allow2selectSamples_gdc.exp.html](https://github.com/stjude/sjpp/tree/enable_allow2selectSamples_gdc.exp.html) ) so that clicking dendrogram will highlight it and show two options: zoom in and create cohort (converted to cases.case_id and console log)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
