### PR TITLE
load premade matrix map by name

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -120,11 +120,6 @@ export async function getPlotConfig(opts = {}, app) {
 		}
 	}
 
-	if (opts.name) {
-		// should be identifier of premade plot; try to load
-		config = await app.vocabApi.getMatrixByName(opts.name)
-	}
-
 	const s = config.settings
 	const fontsize = Math.max(s.matrix.rowh + s.matrix.rowspace - 3 * s.matrix.rowlabelpad, 12)
 
@@ -144,6 +139,12 @@ export async function getPlotConfig(opts = {}, app) {
 
 	const overrides = app.vocabApi.termdbConfig.matrix || {}
 	copyMerge(config.settings.matrix, overrides.settings)
+
+	if (opts.name) {
+		// name should be identifier of a premade plot from the datase; load and override into config{}
+		// TODO err handling
+		copyMerge(config, await app.vocabApi.getMatrixByName(opts.name))
+	}
 
 	const os = opts?.settings?.matrix
 	if (os) {

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -15,7 +15,7 @@ export async function getPlotConfig(opts = {}, app) {
 		Mutations: 'Mutations'
 	}
 
-	let config = {
+	const config = {
 		// data configuration
 		termgroups: [],
 		samplegroups: [],
@@ -141,9 +141,11 @@ export async function getPlotConfig(opts = {}, app) {
 	copyMerge(config.settings.matrix, overrides.settings)
 
 	if (opts.name) {
-		// name should be identifier of a premade plot from the datase; load and override into config{}
-		// TODO err handling
-		copyMerge(config, await app.vocabApi.getMatrixByName(opts.name))
+		// name should be identifier of a premade plot from the datase; load data of the premade plot and override into config{}
+		const data = await app.vocabApi.getMatrixByName(opts.name)
+		if (!data) throw 'error from getMatrixByName()'
+		if (data.error) throw data.error
+		copyMerge(config, data)
 	}
 
 	const os = opts?.settings?.matrix

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -15,7 +15,7 @@ export async function getPlotConfig(opts = {}, app) {
 		Mutations: 'Mutations'
 	}
 
-	const config = {
+	let config = {
 		// data configuration
 		termgroups: [],
 		samplegroups: [],
@@ -118,6 +118,11 @@ export async function getPlotConfig(opts = {}, app) {
 				barh: 32 // default bar height for continuous terms
 			}
 		}
+	}
+
+	if (opts.name) {
+		// should be identifier of premade plot; try to load
+		config = await app.vocabApi.getMatrixByName(opts.name)
 	}
 
 	const s = config.settings

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -749,7 +749,7 @@ export class TermdbVocab extends Vocab {
 			}
 			if (opts.filter0) init.body.filter0 = opts.filter0 // avoid adding "undefined" value
 			if (opts.isHierCluster) init.body.isHierCluster = true // special arg from matrix, just pass along
-			if (copies.find(tw => tw.term.id && currentGeneNames?.length)) {
+			if (this.vocab.dslabel == 'GDC' && copies.find(tw => tw.term.id) && currentGeneNames?.length) {
 				/* term.id is present meaning term is dictionary term (FIXME if this is unreliable)
 				and there are gene terms, add this to limit to mutated cases
 				*/

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -342,11 +342,10 @@ function trigger_genesetByTermId(q, res, tdb) {
 
 async function get_matrix(q, req, res, ds, genome) {
 	if (q.getPlotDataByName) {
-		// send back the config for pre-built matrix plot
-		if (!ds.cohort.matrixplots) throw 'ds.cohort.matrixplots missing for the dataset'
-		if (!ds.cohort.matrixplots.plots) throw 'ds.cohort.matrixplots.plots missing for the dataset'
+		// send back the config for premade matrix plot
+		if (!ds.cohort?.matrixplots?.plots) throw 'ds.cohort.matrixplots.plots missing for the dataset'
 		const plot = ds.cohort.matrixplots.plots.find(p => p.name === q.getPlotDataByName)
-		if (!plot) throw `plot name: q.getPlotDataByName=${getPlotDataByName} missing in ds.cohort.matrixplots.plots`
+		if (!plot) throw 'invalid name of premade matrix plot' // invalid name could be attack string, avoid returning it so it won't be printed in html
 		res.send(plot.matrixConfig)
 		return
 	}


### PR DESCRIPTION
## Description

did this fix to load a premade map by [direct link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:[{%22chartType%22:%22matrix%22,%22name%22:%22Matrix%20plot%22}]}), just like scatter plot
to make it easier to debug the actual issue

err handling bug fixed so it will report wrong plot name or lack of support on backend
we will keep the GDC hardcode in this PR and try to tackle it in next branch


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
