### PR TITLE
Hic.6: Reverted hic views to original order and click behavoir

### DIFF
--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -74,8 +74,11 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('margin-right', '10px')
 		.append('select')
 		.on('change', async () => {
-			const selectedmatrixType = self.dom.controlsDiv.matrixType.node().value
-			await setMatrixType(hic, selectedmatrixType, self)
+			const matrixType = self.dom.controlsDiv.matrixType.node().value
+			if (self.inwholegenome) self.wholegenome.matrixType = matrixType
+			if (self.inchrpair) self.chrpairview.matrixType = matrixType
+			if (self.indetail) self.detailview.matrixType = matrixType
+			await getData(hic, self)
 		})
 	const matrixTypevalues = [
 		//Allow for customer friendly labels but pass the appropriate straw parameter
@@ -162,6 +165,12 @@ function addLabel(tr: Elem, text: string) {
 		.text(text.toUpperCase())
 }
 
+/**
+ * Show either NONE if no normalization methods present in the hic file of dropdown of normalization methods
+ * read from the hic file.
+ * @param hic File input
+ * @param self App object
+ */
 function makeNormMethDisplay(hic: any, self: any) {
 	if (!hic.normalization?.length) {
 		hic.nmethselect = self.dom.controlsDiv.nmeth.text(defaultnmeth)
@@ -170,8 +179,11 @@ function makeNormMethDisplay(hic: any, self: any) {
 			.style('margin-right', '10px')
 			.append('select')
 			.on('change', async () => {
-				const v = hic.nmethselect.node().value
-				await setnmeth(hic, v, self)
+				const nmeth = hic.nmethselect.node().value
+				if (self.inwholegenome) self.wholegenome.nmeth = nmeth
+				if (self.inchrpair) self.chrpairview.nmeth = nmeth
+				if (self.indetail) self.detailview.nmeth = nmeth
+				await getData(hic, self)
 			})
 		for (const n of hic.normalization) {
 			hic.nmethselect.append('option').text(n)
@@ -179,9 +191,14 @@ function makeNormMethDisplay(hic: any, self: any) {
 	}
 }
 
-async function setnmeth(hic: any, nmeth: string, self: any) {
+/**
+ * Get data from user inputs ()
+ * @param hic
+ * @param self
+ * @returns
+ */
+async function getData(hic: any, self: any) {
 	if (self.inwholegenome) {
-		self.wholegenome.nmeth = nmeth
 		const manychr = hic.atdev ? 3 : hic.chrlst.length
 		for (let i = 0; i < manychr; i++) {
 			const lead = hic.chrlst[i]
@@ -199,57 +216,13 @@ async function setnmeth(hic: any, nmeth: string, self: any) {
 	}
 
 	if (self.inchrpair) {
-		self.chrpairview.nmeth = nmeth
 		await getdata_chrpair(hic, self)
 		return
 	}
 
-	if (self.inhorizontal) {
-		self.chrpairview.nmeth = nmeth
-		//need launch function here
-		return
-	}
-
 	if (self.indetail) {
-		self.detailview.nmeth = nmeth
 		getdata_detail(hic, self)
-	}
-}
-
-async function setMatrixType(hic: any, matrixType: string, self: any) {
-	if (self.inwholegenome) {
-		self.wholegenome.matrixType = matrixType
-		const manychr = hic.atdev ? 3 : hic.chrlst.length
-
-		for (let i = 0; i < manychr; i++) {
-			const lead = hic.chrlst[i]
-
-			for (let j = 0; j <= i; j++) {
-				const follow = hic.chrlst[j]
-
-				try {
-					await getdata_leadfollow(hic, lead, follow, self)
-				} catch (e: any) {
-					self.errList.push(e.message || e)
-				}
-			}
-		}
-
-		if (self.errList.length) {
-			self.error(self.errList)
-		}
-
 		return
-	}
-
-	if (self.inchrpair) {
-		self.chrpairview.matrixType = matrixType
-		await getdata_chrpair(hic, self)
-		return
-	}
-	if (self.indetail) {
-		self.detailview.matrixType = matrixType
-		getdata_detail(hic, self)
 	}
 }
 

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -109,8 +109,8 @@ export function initWholeGenomeControls(hic: any, self: any) {
 			self.dom.controlsDiv.zoomDiv.style('display', 'none')
 			self.inwholegenome = true
 			self.inchrpair = false
-			self.inhorizontal = false
 			self.indetail = false
+			self.inhorizontal = false
 			switchview(hic, self)
 		})
 
@@ -123,8 +123,8 @@ export function initWholeGenomeControls(hic: any, self: any) {
 			self.dom.controlsDiv.zoomDiv.style('display', 'none')
 			self.inwholegenome = false
 			self.inchrpair = true
-			self.inhorizontal = false
 			self.indetail = false
+			self.inhorizontal = false
 			switchview(hic, self)
 		})
 
@@ -133,12 +133,12 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('display', 'none')
 		.style('padding', '2px')
 		.style('margin', '4px 0px')
-		.html('&#8810; Horizontal View')
+		.html('Horizontal View &#8811;')
 		.on('click', () => {
 			self.inwholegenome = false
 			self.inchrpair = false
-			self.inhorizontal = true
 			self.indetail = false
+			self.inhorizontal = true
 			switchview(hic, self)
 		})
 
@@ -147,7 +147,14 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('display', 'none')
 		.style('padding', '2px')
 		.style('margin', '4px 0px')
-		.html('Detailed View &#8811;')
+		.html('&#8810; Detailed View')
+		.on('click', () => {
+			self.inwholegenome = false
+			self.inchrpair = false
+			self.indetail = true
+			self.inhorizontal = false
+			switchview(hic, self)
+		})
 
 	self.dom.controlsDiv.zoomDiv = menuTable.append('tr').style('display', 'none')
 	addLabel(self.dom.controlsDiv.zoomDiv, 'ZOOM')
@@ -192,7 +199,7 @@ function makeNormMethDisplay(hic: any, self: any) {
 }
 
 /**
- * Get data from user inputs ()
+ * Request data when user changes dropdowns per view
  * @param hic
  * @param self
  * @returns

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -77,9 +77,14 @@ export function initWholeGenomeControls(hic: any, self: any) {
 			const selectedmatrixType = self.dom.controlsDiv.matrixType.node().value
 			await setMatrixType(hic, selectedmatrixType, self)
 		})
-	const matrixTypevalues = ['observed', 'expected', 'oe']
+	const matrixTypevalues = [
+		//Allow for customer friendly labels but pass the appropriate straw parameter
+		{ label: 'Observed', value: 'observed' },
+		{ label: 'Expected', value: 'expected' },
+		{ label: 'Observed/Expected', value: 'oe' }
+	]
 	for (const matrixType of matrixTypevalues) {
-		self.dom.controlsDiv.matrixType.append('option').text(matrixType)
+		self.dom.controlsDiv.matrixType.append('option').text(matrixType.label).attr('value', matrixType.value)
 	}
 
 	const viewRow = menuTable.append('tr')

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -1,5 +1,5 @@
 import { bplen } from '#shared/common'
-import { nmeth2select, oeOption4select } from './hic.straw'
+import { nmeth2select, matrixType2select } from './hic.straw'
 import { getdata_chrpair, getdata_detail, getdata_leadfollow, defaultnmeth, showBtns } from './hic.straw'
 import { Elem } from '../../types/d3'
 import blocklazyload from '#src/block.lazyload'
@@ -73,16 +73,13 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.append('td')
 		.style('margin-right', '10px')
 		.append('select')
-
 		.on('change', async () => {
-			const selectedOEOption = self.dom.controlsDiv.matrixType.node().value
-			//console.log(selectedOEOption)
-			// Handle the selected option
-			await setOEOption(hic, selectedOEOption, self)
+			const selectedmatrixType = self.dom.controlsDiv.matrixType.node().value
+			await setMatrixType(hic, selectedmatrixType, self)
 		})
 	const matrixTypevalues = ['observed', 'expected', 'oe']
-	for (const oeOption of matrixTypevalues) {
-		self.dom.controlsDiv.matrixType.append('option').text(oeOption)
+	for (const matrixType of matrixTypevalues) {
+		self.dom.controlsDiv.matrixType.append('option').text(matrixType)
 	}
 
 	const viewRow = menuTable.append('tr')
@@ -214,9 +211,9 @@ async function setnmeth(hic: any, nmeth: string, self: any) {
 	}
 }
 
-async function setOEOption(hic: any, oeOption: string, self: any) {
+async function setMatrixType(hic: any, matrixType: string, self: any) {
 	if (self.inwholegenome) {
-		self.wholegenome.oeOption = oeOption
+		self.wholegenome.matrixType = matrixType
 		const manychr = hic.atdev ? 3 : hic.chrlst.length
 
 		for (let i = 0; i < manychr; i++) {
@@ -241,12 +238,12 @@ async function setOEOption(hic: any, oeOption: string, self: any) {
 	}
 
 	if (self.inchrpair) {
-		self.chrpairview.oeOption = oeOption
+		self.chrpairview.matrixType = matrixType
 		await getdata_chrpair(hic, self)
 		return
 	}
 	if (self.indetail) {
-		self.detailview.oeOption = oeOption
+		self.detailview.matrixType = matrixType
 		getdata_detail(hic, self)
 	}
 }
@@ -317,13 +314,13 @@ function switchview(hic: any, self: any) {
 
 	if (self.inwholegenome) {
 		nmeth2select(hic, self.wholegenome)
-		oeOption4select(self.wholegenome, self)
+		matrixType2select(self.wholegenome, self)
 		self.dom.plotDiv.plot.node().appendChild(self.wholegenome.svg.node())
 		self.dom.controlsDiv.inputBpMaxv.property('value', self.wholegenome.bpmaxv)
 		self.dom.controlsDiv.resolution.text(bplen(self.wholegenome.resolution) + ' bp')
 	} else if (self.inchrpair) {
 		nmeth2select(hic, self.chrpairview)
-		oeOption4select(self.chrpairview, self)
+		matrixType2select(self.chrpairview, self)
 		self.dom.plotDiv.yAxis.node().appendChild(self.chrpairview.axisy.node())
 		self.dom.plotDiv.xAxis.node().appendChild(self.chrpairview.axisx.node())
 		self.dom.plotDiv.plot.node().appendChild(self.chrpairview.canvas)
@@ -331,7 +328,7 @@ function switchview(hic: any, self: any) {
 		self.dom.controlsDiv.resolution.text(bplen(self.chrpairview.resolution) + ' bp')
 	} else if (self.indetail) {
 		nmeth2select(hic, self.detailview)
-		oeOption4select(self.detailview, self)
+		matrixType2select(self.detailview, self)
 	} else if (self.inhorizontal) {
 		//TODO: Problem with this is it rerenders. Maybe a way to save the rendering and just show/hide?
 		blocklazyload(self.horizontalview.args)

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -304,6 +304,7 @@ function switchview(hic: any, self: any) {
 		self.dom.controlsDiv.inputBpMaxv.property('value', self.wholegenome.bpmaxv)
 		self.dom.controlsDiv.resolution.text(bplen(self.wholegenome.resolution) + ' bp')
 	} else if (self.inchrpair) {
+		self.dom.controlsDiv.view.text(`${self.chrx.chr}-${self.chry.chr} Pair`)
 		nmeth2select(hic, self.chrpairview)
 		matrixType2select(self.chrpairview, self)
 		self.dom.plotDiv.yAxis.node().appendChild(self.chrpairview.axisy.node())

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -1236,14 +1236,18 @@ async function detailViewUpdateRegionFromBlock(hic: any, self: any) {
 	await detailViewUpdateHic(hic, self)
 }
 
-/** */
+/**
+ * Identifies the selected matrix type from the dropdown and sets it to the view object
+ * @param v view object within self (e.g. self.wholegenome) Each view object has its own matrixType
+ * @param self
+ */
 export function matrixType2select(v: any, self: any) {
 	const options = self.dom.controlsDiv.matrixType.node().options
 	const selectedOption = Array.from(options).find(
 		(o: any) => o.value === self.dom.controlsDiv.matrixType.node().value
 	) as any
 	selectedOption.selected = true
-	v.matrixType = selectedOption.value // Return the selected option value
+	v.matrixType = selectedOption.value
 }
 
 /**
@@ -1604,7 +1608,6 @@ export function getdata_detail(hic: any, self: any) {
 }
 
 export function hicparsefragdata(items: any) {
-	console.log(items)
 	const id2coord = new Map()
 	let min: number | null = null,
 		max: number | any

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -150,7 +150,7 @@ class Hicstat {
 		}
 		this.errList = []
 		this.wholegenome = {
-			oeOption: 'observed',
+			matrixType: 'observed',
 			binpx: 1,
 			/** wholegenome is fixed to use lowest bp resolution, and fixed cutoff value for coloring*/
 			bpmaxv: 5000,
@@ -383,7 +383,7 @@ class Hicstat {
 		this.dom.controlsDiv.view.text(`${chrx}-${chry} Pair`)
 		const horizontalView = this.init_horizontalView.bind(this)
 		nmeth2select(hic, this.chrpairview)
-		oeOption4select(this.chrpairview, this)
+		matrixType2select(this.chrpairview, this)
 
 		this.inwholegenome = false
 		this.inchrpair = true
@@ -529,7 +529,7 @@ class Hicstat {
 	async init_horizontalView(hic: any, chrx: string, chry: string, x: number, y: number) {
 		this.dom.controlsDiv.view.text('Horizontal')
 		nmeth2select(hic, this.horizontalview)
-		oeOption4select(this.horizontalview, this)
+		matrixType2select(this.horizontalview, this)
 
 		//Clear elements created in chr pair view
 		this.chrpairview.axisy.remove()
@@ -608,7 +608,7 @@ class Hicstat {
 	async init_detailView(hic: any, chrx: string, chry: string, x: number, y: number) {
 		this.dom.controlsDiv.view.text('Detailed')
 		nmeth2select(hic, this.detailview)
-		oeOption4select(this.detailview, this)
+		matrixType2select(this.detailview, this)
 
 		this.inwholegenome = false
 		this.inchrpair = false
@@ -959,7 +959,7 @@ export async function getdata_leadfollow(hic: any, lead: any, follow: any, self:
 	}
 
 	const arg = {
-		oevalues: self.wholegenome.oeOption,
+		matrixType: self.wholegenome.matrixType,
 		file: hic.file,
 		url: hic.url,
 		pos1: hic.nochr ? lead.replace('chr', '') : lead,
@@ -1150,7 +1150,7 @@ export async function getdata_chrpair(hic: any, self: any) {
 	const ctx = self.chrpairview.ctx
 
 	const arg = {
-		oevalues: self.chrpairview.oeOption,
+		matrixType: self.chrpairview.matrixType,
 		jwt: hic.jwt,
 		file: hic.file,
 		url: hic.url,
@@ -1237,13 +1237,13 @@ async function detailViewUpdateRegionFromBlock(hic: any, self: any) {
 }
 
 /** */
-export function oeOption4select(v: any, self: any) {
+export function matrixType2select(v: any, self: any) {
 	const options = self.dom.controlsDiv.matrixType.node().options
 	const selectedOption = Array.from(options).find(
 		(o: any) => o.value === self.dom.controlsDiv.matrixType.node().value
 	) as any
 	selectedOption.selected = true
-	v.oeOption = selectedOption.value // Return the selected option value
+	v.matrixType = selectedOption.value // Return the selected option value
 }
 
 /**
@@ -1413,7 +1413,7 @@ export function getdata_detail(hic: any, self: any) {
 	const ystop = self.detailview.ystop
 
 	const par: HicstrawArgs = {
-		oevalues: self.detailview.oeOption,
+		matrixType: self.detailview.matrixType,
 		jwt: hic.jwt,
 		file: hic.file,
 		url: hic.url,

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -28,7 +28,7 @@ export type HicRunProteinPaintTrackArgs = BaseTrackArgs &
 	}
 
 export type HicstrawArgs = SharedArgs & {
-	oevalues: 'observed' | 'expected' | 'oe'
+	matrixType: 'observed' | 'expected' | 'oe'
 	jwt: any
 	pos1: string
 	pos2: string
@@ -89,7 +89,7 @@ export type HicstrawDom = {
 
 export type WholeGenomeView = {
 	/** value for o,e,and oe option */
-	oeOption: 'observed' | 'expected' | 'oe'
+	matrixType: 'observed' | 'expected' | 'oe'
 	/** # pixel per bin, may set according to resolution */
 	binpx: number
 	/** Appears as the cutoff value for the user in the menu */
@@ -114,7 +114,7 @@ export type WholeGenomeView = {
 }
 
 export type ChrPairView = {
-	oeOption: 'observed' | 'expected' | 'oe'
+	matrixType: 'observed' | 'expected' | 'oe'
 	axisx: any //dom
 	axisy: any //dom
 	binpx: number
@@ -140,7 +140,7 @@ export type HorizontalView = {
 }
 
 export type DetailView = {
-	oeOption: 'observed' | 'expected' | 'oe'
+	matrixType: 'observed' | 'expected' | 'oe'
 	bbmargin: number
 	canvas?: any //dom
 	ctx: any //dom

--- a/server/routes/hicdata.ts
+++ b/server/routes/hicdata.ts
@@ -40,7 +40,7 @@ export const api: any = {
 	}
 }
 
-function init({ genomes }) {
+function init() {
 	return async (req: any, res: any): Promise<void> => {
 		try {
 			const payload = await handle_hicdata(req.query as HicdataRequest)
@@ -60,7 +60,7 @@ function handle_hicdata(q: HicdataRequest) {
 		if (e) reject({ error: 'illegal file name' })
 
 		const par = [
-			q.oevalues || 'observed',
+			q.matrixType || 'observed',
 			q.nmeth || 'NONE',
 			file,
 			q.pos1,

--- a/server/shared/types/routes/hicdata.ts
+++ b/server/shared/types/routes/hicdata.ts
@@ -1,6 +1,6 @@
 export type HicdataRequest = {
 	/** Value is the 1st parameter of straw tool, and can only use these specific strings but not anything else. */
-	oevalues: 'observed' | 'expected' | 'oe'
+	matrixType: 'observed' | 'expected' | 'oe'
 	/** HiC file path from tp/ */
 	file?: string
 	/** Remote HiC file URL */


### PR DESCRIPTION
## Description
- Reverted detail and horizontal view back to original order
- Customer friendly matrix type dropdown labels 
- Minor code consolidation

Test with http://localhost:3000/?genome=hg38&hicfile=proteinpaint_demo/hg38/hic/hic_demo_v9.hic&enzyme=MboI and other hic whole genome views from http://localhost:3000/url.html.

Please note: Future work includes updating rendering when user selects 'Observed/Expected` so the whole genome view does not appear blank. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
