### PR TITLE
detect undefined x1, x2 hits before trying to render a bam variant

### DIFF
--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -463,17 +463,18 @@ function may_render_variant(data, tk, block) {
 			let x1, x2 // on screen pixel start/stop of the variant box
 			{
 				const hits = block.seekcoord(tk.variants[0].chr, tk.variants[var_idx].pos)
-				if (hits) {
+				if (hits?.length) {
 					x1 = hits[0].x - block.exonsf / 2
 				}
 			}
 			{
 				const hits = block.seekcoord(tk.variants[0].chr, tk.variants[var_idx].pos + tk.variants[var_idx].ref.length)
-				if (hits) {
+				if (hits?.length) {
 					x2 = hits[0].x - block.exonsf / 2
 				}
 			}
-			if (x1 >= block.width || x2 <= 0) {
+
+			if ((x1 !== undefined && x1 >= block.width) || x2 <= 0 || (x1 === undefined && x2 === undefined)) {
 				// variant is out of range, do not show
 				return
 			}

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -463,21 +463,18 @@ function may_render_variant(data, tk, block) {
 			let x1, x2 // on screen pixel start/stop of the variant box
 			{
 				const hits = block.seekcoord(tk.variants[0].chr, tk.variants[var_idx].pos)
-				if (hits?.length) {
+				if (hits[0]) {
 					x1 = hits[0].x - block.exonsf / 2
 				}
 			}
 			{
 				const hits = block.seekcoord(tk.variants[0].chr, tk.variants[var_idx].pos + tk.variants[var_idx].ref.length)
-				if (hits?.length) {
+				if (hits[0]) {
 					x2 = hits[0].x - block.exonsf / 2
 				}
 			}
 
-			if ((x1 !== undefined && x1 >= block.width) || x2 <= 0 || (x1 === undefined && x2 === undefined)) {
-				// variant is out of range, do not show
-				return
-			}
+			if (x1 === undefined || x2 === undefined || x1 >= block.width || x2 <= 0) return // variant is out of range, do not show
 
 			// will render variant in a row
 			let variant_box_width = x2 - x1

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- detect empty hits before trying to render bam variants


### PR DESCRIPTION
## Description
Fixes https://gdc-ctds.atlassian.net/browse/SV-2353.

Instead of a code/read error, the follwing message will show up instead for empty hits for x1/x2.
<img width="304" alt="Screenshot 2024-01-13 at 12 41 34 PM" src="https://github.com/stjude/proteinpaint/assets/411031/e691bbc2-d0c3-4238-b371-8bc37cf5cbd0">

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
