### PR TITLE
Hic.7: Show negative values and new cloak

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1193,7 +1193,50 @@ sandbox header
     padding: 30px 0;
 }
 
-.add_term_btn
-{
+.add_term_btn {
     border-radius: 6px;
 }
+
+#sjpp-loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color:rgba(255, 255, 255, 0.8);
+}
+
+.sjpp-spinner {
+    position: absolute;
+    left: 50%;
+    top: 30%;
+    height: 60px;
+    width: 60px;
+    margin: 0px auto;
+    -webkit-animation: rotation .6s infinite linear;
+    -moz-animation: rotation .6s infinite linear;
+    -o-animation: rotation .6s infinite linear;
+    animation: rotation .6s infinite linear;
+    border-left: 6px solid rgba(0, 174, 239, .15);
+    border-right: 6px solid rgba(0, 174, 239, .15);
+    border-bottom: 6px solid rgba(0, 174, 239, .15);
+    border-top: 6px solid rgba(0, 174, 239, .8);
+    border-radius: 100%;
+}
+
+@-webkit-keyframes rotation {
+    from {-webkit-transform: rotate(0deg);}
+    to {-webkit-transform: rotate(359deg);}
+ }
+ @-moz-keyframes rotation {
+    from {-moz-transform: rotate(0deg);}
+    to {-moz-transform: rotate(359deg);}
+ }
+ @-o-keyframes rotation {
+    from {-o-transform: rotate(0deg);}
+    to {-o-transform: rotate(359deg);}
+ }
+ @keyframes rotation {
+    from {transform: rotate(0deg);}
+    to {transform: rotate(359deg);}
+ }

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -1,6 +1,13 @@
 import { bplen } from '#shared/common'
 import { nmeth2select, matrixType2select } from './hic.straw'
-import { getdata_chrpair, getdata_detail, getdata_leadfollow, defaultnmeth, showBtns } from './hic.straw'
+import {
+	getdata_chrpair,
+	getdata_detail,
+	getdata_leadfollow,
+	defaultnmeth,
+	showBtns,
+	makeWholeGenomeElements
+} from './hic.straw'
 import { Elem } from '../../types/d3'
 import blocklazyload from '#src/block.lazyload'
 
@@ -55,7 +62,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('width', '80px')
 		.style('margin-left', '0px')
 		.attr('type', 'number')
-		.property('value', self.wholegenome.bpmaxv)
+		.property('value', self.genomeview.bpmaxv)
 		.on('keyup', (event: KeyboardEvent) => {
 			if (event.code != 'Enter') return
 			const v: any = (event.target as HTMLInputElement).value
@@ -75,7 +82,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.append('select')
 		.on('change', async () => {
 			const matrixType = self.dom.controlsDiv.matrixType.node().value
-			if (self.inwholegenome) self.wholegenome.matrixType = matrixType
+			if (self.ingenome) self.genomeview.matrixType = matrixType
 			if (self.inchrpair) self.chrpairview.matrixType = matrixType
 			if (self.indetail) self.detailview.matrixType = matrixType
 			await getData(hic, self)
@@ -108,7 +115,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.on('click', () => {
 			self.dom.controlsDiv.view.text('Genome')
 			self.dom.controlsDiv.zoomDiv.style('display', 'none')
-			self.inwholegenome = true
+			self.ingenome = true
 			self.inchrpair = false
 			self.indetail = false
 			self.inhorizontal = false
@@ -122,7 +129,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('margin', '4px 0px')
 		.on('click', () => {
 			self.dom.controlsDiv.zoomDiv.style('display', 'none')
-			self.inwholegenome = false
+			self.ingenome = false
 			self.inchrpair = true
 			self.indetail = false
 			self.inhorizontal = false
@@ -136,7 +143,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('margin', '4px 0px')
 		.html('Horizontal View &#8811;')
 		.on('click', () => {
-			self.inwholegenome = false
+			self.ingenome = false
 			self.inchrpair = false
 			self.indetail = false
 			self.inhorizontal = true
@@ -150,7 +157,7 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		.style('margin', '4px 0px')
 		.html('&#8810; Detailed View')
 		.on('click', () => {
-			self.inwholegenome = false
+			self.ingenome = false
 			self.inchrpair = false
 			self.indetail = true
 			self.inhorizontal = false
@@ -188,7 +195,7 @@ function makeNormMethDisplay(hic: any, self: any) {
 			.append('select')
 			.on('change', async () => {
 				const nmeth = hic.nmethselect.node().value
-				if (self.inwholegenome) self.wholegenome.nmeth = nmeth
+				if (self.ingenome) self.genomeview.nmeth = nmeth
 				if (self.inchrpair) self.chrpairview.nmeth = nmeth
 				if (self.indetail) self.detailview.nmeth = nmeth
 				await getData(hic, self)
@@ -206,7 +213,7 @@ function makeNormMethDisplay(hic: any, self: any) {
  * @returns
  */
 async function getData(hic: any, self: any) {
-	if (self.inwholegenome) {
+	if (self.ingenome) {
 		const manychr = hic.atdev ? 3 : hic.chrlst.length
 		for (let i = 0; i < manychr; i++) {
 			const lead = hic.chrlst[i]
@@ -241,12 +248,12 @@ async function getData(hic: any, self: any) {
  * @returns
  */
 function setmaxv(self: any, maxv: number) {
-	if (self.inwholegenome) {
+	if (self.ingenome) {
 		// viewing whole genome
-		self.wholegenome.bpmaxv = maxv
-		if (!self.wholegenome.lead2follow) return
-		const binpx = self.wholegenome.binpx
-		for (const [lead, a] of self.wholegenome.lead2follow) {
+		self.genomeview.bpmaxv = maxv
+		if (!self.genomeview.lead2follow) return
+		const binpx = self.genomeview.binpx
+		for (const [lead, a] of self.genomeview.lead2follow) {
 			for (const [follow, b] of a) {
 				for (const [leadpx, followpx, v] of b.data) {
 					const p = v >= maxv ? 0 : Math.floor((255 * (maxv - v)) / maxv)
@@ -300,14 +307,14 @@ function switchview(hic: any, self: any) {
 	self.dom.plotDiv.yAxis.selectAll('*').remove()
 	self.dom.plotDiv.plot.selectAll('*').remove()
 
-	if (self.inwholegenome) {
-		nmeth2select(hic, self.wholegenome)
-		matrixType2select(self.wholegenome, self)
-		self.dom.plotDiv.plot.node().appendChild(self.wholegenome.svg.node())
-		self.dom.controlsDiv.inputBpMaxv.property('value', self.wholegenome.bpmaxv)
-		self.dom.controlsDiv.resolution.text(bplen(self.wholegenome.resolution) + ' bp')
+	if (self.ingenome) {
+		nmeth2select(hic, self.genomeview)
+		matrixType2select(self.genomeview, self)
+		self.dom.plotDiv.plot.node().appendChild(self.genomeview.svg.node())
+		self.dom.controlsDiv.inputBpMaxv.property('value', self.genomeview.bpmaxv)
+		self.dom.controlsDiv.resolution.text(bplen(self.genomeview.resolution) + ' bp')
 	} else if (self.inchrpair) {
-		self.dom.controlsDiv.view.text(`${self.chrx.chr}-${self.chry.chr} Pair`)
+		self.dom.controlsDiv.view.text(`${self.x.chr}-${self.y.chr} Pair`)
 		nmeth2select(hic, self.chrpairview)
 		matrixType2select(self.chrpairview, self)
 		self.dom.plotDiv.yAxis.node().appendChild(self.chrpairview.axisy.node())

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -1,13 +1,6 @@
 import { bplen } from '#shared/common'
 import { nmeth2select, matrixType2select } from './hic.straw'
-import {
-	getdata_chrpair,
-	getdata_detail,
-	getdata_leadfollow,
-	defaultnmeth,
-	showBtns,
-	makeWholeGenomeElements
-} from './hic.straw'
+import { getdata_chrpair, getdata_detail, defaultnmeth, showBtns, makeWholeGenomeElements } from './hic.straw'
 import { Elem } from '../../types/d3'
 import blocklazyload from '#src/block.lazyload'
 
@@ -215,17 +208,7 @@ function makeNormMethDisplay(hic: any, self: any) {
 async function getData(hic: any, self: any) {
 	if (self.ingenome) {
 		const manychr = hic.atdev ? 3 : hic.chrlst.length
-		for (let i = 0; i < manychr; i++) {
-			const lead = hic.chrlst[i]
-			for (let j = 0; j <= i; j++) {
-				const follow = hic.chrlst[j]
-				try {
-					await getdata_leadfollow(hic, lead, follow, self)
-				} catch (e: any) {
-					self.errList.push(e.message || e)
-				}
-			}
-		}
+		await makeWholeGenomeElements(hic, self, manychr)
 		if (self.errList.length) self.error(self.errList)
 		return
 	}

--- a/client/tracks/hic/controls.whole.genome.ts
+++ b/client/tracks/hic/controls.whole.genome.ts
@@ -84,7 +84,8 @@ export function initWholeGenomeControls(hic: any, self: any) {
 		//Allow for customer friendly labels but pass the appropriate straw parameter
 		{ label: 'Observed', value: 'observed' },
 		{ label: 'Expected', value: 'expected' },
-		{ label: 'Observed/Expected', value: 'oe' }
+		//'oe' is the straw parameter and returns a ratio. Server code applies log().
+		{ label: 'Log(Observed/Expected)', value: 'oe' }
 	]
 	for (const matrixType of matrixTypevalues) {
 		self.dom.controlsDiv.matrixType.append('option').text(matrixType.label).attr('value', matrixType.value)
@@ -289,7 +290,9 @@ function setmaxv(self: any, maxv: number) {
 /**
  * Click buttons in menu to switch between views (whole genome, chr-chr pair, detail, horizontal).
  * Launches or rerenders previously created views.
- * @param hic
+ * @param hic file input
+ * @param self app obj
+
  */
 function switchview(hic: any, self: any) {
 	//Remove all previous elements

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -145,13 +145,7 @@ class Hicstat {
 		this.dom = {
 			errorDiv: hic.holder.append('div').classed('sjpp-hic-error', true),
 			controlsDiv: hic.holder.append('div').classed('sjpp-hic-controls', true).style('display', 'inline-block'),
-			loadingDiv: hic.holder
-				.append('div')
-				.classed('sjpp-hic-loading', true)
-				.text('Loading...')
-				.style('padding', '10px 20px')
-				.style('color', '#8AB1D4')
-				.style('font-size', '1.5em'),
+			loadingDiv: d3select('body').append('div').attr('id', 'sjpp-loading-overlay'),
 			plotDiv: hic.holder.append('div').classed('sjpp-hic-main', true).style('display', 'inline-block'),
 			tip: new client.Menu()
 		}
@@ -209,6 +203,7 @@ class Hicstat {
 	}
 
 	async render(hic: any) {
+		this.dom.loadingDiv.append('div').attr('class', 'sjpp-spinner').style('display', '')
 		await hicParseFile(hic, this.debugmode, this)
 		initWholeGenomeControls(hic, this)
 		this.dom.plotDiv.append('table').classed('sjpp-hic-plot-main', true)
@@ -229,7 +224,7 @@ class Hicstat {
 	}
 
 	async init_wholeGenomeView(hic: any) {
-		this.dom.loadingDiv.style('visibility', 'visible')
+		this.dom.loadingDiv.style('display', '')
 		this.dom.controlsDiv.view.text('Genome')
 		const resolution = hic.bpresolution[0]
 
@@ -385,7 +380,7 @@ class Hicstat {
 		// 	}
 		// }
 		if (this.errList.length) this.error(this.errList)
-		this.dom.loadingDiv.style('visibility', 'hidden')
+		this.dom.loadingDiv.style('display', 'none')
 
 		if (this.errList.length) this.error(this.errList)
 
@@ -960,7 +955,7 @@ function chrpair_mouseover(self: any, img: any, x_chr: string, y_chr: string) {
 }
 
 export async function makeWholeGenomeElements(hic: any, self: any, manychrArg?: number) {
-	self.dom.loadingDiv.style('visibility', 'visible')
+	self.dom.loadingDiv.style('display', '')
 	const manychr = manychrArg || (hic.atdev ? atdev_chrnum : hic.chrlst.length)
 	const vlst = [] as number[]
 
@@ -974,7 +969,7 @@ export async function makeWholeGenomeElements(hic: any, self: any, manychrArg?: 
 	await setViewCutoff(vlst, self.genomeview, self)
 
 	await colorizeGenomeElements(self)
-	self.dom.loadingDiv.style('visibility', 'hidden')
+	self.dom.loadingDiv.style('display', 'none')
 }
 
 async function getWholeGenomeData(hic: any, self: any, lead: any, follow: any, vlst: any) {

--- a/client/tracks/hic/hic.straw.ts
+++ b/client/tracks/hic/hic.straw.ts
@@ -749,7 +749,6 @@ class Hicstat {
 		nmeth2select(hic, this.horizontalview)
 		matrixType2select(this.horizontalview, this)
 
-		//Clear elements created in chr pair view
 		this.dom.plotDiv.xAxis.selectAll('*').remove()
 		this.dom.plotDiv.yAxis.selectAll('*').remove()
 		this.dom.plotDiv.plot.selectAll('*').remove()
@@ -987,11 +986,21 @@ export async function getdata_leadfollow(hic: any, lead: any, follow: any, self:
 
 			obj.data.push([leadpx, followpx, v])
 
-			const p =
-				v >= self.wholegenome.bpmaxv ? 0 : Math.floor((255 * (self.wholegenome.bpmaxv - v)) / self.wholegenome.bpmaxv)
-			obj.ctx.fillStyle = 'rgb(255,' + p + ',' + p + ')'
+			let p: number
+			if (v >= 0) {
+				// positive, use red
+				p =
+					v >= self.wholegenome.bpmaxv ? 0 : Math.floor((255 * (self.wholegenome.bpmaxv - v)) / self.wholegenome.bpmaxv)
+				obj.ctx.fillStyle = `rgb(255, ${p}, ${p})`
+				obj.ctx2.fillStyle = `rgb(255, ${p}, ${p})`
+			} else {
+				// negative, use blue
+				p = Math.floor((255 * (self.wholegenome.bpmaxv + v)) / self.wholegenome.bpmaxv)
+				obj.ctx.fillStyle = `rgb(${p}, ${p}, 255)`
+				obj.ctx2.fillStyle = `rgb(${p}, ${p}, 255)`
+			}
+
 			obj.ctx.fillRect(followpx, leadpx, binpx, binpx)
-			obj.ctx2.fillStyle = 'rgb(255,' + p + ',' + p + ')'
 			obj.ctx2.fillRect(leadpx, followpx, binpx, binpx)
 		}
 		obj.img.attr('xlink:href', obj.canvas.toDataURL())
@@ -1205,8 +1214,14 @@ export async function getdata_chrpair(hic: any, self: any) {
 		self.dom.controlsDiv.inputBpMaxv.property('value', maxv)
 
 		for (const [x, y, v] of self.chrpairview.data) {
-			const p = v >= maxv ? 0 : Math.floor((255 * (maxv - v)) / maxv)
-			ctx.fillStyle = 'rgb(255,' + p + ',' + p + ')'
+			//Show red for positive values and blue for negative values
+			if (v >= 0) {
+				const p = v >= maxv ? 0 : Math.floor((255 * (maxv - v)) / maxv)
+				ctx.fillStyle = `rgb(255, ${p}, ${p})`
+			} else {
+				const p = Math.floor((255 * (maxv + v)) / maxv)
+				ctx.fillStyle = `rgb(${p}, ${p}, 255)`
+			}
 			ctx.fillRect(x, y, binpx, binpx)
 		}
 	} catch (err: any) {
@@ -1590,9 +1605,13 @@ export function getdata_detail(hic: any, self: any) {
 			self.dom.controlsDiv.inputBpMaxv.property('value', maxv)
 
 			for (const [x, y, w, h, v] of lst) {
-				const p = v >= maxv ? 0 : Math.floor((255 * (maxv - v)) / maxv)
-				ctx.fillStyle = 'rgb(255,' + p + ',' + p + ')'
-
+				if (v >= 0) {
+					const p = v >= maxv ? 0 : Math.floor((255 * (maxv - v)) / maxv)
+					ctx.fillStyle = `rgb(255, ${p}, ${p})`
+				} else {
+					const p = Math.floor((255 * (maxv + v)) / maxv)
+					ctx.fillStyle = `rgb(${p}, ${p}, 255)`
+				}
 				ctx.fillRect(x, y, w, h)
 			}
 

--- a/client/tracks/hic/parse.genome.ts
+++ b/client/tracks/hic/parse.genome.ts
@@ -81,7 +81,7 @@ export async function hicParseFile(hic: any, debugmode: boolean, self: any) {
 	/** Default args for each view */
 	const initialNmeth = hic.normalization.length ? hic.normalization[0] : defaultnmeth
 
-	self.wholegenome.nmeth = initialNmeth
+	self.genomeview.nmeth = initialNmeth
 	self.chrpairview.nmeth = initialNmeth
 	self.detailview.nmeth = initialNmeth
 

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -1,5 +1,5 @@
 import { BaseTrackArgs } from './tracks.ts'
-import { Elem, Input, SvgG } from '../types/d3'
+import { Elem, Input, Svg, SvgG } from '../types/d3'
 import { Selection } from 'd3-selection'
 
 type SharedArgs = {
@@ -51,6 +51,8 @@ export type MainPlotDiv = {
 }
 
 export type HicstrawDom = {
+	/** Holds the cloak when the view is loading. */
+	loadingDiv: Elem
 	/** Placeholder div for displaying errors to the user */
 	errorDiv: Elem
 	/** Control panel. Appears as a collapsible burger menu*/
@@ -61,7 +63,7 @@ export type HicstrawDom = {
 		inputBpMaxv: Input
 		/** Text display of resolution */
 		resolution: Elem
-		/** Hardcoded display of 'observed' matrix type. Change to dropdown in future. */
+		/** User select matrix type. Returns straw values based on selected type. */
 		matrixType: Elem
 		/** Displays text of the user's current view and buttons for other views (except in genome view) */
 		view: Elem
@@ -88,7 +90,9 @@ export type HicstrawDom = {
 }
 
 export type WholeGenomeView = {
-	/** value for o,e,and oe option */
+	/** Arrays of hicdata response [pos1, pos2, and value] reformatted for rendering */
+	data: number[][]
+	/** Straw parameter to return matrix type from dropdown */
 	matrixType: 'observed' | 'expected' | 'oe'
 	/** # pixel per bin, may set according to resolution */
 	binpx: number
@@ -98,7 +102,22 @@ export type WholeGenomeView = {
 	layer_map: SvgG
 	/** second g layer underneath the svg */
 	layer_sv: SvgG
-	lead2follow?: Map<string, Map<string, { x: number; y: number }>>
+	/** SVG elements and data for individual canvases */
+	lead2follow?: Map<
+		string,
+		Map<
+			string,
+			Partial<{
+				canvas: Elem
+				canvas2?: Elem
+				x: number
+				y: number
+				data: number[][]
+				img: Elem
+				img2?: Elem
+			}>
+		>
+	>
 	/** Normalization method tied to this view. Intended to render independently of other views */
 	nmeth: string
 	/** Displays the chr on the x axis to the user next to the cell's upper left corner.
@@ -115,12 +134,12 @@ export type WholeGenomeView = {
 
 export type ChrPairView = {
 	matrixType: 'observed' | 'expected' | 'oe'
-	axisx: any //dom
-	axisy: any //dom
+	axisx?: Svg
+	axisy?: Svg
 	binpx: number
-	canvas?: any //dom
+	canvas: any //dom
 	ctx: any //dom
-	data: any
+	data: number[][]
 	/** Normalization method tied to this view. Intended to render independently of other views */
 	nmeth: string
 	/** Calculated resolution. Displayed in menu for user */

--- a/client/types/hic.ts
+++ b/client/types/hic.ts
@@ -1,5 +1,5 @@
 import { BaseTrackArgs } from './tracks.ts'
-import { Elem, Input, Svg, SvgG } from '../types/d3'
+import { Div, Elem, Input, Svg, SvgG } from '../types/d3'
 import { Selection } from 'd3-selection'
 
 type SharedArgs = {
@@ -52,7 +52,7 @@ export type MainPlotDiv = {
 
 export type HicstrawDom = {
 	/** Holds the cloak when the view is loading. */
-	loadingDiv: Elem
+	loadingDiv: Div
 	/** Placeholder div for displaying errors to the user */
 	errorDiv: Elem
 	/** Control panel. Appears as a collapsible burger menu*/

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Features:
+- Hi-C whole genome view supports different matrix types (e.g. observed, expected, etc.). Users can select different matrix types from dropdown.
+- The Hi-C whole genome view now calculates the cutoff on load and with user changes. Previously, the default was 5000. 

--- a/server/routes/hicdata.ts
+++ b/server/routes/hicdata.ts
@@ -86,7 +86,7 @@ function handle_hicdata(q: HicdataRequest) {
 			}
 			const n1 = Number.parseInt(l[0])
 			const n2 = Number.parseInt(l[1])
-			const v = Number.parseFloat(l[2])
+			const v = q.matrixType == 'oe' ? Math.log(Number.parseFloat(l[2])) : Number.parseFloat(l[2])
 			if (Number.isNaN(n1) || Number.isNaN(n2) || Number.isNaN(v)) {
 				fieldnotnumerical++
 				return


### PR DESCRIPTION
## Description
- Cutoff in the whole genome view is calculated rather than hardcoded
- Change `observed/expected` option to `log(observed/expected)`. Negative values for the log(o/e) now show on blue scale
- New cloak, from the gdc matrix, over the whole genome view whilst data is loading.

Test with:
1. http://localhost:3000/?genome=hg38&hicfile=proteinpaint_demo/hg38/hic/hic_demo_v9.hic&enzyme=MboI
2. Other hic files from http://localhost:3000/url.html

## Checklist
[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
