### PR TITLE
Cancel stale fetch requests and fix related errors

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -151,7 +151,8 @@ export function dofetch2(path, init = {}, opts = {}) {
 						if (opts.cacheAs == 'decoded') {
 							// should prefer to store results as a deeply frozen object instead of a Response interface,
 							// but must not return the same object to be reused by different requests
-							opts.serverData[dataName] = deepFreeze(result)
+							deepFreeze(result)
+							opts.serverData[dataName] = result
 							result = structuredClone(result)
 						} else {
 							// per https://developer.mozilla.org/en-US/docs/Web/API/Response/clone,

--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -705,7 +705,7 @@ tape('sort samples by CNV+SSM > SSM-only', function (test) {
 		test.equal(index_2660, 11, `should be in the expected order`)
 		const index_3472 = r.find(rect => rect.textContent == '3472').__data__.index
 		test.true(index_3472, r.length - 1, `should be in the expected order`)
-		//if (test._ok) matrix.Inner.app.destroy()
+		if (test._ok) matrix.Inner.app.destroy()
 		test.end()
 	}
 })
@@ -974,7 +974,7 @@ tape('sort sample groups by Hits 2', function (test) {
 		)._groups[0]
 		test.true(matrixGroupLabels[0].textContent.startsWith('10 to <15'), `should have the expected left-most group name`)
 		test.true(matrixGroupLabels[4].textContent.startsWith('≥20'), `should have the right-most expected group name`)
-		//if (test._ok) matrix.Inner.app.destroy()
+		if (test._ok) matrix.Inner.app.destroy()
 		test.end()
 	}
 })

--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -124,6 +124,7 @@ class GenesetComp {
 	}
 
 	async render() {
+		if (!this.dom?.holder) return
 		this.dom.holder
 			.append('p')
 			.text(`No default genes. Please change the cohort or define a gene set to launch ${this.state.config.toolName}.`)

--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -43,7 +43,7 @@ class GenesetComp {
 		// in the app init(), and that app instance should return without having to wait
 		// for this component to finish the initial genes request and fully render
 		// NOTE: This is an important accomodation of rapid-fire cohort changes in the gdc portal
-		this.noWait()
+		this.noWait().catch(console.warn)
 	}
 
 	async noWait() {

--- a/client/plots/hierCluster.js
+++ b/client/plots/hierCluster.js
@@ -298,7 +298,8 @@ export class HierCluster extends Matrix {
 			this.config.termgroups.find(grp => grp.type == 'hierCluster') ||
 			this.termOrder?.find(t => t.grp.type == 'hierCluster')?.grp
 
-		const [d, stale] = await this.api.detectStale(() => this.requestData())
+		const abortCtrl = new AbortController()
+		const [d, stale] = await this.api.detectStale(() => this.requestData({ signal: abortCtrl.signal }), { abortCtrl })
 		if (stale) throw `stale sequenceId`
 		if (d.error) throw d.error
 		const s = this.settings.hierCluster
@@ -382,7 +383,7 @@ export class HierCluster extends Matrix {
 		}
 	}
 
-	async requestData() {
+	async requestData({ signal }) {
 		// temporary fix to get rid of hard/soft filter and only keep dictionary legend filter,
 		// soft filter shouldn't be used to filter out any samples for hierCluster
 		// TODO: add hard filter back to filter out samples
@@ -404,7 +405,7 @@ export class HierCluster extends Matrix {
 			filter: filterJoin([this.state.filter, dictionaryLegendFilter]),
 			filter0: this.state.filter0
 		}
-		return await dofetch3('termdb/cluster', { body })
+		return await dofetch3('termdb/cluster', { body, signal })
 	}
 
 	combineData() {

--- a/client/plots/matrix.data.js
+++ b/client/plots/matrix.data.js
@@ -127,12 +127,14 @@ export async function setData(_data) {
 	if (this.config.divideBy) terms.push(this.config.divideBy)
 	this.numTerms = terms.length
 
+	const abortCtrl = new AbortController()
 	const opts = {
 		terms,
 		filter: this.state.filter,
 		filter0: this.state.filter0,
 		loadingDiv: this.chartType != 'hierCluster' && this.dom.loadingDiv,
-		maxGenes: this.state.config.settings.matrix.maxGenes
+		maxGenes: this.state.config.settings.matrix.maxGenes,
+		signal: abortCtrl.signal
 		//termsPerRequest: 100 // this is just for testing
 	}
 
@@ -143,7 +145,9 @@ export async function setData(_data) {
 			*/
 		opts.isHierCluster = 1
 	}
-	const [data, stale] = await this.api.detectStale(() => this.app.vocabApi.getAnnotatedSampleData(opts, _data))
+	const [data, stale] = await this.api.detectStale(() => this.app.vocabApi.getAnnotatedSampleData(opts, _data), {
+		abortCtrl
+	})
 	if (stale) throw `stale sequenceId`
 	this.data = data
 	this.origData = structuredClone(this.data)

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -366,11 +366,12 @@ export function setInteractivity(self) {
 function setResizeHandler(self) {
 	let resizeId
 	select(window).on(`resize.sjpp-${self.id}`, () => {
-		clearTimeout(resizeId)
-		resizeId = setTimeout(resize, 200)
+		if (resizeId) clearTimeout(resizeId)
+		if (self.dimensions && self.layout) resizeId = setTimeout(resize, 200)
 	})
 	function resize() {
-		self.main()
+		// !!! this.abortCtl.abort()
+		if (self.dimensions && self.layout) self.main()
 	}
 }
 

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -163,7 +163,7 @@ export class Matrix {
 
 			// may skip data requests when changes are not expected to affect the request payload
 			if (this.stateDiff.nonsettings) {
-				this.dom.svg.style('opacity', 0.001)
+				this.dom.svg.style('opacity', 0.001).style('pointer-events', 'none')
 				// reset highlighted dendrogram children to black when data request is triggered
 				delete this.clickedChildren
 				try {
@@ -184,7 +184,7 @@ export class Matrix {
 					if (e == 'no data') {
 						this.showNoMatchingDataMessage()
 						return
-					} else if (e == 'stale sequenceId') {
+					} else if (e == 'stale sequenceId' || e.name == 'AbortError') {
 						// ignore this error, but skip this update since a subsequent action is being processed
 						return
 					} else {
@@ -220,7 +220,7 @@ export class Matrix {
 			if (this.plotDendrogramHclust) this.plotDendrogramHclust()
 			this.render()
 			this.dom.loadingDiv.style('display', 'none')
-			this.dom.svg.style('opacity', 1).style('display', '')
+			this.dom.svg.style('display', '').style('opacity', 1).style('pointer-events', '')
 
 			const [xGrps, yGrps] = !this.settings.matrix.transpose ? ['sampleGrps', 'termGrps'] : ['termGrps', 'sampleGrps']
 			const d = this.dimensions
@@ -259,7 +259,9 @@ export class Matrix {
 	showNoMatchingDataMessage() {
 		this.forcedSampleCount = 0
 		this.dom.svg.style('opacity', 0.001).style('display', 'none')
-		this.controlsRenderer.main({ sampleCount: 0 })
+		// an error on initial load/data request will cause computed data/settings to be empty,
+		// which would cause input values to be empty for controls and likely thrown errors
+		if (this.termOrder && this.dimensions) this.controlsRenderer.main({ sampleCount: 0 })
 		this.dom.loadingDiv.html('')
 		const div = this.dom.loadingDiv
 			.append('div')

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -31,6 +31,7 @@ export class Matrix {
 
 	async init(appState) {
 		const opts = this.opts
+		if (opts.reactsTo) this.reactsTo = opts.reactsTo
 		this.setDom = setMatrixDom
 		this.setDom(opts)
 

--- a/client/plots/regression.inputs.values.table.js
+++ b/client/plots/regression.inputs.values.table.js
@@ -187,7 +187,8 @@ function setRenderers(self) {
 					}
 				}
 				self.plotAppApi = await appInit(opts)
-				self.violinApi = self.plotAppApi.getComponents('plots.0')
+				const plotId = self.plotAppApi.getState().plots[0].id
+				self.violinApi = self.plotAppApi.getComponents(`plots.${plotId}`)
 			}
 		} else {
 			// mode is neither continuous nor spline

--- a/client/plots/test/hierCluster.integration.spec.js
+++ b/client/plots/test/hierCluster.integration.spec.js
@@ -65,7 +65,9 @@ async function getHierClusterApp(_opts = {}) {
 	const opts = Object.assign(defaults, _opts)
 	const app = await appInit(opts)
 	holder.select('.sja_errorbar').node()?.lastChild.click()
-	const hc = app.Inner.components.plots[0].Inner
+	const hc = Object.values(app.Inner.components.plots).find(
+		p => p.type == 'hierCluster' || p.chartType == 'hierCluster'
+	).Inner
 	// mock requestData() directly on the instance itself and without modifying the HierCluster.prototype
 	hc.requestData = requestData
 	const termgroups = structuredClone(hc.config.termgroups)

--- a/client/rx/index.js
+++ b/client/rx/index.js
@@ -298,7 +298,6 @@ export function getAppApi(self) {
 		type: self.type,
 		opts: self.opts,
 		async dispatch(action) {
-			latestActionSequenceId = action?.sequenceId
 			self.bus.emit('preDispatch')
 			try {
 				if (middlewares.length) {
@@ -317,6 +316,7 @@ export function getAppApi(self) {
 				// expect store.write() to be debounced and handler rapid succession of dispatches
 				// replace app.state if there is an action
 				if (action) self.state = await self.store.write(action)
+				latestActionSequenceId = action?.sequenceId
 				// TODO: may need to group calls to self.main by action type and plot.id,
 				// in order to debounce correctly
 				if (self.main) await self.main()
@@ -848,4 +848,8 @@ export function deepEqual(x, y) {
 		}
 		return true
 	} else return false
+}
+
+export function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/client/rx/index.js
+++ b/client/rx/index.js
@@ -494,6 +494,7 @@ export function getComponentApi(self) {
 		// can also tie-in a function call to the fresheness of the component action.
 		//
 		async detectStale(asyncFxn, opts = {}) {
+			let errMsg = ''
 			try {
 				const actionSequenceId = latestActionSequenceId
 				const promises = []
@@ -507,6 +508,7 @@ export function getComponentApi(self) {
 									clearInterval(i)
 									try {
 										opts.abortCtrl.abort()
+										throw `stale sequenceId`
 									} catch (e) {
 										reject(e)
 									}
@@ -529,6 +531,7 @@ export function getComponentApi(self) {
 				}
 				return [result]
 			} catch (e) {
+				if (typeof e == 'string' && e.includes('sequenceId')) console.warn(e)
 				throw e
 			}
 		},

--- a/release.txt
+++ b/release.txt
@@ -3,3 +3,4 @@ Fixes:
 - Do not re-render the matrix controls as part of displaying a no data message when svg dimensions and layout have not been computed yet
 - Do not assign a non-auth related error as a token verification message, which caused the matrix to not rerender even with subsequent valid data
 - Do not display a mouseover over a hidden matrix or hier cluster svg
+- an unrendered matrix or hierCluster should not react to window resize

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,5 @@
-
+Fixes:
+- Cancel stale fetch requests to unblock current geneset, matrix, and hierCluster requests that are being throttled by the browser's concurrent request limit
+- Do not re-render the matrix controls as part of displaying a no data message when svg dimensions and layout have not been computed yet
+- Do not assign a non-auth related error as a token verification message, which caused the matrix to not rerender even with subsequent valid data
+- Do not display a mouseover over a hidden matrix or hier cluster svg


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/1285
Closes https://github.com/stjude/proteinpaint/issues/1287

Fixes:
- Cancel stale fetch requests to unblock current geneset, matrix, and hierCluster requests that are being throttled by the browser's concurrent request limit
- Do not re-render the matrix controls as part of displaying a no data message when svg dimensions and layout have not been computed yet
- Do not assign a non-auth related error as a token verification message, which caused the matrix to not rerender even with subsequent valid data
- Do not display a mouseover over a hidden matrix or hier cluster svg
- an unrendered matrix or hierCluster should not react to window resize

To test, follow the testing instructions in the linked issues. Also run/open 
- http://localhost:3000/testrun.html?dir=mass&name=matrix.integration and 
- http://localhost:3000/testrun.html?dir=plots&name=hierCluster.integration

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
