### PR TITLE
feat: Mds3 track uses simpler radio buttons to toggle between view mo…

### DIFF
--- a/client/dom/numericAxis.js
+++ b/client/dom/numericAxis.js
@@ -1,5 +1,4 @@
 import { keyupEnter } from '#src/client'
-//import {make_radios} from './radiobuttons.js'
 
 /*
 configure numeric axis

--- a/client/dom/radiobutton.js
+++ b/client/dom/radiobutton.js
@@ -17,10 +17,12 @@
 .inputName
 	common Name of <input>, use random number if not given
 */
+
+let nameSuffix = 0
+
 export function make_radios(arg) {
 	const { holder, options, callback, styles } = arg
-	let nameSuffix = 0
-	const inputName = arg.inputName || 'dom-radio-' + nameSuffix++
+	const inputName = arg.inputName || 'pp-dom-radio-' + nameSuffix++
 
 	const divs = holder
 		.selectAll()

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -4,6 +4,7 @@ import { itemtable } from './itemtable'
 import { makelabel, positionLeftlabelg } from './leftlabel'
 import { to_textfile } from '#dom/downloadTextfile'
 import { Tabs } from '../dom/toggleButtons'
+import { make_radios } from '../dom/radiobutton'
 import { rangequery_rglst } from './tk'
 import { samples2columnsRows, block2source } from './sampletable'
 import { dt2label, mclass, dtsnvindel, dtsv, dtfusionrna } from '#shared/common'
@@ -89,6 +90,7 @@ function menu_variants(tk, block) {
 		.append('div')
 		.text('List')
 		.attr('class', 'sja_menuoption')
+		.style('border-radius', '0px')
 		.on('click', () => {
 			listSkewerData(tk, block)
 		})
@@ -97,6 +99,7 @@ function menu_variants(tk, block) {
 		tk.menutip.d
 			.append('div')
 			.text('Cancel highlight')
+			.style('border-radius', '0px')
 			.attr('class', 'sja_menuoption')
 			.on('click', () => {
 				delete tk.skewer.hlssmid
@@ -124,6 +127,7 @@ function menu_variants(tk, block) {
 				.append('div')
 				.text('Collapse')
 				.attr('class', 'sja_menuoption')
+				.style('border-radius', '0px')
 				.on('click', () => {
 					fold_glyph(tk.skewer.data, tk)
 					tk.menutip.hide()
@@ -133,6 +137,7 @@ function menu_variants(tk, block) {
 				.append('div')
 				.text('Expand')
 				.attr('class', 'sja_menuoption')
+				.style('border-radius', '0px')
 				.on('click', () => {
 					settle_glyph(tk, block)
 					tk.menutip.hide()
@@ -145,6 +150,7 @@ function menu_variants(tk, block) {
 			.append('div')
 			.text(tk.skewer.hideDotLabels ? 'Show all variant labels' : 'Hide all variant labels')
 			.attr('class', 'sja_menuoption')
+			.style('border-radius', '0px')
 			.on('click', () => {
 				tk.skewer.hideDotLabels = !tk.skewer.hideDotLabels
 				tk.load()
@@ -158,6 +164,7 @@ function menu_variants(tk, block) {
 			.append('div')
 			.text('Download')
 			.attr('class', 'sja_menuoption')
+			.style('border-radius', '0px')
 			.on('click', () => {
 				downloadVariants(tk, block)
 				tk.menutip.hide()
@@ -239,28 +246,26 @@ function mayAddSkewerModeOption(tk, block) {
 		return
 	}
 	// there are more than 1 mode, print name of current mode
-	tk.menutip.d
-		.append('div')
-		.style('margin', '10px 10px 3px 10px')
-		.style('font-size', '.7em')
-		.text(getViewmodeName(tk.skewer.viewModes.find(n => n.inuse)))
-	// show available modes
-	for (const n of tk.skewer.viewModes) {
-		if (n.inuse) continue
-		// a mode not in use; make option to switch to it
-		tk.menutip.d
-			.append('div')
-			.text(getViewmodeName(n))
-			.attr('class', 'sja_menuoption')
-			.on('click', () => {
-				for (const i of tk.skewer.viewModes) i.inuse = false
-				n.inuse = true
-				tk.menutip.hide()
-				may_render_skewer({ skewer: tk.skewer.rawmlst }, tk, block)
-				positionLeftlabelg(tk, block)
-				tk._finish()
-			})
+	const options = []
+	for (const [idx, v] of tk.skewer.viewModes.entries()) {
+		const o = {
+			label: getViewmodeName(v),
+			value: idx
+		}
+		if (v.inuse) o.checked = true
+		options.push(o)
 	}
+	make_radios({
+		holder: tk.menutip.d.append('div').style('margin', '10px'),
+		options,
+		callback: async idx => {
+			for (const i of tk.skewer.viewModes) i.inuse = false
+			tk.skewer.viewModes[idx].inuse = true
+			may_render_skewer({ skewer: tk.skewer.rawmlst }, tk, block)
+			positionLeftlabelg(tk, block)
+			tk._finish()
+		}
+	})
 }
 
 function getViewmodeName(n) {

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -918,6 +918,7 @@ function render_axis(tk, nm, block) {
 				.d.append('div')
 				.text('Cancel')
 				.attr('class', 'sja_menuoption')
+				.style('border-radius', '0px')
 				.on('click', () => {
 					tk.menutip.hide()
 					nm.inuse = false

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -1704,9 +1704,7 @@ function configPanel(tk, block) {
 			callback: v => {
 				tk.asPaired = v
 				loadTk(tk, block)
-			},
-			inputName: 'show-reads-radios' /* Fix for show reads and strictness radio 
-			buttons operating independently */
+			}
 		})
 	}
 	{
@@ -1767,9 +1765,7 @@ function configPanel(tk, block) {
 			callback: v => {
 				tk.strictness = v
 				loadTk(tk, block)
-			},
-			inputName: 'strictness-radios' /* Fix for show reads and strictness radio 
-			buttons operating independently */
+			}
 		})
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Mds3 track uses simpler radio buttons to toggle between view modes such as lollipop and occurrence


### PR DESCRIPTION
…des such as lollipop and occurrence

## Description

applies to gdc and non-gdc ds. radiobuttons are more understandable than the old menu options like below:
<img width="195" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/2c476788-4066-4a24-beb1-471a365ae5e6">

also fixed a bug in make_radio() and fixed its use in bam tk config ui
all mds3 tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
