### PR TITLE
Color column in groups table

### DIFF
--- a/client/dom/table.js
+++ b/client/dom/table.js
@@ -281,6 +281,7 @@ export function renderTable({
 						})
 					input.node().focus()
 					input.node().select()
+					column.editCallback(i, cell)
 				})
 			}
 			if (column.width) td.style('width', column.width)

--- a/client/dom/table.js
+++ b/client/dom/table.js
@@ -265,7 +265,7 @@ export function renderTable({
 			cell.__td = td
 
 			const column = columns[colIdx]
-			if (column.editCallback && cell.value) {
+			if (column.editCallback && (cell.value || cell.color)) {
 				td.on('click', event => {
 					event.stopImmediatePropagation()
 					const isEdit = td.select('input').empty()

--- a/client/dom/table.js
+++ b/client/dom/table.js
@@ -278,10 +278,10 @@ export function renderTable({
 							const value = input.node().value
 							cell.value = value
 							td.text(cell.value)
+							column.editCallback(i, cell)
 						})
 					input.node().focus()
 					input.node().select()
-					column.editCallback(i, cell)
 				})
 			}
 			if (column.width) td.style('width', column.width)

--- a/client/dom/table.js
+++ b/client/dom/table.js
@@ -265,7 +265,7 @@ export function renderTable({
 			cell.__td = td
 
 			const column = columns[colIdx]
-			if (column.editCallback && (cell.value || cell.color)) {
+			if (column.editCallback && cell.value) {
 				td.on('click', event => {
 					event.stopImmediatePropagation()
 					const isEdit = td.select('input').empty()
@@ -278,7 +278,6 @@ export function renderTable({
 							const value = input.node().value
 							cell.value = value
 							td.text(cell.value)
-							column.editCallback(i, cell)
 						})
 					input.node().focus()
 					input.node().select()

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -39,6 +39,7 @@ class MassGroups {
 		}
 		initUI(this)
 		this.tip = new Menu({ padding: '0px' })
+		this.colorScale = getColors(5)
 	}
 
 	getState(appState) {
@@ -280,24 +281,23 @@ async function updateUI(self) {
 		termdbConfig: self.state.termdbConfig,
 		callback: f => {
 			// create new group
-			const name = 'New group'
+			let name = 'New group'
 			let i = 0
 			while (1) {
 				const name2 = name + (i == 0 ? '' : ' ' + i)
 				if (!groups.find(g => g.name == name2)) break
 				i++
 			}
+			name = name + (i == 0 ? '' : ' ' + i)
 			const newGroup = {
-				name: name + (i == 0 ? '' : ' ' + i),
-				filter: f
+				name,
+				filter: f,
+				color: rgb(self.colorScale(name)).formatHex()
 			}
 			groups.push(newGroup)
 			// assign colors
-			const colorScale = getColors(groups.length)
-			for (const group of groups) {
-				group.color = rgb(colorScale(group.name)).formatHex()
-			}
-			self.app.dispatch({
+
+			newGroup.color = self.app.dispatch({
 				type: 'app_refresh',
 				state: { groups }
 			})

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -295,9 +295,7 @@ async function updateUI(self) {
 				color: rgb(self.colorScale(name)).formatHex()
 			}
 			groups.push(newGroup)
-			// assign colors
-
-			newGroup.color = self.app.dispatch({
+			self.app.dispatch({
 				type: 'app_refresh',
 				state: { groups }
 			})

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -71,7 +71,6 @@ class MassGroups {
 	async groups2samplelst(groups) {
 		const samplelstGroups = []
 		for (const g of groups) {
-			console.log(g)
 			const samples = await this.app.vocabApi.getFilteredSampleCount(g.filter, 'list')
 			const items = []
 			for (const sample of samples) {
@@ -425,8 +424,6 @@ async function updateUI(self) {
 async function clickLaunchBtn(self) {
 	// click button to create samplelst tw
 	// collect groups in use
-	console.log('self.state.groups:', self.state.groups)
-
 	const groups = []
 	for (const i of self.selectedGroupsIdx) {
 		const g = self.state.groups[i]
@@ -440,8 +437,6 @@ async function clickLaunchBtn(self) {
 	// 1 or more groups are in use, generate samplelst tw and save it to state
 	const tw = await self.groups2samplelst(groups)
 	tw.term.name = name
-
-	console.log('tw:', tw)
 
 	self.app.vocabApi.addCustomTerm({ name, tw })
 

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -71,6 +71,7 @@ class MassGroups {
 	async groups2samplelst(groups) {
 		const samplelstGroups = []
 		for (const g of groups) {
+			console.log(g)
 			const samples = await this.app.vocabApi.getFilteredSampleCount(g.filter, 'list')
 			const items = []
 			for (const sample of samples) {
@@ -341,7 +342,7 @@ async function updateUI(self) {
 				label: 'COLOR',
 				editCallback: async (i, cell) => {
 					await self.app.dispatch({
-						type: 'change_group_color',
+						type: 'change_color_group',
 						index: i,
 						newColor: cell.color
 					})

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -401,12 +401,10 @@ TdbStore.prototype.actions = {
 	},
 
 	change_color_group(action) {
-		console.log('action:', action)
 		const index = action.index
 		const newColor = action.newColor
 		if (this.state.nav.header_mode != 'hidden') {
 			this.state.groups[index].color = newColor
-			console.log('this.state.groups:', this.state.groups)
 		} else {
 			for (const plot of this.state.plots) {
 				if (plot?.groups) {

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -400,7 +400,7 @@ TdbStore.prototype.actions = {
 		}
 	},
 
-	change_group_color(action) {
+	change_color_group(action) {
 		console.log('action:', action)
 		const index = action.index
 		const newColor = action.newColor

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -400,6 +400,22 @@ TdbStore.prototype.actions = {
 		}
 	},
 
+	change_group_color(action) {
+		console.log('action:', action)
+		const index = action.index
+		const newColor = action.newColor
+		if (this.state.nav.header_mode != 'hidden') {
+			this.state.groups[index].color = newColor
+			console.log('this.state.groups:', this.state.groups)
+		} else {
+			for (const plot of this.state.plots) {
+				if (plot?.groups) {
+					plot.groups[index].color = newColor
+				}
+			}
+		}
+	},
+
 	delete_group({ name }) {
 		if (this.state.nav.header_mode != 'hidden') {
 			const i = this.state.groups.findIndex(i => i.name == name)

--- a/client/termsetting/handlers/samplelst.ts
+++ b/client/termsetting/handlers/samplelst.ts
@@ -89,7 +89,7 @@ export function getSamplelstTW(groups: any, name = 'groups', notIn = true) {
 	const qgroups: any = []
 	let samples: any
 	for (const group of groups) {
-		values[group.name] = { key: group.name, label: group.name }
+		values[group.name] = { key: group.name, label: group.name, color: group.color }
 		samples = getGroupSamples(group)
 		const qgroup = {
 			name: group.name,
@@ -100,7 +100,7 @@ export function getSamplelstTW(groups: any, name = 'groups', notIn = true) {
 	}
 	if (groups.length == 1 && notIn) {
 		const name2 = 'Not in ' + groups[0].name
-		values[name2] = { key: name2, label: name2 }
+		values[name2] = { key: name2, label: name2, color: groups[0].color }
 		qgroups.push({
 			name: name2,
 			in: false,

--- a/client/termsetting/handlers/samplelst.ts
+++ b/client/termsetting/handlers/samplelst.ts
@@ -1,6 +1,7 @@
 import { getPillNameDefault, get$id } from '#termsetting'
 import { renderTable } from '#dom/table'
 import { SampleLstTermSettingInstance, PillData, SampleLstTW } from '#shared/types/index'
+import { rgb } from 'd3'
 
 export function getHandler(self: SampleLstTermSettingInstance) {
 	return {
@@ -100,7 +101,7 @@ export function getSamplelstTW(groups: any, name = 'groups', notIn = true) {
 	}
 	if (groups.length == 1 && notIn) {
 		const name2 = 'Not in ' + groups[0].name
-		values[name2] = { key: name2, label: name2, color: groups[0].color }
+		values[name2] = { key: name2, label: name2, color: '#aaa' }
 		qgroups.push({
 			name: name2,
 			in: false,

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
-
-feat: allow custom colors to be specified for custom groups;
+Features
+- custom colors can now be assigned to custom groups

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
 
+feat: allow custom colors to be specified for custom groups;


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/838

Color column is now implemented in the `GROUPS` table. Each group is assigned a default color and colors can be edited. Selected colors are stored in custom term.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
