### PR TITLE
Fixed hardclip rendering, undeleted boxes when group is deleted

### DIFF
--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -753,7 +753,6 @@ function setTkHeight(tk) {
 
 	let var_idx = 0
 	for (const g of tk.groups) {
-		//console.log('tk.dom.variantg:', tk.dom.variantg)
 		if (g.data.type.includes('support_alt')) {
 			g.variantg.attr('transform', 'translate(0,' + h + ')')
 			h += tk.dom.variantrowheight + tk.dom.variantrowbottompad
@@ -908,6 +907,8 @@ function deleteGroupDom(g) {
 	g.dom.diff_score_barplot_partstack?.remove()
 	g.dom.read_names_g?.remove()
 	g.dom.leftg.remove()
+	g.dom.box_stay?.remove()
+	g.dom.box_move?.remove()
 	g.dom.rightg.remove()
 }
 

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -2271,9 +2271,12 @@ async function getReadInfo(tk, block, box, ridx) {
 					chrom: tk.variants[0].chr,
 					ref_positions: tk.variants.ref_positions,
 					refalleles: tk.variants.refalleles,
-					altalleles: tk.variants.altalleles
+					altalleles: tk.variants.altalleles,
+					start: box.start,
+					stop: box.stop,
+					paired: tk.asPaired
 			  }
-			: {}
+			: { start: box.start, stop: box.stop, paired: tk.asPaired }
 	)
 	const data = await dofetch3('tkbam', param)
 	if (data.error) {

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -40,7 +40,7 @@ tk.pileupheight
 tk.pileupbottompad
 tk.alleleAlreadyUpdated // When true (in case of pan/zoom by user) prevents repeated reference genome queries for alt/refallele and left/rightflankseq
 tk.drop_pcrduplicates // By default, hides PCR duplicates. Can be changed to show PCR duplicates from config panel
-tk.supplementary_alignments // By default, hides supplementary alignments. Can be changed to show supplementary alignments from config panel
+tk.drop_supplementary_alignments // By default, hides supplementary alignments. Can be changed to show supplementary alignments from config panel
 tk.show_readnames // Shows read names when this flag is true. By default, read names are hidden
 
 tk.dom{}
@@ -294,7 +294,7 @@ async function getData(tk, block, additional = {}) {
 	if (tk.indexURL) body.indexURL = tk.indexURL
 
 	if (tk.drop_pcrduplicates) body.drop_pcrduplicates = 1
-	if (tk.supplementary_alignments) body.supplementary_alignments = 1
+	if (tk.drop_supplementary_alignments) body.drop_supplementary_alignments = 1
 	if (window.devicePixelRatio > 1) body.devicePixelRatio = window.devicePixelRatio
 
 	const data = await dofetch3('tkbam', { headers: getHeaders(tk), body })
@@ -924,9 +924,9 @@ function makeTk(tk, block) {
 		// attribute is not set, set to true by default
 		tk.drop_pcrduplicates = true
 	}
-	if (tk.supplementary_alignments == undefined) {
+	if (tk.drop_supplementary_alignments == undefined) {
 		// attribute is not set, set to true by default
-		tk.supplementary_alignments = true
+		tk.drop_supplementary_alignments = true
 	}
 
 	if (tk.show_readnames == undefined) {
@@ -1574,7 +1574,7 @@ async function align_reads_to_allele(tk, group, block) {
 	if (tk.asPaired) body.asPaired = 1
 	if ('nochr' in tk) body.nochr = tk.nochr
 	if (tk.drop_pcrduplicates) body.drop_pcrduplicates = 1
-	if (tk.supplementary_alignments) body.supplementary_alignments = 1
+	if (tk.drop_supplementary_alignments) body.drop_supplementary_alignments = 1
 	if (group.partstack) {
 		body.stackstart = group.partstack.start
 		body.stackstop = group.partstack.stop
@@ -1629,10 +1629,10 @@ function configPanel(tk, block) {
 		make_one_checkbox({
 			holder: d.append('div'),
 			labeltext: 'Drop supplementary alignments',
-			checked: tk.supplementary_alignments,
+			checked: tk.drop_supplementary_alignments,
 			divstyle: { display: 'block', margin: '10px 5px', height: '10px', 'margin-left': '6.5px' },
 			callback: () => {
-				tk.supplementary_alignments = !tk.supplementary_alignments
+				tk.drop_supplementary_alignments = !tk.drop_supplementary_alignments
 				loadTk(tk, block)
 			}
 		})

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -40,6 +40,7 @@ tk.pileupheight
 tk.pileupbottompad
 tk.alleleAlreadyUpdated // When true (in case of pan/zoom by user) prevents repeated reference genome queries for alt/refallele and left/rightflankseq
 tk.drop_pcrduplicates // By default, hides PCR duplicates. Can be changed to show PCR duplicates from config panel
+tk.supplementary_alignments // By default, hides supplementary alignments. Can be changed to show supplementary alignments from config panel
 tk.show_readnames // Shows read names when this flag is true. By default, read names are hidden
 
 tk.dom{}
@@ -293,6 +294,7 @@ async function getData(tk, block, additional = {}) {
 	if (tk.indexURL) body.indexURL = tk.indexURL
 
 	if (tk.drop_pcrduplicates) body.drop_pcrduplicates = 1
+	if (tk.supplementary_alignments) body.supplementary_alignments = 1
 	if (window.devicePixelRatio > 1) body.devicePixelRatio = window.devicePixelRatio
 
 	const data = await dofetch3('tkbam', { headers: getHeaders(tk), body })
@@ -919,6 +921,10 @@ function makeTk(tk, block) {
 	if (tk.drop_pcrduplicates == undefined) {
 		// attribute is not set, set to true by default
 		tk.drop_pcrduplicates = true
+	}
+	if (tk.supplementary_alignments == undefined) {
+		// attribute is not set, set to true by default
+		tk.supplementary_alignments = true
 	}
 
 	if (tk.show_readnames == undefined) {
@@ -1566,6 +1572,7 @@ async function align_reads_to_allele(tk, group, block) {
 	if (tk.asPaired) body.asPaired = 1
 	if ('nochr' in tk) body.nochr = tk.nochr
 	if (tk.drop_pcrduplicates) body.drop_pcrduplicates = 1
+	if (tk.supplementary_alignments) body.supplementary_alignments = 1
 	if (group.partstack) {
 		body.stackstart = group.partstack.start
 		body.stackstop = group.partstack.stop
@@ -1612,6 +1619,18 @@ function configPanel(tk, block) {
 			divstyle: { display: 'block', margin: '10px 5px', height: '10px', 'margin-left': '6.5px' },
 			callback: () => {
 				tk.drop_pcrduplicates = !tk.drop_pcrduplicates
+				loadTk(tk, block)
+			}
+		})
+	}
+	{
+		make_one_checkbox({
+			holder: d.append('div'),
+			labeltext: 'Drop supplementary alignments',
+			checked: tk.supplementary_alignments,
+			divstyle: { display: 'block', margin: '10px 5px', height: '10px', 'margin-left': '6.5px' },
+			callback: () => {
+				tk.supplementary_alignments = !tk.supplementary_alignments
 				loadTk(tk, block)
 			}
 		})

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -606,6 +606,7 @@ function may_render_variant(data, tk, block) {
 			var_idx += 1
 		}
 	}
+
 	if (tk.variants.length == 1) {
 		// Rendering FS score
 		tk.fs_string.text('FS = ' + data.strand_probability)
@@ -747,7 +748,7 @@ function setTkHeight(tk) {
 		tk.dom.variantg.attr('transform', 'translate(0,' + h + ')')
 	}
 	if (tk.dom.alleleSimilarityHeaderG) {
-		tk.dom.alleleSimilarityHeaderG.attr('transform', 'translate(0,' + h + ')')
+		tk.dom.alleleSimilarityHeaderG.attr('transform', 'translate(0,' + (tk.pileupheight - tk.pileupbottompad * 2) + ')')
 	}
 
 	let var_idx = 0

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -3119,6 +3119,7 @@ async function query_oneread(req, r) {
 			const s = parse_one_segment({ sam_info: line, keepallboxes: true, keepmatepos: true, keepunmappedread: true }, r)
 			if (!s) return
 			else if (req.query.show_unmapped && s.discord_unmapped2) return // Make sure the read being parse is mapped, especially in cases where the umapped mate is missing
+			if ((req.query.start != s.segstart_original || req.query.stop != s.segstop) && req.query.paired == 'false') return
 			if (req.query.show_unmapped && req.query.getfirst) {
 				// In case first read is mapped and second unmapped
 				if (s.islast) {

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -765,6 +765,10 @@ async function get_q(genome, req) {
 	if (req.query.drop_pcrduplicates) {
 		q.drop_pcrduplicates = true
 	}
+	if (req.query.supplementary_alignments) {
+		q.supplementary_alignments = true
+	}
+
 	if (req.query.variant) {
 		q.diff_score_plotwidth = Number(req.query.diff_score_plotwidth)
 		if (req.query.max_diff_score) {
@@ -1414,6 +1418,10 @@ async function query_region(r, q) {
 			if (flag & 0x400 && q.drop_pcrduplicates) {
 				return
 			}
+			// Show/Hide secondary alignments
+			if (flag & 0x800 && q.supplementary_alignments) {
+				return
+			}
 			if (q.downsample) {
 				// apply downsampling based on the ratio specified in .keep and .skip
 				const d = q.downsample
@@ -1463,6 +1471,10 @@ async function run_samtools_depth(q, r) {
 	if (q.drop_pcrduplicates) {
 		args.push('-G')
 		args.push('0x400')
+	}
+	if (q.supplementary_alignments) {
+		args.push('-G')
+		args.push('0x800')
 	}
 	await utils.get_lines_bigfile({
 		isbam: true,

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -765,8 +765,8 @@ async function get_q(genome, req) {
 	if (req.query.drop_pcrduplicates) {
 		q.drop_pcrduplicates = true
 	}
-	if (req.query.supplementary_alignments) {
-		q.supplementary_alignments = true
+	if (req.query.drop_supplementary_alignments) {
+		q.drop_supplementary_alignments = true
 	}
 
 	if (req.query.variant) {
@@ -1419,7 +1419,7 @@ async function query_region(r, q) {
 				return
 			}
 			// Show/Hide secondary alignments
-			if (flag & 0x800 && q.supplementary_alignments) {
+			if (flag & 0x800 && q.drop_supplementary_alignments) {
 				return
 			}
 			if (q.downsample) {
@@ -1472,7 +1472,7 @@ async function run_samtools_depth(q, r) {
 		args.push('-G')
 		args.push('0x400')
 	}
-	if (q.supplementary_alignments) {
+	if (q.drop_supplementary_alignments) {
 		args.push('-G')
 		args.push('0x800')
 	}
@@ -1875,7 +1875,7 @@ function parse_one_segment(arg, r, q) {
 				}
 				if (segment.boxes.length == 0) {
 					// this is the first box, will not consume ref
-					// shift softclip start to left, so its end will be pos, will not increment pos
+					// shift hardclip start to left, so its end will be pos, will not increment pos
 					b.start -= len
 					b.cidx = 0
 					if (keepallboxes || Math.max(pos, r.start) <= Math.min(pos + len - 1, r.stop)) {
@@ -1891,7 +1891,7 @@ function parse_one_segment(arg, r, q) {
 			}
 			if (cigar == 'N') {
 				// no seq
-			} else if (cigar == 'P' || cigar == 'D' || cigar == 'H') {
+			} else if (cigar == 'P' || cigar == 'D') {
 				// padding or del, no sequence in read
 			} else {
 				// will consume read seq


### PR DESCRIPTION
## Description
1) Fixed issue of rendering of hard clipped reads.
2) Pushed "Allele similarity" label upwards when alt allele is at the bottom of the page.
3) Deleted boxes in a group, when the group itself is being deleted.
4) Implemented filtering of supplementary alignment reads from UI (like how its implemented for PCR/optical duplicates).


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
