### PR TITLE
Better JSON nomenclature about hiercluster dendrogram data from R

### DIFF
--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -482,30 +482,30 @@ async function geneExpressionClustering(data, q, ds) {
 
 	const row_coordinates = []
 	for (const item of Routput.RowNodeJson) {
-		row_coordinates.push({ x: item['x'], y: item['y'] })
+		row_coordinates.push({ x: item.x, y: item.y })
 	}
 	const col_coordinates = []
 	for (const item of Routput['ColNodeJson']) {
-		col_coordinates.push({ x: item['x'], y: item['y'] })
+		col_coordinates.push({ x: item.x, y: item.y })
 	}
 	const row_names_index = []
 	const col_names_index = []
 
 	for (const item of Routput['RowDendOrder']) {
-		row_names_index.push(item['ind'])
+		row_names_index.push(item.ind)
 	}
 	for (const item of Routput['ColumnDendOrder']) {
-		col_names_index.push(item['ind'])
+		col_names_index.push(item.ind)
 	}
 
 	const row_names = []
 	const col_names = []
 
 	for (const item of Routput['SortedRowNames']) {
-		row_names.push(item['gene'])
+		row_names.push(item.gene)
 	}
 	for (const item of Routput['SortedColumnNames']) {
-		col_names.push(item['sample'])
+		col_names.push(item.sample)
 	}
 
 	const row_output = await parseclust(row_coordinates, row_names_index)
@@ -514,7 +514,7 @@ async function geneExpressionClustering(data, q, ds) {
 	const matrix_1d = []
 	//console.log(Routput['OutputMatrix'])
 	for (const item of Routput['OutputMatrix']) {
-		matrix_1d.push(item['elem'][0])
+		matrix_1d.push(item.elem[0])
 	}
 
 	// Converting the 1D array to 2D array column-wise

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -482,42 +482,43 @@ async function geneExpressionClustering(data, q, ds) {
 
 	const row_coordinates = []
 	for (const item of Routput.RowNodeJson) {
-		row_coordinates.push({ x: item[0].x[0], y: item[1].y[0] })
+		row_coordinates.push({ x: item['x'], y: item['y'] })
 	}
-	let col_coordinates = []
+	const col_coordinates = []
 	for (const item of Routput['ColNodeJson']) {
-		col_coordinates.push({ x: item[0].x[0], y: item[1].y[0] })
+		col_coordinates.push({ x: item['x'], y: item['y'] })
 	}
-	let matrix_1d = []
+	const row_names_index = []
+	const col_names_index = []
+
+	for (const item of Routput['RowDendOrder']) {
+		row_names_index.push(item['ind'])
+	}
+	for (const item of Routput['ColumnDendOrder']) {
+		col_names_index.push(item['ind'])
+	}
+
+	const row_names = []
+	const col_names = []
+
+	for (const item of Routput['SortedRowNames']) {
+		row_names.push(item['gene'])
+	}
+	for (const item of Routput['SortedColumnNames']) {
+		col_names.push(item['sample'])
+	}
+
+	const row_output = await parseclust(row_coordinates, row_names_index)
+	const col_output = await parseclust(col_coordinates, col_names_index)
+
+	const matrix_1d = []
 	//console.log(Routput['OutputMatrix'])
 	for (const item of Routput['OutputMatrix']) {
 		matrix_1d.push(item['elem'][0])
 	}
-	let row_names_index = []
-	let col_names_index = []
-
-	for (const item of Routput['RowDendOrder']) {
-		row_names_index.push(item['i'][0])
-	}
-	for (const item of Routput['ColumnDendOrder']) {
-		col_names_index.push(item['i'][0])
-	}
-
-	let row_names = []
-	let col_names = []
-
-	for (const item of Routput['SortedRowNames']) {
-		row_names.push(item['gene'][0])
-	}
-	for (const item of Routput['SortedColumnNames']) {
-		col_names.push(item['sample'][0])
-	}
-
-	let row_output = await parseclust(row_coordinates, row_names_index)
-	let col_output = await parseclust(col_coordinates, col_names_index)
 
 	// Converting the 1D array to 2D array column-wise
-	let output_matrix = []
+	const output_matrix = []
 	for (let i = 0; i < row_names.length; i++) {
 		if (col_names.length > 0) {
 			let row = []
@@ -606,8 +607,8 @@ async function parseclust(coordinates, names_index) {
         */
 
 	let first = 1
-	let xs = []
-	let ys = []
+	const xs = []
+	const ys = []
 	for (const item of coordinates) {
 		//console.log(item)
 		if (Number(item.x) % 1 != 0 && Number(item.y == 0)) {
@@ -624,9 +625,9 @@ async function parseclust(coordinates, names_index) {
 
 	let depth_start_position = 0 // Initializing position of depth start to position 0 in R output
 	let i = 0
-	let depth_first_branch = []
-	let prev_ys = []
-	let prev_xs = []
+	const depth_first_branch = []
+	const prev_ys = []
+	const prev_xs = []
 	let break_point = false
 	let old_depth_start_position = 0
 	let node_children = []

--- a/server/utils/hclust.R
+++ b/server/utils/hclust.R
@@ -93,15 +93,18 @@ row_node_coordinates <- get_nodes_xy(
   type = "rectangle"
 )
 
-row_node_transform <- apply(row_node_coordinates, 1, function(row){
-    lapply(c(1,2), function(col_index){
-        if (col_index == 1) {
-          list(x=row[col_index])       
-        } else if (col_index == 2) {
-          list(y=row[col_index])
-        }
-    })
-})
+row_node_df <- as.data.frame(row_node_coordinates)
+colnames(row_node_df) <- c("x","y")
+
+#row_node_transform <- apply(row_node_coordinates, 1, function(row){
+#    lapply(c(1,2), function(col_index){
+#        if (col_index == 1) {
+#          list(x=row[col_index])
+#        } else if (col_index == 2) {
+#          list(y=row[col_index])
+#        }
+#    })
+#})
 
 # For columns (i.e samples)
 ColumnDist <- dist(t(normalized_matrix), method = "euclidean") # Transposing the matrix
@@ -118,15 +121,9 @@ col_node_coordinates <- get_nodes_xy(
   ColumnDendro,
   type = "rectangle"
 )
-col_node_transform <- apply(col_node_coordinates, 1, function(col){
-    lapply(c(1,2), function(col_index){
-        if (col_index == 1) {
-          list(x=col[col_index])       
-        } else if (col_index == 2) {
-          list(y=col[col_index])
-        }
-    })
-})
+
+col_node_df <- as.data.frame(col_node_coordinates)
+colnames(col_node_df) <- c("x","y")
 
 # Sorting the matrix
 
@@ -140,26 +137,43 @@ SortedColumnNames <- colnames(normalized_matrix)[ColumnDend$order]
 
 output_df <- list()
 output_df$method <- input$cluster_method
-output_df$RowNodeJson <- row_node_transform
-output_df$ColNodeJson <- col_node_transform
-output_df$RowDendOrder <- {lapply(1:length(RowDend$order), function(y){
-    list(i=RowDend$order[y])
-})}
-output_df$ColumnDendOrder <- {lapply(1:length(ColumnDend$order), function(y){
-    list(i=ColumnDend$order[y])
-})}
-output_df$SortedRowNames <- {lapply(1:length(SortedRowNames), function(y){
-    list(gene=SortedRowNames[y])
-})}
-output_df$SortedColumnNames <- {lapply(1:length(SortedColumnNames), function(y){
-    list(sample=SortedColumnNames[y])
-})}
+output_df$RowNodeJson <- row_node_df
+output_df$ColNodeJson <- col_node_df
+#output_df$RowDendOrder <- {lapply(1:length(RowDend$order), function(y){
+#    list(i=RowDend$order[y])
+#})}
+row_dend_order_df <- as.data.frame(RowDend$order)
+colnames(row_dend_order_df) <- c("ind")
+output_df$RowDendOrder <- row_dend_order_df
+
+col_dend_order_df <- as.data.frame(ColumnDend$order)
+colnames(col_dend_order_df) <- c("ind")
+output_df$ColumnDendOrder <- col_dend_order_df
+
+#output_df$SortedRowNames <- {lapply(1:length(SortedRowNames), function(y){
+#    list(gene=SortedRowNames[y])
+#})}
+
+sorted_row_names_df <- as.data.frame(SortedRowNames)
+colnames(sorted_row_names_df) <- c("gene")
+output_df$SortedRowNames <- sorted_row_names_df
+
+sorted_col_names_df <- as.data.frame(SortedColumnNames)
+colnames(sorted_col_names_df) <- c("sample")
+output_df$SortedColumnNames <- sorted_col_names_df
+
 output_df$OutputMatrix <- {lapply(1:length(normalized_matrix), function(y){
     list(elem=normalized_matrix[y])
 })}
-#print ("output_json")
-output_json <- toJSON(output_df)
-print (output_json)
+
+# Converting to data frame does not work for the raw counts since the key of the json needs to be unique.
+
+#output_matrix_df <- as.data.frame(normalized_matrix)
+#colnames(output_matrix_df) <- c(rep("elem",dim(normalized_matrix)[2]))
+#print (output_matrix_df)
+#output_df$OutputMatrix <- output_matrix_df
+
+toJSON(output_df)
 
 #cat("rowindexes",RowDend$order,"\n",sep="\t") # Prints out row indices
 #cat("colindexes",ColumnDend$order,"\n",sep="\t") # Prints out column indicies


### PR DESCRIPTION
## Description
Better JSON nomenclature output from hclust.R. Except for the matrix (gene counts), all other variables are first converted into dataframes. In case of gene counts, the older implementation is used because R dataframes require unique column names. 

Sidenote:

The EMT77 example was taking around 24sec. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
