### PR TITLE
Fix the detection of sorting-related updates in matrix app

### DIFF
--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -552,7 +552,6 @@ function setTermActions(self) {
 			genome: self.app.opts.genome,
 			nobox: true,
 			query: t.tw.term.name,
-			filter0: self.config.filter0,
 			tklst: [
 				{
 					type: 'mds3',

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -552,6 +552,7 @@ function setTermActions(self) {
 			genome: self.app.opts.genome,
 			nobox: true,
 			query: t.tw.term.name,
+			filter0: self.config.filter0,
 			tklst: [
 				{
 					type: 'mds3',

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,4 @@
-
+Fixes:
+- Fix the detection of termgroup related changes in the matrix app as distinct from the hier cluster
+- Send the cohort filter when launching a lollipop track from the matrix plot
+- Fix the detection of sorting-related updates in the matrix app, as distinct from the hier cluster

--- a/release.txt
+++ b/release.txt
@@ -1,4 +1,2 @@
 Fixes:
-- Fix the detection of termgroup related changes in the matrix app as distinct from the hier cluster
-- Send the cohort filter when launching a lollipop track from the matrix plot
 - Fix the detection of sorting-related updates in the matrix app, as distinct from the hier cluster


### PR DESCRIPTION
## Description

Bug was introduced in https://github.com/stjude/proteinpaint/issues/989

Copied from https://gdc-ctds.atlassian.net/browse/SV-2420:

In OncoMatrix, the user can drag a gene up or down to change the order of the genes. This only works once. After one gene is dragged to a new position, no genes can be dragged to new positions.

Create a cohort with TCGA-BRCA
- Launch OncoMatrix
- Drag PIK3CA to lower position.  This works.
- Try to drag any gene, including PIK3CA, to another positions.  This no longer works.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
