### PR TITLE
fix: Bug fix for GDC mds3 category total sample count to respond/shri…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Bug fix for GDC mds3 category total sample count to respond/shrink with cohort change

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1907,7 +1907,7 @@ function termid2size_query(termlst) {
 	const query = `query termislst2total( $filters: FiltersArgument) {
 		explore {
 			cases {
-				aggregations (filters: $filters, aggregations_filter_themselves: true) {
+				aggregations (case_filters: $filters, aggregations_filter_themselves: true) {
 					${lst.join('\n')}
 				}
 			}


### PR DESCRIPTION
…nk with cohort change

## Description

closes #1306 
[test here](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.demographic.gender%22,%22name%22:%22Gender%22,%22isleaf%22:true,%22type%22:%22categorical%22,%22parent_id%22:%22case.demographic%22,%22included_types%22:[%22categorical%22],%22child_types%22:[],%22values%22:{%22female%22:{%22label%22:%22female%22,%22samplecount%22:115},%22male%22:{%22label%22:%22male%22,%22samplecount%22:49},%22not%20reported%22:{%22label%22:%22not%20reported%22,%22samplecount%22:1}},%22samplecount%22:{}},%22values%22:[{%22key%22:%22female%22}],%22isnot%22:true}}]}) filtering by non-female cases
click E17K. hover at the blue slice to see total of 2825 for Adenoma
<img width="297" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/648d3b08-de79-423b-ba45-41c39061d8aa">

incomparison, when not using filter, its total is 5258
<img width="150" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/ce1911bc-321a-48e8-95a9-0ee76e3fd1f1">

it should not affect any other gdc views, as `termid2totalsize2` mechanism is only used for lollipop

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
