### PR TITLE
Passing sorted clustered matrix to client side

### DIFF
--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -358,8 +358,6 @@ class HierCluster extends Matrix {
 			}
 		}
 
-		c.sampleNameLst = c.col_names_index.map(i => c.sampleNameLst[i - 1])
-		c.geneNameLst = c.row_names_index.map(i => c.geneNameLst[i - 1])
 		const orderedTw = c.geneNameLst.map(name => twlst.find(tw => tw.term.name === name))
 		this.hcTermGroup.lst = orderedTw
 

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -512,6 +512,18 @@ async function geneExpressionClustering(data, q, ds) {
 	const row_output = await parseclust(row_coordinates, row_names_index)
 	const col_output = await parseclust(col_coordinates, col_names_index)
 
+	// Sorting 2D array
+	const output_matrix = []
+	for (let i = 0; i < row_names_index.length; i++) {
+		if (col_names.length > 0) {
+			let row = []
+			for (let j = 0; j < col_names_index.length; j++) {
+				row.push(inputData.matrix[row_names_index[i] - 1][col_names_index[j] - 1])
+			}
+			output_matrix.push(row)
+		}
+	}
+
 	/* rust is no longer used
 
 	const rust_output = await run_rust('cluster', JSON.stringify(inputData))
@@ -537,7 +549,7 @@ async function geneExpressionClustering(data, q, ds) {
 	return {
 		geneNameLst: row_names,
 		sampleNameLst: col_names,
-		matrix: inputData.matrix,
+		matrix: output_matrix,
 		row_dendro: row_output.dendrogram,
 		row_children: row_output.children,
 		row_names_index: row_names_index,

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -516,7 +516,7 @@ async function geneExpressionClustering(data, q, ds) {
 	const output_matrix = []
 	for (let i = 0; i < row_names_index.length; i++) {
 		if (col_names.length > 0) {
-			let row = []
+			const row = []
 			for (let j = 0; j < col_names_index.length; j++) {
 				row.push(inputData.matrix[row_names_index[i] - 1][col_names_index[j] - 1])
 			}


### PR DESCRIPTION
## Description

In this branch, the input matrix is sorted based on the indices given by hclust. Then the sorted matrix is passed to client side.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
