### PR TITLE
Client side code for o, e, and oe option

### DIFF
--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -74,7 +74,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 
 		.on('change', async () => {
 			const selectedOEOption = self.dom.controlsDiv.matrixType.node().value
-			console.log(selectedOEOption)
+			//console.log(selectedOEOption)
 			// Handle the selected option
 			await setOEOption(hic, selectedOEOption, self)
 		})

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -866,7 +866,7 @@ export async function getdata_leadfollow(hic: any, lead: any, follow: any, self:
 		resolution: resolution
 	}
 
-	console.log(arg)
+	//console.log(arg)
 
 	try {
 		const data = await client.dofetch2('/hicdata', {
@@ -1059,7 +1059,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 		nmeth: self.chrpairview.nmeth,
 		resolution: resolution
 	}
-	console.log(arg)
+	//console.log(arg)
 	try {
 		const data = await client.dofetch2('/hicdata', {
 			method: 'POST',

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -60,6 +60,8 @@ hic.atdev controls dev-shortings
 
 */
 
+const oeOption = 'expected'
+//export const defaultOEOption = 'observed'
 /** Default normalization method if none returned from the server. Exported to parsing and controls script*/
 export const defaultnmeth = 'NONE'
 
@@ -130,6 +132,7 @@ class Hicstat {
 		}
 		this.errList = []
 		this.wholegenome = {
+			oeOption: 'observed',
 			binpx: 1,
 			/** wholegenome is fixed to use lowest bp resolution, and fixed cutoff value for coloring*/
 			bpmaxv: 5000,
@@ -853,6 +856,8 @@ export async function getdata_leadfollow(hic: any, lead: any, follow: any, self:
 	}
 
 	const arg = {
+		oevalues: self.wholegenome.oeOption,
+		// oevalues:oeOption
 		file: hic.file,
 		url: hic.url,
 		pos1: hic.nochr ? lead.replace('chr', '') : lead,
@@ -860,6 +865,8 @@ export async function getdata_leadfollow(hic: any, lead: any, follow: any, self:
 		nmeth: self.wholegenome.nmeth,
 		resolution: resolution
 	}
+
+	console.log(arg)
 
 	try {
 		const data = await client.dofetch2('/hicdata', {
@@ -1043,6 +1050,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 	const ctx = self.chrpairview.ctx
 
 	const arg = {
+		oevalues: self.chrpairview.oeOption,
 		jwt: hic.jwt,
 		file: hic.file,
 		url: hic.url,
@@ -1051,6 +1059,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 		nmeth: self.chrpairview.nmeth,
 		resolution: resolution
 	}
+	console.log(arg)
 	try {
 		const data = await client.dofetch2('/hicdata', {
 			method: 'POST',
@@ -1118,6 +1127,16 @@ export function nmeth2select(hic: any, v: any) {
 	const selectedNmeth = Array.from(options).find((o: any) => o.value === hic.nmethselect.node().value) as any
 	selectedNmeth.selected = true
 	v.nmeth = selectedNmeth.value
+}
+
+/** */
+export function oeOption4select(v: any, self: any) {
+	const options = self.dom.controlsDiv.matrixType.node().options
+	const selectedOption = Array.from(options).find(
+		(o: any) => o.value === self.dom.controlsDiv.matrixType.node().value
+	) as any
+	selectedOption.selected = true
+	v.oeOption = selectedOption.value // Return the selected option value
 }
 
 //////////////////// __detail view__ ////////////////////
@@ -1309,6 +1328,7 @@ export function getdata_detail(hic: any, self: any) {
 	const ystop = self.detailview.ystop
 
 	const par: HicstrawArgs = {
+		oevalues: self.detailview.oeOption,
 		jwt: hic.jwt,
 		file: hic.file,
 		url: hic.url,

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -28,6 +28,7 @@ export type HicRunProteinPaintTrackArgs = BaseTrackArgs &
 	}
 
 export type HicstrawArgs = SharedArgs & {
+	oevalues: 'observed' | 'expected' | 'oe'
 	jwt: any
 	pos1: string
 	pos2: string
@@ -85,6 +86,8 @@ export type HicstrawDom = {
 }
 
 export type WholeGenomeView = {
+	/** value for o,e,and oe option */
+	oeOption: 'observed' | 'expected' | 'oe'
 	/** # pixel per bin, may set according to resolution */
 	binpx: number
 	/** Appears as the cutoff value for the user in the menu */
@@ -109,6 +112,7 @@ export type WholeGenomeView = {
 }
 
 export type ChrPairView = {
+	oeOption: 'observed' | 'expected' | 'oe'
 	axisx: any //dom
 	axisy: any //dom
 	binpx: number
@@ -124,6 +128,7 @@ export type ChrPairView = {
 }
 
 export type DetailView = {
+	oeOption: 'observed' | 'expected' | 'oe'
 	bbmargin: number
 	canvas?: any //dom
 	ctx: any //dom

--- a/server/routes/hicdata.ts
+++ b/server/routes/hicdata.ts
@@ -68,7 +68,7 @@ function handle_hicdata(q: HicdataRequest) {
 			q.isfrag ? 'FRAG' : 'BP',
 			q.resolution
 		]
-
+		//console.log(par)
 		const ps = spawn(serverconfig.hicstraw, par)
 		const rl = readline.createInterface({ input: ps.stdout })
 


### PR DESCRIPTION
## Description

The client side code for selecting the 'observed', 'expected', and 'oe' options. The user can select any option among them using drop-down menu for whole genome, chromosome, and detailed view. 

Test it by: (http://localhost:3000/?genome=hg38&hicfile=proteinpaint_demo/hg38/hic/hic_demo.hic&enzyme=MboI) and other demo files.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
