### PR TITLE
fix: Gene exp clustering will display an alert msg to inform user tha…

### DIFF
--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -324,6 +324,15 @@ class HierCluster extends Matrix {
 		}
 		const d = await dofetch3('mds3', { body })
 		if (d.error) throw d.error
+
+		if (!d.clustering) {
+			// simple stop-gap data validation
+			// lacks essential data part
+			if (d.gene) {
+				// for now backend returns {gene:str, data:{}} if there's only 1 eligible gene
+				throw `Cannot do clustering: data is only available for 1 gene (${d.gene}). Try again by adding more genes.`
+			}
+		}
 		this.hierClusterData = d
 
 		const c = this.hierClusterData.clustering

--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -332,6 +332,7 @@ class HierCluster extends Matrix {
 				// for now backend returns {gene:str, data:{}} if there's only 1 eligible gene
 				throw `Cannot do clustering: data is only available for 1 gene (${d.gene}). Try again by adding more genes.`
 			}
+			throw 'Cannot do clustering: invalid server response (lacks .clustering{})'
 		}
 		this.hierClusterData = d
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Gene exp clustering will display an alert msg to inform user that a map is not doable when there is just one gene

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -263,8 +263,9 @@ async function load_driver(q, ds) {
 		const { gene2sample2value, byTermId, bySampleId } = await ds.queries.geneExpression.get(q)
 		if (gene2sample2value.size == 0) throw 'no data'
 		if (gene2sample2value.size == 1) {
-			// get data for only 1 gene; may create violin plot
-			return { gene2sample2value }
+			// get data for only 1 gene; still return data, may create violin plot later
+			const g = Array.from(gene2sample2value.keys())[0]
+			return { gene: g, data: gene2sample2value.get(g) }
 		}
 
 		// have data for multiple genes, run clustering


### PR DESCRIPTION
…t a map is not doable when there is just one gene

## Description

closes #998 

test at gdc link with [IDH1, ATRX, TERT](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22and%22,%22content%22:[{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.project.project_id%22,%22value%22:[%22TCGA-GBM%22]}}]}},%22plots%22:[{%22chartType%22:%22hierCluster%22,%22genes%22:[{%22gene%22:%22TERT%22},{%22gene%22:%22IDH1%22},{%22gene%22:%22ATRX%22}],%22termgroups%22:[{%22name%22:%22Variables%22,%22lst%22:[{%22id%22:%22case.demographic.gender%22},{%22id%22:%22case.project.project_id%22}]}]}]}), due to the gene_selection call, only 1 is left and causes unknown err seen before
this also handles user auto reducing to 1 gene for non-gdc ds


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
