### PR TITLE
fix the handling and display of no data errors in the hier cluster app

### DIFF
--- a/client/plots/matrix.data.js
+++ b/client/plots/matrix.data.js
@@ -131,7 +131,7 @@ export async function setData(_data) {
 		terms,
 		filter: this.state.filter,
 		filter0: this.state.filter0,
-		loadingDiv: this.dom.loadingDiv,
+		loadingDiv: this.chartType != 'hierCluster' && this.dom.loadingDiv,
 		maxGenes: this.state.config.settings.matrix.maxGenes
 		//termsPerRequest: 100 // this is just for testing
 	}

--- a/client/plots/matrix.dom.js
+++ b/client/plots/matrix.dom.js
@@ -7,7 +7,7 @@ export function setMatrixDom(opts) {
 	const controls = this.opts.controls || holder.append('div')
 	const loadingDiv = holder
 		.append('div')
-		.style('position', 'absolute')
+		.style('position', 'relative')
 		.style('top', this.opts.controls ? 0 : '50px')
 		.style('left', '50px')
 	const errdiv = holder.append('div').attr('class', 'sja_errorbar').style('display', 'none')

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -813,7 +813,7 @@ export class TermdbVocab extends Vocab {
 			throw e
 		}
 		try {
-			opts.loadingDiv?.html(`Processing data ...`)
+			if (opts.loadingDiv) opts.loadingDiv.html(`Processing data ...`)
 			const dictTerm$ids = opts.terms.filter(tw => !nonDictionaryTermTypes.has(tw.term.type)).map(tw => tw.$id)
 			// const lst = Object.values(samples)
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- fix the display of no data error message and hiding of previously rendered heatmap in the hier cluster app


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2392

To test: 
- load http://localhost:3000/example.gdc.exp.html?cohort=CDDP_EAGLE-1
- change the cohort to APOLLO-LUAD
- a no data message should appear and the rendered heatmap should disappear, previously the heatmap remained visible

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
