### PR TITLE
update the menu of brushing matrix and clicking dendrogram

### DIFF
--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -128,6 +128,7 @@ class HierCluster extends Matrix {
 			.enter()
 			.append('div')
 			.attr('class', 'sja_menuoption')
+			.style('border-radius', '0px')
 			.html(d => d.label)
 			.on('click', event => {
 				this.dom.dendroClickMenu.d.selectAll('*').remove()

--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -121,8 +121,8 @@ class HierCluster extends Matrix {
 
 		this.mouseout()
 		this.dom.tip.hide()
-		this.app.tip.clear()
-		this.app.tip.d
+		this.dom.dendroClickMenu.d.selectAll('*').remove()
+		this.dom.dendroClickMenu.d
 			.selectAll('div')
 			.data(optionArr)
 			.enter()
@@ -130,10 +130,10 @@ class HierCluster extends Matrix {
 			.attr('class', 'sja_menuoption')
 			.html(d => d.label)
 			.on('click', event => {
-				this.app.tip.hide()
+				this.dom.dendroClickMenu.d.selectAll('*').remove()
 				event.target.__data__.callback()
 			})
-		this.app.tip.show(event.clientX, event.clientY)
+		this.dom.dendroClickMenu.show(event.clientX, event.clientY)
 	}
 
 	// zoom in matrix to the selected dendrogram branch

--- a/client/plots/matrix.dom.js
+++ b/client/plots/matrix.dom.js
@@ -1,4 +1,5 @@
 import { Menu } from '#dom/menu'
+import { select } from 'd3-selection'
 
 export function setMatrixDom(opts) {
 	const holder = opts.controls ? opts.holder : opts.holder.append('div')
@@ -33,6 +34,8 @@ export function setMatrixDom(opts) {
 
 	const tip = new Menu({ padding: '5px' })
 	const clickMenu = new Menu({ padding: '0px' })
+	const brushMenu = new Menu({ padding: '0px' })
+	const dendroClickMenu = new Menu({ padding: '0px' })
 	this.dom = {
 		header: opts.header,
 		holder,
@@ -114,7 +117,9 @@ export function setMatrixDom(opts) {
 		tip,
 		menutop: tip.d.append('div'),
 		menubody: tip.d.append('div'),
-		clickMenu
+		clickMenu,
+		brushMenu,
+		dendroClickMenu
 	}
 
 	this.dom.colBeam = this.dom.highlightBeamG
@@ -135,6 +140,9 @@ export function setMatrixDom(opts) {
 		this.lastActiveLabel = this.activeLabel
 		delete this.activeLabel
 	}
+
+	// remove the matrix brush zoom area when clicking on body
+	select('body').on(`mousedown.matrixZoom-${this.id}`, this.resetInteractions)
 
 	window.onscroll = this.scrollStopHandler
 	const contentDiv = this.dom.holder.node().closest('.sjpp-output-sandbox-content')

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -2098,6 +2098,7 @@ function setZoomPanActions(self) {
 			.enter()
 			.append('div')
 			.attr('class', 'sja_menuoption')
+			.style('border-radius', '0px')
 			.html(d => d.label)
 			.on('click', event => {
 				self.dom.brushMenu.d.selectAll('*').remove()

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -180,6 +180,9 @@ export function setInteractivity(self) {
 		const geneName = sampleData.term?.type == 'geneVariant' ? sampleData.term.name : null
 
 		self.dom.clickMenu.d.selectAll('*').remove()
+		self.dom.dendroClickMenu.d.selectAll('*').remove()
+		self.dom.brushMenu.d.selectAll('*').remove()
+
 		if (self.dom.sampleListMenu) self.dom.sampleListMenu.destroy()
 
 		if (self.state.termdbConfig.urlTemplates) {
@@ -2084,10 +2087,12 @@ function setZoomPanActions(self) {
 			}
 		}
 
+		self.dom.dendroClickMenu.d.selectAll('*').remove() // close the dendrogram clicking menu when brushing
+		self.dom.clickMenu.d.selectAll('*').remove() // close the matrix cell click menu when brushing
 		self.mouseout()
 		self.dom.tip.hide()
-		self.app.tip.clear()
-		self.app.tip.d
+		self.dom.brushMenu.d.selectAll('*').remove()
+		self.dom.brushMenu.d
 			.selectAll('div')
 			.data(optionArr)
 			.enter()
@@ -2095,10 +2100,10 @@ function setZoomPanActions(self) {
 			.attr('class', 'sja_menuoption')
 			.html(d => d.label)
 			.on('click', event => {
-				self.app.tip.hide()
+				self.dom.brushMenu.d.selectAll('*').remove()
 				event.target.__data__.callback()
 			})
-		self.app.tip.show(event.clientX, event.clientY)
+		self.dom.brushMenu.show(event.clientX, event.clientY)
 	}
 
 	// show the list of clicked samples as a table


### PR DESCRIPTION
## Description
maintain consistent menu appearance. remove white margin and do not use rounded corners
after brushing and click on outside white space, dismiss the menu and the brush
close denrogram menu and brush menu after clicking on matrix cell
close cell menu and dendrogram menu after brushing

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
