### PR TITLE
Disable term group menu for hierCluster gene expression term group,an…

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1462,6 +1462,12 @@ function setTermGroupActions(self) {
 			{ label: 'Sort', callback: self.showSortMenu },
 			{ label: 'Delete', callback: self.removeTermGroup }
 		]
+		if (self.chartType == 'hierCluster') {
+			// Do not show the 'Edit' and 'Sort' option in the term group menu for hierCluster term groups
+			// for hiercluster gene expression term group, the term group menu won't be shown after clicking the term group label.
+			menuOptions.splice(0, 1)
+			menuOptions.splice(1, 1)
+		}
 
 		holder
 			.append('div')
@@ -1765,7 +1771,17 @@ function setLabelDragEvents(self, prefix) {
 		}
 		//const cls = event.target.className?.baseVal || event.target.parentNode.className?.baseVal || ''
 		if (event.target.innerHTML.includes('grouped by')) return
-		if (event.target.tagName === 'text') select(event.target).style('fill', 'blue')
+		if (event.target.tagName === 'text') {
+			if (
+				self.chartType == 'hierCluster' &&
+				event.target.__data__.grp.name == self.config.settings.hierCluster.termGroupName
+			) {
+				// do not change color when hovering over for hierCluster gene expression term group name label
+				// as the term group menu is disabled for hierCluster gene expression term group for now
+				return
+			}
+			select(event.target).style('fill', 'blue')
+		}
 		if (!self.dragged) return
 		// TODO: why is the element-bound __data__ (t) not provided as a second argument by d3??
 		self.hovered = event.target.__data__
@@ -1873,7 +1889,11 @@ function setLabelDragEvents(self, prefix) {
 			delete self.dragged
 		} else if (prefix == 'term') {
 			self.showTermMenu(event)
-		} else {
+		} else if (
+			self.chartType !== 'hierCluster' ||
+			event.target.__data__.grp.name !== self.config.settings.hierCluster.termGroupName
+		) {
+			// Do not show the term group menu for hierCluster gene expression term group
 			self.showTermGroupMenu(event)
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
 
+Fixes:
+-Disable the term group menu for hierCluster gene expression term group, and remove the 'edit' and 'sort' options for other hier cluster term groups 


### PR DESCRIPTION
…d remove the 'edit' and 'sort' options for other hiercluster term groups

## Description



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
