### PR TITLE
new helper table2col() to standardize 2-col table making

### DIFF
--- a/client/dom/table2col.js
+++ b/client/dom/table2col.js
@@ -1,8 +1,53 @@
 /*
+make a html table of two columns, for showing a list of key-value pairs.
+1st column shows key in gray text, 2nd column shows value in black text, or arbitrary button/svg etc
+as rows are added, as soon as table width exceeds a limit, it auto scrolls
+
+to create new table, do:
+
+	const table = table2col({holder})
+
+when a new row needs to be added, do:
+
+	const [td1,td2] = table.addRow()
+	td1.text('Key')
+	td2.text('Value')
+
+
+arg{}
+	.holder
+	.margin todo
+*/
+export function table2col(arg) {
+	const scrollDiv = arg.holder.append('div').style('max-width', '80vw')
+
+	const table = scrollDiv.append('table').style('margin', '5px 8px').attr('class', 'sja_simpletable')
+	return {
+		scrollDiv,
+		table,
+		addRow: () => {
+			if (table.node().offsetHeight > 500) {
+				scrollDiv
+					.style('height', '450px')
+					.style('resize', 'both')
+					.style('overflow-y', 'scroll')
+					.attr('class', 'sjpp_show_scrollbar')
+			}
+			const tr = table.append('tr')
+			const td1 = tr.append('td').style('padding', '3px').style('color', '#858585')
+			const td2 = tr.append('td')
+			return [td1, td2]
+		}
+	}
+}
+
+/*
 data[ {} ]
 .kvlst[]
 .k
 .v
+
+deprecated, replace with above
 */
 export function make_table_2col(holder, data, overlen) {
 	const color = '#9e9e9e'
@@ -14,44 +59,22 @@ export function make_table_2col(holder, data, overlen) {
 	for (const i of data) {
 		const tr = table.append('tr')
 		if (i.kvlst) {
-			tr.append('td')
-				.attr('rowspan', i.kvlst.length)
-				.style('padding', '3px')
-				.style('color', color)
-				.html(i.k)
-			tr.append('td')
-				.style('padding', '3px')
-				.style('color', color)
-				.html(i.kvlst[0].k)
-			tr.append('td')
-				.style('padding', '3px')
-				.html(i.kvlst[0].v)
+			tr.append('td').attr('rowspan', i.kvlst.length).style('padding', '3px').style('color', color).html(i.k)
+			tr.append('td').style('padding', '3px').style('color', color).html(i.kvlst[0].k)
+			tr.append('td').style('padding', '3px').html(i.kvlst[0].v)
 			for (let j = 1; j < i.kvlst.length; j++) {
 				const tr2 = table.append('tr')
-				tr2
-					.append('td')
-					.style('padding', '3px')
-					.style('color', color)
-					.html(i.kvlst[j].k)
-				tr2
-					.append('td')
-					.style('padding', '3px')
-					.html(i.kvlst[j].v)
+				tr2.append('td').style('padding', '3px').style('color', color).html(i.kvlst[j].k)
+				tr2.append('td').style('padding', '3px').html(i.kvlst[j].v)
 			}
 		} else {
-			tr.append('td')
-				.attr('colspan', 2)
-				.style('padding', '3px')
-				.style('color', color)
-				.html(i.k)
+			tr.append('td').attr('colspan', 2).style('padding', '3px').style('color', color).html(i.k)
 			const td = tr.append('td').style('padding', '3px')
 			if (overlen && i.v.length > overlen) {
 				td.html(i.v.substr(0, overlen - 3) + ' ...&raquo;')
 					.attr('class', 'sja_clbtext')
 					.on('click', () => {
-						td.html(i.v)
-							.classed('sja_clbtext', false)
-							.on('click', null)
+						td.html(i.v).classed('sja_clbtext', false).on('click', null)
 					})
 			} else {
 				td.html(i.v)

--- a/client/src/block.tk.bam.gdc.js
+++ b/client/src/block.tk.bam.gdc.js
@@ -8,7 +8,7 @@ import { addGeneSearchbox, string2variant } from '#dom/genesearch'
 import { Menu } from '#dom/menu'
 import { Tabs } from '../dom/toggleButtons'
 import { renderTable } from '#dom/table'
-import { make_table_2col } from '#dom/table2col'
+import { table2col } from '../dom/table2col'
 
 /*
 
@@ -401,15 +401,15 @@ export async function bamsliceui({
 			}
 			gdc_args.bam_files.push(file)
 
-			const rows = []
+			const table = table2col({ holder: baminfo_table })
 			for (const row of baminfo_rows) {
-				rows.push({
-					k: row.title,
-					v: row.url ? `<a href=${row.url}${onebam.file_uuid} target=_blank>${onebam[row.key]}</a>` : onebam[row.key]
-				})
+				const [td1, td2] = table.addRow()
+				td1.text(row.title)
+				td2.html(
+					row.url ? `<a href=${row.url}${onebam.file_uuid} target=_blank>${onebam[row.key]}</a>` : onebam[row.key]
+				)
 				file.about.push({ k: row.title, v: onebam[row.key] })
 			}
-			make_table_2col(baminfo_table, rows)
 		}
 
 		function update_multifile_table(files) {


### PR DESCRIPTION
## Description

a straightforward html table that auto scrolls when tall enough

replaces grid layout used in mds3 item/sample table, which is complex and has this defect (clicking from sunburst)
<img width="330" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/c97dba03-0735-4897-8741-f0b08cda3807">


replaces the old make_table_2col(), did it in gdc bam slicing ui and later will fix additional places


test at http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC,
and http://localhost:3000/?gdcbamslice=1&gdc_id=00493087-9d9d-40ca-86d5-936f1b951c93_wxs_gdc_realn.bam&gdc_var=chr2:g.208248388C%3ET

ui should look the same as before
mds3 and bam slicing ui tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
