### PR TITLE
Hic.3: Burger menu for hic whole genome view

### DIFF
--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -41,12 +41,12 @@ export function initWholeGenomeControls(hic: any, self: any) {
 
 	const normalizationRow = menuTable.append('tr')
 	addLabel(normalizationRow, 'NORMALIZATION')
-	self.dom.nmeth = normalizationRow.append('td') //placeholder until data is returned from server
+	self.dom.controlsDiv.nmeth = normalizationRow.append('td') //placeholder until data is returned from server
 	makeNormMethDisplay(hic, self)
 
 	const cutoffRow = menuTable.append('tr')
 	addLabel(cutoffRow, 'CUTOFF')
-	self.dom.inputBpMaxv = cutoffRow
+	self.dom.controlsDiv.inputBpMaxv = cutoffRow
 		.append('td')
 		.append('input')
 		.style('width', '80px')
@@ -62,44 +62,50 @@ export function initWholeGenomeControls(hic: any, self: any) {
 
 	const resolutionRow = menuTable.append('tr')
 	addLabel(resolutionRow, 'RESOLUTION')
-	self.dom.resolutionInput = resolutionRow.append('td').append('span')
+	self.dom.controlsDiv.resolutionInput = resolutionRow.append('td').append('span')
 
 	const viewRow = menuTable.append('tr')
 	addLabel(viewRow, 'VIEW')
-	self.dom.viewBtnDiv = viewRow.append('td')
-	self.dom.view = self.dom.viewBtnDiv.append('span').style('padding-right', '5px').style('display', 'block')
+	self.dom.controlsDiv.viewBtnDiv = viewRow.append('td')
+	self.dom.controlsDiv.view = self.dom.controlsDiv.viewBtnDiv
+		.append('span')
+		.style('padding-right', '5px')
+		.style('display', 'block')
 
-	hic.wholegenomebutton = self.dom.viewBtnDiv
+	hic.wholegenomebutton = self.dom.controlsDiv.viewBtnDiv
 		.append('button')
 		.style('display', 'none')
 		.html('&#8592; Genome')
 		.on('click', () => {
-			self.dom.view.text('Genome')
-			self.dom.zoomRow.style('display', 'none')
+			self.dom.controlsDiv.view.text('Genome')
+			self.dom.controlsDiv.zoom.style('display', 'none')
 			hic.inwholegenome = true
 			hic.inchrpair = false
 			hic.indetail = false
 			switchview(hic, self)
 		})
 
-	hic.chrpairviewbutton = self.dom.viewBtnDiv
+	hic.chrpairviewbutton = self.dom.controlsDiv.viewBtnDiv
 		.append('button')
 		.style('display', 'none')
 		.on('click', () => {
-			self.dom.zoomRow.style('display', 'none')
+			self.dom.controlsDiv.zoom.style('display', 'none')
 			hic.inwholegenome = false
 			hic.inchrpair = true
 			hic.indetail = false
 			switchview(hic, self)
 		})
 
-	hic.horizontalViewBtn = self.dom.viewBtnDiv.append('button').style('display', 'none').html('Horizontal View &#8594;')
+	hic.horizontalViewBtn = self.dom.controlsDiv.viewBtnDiv
+		.append('button')
+		.style('display', 'none')
+		.html('Horizontal View &#8594;')
 
-	self.dom.zoomRow = menuTable.append('tr').style('display', 'none')
-	addLabel(self.dom.zoomRow, 'ZOOM')
-	const zoomDiv = self.dom.zoomRow.append('td')
-	self.dom.zoomIn = zoomDiv.append('button').style('margin-right', '10px').text('In')
-	self.dom.zoomOut = zoomDiv.append('button').style('margin-right', '10px').text('Out')
+	self.dom.controlsDiv.zoom = menuTable.append('tr').style('display', 'none')
+	addLabel(self.dom.controlsDiv.zoom, 'ZOOM')
+	const zoomDiv = self.dom.controlsDiv.zoom.append('td')
+	self.dom.controlsDiv.zoom.in = zoomDiv.append('button').style('margin-right', '10px').text('In')
+	self.dom.controlsDiv.zoom.out = zoomDiv.append('button').style('margin-right', '10px').text('Out')
 }
 
 function addLabel(tr: any, text: string) {
@@ -108,14 +114,14 @@ function addLabel(tr: any, text: string) {
 
 function makeNormMethDisplay(hic: any, self: any) {
 	if (!hic.normalization?.length) {
-		hic.nmethselect = self.dom.nmeth.text(defaultnmeth)
+		hic.nmethselect = self.dom.controlsDiv.nmeth.text(defaultnmeth)
 	} else {
-		hic.nmethselect = self.dom.nmeth
+		hic.nmethselect = self.dom.controlsDiv.nmeth
 			.style('margin-right', '10px')
 			.append('select')
-			.on('change', () => {
+			.on('change', async () => {
 				const v = hic.nmethselect.node().value
-				setnmeth(hic, v)
+				await setnmeth(hic, v, self)
 			})
 		for (const n of hic.normalization) {
 			hic.nmethselect.append('option').text(n)
@@ -123,7 +129,7 @@ function makeNormMethDisplay(hic: any, self: any) {
 	}
 }
 
-async function setnmeth(hic: any, nmeth: string) {
+async function setnmeth(hic: any, nmeth: string, self: any) {
 	if (hic.inwholegenome) {
 		hic.wholegenome.nmeth = nmeth
 		const manychr = hic.atdev ? 3 : hic.chrlst.length
@@ -220,8 +226,8 @@ function switchview(hic: any, self: any) {
 		hic.wholegenomebutton.style('display', 'none')
 		hic.chrpairviewbutton.style('display', 'none')
 		hic.horizontalViewBtn.style('display', 'none')
-		self.dom.inputBpMaxv.property('value', hic.wholegenome.bpmaxv)
-		self.dom.resolutionInput.text(bplen(hic.wholegenome.resolution) + ' bp')
+		self.dom.controlsDiv.inputBpMaxv.property('value', hic.wholegenome.bpmaxv)
+		self.dom.controlsDiv.resolutionInput.text(bplen(hic.wholegenome.resolution) + ' bp')
 		nmeth2select(hic, hic.wholegenome.nmeth)
 	} else if (hic.inchrpair) {
 		self.dom.plotDiv.yAxis.selectAll('*').remove()
@@ -233,8 +239,8 @@ function switchview(hic: any, self: any) {
 		hic.wholegenomebutton.style('display', 'inline-block')
 		hic.chrpairviewbutton.style('display', 'none')
 		hic.horizontalViewBtn.style('display', 'none')
-		self.dom.inputBpMaxv.property('value', hic.chrpairview.bpmaxv)
-		self.dom.resolutionInput.text(bplen(hic.chrpairview.resolution) + ' bp')
+		self.dom.controlsDiv.inputBpMaxv.property('value', hic.chrpairview.bpmaxv)
+		self.dom.controlsDiv.resolutionInput.text(bplen(hic.chrpairview.resolution) + ' bp')
 		nmeth2select(hic, hic.chrpairview.nmeth)
 	}
 }

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -44,7 +44,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 
 	const cutoffRow = menuTable.append('tr')
 	addLabel(cutoffRow, 'CUTOFF')
-	self.dom.inputBpMaxv = cutoffRow
+	hic.inputBpMaxv = cutoffRow
 		.append('td')
 		.append('input')
 		.style('width', '80px')
@@ -74,7 +74,6 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.on('click', () => {
 			self.dom.view.text('Genome')
 			self.dom.zoomRow.style('display', 'none')
-			self.dom.detailView.style('display', 'none')
 			hic.inwholegenome = true
 			hic.inchrpair = false
 			hic.indetail = false
@@ -85,7 +84,6 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.append('button')
 		.style('display', 'none')
 		.on('click', () => {
-			self.dom.detailView.style('display', 'none')
 			self.dom.zoomRow.style('display', 'none')
 			hic.inwholegenome = false
 			hic.inchrpair = true
@@ -93,15 +91,13 @@ export function initWholeGenomeControls(hic: any, self: any) {
 			switchview(hic, self)
 		})
 
+	hic.horizontalViewBtn = self.dom.viewBtnDiv.append('button').style('display', 'none').html('Horizontal View &#8594;')
+
 	self.dom.zoomRow = menuTable.append('tr').style('display', 'none')
 	addLabel(self.dom.zoomRow, 'ZOOM')
 	const zoomDiv = self.dom.zoomRow.append('td')
 	self.dom.zoomIn = zoomDiv.append('button').text('In')
 	self.dom.zoomOut = zoomDiv.append('button').text('Out')
-	const detailView = menuTable.append('tr')
-	detailView.append('td') //Leave blank
-	self.dom.detailView = detailView.append('td').style('display', 'none')
-	self.dom.horizontalView = self.dom.detailView.append('button').text('Horizontal View')
 }
 
 function addLabel(tr: any, text: string) {
@@ -174,6 +170,7 @@ function switchview(hic: any, self: any) {
 		self.dom.plotDiv.plot.node().appendChild(hic.wholegenome.svg.node())
 		hic.wholegenomebutton.style('display', 'none')
 		hic.chrpairviewbutton.style('display', 'none')
+		hic.horizontalViewBtn.style('display', 'none')
 		self.dom.inputBpMaxv.property('value', hic.wholegenome.bpmaxv)
 		self.dom.resolutionInput.text(bplen(hic.wholegenome.resolution) + ' bp')
 		nmeth2select(hic, hic.wholegenome.nmeth)
@@ -186,6 +183,7 @@ function switchview(hic: any, self: any) {
 		self.dom.plotDiv.plot.node().appendChild(hic.chrpairview.canvas)
 		hic.wholegenomebutton.style('display', 'inline-block')
 		hic.chrpairviewbutton.style('display', 'none')
+		hic.horizontalViewBtn.style('display', 'none')
 		self.dom.inputBpMaxv.property('value', hic.chrpairview.bpmaxv)
 		self.dom.resolutionInput.text(bplen(hic.chrpairview.resolution) + ' bp')
 		nmeth2select(hic, hic.chrpairview.nmeth)

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -8,6 +8,7 @@ import blocklazyload from '#src/block.lazyload'
 import { HicstrawArgs } from '../../types/hic.ts'
 import { showErrorsWithCounter } from '../../dom/sayerror'
 import { hicParseFile } from './parse.genome.ts'
+import { initWholeGenomeControls } from './controls.whole.genome.ts'
 
 /*
 
@@ -48,6 +49,9 @@ JumpTo:  __detail  __whole
 hic.atdev controls dev-shortings
 
 */
+
+/** Default normalization method if none returned from the server. Exported to parsing and controls script*/
+export const defaultnmeth = 'NONE'
 
 const atdev_chrnum = 8
 
@@ -212,7 +216,8 @@ class Hicstat {
 	}
 
 	async render(hic: any) {
-		//initWholeGenomeControls(this)
+		hic.tip = new client.Menu()
+		initWholeGenomeControls(hic, this)
 		this.dom.plotDiv.append('table').classed('sjpp-hic-genome-main', true)
 		this.dom.plotDiv.tr1 = this.dom.plotDiv.append('tr')
 		this.dom.plotDiv.tr2 = this.dom.plotDiv.append('tr')
@@ -611,11 +616,11 @@ class Hicstat {
 		global zoom buttons
 		*/
 		{
-			self.dom.zoomIn.style('margin-right', '10px').on('click', () => {
+			self.dom.zoomIn.on('click', () => {
 				hic.detailview.xb.zoomblock(2, false)
 				hic.detailview.yb.zoomblock(2, false)
 			})
-			self.dom.zoomOut.style('margin-right', '10px').on('click', () => {
+			self.dom.zoomOut.on('click', () => {
 				hic.detailview.xb.zoomblock(2, true)
 				hic.detailview.yb.zoomblock(2, true)
 			})
@@ -810,9 +815,8 @@ export async function init_hicstraw(hic: BaseHic & Partial<Hic> & HicWholeGenomS
 		}
 	}
 
-	hic.tip = new client.Menu()
+	await hicParseFile(hic, debugmode)
 	const hicstat = new Hicstat(hic)
-	await hicParseFile(hic, hicstat, debugmode)
 	hicstat.render(hic)
 }
 
@@ -1136,8 +1140,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 				hic.chrpairview.data.push([y, x, v])
 			}
 		}
-
-		const maxv = vlst.sort((a, b) => a - b)[Math.floor(vlst.length * 0.99)]
+		const maxv = vlst.sort((a: number, b: number) => a - b)[Math.floor(vlst.length * 0.99)] as number
 		hic.chrpairview.bpmaxv = maxv
 		self.dom.inputBpMaxv.property('value', maxv)
 

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -85,6 +85,25 @@ type BaseHic = {
 	error: (f: string | string[]) => void
 }
 
+type HicstrawDom = {
+	errorDiv: any
+	controlsDiv: {
+		inputBpMaxv: HTMLInputElement
+		resolutionInput: any
+		viewBtnDiv: HTMLElement
+		zoom: {
+			in: HTMLButtonElement
+			out: HTMLButtonElement
+		}
+	}
+	plotDiv: {
+		plot: any
+		xAxis: any
+		yAxis: any
+		blank: any
+	}
+}
+
 type HicWholeGenomSvg = {
 	wholegenome: Partial<{
 		binpx: number
@@ -153,17 +172,14 @@ type Hic = {
 	}
 	hostURL: string
 	inwholegenome: boolean
-	inputbpmaxv: Selection<HTMLInputElement, any, any, any> //dom
 	inchrpair: boolean
 	indetail: boolean
 	inlineview: boolean
 	/** TODO: define this somewhere */
 	jwt: any
 	name: string
-	nmethselect: any //dom, dropdown menu
 	nochr: boolean
 	normalization: string[]
-	ressays: any //dom, resolution input
 	sv: {
 		file: string
 		header: string
@@ -174,7 +190,7 @@ type Hic = {
 	tklst: any
 	url: string
 	version: string
-	wholegenomebutton: Selection<HTMLButtonElement, any, any, any> //dom
+	wholegenomebutton: HTMLButtonElement
 }
 
 /**
@@ -188,8 +204,8 @@ type Hic = {
  */
 class Hicstat {
 	dom: {
-		errorDiv: Selection<HTMLDivElement, any, any, any>
-		controlsDiv: Selection<HTMLDivElement, any, any, any>
+		errorDiv: HTMLDivElement
+		controlsDiv: HTMLDivElement
 		plotDiv: any
 	}
 	errList: string[]
@@ -236,11 +252,11 @@ class Hicstat {
 	}
 
 	async init_wholeGenomeView(hic: any, self: any) {
-		self.dom.view.text('Genome')
+		self.dom.controlsDiv.view.text('Genome')
 		const resolution = hic.bpresolution[0]
 
 		//TODO modify with controls.whole.genome.ts
-		self.dom.resolutionInput.text(common.bplen(resolution) + ' bp')
+		self.dom.controlsDiv.resolutionInput.text(common.bplen(resolution) + ' bp')
 
 		// # pixel per bin, may set according to resolution
 		const binpx = 1
@@ -397,7 +413,7 @@ class Hicstat {
 	}
 
 	async init_chrPairView(hic: any, chrx: any, chry: any, self: any) {
-		self.dom.view.text(`${chrx}-${chry} Pair`)
+		self.dom.controlsDiv.view.text(`${chrx}-${chry} Pair`)
 		const detailView = this.init_detailView.bind(this)
 		nmeth2select(hic, hic.chrpairview.nmeth)
 
@@ -431,7 +447,7 @@ class Hicstat {
 			hic.error('no suitable resolution')
 			return
 		}
-		self.dom.resolutionInput.text(common.bplen(resolution) + ' bp')
+		self.dom.controlsDiv.resolutionInput.text(common.bplen(resolution) + ' bp')
 
 		let binpx = 1
 		while ((binpx * maxchrlen) / resolution < 600) {
@@ -511,8 +527,8 @@ class Hicstat {
 	}
 
 	async init_detailView(hic: any, chrx: any, chry: any, x: any, y: any, self: any) {
-		self.dom.view.text('Detailed')
-		self.dom.zoomRow.style('display', 'contents')
+		self.dom.controlsDiv.view.text('Detailed')
+		self.dom.controlsDiv.zoom.style('display', 'contents')
 		nmeth2select(hic, hic.detailview.nmeth)
 
 		hic.indetail = true
@@ -616,11 +632,11 @@ class Hicstat {
 		global zoom buttons
 		*/
 		{
-			self.dom.zoomIn.on('click', () => {
+			self.dom.controlsDiv.zoom.in.on('click', () => {
 				hic.detailview.xb.zoomblock(2, false)
 				hic.detailview.yb.zoomblock(2, false)
 			})
-			self.dom.zoomOut.on('click', () => {
+			self.dom.controlsDiv.zoom.out.on('click', () => {
 				hic.detailview.xb.zoomblock(2, true)
 				hic.detailview.yb.zoomblock(2, true)
 			})
@@ -1102,7 +1118,6 @@ export async function getdata_chrpair(hic: any, self: any) {
 		nmeth: hic.chrpairview.nmeth,
 		resolution: resolution
 	}
-
 	try {
 		const data = await client.dofetch2('/hicdata', {
 			method: 'POST',
@@ -1142,7 +1157,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 		}
 		const maxv = vlst.sort((a: number, b: number) => a - b)[Math.floor(vlst.length * 0.99)] as number
 		hic.chrpairview.bpmaxv = maxv
-		self.dom.inputBpMaxv.property('value', maxv)
+		self.dom.controlsDiv.inputBpMaxv.property('value', maxv)
 
 		for (const [x, y, v] of hic.chrpairview.data) {
 			const p = v >= maxv ? 0 : Math.floor((255 * (maxv - v)) / maxv)
@@ -1225,7 +1240,7 @@ async function detailViewUpdateHic(
 		if (!xfragment) {
 			// use bpresolution, not fragment
 			hic.detailview.resolution = resolution
-			self.dom.resolutionInput.text(common.bplen(resolution) + ' bp')
+			self.dom.controlsDiv.resolutionInput.text(common.bplen(resolution) + ' bp')
 			// fixed bin size only for bp bins
 			hic.detailview.xbinpx = hic.detailview.canvas.attr('width') / ((xstop - xstart) / resolution!)
 			hic.detailview.ybinpx = hic.detailview.canvas.attr('height') / ((ystop - ystart) / resolution!)
@@ -1278,7 +1293,7 @@ async function detailViewUpdateHic(
 				if (resolution == null) {
 					resolution = hic.fragresolution[hic.fragresolution.length - 1]
 				}
-				self.dom.resolutionInput.text(resolution! > 1 ? resolution + ' fragments' : 'single fragment')
+				self.dom.controlsDiv.resolutionInput.text(resolution! > 1 ? resolution + ' fragments' : 'single fragment')
 				hic.detailview.resolution = resolution
 			}
 		}
@@ -1525,7 +1540,7 @@ export function getdata_detail(hic: any, self: any) {
 			maxv *= 0.8
 
 			hic.detailview.bpmaxv = maxv
-			self.dom.inputBpMaxv.property('value', maxv)
+			self.dom.controlsDiv.inputBpMaxv.property('value', maxv)
 
 			for (const [x, y, w, h, v] of lst) {
 				const p = v >= maxv ? 0 : Math.floor((255 * (maxv - v)) / maxv)

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -506,9 +506,8 @@ class Hicstat {
 	}
 
 	async init_detailView(hic: any, chrx: any, chry: any, x: any, y: any, self: any) {
-		self.dom.view.text('Detail')
+		self.dom.view.text('Detailed')
 		self.dom.zoomRow.style('display', 'contents')
-		self.dom.detailView.style('display', 'contents')
 		nmeth2select(hic, hic.detailview.nmeth)
 
 		hic.indetail = true
@@ -621,7 +620,7 @@ class Hicstat {
 				hic.detailview.yb.zoomblock(2, true)
 			})
 
-			self.dom.horizontalView.on('click', () => {
+			hic.horizontalViewBtn.style('display', 'block').on('click', () => {
 				const regionx = hic.detailview.xb.rglst[0]
 				const regiony = hic.detailview.yb.rglst[0]
 

--- a/client/tracks/hic/parse.genome.ts
+++ b/client/tracks/hic/parse.genome.ts
@@ -91,7 +91,7 @@ export async function hicParseFile(hic: any, self: any, debugmode: boolean) {
 	hic.inlineview = false
 
 	//TODO: move to rendering code
-	const showNMethDiv = initWholeGenomeControls(hic, self)
+	initWholeGenomeControls(hic, self)
 	// data tasks:
 	// 1. load sv
 	// 2. stat the hic file
@@ -112,9 +112,9 @@ export async function hicParseFile(hic: any, self: any, debugmode: boolean) {
 		const err = hicparsestat(hic, data.out)
 		if (err) throw { message: err }
 		if (!hic.normalization?.length) {
-			hic.nmethselect = showNMethDiv.text(defaultnmeth)
+			hic.nmethselect = self.dom.nmeth.text(defaultnmeth)
 		} else {
-			hic.nmethselect = showNMethDiv
+			hic.nmethselect = self.dom.nmeth
 				.style('margin-right', '10px')
 				.append('select')
 				.on('change', () => {
@@ -209,12 +209,12 @@ async function setnmeth(hic: any, nmeth: string) {
 
 	if (hic.inchrpair) {
 		hic.chrpairview.nmeth = nmeth
-		await getdata_chrpair(hic)
+		await getdata_chrpair(hic, self)
 		return
 	}
 	if (hic.indetail) {
 		hic.detailview.nmeth = nmeth
-		getdata_detail(hic)
+		getdata_detail(hic, self)
 	}
 }
 


### PR DESCRIPTION
## Description
Controls moved into a collapsible burger menu. Controls work the same except for:
1. The 'view' is now listed. When the user clicks in and out of the genome, chr#-chr#, or detailed views, the menu updates.
2. The zoom buttons and horizontal view button render in the menu. Once out of the detailed view, the buttons and zoom menu row should disappear. 

More code reorganization as well. 

Test with http://localhost:3000/?genome=hg19&hicfile=proteinpaint_demo/hg19/hic/hic_demo.hic&enzyme=MboI and other demo files. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
