### PR TITLE
Exclude hidden categories when computing cuminc axes

### DIFF
--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -1268,16 +1268,16 @@ export async function getPlotConfig(opts, app) {
 function getPj(self) {
 	const pj = new Partjson({
 		template: {
-			xMin: '>$time',
-			xMax: '<$time',
+			xMin: '>=x()',
+			xMax: '<=x()',
 			yMin: '>=yMin()',
 			yMax: '<=yMax()',
 			charts: [
 				{
 					chartId: '@key',
 					chartTitle: '=chartTitle()',
-					xMin: '>$time',
-					xMax: '<$time',
+					xMin: '>=x()',
+					xMax: '<=x()',
 					'__:xTickValues': '=xTickValues()',
 					'__:yTickValues': '=yTickValues()',
 					'__:xScale': '=xScale()',
@@ -1337,14 +1337,16 @@ function getPj(self) {
 				if (t2 && t2.term.values && seriesId in t2.term.values) return t2.term.values[seriesId].label
 				return seriesId
 			},
-			y(row, context) {
-				const seriesId = context.context.parent.seriesId
-				return seriesId == 'CI' ? [row.low, row.high] : row[seriesId]
+			x(row) {
+				if (self.settings.hidden.includes(row.seriesId)) return
+				return row.time
 			},
 			yMin(row) {
+				if (self.settings.hidden.includes(row.seriesId)) return
 				return self.settings.ciVisible ? row.low : row.cuminc
 			},
 			yMax(row) {
+				if (self.settings.hidden.includes(row.seriesId)) return
 				return self.settings.ciVisible ? row.high : row.cuminc
 			},
 			xTickValues(row, context) {
@@ -1354,8 +1356,9 @@ function getPj(self) {
 					return s.xTickValues
 				} else {
 					// compute x-tick values
-					const xMin = s.scale == 'byChart' ? context.self.xMin : context.root.xMin
-					const xMax = s.scale == 'byChart' ? context.self.xMax : context.root.xMax
+					// uncomment .scale code when the control input is added
+					const xMin = /*s.scale == 'byChart' ? context.self.xMin : */ context.root.xMin
+					const xMax = /*s.scale == 'byChart' ? context.self.xMax : */ context.root.xMax
 					return computeTickValues(xMin, xMax)
 				}
 			},
@@ -1379,8 +1382,9 @@ function getPj(self) {
 					return s.yTickValues
 				} else {
 					// compute y-tick values
-					const yMin = s.scale == 'byChart' ? context.self.yMin : context.root.yMin
-					const yMax = s.scale == 'byChart' ? context.self.yMax : context.root.yMax
+					// uncomment .scale code when the control input is added
+					const yMin = /*s.scale == 'byChart' ? context.self.yMin : */ context.root.yMin
+					const yMax = /*s.scale == 'byChart' ? context.self.yMax : */ context.root.yMax
 					return computeTickValues(yMin, yMax)
 				}
 			},

--- a/client/termsetting/handlers/numeric.toggle.ts
+++ b/client/termsetting/handlers/numeric.toggle.ts
@@ -3,6 +3,7 @@ import { getPillNameDefault, set_hiddenvalues } from '../termsetting'
 import { copyMerge } from '../../rx'
 import { PillData, HandlerGenerator, Handler } from '../types'
 import { VocabApi } from '../../shared/types/vocab.ts'
+import roundValue from '#shared/roundValue'
 import {
 	NumericTerm,
 	NumericQ,
@@ -164,7 +165,7 @@ export async function fillTW(tw: NumericTW, vocabApi: VocabApi, defaultQ: Defaul
 			if (!q.type || q.type != 'custom-bin') throw '.type must be custom-bin when .preferredBins=median'
 			const result = await vocabApi.getPercentile(tw.term.id!, [50])
 			if (!result.values) throw '.values[] missing from vocab.getPercentile()'
-			const median = result.values[0]
+			const median = roundValue(result.values[0], 2)
 			if (!Number.isFinite(median)) throw 'median value not a number'
 			const medianQ = JSON.parse(JSON.stringify(defaultQ))
 			delete medianQ.preferredBins


### PR DESCRIPTION
## Description

Previously, cuminc axes were computed based on values from all terms (including hidden terms). Now axes are computed based only on values from visible terms.

Compare this [example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Breast%22,%22q%22:{}},%22term2%22:{%22id%22:%22chestrt_yn%22,%22q%22:{%22type%22:%22custom-bin%22,%22mode%22:%22discrete%22,%22lst%22:[{%22startunbounded%22:true,%22stop%22:200,%22stopinclusive%22:false,%22label%22:%22%3C200%22},{%22start%22:200,%22startinclusive%22:true,%22stopunbounded%22:true,%22label%22:%22%E2%89%A5200%22}]}}}],%22nav%22:{%22activeTab%22:1}}) between this branch and master.

This is a draft PR, because a `{NON-NUMERIC-THAN: {…}}` error appears in the browser console. Error seems to be from partjson when performing a numeric comparison with `undefined`. **CORRECTION:** this error only appears when `node_modules` is out of date. If you see this error, run `npm run reset` from sjpp directory.

Additional cuminc-related commits:
- round median value of numeric overlay term

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
