### PR TITLE
toggle switching between filters/case_filters for v1/v2 queries

### DIFF
--- a/server/routes/gdc.maf.ts
+++ b/server/routes/gdc.maf.ts
@@ -2,6 +2,7 @@ import { GdcMafRequest, GdcMafResponse, File } from '#shared/types/routes/gdc.ma
 import path from 'path'
 import got from 'got'
 import serverconfig from '#src/serverconfig.js'
+import { PREFIX } from '#src/mds3.gdc.js'
 
 /*
 this route lists available gdc MAF files based on user's cohort filter
@@ -98,7 +99,7 @@ async function listMafFiles(q: GdcMafRequest) {
 	const headers = { 'Content-Type': 'application/json', Accept: 'application/json' }
 
 	const data = {
-		filters,
+		[`${PREFIX}filters`]: filters,
 		size: maxFileNumber,
 		fields: [
 			'id',


### PR DESCRIPTION
## Description

i've tested each change and they don't break v1 usage
if the changes work for v2, oncomatrix with gene=TP53 filter should show ssm for all genes. could you test it?

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
