### PR TITLE
Gene exp launcher fixes

### DIFF
--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -3,17 +3,19 @@ import { showGenesetEdit } from '../dom/genesetEdit.ts'
 import { fillTermWrapper } from '#termsetting'
 import { dofetch3 } from '#common/dofetch'
 
-/*
-FIXME please fully explain functionality and arg, e.g. toolName
-(now that both oncomatrix and gdccluster are both routed through it, how is this connected to the downstream tool)
+// This is a reactive geneset component, meant for use within plotApp.
+//
+// 1. plotApp is initialized with geneset as the first plot/component
+// 2. if there are opts.genes, geneset would simply call its opts.callback right away (not even render the edit UI)
+// 3. if not, then geneset would render the edit UI, and also use its opts.callback to supply the wrapped genes
+// 4. in the opts.callback, the matrix/hierCluster will dispatch plot_delete to remove the geneset as the plot,
+//    and also plot_create to render the target plot (like matrix, hierCluster)
+//
+// The reactivity is rquired to toggle loading overlay visibility
+// and to create a new plot within the same plot app, once a valid geneset is
+// obtained from the server.
+//
 
-This is a reactive geneset component, meant for use with
-plotApp to offer a geneset edit UI when there are no starting gene lst.
-The reactivity has to mostly to do with toggling loading overlay visibility
-and creating a new plot within the same plot app, once a valid geneset is
-obtained from the server.
- - Use dom/genesetEdit to directly use the non-reactive version.
-*/
 class GenesetComp {
 	constructor(opts) {
 		this.type = 'geneset'

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -14,6 +14,7 @@ export class MatrixControls {
 		this.type = 'matrixControls'
 		this.opts = opts
 		this.parent = opts.parent
+		this.overrides = {}
 
 		this.opts.holder.style('margin', '10px 10px 20px 10px').style('white-space', 'nowrap')
 		const state = this.parent.getState(appState)
@@ -68,7 +69,7 @@ export class MatrixControls {
 			//.property('disabled', d => d.disabled)
 			.datum({
 				label: l.Samples || `Samples`,
-				getCount: () => this.parent.sampleOrder.length,
+				getCount: () => ('sampleCount' in this.overrides ? this.overrides.sampleCount : this.parent.sampleOrder.length),
 				rows: [
 					{
 						label: `Sort ${l.Samples}`,
@@ -644,7 +645,8 @@ export class MatrixControls {
 			.on('click.sjpp-matrix-download', () => to_svg(this.opts.getSvg(), 'matrix', { apply_dom_styles: true }))
 	}
 
-	main() {
+	main(overrides = {}) {
+		this.overrides = overrides
 		this.parent.app.tip.hide()
 
 		this.btns

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -159,6 +159,7 @@ export class Matrix {
 
 			// may skip data requests when changes are not expected to affect the request payload
 			if (this.stateDiff.nonsettings) {
+				this.dom.svg.style('opacity', 0.001)
 				// reset highlighted dendrogram children to black when data request is triggered
 				delete this.clickedChildren
 				try {
@@ -212,7 +213,7 @@ export class Matrix {
 			if (this.plotDendrogramHclust) this.plotDendrogramHclust()
 			this.render()
 			this.dom.loadingDiv.style('display', 'none')
-			this.dom.svg.style('display', '')
+			this.dom.svg.style('opacity', 1).style('display', '')
 
 			const [xGrps, yGrps] = !this.settings.matrix.transpose ? ['sampleGrps', 'termGrps'] : ['termGrps', 'sampleGrps']
 			const d = this.dimensions
@@ -250,7 +251,9 @@ export class Matrix {
 	}
 
 	showNoMatchingDataMessage() {
-		this.controlsRenderer.main()
+		this.forcedSampleCount = 0
+		this.dom.svg.style('opacity', 0.001).style('display', 'none')
+		this.controlsRenderer.main({ sampleCount: 0 })
 		this.dom.loadingDiv.html('')
 		const div = this.dom.loadingDiv
 			.append('div')

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -250,6 +250,7 @@ export class Matrix {
 	}
 
 	showNoMatchingDataMessage() {
+		this.controlsRenderer.main()
 		this.dom.loadingDiv.html('')
 		const div = this.dom.loadingDiv
 			.append('div')

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -155,6 +155,9 @@ export class Matrix {
 
 			// see matrix.data for logic to be able to skip server data request or re-ordering
 			this.computeStateDiff()
+			// must remember the previous state right away, so that subsequent computeStateDiffs
+			// has the correct reference in case of errors
+			this.prevState = this.state
 			this.dom.loadingDiv.html('').style('display', '').style('position', 'relative').style('left', '45%')
 
 			// may skip data requests when changes are not expected to affect the request payload
@@ -246,7 +249,6 @@ export class Matrix {
 			}
 		}
 
-		this.prevState = this.state
 		this.resetInteractions()
 	}
 

--- a/client/src/launchGdcHierCluster.js
+++ b/client/src/launchGdcHierCluster.js
@@ -93,6 +93,8 @@ export async function init(arg, holder, genomes) {
 				features: ['recover'],
 				callbacks: arg.opts?.app?.callbacks || {}
 			},
+			hierCluster: arg.opts?.hierCluster || {},
+			matrix: arg.opts?.matrix || {},
 			geneset: {
 				mode: 'expression',
 				genome,
@@ -172,13 +174,9 @@ export async function init(arg, holder, genomes) {
 		})
 
 		let hierClusterApi
-		const api = Object.freeze({
+		const api = {
 			type: 'hierCluster',
 			update: async _arg => {
-				if (!plotAppApi) {
-					Object.assign(pendingArg, _arg)
-					return
-				}
 				if ('filter0' in _arg) {
 					plotAppApi.dispatch({
 						type: 'filter_replace',
@@ -193,7 +191,7 @@ export async function init(arg, holder, genomes) {
 					})
 				}
 			}
-		})
+		}
 
 		return api
 	} catch (e) {

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -248,10 +248,6 @@ export async function init(arg, holder, genomes) {
 
 		const api = {
 			update: async arg => {
-				if (!plotAppApi) {
-					Object.assign(pendingArg, arg)
-					return
-				}
 				if ('filter0' in arg) {
 					plotAppApi.dispatch({
 						type: 'filter_replace',

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,4 @@
 Fixes:
 - refresh the case count when there is no matching oncomatrix data
+- pass opts.hierCluster in the launcher to handle create cohort
+- hide the svg on error or matching data

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- refresh the case count when there is no matching oncomatrix data


### PR DESCRIPTION
## Description

To test, connect to qa-orange:
- open http://localhost:3000/example.gdc.matrix.html?maxGenes=5&cohort=CMI-MPC: should have case count
- switch to FM-AD cohort: should display no matching data, 0 case count, 5 genes
- switch to another cohort: matrix should render and have case count in the button label
- do similar test with http://localhost:3000/example.gdc.exp.html?cohort=CDDP_EAGLE-1

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
