### PR TITLE
Regulomedb links

### DIFF
--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -260,7 +260,7 @@ function setRenderers(self) {
 		self.mayshow_warn(result)
 		if (result.sampleSize) self.newDiv('Sample size:', result.sampleSize)
 		if (result.eventCnt) self.newDiv('Number of events:', result.eventCnt)
-		if (result.headerRow) self.newDiv(result.headerRow.k, result.headerRow.v)
+		self.mayshow_headerRow(result)
 		self.mayshow_splinePlots(result)
 		self.mayshow_residuals(result)
 		self.mayshow_coefficients(result)
@@ -295,6 +295,44 @@ function setRenderers(self) {
 		for (const line of warnings) {
 			div.append('p').style('margin', '5px').text(line)
 		}
+	}
+
+	self.mayshow_headerRow = result => {
+		if (!result.headerRow) return
+		const k = result.headerRow.k
+		const v = result.headerRow.v
+		const snplocusInput = self.parent.inputs.independent.inputLst.find(i => i.term && i.term.term.type == 'snplocus')
+		let lst
+		if (snplocusInput) {
+			// header row is for snplocus results
+			const snpid = v.snpid
+			const snp = snplocusInput.term.term.snps.find(snp => snp.snpid == snpid)
+			// snp id label
+			const urls = []
+			if (snp.dbsnp) urls.push(`<a href="https://www.ncbi.nlm.nih.gov/snp/${snpid}" target="_blank">dbSNP</a>`)
+			urls.push(
+				`<a href="https://regulomedb.org/regulome-search?regions=${snp.chr}%3A${snp.pos}-${snp.pos + 1}&genome=${
+					self.parent.genomeObj.name == 'hg38' ? 'GRCh38' : self.parent.genomeObj.name
+				}" target="_blank">RegulomeDB</a>`
+			)
+			const snpid_label = `${snpid} (${urls.join(', ')})`
+			// gt label
+			const gt_label = `Genotypes: ${v.gtcounts.join(', ')}`
+			if (v.monomorphic) {
+				lst = [snpid_label, gt_label]
+			} else {
+				// effect allele label
+				const effale_label = `Effect allele: ${v.effAle}`
+				// allel frequency label
+				const af_label = `Allele frequency: ${v.af}`
+				lst = [snpid_label, effale_label, af_label, gt_label]
+			}
+		} else {
+			// header row is not for snplocus results
+			lst = v
+		}
+
+		self.newDiv(k, lst.join('&nbsp;&#65372;&nbsp;'))
 	}
 
 	self.mayshow_splinePlots = result => {

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -67,7 +67,6 @@ export class RegressionResults {
 		const holder = this.opts.holder
 		holder
 			.append('div')
-			.attr('id', 'pp-regression-results-title')
 			.style('margin-top', '10px')
 			.style('padding-top', '20px')
 			.style('font-size', '1.2em')
@@ -115,7 +114,9 @@ export class RegressionResults {
 			await this.displayResult(data)
 
 			// scroll to results
-			document.getElementById('pp-regression-results-title').scrollIntoView({ behavior: 'smooth' })
+			const results_y = this.dom.holder.node().getBoundingClientRect().top + window.scrollY
+			const nav_height = document.querySelector('.sjpp-nav').getBoundingClientRect().height
+			window.scroll({ behavior: 'smooth', top: results_y - nav_height })
 		} catch (e) {
 			this.hasError = true
 			this.dom.holder.style('display', 'block')
@@ -1119,7 +1120,9 @@ async function createGenomebrowser(self, input, resultLst) {
 		click_snvindel: async m => {
 			self.displayResult_oneset(m.regressionResult.data)
 			await mayCheckLD(m, input, self)
-			self.dom.oneSetResultDiv.node().scrollIntoView({ behavior: 'smooth' })
+			const result_y = self.dom.oneSetResultDiv.node().getBoundingClientRect().top + window.scrollY
+			const nav_height = document.querySelector('.sjpp-nav').getBoundingClientRect().height
+			window.scroll({ behavior: 'smooth', top: result_y - nav_height })
 		}
 	})
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -293,13 +293,22 @@ export class TermdbVocab extends Vocab {
 						if (!contQkeys.includes(key)) delete q[key]
 					}
 				}
+				const term = JSON.parse(JSON.stringify(t.term))
+				if (term.snps) {
+					// remove unneeded parameters from term
+					for (const snp of term.snps) {
+						snp.genome = this.vocab.genome
+						delete snp.mlst
+					}
+				}
 				return {
 					id: t.id,
 					q,
 					type: t.term.type,
 					refGrp: t.q.mode == 'continuous' ? 'NA' : t.refGrp,
 					interactions: t.interactions || [],
-					values: t.term.values
+					values: t.term.values,
+					term
 				}
 			})
 		}

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -293,22 +293,13 @@ export class TermdbVocab extends Vocab {
 						if (!contQkeys.includes(key)) delete q[key]
 					}
 				}
-				const term = JSON.parse(JSON.stringify(t.term))
-				if (term.snps) {
-					// remove unneeded parameters from term
-					for (const snp of term.snps) {
-						snp.genome = this.vocab.genome
-						delete snp.mlst
-					}
-				}
 				return {
 					id: t.id,
 					q,
 					type: t.term.type,
 					refGrp: t.q.mode == 'continuous' ? 'NA' : t.refGrp,
 					interactions: t.interactions || [],
-					values: t.term.values,
-					term
+					values: t.term.values
 				}
 			})
 		}

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -1079,18 +1079,39 @@ function getLine4OneSnp(snpid, tw) {
 	const gt2count = tw.snpgt2count.get(snpid)
 	if (!gt2count) return { k: 'Error', v: 'Variant not found' }
 
+	const snp = tw.term.snps.find(snp => snp.snpid == snpid)
+
+	// snp id label
+	const urls = []
+	if (snp.dbsnp) urls.push(`<a href="https://www.ncbi.nlm.nih.gov/snp/${snpid}" target="_blank">dbSNP</a>`)
+	urls.push(
+		`<a href="https://regulomedb.org/regulome-search?regions=${snp.chr}%3A${snp.pos}-${snp.pos + 1}&genome=${
+			snp.genome == 'hg38' ? 'GRCh38' : snp.genome
+		}" target="_blank">RegulomeDB</a>`
+	)
+	const snpid_label = `${snpid} (${urls.join(', ')})`
+
+	// gt label
+	const gts = []
+	for (const [gt, c] of gt2count) gts.push(gt + '=' + c)
+	const gt_label = `Genotypes: ${gts.join(', ')}`
+
+	let lst
 	if (tw.monomorphicLst.includes(snpid)) {
-		const [gt, c] = [...gt2count][0]
-		return { k: 'Genotype', v: gt + '=' + c }
-	}
-	const lst = [
-		`${tw.q.alleleType == 0 ? 'Minor' : 'Alternative'} allele=${
+		lst = [snpid_label, gt_label]
+	} else {
+		// effect allele label
+		const effale_label = `Effect allele: ${
 			tw.highAFsnps.has(snpid) ? tw.highAFsnps.get(snpid).effAle : tw.lowAFsnps.get(snpid).effAle
-		}`,
-		'AF=' + tw.snpid2AFstr.get(snpid)
-	]
-	for (const [gt, c] of gt2count) lst.push(gt + '=' + c)
-	return { k: 'Variant:', v: lst.join('&nbsp;&nbsp;&nbsp;') }
+		}`
+
+		// allel frequency label
+		const af_label = `Allele frequency: ${tw.snpid2AFstr.get(snpid)}`
+
+		lst = [snpid_label, effale_label, af_label, gt_label]
+	}
+
+	return { k: 'Variant:', v: lst.join('&nbsp;&#65372;&nbsp;') }
 }
 
 /*

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -1078,40 +1078,16 @@ function getLine4OneSnp(snpid, tw) {
 	// get summary line for one snp to show in result
 	const gt2count = tw.snpgt2count.get(snpid)
 	if (!gt2count) return { k: 'Error', v: 'Variant not found' }
-
-	const snp = tw.term.snps.find(snp => snp.snpid == snpid)
-
-	// snp id label
-	const urls = []
-	if (snp.dbsnp) urls.push(`<a href="https://www.ncbi.nlm.nih.gov/snp/${snpid}" target="_blank">dbSNP</a>`)
-	urls.push(
-		`<a href="https://regulomedb.org/regulome-search?regions=${snp.chr}%3A${snp.pos}-${snp.pos + 1}&genome=${
-			snp.genome == 'hg38' ? 'GRCh38' : snp.genome
-		}" target="_blank">RegulomeDB</a>`
-	)
-	const snpid_label = `${snpid} (${urls.join(', ')})`
-
-	// gt label
-	const gts = []
-	for (const [gt, c] of gt2count) gts.push(gt + '=' + c)
-	const gt_label = `Genotypes: ${gts.join(', ')}`
-
-	let lst
+	const gtcounts = []
+	for (const [gt, c] of gt2count) gtcounts.push(gt + '=' + c)
+	const snp = { snpid, gtcounts }
 	if (tw.monomorphicLst.includes(snpid)) {
-		lst = [snpid_label, gt_label]
+		snp.monomorphic = true
 	} else {
-		// effect allele label
-		const effale_label = `Effect allele: ${
-			tw.highAFsnps.has(snpid) ? tw.highAFsnps.get(snpid).effAle : tw.lowAFsnps.get(snpid).effAle
-		}`
-
-		// allel frequency label
-		const af_label = `Allele frequency: ${tw.snpid2AFstr.get(snpid)}`
-
-		lst = [snpid_label, effale_label, af_label, gt_label]
+		snp.effAle = tw.highAFsnps.has(snpid) ? tw.highAFsnps.get(snpid).effAle : tw.lowAFsnps.get(snpid).effAle
+		snp.af = tw.snpid2AFstr.get(snpid)
 	}
-
-	return { k: 'Variant:', v: lst.join('&nbsp;&#65372;&nbsp;') }
+	return { k: 'Variant:', v: snp }
 }
 
 /*

--- a/server/src/termdb.snp.js
+++ b/server/src/termdb.snp.js
@@ -456,10 +456,12 @@ async function validateInputCreateCache_by_coord(q, ds, genome) {
 			const altAlleles = l[3].split(',')
 
 			// if valid vcf ID is avaialble, use it since it should be snp rsid
-			const snpid = vcfId && vcfId != '.' ? vcfId : pos + '.' + refAllele + '.' + altAlleles.join(',')
+			const dbsnp = vcfId && vcfId != '.' ? vcfId : null
+			const snpid = dbsnp || pos + '.' + refAllele + '.' + altAlleles.join(',')
 
 			const variant = {
 				snpid,
+				dbsnp,
 				chr: q.chr,
 				pos
 			}


### PR DESCRIPTION
## Description

- Added dbSNP and RegulomeDB links to variant line in snplocus results
- Reformatted variant line in results
- Improved scrolling to regression results

Test by running [snplocus regression](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22LV_Ejection_Fraction_3D%22},%22independent%22:[{%22id%22:%22sex%22,%22refGrp%22:%222%22},{%22term%22:{%22type%22:%22snplocus%22},%22q%22:{%22chr%22:%22chr17%22,%22start%22:7664218,%22stop%22:7671018,%22AFcutoff%22:5,%22alleleType%22:0,%22geneticModel%22:0,%22restrictAncestry%22:{%22name%22:%22European%20ancestry%22,%22tvs%22:{%22term%22:{%22id%22:%22genetic_race%22,%22type%22:%22categorical%22,%22name%22:%22Genetically%20defined%20race%22},%22values%22:[{%22key%22:%22European%20Ancestry%22,%22label%22:%22European%20Ancestry%22}]}},%22variant_filter%22:{%22type%22:%22tvslst%22,%22join%22:%22and%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22Bad%22,%22key%22:%22Bad%22}],%22term%22:{%22id%22:%22QC%22,%22name%22:%22Classification%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22,%22values%22:{%22Good%22:{%22label%22:%22Good%22,%22key%22:%22Good%22},%22Bad%22:{%22label%22:%22Bad%22,%22key%22:%22Bad%22}}}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22SJcontrol_CR%22,%22name%22:%22SJLIFE%20control%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR%22,%22name%22:%22Call%20rate,%20SJLIFE+CCSS%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_sjlife%22,%22name%22:%22SJLIFE%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_ccss%22,%22name%22:%22CCSS%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22yes%22,%22key%22:%221%22}],%22term%22:{%22id%22:%22Polymer_region%22,%22name%22:%22Polymer%20region%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22}}}]}}}]}]}) and clicking on a variant. Can test on different kinds of variants.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
