### PR TITLE
at launching oncomatrix, show geneset edit ui to gracefully handl…

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -116,7 +116,12 @@ export async function getPlotConfig(opts = {}, app) {
 				cnvUnit: 'log2ratio',
 				ignoreCnvValues: false, //will ignore numeric CNV values if true
 
-				barh: 32 // default bar height for continuous terms
+				barh: 32, // default bar height for continuous terms,
+
+				// possible string entries:
+				// - "genesetEdit", for gene-centric embedders only like GDC OncoMatrix
+				// - may add other optional hints later
+				showHints: []
 			}
 		}
 	}

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -192,8 +192,7 @@ export class Matrix {
 				!this.config.legendGrpFilter.lst.length &&
 				!this.config.legendValueFilter.lst.length
 			) {
-				this.dom.loadingDiv.html('No matching sample data').style('display', '')
-				this.dom.svg.style('display', 'none')
+				this.showNoMatchingDataMessage()
 				return
 			}
 
@@ -242,6 +241,45 @@ export class Matrix {
 
 		this.prevState = this.state
 		this.resetInteractions()
+	}
+
+	showNoMatchingDataMessage() {
+		this.dom.loadingDiv.html('')
+		const div = this.dom.loadingDiv
+			.append('div')
+			.style('display', 'inline-block')
+			.style('text-align', 'center')
+			.style('position', 'relative')
+			.style('left', '-150px')
+		div.append('div').html('No matching cohort sample data for the current gene list.')
+		if (this.settings.matrix.showHints?.includes('genesetEdit')) {
+			const div1 = div.append('div')
+			div1.append('span').html('You may view and modify the gene list from the ')
+			div1
+				.append('span')
+				.style('cursor', 'pointer')
+				.style('text-decoration', 'underline')
+				.html('Gene Set Edit Group option.')
+				.on('click', () => {
+					const GenesBtn = this.controlsRenderer.btns
+						.filter(d => d.label == 'Genes')
+						?.node()
+						.click()
+					const i = setInterval(() => {
+						const editBtn = this.app.tip.d
+							.selectAll('button')
+							.filter(function () {
+								return this.innerHTML == 'Edit Group'
+							})
+							.node()
+						if (editBtn) {
+							editBtn.click()
+							clearInterval(i)
+						}
+					}, 100)
+				})
+		}
+		this.dom.svg.style('display', 'none')
 	}
 
 	sampleKey(s) {

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -259,7 +259,7 @@ export class Matrix {
 				.append('span')
 				.style('cursor', 'pointer')
 				.style('text-decoration', 'underline')
-				.html('Gene Set Edit Group option.')
+				.html('Gene Set Edit Group menu.')
 				.on('click', () => {
 					const GenesBtn = this.controlsRenderer.btns
 						.filter(d => d.label == 'Genes')

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -113,11 +113,11 @@ export async function init(arg, holder, genomes) {
 		const genes = await getGenes(arg, arg.filter0, settings.matrix)
 
 		if (!genes || genes.length == 0) {
-			holder.append('p').text('No default genes. Please define a gene set to launch OncoMatrix.')
 			// geneset edit ui requires vocabApi
 			const tempDiv = holder.append('div') // single-use div to show edit ui;
+			tempDiv.append('p').text('No default genes. Please define a gene set to launch OncoMatrix.')
 			showGenesetEdit({
-				holder: tempDiv,
+				holder: tempDiv.append('div'),
 				genome,
 				vocabApi: await vocabInit({ state: { genome: gdcGenome, dslabel: gdcDslabel } }),
 				callback: async result => {

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -122,7 +122,17 @@ export async function init(arg, holder, genomes) {
 				vocabApi: await vocabInit({ state: { genome: gdcGenome, dslabel: gdcDslabel } }),
 				callback: async result => {
 					tempDiv.remove()
-					const plotAppApi = await launchWithGenes(result.geneList, genome, arg, holder)
+					const plotAppApi = await launchWithGenes(
+						await Promise.all(
+							result.geneList.map(async i => {
+								return await fillTermWrapper({ term: { name: i.name, type: 'geneVariant' } })
+							})
+						),
+						genome,
+						arg,
+						settings,
+						holder
+					)
 					// FIXME plotAppApi generated inside callback is no longer returned where it supposed to be, may break app update on GFF cohort change
 				}
 			})
@@ -130,7 +140,7 @@ export async function init(arg, holder, genomes) {
 		}
 
 		// has default genes; launch map with these
-		const plotAppApi = await launchWithGenes(genes, genome, arg, holder)
+		const plotAppApi = await launchWithGenes(genes, genome, arg, settings, holder)
 		const matrixApi = plotAppApi.getComponents('plots.0')
 
 		const api = {
@@ -197,7 +207,7 @@ async function getGenes(arg, filter0, matrix) {
 	)
 }
 
-async function launchWithGenes(genes, genome, arg, holder) {
+async function launchWithGenes(genes, genome, arg, settings, holder) {
 	const opts = {
 		holder,
 		genome,

--- a/server/routes/termdb.getrootterm.ts
+++ b/server/routes/termdb.getrootterm.ts
@@ -1,4 +1,5 @@
 import { getroottermRequest, getroottermResponse } from '#shared/types/routes/termdb.getrootterm.ts'
+import { get_ds_tdb } from '../src/termdb'
 
 export const api: any = {
 	endpoint: 'termdb/rootterm',
@@ -38,14 +39,14 @@ export const api: any = {
 function init({ genomes }) {
 	return async (req: any, res: any): Promise<void> => {
 		const q = req.query as getroottermRequest
+		const cohortValues = q.cohortValues ? q.cohortValues : ''
+		const treeFilter = q.treeFilter ? q.treeFilter : ''
+		//res.send({ lst: await tdb.q.getRootTerms(cohortValues, treeFilter) })
+
 		try {
 			const g = genomes[req.query.genome]
 			if (!g) throw 'invalid genome name'
-			const ds = g.datasets[req.query.dslabel]
-			if (!ds) throw 'invalid dataset name'
-			const tdb = ds.cohort.termdb
-			if (!tdb) throw 'invalid termdb object'
-
+			const [ds, tdb] = get_ds_tdb(g, q)
 			await trigger_rootterm(q, res, tdb) // as getroottermResponse
 		} catch (e) {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/server/routes/termdb.gettermchildren.ts
+++ b/server/routes/termdb.gettermchildren.ts
@@ -1,5 +1,6 @@
 import { gettermchildrenRequest, gettermchildrenResponse } from '#shared/types/routes/termdb.gettermchildren.ts'
 import { copy_term } from '#src/termdb.js'
+import { get_ds_tdb } from '../src/termdb'
 
 export const api: any = {
 	endpoint: 'termdb/termchildren',
@@ -42,12 +43,7 @@ function init({ genomes }) {
 		const q = req.query as gettermchildrenRequest
 		try {
 			const g = genomes[req.query.genome]
-			if (!g) throw 'invalid genome name'
-			const ds = g.datasets[req.query.dslabel]
-			if (!ds) throw 'invalid dataset name'
-			const tdb = ds.cohort.termdb
-			if (!tdb) throw 'invalid termdb object'
-
+			const [ds, tdb] = get_ds_tdb(g, q)
 			await trigger_children(q, res, tdb)
 		} catch (e) {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
…e case of no default genes, rather than breaking

## Description

closes #1147 
test at http://localhost:3000/example.gdc.matrix.html?cohort=APOLLO-LUAD. this cohort has only CNV and no SSM. current prod top_mutated_gene API will return no gene

https://github.com/stjude/proteinpaint/issues/1146 should be fixed first so groups is optional
also there's an issue of not returning API object from gsEdit callback

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
