### PR TITLE
mds3 CI and non-CI tests are now 199 combined

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -22,7 +22,7 @@ export type Button = {
 	disabled?: (index: number) => boolean
 	button: any
 	onChange?: (idx: number[], button: any) => void //Called when selecting rows, it would update the button text
-	class?: string //to customize button style
+	class?: string //to customize button style or to assist detection in testing
 }
 
 export type TableArgs = {
@@ -277,17 +277,17 @@ export function renderTable({
 			.style('float', 'right')
 			.style('padding-bottom', '5px')
 
-		for (const button of buttons) {
-			button.button = footerDiv
+		for (const bCfg of buttons) {
+			bCfg.button = footerDiv
 				.append('button')
-				.text(button.text)
+				.text(bCfg.text)
 				.style('margin', '10px 10px 0 0')
 				.on('click', e => {
-					button.callback(getCheckedRowIndex(), button.button.node())
+					bCfg.callback(getCheckedRowIndex(), bCfg.button.node())
 				})
-			if (button.class) button.button.attr('class', button.class)
+			if (bCfg.class) bCfg.button.attr('class', bCfg.class)
 			//else button.button.attr('class', 'sjpp_apply_btn')
-			button.button.node().disabled = selectedRows.length == 0 && !selectAll
+			bCfg.button.node().disabled = selectedRows.length == 0 && !selectAll
 		}
 
 		// call function to update buttons with .onChange(), so their text can reflect default checkbox selection

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -376,7 +376,7 @@ function menu_listSamples(buttonrow, data, tk, block) {
 	buttonrow
 		.append('div')
 		.text(`List ${data.sampleTotalNumber} sample${data.sampleTotalNumber > 1 ? 's' : ''}`)
-		.attr('class', 'sja_menuoption')
+		.attr('class', 'sja_menuoption sja_mds3_slb_sampletablebtn')
 		.on('click', async () => {
 			tk.menutip.clear()
 			const wait = tk.menutip.d.append('div').text('Loading...').style('margin', '15px')

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -131,6 +131,7 @@ export async function displaySampleTable(samples, args) {
 		params.buttons = [
 			{
 				text: args.tk.allow2selectSamples.buttonText,
+				class: args.tk.allow2selectSamples.class,
 				callback: sampleIdxLst => {
 					// argument is list of array index of selected samples
 					feedSample2selectCallback(args.tk, args.block, samples, sampleIdxLst)
@@ -280,7 +281,7 @@ function printSampleName(sample, tk, div, block, thisMutation) {
 	if (tk.allow2selectSamples) {
 		// display button for selecting this sample alone
 		const t = tk.allow2selectSamples.buttonText
-		extraRow
+		const btn = extraRow
 			.append('button')
 			.style('margin-right', '10px')
 			.text(t.endsWith('s') ? t.substring(0, t.length - 1) : t)
@@ -289,6 +290,7 @@ function printSampleName(sample, tk, div, block, thisMutation) {
 				tk.itemtip.hide()
 				tk.menutip.hide()
 			})
+		if (tk.allow2selectSamples.class) btn.attr('class', tk.allow2selectSamples.class)
 	}
 
 	if (tk.mds.queries?.singleSampleMutation) {

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -405,7 +405,7 @@ export async function testVariantLeftLabel(test, tk, bb) {
 	}
 }
 
-tape.only('Official - allow2selectSamples', test => {
+tape('Official - allow2selectSamples', test => {
 	testAllow2selectSamples('hg38-test', 'tp53', 'TermdbTest', test)
 })
 
@@ -414,7 +414,8 @@ export async function testAllow2selectSamples(genome, gene, dslabel, test) {
 must use a gene with both single and multi occurrence mutations to test
 */
 	const holder = getHolder()
-	const buttonText = 'SElect sample'
+	const buttonText = 'SElect SAmple'
+	const buttonClass = 'testclassabc'
 	runproteinpaint({
 		holder,
 		genome,
@@ -426,6 +427,7 @@ must use a gene with both single and multi occurrence mutations to test
 				callbackOnRender,
 				allow2selectSamples: {
 					buttonText, // hardcoded text should show in selection button
+					class: buttonClass,
 					callback: () => {} // TODO figure out a way to verify callback is called by clicking button
 				}
 			}
@@ -440,9 +442,8 @@ must use a gene with both single and multi occurrence mutations to test
 		singletonMutationDisc.dispatchEvent(new Event('click'))
 		await whenVisible(tk.itemtip.d)
 		{
-			//const buttons = tk.itemtip.d.selectAll('button').nodes()
-			const buttons = await detectGte({ elem: tk.itemtip.d.node(), selector: 'button', count: 1 })
-			test.equal(buttons[0].innerHTML, buttonText, '1st button in single-sample menu shows buttonText')
+			const button = await detectOne({ elem: tk.itemtip.dnode, selector: '.' + buttonClass })
+			test.equal(button.innerHTML, buttonText, buttonText + ' button created in single-sample menu')
 			// TODO trigger click on selection button
 		}
 
@@ -454,9 +455,9 @@ must use a gene with both single and multi occurrence mutations to test
 		multiMutationDisc.dispatchEvent(new Event('click'))
 		await whenVisible(tk.itemtip.d)
 		{
-			const buttons = tk.itemtip.d.selectAll('button').nodes()
-			test.equal(buttons[buttons.length - 1].innerHTML, buttonText, 'last button in multi-sample menu shows buttonText')
-			test.ok(buttons[buttons.length - 1].disabled, 'button is also disabled (when no checkbox is checked)')
+			const button = await detectOne({ elem: tk.itemtip.dnode, selector: '.' + buttonClass, maxTime: 10000 })
+			test.equal(button.innerHTML, buttonText, buttonText + ' button created in multi-sample menu')
+			test.ok(button.disabled, 'button is also disabled (when no checkbox is checked)')
 			// must check one checkbox first to
 		}
 
@@ -466,10 +467,9 @@ must use a gene with both single and multi occurrence mutations to test
 		{
 			const btn = await detectOne({ elem: tk.menutip.dnode, selector: '.sja_mds3_slb_sampletablebtn' })
 			btn.dispatchEvent(new Event('click'))
-			await detectOne({ elem: tk.menutip.dnode, selector: 'table' }) // wait when table is shown
-			const buttons = tk.menutip.d.selectAll('button').nodes()
-			test.equal(buttons[buttons.length - 1].innerHTML, buttonText, 'last button in sample table shows buttonText')
-			test.ok(buttons[buttons.length - 1].disabled, 'button is also disabled (when no checkbox is checked)')
+			const button = await detectOne({ elem: tk.menutip.dnode, selector: '.' + buttonClass, maxTime: 10000 })
+			test.equal(button.innerHTML, buttonText, buttonText + ' button is created in leftlabel sample table')
+			test.ok(button.disabled, 'button is also disabled (when no checkbox is checked)')
 		}
 		if (test._ok) {
 			tk.menutip.d.remove()

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -14,7 +14,7 @@ Official - Collapse and expand mutations from variant link
 Incorrect dslabel
 TP53 custom data, no sample
 Custom variants, missing or invalid mclass
-Custom dataset with custom variants, WITH samples
+Custom variants WITH samples
 Custom data with samples and sample selection
 Numeric mode custom dataset, with mode change
 
@@ -73,12 +73,16 @@ export async function findSingletonMutationTestDiscoCnvPlots(test, tk, holder) {
 	test.pass('itemtip shows with variant table')
 
 	/* surprise
-	in mbmeta, as soon as itemtip.d is shown, buttons are already created; calling detectLst() will timeout
+	in termdbtest, as soon as itemtip.d is shown, buttons are already created; calling detectLst() will timeout
 	in gdc, there's a delay (api request) for buttons to be shown after itemtip, thus must use detectLst
 	*/
 	let buttons = tk.itemtip.d.selectAll('button').nodes()
 	if (buttons.length == 0) {
-		buttons = await detectGte({ elem: tk.itemtip.d.node(), selector: 'button', count: 2 })
+		/* use count=1 to detect 1 or more buttons
+		gdc has 1 button (disco)
+		termdbtest has 2 buttons (disco, methy)
+		*/
+		buttons = await detectGte({ elem: tk.itemtip.d.node(), selector: 'button', count: 1 })
 	}
 	/* multiplt buttons can be shown, based on data availability
 	#1: disco
@@ -521,7 +525,7 @@ tape('Custom variants, missing or invalid mclass', test => {
 			{
 				type: 'mds3',
 				name: 'Missing or invalid class assignments',
-				custom_variants: custom_variants,
+				custom_variants,
 				callbackOnRender
 			}
 		]
@@ -544,7 +548,7 @@ tape('Custom variants, missing or invalid mclass', test => {
 	}
 })
 
-tape('Custom dataset with custom variants, WITH samples', test => {
+tape('Custom variants WITH samples', test => {
 	test.timeoutAfter(3000)
 	const holder = getHolder()
 
@@ -565,6 +569,7 @@ tape('Custom dataset with custom variants, WITH samples', test => {
 	})
 
 	async function callbackOnRender(tk, bb) {
+		test.ok(tk.leftlabels.doms.samples, 'tk.leftlabels.doms.samples is set')
 		const variantNum = new Set()
 		for (const variant of custom_variants) {
 			//Test all custom variant entries successfully passed to block instance

--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -5,7 +5,8 @@ const {
 	findSingletonMutationTestDiscoCnvPlots,
 	testMclassFiltering,
 	testSampleSummary2subtrack,
-	testVariantLeftLabel
+	testVariantLeftLabel,
+	testAllow2selectSamples
 } = require('./mds3.integration.spec')
 
 /**************
@@ -19,6 +20,7 @@ GDC - GENCODE gene ENSG00000133703
 GDC - RefSeq NM_005163
 GDC - KRAS SSM ID
 GDC - ssm by range
+GDC - allow2selectSamples
 geneSearch4GDCmds3
 
 GDC - gene hoxa1 - Disco button
@@ -181,6 +183,10 @@ tape('GDC - ssm by range', test => {
 		if (test._ok) holder.remove()
 		test.end()
 	}
+})
+
+tape('GDC - allow2selectSamples', test => {
+	testAllow2selectSamples('hg38', 'IDH1', 'GDC', test)
 })
 
 tape('geneSearch4GDCmds3', async test => {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -671,7 +671,7 @@ export class TermdbVocab extends Vocab {
     .samples{}
         [sample]{}
             sample: the sample ID
-            [$id]: { // $id is tw id, not term id
+            [$id]: {} // $id is tw id, not term id
 				key, value, // only used for dict term
 				values:[]
 					// used for non-dict term e.g. gene mutation


### PR DESCRIPTION
## Description
closes #1271 

portal code changes:
- clarify minor detail in table.ts
- add class name in mds3 to assist testing
- runpp({allow2selectSample}) can supply a button class that is rendered by table.ts for reliable detection (and eventually triggering)

previous disabled subtk filtering test are reenabled and passing

gdc api is slow and tests take a while. i increased `detectOne({maxTime})` to 10 seconds for some. if you noticed timeout we can continue to add maxTime

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
