### PR TITLE
Automatically clear up GDC bam cache space 

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- In GDC BAM slicing, before creating new cache file, find out old enough ones to delete to free up storage


### PR DESCRIPTION
## Description

To test, add a `features.bamCache: {"checkWait": 10000}}` entry, or some other convenient wait time in milliseconds, and  open a sequence read view. Do this multiple times rapidly or slowly, with different files/genes, there should be no errors.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
