### PR TITLE
Hic.oe1: Server side code for o,e,o/e options

### DIFF
--- a/server/routes/hicdata.ts
+++ b/server/routes/hicdata.ts
@@ -60,7 +60,6 @@ function handle_hicdata(q: HicdataRequest) {
 		if (e) reject({ error: 'illegal file name' })
 
 		const par = [
-			// TODO add option for observed/oe
 			q.oevalues || 'observed',
 			q.nmeth || 'NONE',
 			file,

--- a/server/routes/hicdata.ts
+++ b/server/routes/hicdata.ts
@@ -61,6 +61,7 @@ function handle_hicdata(q: HicdataRequest) {
 
 		const par = [
 			// TODO add option for observed/oe
+			q.oevalues || 'observed',
 			q.nmeth || 'NONE',
 			file,
 			q.pos1,

--- a/server/shared/types/routes/hicdata.ts
+++ b/server/shared/types/routes/hicdata.ts
@@ -1,5 +1,5 @@
 export type HicdataRequest = {
-	/** oe values  */
+	/** specify whether observed, expected, or observed/expected(o/e) values.  */
 	oevalues: string
 
 	/** HiC file path from tp/ */

--- a/server/shared/types/routes/hicdata.ts
+++ b/server/shared/types/routes/hicdata.ts
@@ -1,4 +1,7 @@
 export type HicdataRequest = {
+	/** oe values  */
+	oevalues: string
+
 	/** HiC file path from tp/ */
 	file?: string
 	/** Remote HiC file URL */

--- a/server/shared/types/routes/hicdata.ts
+++ b/server/shared/types/routes/hicdata.ts
@@ -1,5 +1,5 @@
 export type HicdataRequest = {
-	/** specify whether observed, expected, or observed/expected(o/e) values.  */
+	/** Value is the 1st parameter of straw tool, and can only use these specific strings but not anything else. */
 	oevalues: 'observed' | 'expected' | 'oe'
 
 	/** HiC file path from tp/ */

--- a/server/shared/types/routes/hicdata.ts
+++ b/server/shared/types/routes/hicdata.ts
@@ -1,6 +1,6 @@
 export type HicdataRequest = {
 	/** specify whether observed, expected, or observed/expected(o/e) values.  */
-	oevalues: string
+	oevalues: 'observed' | 'expected' | 'oe'
 
 	/** HiC file path from tp/ */
 	file?: string


### PR DESCRIPTION
## Description
New variable named oevalues added to the server/routes/hicdata.ts, which can take options of 'observed', 'expected', and 'oe' for running the 'straw' command.  

- It helps to calculate the observed, expected, and oe values for the whole genome as well as for chromosomes.
- By default the option in the straw is 'observed'.

Test it by: (http://localhost:3000/?genome=hg38&hicfile=proteinpaint_demo/hg38/hic/hic_demo_v9.hic&enzyme=MboI) and other demo files.
 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
