### PR TITLE
add menu options after clicking dendrogram

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
 
+Features:
+-add menu options after clicking gene expression dendrogram


### PR DESCRIPTION
## Description
for non-GDC, clicking dendrogram show three options: "zoom in", "list samples", "add to a group"
for GDC, show "zoom in" and "list samples",  if allow2selectSamples presents (example.gdc.exp.html), show an additional "create cohort" option. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
