### PR TITLE
Handle snp-related links in dataset file

### DIFF
--- a/client/dom/ssmLink.ts
+++ b/client/dom/ssmLink.ts
@@ -1,35 +1,69 @@
 import { UrlTemplateSsm } from '#shared/types/dataset.ts'
 
 /*
-Make html links from ssm (simple somatic mutation) urls
+Make html links from one m object (m is ssm-simple somatic mutation, snvindel, or nonmutation)
+extendable to support multiple link formats
 
 Arguments:
-    - ssm_urls: ssm url(s) specified in dataset file, can be either array or object
-    - m: m element from snp.mlst
 
-Returns: array of html links (if ssm_urls is array) or html string (if ssm_urls is object)
+ssm_urls:
+	see type def
+m:
+	variant object
+variantNameDom:
+	dom (<span>) that's already rendered with the variant name. 
+	if ssm url config.shownSeparately=false , <a> tag is rendered into this <span>, so the link appears over the variant name
+	otherwise the new link html is added to separateUrls[] and returned
+genome:
+	only used for regulomedb for now
+
+Returns:
+
+separateUrls[]: array of html links (if ssm_urls is array) or html string (if ssm_urls is object)
 */
-export function makeSsmLink(ssm_urls: UrlTemplateSsm | UrlTemplateSsm[], m: object, genome: string) {
+export function makeSsmLink(
+	ssm_urls: UrlTemplateSsm | UrlTemplateSsm[],
+	m: object,
+	variantNameDom: any,
+	genome: string
+) {
+	// urls shown separately
+	const separateUrls: string[] = []
+
 	if (Array.isArray(ssm_urls)) {
 		// ssm_urls is array
-		const htmls = []
 		for (const ssm_url of ssm_urls) {
-			if (ssm_url.namekey == 'chr:pos') {
-				const coord = `${m.chr}%3A${m.pos}-${m.pos + 1}`
-				htmls.push(
-					`<a href="${ssm_url.base}regions=${coord}&genome=${genome == 'hg38' ? 'GRCh38' : genome}" target="_blank">${
-						ssm_url.linkText
-					}</a>`
-				)
-			} else {
-				if (ssm_url.namekey in m)
-					htmls.push(`<a href="${ssm_url.base}${m[ssm_url.namekey]}" target="_blank">${ssm_url.linkText}</a>`)
+			if (ssm_url.namekey == 'regulomedb') {
+				// this key corresponds to hardcoded logic to build regulomedb link with special requirements that also include genome
+				if (typeof m.chr == 'string' && Number.isInteger(m.pos)) {
+					const coord = `${m.chr}%3A${m.pos}-${m.pos + 1}`
+					separateUrls.push(
+						`<a href="${ssm_url.base}regions=${coord}&genome=${genome == 'hg38' ? 'GRCh38' : genome}" target="_blank">${
+							ssm_url.linkText
+						}</a>`
+					)
+				}
+				continue
 			}
+			makeGeneralLink(ssm_url, m, variantNameDom, separateUrls)
 		}
-		return htmls
 	} else {
-		// ssm_urls is object
-		const ssm_url = ssm_urls
-		if (ssm_url.namekey in m) return `<a href="${ssm_url.base}${m[ssm_url.namekey]}" target="_blank"></a>`
+		makeGeneralLink(ssm_urls, m, variantNameDom, separateUrls)
 	}
+	return separateUrls
+}
+
+function makeGeneralLink(ssm_url: UrlTemplateSsm, m: object, variantNameDom: any, separateUrls: string[]) {
+	const mValue = m[ssm_url.namekey]
+	if (mValue == undefined) return // m{} does not have valid value which is required to compose a url. do not make
+
+	const url = ssm_url.base + mValue
+
+	if (ssm_url.shownSeparately) {
+		// to generate a link separate from variantNameDom
+		separateUrls.push(`<a href="${url}" target="_blank">${ssm_url.linkText || mValue}</a>`)
+		return
+	}
+	// not showing separately
+	variantNameDom.html(`<a href="${url}" target="_blank">${variantNameDom.html()}</a>`)
 }

--- a/client/dom/ssmLink.ts
+++ b/client/dom/ssmLink.ts
@@ -1,0 +1,33 @@
+/*
+Make html links from ssm (simple somatic mutation) urls
+
+Arguments:
+    - ssm_urls: ssm url(s) specified in dataset file, can be either array or object
+    - m: m element from snp.mlst
+
+Returns: array of html links (if ssm_urls is array) or html string (if ssm_urls is object)
+*/
+export function makeSsmLink(ssm_urls: object | object[], m: object, genome: string) {
+	if (Array.isArray(ssm_urls)) {
+		// ssm_urls is array
+		const htmls = []
+		if (m.vcf_id) {
+			const dbsnp_url = ssm_urls.find(url => url.namekey == 'vcf_id')
+			if (dbsnp_url) htmls.push(`<a href="${dbsnp_url.base}${m.vcf_id}" target="_blank">${dbsnp_url.linkText}</a>`)
+		}
+		const regulome_url = ssm_urls.find(url => url.namekey == 'chr:pos')
+		if (regulome_url) {
+			const coord = `${m.chr}%3A${m.pos}-${m.pos + 1}`
+			htmls.push(
+				`<a href="${regulome_url.base}regions=${coord}&genome=${
+					genome == 'hg38' ? 'GRCh38' : genome
+				}" target="_blank">${regulome_url.linkText}</a>`
+			)
+		}
+		return htmls
+	} else {
+		// ssm_urls is object
+		const ssm_url = ssm_urls
+		if (ssm_url.namekey in m) return `<a href="${ssm_url.base}${m[ssm_url.namekey]}" target="_blank"></a>`
+	}
+}

--- a/client/dom/ssmLink.ts
+++ b/client/dom/ssmLink.ts
@@ -1,3 +1,5 @@
+import { UrlTemplateSsm } from '#shared/types/dataset.ts'
+
 /*
 Make html links from ssm (simple somatic mutation) urls
 
@@ -7,22 +9,22 @@ Arguments:
 
 Returns: array of html links (if ssm_urls is array) or html string (if ssm_urls is object)
 */
-export function makeSsmLink(ssm_urls: object | object[], m: object, genome: string) {
+export function makeSsmLink(ssm_urls: UrlTemplateSsm | UrlTemplateSsm[], m: object, genome: string) {
 	if (Array.isArray(ssm_urls)) {
 		// ssm_urls is array
 		const htmls = []
-		if (m.vcf_id) {
-			const dbsnp_url = ssm_urls.find(url => url.namekey == 'vcf_id')
-			if (dbsnp_url) htmls.push(`<a href="${dbsnp_url.base}${m.vcf_id}" target="_blank">${dbsnp_url.linkText}</a>`)
-		}
-		const regulome_url = ssm_urls.find(url => url.namekey == 'chr:pos')
-		if (regulome_url) {
-			const coord = `${m.chr}%3A${m.pos}-${m.pos + 1}`
-			htmls.push(
-				`<a href="${regulome_url.base}regions=${coord}&genome=${
-					genome == 'hg38' ? 'GRCh38' : genome
-				}" target="_blank">${regulome_url.linkText}</a>`
-			)
+		for (const ssm_url of ssm_urls) {
+			if (ssm_url.namekey == 'chr:pos') {
+				const coord = `${m.chr}%3A${m.pos}-${m.pos + 1}`
+				htmls.push(
+					`<a href="${ssm_url.base}regions=${coord}&genome=${genome == 'hg38' ? 'GRCh38' : genome}" target="_blank">${
+						ssm_url.linkText
+					}</a>`
+				)
+			} else {
+				if (ssm_url.namekey in m)
+					htmls.push(`<a href="${ssm_url.base}${m[ssm_url.namekey]}" target="_blank">${ssm_url.linkText}</a>`)
+			}
 		}
 		return htmls
 	} else {

--- a/client/mds3/itemtable.js
+++ b/client/mds3/itemtable.js
@@ -429,21 +429,18 @@ function print_mname(div, m) {
 }
 
 export function print_snv(holder, m, tk, block) {
-	let snv_label = `${m.chr}:${m.pos + 1} ${m.ref && m.alt ? m.ref + '>' + m.alt : ''}`
-	if (m.vcf_id) snv_label += `&nbsp;&#65372;&nbsp;${m.vcf_id}`
-	const ssm = tk.mds.termdbConfig?.urlTemplates?.ssm || tk.mds.queries?.snvindel?.ssmUrl // ssm url definition can come from two places
-	if (ssm) {
-		const ssm_htmls = makeSsmLink(ssm, m, block.genome.name)
-		if (ssm_htmls) {
-			if (Array.isArray(ssm_htmls)) {
-				snv_label += `&nbsp;(${ssm_htmls.join(', ')})`
-			} else {
-				const ssm_html = ssm_htmls
-				snv_label = ssm_html.replace('</a>', `${snv_label}</a>`)
-			}
+	// first print snv name. ref/alt may be missing if data is non-mutation
+	// later its html may be rewritten with a link
+	const ssmNameDom = holder.append('span').text(`${m.chr}:${m.pos + 1} ${m.ref && m.alt ? m.ref + '>' + m.alt : ''}`)
+
+	// ssm url definition can come from two places! see type def
+	const urlConfig = tk.mds.termdbConfig?.urlTemplates?.ssm || tk.mds.queries?.snvindel?.ssmUrl
+	if (urlConfig) {
+		const separateUrls = makeSsmLink(urlConfig, m, ssmNameDom, block.genome.name)
+		if (separateUrls?.length) {
+			holder.append('span').style('margin-left', '10px').html(separateUrls.join(' '))
 		}
 	}
-	holder.html(snv_label)
 }
 
 // function is not used

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -214,7 +214,7 @@ async function make_singleSampleTable(s, arg) {
 				if (m) {
 					// found m object by id, can make a better display
 					if (m.dt == 1) {
-						print_snv(td, m, arg.tk)
+						print_snv(td, m, arg.tk, arg.block)
 					} else if (m.dt == 2 || m.dt == 5) {
 						printSvPair(m.pairlst[0], td)
 					} else {

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -195,7 +195,8 @@ type SnvIndelQuery = {
 	format?: SnvIndelFormat
 	variant_filter?: VariantFilter
 	populations?: Population[]
-	/** this definition can appear either in queries.snvindel{} or termdb{}
+	/** NOTE **
+	this definition can appear either in queries.snvindel{} or termdb{}
 	so that it can work for a termdb-less ds, e.g. clinvar, where termdbConfig cannot be made */
 	ssmUrl?: UrlTemplateSsm
 }
@@ -555,7 +556,8 @@ export type UrlTemplateSsm = UrlTemplateBase & {
 	/** to create separate link, but not directly on chr.pos.ref.alt string.
 	name of link is determined by either namekey or linkText. former allows to retrieve a name per m that's different from chr.pos.xx */
 	shownSeparately?: true
-	/** optional name of link, same name will be used for all links. e.g. "ClinVar" */
+	/** optional name of link, if set, same name will be used for all links. e.g. "ClinVar".
+	if missing, name is value of m[url.namekey], as used in url itself (e.g. snp rsid) */
 	linkText?: string
 }
 

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -551,7 +551,7 @@ type UrlTemplateBase = {
 	namekey: string
 	defaultText?: string
 }
-type UrlTemplateSsm = UrlTemplateBase & {
+export type UrlTemplateSsm = UrlTemplateBase & {
 	/** to create separate link, but not directly on chr.pos.ref.alt string.
 	name of link is determined by either namekey or linkText. former allows to retrieve a name per m that's different from chr.pos.xx */
 	shownSeparately?: true

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -597,7 +597,7 @@ type Termdb = {
 	urlTemplates?: {
 		gene?: UrlTemplateBase // gene link definition
 		sample?: UrlTemplateBase // sample link definition
-		ssm?: UrlTemplateSsm // ssm link definition
+		ssm?: UrlTemplateSsm | UrlTemplateSsm[] // ssm link definition
 	}
 
 	//GDC

--- a/server/src/termdb.snp.js
+++ b/server/src/termdb.snp.js
@@ -456,12 +456,10 @@ async function validateInputCreateCache_by_coord(q, ds, genome) {
 			const altAlleles = l[3].split(',')
 
 			// if valid vcf ID is avaialble, use it since it should be snp rsid
-			const dbsnp = vcfId && vcfId != '.' ? vcfId : null
-			const snpid = dbsnp || pos + '.' + refAllele + '.' + altAlleles.join(',')
+			const snpid = vcfId && vcfId != '.' ? vcfId : pos + '.' + refAllele + '.' + altAlleles.join(',')
 
 			const variant = {
 				snpid,
-				dbsnp,
 				chr: q.chr,
 				pos
 			}


### PR DESCRIPTION
## Description

Instead of hardcoding snp-related links (e.g., dbSNP, RegulomeDB) in the pp code, this PR moves these links to the dataset file. Needed to convert `urlTemplates.ssm` in the sjlife dataset file to an array to specify both dbsnp and regulomedb urls (see associated sjpp PR: https://github.com/stjude/sjpp/pull/299). PP code can now handle `urlTemplates.ssm` as either an array or object.

Can test by opening the following examples and seeing how the snp-related links are rendered:
- Regression results: open this [example](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22LV_Ejection_Fraction_3D%22},%22independent%22:[{%22id%22:%22sex%22,%22refGrp%22:%222%22},{%22term%22:{%22type%22:%22snplocus%22},%22q%22:{%22chr%22:%22chr17%22,%22start%22:7664218,%22stop%22:7671018,%22AFcutoff%22:5,%22alleleType%22:0,%22geneticModel%22:0,%22restrictAncestry%22:{%22name%22:%22European%20ancestry%22,%22tvs%22:{%22term%22:{%22id%22:%22genetic_race%22,%22type%22:%22categorical%22,%22name%22:%22Genetically%20defined%20race%22},%22values%22:[{%22key%22:%22European%20Ancestry%22,%22label%22:%22European%20Ancestry%22}]}},%22variant_filter%22:{%22type%22:%22tvslst%22,%22join%22:%22and%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22Bad%22,%22key%22:%22Bad%22}],%22term%22:{%22id%22:%22QC%22,%22name%22:%22Classification%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22,%22values%22:{%22Good%22:{%22label%22:%22Good%22,%22key%22:%22Good%22},%22Bad%22:{%22label%22:%22Bad%22,%22key%22:%22Bad%22}}}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22SJcontrol_CR%22,%22name%22:%22SJLIFE%20control%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR%22,%22name%22:%22Call%20rate,%20SJLIFE+CCSS%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_sjlife%22,%22name%22:%22SJLIFE%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_ccss%22,%22name%22:%22CCSS%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22yes%22,%22key%22:%221%22}],%22term%22:{%22id%22:%22Polymer_region%22,%22name%22:%22Polymer%20region%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22}}}]}}}]}]}) and click on any variant.
- SJLIFE genome browser: open this [example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22chr%22:%22chr10%22,%22start%22:61901683,%22stop%22:62096944}}]}) and click on any variant.
- GDC genome browser: open this [example](http://localhost:3000/?genome=hg38&block=1&position=chr2:208248128-208248783&mds3=GDC) and click on any variant




## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
