### PR TITLE
fix for unknown ds in routes for getrootterm and getchildren

### DIFF
--- a/server/routes/termdb.getrootterm.ts
+++ b/server/routes/termdb.getrootterm.ts
@@ -1,4 +1,5 @@
 import { getroottermRequest, getroottermResponse } from '#shared/types/routes/termdb.getrootterm.ts'
+import { get_ds_tdb } from '#src/termdb.js'
 
 export const api: any = {
 	endpoint: 'termdb/rootterm',
@@ -41,9 +42,8 @@ function init({ genomes }) {
 		try {
 			const g = genomes[req.query.genome]
 			if (!g) throw 'invalid genome name'
-			const ds = g.datasets[req.query.dslabel]
+			const [ds, tdb] = await get_ds_tdb(g, q)
 			if (!ds) throw 'invalid dataset name'
-			const tdb = ds.cohort.termdb
 			if (!tdb) throw 'invalid termdb object'
 
 			await trigger_rootterm(q, res, tdb) // as getroottermResponse

--- a/server/routes/termdb.gettermchildren.ts
+++ b/server/routes/termdb.gettermchildren.ts
@@ -1,5 +1,6 @@
 import { gettermchildrenRequest, gettermchildrenResponse } from '#shared/types/routes/termdb.gettermchildren.ts'
 import { copy_term } from '#src/termdb.js'
+import { get_ds_tdb } from '#src/termdb.js'
 
 export const api: any = {
 	endpoint: 'termdb/termchildren',
@@ -43,9 +44,8 @@ function init({ genomes }) {
 		try {
 			const g = genomes[req.query.genome]
 			if (!g) throw 'invalid genome name'
-			const ds = g.datasets[req.query.dslabel]
+			const [ds, tdb] = await get_ds_tdb(g, q)
 			if (!ds) throw 'invalid dataset name'
-			const tdb = ds.cohort.termdb
 			if (!tdb) throw 'invalid termdb object'
 
 			await trigger_children(q, res, tdb)

--- a/server/routes/termdb.gettermchildren.ts
+++ b/server/routes/termdb.gettermchildren.ts
@@ -1,6 +1,5 @@
 import { gettermchildrenRequest, gettermchildrenResponse } from '#shared/types/routes/termdb.gettermchildren.ts'
-import { copy_term } from '#src/termdb.js'
-import { get_ds_tdb } from '#src/termdb.js'
+import { copy_term, get_ds_tdb } from '#src/termdb.js'
 
 export const api: any = {
 	endpoint: 'termdb/termchildren',

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -107,7 +107,7 @@ export function get_ds_tdb(genome, q) {
 	}
 	// not matching with dataset
 	if (!genome.termdbs) {
-		throw 'genome-level termdb not available'
+		throw 'invalid dslabel'
 	}
 	const ds = genome.termdbs[q.dslabel]
 	if (!ds) {


### PR DESCRIPTION
## Description

This should fix the issue. @siosonel do you think methods like `copy_term` and `get_ds_tdb` should be moved out of termdb.js into server/shared? 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
