### PR TITLE
Ordering by numeric values in scatter tooltip

### DIFF
--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -33,7 +33,15 @@ export function setInteractivity(self) {
 		})
 		samples.sort((s1, s2) => {
 			if (!('sampleId' in s1)) return 1
-			if (s1.category.includes(mclass.WT.label) || s1.category.includes(mclass.Blank.label)) return 1
+			if (self.config.colorTW) {
+				if (self.config.colorTW.term.type == 'categorical') {
+					if (s1.category.includes(mclass.WT.label) || s1.category.includes(mclass.Blank.label)) return 1
+				} // numeric
+				else {
+					if (s1.category < s2.category) return -1
+					else if (s1.category > s2.category) return 1
+				}
+			}
 			if (s1.shape.includes(mclass.WT.label) || s1.shape.includes(mclass.Blank.label)) return 1
 
 			return -1

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -36,6 +36,8 @@ export function setInteractivity(self) {
 			if (self.config.term) {
 				//coordinates from terms
 				if (s1.x < s2.x) return -1
+				if (s1.x > s2.x) return 1
+				if (s1.y < s2.y) return -1
 				return 1
 			}
 

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -191,7 +191,7 @@ export function setInteractivity(self) {
 							}
 						}
 					}
-					let chars = node.value.length
+					let chars = node.value.toString().length
 					const width = chars * 9 + 60
 					const svg = td.append('svg').attr('width', width).attr('height', '25px')
 					const g = svg.append('g').attr('transform', 'translate(10, 14)')

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -33,6 +33,12 @@ export function setInteractivity(self) {
 		})
 		samples.sort((s1, s2) => {
 			if (!('sampleId' in s1)) return 1
+			if (self.config.term) {
+				//coordinates from terms
+				if (s1.x < s2.x) return -1
+				return 1
+			}
+
 			if (self.config.colorTW) {
 				if (self.config.colorTW.term.type == 'categorical') {
 					if (s1.category.includes(mclass.WT.label) || s1.category.includes(mclass.Blank.label)) return 1


### PR DESCRIPTION
## Description

Fixes #1025 and adds more logic to order numeric samples.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
