### PR TITLE
Cuminc plot improvements

### DIFF
--- a/client/dom/svgSeriesTips.js
+++ b/client/dom/svgSeriesTips.js
@@ -51,7 +51,8 @@ export function getSeriesTip(line, rect, _tip = null) {
 				// equal to xVal
 				const max = Math.max(...data.filter(d => d.x <= xVal).map(d => d.x))
 				// store html of this timepoint
-				seriesHtmls.push(data.find(d => d.x == max).html)
+				const timepoint = data.find(d => d.x == max)
+				if (timepoint) seriesHtmls.push(timepoint.html)
 			}
 		}
 

--- a/client/dom/svgSeriesTips.js
+++ b/client/dom/svgSeriesTips.js
@@ -40,23 +40,20 @@ export function getSeriesTip(line, rect, _tip = null) {
 		const xVal = +opts.xScale.invert(mx).toFixed(opts.decimals)
 		const x = opts.xScale(xVal) /* + 0.5*/ // do not add a small float value here; otherwise, the line will not match up with the data
 
-		line
-			.style('display', '')
-			.attr('stroke', '#aaa')
-			.attr('stroke-dasharray', 4)
-			.attr('x1', x)
-			.attr('x2', x)
+		line.style('display', '').attr('stroke', '#aaa').attr('stroke-dasharray', 4).attr('x1', x).attr('x2', x)
 
-		const seriesHtmls = opts.serieses
-			.map(s => {
-				let matched
-				for (const d of s.data) {
-					if (d.x > xVal) break
-					matched = d
-				}
-				return !matched ? null : matched.html
-			})
-			.filter(d => d)
+		const seriesHtmls = []
+		for (const series of opts.serieses) {
+			const data = series.data
+			if (xVal <= Math.max(...data.map(d => d.x))) {
+				// xVal is within range of series timepoints
+				// determine max timepoint that is less than or
+				// equal to xVal
+				const max = Math.max(...data.filter(d => d.x <= xVal).map(d => d.x))
+				// store html of this timepoint
+				seriesHtmls.push(data.find(d => d.x == max).html)
+			}
+		}
 
 		if (seriesHtmls.length) {
 			tip
@@ -137,10 +134,7 @@ export function getSeriesTip(line, rect, _tip = null) {
 			because of non-deactivated references
 		*/
 		destroy() {
-			rect
-				.on('mouseover', null)
-				.on('mousemove', null)
-				.on('mouseout', null)
+			rect.on('mouseover', null).on('mousemove', null).on('mouseout', null)
 		}
 	}
 }

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -672,7 +672,14 @@ function setRenderers(self) {
 			// add in charts with no data
 			data.push(
 				...self.noData.map(chartId => {
-					return { chartId, chartTitle: chartId }
+					let chartTitle = chartId
+					const t0 = self.config.term0
+					if (t0.q && t0.q.groupsetting && t0.q.groupsetting.inuse) return { chartId, chartTitle }
+					if (t0.term.values) {
+						const value = t0.term.values[chartId]
+						if (value && value.label) chartTitle = value.label
+					}
+					return { chartId, chartTitle }
 				})
 			)
 		}

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -720,7 +720,7 @@ function setRenderers(self) {
 			.append('div')
 			.attr('class', 'sjpcb-cuminc-title')
 			.style('text-align', 'center')
-			.style('width', s.svgw + 50 + 'px')
+			.style('width', `${s.svgw + 50}px`)
 			.style('height', s.chartTitleDivHt + 'px')
 			.style('font-weight', '600')
 			.style('margin', '5px')
@@ -733,7 +733,7 @@ function setRenderers(self) {
 			.append('div')
 			.attr('class', 'pp-cuminc-chart-noData')
 			.style('display', 'none')
-			.style('width', s.svgw + 50 + 'px')
+			.style('width', `${s.svgw + 50}px`)
 			.style('margin', '40px 5px')
 			.text('No cumulative incidence data')
 
@@ -817,7 +817,7 @@ function setRenderers(self) {
 
 		div
 			.select('.sjpcb-cuminc-title')
-			.style('width', s.svgw + 50 + 'px')
+			.style('width', `${s.svgw + 50}px`)
 			.style('height', s.chartTitleDivHt + 'px')
 			.datum(chart.chartId)
 			.html(chart.chartTitle)
@@ -838,7 +838,7 @@ function setRenderers(self) {
 			div
 				.select('.pp-cuminc-chart-noData')
 				.style('display', 'block')
-				.style('width', s.svgw + 50 + 'px')
+				.style('width', `${s.svgw + 50}px`)
 		}
 
 		// div for chart-specific legends

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -707,16 +707,13 @@ function setRenderers(self) {
 			.append('div')
 			.attr('class', 'pp-cuminc-chart')
 			.style('opacity', chart.serieses ? 0 : 1) // if the data can be plotted, slowly reveal plot
-			//.style("position", "absolute")
 			.style('display', 'inline-block')
 			.style('margin', s.chartMargin + 'px')
 			.style('padding', '10px')
 			.style('top', 0)
 			.style('left', 0)
-			.style('text-align', 'left')
+			.style('text-align', 'center')
 			.style('vertical-align', 'top')
-			//.style('border', '1px solid #eee')
-			//.style('box-shadow', '0px 0px 1px 0px #ccc')
 			.style('background', 1 || s.orderChartsBy == 'organ-system' ? chart.color : '')
 
 		div
@@ -736,63 +733,69 @@ function setRenderers(self) {
 			.append('div')
 			.attr('class', 'pp-cuminc-chart-noData')
 			.style('display', 'none')
-			.style('text-align', 'center')
-			.style('margin', '30px')
+			.style('width', s.svgw + 50 + 'px')
+			.style('margin', '40px 5px')
 			.text('No cumulative incidence data')
 
 		if (chart.serieses) {
+			// series in chart
 			setVisibleSerieses(chart, s)
 
 			const svg = div.append('svg').attr('class', 'pp-cuminc-svg')
 			renderSVG(svg, chart, s, 0)
 
 			div.transition().duration(s.duration).style('opacity', 1)
-
-			// div for chart-specific legends
-			div
-				.append('div')
-				.attr('class', 'pp-cuminc-chartLegends')
-				.style('vertical-align', 'top')
-				.style('margin', '10px 10px 10px 30px')
-				.style('display', 'none')
-
-			// p-values legend
-			if (self.tests && chart.chartId in self.tests) {
-				const holder = div.select('.pp-cuminc-chartLegends').style('display', 'inline-block').append('div')
-				renderPvalues({
-					title: "Group comparisons (Gray's test)",
-					holder,
-					plot: 'cuminc',
-					tests: self.tests[chart.chartId],
-					s,
-					bins: self.refs.bins
-				})
-			}
-
-			// skipped series legends
-			// series with no events
-			if (self.noEvents && chart.chartId in self.noEvents) {
-				const skipdiv = div
-					.select('.pp-cuminc-chartLegends')
-					.style('display', 'inline-block')
-					.append('div')
-					.style('margin', '30px 0px')
-				const title = 'Skipped series (no events)'
-				renderSkippedSeries(skipdiv, title, self.noEvents[chart.chartId], s)
-			}
-			// series with low sample size
-			if (self.lowSampleSize && chart.chartId in self.lowSampleSize) {
-				const skipdiv = div
-					.select('.pp-cuminc-chartLegends')
-					.style('display', 'inline-block')
-					.append('div')
-					.style('margin', '30px 0px')
-				const title = 'Skipped series (low sample size)'
-				renderSkippedSeries(skipdiv, title, self.lowSampleSize[chart.chartId], s)
-			}
 		} else {
 			// no series in chart
 			div.select('.pp-cuminc-chart-noData').style('display', 'block')
+		}
+
+		// div for chart-specific legends
+		div
+			.append('div')
+			.attr('class', 'pp-cuminc-chartLegends')
+			.style('vertical-align', 'top')
+			.style('text-align', chart.serieses ? 'left' : 'center')
+			.style('margin', chart.serieses ? '10px 30px 0px 20px' : '0px')
+			.style('display', 'none')
+
+		if (chart.chartId in self.tests) {
+			// p-values legend
+			const holder = div
+				.select('.pp-cuminc-chartLegends')
+				.style('display', 'inline-block')
+				.append('div')
+				.style('margin-bottom', '30px')
+			renderPvalues({
+				title: "Group comparisons (Gray's test)",
+				holder,
+				plot: 'cuminc',
+				tests: self.tests[chart.chartId],
+				s,
+				bins: self.refs.bins
+			})
+		}
+
+		if (chart.chartId in self.noEvents) {
+			// legend for series with no events
+			const skipdiv = div
+				.select('.pp-cuminc-chartLegends')
+				.style('display', 'inline-block')
+				.append('div')
+				.style('margin-bottom', '30px')
+			const title = 'Skipped series (no events)'
+			renderSkippedSeries(skipdiv, title, self.noEvents[chart.chartId], s)
+		}
+
+		if (chart.chartId in self.lowSampleSize) {
+			// legend for series with low sample size
+			const skipdiv = div
+				.select('.pp-cuminc-chartLegends')
+				.style('display', 'inline-block')
+				.append('div')
+				.style('margin-bottom', '30px')
+			const title = 'Skipped series (low sample size)'
+			renderSkippedSeries(skipdiv, title, self.lowSampleSize[chart.chartId], s)
 		}
 	}
 
@@ -814,7 +817,7 @@ function setRenderers(self) {
 
 		div
 			.select('.sjpcb-cuminc-title')
-			.style('width', s.svgw + 50)
+			.style('width', s.svgw + 50 + 'px')
 			.style('height', s.chartTitleDivHt + 'px')
 			.datum(chart.chartId)
 			.html(chart.chartTitle)
@@ -831,47 +834,53 @@ function setRenderers(self) {
 			setVisibleSerieses(chart, s)
 
 			renderSVG(div.select('svg'), chart, s, s.duration)
-
-			// div for chart-specific legends
-			div.select('.pp-cuminc-chartLegends').selectAll('*').remove()
-
-			// p-values legend
-			if (self.tests && chart.chartId in self.tests) {
-				const holder = div.select('.pp-cuminc-chartLegends').style('display', 'inline-block').append('div')
-				renderPvalues({
-					title: "Group comparisons (Gray's test)",
-					holder,
-					plot: 'cuminc',
-					tests: self.tests[chart.chartId],
-					s,
-					bins: self.refs.bins
-				})
-			}
-
-			// skipped series legends
-			// series with no events
-			if (self.noEvents && chart.chartId in self.noEvents) {
-				const skipdiv = div
-					.select('.pp-cuminc-chartLegends')
-					.style('display', 'inline-block')
-					.append('div')
-					.style('margin', '30px 0px')
-				const title = 'Skipped series (no events)'
-				renderSkippedSeries(skipdiv, title, self.noEvents[chart.chartId], s)
-			}
-			// series with low sample size
-			if (self.lowSampleSize && chart.chartId in self.lowSampleSize) {
-				const skipdiv = div
-					.select('.pp-cuminc-chartLegends')
-					.style('display', 'inline-block')
-					.append('div')
-					.style('margin', '30px 0px')
-				const title = 'Skipped series (low sample size)'
-				renderSkippedSeries(skipdiv, title, self.lowSampleSize[chart.chartId], s)
-			}
 		} else {
-			// no series in chart
-			div.select('.pp-cuminc-chart-noData').style('display', 'block')
+			div
+				.select('.pp-cuminc-chart-noData')
+				.style('display', 'block')
+				.style('width', s.svgw + 50 + 'px')
+		}
+
+		// div for chart-specific legends
+		div.select('.pp-cuminc-chartLegends').selectAll('*').remove()
+
+		if (chart.chartId in self.tests) {
+			// p-values legend
+			const holder = div
+				.select('.pp-cuminc-chartLegends')
+				.style('display', 'inline-block')
+				.append('div')
+				.style('margin-bottom', '30px')
+			renderPvalues({
+				title: "Group comparisons (Gray's test)",
+				holder,
+				plot: 'cuminc',
+				tests: self.tests[chart.chartId],
+				s,
+				bins: self.refs.bins
+			})
+		}
+
+		if (chart.chartId in self.noEvents) {
+			// legend for series with no events
+			const skipdiv = div
+				.select('.pp-cuminc-chartLegends')
+				.style('display', 'inline-block')
+				.append('div')
+				.style('margin-bottom', '30px')
+			const title = 'Skipped series (no events)'
+			renderSkippedSeries(skipdiv, title, self.noEvents[chart.chartId], s)
+		}
+
+		if (chart.chartId in self.lowSampleSize) {
+			// legend for series with low sample size
+			const skipdiv = div
+				.select('.pp-cuminc-chartLegends')
+				.style('display', 'inline-block')
+				.append('div')
+				.style('margin-bottom', '30px')
+			const title = 'Skipped series (low sample size)'
+			renderSkippedSeries(skipdiv, title, self.lowSampleSize[chart.chartId], s)
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes for cuminc chart with no data:
- Use term.values, if available, for chart title
- Render chart legends to inform user why no cuminc data is available
- Test using [example 1](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term0%22:{%22id%22:%22sex%22,%22q%22:{}},%22term%22:{%22id%22:%22Breast%22,%22q%22:{}},%22term2%22:{%22id%22:%22chestrt_yn%22,%22q%22:{%22type%22:%22custom-bin%22,%22mode%22:%22discrete%22,%22lst%22:[{%22startunbounded%22:true,%22stop%22:200,%22stopinclusive%22:false,%22label%22:%22%3C200%22},{%22start%22:200,%22startinclusive%22:true,%22stopunbounded%22:true,%22label%22:%22%E2%89%A5200%22}]}}}],%22nav%22:{%22activeTab%22:1}}) and [example 2](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term0%22:{%22id%22:%22genetic_race%22,%22q%22:{}},%22term%22:{%22id%22:%22Breast%22,%22q%22:{}},%22term2%22:{%22id%22:%22hrtavg%22,%22q%22:{%22type%22:%22custom-bin%22,%22mode%22:%22discrete%22,%22lst%22:[{%22startunbounded%22:true,%22stop%22:200,%22stopinclusive%22:false,%22label%22:%22%3C200%22},{%22start%22:200,%22startinclusive%22:true,%22stopunbounded%22:true,%22label%22:%22%E2%89%A5200%22}]}}}],%22nav%22:{%22activeTab%22:1}})

Changes to series tip (will apply to cuminc and survival plots):
- Only series that overlap mouse cursor will be displayed in series tip
- Test using this [example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Cardiomyopathy%22,%22q%22:{}},%22term2%22:{%22id%22:%22genetic_race%22}}],%22nav%22:{%22activeTab%22:1}}) and hover mouse over series. Number of series in tip should be the number of series that overlap the vertical line.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
