### PR TITLE
fix: BAM track bug fix to not to break by hide/show toggling at track…

### DIFF
--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -796,14 +796,7 @@ function updateExistingGroups(data, tk, block) {
 	for (let i = 0; i < tk.groups.length; i++) {
 		const group = data.groups.find(g => g.type == tk.groups[i].data.type)
 		if (!group) {
-			tk.groups[i].dom.message_rowg.remove()
-			tk.groups[i].dom.img_fullstack.remove()
-			tk.groups[i].dom.img_partstack.remove()
-			tk.groups[i].dom.diff_score_barplot_fullstack.remove()
-			tk.groups[i].dom.diff_score_barplot_partstack.remove()
-			tk.groups[i].dom.read_names_g.remove()
-			tk.groups[i].dom.leftg.remove()
-			tk.groups[i].dom.rightg.remove()
+			deleteGroupDom(tk.groups[i])
 			tk.groups.splice(i, 1) // Deleting the group
 		}
 	}
@@ -902,6 +895,17 @@ function update_box_stay(group, tk, block) {
 	}
 	// clicked template not found
 	group.dom.box_stay.attr('width', 0)
+}
+
+function deleteGroupDom(g) {
+	g.dom.message_rowg.remove()
+	g.dom.img_fullstack.remove()
+	g.dom.img_partstack.remove()
+	g.dom.diff_score_barplot_fullstack?.remove()
+	g.dom.diff_score_barplot_partstack?.remove()
+	g.dom.read_names_g?.remove()
+	g.dom.leftg.remove()
+	g.dom.rightg.remove()
 }
 
 function makeTk(tk, block) {
@@ -1008,6 +1012,17 @@ function makeTk(tk, block) {
 			.on('mouseout', () => {
 				tk.tktip.hide()
 			})
+	}
+
+	/* 
+	on makeTk(), existing settings and doms must be cleared
+	at block tk menu, hide and reshow this tk will trigger makeTk() on this tk a second time
+	if following things are not cleared, somehow some group img will become homeless
+	*/
+	delete tk.alleleAlreadyUpdated
+	if (tk.groups) {
+		for (const g of tk.groups) deleteGroupDom(g)
+		delete tk.groups
 	}
 }
 

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - BAM track bug fix to handle reads with no sequence and not to break.
+- BAM track bug fix to not to break by hide/show toggling at track menu


### PR DESCRIPTION
… menu

## Description

closes #1297 
now hide/reshow a bam tk from `Tracks` menu will not break, for both no-variant and variant-typing mode
i've verified it does not affect gdc bam slicing

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
