### PR TITLE
Genetic data download

### DIFF
--- a/client/termsetting/handlers/snplocus.ts
+++ b/client/termsetting/handlers/snplocus.ts
@@ -69,39 +69,45 @@ export function getHandler(self) {
 	}
 }
 
-async function makeEditMenu(self, div: any) {
+async function makeEditMenu(self, div0: any) {
+	const div = div0.append('div').style('margin', '15px')
+
 	const select_ancestry = await mayRestrictAncestry(self, div)
 
 	const coordResult = addGeneSearchbox({
 		genome: self.opts.genomeObj,
 		tip: self.dom.tip2,
-		row: div.append('div').style('margin', '15px'),
+		row: div.append('div').style('margin-top', '20px'),
 		defaultCoord: self.q && self.q.chr ? { chr: self.q.chr, start: self.q.start, stop: self.q.stop } : null
 	})
+
+	div.select('.sja_genesearchinput').style('margin', '0px')
+
 	div
 		.append('span')
-		.style('margin-left', '15px')
-		.style('margin-top', '-10px')
-		.style('margin-bottom', '5px')
+		.style('margin', '5px 0px')
 		.style('display', 'inline-block')
 		.style('opacity', 0.4)
 		.style('font-size', '.7em')
 		.html(
-			'"Gene": Gene name (e.g. AKT1)</br>“Position”: chr:start-stop (e.g. chr1:5000-6000)</br>"dbSNP": dbSNP accession (e.g. rs1042522)'
+			'"Gene": Gene name (e.g. AKT1)</br>"Position": chr:start-stop (e.g. chr1:5000-6000)</br>"dbSNP": dbSNP accession (e.g. rs1042522)'
 		)
 
 	await mayDisplayVariantFilter(self, self.q?.variant_filter, div)
 
 	const [input_AFcutoff, select_alleleType, select_geneticModel] = makeSnpSelect(
-		div.append('div').style('margin', '15px'),
+		div.append('div').attr('class', 'sjpp-snp-select').style('margin-top', '15px'),
 		self,
 		'snplocus'
 	)
 
+	// hide snp select for data download
+	if (self.usecase.target == 'dataDownload') div.select('.sjpp-snp-select').style('display', 'none')
+
 	// submit button
 	div
 		.append('button')
-		.style('margin', '0px 15px 15px 15px')
+		.style('margin-top', '15px')
 		.text('Submit')
 		.on('click', async event => {
 			if (!coordResult.chr) return window.alert('Invalid coordinate')
@@ -240,9 +246,9 @@ async function mayDisplayVariantFilter(self, filterInState: any, holder: any, ca
 		// use default filter from dataset
 		self.variantFilter.active = JSON.parse(JSON.stringify(self.variantFilter.filter))
 	}
-	const div = holder.append('div').style('margin', '15px')
+	const div = holder.append('div').style('margin-top', '15px')
 
-	div.append('span').text('VARIANT FILTERS').style('font-size', '.8em').style('opacity', 0.6)
+	div.append('span').text('VARIANT FILTERS').style('font-size', '.8em').style('opacity', 0.5)
 
 	const filterBody = div.append('div')
 

--- a/client/termsetting/handlers/snplst.ts
+++ b/client/termsetting/handlers/snplst.ts
@@ -322,11 +322,7 @@ function renderSnpEditTable(self, select_alleleType: any) {
 	for (const [i, snp] of self.term.snps.entries()) {
 		//const invalid_snp = snp.invalid || (!snp.alleles && !snp.gt2count) ? true : false
 		let invalid_snp: boolean | string = false
-		if (snp.invalid) {
-			invalid_snp = snp.invalid
-		} else if (!snp.alleles && !snp.gt2count) {
-			invalid_snp = 'NOT ANNNOTATED IN COHORT'
-		}
+		if (snp.invalid || (!snp.alleles && !snp.gt2count)) invalid_snp = 'NOT ANNNOTATED IN COHORT'
 
 		const rowcolor = (i + 2) % 2 ? '#eee' : '#fff'
 		const tr = self.dom.snplst_table.append('tr').style('background', rowcolor)

--- a/client/termsetting/handlers/snplst.ts
+++ b/client/termsetting/handlers/snplst.ts
@@ -211,7 +211,7 @@ async function makeEditMenu(self, div0: any) {
 	if (self.usecase.target == 'dataDownload') editUIholder.select('.sjpp-snp-select').style('display', 'none')
 
 	// bottom row for submit button and message
-	const btnRow = editUIholder.append('div').style('margin-top', '15px')
+	const btnRow = editUIholder.append('div').style('margin-top', '20px')
 	btnRow
 		.append('button')
 		.text('Submit')
@@ -631,8 +631,9 @@ export function makeSnpSelect(div: any, self, termtype: string) {
 	{
 		input_AFcutoff_label = div
 			.append('div')
-			.style('opacity', 0.4)
-			.style('font-size', '.7em')
+			.style('opacity', 0.5)
+			.style('font-size', '.8em')
+			.style('margin-bottom', '2px')
 			.text('EFFECT ALLELE FREQUENCY CUTOFF')
 
 		self.dom.input_AFcutoff_label = input_AFcutoff_label
@@ -662,15 +663,22 @@ export function makeSnpSelect(div: any, self, termtype: string) {
 				text = 'Variants below this cutoff are analyzed by the cumulative incidence test'
 			}
 		}
-		row.append('span').style('margin-left', '10px').style('opacity', 0.5).style('font-size', '.7em').text(text)
+		row
+			.append('span')
+			.style('margin-left', '10px')
+			.style('opacity', 0.5)
+			.style('font-size', '.7em')
+			.style('font-style', 'italic')
+			.text(text)
 	}
 
 	// select - allele type
 	div
 		.append('div')
-		.style('margin-top', '10px')
-		.style('opacity', 0.4)
-		.style('font-size', '.7em')
+		.style('margin-top', '15px')
+		.style('opacity', 0.5)
+		.style('font-size', '.8em')
+		.style('margin-bottom', '2px')
 		.text('SET EFFECT ALLELE AS')
 	const select_alleleType = div.append('select')
 	select_alleleType.append('option').text('Minor allele')
@@ -685,8 +693,9 @@ export function makeSnpSelect(div: any, self, termtype: string) {
 		.append('div')
 		.style('display', 'inline-block')
 		.style('margin-left', '15px')
-		.style('opacity', 0.4)
+		.style('opacity', 0.5)
 		.style('font-size', '.7em')
+		.style('font-style', 'italic')
 		.text(getSetEffectAlleleAsHint(select_alleleType))
 	self.dom.setEffectAlleleAsHint = setEffectAlleleAsHint
 	select_alleleType.on('change', async () => {
@@ -705,7 +714,13 @@ export function makeSnpSelect(div: any, self, termtype: string) {
 	})
 
 	// select - genetic model
-	div.append('div').style('margin-top', '10px').style('opacity', 0.4).style('font-size', '.7em').text('GENETIC MODEL')
+	div
+		.append('div')
+		.style('margin-top', '15px')
+		.style('margin-bottom', '2px')
+		.style('opacity', 0.5)
+		.style('font-size', '.8em')
+		.text('GENETIC MODEL')
 	const select_geneticModel = div.append('select')
 	select_geneticModel.append('option').text('Additive: EE=2, EN=1, NN=0')
 	select_geneticModel.append('option').text('Dominant: EE=1, EN=1, NN=0')
@@ -717,21 +732,22 @@ export function makeSnpSelect(div: any, self, termtype: string) {
 		.append('div')
 		.style('display', 'inline-block')
 		.style('margin-left', '15px')
-		.style('opacity', 0.4)
+		.style('opacity', 0.5)
 		.style('font-size', '.7em')
+		.style('font-style', 'italic')
 		.html('E = effect allele; N = non-effect allele')
 
 	// select - missing genotype
 	const missingGenotypeLabel = div
 		.append('div')
-		.style('margin-top', '10px')
-		.style('opacity', 0.4)
+		.style('margin-top', '15px')
+		.style('opacity', 0.5)
 		.style('font-size', '.7em')
 	if (termtype == 'snplocus') {
 		// do not create <select> for this option
 		missingGenotypeLabel.text('Samples with missing genotypes are dropped.')
 	} else {
-		missingGenotypeLabel.text('MISSING GENOTYPE')
+		missingGenotypeLabel.text('MISSING GENOTYPE').style('font-size', '.8em').style('margin-bottom', '2px')
 		select_missingGenotype = div.append('select')
 		select_missingGenotype.append('option').text('Impute as homozygous for non-effect allele')
 		select_missingGenotype.append('option').text('Drop sample')

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -315,6 +315,7 @@ function makeRinput(q, sampledata) {
 			if (tw.type == 'snplst') {
 				for (const snpid of tw.highAFsnps.keys()) {
 					if (!id2value.get(snpid)) {
+						// TODO: is this already handled in doImputation()?
 						skipsample = true
 						break
 					}
@@ -1286,7 +1287,9 @@ samples {Map}
 	as those will miss value for dict terms and ineligible for analysis
 
 useAllSamples true/false
-	if true, populate "samples" with all of those from cache file
+	if true
+		-populate "samples" with all of those from cache file
+		-do not perform imputation
 */
 export async function getSampleData_snplstOrLocus(tw, samples, useAllSamples) {
 	const lines = (await utils.read_file(path.join(serverconfig.cache_snpgt.dir, tw.q.cacheid))).split('\n')
@@ -1350,8 +1353,7 @@ export async function getSampleData_snplstOrLocus(tw, samples, useAllSamples) {
 	}
 
 	// imputation
-	// do not impute for snplocus
-	if (tw.type != 'snplocus') {
+	if (tw.type == 'snplst' && !useAllSamples) {
 		doImputation(snp2sample, tw, cachesampleheader, sampleinfilter)
 	}
 


### PR DESCRIPTION
## Description

- Simplified snplst and snplocus edit menus for data download
- Disabled genotype imputation for data download (previously, missing genotypes were imputed for data download)
- Minor modifications of snplst and snplocus edit menus for regression
- Show appropriate message in snplst edit menu when valid snp (rs1641548) and invalid snp (rs164154) are inputted


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
