### PR TITLE
fix to pass gdc info to api-calling code

### DIFF
--- a/server/routes/termdb.singleSampleMutation.ts
+++ b/server/routes/termdb.singleSampleMutation.ts
@@ -25,7 +25,7 @@ export const api: any = {
 
 function init({ genomes }) {
 	return async (req: any, res: any): Promise<void> => {
-		const q = req.query as TermdbSingleSampleMutationRequest
+		const q: TermdbSingleSampleMutationRequest = req.query
 		let result
 		try {
 			const g = genomes[q.genome]

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -203,6 +203,20 @@ app.use((req, res, next) => {
 		// if using req.params based on expressjs server route /:paramName interpolation
 		Object.assign(req.query, req.body)
 	}
+
+	/*
+	!!more or less quick fix!!
+	in gdc environment, this will pass sessionid from cookie to req.query
+	to be added to request header where it's querying gdc api
+	by doing this, route code is worry-free and no need to pass "req{}" to gdc purpose-specific code doing the API calls
+	these *protected* contents are not used in non-gdc code
+	*/
+	req.query.__protected__ = {}
+	if (req.cookies?.sessionid) {
+		req.query.__protected__.sessionid = req.cookie.sessionid
+	}
+	Object.freeze(req.query.__protected__)
+
 	log(req)
 	setHeaders(res)
 	res.header(

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -204,8 +204,12 @@ app.use((req, res, next) => {
 		Object.assign(req.query, req.body)
 	}
 
+	// log the request before adding protected info
+	log(req)
+
 	/*
-	!!more or less quick fix!!
+	!!! put this code after logging the request, so these protected info are not logged !!!
+	!! more or less quick fix !!
 	in gdc environment, this will pass sessionid from cookie to req.query
 	to be added to request header where it's querying gdc api
 	by doing this, route code is worry-free and no need to pass "req{}" to gdc purpose-specific code doing the API calls
@@ -213,11 +217,10 @@ app.use((req, res, next) => {
 	*/
 	req.query.__protected__ = {}
 	if (req.cookies?.sessionid) {
-		req.query.__protected__.sessionid = req.cookie.sessionid
+		req.query.__protected__.sessionid = req.cookies.sessionid
 	}
 	Object.freeze(req.query.__protected__)
 
-	log(req)
 	setHeaders(res)
 	res.header(
 		'Access-Control-Allow-Origin',

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -13,6 +13,10 @@ function mayLog(...args) {
 	if (serverconfig.debugmode) console.log(args.join(' '))
 }
 
+// TODO fix in next PR
+// if geneExpHost is set, it is hitting v1 api and use "filters"; if not set, it is hitting v2 and must use "case_filters" to be cohort_centric. use it as "const body = { [`${prefix}filters`]: {...} } "  after softlaunch, delete all usage of REPLACE and always use "case_filters"
+const PREFIX = serverconfig.features.geneExpHost ? '' : 'case_'
+
 /*
 GDC API
 
@@ -1126,11 +1130,22 @@ function parseArribaName(f, str) {
 ////////////////////////// CNV ends /////////////////////////////
 
 export function getheaders(q) {
-	// q is req.query{}
+	/*
+	q { 
+		token,
+		//token is only used for adhoc testing outside of gdc env, by directly add token string in runpp(), this is not used in gdc portal
+		sessionid,
+		__protected__:{sessionid}
+		// see middleware
+	}
+	*/
 	const h = { 'Content-Type': 'application/json', Accept: 'application/json' }
 	if (q) {
 		if (q.token) h['X-Auth-Token'] = q.token
 		if (q.sessionid) h['Cookie'] = 'sessionid=' + q.sessionid
+		if (q.__protected__?.sessionid) {
+			h['Cookie'] = 'sessionid=' + q.__protected__.sessionid
+		}
 	}
 	return h
 }


### PR DESCRIPTION
## Description

on local hitting v1 everything should be the same
on gdc vpn hitting v2 should allow to pull controlled data after sign in

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
