### PR TITLE
Plotting violin with kde

### DIFF
--- a/client/dom/densityplot.js
+++ b/client/dom/densityplot.js
@@ -1,4 +1,4 @@
-import { scaleLinear, axisBottom, axisLeft, line as d3line, curveMonotoneX, format, brushX } from 'd3'
+import { scaleLinear, axisBottom, axisLeft, line as d3line, curveMonotoneX, format, brushX, extent } from 'd3'
 
 /*
 ********************** EXPORTED
@@ -29,7 +29,6 @@ export async function make_densityplot(holder, data, callabck, term) {
 	//density data, add first and last values to array
 	density_data.unshift([data.density_data.minvalue, 0])
 	density_data.push([data.density_data.maxvalue, 0])
-
 	let min = data.density_data.minvalue
 	let max = data.density_data.maxvalue
 	const xscale = scaleLinear()
@@ -50,10 +49,11 @@ export async function make_densityplot(holder, data, callabck, term) {
 	const x_axis = axisBottom().scale(xscaleTicks)
 
 	x_axis
+	const [densityMin, densityMax] = extent(density_data.map(d => d[1]))
 
 	// y-scale
 	const yscale = scaleLinear()
-		.domain([0, data.density_data.densitymax])
+		.domain([densityMin, densityMax])
 		.range([height + ypad, ypad])
 
 	const y_axis = axisLeft()

--- a/client/dom/densityplot.js
+++ b/client/dom/densityplot.js
@@ -1,4 +1,4 @@
-import { scaleLinear, axisBottom, axisLeft, line as d3line, curveMonotoneX, format, brushX, extent } from 'd3'
+import { scaleLinear, axisBottom, axisLeft, line as d3line, curveMonotoneX, format, brushX } from 'd3'
 
 /*
 ********************** EXPORTED
@@ -24,13 +24,11 @@ export async function make_densityplot(holder, data, callabck, term) {
 	svg.attr('width', width + xpad * 2).attr('height', height + ypad * 2 + xaxis_height)
 	//density data, add first and last values to array
 
-	const density_data = data.density_data.density
+	const density_data = data.density_data
 
 	//density data, add first and last values to array
-	density_data.unshift([data.density_data.minvalue, 0])
-	density_data.push([data.density_data.maxvalue, 0])
-	let min = data.density_data.minvalue
-	let max = data.density_data.maxvalue
+	let min = density_data.minvalue
+	let max = density_data.maxvalue
 	const xscale = scaleLinear()
 		.domain([min, max])
 		.range([xpad, width - xpad])
@@ -49,17 +47,12 @@ export async function make_densityplot(holder, data, callabck, term) {
 	const x_axis = axisBottom().scale(xscaleTicks)
 
 	x_axis
-	const [densityMin, densityMax] = extent(density_data.map(d => d[1]))
 
 	// y-scale
 	const yscale = scaleLinear()
-		.domain([densityMin, densityMax])
+		.domain([0, data.density_data.densitymax])
 		.range([height + ypad, ypad])
-
-	const y_axis = axisLeft()
-		.scale(yscale)
-		.ticks(data.density_data.densitymax < default_ticks ? data.density_data.densitymax : default_ticks)
-		.tickFormat(format('d'))
+	const y_axis = axisLeft().scale(yscale).ticks(default_ticks).tickFormat(format('d'))
 
 	const g = svg.append('g').attr('transform', `translate(${xpad}, 0)`)
 
@@ -77,7 +70,7 @@ export async function make_densityplot(holder, data, callabck, term) {
 
 	// plot the data as a line
 	g.append('path')
-		.datum(density_data)
+		.datum(density_data.density)
 		.attr('class', 'line')
 		.attr('d', line)
 		.style('fill', '#eee')

--- a/client/dom/densityplot.js
+++ b/client/dom/densityplot.js
@@ -25,7 +25,6 @@ export async function make_densityplot(holder, data, callabck, term) {
 	//density data, add first and last values to array
 
 	const density_data = data.density_data
-	console.log(density_data)
 	//density data, add first and last values to array
 	let min = density_data.minvalue
 	let max = density_data.maxvalue

--- a/client/dom/densityplot.js
+++ b/client/dom/densityplot.js
@@ -25,7 +25,7 @@ export async function make_densityplot(holder, data, callabck, term) {
 	//density data, add first and last values to array
 
 	const density_data = data.density_data
-
+	console.log(density_data)
 	//density data, add first and last values to array
 	let min = density_data.minvalue
 	let max = density_data.maxvalue
@@ -50,7 +50,7 @@ export async function make_densityplot(holder, data, callabck, term) {
 
 	// y-scale
 	const yscale = scaleLinear()
-		.domain([0, data.density_data.densitymax])
+		.domain([0, density_data.densityMax])
 		.range([height + ypad, ypad])
 	const y_axis = axisLeft().scale(yscale).ticks(default_ticks).tickFormat(format('d'))
 
@@ -59,13 +59,12 @@ export async function make_densityplot(holder, data, callabck, term) {
 	// SVG line generator
 	const line = d3line()
 		.x(function (d) {
-			return xscale(d[0])
+			return xscale(d.x0)
 		})
 		.y(function (d) {
-			return yscale(d[1])
+			return yscale(d.density)
 		})
 		.curve(curveMonotoneX)
-
 	g.append('g').attr('transform', `translate(${xpad}, 0)`).call(y_axis)
 
 	// plot the data as a line

--- a/client/filter/densityplot.js
+++ b/client/filter/densityplot.js
@@ -68,10 +68,10 @@ export function makeDensityPlot(opts) {
 	// SVG line generator
 	const line = d3line()
 		.x(function (d) {
-			return xscale(d[0])
+			return xscale(d.x0)
 		})
 		.y(function (d) {
-			return yscale(d[1])
+			return yscale(d.density)
 		})
 		.curve(curveMonotoneX)
 	// plot the data as a line

--- a/client/filter/densityplot.js
+++ b/client/filter/densityplot.js
@@ -38,15 +38,11 @@ export function makeDensityPlot(opts) {
 	svg.attr('width', width + xpad * 2).attr('height', height + ypad * 2 + xaxis_height)
 
 	//density data, add first and last values to array
-	const density_data = data.density
-	density_data.unshift([data.minvalue, 0])
-	density_data.push([data.maxvalue, 0])
 
 	// x-axis
 	const xscale = scaleLinear()
 		.domain([data.minvalue, data.maxvalue])
 		.range([xpad, width - xpad])
-
 	let min = data.minvalue
 	let max = data.maxvalue
 	const vc = term?.valueConversion
@@ -80,7 +76,7 @@ export function makeDensityPlot(opts) {
 		.curve(curveMonotoneX)
 	// plot the data as a line
 	g.append('path')
-		.datum(density_data)
+		.datum(data.density)
 		.attr('class', 'line')
 		.attr('d', line)
 		.style('fill', '#eee')

--- a/client/filter/densityplot.js
+++ b/client/filter/densityplot.js
@@ -1,4 +1,4 @@
-import { scaleLinear, axisBottom, line as d3line, curveMonotoneX, format, extent } from 'd3'
+import { scaleLinear, axisBottom, line as d3line, curveMonotoneX, format } from 'd3'
 
 /*
 	opts{}
@@ -42,7 +42,6 @@ export function makeDensityPlot(opts) {
 	density_data.unshift([data.minvalue, 0])
 	density_data.push([data.maxvalue, 0])
 
-	const [densityMin, densityMax] = extent(density_data.map(d => d[1]))
 	// x-axis
 	const xscale = scaleLinear()
 		.domain([data.minvalue, data.maxvalue])
@@ -65,7 +64,7 @@ export function makeDensityPlot(opts) {
 
 	// y-scale
 	const yscale = scaleLinear()
-		.domain([densityMin, densityMax])
+		.domain([0, data.densitymax])
 		.range([height + ypad, ypad])
 
 	const g = svg.append('g').attr('transform', `translate(${xpad}, 0)`)

--- a/client/filter/densityplot.js
+++ b/client/filter/densityplot.js
@@ -1,4 +1,4 @@
-import { scaleLinear, axisBottom, line as d3line, curveMonotoneX, format } from 'd3'
+import { scaleLinear, axisBottom, line as d3line, curveMonotoneX, format, extent } from 'd3'
 
 /*
 	opts{}
@@ -42,6 +42,7 @@ export function makeDensityPlot(opts) {
 	density_data.unshift([data.minvalue, 0])
 	density_data.push([data.maxvalue, 0])
 
+	const [densityMin, densityMax] = extent(density_data.map(d => d[1]))
 	// x-axis
 	const xscale = scaleLinear()
 		.domain([data.minvalue, data.maxvalue])
@@ -64,7 +65,7 @@ export function makeDensityPlot(opts) {
 
 	// y-scale
 	const yscale = scaleLinear()
-		.domain([0, data.densitymax])
+		.domain([densityMin, densityMax])
 		.range([height + ypad, ypad])
 
 	const g = svg.append('g').attr('transform', `translate(${xpad}, 0)`)
@@ -78,7 +79,6 @@ export function makeDensityPlot(opts) {
 			return yscale(d[1])
 		})
 		.curve(curveMonotoneX)
-
 	// plot the data as a line
 	g.append('path')
 		.datum(density_data)

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -213,14 +213,18 @@ async function fillMenu(self, div, tvs) {
 // convert violin data (vd) to old density data (dd)
 export function convertViolinData(vd) {
 	const p = vd.plots[0] || { plotValueCount: 0, biggestBin: 0, bins: [] } // assuming only one plot
+	const bins = []
+	let densitymax = 0
+	p.bins.forEach(b => {
+		if (densitymax < b.density) densitymax = b.density
+		bins.push([b.x0, b.density])
+	})
 	const dd = {
 		minvalue: vd.min,
 		maxvalue: vd.max,
 		samplecount: p.plotValueCount,
-		densitymax: p.biggestBin,
-		density: p.bins.map(i => {
-			return [i.x0, i.density]
-		})
+		densitymax,
+		density: bins
 	}
 	return dd
 }

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -219,7 +219,7 @@ export function convertViolinData(vd) {
 		samplecount: p.plotValueCount,
 		densitymax: p.biggestBin,
 		density: p.bins.map(i => {
-			return [i.x0, i.binValueCount]
+			return [i.x0, i.density]
 		})
 	}
 	return dd

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -212,19 +212,13 @@ async function fillMenu(self, div, tvs) {
 
 // convert violin data (vd) to old density data (dd)
 export function convertViolinData(vd) {
-	const p = vd.plots[0] || { plotValueCount: 0, biggestBin: 0, bins: [] } // assuming only one plot
-	const bins = []
-	let densitymax = 0
-	p.bins.forEach(b => {
-		if (densitymax < b.density) densitymax = b.density
-		bins.push([b.x0, b.density])
-	})
+	const p = vd.plots[0] || { plotValueCount: 0, biggestBin: 0 } // assuming only one plot
 	const dd = {
 		minvalue: vd.min,
 		maxvalue: vd.max,
 		samplecount: p.plotValueCount,
-		densitymax,
-		density: bins
+		densitymax: p.density.densityMax,
+		density: p.density.bins
 	}
 	return dd
 }

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { getRunPp } from '../../test/front.helpers.js'
 import { fillTermWrapper } from '#termsetting'
 import { getFilterItemByTag, filterJoin } from '#filter'
-import { sleep, detectOne, detectGte } from '../../test/test.helpers.js'
+import { sleep, detectOne, detectGte, detectLst } from '../../test/test.helpers.js'
 
 /***************** Test Layout *****************:
 
@@ -361,21 +361,15 @@ tape('test basic controls', function (test) {
 	}
 
 	async function changeOverlayTerm(violin, violinDiv) {
-		const changeOvTerm = await detectGte({
-			elem: violinDiv.node(),
-			selector: '.sjpp-vp-path',
-			count: 3,
-			async trigger() {
-				await violin.Inner.app.dispatch({
-					type: 'plot_edit',
-					id: violin.Inner.id,
-					config: {
-						term2: await fillTermWrapper({ id: 'genetic_race' }, violin.Inner.app.vocabApi)
-					}
-				})
+		const term2 = await fillTermWrapper({ id: 'genetic_race' }, violin.Inner.app.vocabApi)
+
+		await violin.Inner.app.dispatch({
+			type: 'plot_edit',
+			id: violin.Inner.id,
+			config: {
+				term2
 			}
 		})
-		test.ok(changeOvTerm, 'Overlay Term has been changed')
 		test.true(violin.Inner.app.Inner.state.plots[0].term2.id === 'genetic_race', 'Overlay term changed')
 	}
 
@@ -390,7 +384,8 @@ tape('test basic controls', function (test) {
 					config: {
 						settings: {
 							violin: {
-								unit: 'log'
+								unit: 'log',
+								plotThickness: 150
 							}
 						}
 					}
@@ -745,11 +740,11 @@ tape('term1 as numerical and term2 condition', function (test) {
 		test.end()
 	}
 	async function testConditionTermOrder(violin, violinDiv) {
-		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 5 })
+		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 10 })
 		test.ok(groups, 'Condition groups exist')
 
 		test.deepEqual(
-			groups.map(k => k.__data__.label),
+			groups.filter((k, i) => i % 2 == 0).map(k => k.__data__.label),
 			violin.Inner.data.plots.map(k => k.label),
 			'Order of conditional categories in term2 is accurate'
 		)
@@ -1036,14 +1031,15 @@ tape('Load linear regression-violin UI', function (test) {
 		test.end()
 	}
 	async function regressionViolinRendering(regression) {
-		const regressionVp = await detectOne({
+		const regressionVp = await detectLst({
 			elem: regression.Inner.dom.inputs.node(),
-			selector: '.sjpp-vp-path'
+			selector: '.sjpp-vp-path',
+			count: 2
 		})
-		test.ok(regressionVp, 'Violin plot for regression UI exists')
+		test.ok(regressionVp.length == 2, 'Violin plot for regression UI exists')
 
 		const expectedPathColor = 'rgb(221, 221, 221)'
-		test.equal(expectedPathColor, getComputedStyle(regressionVp).fill, 'Path fill matches expected fill')
+		test.equal(expectedPathColor, getComputedStyle(regressionVp[0]).fill, 'Path fill matches expected fill')
 	}
 })
 

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -298,31 +298,23 @@ tape('test basic controls', function (test) {
 	}
 
 	async function changeDataSymbol(violin, violinDiv) {
-		const datasymbol = await detectGte({
-			elem: violinDiv.node(),
-			selector: '.sjpp-rug-img',
-			count: 2,
-			async trigger() {
-				await violin.Inner.app.dispatch({
-					type: 'plot_edit',
-					id: violin.Inner.id,
-					config: {
-						settings: {
-							violin: {
-								datasymbol: 'rug'
-							}
-						}
+		await violin.Inner.app.dispatch({
+			type: 'plot_edit',
+			id: violin.Inner.id,
+			config: {
+				settings: {
+					violin: {
+						datasymbol: 'rug'
 					}
-				})
+				}
 			}
 		})
-		test.ok(datasymbol, 'Data symbol exists')
 		test.true(violin.Inner.app.Inner.state.plots[0].settings.violin.datasymbol === 'rug', 'Data Symbol are now Ticks')
 	}
 
 	async function changeStrokeWidth(violin) {
 		const testStrokeWidth = 1
-		violin.Inner.app.dispatch({
+		await violin.Inner.app.dispatch({
 			type: 'plot_edit',
 			id: violin.Inner.id,
 			config: {
@@ -333,7 +325,7 @@ tape('test basic controls', function (test) {
 				}
 			}
 		})
-		await sleep(20)
+		//await sleep(20)
 		test.true(
 			violin.Inner.app.Inner.state.plots[0].settings.violin.strokeWidth === testStrokeWidth,
 			`Stroke width changed to ${testStrokeWidth}`
@@ -342,7 +334,7 @@ tape('test basic controls', function (test) {
 
 	async function changeSymbolSize(violin) {
 		const testSymSize = 10
-		violin.Inner.app.dispatch({
+		await violin.Inner.app.dispatch({
 			type: 'plot_edit',
 			id: violin.Inner.id,
 			config: {
@@ -353,7 +345,6 @@ tape('test basic controls', function (test) {
 				}
 			}
 		})
-		await sleep(20)
 		test.true(
 			violin.Inner.app.Inner.state.plots[0].settings.violin.radius === testSymSize,
 			`Symbol size changed to ${testSymSize}`

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -1,6 +1,6 @@
 import { getCompInit, copyMerge } from '../rx'
 import { controlsInit } from './controls'
-import violinRenderer from './violin.renderer'
+import setViolinRenderer from './violin.renderer'
 import htmlLegend from '../dom/html.legend'
 import { fillTermWrapper } from '#termsetting'
 import { setInteractivity } from './violin.interactivity'
@@ -57,7 +57,7 @@ class ViolinPlot {
 				.style('margin-right', '30px')
 		}
 
-		violinRenderer(this)
+		setViolinRenderer(this)
 		setInteractivity(this)
 
 		if (this.opts.mode != 'minimal') {
@@ -240,11 +240,7 @@ class ViolinPlot {
 
 		return {
 			termfilter: appState.termfilter,
-			config: Object.assign({}, config, {
-				settings: {
-					violin: config.settings.violin
-				}
-			}),
+			config,
 			displaySampleIds: appState.termdbConfig.displaySampleIds,
 			hasVerifiedToken: this.app.vocabApi.hasVerifiedToken()
 		}

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -107,8 +107,8 @@ class ViolinPlot {
 				chartType: 'violin',
 				settingsKey: 'method',
 				options: [
-					{ label: 'KDE', value: 'KDE' },
-					{ label: 'Histogram', value: 'Histogram' }
+					{ label: 'KDE', value: 0 },
+					{ label: 'Histogram', value: 1 }
 				]
 			},
 
@@ -330,7 +330,7 @@ class ViolinPlot {
 			axisHeight: s.axisHeight,
 			rightMargin: s.rightMargin,
 			unit: s.unit,
-			isKDE: s.method == 'KDE',
+			method: s.method,
 			ticks: s.ticks,
 			bandwidth: s.bandwidth
 		}
@@ -386,7 +386,7 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		ticks: 20,
 		bandwidth: 5,
 		defaultColor: plotColor,
-		method: 'KDE'
+		method: 0
 	}
 	return Object.assign(defaults, overrides)
 }

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -68,10 +68,10 @@ class ViolinPlot {
 				handlers: {}
 			})
 		}
-		await this.setControls(this.getState(appState))
 	}
 
-	async setControls(state) {
+	async setControls() {
+		this.dom.controls.selectAll('*').remove()
 		this.components = {}
 		if (this.opts.mode == 'minimal') return
 		const inputs = [
@@ -163,16 +163,6 @@ class ViolinPlot {
 				min: 1,
 				max: 50
 			},
-			{
-				label: 'Bandwidth',
-				type: 'number',
-				title:
-					'If the bandwidth is too small, the estimate may include spurious bumps and wiggles; too large, and the estimate reveals little about the underlying distribution',
-				chartType: 'violin',
-				settingsKey: 'bandwidth',
-				min: 1,
-				max: 20
-			},
 
 			{
 				label: 'Plot length',
@@ -227,6 +217,19 @@ class ViolinPlot {
 			}
 		]
 
+		if (this.settings.method == 0) {
+			//KDE
+			inputs.splice(4, 0, {
+				label: 'Bandwidth',
+				type: 'number',
+				title:
+					'If the bandwidth is too small, the estimate may include spurious bumps and wiggles; too large, and the estimate reveals little about the underlying distribution',
+				chartType: 'violin',
+				settingsKey: 'bandwidth',
+				min: 1,
+				max: 20
+			})
+		}
 		this.components.controls = await controlsInit({
 			app: this.app,
 			id: this.id,
@@ -261,6 +264,8 @@ class ViolinPlot {
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings.violin
+		await this.setControls()
+
 		if (this.config.chartType != this.type && this.config.childType != this.type) return
 
 		if (this.dom.header)

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -101,6 +101,14 @@ class ViolinPlot {
 				]
 			},
 			{
+				boxLabel: 'Yes',
+				label: 'Use KDE',
+				type: 'checkbox',
+				chartType: 'violin',
+				settingsKey: 'isKDE',
+				title: `If selected uses the KDE method, otherwise uses a histogram`
+			},
+			{
 				label: 'Data symbol',
 				title: 'Symbol type',
 				type: 'radio',
@@ -261,6 +269,8 @@ class ViolinPlot {
 		const arg = this.validateArg()
 
 		this.data = await this.app.vocabApi.getViolinPlotData(arg)
+		console.log(this.data)
+
 		if (this.settings.plotThickness == undefined) {
 			const thickness = this.data.plots.length == 1 ? 300 : 150
 			this.settings.plotThickness = Math.min(1400 / this.data.plots.length, thickness)
@@ -306,6 +316,7 @@ class ViolinPlot {
 	validateArg() {
 		const { term, term2, settings } = this.config
 		const s = this.settings
+		console.log(s.isKDE)
 		const arg = {
 			filter: this.state.termfilter.filter,
 			svgw: s.svgw / window.devicePixelRatio,
@@ -317,7 +328,7 @@ class ViolinPlot {
 			axisHeight: s.axisHeight,
 			rightMargin: s.rightMargin,
 			unit: s.unit,
-			isKDE: true,
+			isKDE: s.isKDE,
 			ticks: s.ticks,
 			bandwidth: s.bandwidth
 		}
@@ -372,7 +383,8 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		medianThickness: 3,
 		ticks: 20,
 		bandwidth: 5,
-		defaultColor: plotColor
+		defaultColor: plotColor,
+		isKDE: true
 	}
 	return Object.assign(defaults, overrides)
 }

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -152,11 +152,14 @@ class ViolinPlot {
 				max: 50
 			},
 			{
-				label: 'Use common scale',
-				type: 'checkbox',
+				label: 'Bandwidth',
+				type: 'number',
+				title:
+					'If the bandwidth is too small, the estimate may include spurious bumps and wiggles; too large, and the estimate reveals little about the underlying distribution',
 				chartType: 'violin',
-				settingsKey: 'commonThickness',
-				boxLabel: 'Yes'
+				settingsKey: 'bandwidth',
+				min: 1,
+				max: 20
 			},
 
 			{
@@ -262,8 +265,10 @@ class ViolinPlot {
 		const arg = this.validateArg()
 
 		this.data = await this.app.vocabApi.getViolinPlotData(arg)
-		if (this.settings.plotThickness == undefined)
-			this.settings.plotThickness = Math.min(1400 / this.data.plots.length, 150)
+		if (this.settings.plotThickness == undefined) {
+			const thickness = this.data.plots.length == 1 ? 500 : 150
+			this.settings.plotThickness = Math.min(1400 / this.data.plots.length, thickness)
+		}
 		if (this.data.error) throw this.data.error
 		/*
 		.min
@@ -275,7 +280,7 @@ class ViolinPlot {
 			.bins[]
 				.x0
 				.x1
-				.binValueCount
+				.density
 		*/
 		this.toggleLoadingDiv(this.opts.mode == 'minimal' ? 'none' : '')
 		setTimeout(
@@ -316,7 +321,8 @@ class ViolinPlot {
 			axisHeight: s.axisHeight,
 			rightMargin: s.rightMargin,
 			unit: s.unit,
-			ticks: s.ticks
+			ticks: s.ticks,
+			bandwidth: s.bandwidth
 		}
 
 		if (this.opts.mode == 'minimal') {
@@ -357,7 +363,7 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		rowlabelw: 250,
 		brushRange: null, //object with start and end if there is a brush selection
 		svgw: 500, // span length of a plot/svg, not including margin
-		datasymbol: 'bean',
+		datasymbol: 'rug',
 		radius: 3,
 		strokeWidth: 0.2,
 		axisHeight: 60,
@@ -367,8 +373,8 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		plotThickness: undefined,
 		medianLength: 7,
 		medianThickness: 3,
-		ticks: 15,
-		commonThickness: false,
+		ticks: 20,
+		bandwidth: 5,
 		defaultColor: plotColor
 	}
 	return Object.assign(defaults, overrides)

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -180,7 +180,7 @@ class ViolinPlot {
 				chartType: 'violin',
 				settingsKey: 'plotThickness',
 				step: 10,
-				max: 400,
+				max: 500,
 				min: 40,
 				debounceInterval: 1000
 			},
@@ -262,7 +262,7 @@ class ViolinPlot {
 
 		this.data = await this.app.vocabApi.getViolinPlotData(arg)
 		if (this.settings.plotThickness == undefined) {
-			const thickness = this.data.plots.length == 1 ? 500 : 150
+			const thickness = this.data.plots.length == 1 ? 300 : 150
 			this.settings.plotThickness = Math.min(1400 / this.data.plots.length, thickness)
 		}
 		if (this.data.error) throw this.data.error

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -68,10 +68,11 @@ class ViolinPlot {
 				handlers: {}
 			})
 		}
+		await this.setControls()
 	}
 
 	async setControls() {
-		this.dom.controls.selectAll('*').remove()
+		//this.dom.controls.selectAll('*').remove()
 		this.components = {}
 		if (this.opts.mode == 'minimal') return
 		const inputs = [
@@ -111,7 +112,16 @@ class ViolinPlot {
 					{ label: 'Histogram', value: 1 }
 				]
 			},
-
+			{
+				label: 'Bandwidth',
+				type: 'number',
+				title:
+					'It only applies to the KDE method. If the bandwidth is too small, the estimate may include spurious bumps and wiggles; too large, and the estimate reveals little about the underlying distribution',
+				chartType: 'violin',
+				settingsKey: 'bandwidth',
+				min: 1,
+				max: 20
+			},
 			{
 				label: 'Data symbol',
 				title: 'Symbol type',
@@ -217,19 +227,6 @@ class ViolinPlot {
 			}
 		]
 
-		if (this.settings.method == 0) {
-			//KDE
-			inputs.splice(4, 0, {
-				label: 'Bandwidth',
-				type: 'number',
-				title:
-					'If the bandwidth is too small, the estimate may include spurious bumps and wiggles; too large, and the estimate reveals little about the underlying distribution',
-				chartType: 'violin',
-				settingsKey: 'bandwidth',
-				min: 1,
-				max: 20
-			})
-		}
 		this.components.controls = await controlsInit({
 			app: this.app,
 			id: this.id,
@@ -264,7 +261,6 @@ class ViolinPlot {
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings.violin
-		await this.setControls()
 
 		if (this.config.chartType != this.type && this.config.childType != this.type) return
 

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -177,7 +177,7 @@ class ViolinPlot {
 				chartType: 'violin',
 				settingsKey: 'plotThickness',
 				step: 10,
-				max: 200,
+				max: 400,
 				min: 40,
 				debounceInterval: 1000
 			},
@@ -358,7 +358,7 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		brushRange: null, //object with start and end if there is a brush selection
 		svgw: 500, // span length of a plot/svg, not including margin
 		datasymbol: 'bean',
-		radius: 5,
+		radius: 3,
 		strokeWidth: 0.2,
 		axisHeight: 60,
 		rightMargin: 50,

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -317,6 +317,7 @@ class ViolinPlot {
 			axisHeight: s.axisHeight,
 			rightMargin: s.rightMargin,
 			unit: s.unit,
+			isKDE: true,
 			ticks: s.ticks,
 			bandwidth: s.bandwidth
 		}

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -101,13 +101,17 @@ class ViolinPlot {
 				]
 			},
 			{
-				boxLabel: 'Yes',
-				label: 'Use KDE',
-				type: 'checkbox',
+				label: 'Method',
+				title: `If selected uses the KDE method, otherwise uses a histogram`,
+				type: 'radio',
 				chartType: 'violin',
-				settingsKey: 'isKDE',
-				title: `If selected uses the KDE method, otherwise uses a histogram`
+				settingsKey: 'method',
+				options: [
+					{ label: 'KDE', value: 'KDE' },
+					{ label: 'Histogram', value: 'Histogram' }
+				]
 			},
+
 			{
 				label: 'Data symbol',
 				title: 'Symbol type',
@@ -271,7 +275,7 @@ class ViolinPlot {
 		this.data = await this.app.vocabApi.getViolinPlotData(arg)
 
 		if (this.settings.plotThickness == undefined) {
-			const thickness = this.data.plots.length == 1 ? 300 : 150
+			const thickness = this.data.plots.length == 1 ? 200 : 150
 			this.settings.plotThickness = Math.min(1400 / this.data.plots.length, thickness)
 		}
 		if (this.data.error) throw this.data.error
@@ -326,7 +330,7 @@ class ViolinPlot {
 			axisHeight: s.axisHeight,
 			rightMargin: s.rightMargin,
 			unit: s.unit,
-			isKDE: s.isKDE,
+			isKDE: s.method == 'KDE',
 			ticks: s.ticks,
 			bandwidth: s.bandwidth
 		}
@@ -382,7 +386,7 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		ticks: 20,
 		bandwidth: 5,
 		defaultColor: plotColor,
-		isKDE: true
+		method: 'KDE'
 	}
 	return Object.assign(defaults, overrides)
 }

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -269,7 +269,6 @@ class ViolinPlot {
 		const arg = this.validateArg()
 
 		this.data = await this.app.vocabApi.getViolinPlotData(arg)
-		console.log(this.data)
 
 		if (this.settings.plotThickness == undefined) {
 			const thickness = this.data.plots.length == 1 ? 300 : 150
@@ -316,7 +315,6 @@ class ViolinPlot {
 	validateArg() {
 		const { term, term2, settings } = this.config
 		const s = this.settings
-		console.log(s.isKDE)
 		const arg = {
 			filter: this.state.termfilter.filter,
 			svgw: s.svgw / window.devicePixelRatio,

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -327,7 +327,6 @@ export default function violinRenderer(self) {
 				.x(d => svg.axisScale(d.x0))
 				.y(d => wScale(d.density))
 		}
-		console.log(plot.bins)
 
 		const label = plot.label.split(',')[0]
 		const catTerm = self.config.term.q.mode == 'discrete' ? self.config.term : self.config.term2
@@ -341,19 +340,13 @@ export default function violinRenderer(self) {
 		// : self.config.settings.violin.defaultColor
 		if (!plot.color) plot.color = color
 		if (category && !category.color) category.color = color
-		violinG
-			.append('path')
-			.attr('class', 'sjpp-vp-path')
-			.style('fill', self.opts.mode === 'minimal' ? rgb(221, 221, 221) : plot.color)
-			.style('opacity', 0)
-			.attr('stroke', '#000')
-			.attr('stroke-width', 1)
-			.attr('stroke-linejoin', 'round')
-			// .transition()
-			// .delay(self.opts.mode == 'minimal' ? 0 : 300)
-			// .duration(self.opts.mode == 'minimal' ? 0 : 600)
-			.style('opacity', '0.8')
-			.attr('d', areaBuilder(plot.plotValueCount > 3 ? plot.bins : 0)) //do not build violin plots for values 3 or less than 3.
+
+		renderArea(violinG, plot, areaBuilder)
+		renderArea(
+			violinG,
+			plot,
+			areaBuilder.y(d => -wScale(d.density))
+		)
 
 		renderSymbolImage(self, violinG, plot, isH, imageOffset)
 		if (self.opts.mode != 'minimal') renderMedian(violinG, isH, plot, svg, self)
@@ -372,6 +365,22 @@ export default function violinRenderer(self) {
 				.attr('y1', isH ? -s.medianLength : value)
 				.attr('y2', isH ? s.medianLength : value)
 		}
+	}
+
+	function renderArea(violinG, plot, areaBuilder) {
+		violinG
+			.append('path')
+			.attr('class', 'sjpp-vp-path')
+			.style('fill', self.opts.mode === 'minimal' ? rgb(221, 221, 221) : plot.color)
+			.style('opacity', 0)
+			.attr('stroke', rgb(plot.color).darker())
+			.attr('stroke-width', 1)
+			.attr('stroke-linejoin', 'round')
+			// .transition()
+			// .delay(self.opts.mode == 'minimal' ? 0 : 300)
+			// .duration(self.opts.mode == 'minimal' ? 0 : 600)
+			.style('opacity', '0.8')
+			.attr('d', areaBuilder(plot.plotValueCount > 3 ? plot.bins : 0)) //do not build violin plots for values 3 or less than 3.
 	}
 
 	function renderSymbolImage(self, violinG, plot, isH, imageOffset) {

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -1,6 +1,6 @@
 import { axisLeft, axisTop } from 'd3-axis'
 import { scaleLinear, scaleLog } from 'd3-scale'
-import { curveMonotoneX, line } from 'd3-shape'
+import { curveMonotoneX, curveMonotoneY, line } from 'd3-shape'
 import { getColors } from '#shared/common'
 import { brushX, brushY } from 'd3-brush'
 import { renderTable } from '../dom/table'
@@ -324,7 +324,7 @@ export default function setViolinRenderer(self) {
 				.y(d => wScale(d.density))
 		} else {
 			areaBuilder = line()
-				.curve(curveMonotoneX)
+				.curve(curveMonotoneY)
 				.x(d => wScale(d.density))
 				.y(d => svg.axisScale(d.x0))
 		}

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -58,10 +58,15 @@ export default function violinRenderer(self) {
 		const svg = renderSvg(t1, self, isH, settings)
 		renderScale(t1, t2, settings, isH, svg, self)
 
+		let biggestBin = 0
+		for (const plot of self.data.plots) {
+			const max = Math.max(...plot.bins2.map(b => b.binValueCount))
+			if (max > biggestBin) biggestBin = max
+		}
 		for (const [plotIdx, plot] of self.data.plots.entries()) {
 			const violinG = createViolinG(svg, plot, plotIdx, isH)
 			if (self.opts.mode != 'minimal') renderLabels(t1, t2, violinG, plot, isH, settings, tip)
-			renderViolinPlot(plot, self, isH, svg, plotIdx, violinG, imageOffset, self.data.biggestBin)
+			renderViolinPlot(plot, self, isH, svg, plotIdx, violinG, imageOffset, biggestBin)
 			if (self.opts.mode != 'minimal') renderBrushing(t1, t2, violinG, settings, plot, isH, svg)
 			self.labelHideLegendClicking(t2, plot)
 		}
@@ -309,9 +314,17 @@ export default function violinRenderer(self) {
 	}
 
 	function renderViolinPlot(plot, self, isH, svg, plotIdx, violinG, imageOffset, biggestBin) {
+		console.log(plot.bins)
+		console.log(plot.bins2)
+		console.log(plot.bins2[0])
+		const values = plot.bins2.map(b => b.binValueCount)
+		console.log(values)
+		const xMax = Math.max(...values)
+
+		console.log(xMax)
 		// times 0.45 will leave out 10% as spacing between plots
 		const wScale = scaleLinear()
-			.domain(self.settings.commonThickness ? [-biggestBin, biggestBin] : [-plot.biggestBin, plot.biggestBin])
+			.domain(self.settings.commonThickness ? [-biggestBin, biggestBin] : [-xMax, xMax])
 			.range([-self.settings.plotThickness * 0.45, self.settings.plotThickness * 0.45])
 
 		let areaBuilder
@@ -349,7 +362,7 @@ export default function violinRenderer(self) {
 			// .delay(self.opts.mode == 'minimal' ? 0 : 300)
 			// .duration(self.opts.mode == 'minimal' ? 0 : 600)
 			.style('opacity', '0.8')
-			.attr('d', areaBuilder(plot.plotValueCount > 3 ? plot.bins : 0)) //do not build violin plots for values 3 or less than 3.
+			.attr('d', areaBuilder(plot.plotValueCount > 3 ? plot.bins2 : 0)) //do not build violin plots for values 3 or less than 3.
 
 		renderSymbolImage(self, violinG, plot, isH, imageOffset)
 		if (self.opts.mode != 'minimal') renderMedian(violinG, isH, plot, svg, self)

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -328,7 +328,14 @@ export default function setViolinRenderer(self) {
 				.x(d => wScale(d.density))
 				.y(d => svg.axisScale(d.x0))
 		}
-
+		// const X = []
+		// const Y = []
+		// for(const d of plot.density.bins)
+		// {
+		// 	X.push(d.x0)
+		// 	Y.push(d.density)
+		// }
+		// console.log(plot, X, Y)
 		const label = plot.label.split(',')[0]
 		const catTerm = self.config.term.q.mode == 'discrete' ? self.config.term : self.config.term2
 		const category = catTerm?.term.values ? Object.values(catTerm.term.values).find(o => o.label == label) : null

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -311,12 +311,10 @@ export default function setViolinRenderer(self) {
 	}
 
 	function renderViolinPlot(plot, self, isH, svg, plotIdx, violinG, imageOffset) {
-		const values = plot.bins.map(b => b.density)
-		const [densityMin, densityMax] = extent(values)
 		const plotThickness = self.getPlotThickness()
 		// times 0.45 will leave out 10% as spacing between plots
 		const wScale = scaleLinear()
-			.domain([densityMax, densityMin])
+			.domain([plot.density.densityMax, 0])
 			.range([plotThickness * 0.45, 0])
 		let areaBuilder
 		if (isH) {
@@ -379,7 +377,7 @@ export default function setViolinRenderer(self) {
 			// .delay(self.opts.mode == 'minimal' ? 0 : 300)
 			// .duration(self.opts.mode == 'minimal' ? 0 : 600)
 			.style('opacity', '0.8')
-			.attr('d', areaBuilder(plot.bins))
+			.attr('d', areaBuilder(plot.density.bins))
 	}
 
 	function renderSymbolImage(self, violinG, plot, isH, imageOffset) {

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -317,7 +317,7 @@ export default function setViolinRenderer(self) {
 		// times 0.45 will leave out 10% as spacing between plots
 		const wScale = scaleLinear()
 			.domain([densityMax, densityMin])
-			.range([-plotThickness * 0.45, 0])
+			.range([plotThickness * 0.45, 0])
 		let areaBuilder
 		if (isH) {
 			areaBuilder = line()

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -372,6 +372,7 @@ export default function setViolinRenderer(self) {
 	}
 
 	function renderArea(violinG, plot, areaBuilder) {
+		if (plot.density.densityMax == 0) return
 		violinG
 			.append('path')
 			.attr('class', 'sjpp-vp-path')

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -1,6 +1,6 @@
 import { axisLeft, axisTop } from 'd3-axis'
 import { scaleLinear, scaleLog } from 'd3-scale'
-import { area, curveBasis, line } from 'd3-shape'
+import { curveMonotoneX, line } from 'd3-shape'
 import { getColors } from '#shared/common'
 import { brushX, brushY } from 'd3-brush'
 import { renderTable } from '../dom/table'
@@ -321,12 +321,12 @@ export default function setViolinRenderer(self) {
 		let areaBuilder
 		if (isH) {
 			areaBuilder = line()
-				.curve(curveBasis)
+				.curve(curveMonotoneX)
 				.x(d => svg.axisScale(d.x0))
 				.y(d => wScale(d.density))
 		} else {
 			areaBuilder = line()
-				.curve(curveBasis)
+				.curve(curveMonotoneX)
 				.x(d => wScale(d.density))
 				.y(d => svg.axisScale(d.x0))
 		}

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -426,6 +426,7 @@ export class TermdbVocab extends Vocab {
 		// the violin plot may still render when not in session,
 		// but not have an option to list samples
 		const headers = this.mayGetAuthHeaders('termdb')
+
 		const body = Object.assign(
 			{
 				getViolinPlotData: 1,
@@ -433,6 +434,7 @@ export class TermdbVocab extends Vocab {
 				dslabel: this.vocab.dslabel,
 				embedder: window.location.hostname,
 				devicePixelRatio: window.devicePixelRatio,
+				isKDE: arg.isKDE,
 				ticks: arg.ticks,
 				bandwith: arg.bandwidth
 			},

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -441,7 +441,6 @@ export class TermdbVocab extends Vocab {
 			arg,
 			_body
 		)
-
 		if (body.filter) body.filter = getNormalRoot(body.filter)
 		const d = await dofetch3('termdb/violin', { headers, body })
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -426,7 +426,6 @@ export class TermdbVocab extends Vocab {
 		// the violin plot may still render when not in session,
 		// but not have an option to list samples
 		const headers = this.mayGetAuthHeaders('termdb')
-
 		const body = Object.assign(
 			{
 				getViolinPlotData: 1,

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -420,7 +420,7 @@ export class TermdbVocab extends Vocab {
             bins[]
                 x0: number
                 x1: number
-                binValueCount: int
+                density: int
     */
 	async getViolinPlotData(arg, _body = {}) {
 		// the violin plot may still render when not in session,
@@ -433,7 +433,8 @@ export class TermdbVocab extends Vocab {
 				dslabel: this.vocab.dslabel,
 				embedder: window.location.hostname,
 				devicePixelRatio: window.devicePixelRatio,
-				ticks: arg.ticks
+				ticks: arg.ticks,
+				bandwith: arg.bandwidth
 			},
 			arg,
 			_body

--- a/server/shared/test/termdb.violin.unit.spec.js
+++ b/server/shared/test/termdb.violin.unit.spec.js
@@ -16,6 +16,7 @@ tape('\n', function (test) {
 
 tape('compute bins given an array', function (test) {
 	const bins = [
+		{ x0: 0, x1: 0, density: 0 },
 		{ x0: 0, x1: 0.5, density: 0.05929514663008059 },
 		{ x0: 0.5, x1: 1, density: 0.06489024181101011 },
 		{ x0: 1, x1: 1.5, density: 0.06958497684788201 },

--- a/server/shared/test/termdb.violin.unit.spec.js
+++ b/server/shared/test/termdb.violin.unit.spec.js
@@ -39,6 +39,6 @@ tape('compute bins given an array', function (test) {
 		{ x0: 9.5, x1: 10, density: 0.046593637454982 },
 		{ x0: 10, x1: 10, density: 0 }
 	]
-	test.deepEqual(bins, getBinsDensity(axisScale, v), 'should match expected output')
+	test.deepEqual(bins, getBinsDensity(axisScale, v, true), 'should match expected output')
 	test.end()
 })

--- a/server/shared/test/termdb.violin.unit.spec.js
+++ b/server/shared/test/termdb.violin.unit.spec.js
@@ -1,72 +1,44 @@
 import tape from 'tape'
-import { violinBinsObj } from '../violin.bins'
+import { getBinsDensity } from '../violin.bins'
 import { scaleLinear } from 'd3-scale'
 
 const v = { values: [0, 1, 2, 2, 2, 3, 4, 5, 0, 4, 5, 6, 6, 7, 8, 9, 10] }
 
-const axisScale = scaleLinear()
-	.domain([0, 10])
-	.range([0, 100])
+const axisScale = scaleLinear().domain([0, 10]).range([0, 100])
 
 /**************
  test sections
 ***************/
-tape('\n', function(test) {
+tape('\n', function (test) {
 	test.pass('-***- termdb.violinBins specs -***-')
 	test.end()
 })
 
-tape('compute bins given an array', function(test) {
-	const bins = {
-		bins0: [
-			[0, 0],
-			[],
-			[1],
-			[],
-			[2, 2, 2],
-			[],
-			[3],
-			[],
-			[4, 4],
-			[],
-			[5, 5],
-			[],
-			[6, 6],
-			[],
-			[7],
-			[],
-			[8],
-			[],
-			[9],
-			[],
-			[10]
-		],
-		bins: [
-			{ x0: 0, x1: 0.5, binValueCount: 2 },
-			{ x0: 0.5, x1: 1, binValueCount: 0 },
-			{ x0: 1, x1: 1.5, binValueCount: 1 },
-			{ x0: 1.5, x1: 2, binValueCount: 0 },
-			{ x0: 2, x1: 2.5, binValueCount: 3 },
-			{ x0: 2.5, x1: 3, binValueCount: 0 },
-			{ x0: 3, x1: 3.5, binValueCount: 1 },
-			{ x0: 3.5, x1: 4, binValueCount: 0 },
-			{ x0: 4, x1: 4.5, binValueCount: 2 },
-			{ x0: 4.5, x1: 5, binValueCount: 0 },
-			{ x0: 5, x1: 5.5, binValueCount: 2 },
-			{ x0: 5.5, x1: 6, binValueCount: 0 },
-			{ x0: 6, x1: 6.5, binValueCount: 2 },
-			{ x0: 6.5, x1: 7, binValueCount: 0 },
-			{ x0: 7, x1: 7.5, binValueCount: 1 },
-			{ x0: 7.5, x1: 8, binValueCount: 0 },
-			{ x0: 8, x1: 8.5, binValueCount: 1 },
-			{ x0: 8.5, x1: 9, binValueCount: 0 },
-			{ x0: 9, x1: 9.5, binValueCount: 1 },
-			{ x0: 9.5, x1: 10, binValueCount: 0 },
-			{ x0: 10, x1: 10, binValueCount: 1 },
-			{x0: 10, x1: 10, binValueCount: 0}
-		]
-	}
-
-	test.deepEqual(bins, violinBinsObj(axisScale, v), 'should match expected output')
+tape('compute bins given an array', function (test) {
+	const bins = [
+		{ x0: 0, x1: 0.5, density: 0.05929514663008059 },
+		{ x0: 0.5, x1: 1, density: 0.06489024181101011 },
+		{ x0: 1, x1: 1.5, density: 0.06958497684788201 },
+		{ x0: 1.5, x1: 2, density: 0.07424755616532326 },
+		{ x0: 2, x1: 2.5, density: 0.07794546389984566 },
+		{ x0: 2.5, x1: 3, density: 0.08154690447607614 },
+		{ x0: 3, x1: 3.5, density: 0.0841193620305265 },
+		{ x0: 3.5, x1: 4, density: 0.0865310409878237 },
+		{ x0: 4, x1: 4.5, density: 0.08784942548447951 },
+		{ x0: 4.5, x1: 5, density: 0.08807451552049392 },
+		{ x0: 5, x1: 5.5, density: 0.0872063110958669 },
+		{ x0: 5.5, x1: 6, density: 0.08524481221059853 },
+		{ x0: 6, x1: 6.5, density: 0.08219001886468873 },
+		{ x0: 6.5, x1: 7, density: 0.07804193105813755 },
+		{ x0: 7, x1: 7.5, density: 0.07280054879094496 },
+		{ x0: 7.5, x1: 8, density: 0.06833090379008747 },
+		{ x0: 8, x1: 8.5, density: 0.0628965872063111 },
+		{ x0: 8.5, x1: 9, density: 0.0574301149031041 },
+		{ x0: 9, x1: 9.5, density: 0.05106328245583948 },
+		{ x0: 9.5, x1: 10, density: 0.046593637454982 },
+		{ x0: 10, x1: 10.5, density: 0.04141656662665066 },
+		{ x0: 10, x1: 10, density: 0 }
+	]
+	test.deepEqual(bins, getBinsDensity(axisScale, v), 'should match expected output')
 	test.end()
 })

--- a/server/shared/test/termdb.violin.unit.spec.js
+++ b/server/shared/test/termdb.violin.unit.spec.js
@@ -39,6 +39,7 @@ tape('compute bins given an array', function (test) {
 		{ x0: 9.5, x1: 10, density: 0.046593637454982 },
 		{ x0: 10, x1: 10, density: 0 }
 	]
-	test.deepEqual(bins, getBinsDensity(axisScale, v, true), 'should match expected output')
+	const result = getBinsDensity(axisScale, v, true)
+	test.deepEqual(bins, result.bins, 'should match expected output')
 	test.end()
 })

--- a/server/shared/test/termdb.violin.unit.spec.js
+++ b/server/shared/test/termdb.violin.unit.spec.js
@@ -37,7 +37,6 @@ tape('compute bins given an array', function (test) {
 		{ x0: 8.5, x1: 9, density: 0.0574301149031041 },
 		{ x0: 9, x1: 9.5, density: 0.05106328245583948 },
 		{ x0: 9.5, x1: 10, density: 0.046593637454982 },
-		{ x0: 10, x1: 10.5, density: 0.04141656662665066 },
 		{ x0: 10, x1: 10, density: 0 }
 	]
 	test.deepEqual(bins, getBinsDensity(axisScale, v), 'should match expected output')

--- a/server/shared/types/routes/termdb.violin.ts
+++ b/server/shared/types/routes/termdb.violin.ts
@@ -29,7 +29,7 @@ export type getViolinRequest = {
 interface binsEntries {
 	x0: number
 	x1: number
-	binValueCount: number
+	density: number
 }
 interface valuesEntries {
 	id: string

--- a/server/shared/types/routes/termdb.violin.ts
+++ b/server/shared/types/routes/termdb.violin.ts
@@ -24,6 +24,7 @@ export type getViolinRequest = {
 	/** A string representing a unit of measurement (e.g., 'log' for log scale) */
 	unit: string
 	termid: string
+	isKDE: boolean
 }
 
 interface binsEntries {

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -54,12 +54,13 @@ function kde(kernel, thresholds, data, valuesMax, step) {
 	const density = thresholds.map(t => [t, d3.mean(data, d => kernel(t - d))])
 	const bins = []
 	let densityMax = 0
-	density.forEach(element => {
+	for (const element of density) {
 		const bin = { x0: element[0], x1: element[0] + step, density: element[1] }
 		if (bin.density > densityMax) densityMax = bin.density
-		if (bin.x1 > valuesMax) return
+		if (bin.density == 0 && densityMax == 0) continue
+		if (bin.x1 > valuesMax) break
 		bins.push(bin)
-	})
+	}
 	bins.push({ x0: valuesMax, x1: valuesMax, density: 0 })
 
 	return { bins, densityMax }
@@ -74,13 +75,14 @@ function getBinsHist(scale, values, ticks, valuesMax) {
 	const bins = []
 	let densityMax = 0
 	for (const bin of bins0) {
-		bins.push({ x0: bin.x0, x1: bin.x1, density: bin.length })
 		if (bin.length > densityMax) densityMax = bin.length
+		if (bin.length == 0 && densityMax == 0) continue
+		bins.push({ x0: bin.x0, x1: bin.x1, density: bin.length })
 		if (bin.x1 > valuesMax) {
-			bins.push({ x0: valuesMax, x1: valuesMax, density: 0 })
 			break
 		}
 	}
+	bins.push({ x0: valuesMax, x1: valuesMax, density: 0 })
 
 	return { bins, densityMax }
 }

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -32,7 +32,7 @@ output:
 const { bin } = require('d3-array')
 import * as d3 from 'd3'
 
-export function getBinsDensity(scale, plot, ticks = 20, isKDE = false, bandwidth = 7) {
+export function getBinsDensity(scale, plot, isKDE = false, ticks = 20, bandwidth = 7) {
 	const [min, max] = scale.domain() //Min and max for all plots
 	const [valuesMin, valuesMax] = d3.extent(plot.values) //Min and max on plot
 	const step = Math.abs(max - min) / ticks
@@ -51,7 +51,6 @@ function epanechnikov(bandwidth) {
 }
 
 function kde(kernel, thresholds, data, valuesMax, step) {
-	console.log('kde')
 	const density = thresholds.map(t => [t, d3.mean(data, d => kernel(t - d))])
 	const bins = []
 	density.forEach(element => {
@@ -65,7 +64,6 @@ function kde(kernel, thresholds, data, valuesMax, step) {
 }
 
 function getBinsHist(scale, values, max, ticks) {
-	console.log('histogram')
 	const binBuilder = bin()
 		.domain(scale.domain()) /* extent of the data that is lowest to highest*/
 		.thresholds(scale.ticks(ticks)) /* buckets are created which are separated by the threshold*/

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -30,8 +30,14 @@ output:
 
 */
 const { bin } = require('d3-array')
+import * as d3 from 'd3'
 
 export function violinBinsObj(scale, plot, ticks = 15) {
+	const density = kde(epanechnikov(7), scale.ticks(ticks), plot.values)
+	plot.bins2 = []
+	density.forEach(element => {
+		plot.bins2.push({ x0: element[0], x1: element[0] + 500, binValueCount: element[1] })
+	})
 	const bins0 = computeViolinBins(scale, plot.values, ticks)
 	//if (plot.values.every((val, i) => val === plot.values[0])) return { bins0, bins: [] }
 	// array; each element is an array of values belonging to this bin
@@ -63,12 +69,22 @@ export function violinBinsObj(scale, plot, ticks = 15) {
 function computeViolinBins(scale, values, ticks) {
 	// disable this method for now and hardcode ticks to 15.
 	// const uniqueValues = new Set(values)
-	// const ticksCompute = uniqueValues.size === 1 ? 50 : uniqueValues.size <= 10 ? 5 : uniqueValues.size <= 20 ? 10 : 20
+	// const ticksCompute = uniqueValues.size === 1 ? 50 : uniqueValues.size <= 10 ? 5 : uniqueValues.size <= 20
 
 	const binBuilder = bin()
 		.domain(scale.domain()) /* extent of the data that is lowest to highest*/
 		.thresholds(scale.ticks(ticks)) /* buckets are created which are separated by the threshold*/
 		.value(d => d) /* bin the data points into this bucket*/
 
-	return binBuilder(values)
+	const result = binBuilder(values)
+	//console.log(result)
+	return result
+}
+
+function epanechnikov(bandwidth) {
+	return x => (Math.abs((x /= bandwidth)) <= 1 ? (0.75 * (1 - x * x)) / bandwidth : 0)
+}
+
+function kde(kernel, thresholds, data) {
+	return thresholds.map(t => [t, d3.mean(data, d => kernel(t - d))])
 }

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -39,6 +39,7 @@ export function getBinsDensity(scale, plot, ticks = 20, bandwidth = 7) {
 	const density = kde(epanechnikov(bandwidth), scale.ticks(ticks), plot.values)
 
 	const bins = []
+	bins.push({ x0: min, x1: min, density: 0 })
 	density.forEach(element => {
 		bins.push({ x0: element[0], x1: element[0] + step, density: element[1] })
 	})

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -32,17 +32,17 @@ output:
 const { bin } = require('d3-array')
 import * as d3 from 'd3'
 
-export function getBinsDensity(scale, plot, ticks = 20, isKDE = true, bandwidth = 7) {
+export function getBinsDensity(scale, plot, ticks = 20, isKDE = false, bandwidth = 7) {
 	const [min, max] = scale.domain() //Min and max for all plots
 	const [valuesMin, valuesMax] = d3.extent(plot.values) //Min and max on plot
 	const step = Math.abs(max - min) / ticks
 
 	if (valuesMin == valuesMax) return [{ x0: valuesMin, x1: valuesMax, density: 1 }]
-	let bins
-	if (isKDE) bins = kde(epanechnikov(bandwidth), scale.ticks(ticks), plot.values, valuesMax, step)
-	else bins = getBinsHist(scale, plot.values, max, ticks)
-	bins.unshift({ x0: min, x1: min, density: 0 })
 
+	const bins = isKDE
+		? kde(epanechnikov(bandwidth), scale.ticks(ticks), plot.values, valuesMax, step)
+		: getBinsHist(scale, plot.values, max, ticks)
+	bins.unshift({ x0: min, x1: min, density: 0 })
 	return bins
 }
 
@@ -51,6 +51,7 @@ function epanechnikov(bandwidth) {
 }
 
 function kde(kernel, thresholds, data, valuesMax, step) {
+	console.log('kde')
 	const density = thresholds.map(t => [t, d3.mean(data, d => kernel(t - d))])
 	const bins = []
 	density.forEach(element => {
@@ -64,6 +65,7 @@ function kde(kernel, thresholds, data, valuesMax, step) {
 }
 
 function getBinsHist(scale, values, max, ticks) {
+	console.log('histogram')
 	const binBuilder = bin()
 		.domain(scale.domain()) /* extent of the data that is lowest to highest*/
 		.thresholds(scale.ticks(ticks)) /* buckets are created which are separated by the threshold*/

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -40,7 +40,7 @@ export function getBinsDensity(scale, plot, ticks = 20, isKDE = true, bandwidth 
 	if (valuesMin == valuesMax) return [{ x0: valuesMin, x1: valuesMax, density: 1 }]
 	let bins
 	if (isKDE) bins = kde(epanechnikov(bandwidth), scale.ticks(ticks), plot.values, valuesMax, step)
-	else bins = getBinsHist(scale, plot.values, ticks, max)
+	else bins = getBinsHist(scale, plot.values, max, ticks)
 	bins.unshift({ x0: min, x1: min, density: 0 })
 
 	return bins
@@ -63,7 +63,7 @@ function kde(kernel, thresholds, data, valuesMax, step) {
 	return bins
 }
 
-function getBinsHist(scale, values, ticks) {
+function getBinsHist(scale, values, max, ticks) {
 	const binBuilder = bin()
 		.domain(scale.domain()) /* extent of the data that is lowest to highest*/
 		.thresholds(scale.ticks(ticks)) /* buckets are created which are separated by the threshold*/

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -39,9 +39,11 @@ export function getBinsDensity(scale, plot, isKDE = false, ticks = 20, bandwidth
 
 	if (valuesMin == valuesMax) return { bins: [{ x0: valuesMin, x1: valuesMax, density: 1 }], densityMax: valuesMax }
 
-	const result = isKDE
+	let result = isKDE
 		? kde(epanechnikov(bandwidth), scale.ticks(ticks), plot.values, valuesMax, step)
 		: getBinsHist(scale, plot.values, ticks, valuesMax)
+
+	if (isKDE && result.densityMax == 0) result = getBinsHist(scale, plot.values, ticks, valuesMax)
 	result.bins.unshift({ x0: min, x1: min, density: 0 })
 	return result
 }

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -41,7 +41,7 @@ export function getBinsDensity(scale, plot, isKDE = false, ticks = 20, bandwidth
 
 	const bins = isKDE
 		? kde(epanechnikov(bandwidth), scale.ticks(ticks), plot.values, valuesMax, step)
-		: getBinsHist(scale, plot.values, max, ticks)
+		: getBinsHist(scale, plot.values, ticks, valuesMax)
 	bins.unshift({ x0: min, x1: min, density: 0 })
 	return bins
 }
@@ -63,15 +63,20 @@ function kde(kernel, thresholds, data, valuesMax, step) {
 	return bins
 }
 
-function getBinsHist(scale, values, max, ticks) {
+function getBinsHist(scale, values, ticks, valuesMax) {
 	const binBuilder = bin()
 		.domain(scale.domain()) /* extent of the data that is lowest to highest*/
 		.thresholds(scale.ticks(ticks)) /* buckets are created which are separated by the threshold*/
 		.value(d => d) /* bin the data points into this bucket*/
 	const bins0 = binBuilder(values)
 	const bins = []
-	for (const bin of bins0) bins.push({ x0: bin.x0, x1: bin.x1, density: bin.length })
-	bins.push({ x0: max, x1: max, density: 0 })
+	for (const bin of bins0) {
+		bins.push({ x0: bin.x0, x1: bin.x1, density: bin.length })
+		if (bin.x1 > valuesMax) {
+			bins.push({ x0: valuesMax, x1: valuesMax, density: 0 })
+			break
+		}
+	}
 
 	return bins
 }

--- a/server/src/mds3.densityPlot.js
+++ b/server/src/mds3.densityPlot.js
@@ -41,8 +41,8 @@ export async function get_densityplot(term, samples) {
 		.range([xpad, xpad + width])
 
 	const bins = getBinsDensity(xscale, { values })
-	if (!Array.isArray(bins.bins)) throw 'violinBins does not return {bins[]}'
-	if (bins.bins.length == 0) throw 'violinBins {bins[]} empty array'
+	if (!Array.isArray(bins)) throw 'getBinsDensity does not return []'
+	if (bins.length == 0) throw 'getBinsDensity returns an empty array'
 
 	const result = {
 		minvalue,
@@ -52,7 +52,7 @@ export async function get_densityplot(term, samples) {
 		samplecount: values.length,
 		unit: term.unit
 	}
-	for (const b of bins.bins) {
+	for (const b of bins) {
 		if (!Number.isFinite(b.x0)) throw 'b.x0 not number'
 		if (!Number.isFinite(b.x1)) throw 'b.x1 not number'
 		if (!Number.isFinite(b.density)) throw 'b.density not number'

--- a/server/src/mds3.densityPlot.js
+++ b/server/src/mds3.densityPlot.js
@@ -1,5 +1,5 @@
 import { scaleLinear } from 'd3-scale'
-import { violinBinsObj } from '../../server/shared/violin.bins'
+import { getBinsDensity } from '../../server/shared/violin.bins'
 
 /*
 ********************** EXPORTED
@@ -40,7 +40,7 @@ export async function get_densityplot(term, samples) {
 		.domain([minvalue, maxvalue])
 		.range([xpad, xpad + width])
 
-	const bins = violinBinsObj(xscale, { values })
+	const bins = getBinsDensity(xscale, { values })
 	if (!Array.isArray(bins.bins)) throw 'violinBins does not return {bins[]}'
 	if (bins.bins.length == 0) throw 'violinBins {bins[]} empty array'
 
@@ -55,9 +55,9 @@ export async function get_densityplot(term, samples) {
 	for (const b of bins.bins) {
 		if (!Number.isFinite(b.x0)) throw 'b.x0 not number'
 		if (!Number.isFinite(b.x1)) throw 'b.x1 not number'
-		if (!Number.isFinite(b.binValueCount)) throw 'b.binValueCount not number'
-		result.density.push([(b.x0 + b.x1) / 2, b.binValueCount])
-		result.densitymax = Math.max(result.densitymax, b.binValueCount)
+		if (!Number.isFinite(b.density)) throw 'b.density not number'
+		result.density.push([(b.x0 + b.x1) / 2, b.density])
+		result.densitymax = Math.max(result.densitymax, b.density)
 	}
 
 	return result

--- a/server/src/mds3.densityPlot.js
+++ b/server/src/mds3.densityPlot.js
@@ -40,26 +40,18 @@ export async function get_densityplot(term, samples) {
 		.domain([minvalue, maxvalue])
 		.range([xpad, xpad + width])
 	const ticks = 20
-	const bins = getBinsDensity(xscale, { values }, ticks, false)
-	console.log(bins)
-	if (!Array.isArray(bins)) throw 'getBinsDensity does not return []'
-	if (bins.length == 0) throw 'getBinsDensity returns an empty array'
+	const density = getBinsDensity(xscale, { values }, false, ticks, false)
+	if (!Array.isArray(density.bins)) throw 'getBinsDensity does not return []'
+	if (density.bins.length == 0) throw 'getBinsDensity returns an empty array'
 
 	const result = {
 		minvalue,
 		maxvalue,
-		densitymax: 0,
-		density: [], // [ bin position, sample count ]
+		densityMax: density.densityMax,
+		density: density.bins,
 		samplecount: values.length,
 		unit: term.unit,
 		ticks
-	}
-	for (const b of bins) {
-		if (!Number.isFinite(b.x0)) throw 'b.x0 not number'
-		if (!Number.isFinite(b.x1)) throw 'b.x1 not number'
-		if (!Number.isFinite(b.density)) throw 'b.density not number'
-		result.density.push([b.x0, b.density])
-		result.densitymax = Math.max(result.densitymax, b.density)
 	}
 
 	return result

--- a/server/src/mds3.densityPlot.js
+++ b/server/src/mds3.densityPlot.js
@@ -39,8 +39,9 @@ export async function get_densityplot(term, samples) {
 	const xscale = scaleLinear()
 		.domain([minvalue, maxvalue])
 		.range([xpad, xpad + width])
-
-	const bins = getBinsDensity(xscale, { values })
+	const ticks = 20
+	const bins = getBinsDensity(xscale, { values }, ticks, false)
+	console.log(bins)
 	if (!Array.isArray(bins)) throw 'getBinsDensity does not return []'
 	if (bins.length == 0) throw 'getBinsDensity returns an empty array'
 
@@ -50,13 +51,14 @@ export async function get_densityplot(term, samples) {
 		densitymax: 0,
 		density: [], // [ bin position, sample count ]
 		samplecount: values.length,
-		unit: term.unit
+		unit: term.unit,
+		ticks
 	}
 	for (const b of bins) {
 		if (!Number.isFinite(b.x0)) throw 'b.x0 not number'
 		if (!Number.isFinite(b.x1)) throw 'b.x1 not number'
 		if (!Number.isFinite(b.density)) throw 'b.density not number'
-		result.density.push([(b.x0 + b.x1) / 2, b.density])
+		result.density.push([b.x0, b.density])
 		result.densitymax = Math.max(result.densitymax, b.density)
 	}
 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -353,7 +353,6 @@ function createCanvasImg(q, result, ds) {
 		plot.src = canvas.toDataURL()
 		// create bins for violins
 		const isKDE = q.isKDE === 'true' || q.isKDE
-		console.log(isKDE, typeof q.isKDE)
 		plot.bins = getBinsDensity(axisScale, plot, isKDE, q.ticks, q.bandwidth)
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -353,7 +353,6 @@ function createCanvasImg(q, result, ds) {
 		plot.src = canvas.toDataURL()
 		// create bins for violins
 		const isKDE = q.method == 0
-		console.log(isKDE)
 		plot.density = getBinsDensity(axisScale, plot, isKDE, q.ticks, q.bandwidth)
 
 		//generate summary stat values

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -352,7 +352,7 @@ function createCanvasImg(q, result, ds) {
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		plot.bins = getBinsDensity(axisScale, plot, q.ticks, q.isKDE, q.bandwidth)
+		plot.bins = getBinsDensity(axisScale, plot, q.isKDE, q.ticks, q.bandwidth)
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)
 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -352,7 +352,7 @@ function createCanvasImg(q, result, ds) {
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		plot.bins = getBinsDensity(axisScale, plot, q.ticks, true, q.bandwidth)
+		plot.bins = getBinsDensity(axisScale, plot, q.ticks, q.isKDE, q.bandwidth)
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)
 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -353,7 +353,8 @@ function createCanvasImg(q, result, ds) {
 		plot.src = canvas.toDataURL()
 		// create bins for violins
 		const isKDE = q.isKDE === 'true' || q.isKDE
-		plot.bins = getBinsDensity(axisScale, plot, isKDE, q.ticks, q.bandwidth)
+		plot.density = getBinsDensity(axisScale, plot, isKDE, q.ticks, q.bandwidth)
+
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)
 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -7,7 +7,7 @@ import path from 'path'
 import { write_file } from './utils'
 import { getData } from './termdb.matrix'
 import { createCanvas } from 'canvas'
-import { violinBinsObj } from '../../server/shared/violin.bins'
+import { getBinsDensity } from '../../server/shared/violin.bins'
 import summaryStats from '../shared/descriptive.stats'
 import { getOrderedLabels } from './termdb.barchart'
 
@@ -352,13 +352,7 @@ function createCanvasImg(q, result, ds) {
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		const finalVpBins = violinBinsObj(axisScale, plot, q.ticks)
-
-		plot.bins = finalVpBins.bins
-
-		plot.biggestBin = Math.max(...finalVpBins.bins0.map(b => b.length))
-
-		if (biggestBin < plot.biggestBin) biggestBin = plot.biggestBin
+		plot.bins = getBinsDensity(axisScale, plot, q.ticks, q.bandwidth)
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)
 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -352,7 +352,8 @@ function createCanvasImg(q, result, ds) {
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		const isKDE = q.isKDE === 'true'
+		const isKDE = q.isKDE === 'true' || q.isKDE
+		console.log(isKDE, typeof q.isKDE)
 		plot.bins = getBinsDensity(axisScale, plot, isKDE, q.ticks, q.bandwidth)
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -352,7 +352,8 @@ function createCanvasImg(q, result, ds) {
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		plot.bins = getBinsDensity(axisScale, plot, q.isKDE, q.ticks, q.bandwidth)
+		const isKDE = q.isKDE === 'true'
+		plot.bins = getBinsDensity(axisScale, plot, isKDE, q.ticks, q.bandwidth)
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)
 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -305,7 +305,6 @@ function createCanvasImg(q, result, ds) {
 			.domain([result.min, result.max])
 			.range(q.orientation === 'horizontal' ? [0, q.svgw] : [q.svgw, 0])
 	}
-
 	const [width, height] =
 		q.orientation == 'horizontal'
 			? [q.svgw * q.devicePixelRatio, refSize * q.devicePixelRatio]
@@ -329,7 +328,6 @@ function createCanvasImg(q, result, ds) {
 		if (q.devicePixelRatio != 1) {
 			ctx.scale(q.devicePixelRatio, q.devicePixelRatio)
 		}
-
 		q.datasymbol === 'rug'
 			? plot.values.forEach(i => {
 					ctx.beginPath()
@@ -359,6 +357,7 @@ function createCanvasImg(q, result, ds) {
 		plot.bins = finalVpBins.bins
 
 		plot.biggestBin = Math.max(...finalVpBins.bins0.map(b => b.length))
+
 		if (biggestBin < plot.biggestBin) biggestBin = plot.biggestBin
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -352,7 +352,7 @@ function createCanvasImg(q, result, ds) {
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		plot.bins = getBinsDensity(axisScale, plot, q.ticks, q.bandwidth)
+		plot.bins = getBinsDensity(axisScale, plot, q.ticks, true, q.bandwidth)
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values)
 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -352,7 +352,8 @@ function createCanvasImg(q, result, ds) {
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		const isKDE = q.isKDE === 'true' || q.isKDE
+		const isKDE = q.method == 0
+		console.log(isKDE)
 		plot.density = getBinsDensity(axisScale, plot, isKDE, q.ticks, q.bandwidth)
 
 		//generate summary stat values


### PR DESCRIPTION
## Description

Using kde to plot violin and cleanup. Please check. From the controls the ticks and the bandwidth can be modified. I used this [code](https://observablehq.com/@d3/kernel-density-estimation) as a reference. I also increased the default plot thickness for single plots to increase resolution

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
