### PR TITLE
clean up on gdc backend sample name handling

### DIFF
--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2224,13 +2224,10 @@ async function getSnvindelByTerm(ds, term, genome, q) {
 		addFormatValues: true,
 		filter0: q.filter0, // hidden filter
 		filterObj: q.filter, // pp filter, must change key name to "filterObj" to be consistent with mds3 client
-		sessionid: q.sessionid
-	}
-
-	if (ds.queries.geneCnv) {
-		// FIXME !!!!!!!!
-		// may need a boolean flag to specify the geneCnv query is asking for case but not sample id, thus all queries must return data with case id
-		arg.useCaseid4sample = true
+		sessionid: q.sessionid,
+		// !! gdc specific parameter !!
+		// instructs byisoform.get() to return case uuid as sample.sample_id; more or less harmless as it's ignored by non-gdc ds
+		gdcUseCaseuuid: true
 	}
 
 	if (ds.queries.snvindel.byisoform) {

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -109,8 +109,6 @@ q{}
 	actual pp filter, from mds3 client side
 .filter
 	actual pp filter, request does not come from mds3 and maybe getData()
-.useIntegerSampleId
-	if true, return integer sample id
 
 ****** mutation/genomic filters; one of below must be provided
 
@@ -136,6 +134,14 @@ q{}
 	client always provides this, to reflect any user changes
 	if get=sunburst, twLst is an ordered array of terms, for which to build layered sunburst
 	otherwise element order is not essential
+
+******* getter() returns
+{
+	samples[]
+		always present
+	byTermId{}
+		optional, term metadata e.g. bin labels. only gdc does it
+}
 */
 async function variant2samples_getresult(q, ds) {
 	mayAllow2returnFormatValues(q, ds)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -358,7 +358,10 @@ async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 			q2.geneTwLst.push({ term: { name: n, type: 'geneVariant' } })
 		}
 	} else {
-		throw 'calling v2s() but lacks q.currentGeneNames'
+		/* do not throw here
+		gene list is not required for loading dict term for gdc gene exp clustering
+		but it's required for gdc oncomatrix and will break FIXME
+		*/
 	}
 
 	const data = await q.ds.variant2samples.get(q2)


### PR DESCRIPTION
## Description

backend completely drops use of __sampleName
introduce a `gdcUseCaseuuid` flag on function arguments, applied to functions in mds3.gdc.js to determine whether to get case UUID or sample submitter id
(i feel after this round the logic is slightly less convoluted and more tractable)

all CI passes
need some careful testing
may be further simplification to matrix/hiercluster code 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
