### PR TITLE
improve code to generate Allele similarity link and menu content

### DIFF
--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -787,6 +787,10 @@ function may_render_variant(data, tk, block) {
 		}
 
 		// Depicting reference allele
+		if (!ref_color) {
+			// This can happen when the reference group is not present
+			ref_color = '#47C8FF'
+		}
 		if (tk.is_same_ref == true) {
 			html_text.push(
 				'<svg width="10" height="10" style = "display:inline-block;"><rect width="10" height="10" style="fill:' +


### PR DESCRIPTION
## Description

closes #1125 
allele similarity label won't be created in repeat when tk updates; its position is moved to tk.gright and will stay when panning. menu contents are simplified
the hyperlink shows for non-gdc tk and is hidden for gdc
tested to work for bam slicing

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
