### PR TITLE
Converted color to hex so that is read properly by the input control

### DIFF
--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -2,6 +2,7 @@ import { filterJoin, getFilterItemByTag } from '#filter'
 import { renderTable } from '#dom/table'
 import { to_svg } from '#src/client'
 import roundValue from '../../server/shared/roundValue'
+import { rgb } from 'd3'
 
 export function setInteractivity(self) {
 	self.download = () => {
@@ -115,7 +116,7 @@ export function setInteractivity(self) {
 	}
 
 	self.addEditColorToMenu = function (plot) {
-		const color = plot.color
+		const color = rgb(plot.color).formatHex()
 		const input = self.app.tip.d
 			.append('div')
 			.attr('class', 'sja_sharp_border')


### PR DESCRIPTION
## Description

When testing overlay using pnet gender, color was not read properly. Fixed now.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
