### PR TITLE
delete the fadeTimeout to reenable closing the menu when clicking out…

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -231,7 +231,11 @@ export class Menu {
 	confirm({ html, timeout }) {
 		this.d.selectAll('*').remove()
 		this.d.append('div').style('padding', '5px').html(html)
-		if (timeout) this.fadeTimeout = setTimeout(() => this.fadeout(), 3000)
+		if (timeout)
+			this.fadeTimeout = setTimeout(() => {
+				this.fadeout()
+				delete this.fadeTimeout
+			}, 3000)
 	}
 
 	toggle() {

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -58,9 +58,6 @@ export class MatrixControls {
 			.selectAll(':scope>button')
 			.filter(d => d && d.label)
 			.on(`keyup.matrix-${this.parent.id}`, this.keyboardNavHandler)
-			.on('focus.matrix-keyboard-nav', function (d) {
-				this.click()
-			})
 	}
 
 	setSamplesBtn(s) {
@@ -846,8 +843,7 @@ export class MatrixControls {
 					backBtn: {
 						target: 'Genes Menu',
 						callback: () => {
-							GenesBtn.focus()
-							//GenesBtn.click()
+							GenesBtn.click()
 						}
 					}
 				})
@@ -900,7 +896,7 @@ export class MatrixControls {
 					backBtn: {
 						target: 'Genes Menu',
 						callback: () => {
-							GenesBtn.focus()
+							GenesBtn.click()
 						}
 					}
 				})


### PR DESCRIPTION
## Description

…side it; do not automatically open a matrix menu when tabbing to its control button


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
