### PR TITLE
GDC top mutated genes: use features.geneExpHost to toggle usage of genesTable V1 and V2 queries

### DIFF
--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -222,8 +222,6 @@ async function getGenes(arg, filter0, matrix) {
 	const data = await dofetch3('gdc/topMutatedGenes', { body })
 	if (data.error) throw data.error
 	if (!data.genes) return // do not throw and halt. downstream will detect no genes and handle it by showing edit ui
-	console.log(data.genes)
-	throw 'xx'
 	return await Promise.all(
 		// do tempfix of "data.genes.slice(0,3).map" for faster testing
 		data.genes.map(async i => {

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -222,6 +222,8 @@ async function getGenes(arg, filter0, matrix) {
 	const data = await dofetch3('gdc/topMutatedGenes', { body })
 	if (data.error) throw data.error
 	if (!data.genes) return // do not throw and halt. downstream will detect no genes and handle it by showing edit ui
+	console.log(data.genes)
+	throw 'xx'
 	return await Promise.all(
 		// do tempfix of "data.genes.slice(0,3).map" for faster testing
 		data.genes.map(async i => {

--- a/server/routes/gdc.topMutatedGenes.ts
+++ b/server/routes/gdc.topMutatedGenes.ts
@@ -2,6 +2,7 @@ import { GdcTopMutatedGeneRequest, GdcTopMutatedGeneResponse, Gene } from '#shar
 import { mclasscnvgain, mclasscnvloss, dtsnvindel } from '#shared/common.js'
 import got from 'got'
 import serverconfig from '#src/serverconfig.js'
+import { getheaders } from '#src/mds3.gdc.js'
 
 // TODO change to /termdb/topMutatedGenes
 
@@ -450,7 +451,7 @@ async function getGenesGraphql(q: GdcTopMutatedGeneRequest) {
 	}
 
 	const response = await got.post(apihostGraphql, {
-		headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+		headers: getheaders(q),
 		body: JSON.stringify({ query, variables })
 	})
 

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -271,7 +271,7 @@ async function geneExpression_getGenes(genes, genome, case_ids) {
 	// https://docs.gdc.cancer.gov/Encyclopedia/pages/FPKM-UQ/
 	try {
 		const response = await got.post(`${geneExpHost}/gene_expression/gene_selection`, {
-			headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+			headers: getheaders(),
 			body: JSON.stringify({
 				case_ids,
 				gene_ids: ensgLst,
@@ -1125,7 +1125,7 @@ function parseArribaName(f, str) {
 
 ////////////////////////// CNV ends /////////////////////////////
 
-function getheaders(q) {
+export function getheaders(q) {
 	// q is req.query{}
 	const h = { 'Content-Type': 'application/json', Accept: 'application/json' }
 	if (q) {


### PR DESCRIPTION
## Description

closes #1227 
on V1 api: current oncomatrix functions work and can pull top genes; hierCluster Create Group > top gene works

[ should be working ] 
Edgar helped tested on GDC vpn against V2. it can pull appropriate top genes in above scenarios, and also with a gene filter. while using TP53 gene filter, oncomatrix shows no mutation data for all top genes except TP53. that's due to a separate issue that /ssms/ REST API is not working with gene filter

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
