### PR TITLE
Cuminc changes

### DIFF
--- a/client/dom/svgSeriesTips.js
+++ b/client/dom/svgSeriesTips.js
@@ -70,6 +70,7 @@ export function getSeriesTip(line, rect, _tip = null) {
 		.on('mousemove', mouseOver)
 		.on('mouseout', () => {
 			line.style('display', 'none')
+			tip.hide()
 		})
 
 	const opts = {

--- a/client/dom/svgSeriesTips.js
+++ b/client/dom/svgSeriesTips.js
@@ -45,11 +45,12 @@ export function getSeriesTip(line, rect, _tip = null) {
 		const seriesHtmls = []
 		for (const series of opts.serieses) {
 			const data = series.data
-			if (xVal <= Math.max(...data.map(d => d.x))) {
-				// xVal is within range of series timepoints
+			const data_x = data.map(d => d.x)
+			if (xVal >= Math.min(...data_x) && xVal <= Math.max(...data_x)) {
+				// xVal is within range of the series
 				// determine max timepoint that is less than or
 				// equal to xVal
-				const max = Math.max(...data.filter(d => d.x <= xVal).map(d => d.x))
+				const max = Math.max(...data_x.filter(x => x <= xVal))
 				// store html of this timepoint
 				const timepoint = data.find(d => d.x == max)
 				if (timepoint) seriesHtmls.push(timepoint.html)

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -742,9 +742,9 @@ function setRenderers(self) {
 			setVisibleSerieses(chart, s)
 
 			const svg = div.append('svg').attr('class', 'pp-cuminc-svg')
-			renderSVG(svg, chart, s, 0)
+			renderSVG(svg, chart, s)
 
-			div.transition().duration(s.duration).style('opacity', 1)
+			div.style('opacity', 1)
 		} else {
 			// no series in chart
 			div.select('.pp-cuminc-chart-noData').style('display', 'block')
@@ -810,10 +810,7 @@ function setRenderers(self) {
 
 		const div = select(this)
 
-		div
-			.transition()
-			.duration(s.duration)
-			.style('background', 1 || s.orderChartsBy == 'organ-system' ? chart.color : '')
+		div.style('background', 1 || s.orderChartsBy == 'organ-system' ? chart.color : '')
 
 		div
 			.select('.sjpcb-cuminc-title')
@@ -833,7 +830,7 @@ function setRenderers(self) {
 
 			setVisibleSerieses(chart, s)
 
-			renderSVG(div.select('svg'), chart, s, s.duration)
+			renderSVG(div.select('svg'), chart, s)
 		} else {
 			div
 				.select('.pp-cuminc-chart-noData')
@@ -884,14 +881,12 @@ function setRenderers(self) {
 		}
 	}
 
-	function renderSVG(svg, chart, s, duration) {
+	function renderSVG(svg, chart, s) {
 		const extraHeight = s.atRiskVisible
 			? s.axisTitleFontSize + 4 + chart.visibleSerieses.length * 2 * s.axisTitleFontSize
 			: 0
 
 		svg
-			.transition()
-			.duration(duration)
 			.attr('width', s.svgw)
 			.attr('height', s.svgh + extraHeight)
 			.style('overflow', 'visible')

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -1402,7 +1402,7 @@ function getPj(self) {
 				// scale axis according to tick values
 				const s = self.settings
 				const min = Math.min(...context.self.yTickValues)
-				const max = Math.min(100, Math.max(...context.self.yTickValues))
+				const max = Math.max(...context.self.yTickValues)
 				return scaleLinear()
 					.domain([max, min])
 					.range([0, s.svgh - s.svgPadding.top - s.svgPadding.bottom])
@@ -1432,7 +1432,7 @@ function computeTickValues(min, max) {
 	// compute tick values using tick width
 	const tickValues = []
 	let tick = min
-	while (tick < max + tickWidth_rnd) {
+	while (tick <= Math.min(100, max + tickWidth_rnd)) {
 		// using max + tickWidth_rnd to ensure that
 		// the last tick will be greater than the max
 		// value of the data

--- a/client/termsetting/handlers/condition.ts
+++ b/client/termsetting/handlers/condition.ts
@@ -466,7 +466,7 @@ export function fillTW(tw: ConditionTW, vocabApi: VocabApi, defaultQ: ConditionQ
 	// assign breaks
 	if (tw.q.mode == 'binary' || tw.q.mode == 'cox' || tw.q.mode == 'cuminc') {
 		// must have a single break
-		const defaultBreak = tw.q.mode == 'binary' ? 1 : 2
+		const defaultBreak = tw.q.mode == 'binary' ? 1 : 3
 		if (!tw.q.breaks?.length) tw.q.breaks = [defaultBreak]
 		if (tw.q.breaks.length != 1 || ![1, 2, 3, 4, 5].includes(tw.q.breaks[0])) throw 'invalid tw.q.breaks'
 	}


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/1219

- Fixed y-axis rendering issue (can test using the example in the linked issue).
- Series tip is now hidden on a mouseout event (previously, series tip was still visible after removing mouse from region of plot that had data. Can test on a cuminc plot within cox regression and remove mouse from left side of plot).
- Simplified logic for selecting series in series tip
- Removed transition effects on cuminc plot (not sure why these effects were there. Seems like cuminc rendering might now be faster).
- Set default grade=3 for cuminc and cox to more quickly see the effects of treatment on severe outcomes.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
