### PR TITLE
adjust the starting maxLabelWidth based on setl.type == hierCluster vs matrix

### DIFF
--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -452,6 +452,9 @@ export function setRenderers(self) {
 
 		// note: two leftBox.width terms cancels to zero
 		const x = -l.left.offset + hcWidth + maxLabelWidth
+		// with hierCluster:
+		// in case the term dendrograms + max term label width is less than the leftBox.width of all row labels,
+		// then the mainG and top/left dendrograms must be offset have an additional offset based on the difference
 		const xAdjust = !hc.xDendrogramHeight ? 0 : Math.max(leftBox.width - (hc.xDendrogramHeight + maxLabelWidth), 0)
 		const y = (l.top.display == 'none' ? 0 : topBox.height) - l.top.offset + hcHeight
 		self.dom.mainG

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -433,7 +433,7 @@ export function setRenderers(self) {
 			.attr('height', d.svgh)
 
 		//calculate the max gene label
-		let maxLabelWidth = 0,
+		let maxLabelWidth = self.type == 'hierCluster' ? 0 : leftBox.width,
 			maxLabelNumChars = 0
 		if (hc.xDendrogramHeight) {
 			self.dom.termLabelG.selectAll('.sjpp-matrix-label').each(function (d) {


### PR DESCRIPTION
## Description
test with 
- [matrix](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22header_mode%22:%22hidden%22%7D,%22plots%22:%5B%7B%22chartType%22:%22matrix%22,%22termgroups%22:%5B%7B%22lst%22:%5B%7B%22term%22:%7B%22name%22:%22TP53%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22name%22:%22AKT1%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22id%22:%22sex%22%7D,%7B%22id%22:%22agedx%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%7B%22id%22:%22diaggrp%22%7D%5D%7D%5D%7D%5D%7D)
- [hierCluster](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22pediatricMds3%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22hierCluster%22,%22genes%22:[{%22gene%22:%22GAPDH%22},{%22gene%22:%22BCR%22},{%22gene%22:%22ABL1%22},{%22gene%22:%22HOXA1%22}],%22termgroups%22:[{%22name%22:%22Variables%22,%22lst%22:[{%22id%22:%22diagnosis_group_short%22}]}]}]})
- also change the Row Dendrogram Width input value to 10, to test that the x-offset adjustment accounts for the larger of dendro width + max gene label width versus leftBox.width

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
