### PR TITLE
hic.oe4: Client side code for o, e, and oe option

### DIFF
--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -1,5 +1,5 @@
 import { bplen } from '#shared/common'
-import { nmeth2select } from './hic.straw'
+import { nmeth2select, oeOption4select } from './hic.straw'
 import { getdata_chrpair, getdata_detail, getdata_leadfollow, defaultnmeth, showBtns } from './hic.straw'
 import { Elem } from '../../types/d3'
 import blocklazyload from '#src/block.lazyload'
@@ -69,7 +69,21 @@ export function initWholeGenomeControls(hic: any, self: any) {
 
 	const matrixTypeRow = menuTable.append('tr')
 	addLabel(matrixTypeRow, 'matrix type')
-	self.dom.controlsDiv.matrixType = matrixTypeRow.append('td').text('Observed')
+	self.dom.controlsDiv.matrixType = matrixTypeRow
+		.append('td')
+		.style('margin-right', '10px')
+		.append('select')
+
+		.on('change', async () => {
+			const selectedOEOption = self.dom.controlsDiv.matrixType.node().value
+			//console.log(selectedOEOption)
+			// Handle the selected option
+			await setOEOption(hic, selectedOEOption, self)
+		})
+	const matrixTypevalues = ['observed', 'expected', 'oe']
+	for (const oeOption of matrixTypevalues) {
+		self.dom.controlsDiv.matrixType.append('option').text(oeOption)
+	}
 
 	const viewRow = menuTable.append('tr')
 	addLabel(viewRow, 'VIEW')
@@ -200,6 +214,43 @@ async function setnmeth(hic: any, nmeth: string, self: any) {
 	}
 }
 
+async function setOEOption(hic: any, oeOption: string, self: any) {
+	if (self.inwholegenome) {
+		self.wholegenome.oeOption = oeOption
+		const manychr = hic.atdev ? 3 : hic.chrlst.length
+
+		for (let i = 0; i < manychr; i++) {
+			const lead = hic.chrlst[i]
+
+			for (let j = 0; j <= i; j++) {
+				const follow = hic.chrlst[j]
+
+				try {
+					await getdata_leadfollow(hic, lead, follow, self)
+				} catch (e: any) {
+					self.errList.push(e.message || e)
+				}
+			}
+		}
+
+		if (self.errList.length) {
+			self.error(self.errList)
+		}
+
+		return
+	}
+
+	if (self.inchrpair) {
+		self.chrpairview.oeOption = oeOption
+		await getdata_chrpair(hic, self)
+		return
+	}
+	if (self.indetail) {
+		self.detailview.oeOption = oeOption
+		getdata_detail(hic, self)
+	}
+}
+
 /**
  * setting max value from user input
  * @param hic
@@ -266,16 +317,21 @@ function switchview(hic: any, self: any) {
 
 	if (self.inwholegenome) {
 		nmeth2select(hic, self.wholegenome)
+		oeOption4select(self.wholegenome, self)
 		self.dom.plotDiv.plot.node().appendChild(self.wholegenome.svg.node())
 		self.dom.controlsDiv.inputBpMaxv.property('value', self.wholegenome.bpmaxv)
 		self.dom.controlsDiv.resolution.text(bplen(self.wholegenome.resolution) + ' bp')
 	} else if (self.inchrpair) {
 		nmeth2select(hic, self.chrpairview)
+		oeOption4select(self.chrpairview, self)
 		self.dom.plotDiv.yAxis.node().appendChild(self.chrpairview.axisy.node())
 		self.dom.plotDiv.xAxis.node().appendChild(self.chrpairview.axisx.node())
 		self.dom.plotDiv.plot.node().appendChild(self.chrpairview.canvas)
 		self.dom.controlsDiv.inputBpMaxv.property('value', self.chrpairview.bpmaxv)
 		self.dom.controlsDiv.resolution.text(bplen(self.chrpairview.resolution) + ' bp')
+	} else if (self.indetail) {
+		nmeth2select(hic, self.detailview)
+		oeOption4select(self.detailview, self)
 	} else if (self.inhorizontal) {
 		//TODO: Problem with this is it rerenders. Maybe a way to save the rendering and just show/hide?
 		blocklazyload(self.horizontalview.args)

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -64,6 +64,7 @@ hic.atdev controls dev-shortings
 
 */
 
+const oeOption = 'expected'
 /** Default normalization method if none returned from the server. Exported to parsing and controls script*/
 export const defaultnmeth = 'NONE'
 
@@ -150,6 +151,7 @@ class Hicstat {
 		}
 		this.errList = []
 		this.wholegenome = {
+			oeOption: 'observed',
 			binpx: 1,
 			/** wholegenome is fixed to use lowest bp resolution, and fixed cutoff value for coloring*/
 			bpmaxv: 5000,
@@ -955,6 +957,7 @@ export async function getdata_leadfollow(hic: any, lead: any, follow: any, self:
 	}
 
 	const arg = {
+		oevalues: self.wholegenome.oeOption,
 		file: hic.file,
 		url: hic.url,
 		pos1: hic.nochr ? lead.replace('chr', '') : lead,
@@ -1145,6 +1148,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 	const ctx = self.chrpairview.ctx
 
 	const arg = {
+		oevalues: self.chrpairview.oeOption,
 		jwt: hic.jwt,
 		file: hic.file,
 		url: hic.url,
@@ -1228,6 +1232,16 @@ async function detailViewUpdateRegionFromBlock(hic: any, self: any) {
 	self.chrx = self.detailview.xb.rglst[0]
 	self.chry = self.detailview.yb.rglst[0]
 	await detailViewUpdateHic(hic, self)
+}
+
+/** */
+export function oeOption4select(v: any, self: any) {
+	const options = self.dom.controlsDiv.matrixType.node().options
+	const selectedOption = Array.from(options).find(
+		(o: any) => o.value === self.dom.controlsDiv.matrixType.node().value
+	) as any
+	selectedOption.selected = true
+	v.oeOption = selectedOption.value // Return the selected option value
 }
 
 /**
@@ -1397,6 +1411,7 @@ export function getdata_detail(hic: any, self: any) {
 	const ystop = self.detailview.ystop
 
 	const par: HicstrawArgs = {
+		oevalues: self.detailview.oeOption,
 		jwt: hic.jwt,
 		file: hic.file,
 		url: hic.url,

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -383,6 +383,7 @@ class Hicstat {
 		this.dom.controlsDiv.view.text(`${chrx}-${chry} Pair`)
 		const horizontalView = this.init_horizontalView.bind(this)
 		nmeth2select(hic, this.chrpairview)
+		oeOption4select(this.chrpairview, this)
 
 		this.inwholegenome = false
 		this.inchrpair = true
@@ -528,6 +529,7 @@ class Hicstat {
 	async init_horizontalView(hic: any, chrx: string, chry: string, x: number, y: number) {
 		this.dom.controlsDiv.view.text('Horizontal')
 		nmeth2select(hic, this.horizontalview)
+		oeOption4select(this.horizontalview, this)
 
 		//Clear elements created in chr pair view
 		this.chrpairview.axisy.remove()
@@ -606,6 +608,7 @@ class Hicstat {
 	async init_detailView(hic: any, chrx: string, chry: string, x: number, y: number) {
 		this.dom.controlsDiv.view.text('Detailed')
 		nmeth2select(hic, this.detailview)
+		oeOption4select(this.detailview, this)
 
 		this.inwholegenome = false
 		this.inchrpair = false

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -64,7 +64,6 @@ hic.atdev controls dev-shortings
 
 */
 
-const oeOption = 'expected'
 /** Default normalization method if none returned from the server. Exported to parsing and controls script*/
 export const defaultnmeth = 'NONE'
 

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -28,6 +28,7 @@ export type HicRunProteinPaintTrackArgs = BaseTrackArgs &
 	}
 
 export type HicstrawArgs = SharedArgs & {
+	oevalues: 'observed' | 'expected' | 'oe'
 	jwt: any
 	pos1: string
 	pos2: string
@@ -87,6 +88,8 @@ export type HicstrawDom = {
 }
 
 export type WholeGenomeView = {
+	/** value for o,e,and oe option */
+	oeOption: 'observed' | 'expected' | 'oe'
 	/** # pixel per bin, may set according to resolution */
 	binpx: number
 	/** Appears as the cutoff value for the user in the menu */
@@ -111,6 +114,7 @@ export type WholeGenomeView = {
 }
 
 export type ChrPairView = {
+	oeOption: 'observed' | 'expected' | 'oe'
 	axisx: any //dom
 	axisy: any //dom
 	binpx: number
@@ -136,6 +140,7 @@ export type HorizontalView = {
 }
 
 export type DetailView = {
+	oeOption: 'observed' | 'expected' | 'oe'
 	bbmargin: number
 	canvas?: any //dom
 	ctx: any //dom


### PR DESCRIPTION
## Description
The client side code for selecting the 'observed', 'expected', and 'oe' options. The user can select any option among them using drop-down menu for whole genome, chromosome, and detailed view.

Test it by: (http://localhost:3000/?genome=hg38&hicfile=proteinpaint_demo/hg38/hic/hic_demo.hic&enzyme=MboI) and other demo files.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
