### PR TITLE
feat: support an option to adjust the tracked state

### DIFF
--- a/client/rx/src/recover.js
+++ b/client/rx/src/recover.js
@@ -1,4 +1,4 @@
-import { getCompInit, toJson } from '../index.js'
+import { getCompInit, toJson, deepFreeze, deepEqual } from '../index.js'
 
 /*
 opts:{}
@@ -84,7 +84,10 @@ class Recover {
 		if (this.currIndex < this.history.length - 1) {
 			this.history.splice(this.currIndex, this.history.length - (this.currIndex + 1))
 		}
-		this.history.push(this.state)
+		const state = this.opts.adjustTrackedState ? this.opts.adjustTrackedState(this.state) : this.state
+		if (!Object.isFrozen(state)) deepFreeze(state)
+		if (deepEqual(state, this.history[this.history.length - 1])) return
+		this.history.push(state)
 		this.currIndex += 1
 
 		if (this.history.length > this.maxHistoryLen) {

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -253,7 +253,12 @@ async function launchWithGenes(genes, genome, arg, settings, holder) {
 		recover: {
 			undoHtml: 'Undo',
 			redoHtml: 'Redo',
-			resetHtml: 'Restore'
+			resetHtml: 'Restore',
+			adjustTrackedState(state) {
+				const s = structuredClone(state)
+				delete s.termfilter.filter0
+				return s
+			}
 		},
 		matrix: Object.assign(
 			{

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- support an option to adjust the tracked state


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/1161.

To test, use http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=Gliomas.
- changing the selected cohort should not update the undo/redo buttons (should ignore filter0 changes)
- changing a matrix chart setting, like zoom, should affect the unto/redo tracked state

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
