### PR TITLE
hiercluster: bug fix to return expected structure when no sample

### DIFF
--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -1,5 +1,4 @@
 import { TermdbClusterRequest, TermdbClusterResponse } from '#shared/types/routes/termdb.cluster.ts'
-import fs from 'fs'
 import path from 'path'
 import * as utils from '#src/utils.js'
 import serverconfig from '#src/serverconfig.js'

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -117,8 +117,8 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any, genome: any
 	q.get = async (param: TermdbClusterRequest) => {
 		const limitSamples = await mayLimitSamples(param, q.samples, ds)
 		if (limitSamples?.size == 0) {
-			// got 0 sample after filtering, return blank array for no data
-			return new Set()
+			// got 0 sample after filtering, must still return expected structure with no data
+			return { gene2sample2value: new Set(), byTermId: {}, bySampleId: {} }
 		}
 
 		// has at least 1 sample passing filter and with exp data


### PR DESCRIPTION
## Description

this is due to changed term id in Jian's updated pediatric db. 
please pull sjpp master and test with the new `4 gene RHB` link
a separate issue is created for filter ui silently ignoring invalid term

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
