### PR TITLE
Fix for offset out of bounds error for hic file 

### DIFF
--- a/server/src/hicstat.ts
+++ b/server/src/hicstat.ts
@@ -170,15 +170,16 @@ export async function do_hicstat(file: string, isurl: boolean): Promise<HicstatR
 			if (type == 'string') {
 				let str = ''
 				let chr: string | number
-				while ((chr = vectorView.getUint8(pos++)) != 0) {
-					if (pos < vectorView.byteLength) return
+				//Fix for when pos is > than the byteLength and .getUint8() returns undefined
+				while (pos < vectorView.byteLength && (chr = vectorView.getUint8(pos++)) != 0) {
 					if (pos > shunk) await readShunk()
 					const charStr = String.fromCharCode(chr)
 					str += charStr
 				}
 				value = str
 			} else if (type == 'int32') {
-				if (pos + 4 > shunk) await readShunk()
+				if (pos < 0) return //Fix for when pos is negative
+				if (pos + 4 > vectorView.byteLength) await readShunk()
 				value = vectorView.getInt32(pos, true)
 				pos += 4
 			} else throw `No value assigned [server/src/hicstat.ts getViewValue()]`

--- a/server/src/hicstat.ts
+++ b/server/src/hicstat.ts
@@ -170,8 +170,8 @@ export async function do_hicstat(file: string, isurl: boolean): Promise<HicstatR
 			if (type == 'string') {
 				let str = ''
 				let chr: string | number
-
 				while ((chr = vectorView.getUint8(pos++)) != 0) {
+					if (pos < vectorView.byteLength) return
 					if (pos > shunk) await readShunk()
 					const charStr = String.fromCharCode(chr)
 					str += charStr


### PR DESCRIPTION
## Description
Problem:
User reported problems with the ppr URL in this github issue: https://github.com/stjude/sjpp/issues/291. The reason is the `pos` in `server/src/hicstat.ts` is either slightly greater than the `vectorview.byteLength` or negative. Test file path and link in the github issue. 

Fix and comment: 
I included logic to check for the two conditions above but this is a quick fix. Maybe instead of using `shunk` there's byte length value from the file - but that could result in performance differences. Please take a look and provide comment. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
