### PR TITLE
prototype d3 type aliases to help declutter client-side code that use d3

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 **/tmp*/*
-**/shared/checkers/transformed/*
+**/shared/checkers/**/*

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -41,7 +41,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run ESLint
-        run: npx eslint . --ext .ts
+        run: npx eslint . --ext .ts --quiet
 
       - name: Copy serverconfig.json to root
         run: |

--- a/client/types/d3.d.ts
+++ b/client/types/d3.d.ts
@@ -1,0 +1,53 @@
+import { Selection } from 'd3-selection'
+
+/*
+	Below are aliased d3 generic types, so that the type annotation 
+	in other code that use d3-related variables/arguments/returns
+	will not be overly verbose or cluttered. 
+
+	See the usage in d3.type.spec.ts, or for example: 
+		
+	import * as Sel from '../types/d3.d.ts'
+	const holder: Sel.Elem = ...
+	
+	vs 
+
+	import { Selection } from '../types/d3.d.ts'
+	const holder: Selection<HTMLDivElement, any, any, any> = ...
+*/
+
+// most code can use these general element selection types,
+// it has the most used methods like .attr(), .style(), .on(), .node(), etc
+export type Elem = Selection<HTMLElement, any, HTMLElement, any>
+export type Svg = Selection<SVGElement, any, HTMLElement, any>
+export type SvgG = Selection<SVGGElement, any, HTMLElement, any>
+
+// this is meant to easily type all properties of the this.dom object in an rx component
+export type Dom = {
+	[selectionName: string]: Elem | Svg | SvgG
+}
+
+/*
+	Usually, the name of the variable or argument already clearly indicates 
+	the expected Element tagName when it is declared as a general Elem type.
+
+	However, more specific DOM element types may used:
+	
+	- (give examples of commonly experienced d3-related errors due to incorrect 
+	  variable/argument types, that could have been detected statically by typescript)
+
+	- (if that is not a common experience, then maybe it's not a priority to 
+		annotate d3-related variables, arguments, returns with types 
+		-- unless it has the benefit of removing the need to document arguments)
+
+	- (There are lots of other code that cause errors that should be caught statically, 
+		such as
+		- when a server response changes shape and the client code does not get updated
+		- when a dataset js file gets reshaped but validation code does not get updated
+		- etc)
+*/
+
+export type Div = Selection<HTMLDivElement, any, HTMLElement, any>
+export type Span = Selection<HTMLSpanElement, any, any, any>
+export type Input = Selection<HTMLInputElement, any, HTMLElement, any>
+export type Table = Selection<HTMLTableElement, any, HTMLElement, any>

--- a/client/types/test/d3.type.spec.ts
+++ b/client/types/test/d3.type.spec.ts
@@ -1,0 +1,51 @@
+/*
+	Non-asserted type definition tests 
+
+	manually tested in the client dir with
+	
+	npx tsc --esModuleInterop --noEmit --allowImportingTsExtensions types/test/d3.type.spec.ts
+	
+	(or ... types/test/*.type.spec.ts) 
+*/
+
+import { Selection, select } from 'd3-selection'
+import * as Sel from '../d3'
+
+// ------------
+// Declarations
+// ------------
+
+// ok
+const elem: Sel.Elem = select('body').append('div')
+// ok
+const div: Sel.Div = elem.append('div')
+// ok
+const span: Sel.Span = elem.append('span')
+// @ts-expect-error, mismatched element tagName
+const spanAsDiv: Sel.Div = elem.append('span')
+// ok
+const spanGen = <Sel.Span>elem.append('span')
+// ok - should have caught this non-sensical syntax ???
+const spanGen2: Sel.Span = <Sel.Div>elem.append('span')
+
+const dom: Sel.Dom = {
+	a: div,
+	b: span,
+	c: elem.append('svg'),
+	// @ts-expect-error, not an HTML or svg selection
+	d: 1
+}
+
+// ----------------
+// Use in functions
+// ----------------
+
+function abc(arg: Sel.Div) {}
+// ok
+abc(div)
+// @ts-expect-error, mismatched argument type
+abc(span)
+// ok, should be an error !!! this forced type syntax should not be used for generics !!!
+abc(span as Sel.Div)
+// ok - should have been prevented if the @ts-expect-error comment was removed above this variable's declaration
+abc(spanAsDiv)

--- a/client/types/test/d3.type.spec.ts
+++ b/client/types/test/d3.type.spec.ts
@@ -40,7 +40,9 @@ const dom: Sel.Dom = {
 // Use in functions
 // ----------------
 
-function abc(arg: Sel.Div) {}
+function abc(arg: Sel.Div) {
+	console.log(arg)
+}
 // ok
 abc(div)
 // @ts-expect-error, mismatched argument type


### PR DESCRIPTION
## Description


Prototype d3 type aliases with lots of comment and a few questions to help clarify and align the team goal.
- Tested with `npx tsc --esModuleInterop --noEmit --allowImportingTsExtensions types/test/d3.type.spec.ts`
- Please provide counter-examples/arguments if you disagree with the approach or anything else in this prototype

As we borrow and establish coding typescript coding patterns for our team, it would be good to look at how these current patterns could influence our codebase in the long term, to avoid accumulating new patterns that would have to be refactored. For example, I thinks the `Selection<HTMLElement, any, any, amy>` syntax is too verbose and leads to too much clutter, that's why I prototyped the type aliases in this PR. Please comment if you disagree.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
