### PR TITLE
Fixed tvs.samplelst editor

### DIFF
--- a/client/filter/filter.js
+++ b/client/filter/filter.js
@@ -725,7 +725,7 @@ function setRenderers(self) {
 				const itemCopy = JSON.parse(JSON.stringify(item))
 				const keys = 'keys' in values[index] ? values[index].keys : [values[index].key]
 				itemCopy.tvs.values = keys.map(key => {
-					return { key, label: key }
+					return { key, label: key } //may be missing list if term type is samplelst
 				})
 				filterCopy.lst[i] = itemCopy
 				self.refresh(filterUiRoot)

--- a/client/filter/tvs.js
+++ b/client/filter/tvs.js
@@ -140,8 +140,7 @@ function setRenderers(self) {
 		const lstlen = (self.tvs.values && self.tvs.values.length) || (self.tvs.ranges && self.tvs.ranges.length)
 
 		// update the main label
-		one_term_div.select('.term_name_btn').html(self.handler.term_name_gen)
-
+		one_term_div.select('.term_name_btn').html(self.handler.get_pill_label(tvs).txt)
 		// negate button
 		one_term_div
 			.select('.negate_btn')

--- a/client/filter/tvs.js
+++ b/client/filter/tvs.js
@@ -139,6 +139,9 @@ function setRenderers(self) {
 		const tvs = one_term_div.datum()
 		const lstlen = (self.tvs.values && self.tvs.values.length) || (self.tvs.ranges && self.tvs.ranges.length)
 
+		// update the main label
+		one_term_div.select('.term_name_btn').html(self.handler.term_name_gen)
+
 		// negate button
 		one_term_div
 			.select('.negate_btn')

--- a/client/filter/tvs.samplelst.js
+++ b/client/filter/tvs.samplelst.js
@@ -7,6 +7,7 @@ export const handler = {
 	getSelectRemovePos
 }
 async function fillMenu(self, div, tvs) {
+	tvs = JSON.parse(JSON.stringify(tvs))
 	div.selectAll('*').remove()
 	div = div.append('div')
 	div.style('font-size', '0.8em')

--- a/client/filter/tvs.samplelst.js
+++ b/client/filter/tvs.samplelst.js
@@ -74,21 +74,20 @@ function getSelectRemovePos(j) {
 }
 
 function term_name_gen(d) {
-	const [group, n] = getGroupSize(d.term)
-	return `samples in ${group} n=${n}`
+	return getGroupLabel(d.term)
 }
 
 function get_pill_label(tvs) {
-	const [group, n] = getGroupSize(tvs.term)
-	return { txt: `n=${n}` }
+	const label = getGroupLabel(tvs.term)
+	return { txt: `${tvs.isnot ? 'NOT' : ''} ${label}` }
 }
 
-function getGroupSize(term) {
+function getGroupLabel(term) {
 	let n, group
 	for (const item in term.values) {
 		n = term.values[item].list.length
 		group = item
 		break
 	}
-	return [group, n]
+	return `samples in ${group} n=${n}`
 }

--- a/client/filter/tvs.samplelst.js
+++ b/client/filter/tvs.samplelst.js
@@ -9,30 +9,54 @@ async function fillMenu(self, div, tvs) {
 	div.selectAll('*').remove()
 	div = div.append('div')
 	div.style('font-size', '0.8em')
-	div.append('div').style('margin', '10px').html(`<b>Select <i>${tvs.term.name}</i> samples:</b>`)
 	const rows = []
+	let samples, name
 	for (const field in tvs.term.values) {
-		const samples = tvs.term.values[field].list
-		for (const sample of samples) rows.push([{ value: sample.sample }])
+		name = field
+		samples = tvs.term.values[field].list //Only two possible groups and the second one contains the samples not in the first one
+		addTable(div, tvs, field)
+		break
 	}
+	div
+		.append('div')
+		.append('div')
+		.style('display', 'inline-block')
+		.style('float', 'right')
+		.style('padding', '6px 20px')
+		.append('button')
+		.attr('class', 'sjpp_apply_btn sja_filter_tag_btn')
+		.text('Apply')
+		.on('click', () => {
+			for (const field in tvs.term.values) {
+				const value = tvs.term.values[field]
+				value.list = value.list.filter(s => !('checked' in s) || s.checked)
+				break //only the first group is edited
+			}
+			self.opts.callback(tvs)
+		})
+}
+
+export function addTable(div, tvs, field) {
+	div
+		.style('padding', '6px')
+		.append('div')
+		.style('margin', '10px')
+		.style('font-size', '0.8rem')
+		.html(`<b> ${field}</b>.`)
+
+	const value = tvs.term.values[field]
+	const rows = []
+	for (const sample of value.list) rows.push([{ value: sample.sample }])
 	const columns = [{ label: 'Sample' }]
 	renderTable({
 		rows,
 		columns,
 		div,
-		maxWidth: '250px',
-		buttons: [
-			{
-				text: 'APPLY',
-				class: 'sjpp_apply_btn sja_filter_tag_btn',
-				callback: indexes => {
-					const values = []
-					for (const index of indexes) values.push(tvs.values[index])
-					tvs.values = values
-					self.opts.callback(tvs)
-				}
-			}
-		],
+		maxWidth: '30vw',
+		maxHeight: '40vh',
+		noButtonCallback: (index, node) => {
+			value.list[index].checked = node.checked
+		},
 		striped: false,
 		showHeader: false,
 		selectAll: true
@@ -40,8 +64,12 @@ async function fillMenu(self, div, tvs) {
 }
 
 function term_name_gen(d) {
-	const name = 'sample'
-	return name
+	let n
+	for (const group in d.term.values) {
+		n = d.term.values[group].list.length
+		break
+	}
+	return `n=${n}`
 }
 
 function get_pill_label(tvs) {

--- a/client/filter/tvs.samplelst.js
+++ b/client/filter/tvs.samplelst.js
@@ -3,7 +3,8 @@ import { renderTable } from '#dom/table'
 export const handler = {
 	term_name_gen,
 	get_pill_label,
-	fillMenu
+	fillMenu,
+	getSelectRemovePos
 }
 async function fillMenu(self, div, tvs) {
 	div.selectAll('*').remove()
@@ -27,11 +28,16 @@ async function fillMenu(self, div, tvs) {
 		.attr('class', 'sjpp_apply_btn sja_filter_tag_btn')
 		.text('Apply')
 		.on('click', () => {
+			let firstGroup
 			for (const field in tvs.term.values) {
 				const value = tvs.term.values[field]
-				value.list = value.list.filter(s => !('checked' in s) || s.checked)
-				break //only the first group is edited
+
+				if (!firstGroup) {
+					firstGroup = field
+					value.list = value.list.filter(s => !('checked' in s) || s.checked)
+				} else value.list = tvs.term.values[firstGroup].list //not in group
 			}
+
 			self.opts.callback(tvs)
 		})
 }
@@ -62,16 +68,25 @@ export function addTable(div, tvs, field) {
 		selectAll: true
 	})
 }
+function getSelectRemovePos(j) {
+	return j
+}
 
 function term_name_gen(d) {
-	let n
-	for (const group in d.term.values) {
-		n = d.term.values[group].list.length
-		break
-	}
+	const n = getGroupSize(d.term)
 	return `n=${n}`
 }
 
 function get_pill_label(tvs) {
-	return { txt: ` in ${tvs.term.name}` }
+	const n = getGroupSize(tvs.term)
+	return { txt: `n=${n}` }
+}
+
+function getGroupSize(term) {
+	let n
+	for (const group in term.values) {
+		n = term.values[group].list.length
+		break
+	}
+	return n
 }

--- a/client/filter/tvs.samplelst.js
+++ b/client/filter/tvs.samplelst.js
@@ -73,20 +73,21 @@ function getSelectRemovePos(j) {
 }
 
 function term_name_gen(d) {
-	const n = getGroupSize(d.term)
-	return `n=${n}`
+	const [group, n] = getGroupSize(d.term)
+	return `samples in ${group} n=${n}`
 }
 
 function get_pill_label(tvs) {
-	const n = getGroupSize(tvs.term)
+	const [group, n] = getGroupSize(tvs.term)
 	return { txt: `n=${n}` }
 }
 
 function getGroupSize(term) {
-	let n
-	for (const group in term.values) {
-		n = term.values[group].list.length
+	let n, group
+	for (const item in term.values) {
+		n = term.values[item].list.length
+		group = item
 		break
 	}
-	return n
+	return [group, n]
 }

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -437,7 +437,7 @@ export function rebaseGroupFilter(s) {
 		const f = getNormalRoot(structuredClone(s.termfilter.filter))
 		const f2 = getFilterItemByTag(g.filter, 'filterUiRoot')
 		if (!f2) {
-			console.log('filterUiRoot not found')
+			//console.log('filterUiRoot not found')
 			groups.push(g)
 			continue
 		}

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -146,7 +146,7 @@ function get_samplelst(tvs, CTEname) {
 		  ${CTEname} AS (
 				SELECT id as sample
 				FROM sampleidmap
-				WHERE id IN (${Array(samples.length).fill('?').join(', ')})
+				WHERE id ${tvs.isnot ? 'NOT IN' : 'IN'} (${Array(samples.length).fill('?').join(', ')})
 			)`
 		],
 		values: [...samples.map(value => value.sampleId)],

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -136,7 +136,10 @@ function get_survival(tvs, CTEname) {
 
 function get_samplelst(tvs, CTEname) {
 	const samples = []
-	for (const field in tvs.term.values) samples.push(...tvs.term.values[field].list)
+	for (const field in tvs.term.values) {
+		const list = tvs.term.values[field].list
+		samples.push(...list)
+	}
 	return {
 		CTEs: [
 			`


### PR DESCRIPTION
## Description

The tvs.samplelst editor works now, the label reflects the group info and the filter supports negation. I used for label 
`samples in ${group} n=${n}` after discussing it with @siosonel. Otherwise the filter would not make sense.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
