### PR TITLE
matrix: Enable keyboard navigation of menu and control inputs

### DIFF
--- a/client/dom/genesearch.js
+++ b/client/dom/genesearch.js
@@ -132,7 +132,10 @@ export function addGeneSearchbox(arg) {
 
 	let placeholder,
 		width = 150
-	if (arg.geneOnly) {
+
+	if ('placeholder' in arg) {
+		placeholder = arg.placeholder
+	} else if (arg.geneOnly) {
 		placeholder = 'Gene'
 		width = 100 // use shorter width for inputting only one gene name
 	} else {
@@ -232,6 +235,23 @@ export function addGeneSearchbox(arg) {
 					input.value = d.chr + (d.isVariant ? '.' + d.pos + '.' + d.ref + '.' + d.alt : ':' + d.start + '-' + d.stop)
 				}
 				input.blur()
+				return
+			}
+
+			if (event.key == 'ArrowDown') {
+				tip.d
+					.selectAll('.sja_menuoption')
+					.attr('tabindex', 0)
+					.on('keyup', event => {
+						if (event.key == 'Enter') {
+							event.target.click()
+						} else if (event.key == 'ArrowDown') {
+							if (event.target.nextSibling) event.target.nextSibling.focus()
+						} else if (event.key == 'ArrowUp') {
+							if (event.target.previousSibling) event.target.previousSibling.focus()
+						}
+					})
+				tip.d.select('.sja_menuoption').node().focus()
 				return
 			}
 			debouncer()

--- a/client/dom/genesetEdit.ts
+++ b/client/dom/genesetEdit.ts
@@ -30,16 +30,16 @@ type showGenesetEditArg = {
 	mode?: string
 	callback: (CallbackArg) => void
 	vocabApi: any
-	groups?: { name: string }[]
+	groups?: { name: string; lst: Gene[]; type?: 'hierCluster' }[]
 	showGroup: boolean
 }
 
 export function showGenesetEdit(arg: showGenesetEditArg) {
 	const { holder, genome, callback, groups, vocabApi } = arg
 	let mode = arg.mode || (groups?.length && arg.getMode?.(groups.find(g => g.selected)))
-	let geneList = arg.geneLst || groups?.find(g => g.selected)?.lst
+	let geneList = arg.geneList || groups?.find(g => g.selected)?.lst
 	if (groups.length && !geneList?.length) throw `missing or invalid geneLst or groups argument`
-	else if (!groups.length) geneList = []
+	else if (!geneList && !groups.length) geneList = []
 
 	const tip2 = new Menu({ padding: '0px' })
 	holder.selectAll('*').remove()
@@ -145,8 +145,6 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 	  this is primarily based on how matrix gene groups operate; a group is either for mutation data, or exp data, but not both
 	  when this ui is used elsewhere outside of matrix, this assumption can subject to change
 	*/
-
-	renderRightDiv()
 
 	function renderRightDiv() {
 		rightDiv.selectAll('*').remove()
@@ -376,6 +374,7 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 		}
 	}
 
+	renderRightDiv()
 	renderGenes()
 	return api
 }

--- a/client/dom/genesetEdit.ts
+++ b/client/dom/genesetEdit.ts
@@ -171,7 +171,9 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 					const result = await vocabApi.getTopVariablyExpressedGenes(args)
 
 					geneList = []
-					for (const gene of result.genes) geneList.push({ name: gene })
+					if (result.genes) {
+						for (const gene of result.genes) geneList.push({ name: gene })
+					}
 					renderGenes()
 					event.target.disabled = false
 				})
@@ -201,6 +203,7 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 					for (const gene of result.genes) geneList.push({ name: gene })
 					renderGenes()
 					api.dom.loadBt.property('disabled', false)
+					submitBtn.node().focus()
 				})
 		}
 		if (genome?.termdbs?.msigdb) {
@@ -231,6 +234,7 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 										renderGenes()
 									}
 									tip2.hide()
+									submitBtn.node().focus()
 								}
 							}
 						})
@@ -321,6 +325,7 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 
 		api.dom.submitBtn.property('disabled', !geneList?.length)
 		api.dom.clearBtn.property('disabled', !geneList?.length)
+		if (geneList?.length) api.dom.submitBtn.node().focus()
 	}
 
 	function addGene() {

--- a/client/dom/radio2.js
+++ b/client/dom/radio2.js
@@ -34,7 +34,8 @@ export function initRadioInputs(opts) {
 		.style('margin-top', '2px')
 		.style('margin-right', 0)
 		.property('checked', opts.isCheckedFxn)
-		.on('input', opts.listeners.input)
+		.on('mouseup', opts.listeners.input)
+		.on('keyup', opts.listeners.input)
 
 	labels
 		.append('span')

--- a/client/dom/test/genesetEdit.unit.spec.js
+++ b/client/dom/test/genesetEdit.unit.spec.js
@@ -8,20 +8,18 @@ const { Menu } = require('#dom/menu')
  reusable helper functions
 **************************/
 function getHolder() {
-	return select('body').append('div')
+	return select('body').append('div').style('max-width', '800px').style('border', '1px solid #555')
 }
-const holder = getHolder().node()
+
 function sleep(ms) {
 	return new Promise(resolve => setTimeout(resolve, ms))
 }
-
-const geneList = [{ name: 'TP53' }, { name: 'KRAS' }]
 
 /**************
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- dom/geneDictionary -***-')
+	test.pass('-***- dom/genesetEdit -***-')
 	test.end()
 })
 
@@ -42,13 +40,11 @@ tape('Empty opts.geneList', function (test) {
 	function testHG38() {
 		const menu = new Menu({ padding: '0px' })
 		const ui = showGenesetEdit({
-			holder,
-			menu,
+			holder: getHolder(),
 			genome: hg38,
 			callback: () => {},
 			vocabApi,
-			group: null,
-			showGroup: false
+			groups: []
 		})
 		test.true('msigdb' in ui.dom.tdbBtns, `should show MSigDB button for the hg38 genome`)
 		test.equal(ui.dom.genesDiv.selectAll(':scope>div').size(), 0, 'should render 0 gene pills')
@@ -62,13 +58,11 @@ tape('Empty opts.geneList', function (test) {
 	function testHG19() {
 		const menu = new Menu({ padding: '0px' })
 		const ui = showGenesetEdit({
-			holder,
-			menu,
+			holder: getHolder(),
 			genome: hg19,
 			callback: () => {},
 			vocabApi: {},
-			group: null,
-			showGroup: false
+			groups: []
 		})
 		test.false('msigdb' in ui.dom.tdbBtns, `should not show MSigDB button for the hg19 genome`)
 		test.equal(ui.dom.genesDiv.selectAll(':scope>div').size(), 0, 'should render 0 gene pills')
@@ -89,15 +83,14 @@ tape('Non-empty opts.geneList', function (test) {
 
 	function testHG38() {
 		const menu = new Menu({ padding: '0px' })
+		const geneList = [{ name: 'TP53' }, { name: 'KRAS' }]
 		const ui = showGenesetEdit({
-			holder,
-			menu,
+			holder: getHolder(),
 			genome: hg38,
 			geneList,
 			callback: () => {},
 			vocabApi,
-			group: null,
-			showGroup: false
+			groups: []
 		})
 		test.equal(ui.dom.genesDiv.selectAll(':scope>div').size(), geneList.length, 'should render two gene pills')
 		test.equal(ui.dom.submitBtn.property('disabled'), false, `should not have a disabled submit button`)
@@ -114,16 +107,15 @@ tape('gene deletion', function (test) {
 
 	function testHG38() {
 		const menu = new Menu({ padding: '0px' })
+		const geneList = [{ name: 'TP53' }, { name: 'KRAS' }]
 		const len = geneList.length
 		const ui = showGenesetEdit({
-			holder,
-			menu,
+			holder: getHolder(),
 			genome: hg38,
 			geneList,
 			callback: () => {},
 			vocabApi: {},
-			group: null,
-			showGroup: false
+			groups: []
 		})
 		test.equal(ui.dom.genesDiv.selectAll(':scope>div').size(), len, `should render ${len} gene pills`)
 		const geneListCopy = geneList.slice()
@@ -136,23 +128,21 @@ tape('gene deletion', function (test) {
 tape('submit button', function (test) {
 	test.timeoutAfter(100)
 	const vocabApi = {} //Fake vocab api returning  some genes
-
+	const geneList = [{ name: 'TP53' }, { name: 'KRAS' }]
 	const geneLstCopy = structuredClone(geneList)
 	const menu = new Menu({ padding: '0px' })
 	const ui = showGenesetEdit({
-		holder,
-		menu,
+		holder: getHolder(),
 		genome: hg38,
 		geneList,
 		callback,
 		vocabApi,
-		group: null,
-		showGroup: false
+		groups: []
 	})
 	ui.dom.submitBtn.node().click()
 
-	function callback(group, arg) {
-		test.deepEqual(geneLstCopy, arg, `should supply the expected geneList as a callback argument`)
+	function callback({ geneList }) {
+		test.deepEqual(geneLstCopy, geneList, `should supply the expected geneList as a callback argument`)
 		if (test._ok) ui.destroy()
 		test.end()
 	}

--- a/client/mass/test/sampleScatter.integration.spec.js
+++ b/client/mass/test/sampleScatter.integration.spec.js
@@ -696,7 +696,7 @@ tape('Change symbol and reference size from menu', function (test) {
 			.nodes()
 			.find(e => e.value == scatter.Inner.settings.size)
 		sizeInput.value = testSymSize
-		sizeInput.dispatchEvent(new Event('change'))
+		sizeInput.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }))
 	}
 	function testSymbolSize(scatter) {
 		//separate function because wait needed before test to run
@@ -708,7 +708,7 @@ tape('Change symbol and reference size from menu', function (test) {
 			.nodes()
 			.find(e => e.value == scatter.Inner.settings.refSize)
 		refInput.value = testRefSize
-		refInput.dispatchEvent(new Event('change'))
+		refInput.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }))
 	}
 	function testRefDotSize(scatter) {
 		test.equal(
@@ -764,8 +764,8 @@ tape('Change chart width and height from menu', function (test) {
 			},
 			// count: 1,
 			trigger() {
-				widthInput.dispatchEvent(new Event('change'))
-				heightInput.dispatchEvent(new Event('change'))
+				widthInput.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }))
+				heightInput.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }))
 			}
 			// matcher(mutations){
 			// 	let foundH, foundW = 0

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -92,7 +92,7 @@ class TdbConfigUiInit {
 				.style('transition', '0.2s')
 		}
 
-		this.dom.table = this.dom.holder.append('table').attr('cellpadding', 0).attr('cellspacing', 0)
+		this.dom.table = this.dom.holder.append('form').append('table').attr('cellpadding', 0).attr('cellspacing', 0)
 
 		return this.dom.table
 	}
@@ -128,6 +128,9 @@ class TdbConfigUiInit {
 			.selectAll('tr')
 			.filter(this.rowIsVisible)
 			.selectAll('td')
+			.attr('tabindex', function (d, i) {
+				return i + 1
+			})
 			.style('border-top', '2px solid #FFECDD')
 			.style('padding', '5px 10px')
 	}

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -92,7 +92,7 @@ class TdbConfigUiInit {
 				.style('transition', '0.2s')
 		}
 
-		this.dom.table = this.dom.holder.append('form').append('table').attr('cellpadding', 0).attr('cellspacing', 0)
+		this.dom.table = this.dom.holder.append('table').attr('cellpadding', 0).attr('cellspacing', 0)
 
 		return this.dom.table
 	}
@@ -128,9 +128,6 @@ class TdbConfigUiInit {
 			.selectAll('tr')
 			.filter(this.rowIsVisible)
 			.selectAll('td')
-			.attr('tabindex', function (d, i) {
-				return i + 1
-			})
 			.style('border-top', '2px solid #FFECDD')
 			.style('padding', '5px 10px')
 	}

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -171,7 +171,7 @@ function setNumberInput(opts) {
 		('debounceInterval' in opts.parent?.app.opts ? opts.parent?.app.opts.debounceInterval : 100)
 	for (const input of opts.inputs) {
 		let dispatchTimer
-		function debouncedDispatch() {
+		function debouncedDispatch(event) {
 			if (dispatchTimer) clearTimeout(dispatchTimer)
 			dispatchTimer = setTimeout(dispatchChange, debounceTimeout)
 		}
@@ -210,6 +210,10 @@ function setNumberInput(opts) {
 				.attr('max', 'max' in input ? input.max : null) // same
 				.attr('step', input.step || opts.step || null) //step gives the amount by which user can increment
 				.style('width', (input.width || opts.width || 100) + 'px')
+				.on('keyup', event => {
+					if (event.key !== 'Enter') clearTimeout(dispatchTimer)
+					else setTimeout(dispatchChange, debounceTimeout)
+				})
 				.on('change', debouncedDispatch)
 		}
 	}
@@ -385,6 +389,8 @@ function setRadioInput(opts) {
 				}
 		  ]
 
+	if (!('instanceNum' in opts)) opts.instanceNum = `sjpp-${Math.random().toString().slice(-7)}-${Date.now()}`
+
 	const styles = opts.styles || {}
 	for (const input of inputs) {
 		self.inputs[input.settingsKey] = initRadioInputs({
@@ -398,6 +404,8 @@ function setRadioInput(opts) {
 			styles,
 			listeners: {
 				input(event, d) {
+					if (event.key && event.key !== 'Enter') return
+
 					if (opts.callback) {
 						opts.callback(d.value)
 					} else {

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -725,11 +725,10 @@ export class MatrixControls {
 			}
 
 			if (t.customInputs) t.customInputs(this, app, parent, table)
-			table.selectAll('input, button, select, .add_term_btn, .term_name_btn').attr('tabindex', 0)
+			table.selectAll('.add_term_btn, .term_name_btn').attr('tabindex', 0)
 			table.select('.term_name_btn').node()
 		}
 
-		table.selectAll('td').on('keyup.nav-handler', this.keyboardNavHandler)
 		app.tip.showunder(event.target)
 	}
 

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -26,7 +26,39 @@ export class MatrixControls {
 		this.setDimensionsBtn(s)
 		this.setLegendBtn(s)
 		this.setDownloadBtn(s)
-		this.btns = this.opts.holder.selectAll('button').filter(d => d && d.label)
+
+		this.keyboardNavHandler = async event => {
+			console.log(32, event.key, event.target.previousSibling, event.target.nextSibling)
+			if (event.key == 'Tab') {
+			} else if (event.key == 'ArrowLeft') {
+				if (event.target.previousSibling) event.target.previousSibling.focus()
+			} else if (event.key == 'ArrowRight') {
+				if (event.target.nextSibling) event.target.nextSibling.focus()
+			} else if (event.key == 'ArrowDown') {
+				console.log(38, this.parent.app.tip.d.node())
+				this.parent.app.tip.d.node().firstChild.focus()
+			} else if (event.key == 1) {
+			} else if (event.key == 1) {
+			} else if (event.key == 1) {
+			}
+		}
+
+		this.btns = this.opts.holder
+			.selectAll(':scope>button')
+			.filter(d => d && d.label)
+			.on(`keyup.matrix-${this.parent.id}`, this.keyboardNavHandler)
+			// .on('click.sjpp-btn-focus', function() {
+			// 	//this.focus()
+			// })
+			.on('focus.matrix-keyboard-nav', function (d) {
+				this.click()
+			})
+		console.log(
+			29,
+			this.btns.each(function () {
+				console.log(this)
+			})
+		)
 
 		this.setZoomInput()
 		this.setDragToggle({
@@ -38,6 +70,7 @@ export class MatrixControls {
 
 	setSamplesBtn(s) {
 		const l = s.controlLabels
+
 		this.opts.holder
 			.append('button')
 			//.property('disabled', d => d.disabled)
@@ -604,7 +637,7 @@ export class MatrixControls {
 			.style('margin', '2px 0')
 			//.property('disabled', d => d.disabled)
 			.text('Download')
-			.on('click', () => to_svg(this.opts.getSvg(), 'matrix', { apply_dom_styles: true }))
+			.on('click.sjpp-matrix-download', () => to_svg(this.opts.getSvg(), 'matrix', { apply_dom_styles: true }))
 	}
 
 	main() {
@@ -654,6 +687,7 @@ export class MatrixControls {
 		const parent = this.opts.parent
 		const tables = d.tables || [d]
 
+		event.target.focus()
 		app.tip.clear()
 
 		const table = app.tip.d.append('table').attr('class', 'sjpp-controls-table')
@@ -691,6 +725,8 @@ export class MatrixControls {
 
 			if (t.customInputs) t.customInputs(this, app, parent, table)
 		}
+
+		table.selectAll('tr').on('keyup.nav-handler', () => console.log('test')) //this.keyboardNavHandler)
 
 		app.tip.showunder(event.target)
 	}
@@ -874,6 +910,7 @@ export class MatrixControls {
 		termdb.appInit({
 			holder: holder || app.tip.d,
 			vocabApi: this.parent.app.vocabApi,
+			focus: 'off',
 			state: {
 				vocab: this.parent.state.vocab,
 				activeCohort: this.parent.activeCohort,
@@ -889,6 +926,9 @@ export class MatrixControls {
 					this.submit_lst(termlst)
 					app.tip.hide()
 				}
+			},
+			search: {
+				focus: 'off'
 			}
 		})
 	}

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -26,46 +26,39 @@ export class MatrixControls {
 		this.setDimensionsBtn(s)
 		this.setLegendBtn(s)
 		this.setDownloadBtn(s)
-
-		this.keyboardNavHandler = async event => {
-			if (event.target.tagName == 'BUTTON') this.keyEventTarget = event.target
-			/*if (event.key == 'Tab') {
-			} else if (event.key == 'ArrowLeft') {
-				if (event.target.previousSibling) event.target.previousSibling.focus()
-				else event.target.parentNode.focus()
-			} else if (event.key == 'ArrowRight') {
-				if (event.target.nextSibling) event.target.nextSibling.focus()
-				else if (event.target.parentNode.nextSibling) event.target.parentNode.nextSibling()
-			} else if (event.key == 'ArrowDown') { console.log(38, event.target)
-				if (event.target.tagName == 'BUTTON') this.parent.app.tip.d.select('input, select, button').node().focus()
-				else if (!event.target.firstChild?.querySelectorAll('input').length) {
-					if (event.target.nextSibling?.firstChild?.tagName == 'td') event.target.nextSibling?.firstChild.focus()
-				}
-			} else*/ if (event.key == 'Enter' || event.key == 'ArrowDown') {
-				if (event.target.tagName == 'BUTTON') this.parent.app.tip.d.select('input, select').node().focus()
-				if (event.target.querySelectorAll('input')?.length) event.target.querySelector('input').focus()
-			} else if (event.key == 'Backspace' || event.key == 'ArrowUp') {
-				this.keyEventTarget.focus()
-			}
-		}
-
-		this.btns = this.opts.holder
-			.selectAll(':scope>button')
-			.filter(d => d && d.label)
-			.on(`keyup.matrix-${this.parent.id}`, this.keyboardNavHandler)
-			// .on('click.sjpp-btn-focus', function() {
-			// 	//this.focus()
-			// })
-			.on('focus.matrix-keyboard-nav', function (d) {
-				this.click()
-			})
-
 		this.setZoomInput()
 		this.setDragToggle({
 			holder: this.opts.holder.append('div').style('display', 'inline-block'),
 			target: this.parent.dom.seriesesG
 		})
 		this.setSvgScroll(state)
+
+		this.keyboardNavHandler = async event => {
+			if (event.target.tagName == 'BUTTON') this.keyEventTarget = event.target
+			if (event.key == 'Enter' || event.key == 'ArrowDown') {
+				const elems =
+					event.target.tagName == 'BUTTON'
+						? this.parent.app.tip.d.node().querySelectorAll('input, select')
+						: event.target.querySelectorAll('input, select')
+				for (const elem of elems) {
+					if (elem.checkVisibility?.() || (!elem.checkVisibility && elem.getBoundingClientRect().height)) {
+						elem.focus()
+						return false
+					}
+				}
+			} else if ((event.key == 'Tab' && event.shiftKey) || event.key == 'Backspace' || event.key == 'ArrowUp') {
+				this.keyEventTarget.focus()
+				return false
+			} //else if (event.keyShift && el)
+		}
+
+		this.btns = this.opts.holder
+			.selectAll(':scope>button')
+			.filter(d => d && d.label)
+			.on(`keyup.matrix-${this.parent.id}`, this.keyboardNavHandler)
+			.on('focus.matrix-keyboard-nav', function (d) {
+				this.click()
+			})
 	}
 
 	setSamplesBtn(s) {
@@ -725,8 +718,7 @@ export class MatrixControls {
 			}
 
 			if (t.customInputs) t.customInputs(this, app, parent, table)
-			table.selectAll('.add_term_btn, .term_name_btn').attr('tabindex', 0)
-			table.select('.term_name_btn').node()
+			table.selectAll('select, input, button').attr('tabindex', 0).on('keydown', self.keyboardNavHandler)
 		}
 
 		app.tip.showunder(event.target)
@@ -788,17 +780,13 @@ export class MatrixControls {
 
 	showGenegroupEditUi(td, app, tip, tg) {
 		td.append('button')
-			.html('Edit Group')
+			.html('Edit')
 			.on('key', event => {
 				if (event.key == 'Enter') event.target.click()
 			})
 			.on('click', event => {
 				const firstGrpWithGeneTw = tg.find(g => g.lst.find(tw => tw.term.type.startsWith('gene')))
 				tip.showunder(event.target)
-				// const getMode = group => {
-				// 	console.log(807, group, this.parent.config.settings.hierCluster?.termGroupName)
-				// 	return parent.chartType == 'hierCluster' && (group.type == 'hierCluster' || group.name == this.parent.config.settings.hierCluster?.termGroupName) ? 'geneExpression' : ''
-				// }
 				showGenesetEdit({
 					holder: tip.d,
 					/* running hier clustering and the editing group is the group used for clustering
@@ -858,7 +846,7 @@ export class MatrixControls {
 
 	showGenegroupAddUi(td, app, tip, tg) {
 		td.append('button')
-			.html('Add a New Group')
+			.html('Add')
 			.on('key', event => {
 				if (event.key == 'Enter') event.target.click()
 			})
@@ -1040,6 +1028,7 @@ export class MatrixControls {
 				selectBtn: opts.holder
 					.append('button')
 					.attr('title', 'Click the matrix to select data')
+					.attr('tabindex', 100)
 					.style('display', 'inline-block')
 					.style('width', '25px')
 					.style('height', '24.5px')
@@ -1049,6 +1038,7 @@ export class MatrixControls {
 				grabBtn: opts.holder
 					.append('button')
 					.attr('title', 'Click the matrix to drag and move')
+					.attr('tabindex', 100)
 					.style('display', 'inline-block')
 					.style('width', '25px')
 					.style('height', '24.5px')

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -29,17 +29,24 @@ export class MatrixControls {
 
 		this.keyboardNavHandler = async event => {
 			console.log(32, event.key, event.target.previousSibling, event.target.nextSibling)
-			if (event.key == 'Tab') {
+			if (event.target.tagName == 'BUTTON') this.keyEventTarget = event.target
+			/*if (event.key == 'Tab') {
 			} else if (event.key == 'ArrowLeft') {
 				if (event.target.previousSibling) event.target.previousSibling.focus()
+				else event.target.parentNode.focus()
 			} else if (event.key == 'ArrowRight') {
 				if (event.target.nextSibling) event.target.nextSibling.focus()
-			} else if (event.key == 'ArrowDown') {
-				console.log(38, this.parent.app.tip.d.node())
-				this.parent.app.tip.d.node().firstChild.focus()
-			} else if (event.key == 1) {
-			} else if (event.key == 1) {
-			} else if (event.key == 1) {
+				else if (event.target.parentNode.nextSibling) event.target.parentNode.nextSibling()
+			} else if (event.key == 'ArrowDown') { console.log(38, event.target)
+				if (event.target.tagName == 'BUTTON') this.parent.app.tip.d.select('input, select, button').node().focus()
+				else if (!event.target.firstChild?.querySelectorAll('input').length) {
+					if (event.target.nextSibling?.firstChild?.tagName == 'td') event.target.nextSibling?.firstChild.focus()
+				}
+			} else*/ if (event.key == 'Enter' || event.key == 'ArrowDown') {
+				if (event.target.tagName == 'BUTTON') this.parent.app.tip.d.select('input, select').node().focus()
+				if (event.target.querySelectorAll('input')?.length) event.target.querySelector('input').focus()
+			} else if (event.key == 'Backspace' || event.key == 'ArrowUp') {
+				this.keyEventTarget.focus()
 			}
 		}
 
@@ -53,12 +60,6 @@ export class MatrixControls {
 			.on('focus.matrix-keyboard-nav', function (d) {
 				this.click()
 			})
-		console.log(
-			29,
-			this.btns.each(function () {
-				console.log(this)
-			})
-		)
 
 		this.setZoomInput()
 		this.setDragToggle({
@@ -637,6 +638,7 @@ export class MatrixControls {
 			.style('margin', '2px 0')
 			//.property('disabled', d => d.disabled)
 			.text('Download')
+			.on('focus', () => this.parent.app.tip.hide())
 			.on('click.sjpp-matrix-download', () => to_svg(this.opts.getSvg(), 'matrix', { apply_dom_styles: true }))
 	}
 
@@ -690,7 +692,7 @@ export class MatrixControls {
 		event.target.focus()
 		app.tip.clear()
 
-		const table = app.tip.d.append('table').attr('class', 'sjpp-controls-table')
+		const table = app.tip.d.append('form').append('table').attr('class', 'sjpp-controls-table')
 		for (const t of tables) {
 			//if (d.customHeaderRows) d.customHeaderRows(parent, table)
 			if (t.header) {
@@ -724,9 +726,14 @@ export class MatrixControls {
 			}
 
 			if (t.customInputs) t.customInputs(this, app, parent, table)
+
+			table.selectAll('input, button, select').attr('tabindex', (d, i) => i + 1)
+
+			// table.selectAll('td')
+			// 	.attr('tabindex', (d,i) => i + 1)
 		}
 
-		table.selectAll('tr').on('keyup.nav-handler', () => console.log('test')) //this.keyboardNavHandler)
+		table.selectAll('td').on('keyup.nav-handler', this.keyboardNavHandler)
 
 		app.tip.showunder(event.target)
 	}

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -726,15 +726,13 @@ export class MatrixControls {
 			}
 
 			if (t.customInputs) t.customInputs(this, app, parent, table)
-
-			table.selectAll('input, button, select').attr('tabindex', (d, i) => i + 1)
-
+			table.selectAll('input, button, select, .add_term_btn, .term_name_btn').attr('tabindex', (d, i) => i + 1)
+			table.select('.term_name_btn').node()
 			// table.selectAll('td')
 			// 	.attr('tabindex', (d,i) => i + 1)
 		}
 
 		table.selectAll('td').on('keyup.nav-handler', this.keyboardNavHandler)
-
 		app.tip.showunder(event.target)
 	}
 

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1932,7 +1932,7 @@ function setLabelDragEvents(self, prefix) {
 			self.showTermMenu(event)
 		} else if (
 			self.chartType !== 'hierCluster' ||
-			event.target.__data__.grp.name !== self.config.settings.hierCluster.termGroupName
+			event.target.__data__.grp?.name !== self.config.settings.hierCluster.termGroupName
 		) {
 			// Do not show the term group menu for hierCluster gene expression term group
 			self.showTermGroupMenu(event)

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -200,6 +200,10 @@ class TdbApp {
 			.text(!n ? 'Search or click term(s)' : `Submit ${n} term${n > 1 ? 's' : ''}`)
 
 		await this.mayShowCustomTerms()
+		this.dom.holder.selectAll('search, .termbtn, button').attr('tabindex', 0)
+		this.dom.holder.selectAll('.termbtn').on('keyup', event => {
+			if (event.key == 'Enter') event.target.click()
+		})
 	}
 
 	printError(e) {

--- a/client/termdb/search.js
+++ b/client/termdb/search.js
@@ -320,10 +320,8 @@ function setRenderers(self) {
 
 function setInteractivity(self) {
 	self.onKeyup = event => {
-		console.log(314, event.key, self.currData?.lst)
 		// to search snp upon hitting enter
 		if (event.key == 'ArrowDown' && self.currData?.lst?.length) {
-			console.log(316, self.dom.resultDiv.select('.sja_tree_click_term, .sja_menuoption').node())
 			self.dom.resultDiv.select('.sja_tree_click_term, .sja_menuoption').node().focus()
 			return
 		}

--- a/client/termdb/search.js
+++ b/client/termdb/search.js
@@ -105,7 +105,7 @@ function setRenderers(self) {
 			.on('input', debounce(self.onInput, 300))
 			.on('keyup', self.onKeyup)
 
-		self.dom.input.node().focus()
+		if (self.opts.focus != 'off') self.dom.input.node().focus()
 
 		// a holder to contain two side-by-side divs for genes and dictionary term hits
 		self.dom.resultDiv = (self.opts.resultsHolder || self.dom.holder)

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -132,7 +132,7 @@ class TdbTree {
 		await this.renderBranch(root, this.dom.holder)
 		this.dom.holder
 			.selectAll('.termbtn, .sja_tree_click_term')
-			.attr('tabindex', (d, i) => i + 1)
+			.attr('tabindex', 0)
 			.on('keyup', event => {
 				if (event.key == 'Enter') event.target.click()
 			})

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -129,7 +129,13 @@ class TdbTree {
 		const root = this.termsById[root_ID]
 		root.terms = await this.requestTermRecursive(root)
 		this.dom.holder.style('display', 'block')
-		this.renderBranch(root, this.dom.holder)
+		await this.renderBranch(root, this.dom.holder)
+		this.dom.holder
+			.selectAll('.termbtn, .sja_tree_click_term')
+			.attr('tabindex', (d, i) => i + 1)
+			.on('keyup', event => {
+				if (event.key == 'Enter') event.target.click()
+			})
 	}
 
 	getTermsById() {

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -430,7 +430,7 @@ function setRenderers(self) {
 			.each(self.enterPill)
 		self.dom.pilldiv
 			.select('.term_name_btn')
-			.attr('tabindex', self.dom.nopilldiv.select('.add_term_btn')?.attr('tabindex') || 0)
+			.attr('tabindex', 0)
 			.on(`keyup.sjpp-termdb`, event => {
 				if (event.key == 'Enter') event.target.click()
 			})

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -320,6 +320,9 @@ function setRenderers(self) {
 			.append('div')
 			.style('cursor', 'pointer')
 			.on('click', self.clickNoPillDiv)
+			.on(`keyup.sjpp-termdb`, event => {
+				if (event.key == 'Enter') self.showTree(event)
+			})
 		self.dom.pilldiv = self.dom.holder.append('div')
 
 		// nopilldiv - placeholder label
@@ -425,6 +428,12 @@ function setRenderers(self) {
 			.transition()
 			.duration(200)
 			.each(self.enterPill)
+		self.dom.pilldiv
+			.select('.term_name_btn')
+			.attr('tabindex', self.dom.nopilldiv.select('.add_term_btn')?.attr('tabindex') || 0)
+			.on(`keyup.sjpp-termdb`, event => {
+				if (event.key == 'Enter') event.target.click()
+			})
 	}
 
 	self.enterPill = async function (this: string) {
@@ -615,20 +624,25 @@ function setInteractivity(self) {
 			options.push({ label: 'Remove', callback: self.removeTerm } as opt)
 		}
 
-		const d3elem = menuHolder || tip.d
-		d3elem
+		self.openMenu = menuHolder || tip.d
+		self.openMenu
 			.selectAll('div')
 			.data(options)
 			.enter()
 			.append('div')
 			.attr('class', 'sja_menuoption sja_sharp_border')
+			.attr('tabindex', (d, i) => i + 1)
 			.style('display', self.opts.menuLayout == 'horizontal' ? 'inline-block' : 'block')
 			.text((d: opt) => d.label)
 			.on('click', (event: MouseEvent, d: opt) => {
 				self.dom.tip.clear()
 				d.callback(self.dom.tip.d)
 			})
+			.on('keyup', event => {
+				if (event.key == 'Enter') event.target.click()
+			})
 
+		self.openMenu.select('.sja_menuoption').node()?.focus()
 		//self.showFullMenu(tip.d, self.opts.menuOptions)
 	}
 


### PR DESCRIPTION
## Description
Closes https://github.com/stjude/proteinpaint/issues/1123

To test: open matrix and gene expression plots, and 
- try to navigate the controls by pressing Tab
- once the focus is on a matrix/hierCluster control button, press Enter to focus on the menu input under that button
- press Tab to move to the next control or input, press Shift + Tab to move to the previous one
- pressing Enter on a focused button or option should trigger a chart update
- 
NOTES: 
- ~~radio button selection vs focus needs work~~ EDIT: fixed, also clicking on up/down increment on numeric input
- the genesetEdit UI has been updated to handle the display of term group edit/addition (previously worked on @airenzp and used by @congyu-lu in matrix.controls, and may affect may affect screenshots for docs (@karishma-gangwani)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
