### PR TITLE
gdc hiercluster: gene set `Edit Group` button now defaults to clustering group

### DIFF
--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -902,7 +902,8 @@ export class MatrixControls {
 						: '',
 				selected:
 					(this.parent.chartType == 'hierCluster' &&
-						(g.type == 'hierCluster' || g.name == this.parent.config.termGroupName)) ||
+						(g.type == 'hierCluster' ||
+							(g.name && g.name == this.parent.config.settings.hierCluster?.termGroupName))) ||
 					g === firstGrpWithGeneTw
 			}
 		})


### PR DESCRIPTION
## Description

fix #1196 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
