### PR TITLE
Change ownership of  public/bin/*.js files inside docker image

### DIFF
--- a/container/full/app-full.js
+++ b/container/full/app-full.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const spawnSync = require('child_process').spawnSync
 const path = require('path')
 const serverconfigFile = path.join(__dirname, './serverconfig.json')
-
 if (!fs.existsSync(serverconfigFile)) {
 	throw `missing serverconfig.json: did you forget to mount?`
 }
@@ -53,5 +52,7 @@ if (serverconfig.releaseTag) {
 if (!serverconfig.URL) serverconfig.URL = serverconfig.url || '.'
 console.log(`generating public/bin for ${serverconfig.URL}`)
 spawnSync('npx', ['proteinpaint-front', serverconfig.URL], { encoding: 'utf-8' })
+// since the npx command generated non-root owned js files inside the public/bin folder , we need to change the owner of the folder and files to root
+spawnSync('chown', ['-R', 'root:root', './public/bin'], { encoding: 'utf8' })
 
 require('@sjcrh/proteinpaint-server')


### PR DESCRIPTION


## Description

Since public/bin js files inside the docker image are generated and have ownership different than root:root, we need to change the ownership back to "root:root" so docker mounting works properly. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
