### PR TITLE
Scatter tooltip adds mname preffix if available to group samples

### DIFF
--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -89,8 +89,8 @@ export function setInteractivity(self) {
 		let level = showCoords ? 4 : 2
 		let parentCategories = showCoords ? ['y', 'x', ''] : ['']
 		if (self.config.colorTW) addNodes('category', self.config.colorTW)
-		if (self.config.shapeTW) addNodes('shape', self.config.shapeTW)
-		if (self.config.scaleDotTW) addNodes('scale', self.config.scaleDotTW)
+		if (self.config.shapeTW) addNodes('shape', self.config.shapeTW, self.config.colorTW)
+		if (self.config.scaleDotTW) addNodes('scale', self.config.scaleDotTW, self.config.shapeTW)
 		self.dom.tooltip.clear()
 		//Rendering tooltip
 		const div = self.dom.tooltip.d.style('padding', '5px')
@@ -222,11 +222,11 @@ export function setInteractivity(self) {
 			}
 		}
 
-		function addNodes(category, tw) {
+		function addNodes(category, tw, parentTW) {
 			for (const sample of samples) {
 				const value = getCategoryValue(category, sample, tw)
 				let parentId = ''
-				for (const pc of parentCategories) parentId += getCategoryValue(pc, sample)
+				for (const pc of parentCategories) parentId += getCategoryValue(pc, sample, parentTW)
 				const id = value + parentId
 				let node = tree.find(item => item.id == id && item.parentId == parentId)
 				let parent = tree.find(item => item.id == parentId)

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -33,8 +33,8 @@ export function setInteractivity(self) {
 		})
 		samples.sort((s1, s2) => {
 			if (!('sampleId' in s1)) return 1
-			if (s1.category.includes('Wildtype') || s1.category.includes('Not tested')) return 1
-			if (s1.shape.includes('Wildtype') || s1.shape.includes('Not tested')) return 1
+			if (s1.category.includes(mclass.WT.label) || s1.category.includes(mclass.Blank.label)) return 1
+			if (s1.shape.includes(mclass.WT.label) || s1.shape.includes(mclass.Blank.label)) return 1
 
 			return -1
 		})

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -34,6 +34,8 @@ export function setInteractivity(self) {
 		samples.sort((s1, s2) => {
 			if (!('sampleId' in s1)) return 1
 			if (s1.category.includes('Wildtype') || s1.category.includes('Not tested')) return 1
+			if (s1.shape.includes('Wildtype') || s1.shape.includes('Not tested')) return 1
+
 			return -1
 		})
 		if (samples.length == 0) return


### PR DESCRIPTION
## Description

Improved tooltip to group samples considering mname from mutation data. Sorted samples considering mutation data. Fixes bug found during meeting with Giles

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
