### PR TITLE
Termsetting fix

### DIFF
--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -428,12 +428,6 @@ function setRenderers(self) {
 			.transition()
 			.duration(200)
 			.each(self.enterPill)
-		self.dom.pilldiv
-			.select('.term_name_btn')
-			.attr('tabindex', 0)
-			.on(`keyup.sjpp-termdb`, event => {
-				if (event.key == 'Enter') event.target.click()
-			})
 	}
 
 	self.enterPill = async function (this: string) {
@@ -443,6 +437,7 @@ function setRenderers(self) {
 		self.dom.pill_termname = one_term_div
 			.append('div')
 			.attr('class', 'term_name_btn  sja_filter_tag_btn')
+			.attr('tabindex', 0)
 			.style('display', 'flex')
 			.style('grid-area', 'left')
 			.style('position', 'relative')
@@ -450,6 +445,9 @@ function setRenderers(self) {
 			.style('padding', '3px 6px 3px 6px')
 			.style('border-radius', '6px')
 			.html(self.handler!.getPillName)
+			.on(`keyup.sjpp-termdb`, event => {
+				if (event.key == 'Enter') event.target.click()
+			})
 
 		self.updatePill!.call(this)
 	}


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/1200 and https://github.com/stjude/proteinpaint/issues/1203

@siosonel and I worked on this PR. We found that the `tabindex` attribute and `keyup` event should be handled in `enterPill()` to avoid selecting `.term_name_btn`, which can modify the element-bound `.data` of the term_name_button.

All unit tests and integration tests pass.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
