### PR TITLE
number of mutated samples per gene are returned for gdc top mutated g…

### DIFF
--- a/client/dom/genesetEdit.ts
+++ b/client/dom/genesetEdit.ts
@@ -181,7 +181,7 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 					const result = await vocabApi.getTopMutatedGenes(args)
 
 					geneList = []
-					for (const gene of result.genes) geneList.push({ name: gene })
+					for (const gene of result.genes) geneList.push({ name: gene.name })
 					renderGenes()
 					api.dom.loadBtn.property('disabled', false)
 				})

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -225,7 +225,7 @@ async function getGenes(arg, filter0, matrix) {
 	return await Promise.all(
 		// do tempfix of "data.genes.slice(0,3).map" for faster testing
 		data.genes.map(async i => {
-			return await fillTermWrapper({ term: { name: i, type: 'geneVariant' } })
+			return await fillTermWrapper({ term: { name: i.name, type: 'geneVariant' } })
 		})
 	)
 }

--- a/server/shared/types/routes/gdc.topMutatedGenes.ts
+++ b/server/shared/types/routes/gdc.topMutatedGenes.ts
@@ -6,6 +6,20 @@ export type GdcTopMutatedGeneRequest = {
 	/** gdc cohort filter */
 	filter0?: object
 }
+
+export type Gene = {
+	/** FIXME change .name to .gene */
+	name: string
+	/** optional attributes on number of mutated cases per dt */
+	mutationStat?: {
+		/** each stat object is identified by either dt or class */
+		dt?: number
+		class?: string
+		/** number of samples with alterations of this gene */
+		count: number
+	}[]
+}
+
 export type GdcTopMutatedGeneResponse = {
-	genes: string[]
+	genes: Gene[]
 }


### PR DESCRIPTION
…enes

## Description

no visible change to features. test at http://localhost:3000/example.gdc.matrix.html?cohort=Gliomas and it should work
since the gdc graphql api supplies such info, i'm making these available to gensetedit UI to render to achieve a highly visual effect


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
