### PR TITLE
create Renviron file in docker

### DIFF
--- a/container/deps/Dockerfile
+++ b/container/deps/Dockerfile
@@ -49,15 +49,18 @@ RUN curl -L https://github.com/samtools/samtools/releases/download/${htsversion}
 RUN curl -L https://github.com/samtools/bcftools/releases/download/${htsversion}/bcftools-${htsversion}.tar.bz2 | tar xj && \
     (cd bcftools-${htsversion} && ./configure --enable-libgsl --with-htslib=system && make install)
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 'B8F25A8A73EACF41' && \ #pragma: allowlist secret
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 'B8F25A8A73EACF41' && `#pragma: allowlist secret` \
     echo "deb https://cloud.r-project.org/bin/linux/debian buster-cran40/" >> /etc/apt/sources.list \ 
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF' #pragma: allowlist secret
 
 RUN apt-get update && apt-get install -y r-base=4.3.2-1~bustercran.0 -y libargtable2-dev \
 	## install R packages
  	&& R -e "install.packages(c('cmprsk', 'hwde', 'jsonlite', 'survival', 'lmtest', 'dplyr', 'tidyr', 'BiocManager', 'readr'), dependencies=TRUE, repos='http://cran.rstudio.com/')" \
-	## clean up
 	&& R -e "BiocManager::install('edgeR')" \
+    ## set locale encoding in R
+    ## must match encoding configuration in docker
+    && echo "LC_ALL=C.UTF-8" > /root/.Renviron \
+    ## clean up
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds


### PR DESCRIPTION
## Description

This PR creates an `.Renviron` file in docker to specify correct UTF8 encoding in R. To implement this change, you need to rebuild the docker dependencies and then rebuild the container.

Can then test by using this [example](http://localhost:3456/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Cardiovascular%20System%22,%22q%22:{}},%22term2%22:{%22id%22:%22hrtavg%22,%22q%22:{%22type%22:%22custom-bin%22,%22mode%22:%22discrete%22,%22lst%22:[{%22startunbounded%22:true,%22stop%22:100,%22stopinclusive%22:false,%22label%22:%22%3C100%22},{%22start%22:100,%22startinclusive%22:true,%22stopunbounded%22:true,%22label%22:%22%E2%89%A5100%22}]}}}],%22nav%22:{%22activeTab%22:1}}) and making sure that the "greater than or equal to" symbol renders correctly.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
