### PR TITLE
Improved scatter 3D plots

### DIFF
--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -1,4 +1,5 @@
 import { rgb } from 'd3-color'
+import roundValue from '#shared/roundValue'
 
 export function setRenderersThree(self) {
 	self.render2DSerieLarge = async function (chart) {
@@ -121,6 +122,11 @@ export function setRenderersThree(self) {
 		controls.update()
 		camera.position.set(2, 1, 5)
 		camera.lookAt(scene.position)
+		const grid = new THREE.GridHelper(1)
+		grid.position.x = 0.5
+		grid.position.z = 0.5
+
+		scene.add(grid)
 		const axesHelper = new THREE.AxesHelper(3)
 		scene.add(axesHelper)
 		camera.updateMatrix()
@@ -133,9 +139,9 @@ export function setRenderersThree(self) {
 		for (const sample of chart.data.samples) {
 			const opacity = self.getOpacity(sample)
 			if (opacity == 0) continue
-			let x = Math.abs((sample.x - chart.xMin) / (chart.xMax - chart.xMin))
-			let y = Math.abs((sample.y - chart.yMin) / (chart.yMax - chart.yMin))
-			let z = Math.abs((sample.z - chart.zMin) / (chart.zMax - chart.zMin))
+			let x = chart.xMax == chart.xMin ? 0 : Math.abs((sample.x - chart.xMin) / (chart.xMax - chart.xMin))
+			let y = chart.yMax == chart.yMin ? 0 : Math.abs((sample.y - chart.yMin) / (chart.yMax - chart.yMin))
+			let z = chart.zMax == chart.zMin ? 0 : Math.abs((sample.z - chart.zMin) / (chart.zMax - chart.zMin))
 			const color = new THREE.Color(rgb(self.getColor(sample, chart)).toString())
 			const geometry = new THREE.SphereGeometry(0.005, 32)
 			const material = new THREE.MeshLambertMaterial({ color })
@@ -146,6 +152,7 @@ export function setRenderersThree(self) {
 		}
 
 		const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: self.canvas, preserveDrawingBuffer: true })
+		//document.addEventListener( 'pointermove', onPointerMove );
 
 		function animate() {
 			requestAnimationFrame(animate)
@@ -156,4 +163,10 @@ export function setRenderersThree(self) {
 		}
 		animate()
 	}
+}
+
+function onPointerMove(event) {
+	const x = (event.clientX / window.innerWidth) * 2 - 1
+	const y = -(event.clientY / window.innerHeight) * 2 + 1
+	console.log(roundValue(x, 1), roundValue(y, 1))
 }

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -113,28 +113,30 @@ export function setRenderersThree(self) {
 			.append('g')
 			.attr('transform', 'translate(20, 20)')
 		self.renderLegend(chart)
-		const fov = 20
+		const fov = 18
 		const near = 0.1
 		const far = 1000
 		const camera = new THREE.PerspectiveCamera(fov, 1, near, far)
 		const scene = new THREE.Scene()
 		const controls = new OrbitControls.OrbitControls(camera, self.canvas)
 		controls.update()
-		camera.position.set(2, 1, 5)
+		camera.position.set(5, 0.5, 5)
 		camera.lookAt(scene.position)
-		const grid = new THREE.GridHelper(1)
-		grid.position.x = 0.5
-		grid.position.z = 0.5
 
-		scene.add(grid)
-		const axesHelper = new THREE.AxesHelper(3)
-		scene.add(axesHelper)
+		if (self.settings.showAxes) {
+			const axesHelper = new THREE.AxesHelper(1)
+			scene.add(axesHelper)
+			const grid = new THREE.GridHelper(1)
+			grid.position.x = 0.5
+			grid.position.z = 0.5
+			scene.add(grid)
+		}
 		camera.updateMatrix()
 		const whiteColor = new THREE.Color('rgb(255,255,255)')
 		scene.background = whiteColor
 
 		const light = new THREE.DirectionalLight(whiteColor, 2)
-		light.position.set(2, 1, 5)
+		light.position.set(0, 0, 5)
 		scene.add(light)
 		for (const sample of chart.data.samples) {
 			const opacity = self.getOpacity(sample)


### PR DESCRIPTION
## Description

Improved 3d plots. Added grid, customized camera and light positions, hided axes if requested. Looking like this now. Plots can also be zoomed in/out and dragged, as before.

<img width="803" alt="Screenshot 2024-01-30 at 11 46 28 AM" src="https://github.com/stjude/proteinpaint/assets/12271391/68838c1d-850e-4d68-bdbf-b4df64c7afb6">
<img width="803" alt="Screenshot 2024-01-30 at 11 46 36 AM" src="https://github.com/stjude/proteinpaint/assets/12271391/cf6af830-5ea1-4f09-9786-1d25b5cdd506">

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
