### PR TITLE
Rx detect stale

### DIFF
--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -298,14 +298,8 @@ export class HierCluster extends Matrix {
 			this.config.termgroups.find(grp => grp.type == 'hierCluster') ||
 			this.termOrder?.find(t => t.grp.type == 'hierCluster')?.grp
 
-		// track the actionSequenceId before the server request, which may be laggy
-		const actionSequenceId = this.api.notes('actionSequenceId')
-		const d = await this.requestData()
-		if (this.api.notes('actionSequenceId') !== actionSequenceId) {
-			// (an)other state change(s) has been dispatched between the start and completion of the server request
-			console.warn('aborted state update, the server data corresponds to a stale action.sequenceId')
-			return
-		}
+		const [d, stale] = await this.api.detectStale(() => this.requestData())
+		if (stale) throw `stale sequenceId`
 		if (d.error) throw d.error
 		const s = this.settings.hierCluster
 		const twlst = this.hcTermGroup.lst

--- a/client/plots/plot.app.js
+++ b/client/plots/plot.app.js
@@ -129,7 +129,6 @@ class PlotApp {
 		}
 
 		for (const [index, plot] of this.state.plots.entries()) {
-			if (!plot.id) plot.id = `mds3bar_${+new Date()}_${Math.random()}`
 			if (!this.components.plots.find(p => p.id === plot.id)) {
 				const holder = this.dom.holder.append('div')
 				// quick fix to only track the plotDiv for the first plot

--- a/client/rx/test/rx-async.unit.spec.js
+++ b/client/rx/test/rx-async.unit.spec.js
@@ -1,0 +1,183 @@
+import tape from 'tape'
+import * as rx from '../index.js'
+
+/*************************
+ reusable helper functions
+**************************/
+
+export function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**************
+ test sections
+***************/
+
+class TestApp {
+	constructor(opts) {
+		this.type = 'app'
+	}
+
+	async init() {
+		this.store = await storeInit({ app: this.api, state: this.opts.state })
+		this.components = {
+			part: await partInit({ app: this.api })
+		}
+	}
+
+	async main() {}
+}
+
+const appInit = rx.getAppInit(TestApp)
+
+class TestStore {
+	constructor(opts) {
+		this.type = 'store'
+		this.defaultState = {
+			appWait: 0,
+			partWait: 0
+		}
+	}
+}
+
+TestStore.prototype.actions = {
+	app_refresh(action) {
+		rx.copyMerge(this.state, action.state)
+	}
+}
+
+const storeInit = rx.getStoreInit(TestStore)
+
+class TestPart {
+	constructor(opts = {}) {
+		this.type = 'part'
+		this.numStale = 0
+	}
+	getState(appState) {
+		return { wait: appState.partWait || 0 }
+	}
+	async main() {
+		try {
+			const [a, stale] = await this.api.detectStale(() => sleep(this.state.wait))
+			if (stale) this.numStale++
+			else this.currWait = this.state.wait
+		} catch (e) {
+			throw e
+		}
+	}
+}
+
+const partInit = rx.getCompInit(TestPart)
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.pass('-***- rx.core -***-')
+	test.end()
+})
+
+tape('getStoreInit - async', async function (test) {
+	const app = {
+		opts: {
+			state: {},
+			debug: 1
+		}
+	}
+	const store0 = await storeInit({ app, state: app.opts.state })
+	test.equal(typeof store0.write, 'function', 'should provide a write() method')
+	test.equal(typeof store0.copyState, 'function', 'should provide a copyState() method')
+	test.deepEqual(
+		store0.Inner.state,
+		rx.copyMerge({}, store0.Inner.defaultState, app.opts.state),
+		'should have the expected initial state'
+	)
+	test.equal(Object.isFrozen(store0), true, 'should produce a frozen api')
+	test.end()
+})
+
+tape('getCompInit - async', async function (test) {
+	const opts = {
+		app: {
+			opts: {
+				state: { abc: 123 },
+				debug: 1
+			}
+		}
+	}
+	const part0 = await partInit(opts)
+	test.equal('type' in part0, true, 'should have an api.type property, even if undefined)')
+	test.equal('id' in part0, true, 'should set an api.id property, even if undefined')
+	test.equal(typeof part0.update, 'function', 'should provide an update() method')
+	test.equal(typeof part0.on, 'function', 'should provide an on() method')
+	test.equal(typeof part0.getComponents, 'function', 'should provide a getComponents() method')
+	test.end()
+})
+
+tape('getAppInit - async', async function (test) {
+	const opts = {
+		app: {},
+		part: {}
+	}
+	const api0 = await appInit(opts)
+	test.equal(typeof api0.dispatch, 'function', 'should provide a dispatch() method')
+	test.equal(typeof api0.save, 'function', 'should provide a save() method')
+	test.equal(typeof api0.getState, 'function', 'should provide a getState() method')
+	test.equal(typeof api0.middle, 'function', 'should provide a middle() method')
+	test.equal(typeof api0.on, 'function', 'should provide an on() method')
+	test.equal(typeof api0.getComponents, 'function', 'should provide a getComponents() method')
+	test.equal(api0.opts, opts, 'should have an opts property')
+	test.end()
+})
+
+tape('detectStale', async function (test) {
+	const opts = {
+		debug: 1,
+		state: {
+			appWait: 3
+		}
+	}
+	const app = await appInit(structuredClone(opts))
+	try {
+		const d = await Promise.all([
+			(async () => {
+				await sleep(0)
+				await app.dispatch({ type: 'app_refresh', state: { partWait: 10 } })
+			})(),
+			(async () => {
+				await sleep(2)
+				await app.dispatch({ type: 'app_refresh', state: { partWait: 7 } })
+			})(),
+			(async () => {
+				await sleep(4)
+				await app.dispatch({ type: 'app_refresh', state: { partWait: 0 } })
+			})()
+		])
+
+		test.deepEqual(
+			app.getState(),
+			{
+				appWait: 3,
+				partWait: 0
+			},
+			`app should have the last dispatched state`
+		)
+
+		const part = app.getComponents('part').Inner
+		test.deepEqual(
+			{
+				numStale: part.numStale,
+				currWait: part.currWait
+			},
+			{
+				numStale: 2,
+				currWait: 0
+			},
+			`component should have the correct computed state`
+		)
+	} catch (e) {
+		test.fail('error: ' + e)
+	}
+	test.end()
+})

--- a/client/rx/test/rx-core.unit.spec.js
+++ b/client/rx/test/rx-core.unit.spec.js
@@ -5,9 +5,6 @@ import * as rx from '../index.js'
  reusable helper functions
 **************************/
 
-// to run, at /client/, do below:
-// rm -f ../public/bin/bundle.*; npx browserify ./test/init.js ../public/bin/proteinpaint.js src/*/test/core*.spec.js | npx tape-run --static ../public
-
 class TestApp {
 	constructor(opts) {
 		this.type = 'app'
@@ -86,12 +83,12 @@ class TestPart {
  test sections
 ***************/
 
-tape('\n', function(test) {
+tape('\n', function (test) {
 	test.pass('-***- rx.core -***-')
 	test.end()
 })
 
-tape('getOpts', function(test) {
+tape('getOpts', function (test) {
 	// this app object will be its own appApi
 	const app = {
 		opts: {
@@ -121,7 +118,7 @@ tape('getOpts', function(test) {
 	test.end()
 })
 
-tape('getInitFxn', function(test) {
+tape('getInitFxn', function (test) {
 	test.equal(typeof rx.getInitFxn, 'function', 'should be an rx.function')
 
 	const appInit0 = rx.getInitFxn(
@@ -159,7 +156,7 @@ tape('getInitFxn', function(test) {
 	test.end()
 })
 
-tape('getStoreApi', function(test) {
+tape('getStoreApi', function (test) {
 	test.equal(typeof rx.getStoreApi, 'function', 'should be an rx.function')
 
 	const storeInit = rx.getInitFxn(TestStore)
@@ -177,7 +174,7 @@ tape('getStoreApi', function(test) {
 	test.end()
 })
 
-tape('getComponentApi', function(test) {
+tape('getComponentApi', function (test) {
 	test.equal(typeof rx.getComponentApi, 'function', 'should be an rx.function')
 
 	const partInit = rx.getInitFxn(TestPart)
@@ -196,10 +193,11 @@ tape('getComponentApi', function(test) {
 	test.equal(typeof part0.update, 'function', 'should provide an update() method')
 	test.equal(typeof part0.on, 'function', 'should provide an on() method')
 	test.equal(typeof part0.getComponents, 'function', 'should provide a getComponents() method')
+	test.equal(typeof part0.detectStale, 'function', 'should provide a detectStale() method')
 	test.end()
 })
 
-tape('getAppApi', function(test) {
+tape('getAppApi', function (test) {
 	test.equal(typeof rx.getAppApi, 'function', 'should be an rx.function')
 
 	const appInit = rx.getInitFxn(TestApp)
@@ -221,7 +219,7 @@ tape('getAppApi', function(test) {
 	reactive update flow calls various rx apis
 	and methods
 */
-tape('Reactive flow', async function(test) {
+tape('Reactive flow', async function (test) {
 	test.timeoutAfter(100)
 	test.plan(8)
 
@@ -300,7 +298,7 @@ tape('Reactive flow', async function(test) {
 			'dispatch() should trigger component.api.update() but not necessarily component.main()'
 		)
 	}
-	comp2.main = function(state, data) {
+	comp2.main = function (state, data) {
 		test.fail(`must not trigger component.main() when its type's reactsTo.prefix is not matched`)
 	}
 	await app.dispatch(action_fake)
@@ -334,7 +332,7 @@ tape('Reactive flow', async function(test) {
 	await app.dispatch(action_edit)
 })
 
-tape('copyMerge', function(test) {
+tape('copyMerge', function (test) {
 	const target = {
 		setting: {
 			color: 'red'

--- a/client/src/launchGdcHierCluster.js
+++ b/client/src/launchGdcHierCluster.js
@@ -68,7 +68,6 @@ export async function init(arg, holder, genomes) {
 		if (!Number.isInteger(settings.hierCluster.maxGenes)) settings.hierCluster.maxGenes = 100
 
 		if (arg.filter0 && typeof arg.filter0 != 'object') throw 'arg.filter0 not object'
-		let plot_spliced = false
 
 		const plotAppApi = await appInit({
 			holder: select(arg.holder).select('.sja_root_holder'),
@@ -106,10 +105,10 @@ export async function init(arg, holder, genomes) {
 						Only up to 1000 cases with gene expression data will be used to select genes.
 					`)
 				},
-				callback(genesetCompApi, twlst) {
-					// this callback may be called more than once as a user changes a GDC cohort initially,
-					// need to avoid re-deleting/re-creating plots
-					if (plot_spliced || !genesetCompApi) return
+				async callback(genesetCompApi, twlst) {
+					// exit early if the geneset api is already gone,
+					// as caused by race condition from quick changes to the filter0
+					if (!genesetCompApi) return
 					plotAppApi.dispatch({
 						type: 'plot_splice',
 						subactions: [

--- a/client/src/launchGdcMatrix.js
+++ b/client/src/launchGdcMatrix.js
@@ -108,7 +108,6 @@ export async function init(arg, holder, genomes) {
 		if (!Number.isInteger(settings.matrix.maxGenes)) settings.matrix.maxGenes = 50
 
 		if (arg.filter0 && typeof arg.filter0 != 'object') throw 'arg.filter0 not object'
-		let plot_spliced = false
 
 		const plotAppApi = await appInit({
 			holder: select(arg.holder).select('.sja_root_holder'),
@@ -145,11 +144,10 @@ export async function init(arg, holder, genomes) {
 					// 	Only up to 1000 cases with gene expression data will be used to select genes.
 					// `)
 				},
-				callback(genesetCompApi, twlst) {
-					// this callback may be called more than once as a user changes a GDC cohort initially,
-					// need to avoid re-deleting/re-creating plots
-					if (plot_spliced || !genesetCompApi) return
-					plot_spliced = true
+				async callback(genesetCompApi, twlst) {
+					// exit early if the geneset api is already gone,
+					// as caused by race condition from quick changes to the filter0
+					if (!genesetCompApi) return
 					plotAppApi.dispatch({
 						type: 'plot_splice',
 						subactions: [

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- reliably detect stale async results using a rx component api method


### PR DESCRIPTION
## Description

This change creates a new rx api method for components to detect stale updates. This centralizes the code that was previously repeated in the matrix, hierCluster, and geneset code. There are also more unit tests to cover the new detectStale() method.

To test:
- New automated unit tests at http://localhost:3000/testrun.html?dir=rx
- pull sipp/master
- http://localhost:3000/example.gdc.matrix.html?maxGenes=3: use the dropdown to switch cohorts rapidly, the displayed rendered cohort should always match the currently selected cohort
- http://localhost:3000/example.gdc.exp.html?cohort=APOLLO,EAGLE: similar rapid cohort changes 
- in `example.gdc.matrix.html`, uncomment the genes array in lines 53-55: the geneset component should still work with rapid cohort changes

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
