### PR TITLE
gdc MAF: increase to listing 2000 files and 100Mb default limit

### DIFF
--- a/server/routes/gdc.maf.ts
+++ b/server/routes/gdc.maf.ts
@@ -3,15 +3,28 @@ import path from 'path'
 import got from 'got'
 import serverconfig from '#src/serverconfig.js'
 
-const apihost = process.env.PP_GDC_HOST || 'https://api.gdc.cancer.gov'
-const maxFileNumber = 2000
+/*
+this route lists available gdc MAF files based on user's cohort filter
+and return them to client to be shown in a table for selection
+*/
+
+const apihost = process.env.PP_GDC_HOST || 'https://api.gdc.cancer.gov' // to switch to serverconfig export
+
+const maxFileNumber = 1000 // determines max number of files to return to client
+// preliminary testing:
+// 36s for 1000 (87Mb)
+// 78s for 2000 (177Mb)
+// if safe to increase to 2000, maybe fast when this runs in gdc env
+
 const allowedWorkflowType = 'Aliquot Ensemble Somatic Variant Merging and Masking'
-const maxTotalSizeCompressed = serverconfig.features.gdcMafMaxFileSize || 100000000 // 100Mb
+
+// change to 400 so it won't limit number of files; should keep this setting as a safeguard; also it's fast to check file size (.5s in gdc.mafBuild.ts)
+export const maxTotalSizeCompressed = serverconfig.features.gdcMafMaxFileSize || 400000000 // 400Mb
 
 export const api = {
 	endpoint: 'gdc/maf',
 	methods: {
-		get: {
+		all: {
 			init,
 			request: {
 				typeId: 'GdcMafRequest'

--- a/server/routes/gdc.maf.ts
+++ b/server/routes/gdc.maf.ts
@@ -4,9 +4,9 @@ import got from 'got'
 import serverconfig from '#src/serverconfig.js'
 
 const apihost = process.env.PP_GDC_HOST || 'https://api.gdc.cancer.gov'
-const maxFileNumber = 1000
+const maxFileNumber = 2000
 const allowedWorkflowType = 'Aliquot Ensemble Somatic Variant Merging and Masking'
-const maxTotalSizeCompressed = serverconfig.features.gdcMafMaxFileSize || 50000000 // 50Mb
+const maxTotalSizeCompressed = serverconfig.features.gdcMafMaxFileSize || 100000000 // 100Mb
 
 export const api = {
 	endpoint: 'gdc/maf',

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -87,7 +87,7 @@ async function getFileLstUnderSizeLimit(lst: string[]) {
 			op: 'in',
 			content: { field: 'file_id', value: lst }
 		},
-		size: 1000,
+		size: 10000,
 		fields: 'file_size'
 	}
 	const headers = { 'Content-Type': 'application/json', Accept: 'application/json' }


### PR DESCRIPTION
## Description

trying to assess if feasible to double the memory limit from 50Mb to 100Mb. the bigger size the more practical it is. please test what's the memory use and amount of time taken. make sure to remove the `features.gdcMafMaxFileSize` setting on your side

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
