### PR TITLE
set a max num of characters limit on legend group name

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -88,6 +88,7 @@ export async function getPlotConfig(opts = {}, app) {
 				rowlabelvisible: true,
 				rowlabelpad: 1,
 				rowlabelmaxchars: 32,
+				legendGrpLabelMaxChars: 26,
 				grpLabelFontSize: 12,
 				minLabelFontSize: 6,
 				maxLabelFontSize: 14,

--- a/client/plots/matrix.legend.js
+++ b/client/plots/matrix.legend.js
@@ -122,8 +122,10 @@ export function getLegendData(legendGroups, refs, self) {
 		const keys = Object.keys(legend.values).sort()
 		const hasScale = Object.values(legend.values).find(v => v.scale)
 		if (hasScale) {
+			const legendGrpLabelMaxChars = s.legendGrpLabelMaxChars || 26
 			legendData.push({
-				name: $id,
+				name: $id.length < legendGrpLabelMaxChars ? $id : $id.slice(0, legendGrpLabelMaxChars) + '...',
+				//name:$id,
 				order: legend.order,
 				$id: legend.$id,
 				dt: legend.dt,
@@ -180,8 +182,9 @@ export function getLegendData(legendGroups, refs, self) {
 					keys.length < 11 ? scaleOrdinal(schemeCategory10) : scaleOrdinal(schemeCategory20)
 
 			const name = t.tw.legend?.group || t.tw.label || term.name
+			const legendGrpLabelMaxChars = s.legendGrpLabelMaxChars || 26
 			legendData.push({
-				name: name.length < s.rowlabelmaxchars ? name : name.slice(0, s.rowlabelmaxchars) + '...',
+				name: name.length < legendGrpLabelMaxChars ? name : name.slice(0, legendGrpLabelMaxChars) + '...',
 				order: legend.order,
 				$id: legend.$id,
 				dt: legend.dt,


### PR DESCRIPTION
## Description
set a max num of characters limit on legend group name, for long legend group labels like "Gene Expression (CGC genes only)"

before:
![image](https://github.com/stjude/proteinpaint/assets/111394589/718e393a-0ea6-4006-881d-6bcf1b0e3de5)


now:
![image](https://github.com/stjude/proteinpaint/assets/111394589/77208904-3aa0-4253-bdcb-1f5bce0dc3a6)



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
