### PR TITLE
return {body} from cachedFetch to minimize breaking code 

### DIFF
--- a/server/src/termdb.gdc.js
+++ b/server/src/termdb.gdc.js
@@ -154,7 +154,8 @@ export async function initGDCdictionary(ds) {
 
 	let re
 	try {
-		re = await cachedFetch(dictUrl)
+		const { body } = await cachedFetch(dictUrl)
+		re = body
 	} catch (e) {
 		throw 'invalid JSON from GDC dictionary'
 	}
@@ -458,7 +459,7 @@ async function assignDefaultBins(id2term) {
 		let assignedCount = 0,
 			unassignedCount = 0
 
-		const re = await cachedFetch(apihostGraphql, {
+		const { body: re } = await cachedFetch(apihostGraphql, {
 			method: 'POST',
 			body: { query, variables }
 		})
@@ -542,7 +543,7 @@ for this term, the function prints out: "Min=1992  Max=2021"
 */
 async function getNumericTermRange(id) {
 	// getting more datapoints will slow down the response
-	const re = await cachedFetch(apihost + '/ssm_occurrences?size=5000&fields=' + id)
+	const { body: re } = await cachedFetch(apihost + '/ssm_occurrences?size=5000&fields=' + id)
 	if (!Array.isArray(re.data.hits)) return
 	let min = null,
 		max = null
@@ -771,7 +772,7 @@ async function getOpenProjects(ds) {
 		size: 0
 	}
 
-	const re = await cachedFetch(path.join(apihost, 'files'), { method: 'POST', headers, body: data })
+	const { body: re } = await cachedFetch(path.join(apihost, 'files'), { method: 'POST', headers, body: data })
 
 	if (!Array.isArray(re?.data?.aggregations?.['cases.project.project_id']?.buckets)) {
 		console.log("getting open project_id but return is not re.data.aggregations['cases.project.project_id'].buckets[]")
@@ -976,7 +977,7 @@ async function fetchIdsFromGdcApi(ds, size, from, aliquot_id) {
 		param.push('from=' + from)
 	}
 
-	const re = await cachedFetch(apihost + '/cases?' + param.join('&'))
+	const { body: re } = await cachedFetch(apihost + '/cases?' + param.join('&'))
 	if (!Array.isArray(re?.data?.hits)) throw 're.data.hits[] not array'
 
 	//console.log(re.data.hits[0]) // uncomment to examine output
@@ -1076,7 +1077,7 @@ async function checkExpressionAvailability(ds) {
 
 	try {
 		const idLst = [...ds.__gdc.caseIds]
-		const re = await cachedFetch(url, {
+		const { body: re } = await cachedFetch(url, {
 			method: 'post',
 			body: { case_ids: idLst, gene_ids: ['ENSG00000141510'] }
 		})

--- a/server/src/test/utils.unit.spec.js
+++ b/server/src/test/utils.unit.spec.js
@@ -69,7 +69,7 @@ tape('cachedFetch', async test => {
 			}
 		}
 	}
-	const body = await utils.cachedFetch(`http://fake.org/data?random=${Date.now()}` + Date, {}, use)
+	const { body } = await utils.cachedFetch(`http://fake.org/data?random=${Date.now()}` + Date, {}, use)
 	const cachedBody = fs.existsSync(body.info.cacheFile) && fs.readFileSync(body.info.cacheFile).toString('utf-8').trim()
 	delete body.info
 	test.deepEqual(

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -672,7 +672,7 @@ if (serverconfig.features?.extApiCache) {
 
 /**
  *
- * Returns the JSON-decoded response.body
+ * Returns  {body: JSON-decoded body}
  *
  * @param url           string with optional
  * @param opts          {method, header, body, ...} similar to got and node-fetch or browser fetch
@@ -764,7 +764,8 @@ export async function cachedFetch(url, opts = {}, use = {}) {
 		}
 	}
 
-	// this is used for testing
+	// in case the caller needs to know the saved cached id, mostly for testing
 	if (use.metaKey) body[use.metaKey] = { id, cacheFile }
-	return body
+	// may add back other response metadata as needed
+	return { body }
 }


### PR DESCRIPTION
## Description
.. that has been migrated from using `got()`. I used a destructuring syntax that I've seen before but have not used that much
```js
// used this one-liner
 const { body: re } = await cachedFetch(...)

// instead of two lines
const { body } =await cachedFetch(...)
const re = body
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
