### PR TITLE
Do not show the termsetting reuse menu

### DIFF
--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -45,7 +45,7 @@ export function get$id() {
 }
 
 const defaultOpts: { menuOptions: string; menuLayout: string } = {
-	menuOptions: '{edit,reuse}', // ['edit', 'replace', 'save', 'remove'],
+	menuOptions: 'edit', // ['edit', 'replace', 'save', 'remove', 'reuse'],
 	menuLayout: 'vertical'
 }
 
@@ -262,7 +262,8 @@ export class TermSetting {
 		if (!o.menuOptions) o.menuOptions = defaultOpts.menuOptions
 		// support legacy options, now converted to use glob-style pattern matching
 		if (o.menuOptions == 'all') o.menuOptions = '*'
-		for (const opt of ['edit', 'reuse', 'replace', 'remove']) {
+		// skip reuse option
+		for (const opt of ['edit' /*'reuse'*/, , 'replace', 'remove']) {
 			if (minimatch(opt, o.menuOptions)) return // matched at least one menu option
 		}
 		throw `no matches found for termsetting opts.menuOptions='${o.menuOptions}'`
@@ -601,9 +602,9 @@ function setInteractivity(self) {
 
 		// Restored the reuse menu option for now, due to failing integration tests that will require more code changes to fix
 		// Instead of deleting the reuse code, may move the Reuse to the edit menu for recovering saved grouping/bin config
-		if (minimatch('reuse', self.opts.menuOptions)) {
-			options.push({ label: 'Reuse', callback: self.showReuseMenu } as opt)
-		}
+		// if (minimatch('reuse', self.opts.menuOptions)) {
+		// 	options.push({ label: 'Reuse', callback: self.showReuseMenu } as opt)
+		// }
 
 		if (minimatch('replace', self.opts.menuOptions)) {
 			options.push({ label: 'Replace', callback: self.showTree } as opt)

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -263,7 +263,7 @@ export class TermSetting {
 		// support legacy options, now converted to use glob-style pattern matching
 		if (o.menuOptions == 'all') o.menuOptions = '*'
 		// skip reuse option
-		for (const opt of ['edit' /*'reuse'*/, , 'replace', 'remove']) {
+		for (const opt of ['edit', /*'reuse',*/ 'replace', 'remove']) {
 			if (minimatch(opt, o.menuOptions)) return // matched at least one menu option
 		}
 		throw `no matches found for termsetting opts.menuOptions='${o.menuOptions}'`

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -147,7 +147,7 @@ tape('menuOptions', async test => {
 	test.equal(tipd.style('display'), 'block', 'tip is shown upon clicking pill')
 	test.equal(
 		tipd.selectAll('.sja_menuoption').size(),
-		4,
+		3,
 		`the menu should show 3 buttons for edit/replace/remove when menuOptions='all'`
 	)
 
@@ -162,15 +162,15 @@ tape('menuOptions', async test => {
 	pilldiv.click()
 	test.equal(
 		tipd.selectAll('.sja_menuoption').size(),
-		2,
-		`should show 2 menu options when menuOptions is empty/undefined`
+		1,
+		`should show 1 menu option when menuOptions is empty/undefined`
 	)
 
 	opts.pill.Inner.dom.tip.hide()
 	test.end()
 })
 
-tape('Reuse option', async test => {
+tape.skip('Reuse option', async test => {
 	test.timeoutAfter(5000)
 	test.plan(11)
 
@@ -335,7 +335,11 @@ tape('Categorical term', async test => {
 	const tip = opts.pill.Inner.dom.tip
 
 	//check menu buttons on first menu
-	test.equal(tip.d.selectAll('.sja_menuoption.sja_sharp_border').size(), 2, 'Should have 2 buttons for group config')
+	test.equal(
+		tip.d.selectAll('.sja_menuoption.sja_sharp_border').size(),
+		1,
+		'Should have 1 menu option for group config'
+	)
 
 	// check menu buttons on category menu
 	/** Although 27 values, annotations only available for 10. */
@@ -1066,7 +1070,7 @@ tape('Custom vocabulary', async test => {
 	pilldiv.click()
 	const tipd = opts.pill.Inner.dom.tip.d
 	test.equal(tipd.style('display'), 'block', 'tip is shown upon clicking pill')
-	test.equal(tipd.selectAll('.sja_menuoption').size(), 4, 'the menu should show 4 buttons for edit/replace/remove')
+	test.equal(tipd.selectAll('.sja_menuoption').size(), 3, 'the menu should show 3 buttons for edit/replace/remove')
 
 	const replaceBtn = tipd
 		.selectAll('.sja_menuoption')


### PR DESCRIPTION
## Description
Fixes https://github.com/stjude/proteinpaint/issues/315 - should verify with Yutaka that this option is okay to remove since he  had requested this feature before.

NOTE: There are unrelated failing tests in the barchart integration spec.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
