### PR TITLE
support navigation-by-keyboard of bam UI elements

### DIFF
--- a/client/src/block.tk.bam.gdc.js
+++ b/client/src/block.tk.bam.gdc.js
@@ -414,6 +414,7 @@ export async function bamsliceui({
 				)
 				file.about.push({ k: row.title, v: onebam[row.key] })
 			}
+			baminfo_table.select('input').node()?.focus()
 		}
 
 		function update_multifile_table(files) {
@@ -489,43 +490,57 @@ export async function bamsliceui({
 		*/
 		if (data.total < data.loaded) handle.text(`Or, browse ${data.loaded} available BAM files`)
 
-		handle.attr('class', 'sja_clbtext').on('click', event => {
-			const div = tip
-				.clear()
-				.showunder(event.target)
-				.d.append('div')
-				.style('margin', '10px')
-				.style('overflow-y', 'scroll')
-				.style('height', '300px')
-				.style('resize', 'vertical')
-			const table = div.append('table').style('border-spacing', '0px')
-			// header row that stays
-			const tr = table
-				.append('tr')
-				.style('position', 'sticky')
-				.style('top', '0px')
-				.style('background-color', 'white')
-				.style('color', '#aaa')
-				.style('font-size', '.7em')
-			tr.append('td').text('CASE')
-			tr.append('td').text('BAM FILES, SELECT ONE TO VIEW')
-			for (const caseName in data.case2files) {
-				const tr = table.append('tr').attr('class', 'sja_clb_gray')
-				tr.append('td').style('vertical-align', 'top').style('color', '#888').text(caseName)
-				const td2 = tr.append('td')
-				for (const f of data.case2files[caseName]) {
-					// f { sample_type, experimental_strategy, file_size, file_uuid }
-					td2
-						.append('div')
-						.attr('class', 'sja_clbtext')
-						.html(`${f.sample_type}, ${f.experimental_strategy} <span style="font-size:.8em">${f.file_size}</span>`)
-						.on('click', () => {
-							tip.hide()
-							gdcid_input.property('value', f.file_uuid).node().dispatchEvent(new Event('keyup'))
-						})
+		handle
+			.attr('class', 'sja_clbtext')
+			.attr('tabindex', 0)
+			.on('keyup', event => {
+				if (event.key == 'Enter') {
+					event.target.click()
 				}
-			}
-		})
+			})
+			.on('click', event => {
+				const div = tip
+					.clear()
+					.showunder(event.target)
+					.d.append('div')
+					.style('margin', '10px')
+					.style('overflow-y', 'scroll')
+					.style('height', '300px')
+					.style('resize', 'vertical')
+				const table = div.append('table').style('border-spacing', '0px')
+				// header row that stays
+				const tr = table
+					.append('tr')
+					.style('position', 'sticky')
+					.style('top', '0px')
+					.style('background-color', 'white')
+					.style('color', '#aaa')
+					.style('font-size', '.7em')
+				tr.append('td').text('CASE')
+				tr.append('td').text('BAM FILES, SELECT ONE TO VIEW')
+				for (const caseName in data.case2files) {
+					const tr = table.append('tr').attr('class', 'sja_clb_gray')
+					tr.append('td').style('vertical-align', 'top').style('color', '#888').text(caseName)
+					const td2 = tr.append('td')
+					for (const f of data.case2files[caseName]) {
+						// f { sample_type, experimental_strategy, file_size, file_uuid }
+						td2
+							.append('div')
+							.attr('class', 'sja_clbtext')
+							.attr('tabindex', 0)
+							.html(`${f.sample_type}, ${f.experimental_strategy} <span style="font-size:.8em">${f.file_size}</span>`)
+							.on('click', () => {
+								tip.hide()
+								gdcid_input.property('value', f.file_uuid).node().dispatchEvent(new Event('keyup'))
+							})
+							.on('keyup', event => {
+								if (event.key == 'Enter') event.target.click()
+							})
+					}
+				}
+
+				table.select('.sja_clbtext').node().focus()
+			})
 	}
 
 	// this is called after a file/case is found
@@ -673,6 +688,8 @@ export async function bamsliceui({
 				}
 			}
 		}
+
+		div.select('input').node().focus()
 	}
 	async function temp_renderGeneSearch(div) {
 		const geneSearchRow = div.append('div').style('display', 'grid').style('grid-template-columns', '300px auto')

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
-Features
-Added downloadTable function to download data rendered using renderTable
+Fixes:
+- support navigation-by-keyboard of bam UI elements


### PR DESCRIPTION
## Description
To test:
- open http://localhost:3000/example.gdc.bam.html?cohort=Gliomas
- click on the file/case ID/name input
- press Tab: the `or browse 1000 ...` should have focus
- press Enter: a menu with case -> bam file results will open, the first result should have focus
- press Enter again: a table of variants should be displayed, and the first radio button should have focus
- press Space to select the first radio button, or use the up/down arrow keys to focus+select a different radio button
- press Tab to navigate to the Submit button
- press Enter to click the Submit button: if you have not uploaded your GDC token, there should be an error, otherwise a dbGap access message might show up or the actual bam read viz will launch

![Screenshot 2024-01-24 at 6 06 53 PM](https://github.com/stjude/proteinpaint/assets/411031/52084419-f821-49c3-b88f-b088076e1a14)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
