### PR TITLE
detect if bins exists for a numeric term, before processing its legend data (#1089)

### DIFF
--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -65,9 +65,28 @@ export function initWholeGenomeControls(hic: any, self: any) {
 	addLabel(resolutionRow, 'RESOLUTION')
 	self.dom.controlsDiv.resolution = resolutionRow.append('td').append('span')
 
+	// const matrixTypeRow = menuTable.append('tr')
+	// addLabel(matrixTypeRow, 'matrix type') //Display option is another name? Data type? No label?
+	// self.dom.controlsDiv.matrixType = matrixTypeRow.append('td').text('Observed')
+
+	// Drop down
 	const matrixTypeRow = menuTable.append('tr')
-	addLabel(matrixTypeRow, 'matrix type') //Display option is another name? Data type? No label?
-	self.dom.controlsDiv.matrixType = matrixTypeRow.append('td').text('Observed')
+	addLabel(matrixTypeRow, 'MATRIX TYPE')
+	const matrixTypeDropdownContainer = matrixTypeRow.append('td')
+	const matrixTypeDropdown = matrixTypeDropdownContainer.append('select').on('change', () => {
+		const selectedOption = matrixTypeDropdown.property('value')
+		// Handle the selected option as needed
+		console.log('Selected Matrix Type:', selectedOption)
+	})
+
+	// Options for the dropdown
+	const matrixTypeOptions = ['Observed', 'Expected', 'Observed/Expected']
+
+	// Populate dropdown with options
+	matrixTypeOptions.forEach(option => {
+		matrixTypeDropdown.append('option').attr('value', option.toLowerCase()).text(option)
+	})
+	self.dom.controlsDiv.matrixType = matrixTypeDropdownContainer // Update the reference to the dropdown container
 
 	const viewRow = menuTable.append('tr')
 	addLabel(viewRow, 'VIEW')


### PR DESCRIPTION
* detect if bins exists for a numeric term, before processing its legend data

* force a hardcoded bar color for continuous mode term values

* remove any legendValueFilter.lst entries that correspond to an edited tw, to avoid stale/hidden filters being used

## Description



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
