### PR TITLE
improve mds3 tk tests, move reusable testers into CI script

### DIFF
--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -224,7 +224,10 @@ async function listSkewerData(tk, block) {
 		tabs.push({ label: mlst.length + ' ' + dt2label[dt] })
 	}
 	new Tabs({
-		holder: tk.menutip.d.append('div').style('margin', '10px'),
+		holder: tk.menutip.d
+			.append('div')
+			.attr('class', 'sja_pp_vlb_dttabdiv') // for testing
+			.style('margin', '10px'),
 		tabs
 	}).main()
 	let i = 0
@@ -256,7 +259,10 @@ function mayAddSkewerModeOption(tk, block) {
 		options.push(o)
 	}
 	make_radios({
-		holder: tk.menutip.d.append('div').style('margin', '10px'),
+		holder: tk.menutip.d
+			.append('div')
+			.attr('class', 'sja_pp_vlb_viewmoderadiodiv') // for testing
+			.style('margin', '10px'),
 		options,
 		callback: async idx => {
 			for (const i of tk.skewer.viewModes) i.inuse = false

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -6,7 +6,7 @@ const { runproteinpaint } = require('../../test/front.helpers.js')
 /*
 Tests:  
 
-TP53 with hg38-test and custom data
+TP53 custom data, no sample
 Custom variants, missing or invalid mclass
 Custom dataset with custom variants, WITH samples
 Custom data with samples and sample selection
@@ -37,14 +37,13 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('TP53 with hg38-test and custom data', test => {
-	test.timeoutAfter(3000)
+tape('TP53 custom data, no sample', test => {
+	test.timeoutAfter(2000)
 	const holder = getHolder()
 
-	const opts = {
-		gene: 'TP53',
-		name: 'TP53 hg38-test',
-		custom_variants: [
+	const gene = 'TP53',
+		tkname = 'TP53 hg38-test',
+		custom_variants = [
 			{ chr: 'chr17', pos: 7675993, mname: 'point 1', class: 'M', dt: 1 },
 			{ chr: 'chr17', pos: 7676520, mname: 'point 2', class: 'M', dt: 1 },
 			{ chr: 'chr17', pos: 7676381, mname: 'point 3', class: 'M', dt: 1 }
@@ -54,38 +53,36 @@ tape('TP53 with hg38-test and custom data', test => {
 			// { chr: 'chr17', pos: 7673700, mname: 'point 7', class: 'F', dt: 1 },
 			// { chr: 'chr17', pos: 7673534, mname: 'point 8', class: 'I', dt: 1 }
 		]
-	}
 
 	runproteinpaint({
 		holder,
 		noheader: true,
 		genome: 'hg38-test',
-		gene: opts.gene,
+		gene,
 		tracks: [
 			{
 				type: 'mds3',
-				name: opts.name,
-				custom_variants: opts.custom_variants,
+				name: tkname,
+				custom_variants,
 				callbackOnRender
 			}
 		]
 	})
-
 	function callbackOnRender(tk, bb) {
 		// Test mds3 is a track object and bb is block object
-		test.equal(bb.usegm.name, opts.gene, `Should render block.usegm.name = ${opts.gene}`)
+		test.equal(bb.usegm.name, gene, `Should render block.usegm.name = ${gene}`)
 		test.equal(bb.tklst.length, 2, 'Should have two tracks')
 		test.ok(tk.skewer.rawmlst.length > 0, 'Should load mds3 tk with at least 1 data point')
 
 		//Confirm number of custom variants matches in block instance
 		test.equal(
 			tk.custom_variants.length,
-			opts.custom_variants.length,
-			`Should render total # of custom variants = ${opts.custom_variants.length}`
+			custom_variants.length,
+			`Should render total # of custom variants = ${custom_variants.length}`
 		)
 
 		const classes2Check = new Set() //for legend testing below
-		for (const variant of opts.custom_variants) {
+		for (const variant of custom_variants) {
 			classes2Check.add(variant.class)
 			//Test all custom variant entries successfully passed to block instance
 			const variantFound = tk.custom_variants.find(i => i.mname == variant.mname)
@@ -101,12 +98,12 @@ tape('TP53 with hg38-test and custom data', test => {
 		//Legend
 		test.equal(
 			tk.tr_legend.node().querySelectorAll('td')[0].innerText,
-			opts.name,
-			`Should pass custom name = ${opts.name} to legend`
+			tkname,
+			`Should pass custom name = ${tkname} to legend`
 		)
 		for (const mutClass of classes2Check) {
 			const legendArray = tk.legend.mclass.currentData.find(d => d[0] == mutClass)
-			const samples2check = opts.custom_variants.filter(d => d.class == mutClass)
+			const samples2check = custom_variants.filter(d => d.class == mutClass)
 			test.equal(
 				legendArray[1],
 				samples2check.length,

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -1,13 +1,13 @@
 const tape = require('tape')
 const d3s = require('d3-selection')
-const { detectOne, detectGte, whenVisible, detectLst } = require('../../test/test.helpers')
+const { detectOne, detectZero, detectGte, whenVisible, detectLst } = require('../../test/test.helpers')
 const { runproteinpaint } = require('../../test/front.helpers.js')
 
 /**************
  test sections
 ***************
 
-Official data on TP53
+Official data on TP53, extensive ui test
 Official - mclass filtering
 Official - sample summaries table, create subtrack (tk.filterObj)
 Official - Collapse and expand mutations from variant link
@@ -19,6 +19,13 @@ Custom data with samples and sample selection
 Numeric mode custom dataset, with mode change
 
 
+this script exports following test methods to share with non-CI test using GDC/clinvar
+- findSingletonMutationTestDiscoCnvPlots
+- testMclassFiltering
+- testSampleSummary2subtrack
+- testVariantLeftLabel
+
+TODO fix termdbtest data to move sunburst test 
 */
 
 tape('\n', function (test) {
@@ -26,7 +33,7 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('Official data on TP53', test => {
+tape('Official data on TP53, extensive ui test', test => {
 	const holder = getHolder()
 	const gene = 'TP53'
 	runproteinpaint({
@@ -47,6 +54,7 @@ tape('Official data on TP53', test => {
 		test.notOk(tk.leftlabels.doms.close, 'tk.leftlabels.doms.close is not set')
 		test.ok(tk.legend.mclass, 'tk.legend.mclass{} is set')
 		await findSingletonMutationTestDiscoCnvPlots(test, tk)
+		await testVariantLeftLabel(test, tk, bb)
 		if (test._ok) holder.remove()
 		test.end()
 	}
@@ -296,36 +304,71 @@ export async function testSampleSummary2subtrack(genome, gene, dslabel, test) {
 	}
 }
 
-tape('Official - Collapse and expand mutations from variant link', test => {
-	const holder = getHolder()
-	runproteinpaint({
-		holder,
-		noheader: true,
-		nobox: true,
-		genome: 'hg38-test',
-		gene: 'tp53',
-		tracks: [{ type: 'mds3', dslabel: 'TermdbTest', callbackOnRender }]
-	})
-	async function callbackOnRender(tk, bb) {
-		await testCollapseExpand_variantLeftLabel(test, tk, bb, holder)
-	}
-})
-
-export async function testCollapseExpand_variantLeftLabel(test, tk, bb, holder) {
+export async function testVariantLeftLabel(test, tk, bb) {
 	//Click on variant leftlabel to open menu
 	const variantsLeftlabel = tk.leftlabels.doms.variants.node()
+
+	// show menu >>> "List" option
 	variantsLeftlabel.dispatchEvent(new Event('click'))
 	await whenVisible(tk.menutip.d)
-
-	//Click 'Collapse' menu option
 	tk.menutip.d
 		.selectAll('.sja_menuoption')
 		.nodes()
-		.find(e => e.innerHTML == 'Collapse')
+		.find(e => e.innerHTML == 'List')
 		.dispatchEvent(new Event('click'))
-
-	// as soon as collapsing animation starts, none of the sja_aa_disclabel should have "scale(1)"
 	{
+		const dtSet = new Set(tk.skewer.rawmlst.map(i => i.dt))
+		if (dtSet.size > 1) {
+			// more than 1 dt, should show toggle
+			const div = await detectOne({ elem: tk.menutip.d.node(), selector: '.sja_pp_vlb_dttabdiv' })
+			test.ok(div, 'Toggle button div is shown after clicking List (more than 1 dt)')
+		} else {
+			// only 1 dt, should not show toggle
+			const div = await detectZero({ elem: tk.menutip.d.node().firstChild, selector: '.sja_pp_vlb_dttabdiv' })
+			test.equal(div, undefined, 'Toggle button div is not shown after clicking List (only 1 dt)')
+		}
+		// TODO further test variant table contents, based on dtSet
+	}
+
+	// show menu >>> "Download" option
+	variantsLeftlabel.dispatchEvent(new Event('click'))
+	await whenVisible(tk.menutip.d)
+	if (0) {
+		// FIXME not enabled for custom tk yet
+		const op = tk.menutip.d
+			.selectAll('.sja_menuoption')
+			.nodes()
+			.find(e => e.innerHTML == 'Download')
+		test.ok(op, 'Download option is present')
+		// do not trigger clicking, don't know if it will break ci
+	}
+
+	// show menu >>> view mode toggle
+	if (tk.skewer.viewModes.length > 1) {
+		// should show radiobuttons to allow toggling between viewmodes
+		variantsLeftlabel.dispatchEvent(new Event('click'))
+		await whenVisible(tk.menutip.d)
+		const div = await detectOne({ elem: tk.menutip.d.node(), selector: '.sja_pp_vlb_viewmoderadiodiv' })
+		test.ok(div, 'View mode toggle div is shown')
+	}
+
+	const currentViewMode = tk.skewer.viewModes.find(i => i.inuse)
+	if (currentViewMode.type == 'skewer') {
+		// is in skewer mode. can test Collapse/Expand
+		// if not in skewer mode, the options may not be shown
+
+		// show menu >>> "Collapse" option
+		variantsLeftlabel.dispatchEvent(new Event('click'))
+		await whenVisible(tk.menutip.d)
+		const op1 = tk.menutip.d
+			.selectAll('.sja_menuoption')
+			.nodes()
+			.find(e => e.innerHTML == 'Collapse')
+		test.ok(op1, 'Collapse option is shown')
+
+		op1.dispatchEvent(new Event('click'))
+
+		// as soon as collapsing animation starts, none of the sja_aa_disclabel should have "scale(1)"
 		const expandedText = tk.skewer.selection
 			.selectAll('text.sja_aa_disclabel')
 			.nodes()
@@ -334,32 +377,27 @@ export async function testCollapseExpand_variantLeftLabel(test, tk, bb, holder) 
 				e.attributes.transform.value == 'scale(1)'
 			})
 		test.notOk(expandedText, 'No expanded skewer found after collapsing')
-	}
 
-	//Go back and click on 'Expand' to test skewer expanding
-	variantsLeftlabel.dispatchEvent(new Event('click'))
-	await whenVisible(tk.menutip.d)
-
-	tk.menutip.d
-		.selectAll('.sja_menuoption')
-		.nodes()
-		.find(e => e.innerHTML == 'Expand')
-		.dispatchEvent(new Event('click'))
-
-	/* FIXME this fails
-
-	// as soon as expanding animation starts, some sja_aa_disclabel should have opacity!=0
-	{
-		const expandedText = tk.skewer.g
-			.selectAll('text.sja_aa_disclabel')
+		// show menu >>> "Expand" option
+		variantsLeftlabel.dispatchEvent(new Event('click'))
+		await whenVisible(tk.menutip.d)
+		const op2 = tk.menutip.d
+			.selectAll('.sja_menuoption')
 			.nodes()
-			.some(e => e.attributes['fill-opacity'].value != '0')
-		test.ok(expandedText, 'Should find some expanded skewers')
-	}
-	*/
+			.find(e => e.innerHTML == 'Expand')
+		test.ok(op2, 'Expand option is now shown after clicking Collapse')
+		op2.dispatchEvent(new Event('click'))
 
-	if (test._ok) holder.remove()
-	test.end()
+		// as soon as expanding animation starts, some sja_aa_disclabel should have opacity!=0
+		if (0) {
+			// FIXME always fails
+			const expandedText = tk.skewer.g
+				.selectAll('text.sja_aa_disclabel')
+				.nodes()
+				.some(e => e.attributes['fill-opacity'].value != '0')
+			test.ok(expandedText, 'Should find some expanded skewers')
+		}
+	}
 }
 
 tape('Incorrect dslabel', test => {
@@ -416,7 +454,7 @@ tape('TP53 custom data, no sample', test => {
 			}
 		]
 	})
-	function callbackOnRender(tk, bb) {
+	async function callbackOnRender(tk, bb) {
 		// Test mds3 is a track object and bb is block object
 		test.equal(bb.usegm.name, gene, `Should render block.usegm.name = ${gene}`)
 		test.equal(bb.tklst.length, 2, 'Should have two tracks')
@@ -440,6 +478,7 @@ tape('TP53 custom data, no sample', test => {
 		/*** Verify all ui parts are rendered ***/
 		//Left labels
 		test.ok(tk.leftlabels.doms.variants, 'Should render tk.leftlabels.doms.variants')
+		await testVariantLeftLabel(test, tk, bb)
 		test.notOk(tk.leftlabels.doms.filterObj, 'Should NOT render tk.leftlabels.doms.filterObj')
 		test.notOk(tk.leftlabels.doms.close, 'Should NOT render tk.leftlabels.doms.close')
 
@@ -733,7 +772,9 @@ tape('Numeric mode custom dataset, with mode change', test => {
 
 	// TODO all data points should be rendered in svg
 
-	function callbackOnRender(tk, bb) {
+	async function callbackOnRender(tk, bb) {
+		await testVariantLeftLabel(test, tk, bb)
+
 		// verify that all custom data points are present in tk
 		for (const m of custom_variants) {
 			const m2 = tk.skewer.rawmlst.find(i => i.mname == m.mname)

--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -42,8 +42,6 @@ Collapse and expand mutations from variant link
 
 Launch sample table from sunburst
 
-### custom data
-Numeric mode custom dataset, with mode change
 ***************/
 function getHolder() {
 	return d3s

--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -1,6 +1,12 @@
 const tape = require('tape')
 const d3s = require('d3-selection')
 const { detectLst, detectOne, detectZero, whenHidden, whenVisible, detectGte } = require('../../test/test.helpers')
+const {
+	findSingletonMutationTestDiscoCnvPlots,
+	testMclassFiltering,
+	testSampleSummary2subtrack,
+	testCollapseExpand_variantLeftLabel
+} = require('./mds3.integration.spec')
 
 /**************
  test sections
@@ -14,16 +20,11 @@ GDC - KRAS SSM ID
 GDC - ssm by range
 geneSearch4GDCmds3
 
-### ash dataset is based on bcf file with samples
-ASH - gene BCR
-
-Mbmeta - gene p53 - Disco button
-GDC - gene p53 - Disco button
+GDC - gene hoxa1 - Disco button
 
 ### clinvar dataset is based on sample-less bcf file
 Clinvar - gene kras
 
-Incorrect dataset name: ah instead of ASH
 
 Launch variant table from track variant label
 
@@ -35,12 +36,11 @@ ASH - sample summaries table, create subtrack (tk.filterObj)
 
 ###
 GDC - mclass filtering
-ASH - mclass filtering
 Clinvar - mclass filtering
 
 Collapse and expand mutations from variant link
 
-Launch sample table from sunburst
+GDC - Launch sample table from sunburst
 
 ***************/
 function getHolder() {
@@ -228,121 +228,23 @@ tape('geneSearch4GDCmds3', async test => {
 	}
 })
 
-tape('ASH - gene BCR', test => {
-	test.timeoutAfter(3000)
-	const holder = getHolder()
-
-	runproteinpaint({
-		holder,
-		noheader: true,
-		genome: 'hg38',
-		gene: 'BCR',
-		tracks: [{ type: 'mds3', dslabel: 'ASH', callbackOnRender }]
-	})
-	function callbackOnRender(tk, bb) {
-		test.equal(bb.usegm.name, 'BCR', 'block.usegm.name="BCR"')
-		test.equal(bb.tklst.length, 2, 'should have two tracks')
-		test.ok(tk.skewer.rawmlst.length > 0, 'mds3 tk should have loaded many data points')
-		if (test._ok) holder.remove()
-		test.end()
-	}
-})
-
-/*
-want to apply both disco/cnv plot button test on both mbmeta and gdc
-as the data are served from different sources
-somehow running both tests will cause it to be stuck at mbmeta
-*/
-tape('Mbmeta - gene p53 - Disco button', test => {
-	testClickDiscForDiscoButtons(test, 'p53', 'MB_meta_analysis')
-})
-tape('GDC - gene p53 - Disco button', test => {
-	testClickDiscForDiscoButtons(test, 'hoxa1', 'GDC')
-})
-
-async function testClickDiscForDiscoButtons(test, gene, dslabel) {
+tape('GDC - gene hoxa1 - Disco button', test => {
 	const holder = getHolder()
 	runproteinpaint({
 		holder,
 		noheader: true,
 		genome: 'hg38',
-		gene,
-		tracks: [{ type: 'mds3', dslabel, callbackOnRender }]
+		gene: 'hoxa1',
+		tracks: [{ type: 'mds3', dslabel: 'GDC', callbackOnRender }]
 	})
 	async function callbackOnRender(tk, bb) {
-		test.ok(tk.skewer.data.length > 0, 'mds3 tk should be showing some skewers')
-		// find a singleton skewer, click disc
-		const singletonMutationDisc = tk.skewer.g
-			.selectAll('.sja_aa_disckick')
-			.nodes()
-			.find(i => i.__data__.occurrence == 1)
-		test.ok(singletonMutationDisc, 'a singleton mutation is found') // if not found can change to different gene
-		// click the singleton disc to show itemtip
-		singletonMutationDisc.dispatchEvent(new Event('click'))
-		await whenVisible(tk.itemtip.d)
-		test.pass('itemtip shows with variant table')
-
-		/* surprise
-		in mbmeta, as soon as itemtip.d is shown, buttons are already created; calling detectLst() will timeout
-		in gdc, there's a delay (api request) for buttons to be shown after itemtip, thus must use detectLst
-		*/
-		let buttons = tk.itemtip.d.selectAll('button').nodes()
-		if (buttons.length == 0) {
-			buttons = await detectLst({ elem: tk.itemtip.d.node(), selector: 'button' })
-		}
-		/* multiplt buttons can be shown, based on data availability
-		#1: disco
-		#2: methylation cnv
-		*/
-		test.ok(buttons.length >= 1, '1 or more buttons are showing in itemtip')
-
-		for (const btn of buttons) {
-			switch (btn.innerHTML) {
-				case 'Disco plot':
-					await testDisco(btn, tk)
-					break
-				case 'MethylationArray':
-					await testCnv(btn, tk)
-					break
-				default:
-					throw 'unknown button: ' + btn.innerHTML
-			}
-		}
+		await findSingletonMutationTestDiscoCnvPlots(test, tk)
 		if (test._ok) {
 			holder.remove()
-			tk.itemtip.d.remove()
-			tk.menutip.d.remove()
 		}
 		test.end()
 	}
-	async function testDisco(btn, tk) {
-		const name = 'Disco plot'
-		test.equal(btn.innerHTML, name, '1st button is called ' + name)
-		btn.dispatchEvent(new Event('click'))
-
-		// TODO disco now shows in new sandbox
-
-		//await whenVisible(tk.menutip.d) // upon clicking btn, this menu shows to display content
-		//test.pass(`clicking 1st button ${name} the menutip shows`)
-		//const svg = await detectOne({elem: tk.menutip.d.node(), selector:'svg'})
-		//test.ok(svg, '<svg> created in tk.menutip.d as disco plot')
-	}
-	async function testCnv(btn, tk) {
-		const name = 'MethylationArray'
-		test.equal(btn.innerHTML, name, '2nd button is called ' + name)
-		btn.dispatchEvent(new Event('click'))
-
-		// TODO cnv now shows in new sandbox
-
-		/*
-		await whenVisible(tk.menutip.d) // upon clicking btn, this menu shows to display content
-		test.pass(`clicking 2nd button ${name} the menutip shows`)
-		const img = await detectOne({ elem: tk.menutip.d.node(), selector: 'img' })
-		test.ok(img, '<img> found in menutip')
-		// TODO click at a particular position on img, detect if block shows up
-		*/
-	}
-}
+})
 
 tape('Clinvar - gene kras', test => {
 	test.timeoutAfter(3000)
@@ -360,30 +262,6 @@ tape('Clinvar - gene kras', test => {
 		test.ok(tk.skewer.rawmlst.length > 0, 'mds3 tk should have loaded many data points')
 		test.ok(tk.leftlabels.doms.variants, 'tk.leftlabels.doms.variants is set')
 		test.notOk(tk.leftlabels.doms.samples, 'tk.leftlabels.doms.samples is absent')
-		if (test._ok) holder.remove()
-		test.end()
-	}
-})
-
-tape('Incorrect dataset name: ah instead of ASH', test => {
-	test.timeoutAfter(3000)
-	const holder = getHolder()
-	runproteinpaint({
-		holder,
-		noheader: true,
-		genome: 'hg38',
-		gene: 'BCR',
-		tracks: [{ type: 'mds3', dslabel: 'ah', callbackOnRender }]
-	})
-	function callbackOnRender(tk, bb) {
-		// Confirm mds3 track sent to block instance but not rendering
-		test.ok(tk.uninitialized == true, 'Should not render mds3 track and not throw')
-		// Confirm error message appears
-		const errorDivFound = tk.gmiddle
-			.selectAll('text')
-			.nodes()
-			.find(i => i.textContent == 'Error: invalid dsname')
-		test.ok(errorDivFound, 'Should display invalid dsname error')
 		if (test._ok) holder.remove()
 		test.end()
 	}
@@ -439,139 +317,6 @@ tape('Launch variant table from track variant label', test => {
 tape('GDC - sample summaries table, create subtrack (tk.filterObj)', test => {
 	testSampleSummary2subtrack('IDH1', 'GDC', test)
 })
-tape('ASH - sample summaries table, create subtrack (tk.filterObj)', test => {
-	testSampleSummary2subtrack('KRAS', 'ASH', test)
-})
-
-// a helper shared by above two tests
-async function testSampleSummary2subtrack(gene, dslabel, test) {
-	const holder = getHolder()
-
-	runproteinpaint({
-		holder,
-		noheader: true,
-		genome: 'hg38',
-		gene,
-		tracks: [{ type: 'mds3', dslabel, callbackOnRender }]
-	})
-
-	async function callbackOnRender(tk, bb) {
-		// click on "xx samples" left label, to open sample summary panel
-		tk.leftlabels.doms.samples.node().dispatchEvent(new Event('click'))
-		await whenVisible(tk.menutip.d)
-
-		const div = await detectOne({ elem: tk.menutip.d.node(), selector: '.sja_mds3samplesummarydiv' })
-		test.ok(div, 'Sample summary table rendered in menutip')
-
-		for (const tw of tk.mds.variant2samples.twLst) {
-			// each tw should show up in div as a tab
-			const twDiv = tk.menutip.d
-				.selectAll('div')
-				.nodes()
-				.find(e => e.innerText.startsWith(tw.term.name))
-			// the found div is <div>TW.name <span></span></div>, thus must use startsWith
-			test.ok(twDiv, 'Should display tab for ' + tw.term.name)
-		}
-
-		// find one of the clickable label for a category
-		// attach this callback on bb (block instance) to be triggered when the subtrack is loaded
-		bb.onloadalltk_always = async () => {
-			test.equal(
-				bb.tklst.length,
-				3,
-				'now bb has 3 tracks after clicking a category from mds3 tk sample summaries table'
-			)
-
-			const subtk = bb.tklst[2] // mds3 sub-track object created off main one (tk)
-
-			test.equal(subtk.type, 'mds3', '3rd track type is mds3 (subtrack launched from main track)')
-
-			test.ok(
-				Number(tk.leftlabels.doms.variants.text().split(' ')[0]) >
-					Number(subtk.leftlabels.doms.variants.text().split(' ')[0]),
-				'subtrack has fewer number of mutations than main track'
-			)
-			test.ok(
-				Number(tk.leftlabels.doms.samples.text().split(' ')[0]) >
-					Number(subtk.leftlabels.doms.samples.text().split(' ')[0]),
-				'subtrack has fewer number of samples than main track'
-			)
-
-			// click on "samples" left label of subtk, to open sample summary panel
-			subtk.leftlabels.doms.samples.node().dispatchEvent(new Event('click'))
-			await whenVisible(subtk.menutip.d)
-			// same as in main tk, must await for the summary table to be shown in subtk.menutip
-			// that means leftlabels.__samples_data is now created
-			await detectOne({ elem: subtk.menutip.d.node(), selector: '.sja_mds3samplesummarydiv' })
-
-			compareSummary(tk, subtk)
-
-			test.ok(subtk.leftlabels.doms.filterObj, '.leftlabels.doms.filterObj is set on subtrack')
-			// click on the filterObj left label to show menu with filter UI
-			subtk.leftlabels.doms.filterObj.node().dispatchEvent(new Event('click'))
-			await whenVisible(subtk.menutip.d)
-			test.pass('subtk.menutip is shown (with filter UI), after clicking leftlabels.doms.filterObj')
-
-			test.ok(subtk.leftlabels.doms.close, '.leftlabels.doms.close is set on subtrack')
-
-			if (test._ok) {
-				holder.remove()
-				subtk.menutip.d.remove() // Close orphaned popup window
-			}
-			test.end()
-		}
-
-		const categoryDiv = tk.menutip.d.select('.sja_clbtext2')
-		categoryDiv.node().dispatchEvent(new Event('click'))
-	}
-
-	// compare sample summary data between sub and main tk
-	function compareSummary(tk, subtk) {
-		test.ok(
-			subtk.leftlabels.__samples_data.length == tk.leftlabels.__samples_data.length,
-			'main and sub track returned summaries for the same number of terms'
-		)
-		// assuming order of terms in the array are identical between main and sub tk
-		// for the same catgory from same term, sub track must show <= samplecount than main
-
-		// since 'sub<=main' must be used in tests but not 'sub<main', verify at least one category shows sub<main
-		let subLTmainCount = 0
-
-		for (const [i, main] of tk.leftlabels.__samples_data.entries()) {
-			const sub = subtk.leftlabels.__samples_data[i]
-			if (main.numbycategory) {
-				test.ok(
-					main.numbycategory.length >= sub.numbycategory.length,
-					'main.numbycategory.length >= sub for ' + main.termname
-				)
-				const k2c = new Map()
-				for (const a of main.numbycategory) {
-					// a=[categorylabel, #mutated, #total]
-					k2c.set(a[0], { mutated: a[1], total: a[2] })
-				}
-				for (const a of sub.numbycategory) {
-					const a2 = k2c.get(a[0])
-					if (!a2) throw 'a2 not found'
-					test.ok(
-						a[1] <= a2.mutated && a[2] <= a2.total,
-						`sub<=main for mutated/total counts of ${a[0]}, ${main.termname}`
-					)
-					if (a[2] < a2.total) subLTmainCount++
-				}
-			} else if (main.density_data) {
-				if (!Number.isInteger(main.density_data.samplecount)) throw 'main.density_data.samplecount is not integer'
-				test.ok(
-					sub.density_data.samplecount <= main.density_data.samplecount,
-					'sub<=main for density_data.samplecount for ' + main.termname
-				)
-				if (sub.density_data.samplecount < main.density_data.samplecount) subLTmainCount++
-			} else {
-			}
-		}
-
-		test.ok(subLTmainCount > 0, subLTmainCount + ' categories have reduced sample count in subtk')
-	}
-}
 
 tape('GDC - mclass filtering', test => {
 	const holder = getHolder()
@@ -582,53 +327,7 @@ tape('GDC - mclass filtering', test => {
 		tracks: [{ type: 'mds3', dslabel: 'GDC', callbackOnRender }]
 	})
 	async function callbackOnRender(tk, bb) {
-		const allMcount = tk.skewer.rawmlst.length
-		test.ok(
-			tk.skewer.rawmlst.find(m => m.class == 'M'),
-			'has class=M before filtering'
-		)
-		tk.legend.mclass.hiddenvalues.add('M')
-		// must delete this to not to trigger the same function on rerendering
-		delete tk.callbackOnRender
-		bb.onloadalltk_always = () => {
-			test.ok(allMcount > tk.skewer.rawmlst.length, 'fewer mutations left after filtering by mclass')
-			test.notOk(
-				tk.skewer.rawmlst.find(m => m.class == 'M'),
-				'no longer has class=M after filtering'
-			)
-			if (test._ok) holder.remove()
-			test.end()
-		}
-		await tk.load()
-	}
-})
-tape('ASH - mclass filtering', test => {
-	const holder = getHolder()
-	runproteinpaint({
-		holder,
-		genome: 'hg38',
-		gene: 'kras',
-		tracks: [{ type: 'mds3', dslabel: 'ash', callbackOnRender }]
-	})
-	async function callbackOnRender(tk, bb) {
-		const allMcount = tk.skewer.rawmlst.length
-		test.ok(
-			tk.skewer.rawmlst.find(m => m.class == 'M'),
-			'has class=M before filtering'
-		)
-		tk.legend.mclass.hiddenvalues.add('M')
-		// must delete this to not to trigger the same function on rerendering
-		delete tk.callbackOnRender
-		bb.onloadalltk_always = () => {
-			test.ok(allMcount > tk.skewer.rawmlst.length, 'fewer mutations left after filtering by mclass')
-			test.notOk(
-				tk.skewer.rawmlst.find(m => m.class == 'M'),
-				'no longer has class=M after filtering'
-			)
-			if (test._ok) holder.remove()
-			test.end()
-		}
-		await tk.load()
+		await testMclassFiltering(test, tk, bb, holder)
 	}
 })
 tape('Clinvar - mclass filtering', test => {
@@ -640,28 +339,11 @@ tape('Clinvar - mclass filtering', test => {
 		tracks: [{ type: 'mds3', dslabel: 'clinvar', callbackOnRender }]
 	})
 	async function callbackOnRender(tk, bb) {
-		const allMcount = tk.skewer.rawmlst.length
-		test.ok(
-			tk.skewer.rawmlst.find(m => m.class == 'M'),
-			'has class=M before filtering'
-		)
-		tk.legend.mclass.hiddenvalues.add('M')
-		// must delete this to not to trigger the same function on rerendering
-		delete tk.callbackOnRender
-		bb.onloadalltk_always = () => {
-			test.ok(allMcount > tk.skewer.rawmlst.length, 'fewer mutations left after filtering by mclass')
-			test.notOk(
-				tk.skewer.rawmlst.find(m => m.class == 'M'),
-				'no longer has class=M after filtering'
-			)
-			if (test._ok) holder.remove()
-			test.end()
-		}
-		await tk.load()
+		await testMclassFiltering(test, tk, bb, holder)
 	}
 })
 
-tape('Collapse and expand mutations from variant link', test => {
+tape('GDC - Collapse and expand mutations from variant link', test => {
 	test.timeoutAfter(10000) //Fix for succeeding tape tests running before this one finishes
 	//Will throw a not ok error if another test fires
 	const holder = getHolder()
@@ -671,59 +353,15 @@ tape('Collapse and expand mutations from variant link', test => {
 		noheader: true,
 		nobox: true,
 		genome: 'hg38',
-		gene: 'kras',
-		tracks: [{ type: 'mds3', dslabel: 'ASH', callbackOnRender }]
+		gene: 'hoxa1',
+		tracks: [{ type: 'mds3', dslabel: 'GDC', callbackOnRender }]
 	})
 	async function callbackOnRender(tk, bb) {
-		//Click on variant leftlabel to open menu
-		const variantsLeftlabel = tk.leftlabels.doms.variants.node()
-		variantsLeftlabel.dispatchEvent(new Event('click'))
-		await whenVisible(tk.menutip.d)
-
-		//Click 'Collapse' menu option
-		tk.menutip.d
-			.selectAll('.sja_menuoption')
-			.nodes()
-			.find(e => e.innerHTML == 'Collapse')
-			.dispatchEvent(new Event('click'))
-
-		// as soon as collapsing animation starts, none of the sja_aa_disclabel should have "scale(1)"
-		{
-			const expandedText = tk.skewer.selection
-				.selectAll('text.sja_aa_disclabel')
-				.nodes()
-				.some(e => {
-					//console.log(e)
-					e.attributes.transform.value == 'scale(1)'
-				})
-			test.notOk(expandedText, 'No expanded skewer found after collapsing')
-		}
-
-		//Go back and click on 'Expand' to test skewer expanding
-		variantsLeftlabel.dispatchEvent(new Event('click'))
-		await whenVisible(tk.menutip.d)
-
-		tk.menutip.d
-			.selectAll('.sja_menuoption')
-			.nodes()
-			.find(e => e.innerHTML == 'Expand')
-			.dispatchEvent(new Event('click'))
-
-		// as soon as expanding animation starts, some sja_aa_disclabel should have opacity!=0
-		{
-			const expandedText = tk.skewer.g
-				.selectAll('.sja_aa_disclabel')
-				.nodes()
-				.some(e => e.attributes['fill-opacity'].value != '0')
-			test.ok(expandedText, 'Should find some expanded skewers')
-		}
-
-		if (test._ok) holder.remove()
-		test.end()
+		await testCollapseExpand_variantLeftLabel(test, tk, bb, holder)
 	}
 })
 
-tape('Launch sample table from sunburst', test => {
+tape('GDC - Launch sample table from sunburst', test => {
 	const holder = getHolder()
 
 	runproteinpaint({


### PR DESCRIPTION
## Description

lots of testers are applied on termdbtest dataset now, that allows to get rid of ASH and mbmeta ds in non-CI test;
non-CI test covers GDC and clinvar

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
