### PR TITLE
invoke fillTermWrapper in mds3 client to be able to properly use tw.t…

### DIFF
--- a/client/dom/densityplot.js
+++ b/client/dom/densityplot.js
@@ -88,7 +88,7 @@ export async function make_densityplot(holder, data, callabck, term) {
 		.call(x_axis)
 
 	g.append('text')
-		.text(`${data.termname} ${vc ? `(${vc.toUnit}s)` : '(days)'}`)
+		.text(`${data.termname ? data.termname + ', ' : ''}${vc ? `${vc.toUnit}s` : 'days'}`)
 		.attr('fill', 'black')
 		.attr('transform', `translate( ${width / 2} ,  ${ypad + height + 32})`)
 		.attr('font-size', '13px')

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -110,7 +110,8 @@ export function getFilterName(f) {
 			// tvs is categorical
 			if (!Array.isArray(tvs.values)) throw 'f.lst[0].tvs.values not array'
 
-			const catValue = tvs.values[0].key // only assess 1st category name
+			const catKey = tvs.values[0].key
+			const catValue = tvs.term.values?.[catKey]?.label || catKey // only assess 1st category name; only use for display, not computing
 
 			if (tvs.values.length == 1) {
 				// tvs uses only 1 category

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -143,7 +143,11 @@ export default <Mds3>{
 		variantkey: 'ssm_id', // required, tells client to return ssm_id for identifying variants
 
 		// list of term ids as sample details
-		twLst: [{ id: 'sex', q: {} }],
+		twLst: [
+			{ id: 'sex', q: {} },
+			{ id: 'diaggrp', q: {} },
+			{ id: 'agedx', q: {} }
+		],
 
 		// small list of terms for sunburst rings
 		sunburst_twLst: [{ id: 'sex', q: {} }]

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -219,14 +219,6 @@ async function queryMutatedSamples(q, ds) {
 	const twLst = q.twLst ? q.twLst.slice() : []
 
 	if (ds.variant2samples.gdcapi) {
-		/*
-		!!! doubly tricky !!!
-
-		querySamples_gdcapi() will observe numeric tw.q and return bin label if q is discrete;
-		must delete tw.q to avoid this and ensure it to return actual numeric value 
-		*/
-		for (const t of twLst) delete t.q
-
 		return await querySamples_gdcapi(q, twLst, ds, q.geneTwLst)
 	}
 


### PR DESCRIPTION
…erm data

## Description

closes #1198 
all unit and CI tests pass. all mds3 non-ci pass

only visual diff is for termdbtest mds3, sample summary shows:
<img width="221" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/713ac9ed-0c51-4ef8-b00c-d79c3d3c6bf6">

compared to before:
<img width="182" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/d6d98f47-439b-4f6b-82cf-aa0bc84c3c4c">


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
