### PR TITLE
Use graphql query to replace /analysis/top_mutated_genes_by_project in GDC OncoMatrix

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Use graphql query to replace /analysis/top_mutated_genes_by_project in GDC OncoMatrix

--- a/server/shared/types/routes/gdc.topMutatedGenes.ts
+++ b/server/shared/types/routes/gdc.topMutatedGenes.ts
@@ -1,3 +1,11 @@
+export type GdcTopMutatedGeneRequest = {
+	/** to restrict to CGC genes */
+	geneFilter?: 'CGC'
+	/** max number of genes to return */
+	maxGenes?: number
+	/** gdc cohort filter */
+	filter0?: object
+}
 export type GdcTopMutatedGeneResponse = {
 	genes: string[]
 }


### PR DESCRIPTION
## Description

closes #1167 
http://localhost:3000/example.gdc.matrix.html?cohort=APOLLO-LUAD works now with default geneset
all functionalities work

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
