### PR TITLE
Profile speedup

### DIFF
--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -34,8 +34,7 @@ export class profilePlot {
 	}
 
 	getList(tw, data) {
-		const samples = Object.values(data)
-		const sampleValues = Array.from(new Set(samples.map(sample => sample[tw.$id]?.value)))
+		const sampleValues = Array.from(new Set(data.map(sample => sample[tw.id]?.value)))
 		const list = sampleValues.map(value => {
 			return { label: value, value }
 		})
@@ -53,16 +52,18 @@ export class profilePlot {
 		const samplesPerFilter = await this.app.vocabApi.getSamplesPerFilter({
 			filters
 		})
-		const data = await this.app.vocabApi.getAnnotatedSampleData({
+		this.filtersData = await this.app.vocabApi.getAnnotatedSampleDataSimple({
 			terms: [this.config.countryTW, this.config.incomeTW, this.config.typeTW]
 		})
-		const countriesData = data.lst.filter(sample =>
-			samplesPerFilter[this.config.countryTW.id].includes(Number(sample.sample))
+		const countriesData = this.filtersData.lst.filter(sample =>
+			samplesPerFilter[this.config.countryTW.id].includes(sample.sample)
 		)
-		const incomesData = data.lst.filter(sample =>
-			samplesPerFilter[this.config.incomeTW.id].includes(Number(sample.sample))
+		const incomesData = this.filtersData.lst.filter(sample =>
+			samplesPerFilter[this.config.incomeTW.id].includes(sample.sample)
 		)
-		const typesData = data.lst.filter(sample => samplesPerFilter[this.config.typeTW.id].includes(Number(sample.sample)))
+		const typesData = this.filtersData.lst.filter(sample =>
+			samplesPerFilter[this.config.typeTW.id].includes(sample.sample)
+		)
 
 		this.regions = Object.keys(this.config.regionTW.term.values).map(value => {
 			return { label: value, value }
@@ -84,7 +85,7 @@ export class profilePlot {
 		if (!this.settings.facilityType) this.settings.facilityType = this.types[0].value
 
 		const filter = this.config.filter || this.getFilter()
-		this.data = await this.app.vocabApi.getAnnotatedSampleData({
+		this.data = await this.app.vocabApi.getAnnotatedSampleDataSimple({
 			terms: this.twLst,
 			filter
 		})
@@ -126,7 +127,7 @@ export class profilePlot {
 		]
 		inputs.unshift(...additionalInputs)
 		if (this.type == 'profileRadarFacility') {
-			this.data2 = await this.app.vocabApi.getAnnotatedSampleData({
+			this.data2 = await this.app.vocabApi.getAnnotatedSampleDataSimple({
 				terms: this.twLst
 			})
 			this.sites = this.data2.lst.map(sample => {
@@ -289,13 +290,13 @@ export class profilePlot {
 	getPercentage(d) {
 		if (!d) return null
 		if (this.sampleData) {
-			const score = this.sampleData[d.score.$id]?.value
-			const maxScore = this.sampleData[d.maxScore.$id]?.value
+			const score = this.sampleData[d.score.id]?.value
+			const maxScore = this.sampleData[d.maxScore.id]?.value
 			const percentage = (score / maxScore) * 100
 			return Math.round(percentage)
 		} else {
-			const maxScore = this.data.lst[0]?.[d.maxScore.$id]?.value //Max score has the same value for all the samples on this module
-			let scores = this.data.lst.map(sample => (sample[d.score.$id]?.value / maxScore) * 100)
+			const maxScore = this.data.lst[0]?.[d.maxScore.id]?.value //Max score has the same value for all the samples on this module
+			let scores = this.data.lst.map(sample => (sample[d.score.id]?.value / maxScore) * 100)
 			scores.sort((s1, s2) => s1 - s2)
 			const middle = Math.floor(scores.length / 2)
 			const score = scores.length % 2 !== 0 ? scores[middle] : (scores[middle - 1] + scores[middle]) / 2

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -34,7 +34,7 @@ export class profilePlot {
 	}
 
 	getList(tw, data) {
-		const samples = Object.values(data.lst)
+		const samples = Object.values(data)
 		const sampleValues = Array.from(new Set(samples.map(sample => sample[tw.$id]?.value)))
 		const list = sampleValues.map(value => {
 			return { label: value, value }
@@ -44,18 +44,25 @@ export class profilePlot {
 	}
 
 	async setControls(chartType, additionalInputs = []) {
-		const countriesData = await this.app.vocabApi.getAnnotatedSampleData({
-			terms: [this.config.countryTW],
-			filter: this.getFilter([this.config.countryTW.id])
+		const idFilters = [this.config.countryTW.id, this.config.incomeTW.id, this.config.typeTW.id]
+		const filters = {}
+		for (const id of idFilters) {
+			const filter = this.getFilter([id])
+			if (filter) filters[id] = filter
+		}
+		const samplesPerFilter = await this.app.vocabApi.getSamplesPerFilter({
+			filters
 		})
-		const incomesData = await this.app.vocabApi.getAnnotatedSampleData({
-			terms: [this.config.incomeTW],
-			filter: this.getFilter([this.config.incomeTW.id])
+		const data = await this.app.vocabApi.getAnnotatedSampleData({
+			terms: [this.config.countryTW, this.config.incomeTW, this.config.typeTW]
 		})
-		const typesData = await this.app.vocabApi.getAnnotatedSampleData({
-			terms: [this.config.typeTW],
-			filter: this.getFilter([this.config.typeTW.id])
-		})
+		const countriesData = data.lst.filter(sample =>
+			samplesPerFilter[this.config.countryTW.id].includes(Number(sample.sample))
+		)
+		const incomesData = data.lst.filter(sample =>
+			samplesPerFilter[this.config.incomeTW.id].includes(Number(sample.sample))
+		)
+		const typesData = data.lst.filter(sample => samplesPerFilter[this.config.typeTW.id].includes(Number(sample.sample)))
 
 		this.regions = Object.keys(this.config.regionTW.term.values).map(value => {
 			return { label: value, value }

--- a/client/plots/profileRadarFacility.js
+++ b/client/plots/profileRadarFacility.js
@@ -45,8 +45,8 @@ class profileRadarFacility extends profilePlot {
 
 	getPercentage2(d) {
 		if (!d) return null
-		const maxScore = this.data.lst[0]?.[d.maxScore.$id]?.value //Max score has the same value for all the samples on this module
-		let scores = this.data.lst.map(sample => (sample[d.score.$id]?.value / maxScore) * 100)
+		const maxScore = this.data.lst[0]?.[d.maxScore.id]?.value //Max score has the same value for all the samples on this module
+		let scores = this.data.lst.map(sample => (sample[d.score.id]?.value / maxScore) * 100)
 		scores.sort((s1, s2) => s1 - s2)
 		const middle = Math.floor(scores.length / 2)
 		const score = scores.length % 2 !== 0 ? scores[middle] : (scores[middle - 1] + scores[middle]) / 2

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -835,6 +835,9 @@ export class TermdbVocab extends Vocab {
 		}
 	}
 
+	/*
+	Same as getAnnotatedSampleData, but only returns the lst[] of samples and makes a single request to the server.
+	*/
 	async getAnnotatedSampleDataSimple(opts, _refs = {}) {
 		// may check against required auth credentials for the server route
 		const headers = this.mayGetAuthHeaders('termdb')

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -618,6 +618,17 @@ export class TermdbVocab extends Vocab {
 		})
 	}
 
+	async getSamplesPerFilter(opts) {
+		return await dofetch3('termdb', {
+			body: {
+				for: 'getSamplesPerFilter',
+				genome: this.state.vocab.genome,
+				dslabel: this.state.vocab.dslabel,
+				filters: opts.filters
+			}
+		})
+	}
+
 	/*
     The server data sample annotations and refs are both indexed 
     by term id, but will be remapped to be annotated instead with 

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -8,7 +8,7 @@ import { validate as snpValidate } from './termdb.snp'
 import { isUsableTerm } from '#shared/termdb.usecase'
 import { trigger_getSampleScatter } from './termdb.scatter'
 import { trigger_getLowessCurve } from './termdb.scatter'
-import { getData } from './termdb.matrix'
+import { getData, getSamplesPerFilter } from './termdb.matrix'
 import { trigger_getCohortsData } from './termdb.cohort'
 import { get_mds3variantData } from './mds3.variant'
 import roundValue from '#shared/roundValue'
@@ -73,6 +73,7 @@ export function handle_request_closure(genomes) {
 			if (q.for == 'mds3queryDetails') return get_mds3queryDetails(res, ds)
 			if (q.for == 'termTypes') return res.send(await ds.getTermTypes(q))
 			if (q.for == 'matrix') return await get_matrix(q, req, res, ds, genome)
+			if (q.for == 'getSamplesPerFilter') return await getSamplesPerFilter(q, ds, res)
 			if (q.for == 'mds3variantData') return await get_mds3variantData(q, res, ds, genome)
 			if (q.for == 'validateToken') {
 			}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -174,7 +174,6 @@ export async function getSamplesPerFilter(q, ds, res) {
 		const result = (await get_samples(filter, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}
-	console.log(samples)
 	res.send(samples)
 }
 

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -165,6 +165,19 @@ async function mayGetSampleFilterSet(q, nonDictTerms) {
 	return new Set((await get_samples(q.filter, q.ds)).map(i => i.id))
 }
 
+export async function getSamplesPerFilter(q, ds, res) {
+	q.ds = ds
+	const samples = {}
+	for (const id in q.filters) {
+		const filter = q.filters[id]
+		console.log(filter)
+		const result = (await get_samples(filter, q.ds)).map(i => i.id)
+		samples[id] = Array.from(new Set(result))
+	}
+	console.log(samples)
+	res.send(samples)
+}
+
 function divideTerms(lst) {
 	// quick fix to divide list of term to two lists
 	// TODO ways to generalize; may use `shared/usecase2termtypes.js` with "regression":{nonDictTypes:['snplst','prs']}


### PR DESCRIPTION
## Description

Reduced number of requests to the server. Added `getAnnotatedSampleDataSimple` to vocab that makes a single request instead of one for each term, to get the sample annotations. Added also a `getSamplesPerFilter` endpoint to read the filters data once and filter it on the client side.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
