### PR TITLE
gdc bam: add test on hiding token file input, reenable realignment pa…

### DIFF
--- a/client/src/block.tk.bam.gdc.js
+++ b/client/src/block.tk.bam.gdc.js
@@ -125,7 +125,11 @@ export async function bamsliceui({
 	if (callbacks.postRender && typeof callbacks.postRender != 'function') throw 'callbacks.postRender is not function'
 
 	// public api obj to be returned
-	const publicApi = {}
+	const publicApi = {
+		dom: {
+			tip
+		}
+	}
 
 	const genome = genomes[gdc_genome]
 	if (!genome) throw 'missing genome for ' + gdc_genome
@@ -210,10 +214,10 @@ export async function bamsliceui({
 
 	function makeTokenInput() {
 		// make one <tr> with two cells
-		const tr = formDiv.insert('div')
+		const tr = formDiv.insert('div').attr('class', 'sja-gdcbam-tokendiv')
 
 		// cell 1
-		tr.insert('div').style('display', 'inline-block').style('width', '15vw').text('GDC token file')
+		tr.insert('div').style('display', 'inline-block').style('width', '15vw').text('GDC Token File')
 
 		// cell 2
 		const td = tr.insert('div').style('display', 'inline-block')
@@ -267,7 +271,7 @@ export async function bamsliceui({
 			.style('display', 'inline-block')
 			.style('width', '15vw')
 			.style('padding-top', '5px')
-			.text('Enter search string')
+			.text('Enter Search String')
 			.style('vertical-align', 'top')
 
 		// cell 2
@@ -297,6 +301,7 @@ export async function bamsliceui({
 		td.append('br') // add line break from input box
 		const listCaseFileHandle = td
 			.append('div')
+			.attr('class', 'sja-gdcbam-listCaseFileHandle') // for testing
 			.style('margin', '5px')
 			.style('display', 'inline-block')
 			.text('Looking for BAM files from current cohort...')
@@ -560,7 +565,7 @@ export async function bamsliceui({
 		if (data.total < data.loaded) handle.text(`Or, browse ${data.loaded} available BAM files`)
 
 		handle
-			.attr('class', 'sja_clbtext')
+			.classed('sja_clbtext', true) // not to override the class name used for testing
 			.attr('tabindex', 0)
 			.on('keyup', event => {
 				if (event.key == 'Enter') {
@@ -570,7 +575,7 @@ export async function bamsliceui({
 			.on('click', event => {
 				const div = tip
 					.clear()
-					.showunder(event.target)
+					//.showunder(event.target)
 					.d.append('div')
 					.style('margin', '10px')
 					.style('overflow-y', 'scroll')
@@ -609,6 +614,8 @@ export async function bamsliceui({
 				}
 
 				table.select('.sja_clbtext')?.node()?.focus()
+
+				tip.showunder(event.target)
 			})
 	}
 

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -398,17 +398,17 @@ or update existing groups, in which groupidx will be provided
 				.attr('text-anchor', 'middle')
 				.text(m.t)
 			/*
-				TODO
-				clicking header has unresolved issues in GFF, disable until after softlaunch
+			TODO !tk.gdcFile
+				clicking header has unresolved issues in GFF, disable it in GDC until after softlaunch
 				- click on 1st group will show what's from the 4th group
 				- the realignment panel y position can be too high and got covered up by gdc portal component
-			if (m.isheader) {
+			*/
+			if (m.isheader && !tk.gdcFile) {
 				// this message is the header of the group, allow clickable
 				msg.attr('class', 'sja_clbtext2').on('click', () => {
 					click_groupheader(tk, g, block)
 				})
 			}
-			*/
 			y += messagerowheight
 		}
 	}

--- a/client/src/test/block.tk.bam.gdc.spec.js
+++ b/client/src/test/block.tk.bam.gdc.spec.js
@@ -71,6 +71,45 @@ tape('\n', function (test) {
 	test.end()
 })
 
+tape('Hide token input', test => {
+	const holder = getHolder()
+	runproteinpaint({
+		holder,
+		noheader: true,
+		gdcbamslice: {
+			hideTokenInput: true,
+			callbacks: { postRender }
+		}
+	})
+
+	let isFirstUpdate = true
+
+	async function postRender(api) {
+		await detectZero({ elem: holder, selector: '.sja-gdcbam-tokendiv' })
+		test.pass('No token input is shown')
+		const handle = await detectOne({ elem: holder, selector: '.sja-gdcbam-listCaseFileHandle' })
+		test.equal(
+			handle.innerHTML,
+			'Or, browse 1000 available BAM files',
+			'List case file handle is shown with correct text'
+		)
+
+		handle.dispatchEvent(new Event('click'))
+		await whenVisible(api.dom.tip.d.node())
+
+		// FIXME cannot detect a file by class in the tip
+		//const file = await detectOne({elem:api.dom.tip.d.node(), selector:'.sja_clbtext'})
+
+		// trigger click on the text to search by bam and update ui, then use isFirstUpdate =true/false to reuse postRender to test
+
+		if (test._ok) {
+			holder.remove()
+			api.dom.tip.d.remove()
+		}
+		test.end()
+	}
+})
+
 for (const entity of entities) {
 	tape(entity.label, test => {
 		/*** must not use "async (test)=>{}" postRender runs after test finishes!! ***/


### PR DESCRIPTION
…nel for non-gdc tk

## Description

the realignment panel remain disabled after slicing a GDC BAM, it is now reenabled in a local bam
also added a new test to check token input is disabled as it should in GFF. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
