### PR TITLE
Matrix should update when the filter0 changes while the geneset edit UI is displayed

### DIFF
--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -128,6 +128,13 @@ export async function init(arg, holder, genomes) {
 							removedTempDiv = true
 							tempDiv.remove()
 							const plotState = structuredClone(plotAppApi.getState().plots[0])
+							if (pendingArg.termgroups) {
+								// arg.termgroups was not rehydrated on the appInit() of plotApp,
+								// need to rehydrate here manually
+								for (const group of pendingArg.termgroups) {
+									group.lst = await Promise.all(group.lst.map(fillTermWrapper))
+								}
+							}
 							plotState.termgroups = [...(pendingArg.termgroups || []), { lst: genes }]
 							plotAppApi.dispatch({
 								type: 'app_refresh',

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -765,8 +765,10 @@ export class TermdbVocab extends Vocab {
 						const idn = 'id' in tw.term ? tw.term.id : tw.term.name
 
 						for (const sampleId in data.samples) {
-							samplesToShow.add(sampleId)
 							const sample = data.samples[sampleId]
+							// ignore sample objects that are not annotated by other keys besides 'sample'
+							if (!Object.keys(sample).filter(k => k != 'sample').length) continue
+							samplesToShow.add(sampleId)
 							if (!(sampleId in samples)) {
 								// normalize the expected data shape
 								if (!data.refs.bySampleId[sampleId]) data.refs.bySampleId[sampleId] = {}
@@ -824,8 +826,9 @@ export class TermdbVocab extends Vocab {
 				lst.push(...Object.values(samples))
 			} else {
 				// If there are dictionary terms, only show samples that have been annotated
-				// for at least one dictionary terms, otherwise do NOT show samples that
+				// for at least one dictionary term, otherwise do NOT show samples that
 				// are only annotated for non-dictionary terms like gene variants
+				// NOTE: there is an exception when using matrix?.settings?.displayDictRowWithNoValues
 				for (const sampleId in samples) {
 					const row = samples[sampleId]
 					for (const $id in row) {
@@ -834,6 +837,11 @@ export class TermdbVocab extends Vocab {
 							break
 						}
 					}
+				}
+				if (!lst.length && this.termdbConfig?.matrix?.settings?.displayDictRowWithNoValues) {
+					// this prevents the display of 'no matching sample data for the current gene list',
+					// which may be confusing if there is data for genes but not for dictionary terms
+					lst.push(...Object.values(samples))
 				}
 			}
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -869,8 +869,8 @@ export class TermdbVocab extends Vocab {
 	getTwMinCopy(tw) {
 		const idn = 'id' in tw.term ? tw.term.id : tw.term.name
 		const copy = { term: {}, q: tw.q }
-		if ('id' in tw) {
-			copy.term.id = tw.term.id
+		if ('id' in tw || 'id' in tw.term) {
+			copy.term.id = tw.id || tw.term.id
 			if (tw.term.type == 'snplst' || tw.term.type == 'snplocus') {
 				// added following so getData will not break
 				copy.term.type = tw.term.type

--- a/release.txt
+++ b/release.txt
@@ -1,3 +1,4 @@
 Fixes:
 - supply the missing api reference when launching a gdc matrix
 - Option to override the matrix default of not rendering samples that are not annotated for any dictionary term, for more intuitive behavior in gene-centric use-cases
+- Matrix should update when the filter0 changes while the geneset edit UI is displayed

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - supply the missing api reference when launching a gdc matrix
+- Option to override the matrix default of not rendering samples that are not annotated for any dictionary term, for more intuitive behavior in gene-centric use-cases


### PR DESCRIPTION
## Description
Closes https://github.com/stjude/proteinpaint/issues/1163

To test: 
- pull sjpp master
- open http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=APOLLO-LUAD
- the geneset edit UI should be visible, do not use it
- change the cohort, the geneset edit UI should disappear and the matrix should render

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
