### PR TITLE
create a got/fetch wrapper function in the backend

### DIFF
--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -56,7 +56,7 @@ jobs:
           npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions
 
       - name: Create server cache folder
-        run: mkdir server/cache
+        run: if [[ ! -d "server/cache" ]]; then mkdir server/cache; fi
 
       - name: Detect workspaces to test
         run: |

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -6930,7 +6930,7 @@ export async function pp_init(serverconfig) {
 			/*
 		for each raw dataset
 		*/
-
+			if (d.skip) continue
 			if (!d.name) throw 'a nameless dataset from ' + genomename
 			if (g.datasets[d.name]) throw genomename + ' has duplicating dataset name: ' + d.name
 			if (!d.jsfile) throw 'jsfile not available for dataset ' + d.name + ' of ' + genomename

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -9,6 +9,8 @@ import bettersqlite from 'better-sqlite3'
 import _serverconfig from './serverconfig'
 import { Readable } from 'stream'
 import minimatch from 'minimatch'
+import crypto from 'crypto'
+import got from 'got'
 
 export const serverconfig = _serverconfig
 
@@ -652,4 +654,67 @@ export function boxplot_getvalue(lst) {
 	}
 	const out = lst.filter(i => i.value < p25 - iqr * 1.5 || i.value > p75 + iqr * 1.5)
 	return { w1, w2, p05, p25, p50, p75, p95, iqr, out }
+}
+
+const extApiResponseDir = path.join(serverconfig.cachedir, 'extApiResponse')
+if (serverconfig.features?.cacheExtApiResponse && !fs.existsSync(extApiResponseDir)) {
+	fs.mkdirSync(extApiResponseDir, { recursive: true })
+}
+
+/**
+ * @param url           string with optional
+ * @param opts          {method, header, body, ...} similar to got and node-fetch or browser fetch
+ * @param use{}	      non-fetch options to customize the client and/or response properties
+ * 	.metaKey          string key to use when attaching a caching metadata object to the response
+ *    .client           got-like HTTP client with get, post methods, etc
+ *
+ *
+ * !!! NOTE !!!: to clear the cache, `rm [cachedir]/extApiResponse/*`
+ */
+export async function cachedFetch(url, opts = {}, use = {}) {
+	// assume that a non-relative url indicates an external API
+	if (!url.includes(':/')) throw `cannot use cachedFetch wuth a relative URL: ${url}`
+
+	const cacheExtApiResponse = serverconfig.features?.cacheExtApiResponse
+	const id =
+		cacheExtApiResponse &&
+		crypto
+			.createHash('sha1')
+			.update(`${url} ${JSON.stringify(opts.body)}`)
+			.digest('hex')
+	const cacheFile = cacheExtApiResponse && path.join(extApiResponseDir, id)
+
+	let body
+	if (cacheFile && fs.existsSync(cacheFile)) {
+		try {
+			if (cacheExtApiResponse == 'verbose') console.log(`Using cache file ${cacheFile}`)
+			const json = fs.readFileSync(cacheFile)
+			body = JSON.parse(json)
+		} catch (e) {
+			//console.log(e)
+			throw e
+		}
+	} else {
+		try {
+			const method = opts.method?.toLowerCase() || 'get'
+			const client = use.client || got
+			const response = await client[method](url, {
+				headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+				body: method == 'get' ? undefined : JSON.stringify(opts.body || {})
+			})
+
+			if (cacheFile) {
+				if (cacheExtApiResponse == 'verbose') console.log(`caching ${cacheFile}`)
+				fs.writeFileSync(cacheFile, JSON.stringify(response.body), console.error)
+			}
+
+			body = response.body
+		} catch (e) {
+			//console.log(690, e)
+			throw e
+		}
+	}
+
+	if (use.metaKey) body[use.metaKey] = { id, cacheFile }
+	return body
 }

--- a/server/test/serverconfig.json
+++ b/server/test/serverconfig.json
@@ -2,7 +2,8 @@
   "debugmode": true,
   "defaultgenome": "hg38-test",
   "features": {
-    "skip_checkDependenciesAndVersions": 1
+    "skip_checkDependenciesAndVersions": 1,
+    "cacheExtApiResponse": true
   },
   "genomes": [
     {

--- a/server/test/serverconfig.json
+++ b/server/test/serverconfig.json
@@ -3,7 +3,9 @@
   "defaultgenome": "hg38-test",
   "features": {
     "skip_checkDependenciesAndVersions": 1,
-    "cacheExtApiResponse": true
+    "extApiCache": {
+       "fake.org": "fake-test"
+    }
   },
   "genomes": [
     {


### PR DESCRIPTION
## Description

... similar to the client dofetch, that transparently enforces JSON-based data processing and caching

To test manually, add the following to your serverconfig.features. 
```js
      "extApiCache": {
         "portal.gdc.cancer.gov": "portal-v2", // can be naned after data release versions
         "api.gdc.cancer.gov": "api-v1",
         "uat-api.gdc.cancer.gov": "uat-api"
      },
```
The server restart after the first restart should go much faster, especially with regards to seeing `GDC Done caching.

Also `npm run test:unit` from the server dir.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
