### PR TITLE
fix the GDC oncomatrix and gene expression undo/redo state

### DIFF
--- a/client/rx/src/recover.js
+++ b/client/rx/src/recover.js
@@ -85,6 +85,10 @@ class Recover {
 		if (this.state._scope_ == 'none') return
 		this.isRecovering = false
 		const state = this.opts.adjustTrackedState ? this.opts.adjustTrackedState(this.state) : this.state
+		if (!state) {
+			console.error('no state to track')
+			return
+		}
 		if (!Object.isFrozen(state)) deepFreeze(state)
 
 		// the goto() code should not allow currIndex to go back to -1

--- a/client/src/launchGdcHierCluster.js
+++ b/client/src/launchGdcHierCluster.js
@@ -166,6 +166,7 @@ export async function init(arg, holder, genomes) {
 							}
 						}
 					}
+					return s
 				}
 			}
 		})

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -205,6 +205,7 @@ export async function init(arg, holder, genomes) {
 							}
 						}
 					}
+					return s
 				}
 			},
 			matrix: Object.assign(

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Return a defined adjusted state for the GDC matrix and gene expression tools, so that the undo/redo component can react


### PR DESCRIPTION
## Description

This fix puts back a returned adjusted state for the GDC-customized matrix and hierCluster launched apps.

To test:
- open http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=CMI-MPC: the undo/redo buttons should be disabled
- do a chart specific configuration or setting change, like hiding a filter or adding a divide-by term. The undo button should become enabled
- click undo: the redo button should become enabled, the undo button should become disabled


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
