### PR TITLE
fix: Detect failure on GDC data caching and abort launch

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Detect failure on GDC data caching and abort launch


### PR DESCRIPTION
## Description

previously the error at generating default term.bins was not detected and server launches as usual, leading to a confusing bug later on that's hard to troubleshoot. on any error at parsing/caching gdc data, must abort launch

works with "extApiCache" setting

all gdc hierCluster views work
shows a friendly msg on if gdc exp data is available on the instance

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
