### PR TITLE
fix filter creation and group creation error

### DIFF
--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -1,6 +1,7 @@
 import { getCompInit, copyMerge } from '#rx'
 import { select } from 'd3-selection'
 import { controlsInit } from './controls'
+import { getNormalRoot } from '#filter/filter'
 
 const root_ID = 'root'
 const samplesLimit = 15
@@ -102,7 +103,9 @@ class SampleView {
 			})
 		} else {
 			const limit = 100
-			const sampleName2Id = await this.app.vocabApi.getAllSamplesByName({ filter: appState.termfilter?.filter })
+			const sampleName2Id = await this.app.vocabApi.getAllSamplesByName({
+				filter: getNormalRoot(appState.termfilter?.filter)
+			})
 			const allSamples = Object.keys(sampleName2Id)
 
 			const isBigDataset = allSamples.length > 10000

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -47,7 +47,8 @@ export async function getFilterCTEs(filter, ds, CTEname = 'f') {
 			// .CTEname: str
 		} else if (!item.tvs) {
 			throw `filter item should have a 'tvs' or 'lst' property`
-		} else if (!ds.cohort.termdb.q.termjsonByOneid(item.tvs.term.id)) {
+		} else if (item.tvs.term.id && !ds.cohort.termdb.q.termjsonByOneid(item.tvs.term.id)) {
+			// some tvs such as geneVariant and samplelst don't have term id
 			throw 'invalid term id in tvs'
 		} else if (item.tvs.term.type == 'categorical') {
 			f = get_categorical(item.tvs, CTEname_i)


### PR DESCRIPTION
## Description
geneVariant and samplelst TVS don't have term id, so this termjsonByOneid checking will result in filter creation and group creation error


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
