### PR TITLE
always trigger the closing of an embedder's loading overlay

### DIFF
--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -144,7 +144,21 @@ export async function init(arg, holder, genomes) {
 								}
 							})
 							matrixDiv.style('display', '')
+						} else {
+							plotAppApi.dispatch({
+								type: 'filter_replace',
+								filter0: arg.filter0
+							})
 						}
+					} else {
+						// this will force an app.postRender() emit to trigger hiding the loading overlay,
+						// if there is an arg.app.calllbacks.postRender, and even if there is no state change
+						// that would have trigerred a matrix re-render to trigger a postRender closing of
+						// the loading overlay
+						plotAppApi.dispatch({
+							type: 'app_refresh',
+							state: {}
+						})
 					}
 					return
 				}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- always trigger the closing of an embedder's loading overlay, even when there are no chart state changes


### PR DESCRIPTION
## Description

... even when there are no chart state changes. Otherwise, the loading overlay remains visible and obscures the geneset edit UI in the GDC OncoMatrix.

To simulate the issue and test the fix:
- pull sjpp master
- in `launchGdcMatrix.js`, comment out the fixes, lines 148-151 and 158-161
- open http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=APOLLO-LUAD
- Click on the `Toggle Main Div` button, then click again to go back
- The loading overlay will remain visible, it should have been hidden
- To test the fix: uncomment the fixes in `launchGdcMatrix.js`, then reload the page and repeat the toggling of the main div, this time the loading overlay should become hidden as expected


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
