### PR TITLE
Pass cohort filter to lollipop track from matrix gene label click

### DIFF
--- a/client/plots/disco/interactions/DiscoInteractions.ts
+++ b/client/plots/disco/interactions/DiscoInteractions.ts
@@ -61,6 +61,7 @@ export class DiscoInteractions {
 		}
 
 		this.geneClickListener = async (gene: string, mnames: Array<string>) => {
+			const { filter, filter0 } = disco.app.getState().termfilter
 			const arg = {
 				holder: disco.app.opts.holder,
 				genome: disco.app.opts.state.args.genome,
@@ -71,8 +72,8 @@ export class DiscoInteractions {
 						type: 'mds3',
 						dslabel: disco.app.opts.state.dslabel,
 						hlaachange: mnames.join(','),
-						filter0: disco.app.getState().termfilter.filter0
-						// should also pass termfilter.filter ???
+						filter0,
+						filterObj: filter
 					}
 				]
 			}

--- a/client/plots/disco/interactions/DiscoInteractions.ts
+++ b/client/plots/disco/interactions/DiscoInteractions.ts
@@ -70,7 +70,9 @@ export class DiscoInteractions {
 					{
 						type: 'mds3',
 						dslabel: disco.app.opts.state.dslabel,
-						hlaachange: mnames.join(',')
+						hlaachange: mnames.join(','),
+						filter0: disco.app.getState().termfilter.filter0
+						// should also pass termfilter.filter ???
 					}
 				]
 			}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -555,7 +555,9 @@ function setTermActions(self) {
 			tklst: [
 				{
 					type: 'mds3',
-					dslabel: self.app.opts.state.vocab.dslabel
+					dslabel: self.app.opts.state.vocab.dslabel,
+					filter0: self.state.filter0
+					// should also pass self.state.filter ???
 				}
 			]
 		}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -556,8 +556,8 @@ function setTermActions(self) {
 				{
 					type: 'mds3',
 					dslabel: self.app.opts.state.vocab.dslabel,
-					filter0: self.state.filter0
-					// should also pass self.state.filter ???
+					filter0: self.state.filter0,
+					filterObj: self.state.filter
 				}
 			]
 		}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- Pass the cohort filter to the lollipop track from the matrix gene label click
+- Pass the cohort filter to the lollipop track from the matrix and disco plot label click


### PR DESCRIPTION
## Description

Also fixed the Disco gene label click handler.

From the JIRA ticket:
![Screenshot 2024-02-05 at 3 15 20 PM](https://github.com/stjude/proteinpaint/assets/411031/e5b00749-3734-42c1-84c8-9ec39acfa202)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
