### PR TITLE
require src=gdcapi|native for early err detection

### DIFF
--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -69,15 +69,19 @@ export async function validate_query_singleCell(ds: any, genome: any) {
 
 	if (q.samples.src == 'gdcapi') {
 		gdc_validate_query_singleCell_samples(ds, genome)
-	} else {
+	} else if (q.samples.src == 'native') {
 		validateSamplesNative(q.samples as SingleCellSamplesNative, ds)
+	} else {
+		throw 'unknown singleCell.samples.src'
 	}
 	// q.samples.get() added
 
 	if (q.data.src == 'gdcapi') {
 		gdc_validate_query_singleCell_data(ds, genome)
-	} else {
+	} else if (q.data.src == 'native') {
 		validateDataNative(q.data as SingleCellDataNative, ds)
+	} else {
+		throw 'unknown singleCell.data.src'
 	}
 	// q.data.get() added
 }

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -44,8 +44,10 @@ export function validate_query_TopVariablyExpressedGenes(ds: any, genome: any) {
 	if (!q) return
 	if (q.src == 'gdcapi') {
 		gdcValidateQuery(ds, genome)
-	} else {
+	} else if (q.src == 'native') {
 		nativeValidateQuery(ds, genome)
+	} else {
+		throw 'unknown topVariablyExpressedGenes.src'
 	}
 	// added getter: q.getGenes()
 }

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -211,8 +211,9 @@ type SingleSampleMutation = GdcApi & {
 	discoSkipChrM?: boolean
 }
 
-type TopVariablyExpressedGenes = {
-	args?: any
+type TopVariablyExpressedGenesQuery = {
+	src: 'gdcapi' | 'native'
+	// to add optional parameters
 }
 
 type TopMutatedGenes = {
@@ -316,7 +317,7 @@ type Queries = {
 	geneExpression?: GeneExpressionQuery
 	rnaseqGeneCount?: RnaseqGeneCount
 	topMutatedGenes?: TopMutatedGenes
-	topVariablyExpressedGenes?: TopVariablyExpressedGenes
+	topVariablyExpressedGenes?: TopVariablyExpressedGenesQuery
 	trackLst?: TrackLstEntry[]
 	// TODO singleSampleGbtk
 	singleCell?: SingleCellQuery


### PR DESCRIPTION
## Description

to fix the sloppy logic that i think have been the cause of trouble on your end. if pp code sees sjpp dataset config is not uptodate, it crashes

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
