### PR TITLE
allow gdc mds3 tk to work in genomic mode

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -64,21 +64,33 @@ export function makeSampleFilterLabel(data, tk, block, laby) {
 				tk.load()
 			}
 		}
-		if (block.usegm) {
-			/////////////////////////////////////
-			//
-			// GDC specific logic
-			// in gene mode, supply the current gene name as a new parameter
-			// for the vocabApi getCategories() query, so it can pull the number of mutated samples for a term
-			// this parameter is used by some sneaky gdc-specific logic in termdb.matrix.js getData()
-			// should not impact non-gdc datasets
-			//
-			/////////////////////////////////////
-			arg.getCategoriesArguments = { currentGeneNames: [block.usegm.name] }
-			// TODO {name: block.usegm.name, isoform, q:{allowedDt}}
-		}
+		mayAddGetCategoryArgs(arg, block)
 		filterInit(arg).main(tk.filterObj)
 	})
+}
+
+function mayAddGetCategoryArgs(arg, block) {
+	if (block.usegm) {
+		/////////////////////////////////////
+		//
+		// GDC specific logic
+		// in gene mode, supply the current gene name as a new parameter
+		// for the vocabApi getCategories() query, so it can pull the number of mutated samples for a term
+		// this parameter is used by some sneaky gdc-specific logic in termdb.matrix.js getData()
+		// should not impact non-gdc datasets
+		//
+		/////////////////////////////////////
+		arg.getCategoriesArguments = { currentGeneNames: [block.usegm.name] }
+		// TODO {name: block.usegm.name, isoform, q:{allowedDt}}
+	} else {
+		/////////////////////////////////////
+		//
+		// GDC specific logic
+		// in genomic mode, pass rglst for pulling cases mutated in this region, handled in the same way as currentGeneNames
+		//
+		/////////////////////////////////////
+		arg.getCategoriesArguments = { rglst: structuredClone(block.rglst) }
+	}
 }
 
 export function getFilterName(f) {

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -88,7 +88,7 @@ function init({ genomes }) {
 }
 
 async function trigger_getcategories(
-	q: { tid: string | number; type: string; filter: any; term1_q: any; currentGeneNames: any },
+	q: { tid: string | number; type: string; filter: any; term1_q: any; currentGeneNames?: string[]; rglst?: any },
 	res: { send: (arg0: { lst: any[]; orderedLabels: any }) => void },
 	tdb: { q: { termjsonByOneid: (arg0: any) => any } },
 	ds: { assayAvailability: { byDt: { [s: string]: any } | ArrayLike<any> } },

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -99,13 +99,15 @@ async function trigger_getcategories(
 	if (!q.tid) throw '.tid missing'
 	const term =
 		q.type == 'geneVariant' ? { name: q.tid, type: 'geneVariant', isleaf: true } : tdb.q.termjsonByOneid(q.tid)
+
 	const arg = {
 		filter: q.filter,
 		terms:
 			q.type == 'geneVariant'
 				? [{ term: term, q: { isAtomic: true } }]
 				: [{ id: q.tid, term, q: q.term1_q || getDefaultQ(term, q) }],
-		currentGeneNames: q.currentGeneNames
+		currentGeneNames: q.currentGeneNames, // optional, from mds3 mayAddGetCategoryArgs()
+		rglst: q.rglst // optional, from mds3 mayAddGetCategoryArgs()
 	}
 
 	const data = await getData(arg, ds, genome)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -352,6 +352,10 @@ async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 		// !! gdc specific parameter !!
 		isHierCluster: q.isHierCluster
 	}
+	if (q.rglst) {
+		// !! gdc specific parameter !! present for block tk in genomic mode
+		q2.rglst = q.rglst
+	}
 	if (q.currentGeneNames) {
 		q2.geneTwLst = []
 		for (const n of q.currentGeneNames) {


### PR DESCRIPTION
## Description

gdc ssm can now show in genomic tk mode, and works in same way as gene mode, please test at http://localhost:3000/?genome=hg38&block=1&position=chr2:208248128-208248783&mds3=GDC

this switches from graphql to rest API, and issue #470 is resolved as a result of this change
if proven all works, can revert #609 to allow genomic option in gdc view

all unic and CI pass, all matrix/hiercluster examples work


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
