### PR TITLE
refactor adding termsPerRequest to getAnnotatedSampleData

### DIFF
--- a/client/plots/matrix.data.js
+++ b/client/plots/matrix.data.js
@@ -133,6 +133,7 @@ export async function setData(_data) {
 		filter0: this.state.filter0,
 		loadingDiv: this.dom.loadingDiv,
 		maxGenes: this.state.config.settings.matrix.maxGenes
+		//termsPerRequest: 100
 	}
 
 	if (this.chartType == 'hierCluster') {

--- a/client/plots/matrix.data.js
+++ b/client/plots/matrix.data.js
@@ -133,7 +133,7 @@ export async function setData(_data) {
 		filter0: this.state.filter0,
 		loadingDiv: this.dom.loadingDiv,
 		maxGenes: this.state.config.settings.matrix.maxGenes
-		//termsPerRequest: 100
+		//termsPerRequest: 100 // this is just for testing
 	}
 
 	if (this.chartType == 'hierCluster') {

--- a/client/plots/profileRadarFacility.js
+++ b/client/plots/profileRadarFacility.js
@@ -46,8 +46,8 @@ class profileRadarFacility extends profilePlot {
 
 	getPercentage2(d) {
 		if (!d) return null
-		const maxScore = this.data.lst[0]?.[d.maxScore.id]?.value //Max score has the same value for all the samples on this module
-		let scores = this.data.lst.map(sample => (sample[d.score.id]?.value / maxScore) * 100)
+		const maxScore = this.data.lst[0]?.[d.maxScore.$id]?.value //Max score has the same value for all the samples on this module
+		let scores = this.data.lst.map(sample => (sample[d.score.$id]?.value / maxScore) * 100)
 		scores.sort((s1, s2) => s1 - s2)
 		const middle = Math.floor(scores.length / 2)
 		const score = scores.length % 2 !== 0 ? scores[middle] : (scores[middle - 1] + scores[middle]) / 2

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -649,7 +649,7 @@ export class TermdbVocab extends Vocab {
     .terms[{}]     an array of termWrapper objects
         tw.$id       id to disambugate when multiple terms
                      with the same ID are in terms[], such as in matrix plot
-    	
+    .termsPerRequest When provided, a request includes the number of terms specified, improving the response times
     Returns 
     {
         lst: [{
@@ -735,7 +735,7 @@ export class TermdbVocab extends Vocab {
 			const tws = termsToUpdate.splice(0, termsPerRequest)
 			// request data for one term each time, empty list and break while loop
 			// possible to change to pop two or more each time
-			const copies = tws.map(tw => this.getTwMinCopy(tw))
+			const copies = tws.map(this.getTwMinCopy)
 			const init = {
 				headers,
 				credentials: 'include',

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -729,12 +729,10 @@ export class TermdbVocab extends Vocab {
 
 		let numResponses = 0
 		if (opts.loadingDiv) opts.loadingDiv.html('Updating data ...')
-		let termsPerRequest = opts.termsPerRequest || 10
+		let termsPerRequest = opts.termsPerRequest || 1
 		// fetch the annotated sample for each term
 		let index = 0
 		while (index < termsToUpdate.length) {
-			termsPerRequest = index + termsPerRequest > termsToUpdate.length ? termsToUpdate.length - index : termsPerRequest
-
 			const tws = termsToUpdate.slice(index, index + termsPerRequest)
 			// request data for one term each time, empty list and break while loop
 			// possible to change to pop two or more each time

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1201,7 +1201,7 @@ function getTerms2update(lst, count) {
 		n = lst.length
 	while (i < n) {
 		i++
-		const tw = lst.pop()
+		const tw = lst.unshift()
 		if (copies.find(c => c.term.id === tw.term.id || c.term.name === tw.term.name)) tws.push(tw) // move to end of array
 		else copies.push(tw)
 		if (copies.length >= count) break

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -752,7 +752,12 @@ export class TermdbVocab extends Vocab {
 			}
 			if (opts.filter0) init.body.filter0 = opts.filter0 // avoid adding "undefined" value
 			if (opts.isHierCluster) init.body.isHierCluster = true // special arg from matrix, just pass along
-
+			if (tws.find(tw => tw.term.id && currentGeneNames?.length)) {
+				/* term.id is present meaning term is dictionary term (FIXME if this is unreliable)
+				and there are gene terms, add this to limit to mutated cases
+				*/
+				init.body.currentGeneNames = currentGeneNames
+			}
 			promises.push(
 				dofetch3('termdb', init).then(data => {
 					if (data.error) throw data.error

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -731,9 +731,8 @@ export class TermdbVocab extends Vocab {
 		if (opts.loadingDiv) opts.loadingDiv.html('Updating data ...')
 		let termsPerRequest = opts.termsPerRequest || 1
 		// fetch the annotated sample for each term
-		let index = 0
-		while (index < termsToUpdate.length) {
-			const tws = termsToUpdate.slice(index, index + termsPerRequest)
+		while (termsToUpdate.length) {
+			const tws = termsToUpdate.splice(0, termsPerRequest)
 			// request data for one term each time, empty list and break while loop
 			// possible to change to pop two or more each time
 			const copies = tws.map(tw => this.getTwMinCopy(tw))
@@ -802,7 +801,6 @@ export class TermdbVocab extends Vocab {
 					if (opts.loadingDiv) opts.loadingDiv.html(`Updating data (${numResponses}/${promises.length}) ...`)
 				})
 			)
-			index += termsPerRequest
 		}
 		try {
 			if (opts.loadingDiv) opts.loadingDiv.html(`Updating data (0/${promises.length})`)

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -649,7 +649,8 @@ export class TermdbVocab extends Vocab {
     .terms[{}]     an array of termWrapper objects
         tw.$id       id to disambugate when multiple terms
                      with the same ID are in terms[], such as in matrix plot
-    .termsPerRequest When provided, a request includes the number of terms specified, improving the response times
+    .termsPerRequest optional, a number greater than 1;
+	                 when provided, a request includes the number of terms specified, improving the response times
     Returns 
     {
         lst: [{

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1195,15 +1195,25 @@ function mayFillInCategory2samplecount4term(tw, lst, termdbConfig) {
 	}
 }
 
+/*
+from input list of termwrappers, get up to "count" number of unique tw and return in new list; original lst will be truncated
+copies cannot contain multiple tw of same term, e.g. matrix can have same age term in two rows as continuous and discrete, having 2 age tw will confuse downstream code of getAnnotatedSampleData()
+duplicating tw will be pushed to the end of lst and are returned one at a time
+*/
 function getTerms2update(lst, count) {
 	const copies = []
 	let i = 0,
 		n = lst.length
 	while (i < n) {
 		i++
-		const tw = lst.unshift()
-		if (copies.find(c => c.term.id === tw.term.id || c.term.name === tw.term.name)) tws.push(tw) // move to end of array
-		else copies.push(tw)
+		const tw = lst.shift() // first of lst[]
+		if (copies.find(c => c.term.id === tw.term.id || c.term.name === tw.term.name)) {
+			// tw already exists in copies[], do not put into copies[], put it at the end of lst to be processed later
+			lst.push(tw)
+		} else {
+			// tw is not in copies[], which should only contain up to "count" of unique terms
+			copies.push(tw)
+		}
 		if (copies.length >= count) break
 	}
 	return copies

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -706,7 +706,7 @@ export class TermdbVocab extends Vocab {
 		const refs = { byTermId: _refs.byTermId || {}, bySampleId: _refs.bySampleId || {} }
 		const promises = []
 		const samplesToShow = new Set()
-		const termsToUpdate = opts.terms.slice()
+		let termsToUpdate = opts.terms.slice()
 
 		/************** tricky
         need list of gene names of current geneVariant terms from opts.terms[]
@@ -731,7 +731,10 @@ export class TermdbVocab extends Vocab {
 		if (opts.loadingDiv) opts.loadingDiv.html('Updating data ...')
 		let termsPerRequest = opts.termsPerRequest || 1
 		// fetch the annotated sample for each term
+		const pendingTerms = []
 		while (termsToUpdate.length) {
+			const duplicates = termsToUpdate.filter((tw, index) => termsToUpdate.indexOf(tw) !== index)
+			pendingTerms.push(...duplicates)
 			const tws = termsToUpdate.splice(0, termsPerRequest)
 			// request data for one term each time, empty list and break while loop
 			// possible to change to pop two or more each time
@@ -756,6 +759,10 @@ export class TermdbVocab extends Vocab {
 				and there are gene terms, add this to limit to mutated cases
 				*/
 				init.body.currentGeneNames = currentGeneNames
+			}
+			if (termsToUpdate.length == 0 && pendingTerms.length > 0) {
+				termsToUpdate = pendingTerms
+				pendingTerms = []
 			}
 			promises.push(
 				dofetch3('termdb', init).then(data => {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1207,7 +1207,13 @@ function getTerms2update(lst, count) {
 	while (i < n) {
 		i++
 		const tw = lst.shift() // first of lst[]
-		if (copies.find(c => c.term.id === tw.term.id || c.term.name === tw.term.name)) {
+		if (
+			copies.find(
+				c =>
+					c.term.type === tw.term.type &&
+					((('id' in c.term || 'id' in tw.term) && c.term.id === tw.term.id) || c.term.name === tw.term.name)
+			)
+		) {
 			// tw already exists in copies[], do not put into copies[], put it at the end of lst to be processed later
 			lst.push(tw)
 		} else {


### PR DESCRIPTION
## Description

Removed getAnnotatedSampleDataSimple and used instead getAnnotatedSampleData that now receives a termsPerRequestParameter. Please check.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
