### PR TITLE
Do not show read sequence, when no read sequence is present

### DIFF
--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -116,6 +116,8 @@ box {}
 .len   // #bp
 .cidx  // start position in sequence/qual string
 .s (read sequence) FIXME only keep box.s if sequence will be rendered
+	if a read has no sequence ("*" as value), doing box.s=segment.seq.substr() will not break and returns blank string ''
+	thus rendering code may have to test if box.s==''
 .qual[]
 
 

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -2919,7 +2919,13 @@ if b.qual is available, set text color based on it
 				} else {
 					ctx.fillStyle = insertion_hq
 				}
-				const text = b.s.length == 1 ? b.s : b.s.length
+				let text
+				if (b.s == '') {
+					// When sequence read is missing extract length of insertion from the CIGAR sequence
+					text = b.len
+				} else {
+					text = b.s.length == 1 ? b.s : b.s.length
+				}
 				// text y position to observe if the read is in an overlapping pair and shifted down
 				ctx.fillText(text, x, template.y + group.stackheight * (segment.on2ndrow || 0) + group.stackheight / 2)
 			}
@@ -3229,7 +3235,7 @@ async function convertread2html(seg, genome, query) {
 	const quallst = qual2int(seg.qual)
 	let reflst, querylst
 	if (seg.seq == '*') {
-		reflst = ['<td>DNA sequence not available for this read</td>']
+		reflst = ['<td>Nucleotide sequence not available for this read</td>']
 		querylst = ['<td></td>']
 	} else {
 		reflst = ['<td>Reference</td>']


### PR DESCRIPTION
## Description

Fixed issue of read containing a non (*) CIGAR sequence but read sequence is empty (*). This is fundamentally a data issue problem, but BAM tk should be able to handle such cases. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
