### PR TITLE
fix: Numeric termsetting edit UI allows a term to be default with custom binconfig

### DIFF
--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -327,9 +327,10 @@ function renderTypeInputs(self) {
 	const div = self.dom.bins_div.append('div').style('margin', '10px')
 
 	if (self.term.bins.default.type == 'custom-bin') {
-		/* this term's default bin is custom bin! it's without a regular binning config
-		cannot render regular/custom bin switchtab, as regular ui will break without all necessary config data
-		only render custom bin ui
+		/*
+		this term's default bin is custom bin! it's without a regular binning config
+		cannot render regular/custom bin switchtab, as regular ui will break without that part of data
+		only render custom bin ui, and do not allow switching from custom to regular bin size
 		*/
 		self.q.type = 'custom-bin'
 		setqDefaults(self)

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -324,16 +324,30 @@ export function renderBoundaryInclusionInput(self) {
 }
 
 function renderTypeInputs(self) {
-	// toggle switch
-	const bins_div = self.dom.bins_div
 	const div = self.dom.bins_div.append('div').style('margin', '10px')
+
+	if (self.term.bins.default.type == 'custom-bin') {
+		/* this term's default bin is custom bin! it's without a regular binning config
+		cannot render regular/custom bin switchtab, as regular ui will break without all necessary config data
+		only render custom bin ui
+		*/
+		self.q.type = 'custom-bin'
+		setqDefaults(self)
+		setDensityPlot(self)
+		renderCustomBinInputs(self, div)
+		return
+	}
+
+	if (self.term.bins.default.type != 'regular-bin')
+		throw 'self.bins.default.type is neither regular-bin or custom-bin, cannot render ui'
+
+	// toggle switch between regular and custom
 	const tabs: any = [
 		{
 			active: self.q.type == 'regular-bin',
 			label: 'Same bin size',
 			callback: async (event, tab) => {
 				self.q.type = 'regular-bin'
-				self.dom.bins_div = bins_div
 				setqDefaults(self)
 				setDensityPlot(self)
 				if (!tabs[0].isInitialized) {
@@ -347,7 +361,6 @@ function renderTypeInputs(self) {
 			label: 'Varying bin sizes',
 			callback: async (event, tab) => {
 				self.q.type = 'custom-bin'
-				self.dom.bins_div = bins_div
 				setqDefaults(self)
 				setDensityPlot(self)
 				if (!tabs[1].isInitialized) {

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -14,6 +14,7 @@ Tests:
 	Numerical term: range boundaries
 	Numerical term: fixed bins
 	Numerical term: float custom bins
+	Numerical term.bins.default.type=custom-bin
 	Numerical term: toggle menu - 4 options
 	Numerical term: toggle menu - 2 options
 	Numerical term: toggle menu - 1 options
@@ -638,18 +639,58 @@ tape('Numerical term: float custom bins', async test => {
 
 	await opts.pill.main(opts.tsData)
 
-	// create enter event to use for inputs of bin edit menu
-	const enter_event = new KeyboardEvent('keyup', {
-		code: 'Enter',
-		key: 'Enter',
-		keyCode: 13
-	})
-
 	await opts.pillMenuClick('Edit')
 	const tip = opts.pill.Inner.dom.tip
 	const lines = tip.d.select('.binsize_g').node().querySelectorAll('line')
 	test.equal(lines.length, 2, 'should have 2 lines')
 	tip.hide()
+})
+
+tape('Numerical term.bins.default.type=custom-bin', async test => {
+	test.timeoutAfter(3000)
+	test.plan(2)
+
+	// define a custom bin and apply to both term.bins and tw.q
+	const binconfig = {
+		type: 'custom-bin',
+		lst: [
+			{
+				startunbounded: true,
+				startinclusive: false,
+				stopinclusive: true,
+				stop: 5,
+				label: '<=5 years old'
+			},
+			{
+				stopunbounded: true,
+				startinclusive: false,
+				stopinclusive: true,
+				start: 5,
+				label: '> 5 years old'
+			}
+		]
+	}
+
+	const copy = JSON.parse(JSON.stringify(termjson.agedx))
+	copy.bins.default = binconfig
+
+	const opts = await getOpts({ tsData: { term: copy, q: binconfig } })
+
+	await opts.pill.main(opts.tsData)
+
+	await opts.pillMenuClick('Edit')
+	const tip = opts.pill.Inner.dom.tip
+	const lines = tip.d.select('.binsize_g').node().querySelectorAll('line')
+	test.equal(lines.length, 1, 'should have 1 line')
+
+	const tabs = tip.d.select('.sj-toggle-button').node()
+	test.notOk(tabs, 'No switch tab should be rendered for Same/Varying bin size')
+	// if the "Same bin size/Varying bin size" toggle tab is still rendered, click "Same bin size" tab will break!! thus test to avoid it
+
+	if (test._ok) {
+		opts.holder.remove()
+		tip.d.remove()
+	}
 })
 
 tape('Numerical term: toggle menu - 4 options', async test => {

--- a/release.txt
+++ b/release.txt
@@ -1,3 +1,2 @@
-
-Features:
--in hierCluster, allow to filter samples by clicking legend items
+Fixes:
+- Numeric termsetting edit UI allows a term to be default with custom bin config and will not switch to regular binning


### PR DESCRIPTION
## Description

closes #1091 
problem was spotted with [gdc age term](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22case.disease_type%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}],%22divideBy%22:{%22id%22:%22case.demographic.gender%22}}]}). click Age row label > Edit, the `Same/Varying bin size` toggle no longer appears (it broke in master)
<img width="399" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/2d5e5aeb-86f7-41ed-928f-bcdcc2f050cf">

new CI test added
all CI and unit pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
