### PR TITLE
make matrix/hiercluster control label show with "Title Case"

### DIFF
--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -281,21 +281,21 @@ class HierCluster extends Matrix {
 						]
 					},
 					{
-						label: `Column dendrogram height`,
+						label: `Column Dendrogram Height`,
 						title: `The maximum height to render the column dendrogram`,
 						type: 'number',
 						chartType: 'hierCluster',
 						settingsKey: 'yDendrogramHeight'
 					},
 					{
-						label: `Row dendrogram width`,
+						label: `Row Dendrogram Width`,
 						title: `The maximum width to render the row dendrogram`,
 						type: 'number',
 						chartType: 'hierCluster',
 						settingsKey: 'xDendrogramHeight'
 					},
 					{
-						label: `Z-score cap`,
+						label: `Z-Score Cap`,
 						title: `Cap the z-score scale to not exceed this absolute value`,
 						type: 'number',
 						chartType: 'hierCluster',

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -62,7 +62,10 @@ export class MatrixControls {
 						title: `Limit the number of displayed ${l.samples}`,
 						type: 'number',
 						chartType: 'matrix',
-						settingsKey: 'maxSample'
+						settingsKey: 'maxSample',
+						getDisplayStyle(plot) {
+							return plot.chartType == 'hierCluster' ? 'none' : 'table-row'
+						}
 					},
 					{
 						label: `Group ${l.Samples} By`,
@@ -109,7 +112,7 @@ export class MatrixControls {
 							{
 								label: `Hits`,
 								value: 'hits',
-								title: `Sort by the total number of variants for every sample in the group`
+								title: `Sort by the total number of variants for every ${l.sample} in the group`
 							}
 						],
 						getDisplayStyle(plot) {
@@ -117,7 +120,7 @@ export class MatrixControls {
 						}
 					},
 					{
-						label: `${l.Sample} Group Label Max Length`,
+						label: `${l.Sample} Group Label Character Limit`,
 						title: `Truncate the ${l.sample} group label if it exceeds this maximum number of characters`,
 						type: 'number',
 						chartType: 'matrix',
@@ -127,7 +130,7 @@ export class MatrixControls {
 						}
 					},
 					{
-						label: `${l.Sample} Label Max Length`,
+						label: `${l.Sample} Label Character Limit`,
 						title: `Truncate the ${l.sample} label if it exceeds this maximum number of characters`,
 						type: 'number',
 						chartType: 'matrix',
@@ -172,14 +175,14 @@ export class MatrixControls {
 					// 	processInput: tw => {},
 					// },
 					{
-						label: `Row Group Label Max Length`,
+						label: `Row Group Label Character Limit`,
 						title: `Truncate the row group label if it exceeds this maximum number of characters`,
 						type: 'number',
 						chartType: 'matrix',
 						settingsKey: 'termGrpLabelMaxChars'
 					},
 					{
-						label: `Row Label Max Length`,
+						label: `Row Label Character Limit`,
 						title: `Truncate the row label if it exceeds this maximum number of characters`,
 						type: 'number',
 						chartType: 'matrix',
@@ -195,13 +198,12 @@ export class MatrixControls {
 							{
 								label: 'Stacked',
 								value: '',
-								title: 'Show stacked rectangles in the same matrix cell to render variants for the same sample and gene'
+								title: `Show stacked rectangles in the same matrix cell to render variants for the same ${l.sample} and gene`
 							},
 							{
 								label: 'Oncoprint',
 								value: 'oncoprint',
-								title:
-									'Show overlapping rectangles in the same matrix cell to render variants for the same sample and gene'
+								title: `Show overlapping rectangles in the same matrix cell to render variants for the same ${l.sample} and gene`
 							}
 						],
 						styles: { padding: 0, 'padding-right': '10px', margin: 0 }
@@ -328,7 +330,7 @@ export class MatrixControls {
 							},
 							{
 								label: 'Background Color',
-								title: 'Set the background color when there are no alterations or annotation data for a sample',
+								title: `Set the background color when there are no alterations or annotation data for a ${l.sample}`,
 								type: 'color',
 								chartType: 'matrix',
 								settingsKey: 'cellbg',
@@ -337,7 +339,7 @@ export class MatrixControls {
 							},
 							{
 								label: `Use Canvas If # ${l.sample} Exceeds`,
-								title: 'Switch from SVG to canvas rendering when the number of samples exceeds this number',
+								title: `Switch from SVG to canvas rendering when the number of ${l.samples} exceeds this number`,
 								type: 'number',
 								chartType: 'matrix',
 								settingsKey: 'svgCanvasSwitch',

--- a/client/plots/matrix.layout.js
+++ b/client/plots/matrix.layout.js
@@ -188,7 +188,7 @@ export function setLabelsAndScales() {
 
 		t.label = t.tw.label || t.tw.term.name
 		if (t.label.length > s.rowlabelmaxchars) t.label = t.label.slice(0, s.rowlabelmaxchars) + '...'
-		const termGroupName = self.config?.settings.hierCluster?.termGroupName
+		const termGroupName = this.config?.settings.hierCluster?.termGroupName
 		if (s.samplecount4gene && t.tw.term.type.startsWith('gene') && (!termGroupName || t.grp.name !== termGroupName)) {
 			const count =
 				s.samplecount4gene === 'abs'


### PR DESCRIPTION
## Description
Closes https://github.com/stjude/proteinpaint/issues/1111
- make matrix/hiercluster control label casing consistent;
- do not show the max # samples control input for hiercluster


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
