### PR TITLE
The gene expression undo/redo should not track cohort changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Fixes:
 - GDC bam slicing UI can still pull BAM files when experimental_strategy=Methylation Array filtering is used
 - support navigation-by-keyboard of bam UI elements
 - fix the display of no data error message and hiding of previously rendered heatmap in the hier cluster app
+- For hierCluster, set left dendrogram position based on max gene label length, ignore variable labels. 
 
 
 ## 2.39.6

--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -365,6 +365,16 @@ export class HierCluster extends Matrix {
 			return i - j
 		}
 
+		this.hcSampleNameOrder = c.col.order.map(col => col.name)
+		this.hcSampleSorter = (a, b) => {
+			const i = this.hcSampleNameOrder.indexOf(a.sample)
+			const j = this.hcSampleNameOrder.indexOf(b.sample)
+			if (i == -1 && j == -1) return 0
+			if (i == -1) return 1
+			if (j == -1) return -1
+			return i - j
+		}
+
 		// from d.byTermId to byTermId: change byTermId keys from gene names to $ids
 		const byTermId = {}
 		for (const tw of twlst) {

--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -687,6 +687,7 @@ export class HierCluster extends Matrix {
 		} else {
 			throw 'unknown dataType'
 		}
+		lst.sort((a, b) => (a.name < b.name ? -1 : 1))
 		return lst
 	}
 }

--- a/client/plots/matrix.groups.js
+++ b/client/plots/matrix.groups.js
@@ -46,11 +46,11 @@ export function getTermOrder(data) {
 					}
 				}
 			}
-			lst.push({ tw, counts, index })
+			if (grp.type != 'hierCluster' || counts.samples) lst.push({ tw, counts, index })
 		}
 
 		// may override the settings.sortTermsBy with a sorter that is specific to a term group
-		const termSorter = grp.sortTermsBy ? getTermSorter(this, grp) : this.termSorter
+		const termSorter = grp.sortTermsBy || grp.type == 'hierCluster' ? getTermSorter(this, s, grp) : this.termSorter
 		const processedLst = lst
 			.filter(t => {
 				if ('minNumSamples' in t.tw) return t.tw.minNumSamples <= t.counts.samples

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -5,7 +5,11 @@
 export function getSampleSorter(self, settings, rows, opts = {}) {
 	const s = settings
 	validateSettings(s)
-	if (s.sortSamplesBy == 'asListed' || self.config.chartType == 'hierCluster') {
+	if (self.config.chartType == 'hierCluster') {
+		return self.hcSampleSorter
+	}
+
+	if (s.sortSamplesBy == 'asListed') {
 		return (a, b) => {
 			return self.asListedSampleOrder.indexOf(a.sample) - self.asListedSampleOrder.indexOf(b.sample)
 		}

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -269,8 +269,10 @@ function findMatchingValue(annoValues, filterValues) {
 	}
 }
 
-export function getTermSorter(self, s) {
-	if (s.sortTermsBy == 'asListed' || self.config.heirCluster) {
+export function getTermSorter(self, s, grp) {
+	if (grp?.type == 'hierCluster') return self.hcTermSorter
+
+	if (s.sortTermsBy == 'asListed') {
 		//no additional logic required
 		return (a, b) => a.index - b.index
 	}

--- a/client/rx/src/recover.js
+++ b/client/rx/src/recover.js
@@ -78,14 +78,16 @@ class Recover {
 		}
 		if (this.state._scope_ == 'none') return
 		this.isRecovering = false
+		const state = this.opts.adjustTrackedState ? this.opts.adjustTrackedState(this.state) : this.state
+		if (!Object.isFrozen(state)) deepFreeze(state)
+
 		// the goto() code should not allow currIndex to go back to -1
-		if (this.currIndex == -1) this.origState = this.state
+		if (this.currIndex == -1) this.origState = state
 
 		if (this.currIndex < this.history.length - 1) {
 			this.history.splice(this.currIndex, this.history.length - (this.currIndex + 1))
 		}
-		const state = this.opts.adjustTrackedState ? this.opts.adjustTrackedState(this.state) : this.state
-		if (!Object.isFrozen(state)) deepFreeze(state)
+
 		if (deepEqual(state, this.history[this.history.length - 1])) return
 		this.history.push(state)
 		this.currIndex += 1

--- a/client/src/launchGdcHierCluster.js
+++ b/client/src/launchGdcHierCluster.js
@@ -98,11 +98,24 @@ export async function init(arg, holder, genomes) {
 				adjustTrackedState(state) {
 					const s = structuredClone(state)
 					delete s.termfilter.filter0
-					// this twlst is added from the server response, it follows the
-					// dendrogram clustering and sorting of genes
-					// TODO: this twlst should not be tracked in state, since it can be computed
-					// from other state configuration/settings
-					delete s.plots[0]?.termgroups?.find(g => g.type == 'hierCluster')?.lst
+					if (s.plots) {
+						// don't track plot configuration that are not specific to the plot config/settings
+						for (const plot of s.plots) {
+							if (!plot.termgroups) continue
+							for (const grp of plot.termgroups) {
+								if (!grp.lst) continue
+								for (const tw of grp.lst) {
+									if (!tw?.term) continue
+									// this is cohort-dependent and should be ignored like termfilter.filter0
+									delete tw.term.category2samplecount
+									// for GDC, the term.values may not be known ahead of time
+									// and only filled in as data comes in, should ignore this
+									// computed value as to avoid affecting tracked state
+									delete tw.term.values
+								}
+							}
+						}
+					}
 					return s
 				}
 			},

--- a/client/src/launchGdcHierCluster.js
+++ b/client/src/launchGdcHierCluster.js
@@ -98,6 +98,11 @@ export async function init(arg, holder, genomes) {
 				adjustTrackedState(state) {
 					const s = structuredClone(state)
 					delete s.termfilter.filter0
+					// this twlst is added from the server response, it follows the
+					// dendrogram clustering and sorting of genes
+					// TODO: this twlst should not be tracked in state, since it can be computed
+					// from other state configuration/settings
+					delete s.plots[0]?.termgroups?.find(g => g.type == 'hierCluster')?.lst
 					return s
 				}
 			},

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
 Fixes:
--For hierCluster, set left dendrogram position based on max gene label length, ignore variable labels. 
+- ignore the computed twlst of the hierCluster term group when tracking recoverable state

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - ignore the computed twlst of the hierCluster term group when tracking recoverable state
+- Do not modify the hierCluster term group lst with server data, to avoid unnecessary state tracking and to prevent unwanted geneset edits


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2396

Previously, the undo/redo buttons would react to cohort filter0 changes, but the intent is for those buttons to track only chart-specific configuration or settings. The code fixes were to:
- not modify the hcTermGroup.lst with server data: the visible genes and sorting should not affect tracked state
- ignore tw.term.values or .categories2samplecount, which can change with the filter0 in the GDC use case and cause irrelevant state diff

To test:
- pull sjpp/master
- open http://localhost:3000/example.gdc.exp.html?cohort=CDDP_EAGLE-1: the undo/redo should be disabled
- change the cohort to `CMC-MPC` using the dropdown selector: the undo/redo should **remain** disabled
- try other cohort-only change, the undo/redo should remain disabled
- change a setting, for example by adding a variable: the undo/restore button should be enabled
- click on the restore button: the rendered cohort should NOT change 
- adding/removing dictionary term variables (gender, project name, etc) should not affect the sample sorting

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
