### PR TITLE
fix: display total number of mutations on disco plot

### DIFF
--- a/client/plots/disco/DiscoRenderer.ts
+++ b/client/plots/disco/DiscoRenderer.ts
@@ -37,8 +37,11 @@ export class DiscoRenderer {
 			controlsDiv,
 			viewModel.settings.label.prioritizeGeneLabelsByGeneSets,
 			viewModel.settings.label.showPrioritizeGeneLabelsByGeneSets,
-			viewModel.filteredSnvDataLength,
-			viewModel.svnDataLength,
+			viewModel.settings.label.prioritizeGeneLabelsByGeneSets &&
+				viewModel.settings.label.showPrioritizeGeneLabelsByGeneSets
+				? viewModel.filteredSnvDataLength
+				: viewModel.snvDataLength,
+			viewModel.snvDataLength,
 			viewModel.genesetName
 		)
 

--- a/client/plots/disco/data/MutationTypes.ts
+++ b/client/plots/disco/data/MutationTypes.ts
@@ -1,7 +1,0 @@
-export enum MutationTypes {
-	SNV = 1,
-	FUSION = 2,
-	CNV = 4,
-	SV = 5,
-	LOH = 10
-}

--- a/client/plots/disco/label/LabelsMapper.ts
+++ b/client/plots/disco/label/LabelsMapper.ts
@@ -6,10 +6,10 @@ import MLabel from './MLabel.ts'
 import MutationTooltip from '#plots/disco/label/MutationTooltip.ts'
 import Settings from '#plots/disco/Settings.ts'
 import FusionColorProvider from '#plots/disco/fusion/FusionColorProvider.ts'
-import { MutationTypes } from '#plots/disco/data/MutationTypes.ts'
 import FusionTooltip from '#plots/disco/fusion/FusionTooltip.ts'
 import CnvTooltip from '#plots/disco/cnv/CnvTooltip.ts'
 import CnvColorProvider from '#plots/disco/cnv/CnvColorProvider.ts'
+import { dtsnvindel, dtfusionrna } from '#shared/common'
 
 export default class LabelsMapper {
 	private settings: Settings
@@ -29,7 +29,7 @@ export default class LabelsMapper {
 		const outerRadius = innerRadius + this.settings.rings.labelsToLinesDistance
 
 		data.forEach(data => {
-			if (data.dt == MutationTypes.SNV) {
+			if (data.dt == dtsnvindel) {
 				const startAngle = this.calculateStartAngle(data.chr, data.position)
 				const endAngle = this.calculateEndAngle(data.chr, data.position)
 
@@ -48,7 +48,7 @@ export default class LabelsMapper {
 				)
 			}
 
-			if (data.dt == MutationTypes.FUSION) {
+			if (data.dt == dtfusionrna) {
 				const color = FusionColorProvider.getColor(data.chrA, data.chrB)
 				if (data.geneA) {
 					const startAngleSource = this.calculateStartAngle(data.chrA, data.posA)

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -18,6 +18,7 @@ export default class ViewModel {
 	settings: Settings
 	svnDataLength: number
 	filteredSnvDataLength: number
+	snvDataLength
 	genesetName: string
 
 	constructor(
@@ -27,7 +28,8 @@ export default class ViewModel {
 		fusions: Array<Fusion>,
 		filteredSnvDataLength: number,
 		svnDataLength: number,
-		genesetName: string
+		genesetName: string,
+		snvDataLength: number
 	) {
 		this.settings = settings
 		this.rings = rings
@@ -49,6 +51,7 @@ export default class ViewModel {
 		this.legendHeight = this.calculateLegendHeight(legend)
 		this.svnDataLength = svnDataLength
 		this.filteredSnvDataLength = filteredSnvDataLength
+		this.snvDataLength = snvDataLength
 	}
 
 	getElements(ringType: RingType): Array<Arc> {

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -3,23 +3,9 @@ import Reference from '#plots/disco/chromosome/Reference.ts'
 import DataMapper from '#plots/disco/data/DataMapper.ts'
 import Settings from '#plots/disco/Settings.ts'
 import ViewModelProvider from './ViewModelProvider.ts'
+import { dtsnvindel, dtfusionrna } from '#shared/common'
 
 export class ViewModelMapper {
-	static dtNums = [2, 5, 4, 10, 1, 'exonic', 'non-exonic']
-
-	static dtAlias = {
-		1: 'snv', //
-		2: 'sv', //'fusionrna',
-		3: 'geneexpression',
-		4: 'cnv',
-		5: 'sv',
-		6: 'snv', //'itd',
-		7: 'snv', //'del',
-		8: 'snv', //'nloss',
-		9: 'snv', //'closs',
-		10: 'loh'
-	}
-
 	static snvClassLayer = {
 		M: 'exonic',
 		E: 'exonic',
@@ -61,6 +47,11 @@ export class ViewModelMapper {
 		const genesetName = genome?.geneset?.[0] ? genome.geneset[0].name : ''
 
 		const data: Array<any> = opts.args.data
+
+		console.log(
+			'data',
+			data.filter(i => i.dt == dtsnvindel)
+		)
 
 		const reference = new Reference(this.settings, chrSizes, chromosomesOverride)
 

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -48,11 +48,6 @@ export class ViewModelMapper {
 
 		const data: Array<any> = opts.args.data
 
-		console.log(
-			'data',
-			data.filter(i => i.dt == dtsnvindel)
-		)
-
 		const reference = new Reference(this.settings, chrSizes, chromosomesOverride)
 
 		const dataMapper = new DataMapper(this.settings, reference, sampleName, prioritizedGenes)

--- a/client/plots/disco/viewmodel/ViewModelProvider.ts
+++ b/client/plots/disco/viewmodel/ViewModelProvider.ts
@@ -16,6 +16,7 @@ import Labels from '#plots/disco/label/Labels.ts'
 import NonExonicSnvArcsMapper from '#plots/disco/snv/NonExonicSnvArcsMapper.ts'
 import LohArcMapper from '#plots/disco/loh/LohArcMapper.ts'
 import Rings from '#plots/disco/ring/Rings.ts'
+import { dtsnvindel } from '#shared/common'
 
 export default class ViewModelProvider {
 	private settings: Settings
@@ -151,8 +152,9 @@ export default class ViewModelProvider {
 			legend,
 			fusions,
 			dataHolder.filteredSnvData.length,
-			dataHolder.snvData.length - dataHolder.nonExonicSnvData.length,
-			this.genesetName
+			dataHolder.snvData.length,
+			this.genesetName,
+			data.filter(i => i.dt == dtsnvindel).length
 		)
 	}
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- display total number of mutations on disco plot


### PR DESCRIPTION
## Description

Displays the total number snv mutations in the disco plot filter check box label. 

Filters both nonexonic and exonic snv mutations by census genes if only show mutations clicked. 

Deleted MutationType enum as suggested by @siosonel. Now mutation types are imported from "#shared/common" script. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
