### PR TITLE
Hic.5: Switched hic horizontal view and detail view rendering order

### DIFF
--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -281,6 +281,5 @@ function switchview(hic: any, self: any) {
 		blocklazyload(self.horizontalview.args)
 	}
 
-	if (self.chrpairview.chrx && self.chrpairview.chry) showBtns(self, self.chrpairview.chrx, self.chrpairview.chry)
-	else showBtns(self)
+	showBtns(self)
 }

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -42,7 +42,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 
 	const normalizationRow = menuTable.append('tr')
 	addLabel(normalizationRow, 'NORMALIZATION')
-	self.dom.controlsDiv.nmeth = normalizationRow.append('td') //placeholder until data is returned from server
+	self.dom.controlsDiv.nmeth = normalizationRow.append('td').attr('class', 'sjpp-nmeth-select')
 	makeNormMethDisplay(hic, self)
 
 	const cutoffRow = menuTable.append('tr')
@@ -66,7 +66,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 	self.dom.controlsDiv.resolution = resolutionRow.append('td').append('span')
 
 	const matrixTypeRow = menuTable.append('tr')
-	addLabel(matrixTypeRow, 'matrix type') //Display option is another name? Data type? No label?
+	addLabel(matrixTypeRow, 'matrix type')
 	self.dom.controlsDiv.matrixType = matrixTypeRow.append('td').text('Observed')
 
 	const viewRow = menuTable.append('tr')
@@ -77,10 +77,10 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('padding-right', '5px')
 		.style('display', 'block')
 
-	self.dom.controlsDiv.wholegenomebutton = self.dom.controlsDiv.viewBtnDiv
+	self.dom.controlsDiv.genomeViewBtn = self.dom.controlsDiv.viewBtnDiv
 		.append('button')
 		.style('display', 'none')
-		.html('&#8592; Genome')
+		.html('&#8810; Genome')
 		.on('click', () => {
 			self.dom.controlsDiv.view.text('Genome')
 			self.dom.controlsDiv.zoomDiv.style('display', 'none')
@@ -90,7 +90,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 			switchview(hic, self)
 		})
 
-	self.dom.controlsDiv.chrpairviewbutton = self.dom.controlsDiv.viewBtnDiv
+	self.dom.controlsDiv.chrpairViewBtn = self.dom.controlsDiv.viewBtnDiv
 		.append('button')
 		.style('display', 'none')
 		.on('click', () => {
@@ -104,7 +104,12 @@ export function initWholeGenomeControls(hic: any, self: any) {
 	self.dom.controlsDiv.horizontalViewBtn = self.dom.controlsDiv.viewBtnDiv
 		.append('button')
 		.style('display', 'none')
-		.html('Horizontal View &#8594;')
+		.html('Horizontal View &#8810;')
+
+	self.dom.controlsDiv.detailViewBtn = self.dom.controlsDiv.viewBtnDiv
+		.append('button')
+		.style('display', 'none')
+		.html('Detailed View &#8811;')
 
 	self.dom.controlsDiv.zoomDiv = menuTable.append('tr').style('display', 'none')
 	addLabel(self.dom.controlsDiv.zoomDiv, 'ZOOM')
@@ -229,15 +234,15 @@ function setmaxv(self: any, maxv: number) {
  */
 function switchview(hic: any, self: any) {
 	if (self.inwholegenome) {
-		console.log(self.wholegenome.nmeth)
 		nmeth2select(hic, self.wholegenome)
 		self.dom.plotDiv.xAxis.selectAll('*').remove()
 		self.dom.plotDiv.yAxis.selectAll('*').remove()
 		self.dom.plotDiv.plot.selectAll('*').remove()
 		self.dom.plotDiv.plot.node().appendChild(self.wholegenome.svg.node())
-		self.dom.controlsDiv.wholegenomebutton.style('display', 'none')
-		self.dom.controlsDiv.chrpairviewbutton.style('display', 'none')
-		self.dom.controlsDiv.horizontalViewBtn.style('display', 'none')
+		self.dom.controlsDiv.genomeViewBtn.style('display', 'none')
+		self.dom.controlsDiv.chrpairViewBtn.style('display', 'none')
+		self.dom.controlsDiv.horizonalViewBtn.style('display', 'none')
+		self.dom.controlsDiv.detailViewBtn.style('display', 'none')
 		self.dom.controlsDiv.inputBpMaxv.property('value', self.wholegenome.bpmaxv)
 		self.dom.controlsDiv.resolution.text(bplen(self.wholegenome.resolution) + ' bp')
 	} else if (self.inchrpair) {
@@ -248,9 +253,10 @@ function switchview(hic: any, self: any) {
 		self.dom.plotDiv.xAxis.node().appendChild(self.chrpairview.axisx.node())
 		self.dom.plotDiv.plot.selectAll('*').remove()
 		self.dom.plotDiv.plot.node().appendChild(self.chrpairview.canvas)
-		self.dom.controlsDiv.wholegenomebutton.style('display', 'inline-block')
-		self.dom.controlsDiv.chrpairviewbutton.style('display', 'none')
-		self.dom.controlsDiv.horizontalViewBtn.style('display', 'none')
+		self.dom.controlsDiv.genomeViewBtn.style('display', 'inline-block')
+		self.dom.controlsDiv.chrpairViewBtn.style('display', 'none')
+		self.dom.controlsDiv.horizonalViewBtn.style('display', 'none')
+		self.dom.controlsDiv.detailViewBtn.style('display', 'none')
 		self.dom.controlsDiv.inputBpMaxv.property('value', self.chrpairview.bpmaxv)
 		self.dom.controlsDiv.resolution.text(bplen(self.chrpairview.resolution) + ' bp')
 	}

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -83,7 +83,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.append('button')
 		.style('display', 'none')
 		.style('padding', '2px')
-		.style('margin', '2px 0px')
+		.style('margin-top', '4px')
 		.html('&#8810; Genome')
 		.on('click', () => {
 			self.dom.controlsDiv.view.text('Genome')
@@ -99,7 +99,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.append('button')
 		.style('display', 'none')
 		.style('padding', '2px')
-		.style('margin', '2px 0px')
+		.style('margin', '4px 0px')
 		.on('click', () => {
 			self.dom.controlsDiv.zoomDiv.style('display', 'none')
 			self.inwholegenome = false
@@ -113,7 +113,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.append('button')
 		.style('display', 'none')
 		.style('padding', '2px')
-		.style('margin', '2px 0px')
+		.style('margin', '4px 0px')
 		.html('&#8810; Horizontal View')
 		.on('click', () => {
 			self.inwholegenome = false
@@ -127,7 +127,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.append('button')
 		.style('display', 'none')
 		.style('padding', '2px')
-		.style('margin', '2px 0px')
+		.style('margin', '4px 0px')
 		.html('Detailed View &#8811;')
 
 	self.dom.controlsDiv.zoomDiv = menuTable.append('tr').style('display', 'none')

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -2,6 +2,7 @@ import { bplen } from '#shared/common'
 import { nmeth2select } from './hic.straw'
 import { getdata_chrpair, getdata_detail, getdata_leadfollow, defaultnmeth, showBtns } from './hic.straw'
 import { Elem } from '../../types/d3'
+import blocklazyload from '#src/block.lazyload'
 
 /**
  * Renders control panel for hicstraw app (ie whole genome, chr-chr pair, horizontal and detail views)
@@ -276,7 +277,8 @@ function switchview(hic: any, self: any) {
 		self.dom.controlsDiv.inputBpMaxv.property('value', self.chrpairview.bpmaxv)
 		self.dom.controlsDiv.resolution.text(bplen(self.chrpairview.resolution) + ' bp')
 	} else if (self.inhorizontal) {
-		console.log(self)
+		//TODO: Problem with this is it rerenders. Maybe a way to save the rendering and just show/hide?
+		blocklazyload(self.horizontalview.args)
 	}
 
 	if (self.chrpairview.chrx && self.chrpairview.chry) showBtns(self, self.chrpairview.chrx, self.chrpairview.chry)

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -479,9 +479,33 @@ class Hicstat {
 
 		showBtns(this, chrx, chry)
 
+		// default view span
+		const viewrangebpw = this.chrpairview.resolution! * initialbinnum_detail
+
+		let coordx = Math.max(
+			1,
+			Math.floor((x * this.chrpairview.resolution!) / this.chrpairview.binpx!) - viewrangebpw / 2
+		)
+		let coordy = Math.max(
+			1,
+			Math.floor((y * this.chrpairview.resolution!) / this.chrpairview.binpx!) - viewrangebpw / 2
+		)
+
+		// make sure positions are not out of bounds
+		{
+			const lenx = hic.genome.chrlookup[chrx.toUpperCase()].len
+			if (coordx + viewrangebpw >= lenx) {
+				coordx = lenx - viewrangebpw
+			}
+			const leny = hic.genome.chrlookup[chry.toUpperCase()].len
+			if (coordy + viewrangebpw > leny) {
+				coordy = leny - viewrangebpw
+			}
+		}
+
 		//Similar to the detailview.rglst[0]
-		const regionx = { chr: chrx, start: x, stop: y }
-		const regiony = { chr: chry, start: x, stop: y }
+		const regionx = { chr: chrx, start: coordy, stop: coordx }
+		const regiony = { chr: chry, start: coordy, stop: coordx }
 
 		const tracks = [
 			{

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -168,8 +168,8 @@ class Hicstat {
 		}
 		this.inwholegenome = true
 		this.inchrpair = false
-		this.indetail = false
 		this.inhorizontal = false
+		this.indetail = false
 	}
 
 	async error(err: string | string[]) {
@@ -366,8 +366,8 @@ class Hicstat {
 
 		this.inwholegenome = false
 		this.inchrpair = true
-		this.indetail = false
 		this.inhorizontal = false
+		this.indetail = false
 
 		showBtns(this)
 		this.wholegenome.svg!.remove()
@@ -478,15 +478,15 @@ class Hicstat {
 		this.dom.controlsDiv.view.text('Horizontal')
 		nmeth2select(hic, this.horizontalview)
 
-		//Clear elements created in other views
-		this.dom.plotDiv.xAxis.selectAll('*').remove()
-		this.dom.plotDiv.yAxis.selectAll('*').remove()
+		//Clear elements created in chr pair view
+		this.chrpairview.axisy.remove()
+		this.chrpairview.axisx.remove()
 		this.dom.plotDiv.plot.selectAll('*').remove()
 
-		this.inhorizontal = true
-		this.indetail = false
 		this.inwholegenome = false
 		this.inchrpair = false
+		this.inhorizontal = true
+		this.indetail = false
 
 		showBtns(this, chrx, chry)
 
@@ -578,10 +578,10 @@ class Hicstat {
 		this.dom.controlsDiv.view.text('Detailed')
 		nmeth2select(hic, this.detailview)
 
-		this.inhorizontal = false
-		this.indetail = true
 		this.inwholegenome = false
 		this.inchrpair = false
+		this.inhorizontal = false
+		this.indetail = true
 
 		// const isintrachr = chrx == chry
 		showBtns(this, chrx, chry)

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -97,8 +97,11 @@ type Pane = {
  * Parses input file and renders plot. Whole genome view renders as the default.
  * Clicking on chr-chr svg within the whole genonme view launches the chr-pair view.
  * Clicking anywhere within the chr-pair view launches the horizonal view. The detail view can be launched from the Detailed View button.
+ *
+ * Issues:
+ * - CONFIG menu cutoff in detail view. Elem does not allow overflow
+ *
  * TODOs:
- * - ?maybe make chrx and chry more universal? Not in horizontal/detail/chrpair view objs?
  * - add state-like functionality. Move objs for rendering under self and separate hic input. Add functions for views to operate independently of each other.
  * - Possibly type Pane can be import somewhere??
  */
@@ -387,9 +390,6 @@ class Hicstat {
 
 		showBtns(this)
 		this.wholegenome.svg!.remove()
-
-		this.chrpairview.chrx = chrx
-		this.chrpairview.chry = chry
 
 		const chrxlen = hic.genome.chrlookup[chrx.toUpperCase()].len
 		const chrylen = hic.genome.chrlookup[chry.toUpperCase()].len
@@ -895,6 +895,8 @@ function makewholegenome_chrleadfollow(hic: any, lead: any, follow: any, self: a
 		.attr('x', obj.x)
 		.attr('y', obj.y)
 		.on('click', async () => {
+			self.chrx.chr = lead
+			self.chry.chr = follow
 			await self.init_chrPairView(hic, lead, follow, self)
 		})
 		.on('mouseover', () => {
@@ -1131,8 +1133,8 @@ function tell_firstisx(hic: any, chrx: string, chry: string) {
 }
 
 export async function getdata_chrpair(hic: any, self: any) {
-	const chrx = self.chrpairview.chrx
-	const chry = self.chrpairview.chry
+	const chrx = self.chrx.chr
+	const chry = self.chry.chr
 	const isintrachr = chrx == chry
 	// const chrxlen = hic.genome.chrlookup[chrx.toUpperCase()].len
 	// const chrylen = hic.genome.chrlookup[chry.toUpperCase()].len
@@ -1208,7 +1210,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 /**
  * set normalization method from <select>
  * @param hic
- * @param nmeth
+ * @param v view object
  * @returns
  */
 

--- a/client/tracks/hic/test/hicData.ts
+++ b/client/tracks/hic/test/hicData.ts
@@ -33,6 +33,70 @@ const v8 = {
 	version: 8
 }
 
+const v9 = {
+	version: 9,
+	'Genome ID': 'hg38',
+	Chromosomes: {
+		All: '3088286',
+		chr1: '248956422',
+		chr2: '242193529',
+		chr3: '198295559',
+		chr4: '190214555',
+		chr5: '181538259',
+		chr6: '170805979',
+		chr7: '159345973',
+		chr8: '145138636',
+		chr9: '138394717',
+		chr10: '133797422',
+		chr11: '135086622',
+		chr12: '133275309',
+		chr13: '114364328',
+		chr14: '107043718',
+		chr15: '101991189',
+		chr16: '90338345',
+		chr17: '83257441',
+		chr18: '80373285',
+		chr19: '58617616',
+		chr20: '64444167',
+		chr21: '46709983',
+		chr22: '50818468',
+		chrX: '156040895',
+		chrY: '57227415',
+		chrM: '16569'
+	},
+	chrorder: [
+		'All',
+		'chr1',
+		'chr2',
+		'chr3',
+		'chr4',
+		'chr5',
+		'chr6',
+		'chr7',
+		'chr8',
+		'chr9',
+		'chr10',
+		'chr11',
+		'chr12',
+		'chr13',
+		'chr14',
+		'chr15',
+		'chr16',
+		'chr17',
+		'chr18',
+		'chr19',
+		'chr20',
+		'chr21',
+		'chr22',
+		'chrX',
+		'chrY',
+		'chrM'
+	],
+	bpresolution: [2500000, 1000000, 500000, 250000, 100000, 50000, 25000, 10000, 5000, 2000, 1000, 500, 200, 100],
+	fragresolution: [],
+	normalization: ['INTER_SCALE', 'GW_SCALE', 'VC', 'VC_SQRT', 'SCALE']
+}
+
 export const hicData = {
 	hic: {
 		v8: {
@@ -70,6 +134,11 @@ export const hicData = {
 			fragresolution: v8.fragresolution,
 			normalization: v8.normalization,
 			version: v8.version
+		},
+		v9: {
+			enzyme: 'MboI',
+			nochr: true,
+			fragresolution: v9['Fragment-delimited resolutions']
 		}
 	},
 	serverResponse: {
@@ -108,6 +177,15 @@ export const hicData = {
 			chrorder: v8.fragresolution,
 			normalization: v8.normalization,
 			version: v8.version
+		},
+		v9: {
+			'Base pair-delimited resolutions': v9.bpresolution,
+			Chromosomes: v9.Chromosomes,
+			'Fragment-delimited resolutions': v9.fragresolution,
+			'Genome ID': v9['Genome ID'],
+			chrorder: v9.chrorder,
+			normalization: v9.normalization,
+			version: v9.version
 		}
 	}
 }

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -115,8 +115,6 @@ export type ChrPairView = {
 	axisy: any //dom
 	binpx: number
 	canvas?: any //dom
-	chrx: string
-	chry: string
 	ctx: any //dom
 	data: any
 	/** Normalization method tied to this view. Intended to render independently of other views */
@@ -127,7 +125,12 @@ export type ChrPairView = {
 
 export type HorizontalView = {
 	/** args for runpp(). Define this later */
-	args: any
+	args: {
+		hostURL: string
+		jwt: any
+		genome: string
+		nobox: boolean | number
+	}
 	/** Nonfunctional at the moment */
 	nmeth: string
 }

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -68,10 +68,12 @@ export type HicstrawDom = {
 		viewBtnDiv: Elem
 		/** Returns user to the whole genome view from the chr-chr or detailed view*/
 		wholegenomebutton: Elem
-		/** Returns user to the chr-chr pair view from the detailed view */
+		/** Returns user to the chr-chr pair view from the any other view besides whole genome */
 		chrpairviewbutton: Elem
-		/** Opens a pop up of the 2 chr genome browser view in the detailed view */
+		/** Returns user to the 2 chr genome browser view (subpanels) in the detailed view */
 		horizontalViewBtn: Elem
+		/** Displays the detail x/y view, replacing the horizontal view */
+		detailViewBtn: Elem
 		/** Div for zoom buttons visible in the detailed view */
 		zoomDiv: Elem
 		/** Zoom in button whilst in the detailed view */
@@ -137,13 +139,13 @@ export type DetailView = {
 	}
 	/** Normalization method tied to this view. Intended to render independently of other views */
 	nmeth: string
-	xb: DetailedViewAxis
-	yb: DetailedViewAxis
+	xb: DetailViewAxis
+	yb: DetailViewAxis
 	/** Calculated resolution. Displayed in menu for user */
 	resolution: number
 }
 
-export type DetailedViewAxis = {
+export type DetailViewAxis = {
 	leftheadw: number
 	rightheadw: number
 	lpad: number

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -67,9 +67,9 @@ export type HicstrawDom = {
 		/** Self explanatory */
 		viewBtnDiv: Elem
 		/** Returns user to the whole genome view from the chr-chr or detailed view*/
-		wholegenomebutton: Elem
+		genomeViewBtn: Elem
 		/** Returns user to the chr-chr pair view from the any other view besides whole genome */
-		chrpairviewbutton: Elem
+		chrpairViewBtn: Elem
 		/** Returns user to the 2 chr genome browser view (subpanels) in the detailed view */
 		horizontalViewBtn: Elem
 		/** Displays the detail x/y view, replacing the horizontal view */
@@ -123,6 +123,13 @@ export type ChrPairView = {
 	nmeth: string
 	/** Calculated resolution. Displayed in menu for user */
 	resolution: number
+}
+
+export type HorizontalView = {
+	/** args for runpp(). Define this later */
+	args: any
+	/** Nonfunctional at the moment */
+	nmeth: string
 }
 
 export type DetailView = {

--- a/server/shared/types/routes/hicdata.ts
+++ b/server/shared/types/routes/hicdata.ts
@@ -1,13 +1,11 @@
 export type HicdataRequest = {
 	/** Value is the 1st parameter of straw tool, and can only use these specific strings but not anything else. */
 	oevalues: 'observed' | 'expected' | 'oe'
-
 	/** HiC file path from tp/ */
 	file?: string
 	/** Remote HiC file URL */
 	url?: string // FIXME use ts to enforce that either file or url must be given, abort if none is given
 	/** Position of first locus, in the format of chr:start:stop */
-
 	pos1: string
 	/** Position of second locus, in the format of chr:start:stop */
 	pos2: string // portal code must validate pos1 and pos2 values, to prevent xxx:456-321
@@ -15,20 +13,20 @@ export type HicdataRequest = {
 	resolution: number
 	/** If is in fragment resolution */
 	isfrag?: boolean
-
 	/** Normalization method for the queried data */
 	nmeth: string
-	/** Query data type, define enum of observed/oe/expected */
-	//datatype: string
 	/** Minimum value cutoff */
 	mincutoff: number
 }
 
+/** array of 3 numbers */
 export type Item = [
-	// array of 3 numbers
-	number, // position 1
-	number, // position 2
-	number // inter-loci contact value
+	/** position 1 */
+	number,
+	/** position 2 */
+	number,
+	/** inter-loci contact value */
+	number
 ]
 
 export type HicdataResponse = {


### PR DESCRIPTION
## Description
@xzhou82 and @akanksha-r , this is a draft PR for testing and comments. I've checked a few files and it works fine for me. I'd like to know if either of you can come up with a scenario in which this breaks. 

Changes: 
- After clicking in the chr pair view, the horizontal view appears by default instead of the detailed view.
- A new button for the Detailed View appears in the menu in the horizontal view.
- Likewise the horizontal view button acts as a back button from the detail view. 
- Preliminary work on testing v9 files 
- Code reorganization and consolidation

Test with: 
1. http://localhost:3000/?genome=hg38&hicfile=proteinpaint_demo/hg38/hic/hic_demo_v9.hic&enzyme=MboI
2. http://localhost:3000/?genome=hg38&hicfile=MLL14744.hybrid.hic 
3. Other hic files from http://localhost:3000/url.html


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
