### PR TITLE
pvalue cutoff converted to log scale

### DIFF
--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -183,8 +183,9 @@ add:
 		.each(function (d) {
 			d.vo_g = this
 		})
+	if (self.settings.foldchange == 0) throw 'fold change cutoff cannot be zero'
 	const fold_change_cutoff = self.settings.foldchange
-	if (self.settings.pvalue == 0) throw 'p-value cutoff cannot be zero'
+	if (self.settings.pvalue == 0) throw 'p-value significance cannot be zero'
 	const p_value_cutoff = -Math.log10(self.settings.pvalue) // 3 corresponds to p-value =0.05 in -log10 scale.
 	const p_value_adjusted_original = self.settings.adjusted_original_pvalue
 	let num_significant_genes = 0

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -184,6 +184,7 @@ add:
 			d.vo_g = this
 		})
 	const fold_change_cutoff = self.settings.foldchange
+	if (self.settings.pvalue == 0) throw 'p-value cutoff cannot be zero'
 	const p_value_cutoff = -Math.log10(self.settings.pvalue) // 3 corresponds to p-value =0.05 in -log10 scale.
 	const p_value_adjusted_original = self.settings.adjusted_original_pvalue
 	let num_significant_genes = 0

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -184,7 +184,7 @@ add:
 			d.vo_g = this
 		})
 	const fold_change_cutoff = self.settings.foldchange
-	const p_value_cutoff = self.settings.pvalue // 3 corresponds to p-value =0.05 in -log10 scale.
+	const p_value_cutoff = -Math.log10(self.settings.pvalue) // 3 corresponds to p-value =0.05 in -log10 scale.
 	const p_value_adjusted_original = self.settings.adjusted_original_pvalue
 	let num_significant_genes = 0
 	let num_non_significant_genes = 0

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -35,7 +35,7 @@ class DEanalysis {
 		}
 		const inputs = [
 			{
-				label: 'P-value significance',
+				label: 'P-value significance (linear scale)',
 				type: 'number',
 				chartType: 'DEanalysis',
 				settingsKey: 'pvalue',
@@ -44,7 +44,7 @@ class DEanalysis {
 				max: 1
 			},
 			{
-				label: 'Fold change',
+				label: 'Fold change (log scale)',
 				type: 'number',
 				chartType: 'DEanalysis',
 				settingsKey: 'foldchange',
@@ -343,8 +343,8 @@ add:
 			{ label: 'Gene Name' },
 			{ label: 'Gene Symbol' },
 			{ label: 'log2 Fold change' },
-			{ label: 'Original p-value' },
-			{ label: 'Adjusted p-value' }
+			{ label: 'Original p-value (linear scale)' },
+			{ label: 'Adjusted p-value (linear scale)' }
 		]
 		if (self.settings.pvaluetable == true) {
 			const d = holder.append('div').html(`<br>DE analysis results`)


### PR DESCRIPTION
## Description
1) Converting linear p_value cutoff to log scale for filtering significant genes.
2) Clearly delineating references to p-value as linear/log scale in UI. The volcano plot use log p-value scale, but the table and burger menu use linear p-value scale.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
