### PR TITLE
Fix to make cluster to reflect zScoreCap changes

### DIFF
--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -369,9 +369,9 @@ class HierCluster extends Matrix {
 							gene: tw.term.name,
 							chr: tw.term.chr,
 							pos: `${tw.term.start}-${tw.term.stop}`,
-							value,
-							// compute color for each cell based on its numeric value
-							color: this.geneExpValues.scale((value - -zScoreCap) / (zScoreCap * 2))
+							value
+							// the color will be computed in matrix.cells, so that
+							// it can get updated even when there are no nonsetting state diff
 						}
 					]
 				}
@@ -429,6 +429,11 @@ class HierCluster extends Matrix {
 		const [min, max] = [-absMax, absMax]
 		// what's purpose of assigning this.geneExpValues{}, to signal something to matrix code?
 		this.geneExpValues = { scale, min, max }
+	}
+
+	getValueColor(value) {
+		const zScoreCap = this.settings.hierCluster.zScoreCap
+		return this.geneExpValues.scale((value - -zScoreCap) / (zScoreCap * 2))
 	}
 
 	async renderDendrogram() {

--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -739,7 +739,7 @@ export async function getPlotConfig(opts = {}, app) {
 		colorScale: { domain: [0, 0.5, 1], range: ['blue', 'white', 'red'] }
 	}
 	const overrides = app.vocabApi.termdbConfig.hierCluster || {}
-	copyMerge(config.settings.hierCluster, overrides.settings)
+	copyMerge(config.settings.hierCluster, overrides.settings, opts.settings?.hierCluster || {})
 
 	// okay to validate state here?
 	{

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -74,7 +74,7 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 	cell.label = value.label || self.mclass[value.class].label
 	const colorFromq = tw.q?.values && tw.q?.values[value.class]?.color
 	// may overriden by a color scale by dt, if applicable below
-	cell.fill = colorFromq || value.color || self.mclass[value.class]?.color
+	cell.fill = self.getValueColor?.(value.value) || colorFromq || value.color || self.mclass[value.class]?.color
 	cell.class = value.class
 	cell.value = value
 

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -159,24 +159,25 @@ export class Matrix {
 			this.dom.loadingDiv.html('').style('display', '').style('position', 'absolute').style('left', '45%')
 
 			// may skip data requests when changes are not expected to affect the request payload
-			//if (this.stateDiff.nonsettings) {
-			// reset highlighted dendrogram children to black when data request is triggered
-			delete this.clickedChildren
+			if (this.stateDiff.nonsettings) {
+				// reset highlighted dendrogram children to black when data request is triggered
+				delete this.clickedChildren
 
-			const promises = []
-			// get the data
-			if (this.setHierClusterData) promises.push(this.setHierClusterData())
-			promises.push(this.setData())
-			this.dom.loadingDiv.html('Processing data ...')
-			await Promise.all(promises)
-			applyLegendValueFilter(this)
-			if (this.combineData) this.combineData()
-			// tws in the config may be filled-in based on applicable server response data;
-			// these filled-in config, such as tw.term.values|category2samplecount, will need to replace
-			// the corresponding tracked state values in the app store, without causing unnecessary
-			// dispatch notifications, so use app.save()
-			this.app.save({ type: 'plot_edit', id: this.id, config: this.config })
-			//}
+				const promises = []
+				// get the data
+				if (this.setHierClusterData) promises.push(this.setHierClusterData())
+				promises.push(this.setData())
+				this.dom.loadingDiv.html('Processing data ...')
+				await Promise.all(promises)
+				applyLegendValueFilter(this)
+				if (this.combineData) this.combineData()
+				// tws in the config may be filled-in based on applicable server response data;
+				// these filled-in config, such as tw.term.values|category2samplecount, will need to replace
+				// the corresponding tracked state values in the app store, without causing unnecessary
+				// dispatch notifications, so use app.save()
+				this.app.save({ type: 'plot_edit', id: this.id, config: this.config })
+			}
+
 			this.dom.loadingDiv.html('Updating ...').style('display', '')
 			// may skip term or sample ordering when there are
 			// no relevant state/config/setting changes
@@ -197,6 +198,7 @@ export class Matrix {
 			}
 
 			this.setLayout()
+			if (this.setHierColorScale) this.setHierColorScale(this.hierClusterData.clustering)
 			this.serieses = this.getSerieses(this.data)
 
 			// render the data

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -159,24 +159,24 @@ export class Matrix {
 			this.dom.loadingDiv.html('').style('display', '').style('position', 'absolute').style('left', '45%')
 
 			// may skip data requests when changes are not expected to affect the request payload
-			if (this.stateDiff.nonsettings) {
-				// reset highlighted dendrogram children to black when data request is triggered
-				delete this.clickedChildren
+			//if (this.stateDiff.nonsettings) {
+			// reset highlighted dendrogram children to black when data request is triggered
+			delete this.clickedChildren
 
-				const promises = []
-				// get the data
-				if (this.setHierClusterData) promises.push(this.setHierClusterData())
-				promises.push(this.setData())
-				this.dom.loadingDiv.html('Processing data ...')
-				await Promise.all(promises)
-				applyLegendValueFilter(this)
-				if (this.combineData) this.combineData()
-				// tws in the config may be filled-in based on applicable server response data;
-				// these filled-in config, such as tw.term.values|category2samplecount, will need to replace
-				// the corresponding tracked state values in the app store, without causing unnecessary
-				// dispatch notifications, so use app.save()
-				this.app.save({ type: 'plot_edit', id: this.id, config: this.config })
-			}
+			const promises = []
+			// get the data
+			if (this.setHierClusterData) promises.push(this.setHierClusterData())
+			promises.push(this.setData())
+			this.dom.loadingDiv.html('Processing data ...')
+			await Promise.all(promises)
+			applyLegendValueFilter(this)
+			if (this.combineData) this.combineData()
+			// tws in the config may be filled-in based on applicable server response data;
+			// these filled-in config, such as tw.term.values|category2samplecount, will need to replace
+			// the corresponding tracked state values in the app store, without causing unnecessary
+			// dispatch notifications, so use app.save()
+			this.app.save({ type: 'plot_edit', id: this.id, config: this.config })
+			//}
 			this.dom.loadingDiv.html('Updating ...').style('display', '')
 			// may skip term or sample ordering when there are
 			// no relevant state/config/setting changes


### PR DESCRIPTION
## Description

I found that this if 
`if (this.stateDiff.nonsettings) {}`
prevents the cluster to react to the zScoreCap changes. This is a possible fix, if stateDiff can be fixed, please corrrect it. I just wanted to pointed out the issue and a possible solution.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
