### PR TITLE
Validate term ids in filter tvs

### DIFF
--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -48,7 +48,7 @@ export async function getFilterCTEs(filter, ds, CTEname = 'f') {
 		} else if (!item.tvs) {
 			throw `filter item should have a 'tvs' or 'lst' property`
 		} else if (!ds.cohort.termdb.q.termjsonByOneid(item.tvs.term.id)) {
-			throw `missing dictionary term for filter item id=${item.tvs.term.id}`
+			throw 'invalid term id in tvs'
 		} else if (item.tvs.term.type == 'categorical') {
 			f = get_categorical(item.tvs, CTEname_i)
 			// .CTEs: []

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -47,6 +47,8 @@ export async function getFilterCTEs(filter, ds, CTEname = 'f') {
 			// .CTEname: str
 		} else if (!item.tvs) {
 			throw `filter item should have a 'tvs' or 'lst' property`
+		} else if (!ds.cohort.termdb.q.termjsonByOneid(item.tvs.term.id)) {
+			throw `missing dictionary term for filter item id=${item.tvs.term.id}`
 		} else if (item.tvs.term.type == 'categorical') {
 			f = get_categorical(item.tvs, CTEname_i)
 			// .CTEs: []

--- a/server/src/test/termdb.filter.unit.spec.js
+++ b/server/src/test/termdb.filter.unit.spec.js
@@ -10,26 +10,29 @@ const tdb = require('./load.testds').init('termdb.test.js')
 const { server_init_db_queries } = require('../termdb.server.init')
 server_init_db_queries(tdb.ds)
 
-tape('\n', function(test) {
+tape('\n', function (test) {
 	test.pass('-***- modules/termdb.filter specs -***-')
 	test.end()
 })
 
-tape('simple filter', async function(test) {
-	const filter = await getFilterCTEs({
-		type: 'tvslst',
-		in: true,
-		join: '',
-		lst: [
-			{
-				type: 'tvs',
-				tvs: {
-					term: { id: 'wgs_sequenced', type: 'categorical' },
-					values: [{ key: '1', label: 'Yes' }] // always assumed OR
+tape('simple filter', async function (test) {
+	const filter = await getFilterCTEs(
+		{
+			type: 'tvslst',
+			in: true,
+			join: '',
+			lst: [
+				{
+					type: 'tvs',
+					tvs: {
+						term: { id: 'wgs_curated', type: 'categorical' },
+						values: [{ key: '1', label: 'Yes' }] // always assumed OR
+					}
 				}
-			}
-		]
-	})
+			]
+		},
+		tdb.ds
+	)
 
 	//console.log(filter.CTEs.join(',\n'))
 	//console.log(filter.values)
@@ -48,7 +51,7 @@ tape('simple filter', async function(test) {
 	test.end()
 })
 
-tape('nested filter', async function(test) {
+tape('nested filter', async function (test) {
 	const filter = await getFilterCTEs(
 		{
 			type: 'tvslst',
@@ -58,7 +61,7 @@ tape('nested filter', async function(test) {
 				{
 					type: 'tvs',
 					tvs: {
-						term: { id: 'wgs_sequenced', type: 'categorical' },
+						term: { id: 'wgs_curated', type: 'categorical' },
 						values: [{ key: '1', label: 'Yes' }] // always assumed OR
 					}
 				},

--- a/server/src/test/termdb.filter.unit.spec.js
+++ b/server/src/test/termdb.filter.unit.spec.js
@@ -128,3 +128,40 @@ tape('nested filter', async function (test) {
 	test.equal(filter.CTEs.length, 8, 'should return 8 CTE clauses for this complex filter')
 	test.end()
 })
+
+tape('invalid filter term', async function (test) {
+	const message = 'Should throw for invalid term id'
+	try {
+		const filter = await getFilterCTEs(
+			{
+				type: 'tvslst',
+				in: true,
+				join: '',
+				lst: [
+					{
+						type: 'tvs',
+						tvs: {
+							term: {
+								id: 'invalidTerm',
+								name: 'InvalidTerm',
+								type: 'categorical'
+							},
+							values: [
+								{
+									key: 'RMS',
+									label: 'RMS'
+								}
+							]
+						}
+					}
+				]
+			},
+			tdb.ds
+		)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	test.end()
+})


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/1149

Term IDs in filter tvs are now validated. Can test by running this [example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22termfilter%22:%7B%22filter%22:%7B%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22invalidTerm%22,%22name%22:%22InvalidTerm%22,%22type%22:%22categorical%22%7D,%22values%22:%5B%7B%22key%22:%22RMS%22,%22label%22:%22RMS%22%7D%5D%7D%7D%5D%7D%7D%7D).

Could not find a way to test this validation step in the current filter/tvs test scripts. Can prepare a test when the CI for mass UI is developed.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
