### PR TITLE
make additional server middleware assumptions on URL param encoding

### DIFF
--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -52,8 +52,9 @@ jobs:
 
       - name: Run tsc
         run: |
-          cd server && npm run checkers && cd ..
+          cd server && npm run checkers # && cd .. # TODO: enable type check at proteinpaint root dir
           npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions
+          cd ..
 
       - name: Create server cache folder
         run: if [[ ! -d "server/cache" ]]; then mkdir server/cache; fi

--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -256,11 +256,33 @@ function mayAdjustRequest(url, init) {
 				params.push(`${key}=${encodeURIComponent(JSON.stringify(value))}`)
 			}
 		}
+		// NOTE: cannot assume that there are no query parameters in the url argument
+		// (first argument to this function), so those may also have to be parsed first
+		// before it is certain that all URL params are json-encoded
+		//
+		// // tentative transform of pre-supplied URL params
+		// url.split('?')[1]?.split("&").forEach(kv => {
+		// 	const [k, v] = kv.split("=")
+		//  let value
+		// 	try {
+		// 		const value = JSON.parse(v)
+		// 		// if the value can be json-parsed, then assume it is encoded
+		// 		params.push(`${k}=${v}`)
+		// 	} catch(e) {
+		// 		try {
+		// 			const v1 = decodeURIComponent(v)
+		// 			const v2 = JSON.parse(v1)
+		// 			params.push(`${k}=${v2}`)
+		// 		} catch(e) {
+		// 			params.push(`${k}=${v}`)
+		// 		}
+		// 	}
+		// })
+		//
+		// params.push('encoding=json')
 
 		if (!url.includes('?')) url += '?'
 		url += params.join('&')
-		// TODO: may use paramEncoding later to indicate all the other parameter values are json-encoded
-		//url += '&paramEncoding=json'
 	}
 
 	if (!url.includes('embedder=')) {
@@ -442,4 +464,8 @@ function mayAddJwtToRequest(init, body, url) {
 	const route = (h[1] || h[0]).split('/')[1].split('?')[0]
 	const jwt = jwtByDsRoute[dslabel][route] || jwtByDsRoute[dslabel]['/**']
 	if (jwt) init.headers.authorization = 'Bearer ' + btoa(jwt)
+}
+
+function isNumeric(d) {
+	return !isNaN(parseFloat(d)) && isFinite(d) && d !== ''
 }

--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -260,24 +260,24 @@ function mayAdjustRequest(url, init) {
 		// (first argument to this function), so those may also have to be parsed first
 		// before it is certain that all URL params are json-encoded
 		//
-		// // tentative transform of pre-supplied URL params
-		// url.split('?')[1]?.split("&").forEach(kv => {
-		// 	const [k, v] = kv.split("=")
-		//  let value
-		// 	try {
-		// 		const value = JSON.parse(v)
-		// 		// if the value can be json-parsed, then assume it is encoded
-		// 		params.push(`${k}=${v}`)
-		// 	} catch(e) {
+		// tentative transform of pre-supplied URL params
+		// const searchHash = url.split('?')[1] || ''
+		// if (searchHash) {
+		// 	// remove the location hash, then split into key-value params
+		// 	const query = searchHash.split('#')[0].split('&')
+		// 	for(const kv of query) {
+		// 		const [k, v] = kv.split("=")
+		// 	  let value = v
 		// 		try {
-		// 			const v1 = decodeURIComponent(v)
-		// 			const v2 = JSON.parse(v1)
-		// 			params.push(`${k}=${v2}`)
-		// 		} catch(e) {
+		// 			if (value.startsWith('%')) value = decodeURIComponent(v)
+		// 			value = JSON.parse(v)
+		// 			// if the value can be json-parsed, then assume it is encoded
 		// 			params.push(`${k}=${v}`)
+		// 		} catch(e) {
+		// 			params.push(`${k}=${value}`)
 		// 		}
 		// 	}
-		// })
+		// }
 		//
 		// params.push('encoding=json')
 
@@ -464,8 +464,4 @@ function mayAddJwtToRequest(init, body, url) {
 	const route = (h[1] || h[0]).split('/')[1].split('?')[0]
 	const jwt = jwtByDsRoute[dslabel][route] || jwtByDsRoute[dslabel]['/**']
 	if (jwt) init.headers.authorization = 'Bearer ' + btoa(jwt)
-}
-
-function isNumeric(d) {
-	return !isNaN(parseFloat(d)) && isFinite(d) && d !== ''
 }

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -466,7 +466,6 @@ export class TermdbVocab extends Vocab {
 		// for a numeric term, get descriptive statistics
 		// mean, median, standard deviation, min, max
 		const body = {
-			getdescrstats: 1,
 			tid: term_id,
 			genome: this.vocab.genome,
 			dslabel: this.vocab.dslabel,

--- a/server/.babelrc
+++ b/server/.babelrc
@@ -5,7 +5,7 @@
 			"@babel/preset-env", 
 			{
 				"targets": {
-					"node": "12"
+					"node": "16"
 				}
 			}
 		]

--- a/server/routes/termdb.getdescrstats.ts
+++ b/server/routes/termdb.getdescrstats.ts
@@ -1,11 +1,11 @@
 import { getdescrstatsRequest, getdescrstatsResponse } from '#shared/types/routes/termdb.getdescrstats.ts'
-import * as termdbsql from '../src/termdb.sql.js'
+import { get_rows_by_one_key } from '../src/termdb.sql.js'
 import Summarystats from '../shared/descriptive.stats.js'
 
 export const api: any = {
 	endpoint: 'termdb/descrstats',
 	methods: {
-		get: {
+		all: {
 			init,
 			request: {
 				typeId: 'getdescrstatsRequest'
@@ -20,7 +20,6 @@ export const api: any = {
 							genome: 'hg38-test',
 							dslabel: 'TermdbTest',
 							embedder: 'localhost',
-							getdescrstats: 1,
 							tid: 'hrtavg',
 							filter: {
 								type: 'tvslst',
@@ -51,10 +50,6 @@ export const api: any = {
 					}
 				}
 			]
-		},
-		post: {
-			alternativeFor: 'get',
-			init
 		}
 	}
 }
@@ -84,14 +79,14 @@ async function trigger_getdescrstats(q: any, res: any, ds: any) {
 	const term = ds.cohort.termdb.q.termjsonByOneid(q.tid)
 	if (!term) throw 'invalid termid'
 	if (term.type != 'float' && term.type != 'integer') throw 'not numerical term'
-	const rows = await termdbsql.get_rows_by_one_key({
+	const rows = await get_rows_by_one_key({
 		ds,
 		key: q.tid,
-		filter: q.filter ? (typeof q.filter == 'string' ? JSON.parse(q.filter) : q.filter) : null
+		filter: q.filter
 	})
 	const values: number[] = []
 	for (const { value } of rows) {
-		if (term.values && term.values[value] && term.values[value].uncomputable) {
+		if (term.values?.[value]?.uncomputable) {
 			// skip uncomputable values
 			continue
 		}

--- a/server/shared/test/urljson.unit.spec.js
+++ b/server/shared/test/urljson.unit.spec.js
@@ -1,0 +1,57 @@
+import tape from 'tape'
+import { encode, decode } from '../urljson'
+
+/*************************
+ reusable helper functions
+**************************/
+
+function preprocess(params) {
+	return Object.fromEntries(params.split('&').map(kv => kv.split('=').map(decodeURIComponent)))
+}
+
+/**************
+ test sections
+***************/
+
+// Test that the original values are recovered with the expected type
+
+tape('string values', test => {
+	const params = { a: 'abc', b: '123', c: '{}', d: '[]', e: 'false', f: 'true', g: 'null', h: 'undefined' }
+	const encodedParams = encode(structuredClone(params))
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode string values')
+	test.end()
+})
+
+tape('numeric values', test => {
+	const params = { a: 1, b: 0.99, c: 1e2 }
+	const encodedParams = encode(structuredClone(params))
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode numeric values')
+	test.end()
+})
+
+tape('boolean values', test => {
+	const params = { a: true, b: false }
+	const encodedParams = encode(structuredClone(params))
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode boolean values')
+	test.end()
+})
+
+tape('array values', test => {
+	const params = { a: ['xyz', 1, 0, true, false, null, 'null', undefined, { b: 5 }] }
+	const encodedParams = encode(structuredClone(params))
+	// Special handling of undefined value in an array, which JSON.stringify() converts to null
+	params.a[params.a.indexOf(undefined)] = null
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode array values')
+	test.end()
+})
+
+tape('object values', test => {
+	const params = { a: {}, b: { 1: 'test', nested: { x: 99 } }, c: ['xyz', true], d: undefined, e: null }
+	const encodedParams = encode(structuredClone(params))
+	// special handling of undefined value in an object, which JSON.stringify deletes from the object
+	for (const key in params) {
+		if (params[key] === undefined) delete params[key]
+	}
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode object values')
+	test.end()
+})

--- a/server/shared/test/urljson.unit.spec.ts
+++ b/server/shared/test/urljson.unit.spec.ts
@@ -54,7 +54,7 @@ tape('array values', test => {
 	const params: UrlJsonRaw = { a: ['xyz', 1, 0, true, false, null, 'null', undefined, { b: 5 }] }
 	const encodedParams = encode(structuredClone(params))
 	// Special handling of undefined value in an array, which JSON.stringify() converts to null
-	params.a[params.a.indexOf(undefined)] = null
+	if (params.a && Array.isArray(params.a)) params.a[params.a.indexOf(undefined)] = null
 	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correctly encode and decode array values')
 	test.end()
 })

--- a/server/shared/test/urljson.unit.spec.ts
+++ b/server/shared/test/urljson.unit.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { encode, decode, UrlJsonRaw, UrlJsonEncoded } from '../urljson'
+import { encode, decode, UrlJsonRaw, UrlJsonEncoded } from '../urljson.ts'
 
 /*************************
  reusable helper functions
@@ -8,6 +8,9 @@ import { encode, decode, UrlJsonRaw, UrlJsonEncoded } from '../urljson'
 function preprocess(params) {
 	return Object.fromEntries(params.split('&').map(kv => kv.split('=').map(decodeURIComponent)))
 }
+
+// this test may run on nodejs which does not have structuredClone, unlike the browser
+const structuredClone = /*window?.structuredClone ||*/ p => JSON.parse(JSON.stringify(p))
 
 /**************
  test sections
@@ -18,21 +21,32 @@ function preprocess(params) {
 tape('string values', test => {
 	const params: UrlJsonRaw = { a: 'abc', b: '123', c: '{}', d: '[]', e: 'false', f: 'true', g: 'null', h: 'undefined' }
 	const encodedParams = encode(structuredClone(params))
-	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode string values')
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correctly encode and decode string values')
 	test.end()
 })
 
 tape('numeric values', test => {
 	const params: UrlJsonRaw = { a: 1, b: 0.99, c: 1e2 }
 	const encodedParams = encode(structuredClone(params))
-	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode numeric values')
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correctly encode and decode numeric values')
 	test.end()
 })
 
 tape('boolean values', test => {
 	const params: UrlJsonRaw = { a: true, b: false }
 	const encodedParams = encode(structuredClone(params))
-	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode boolean values')
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correctly encode and decode boolean values')
+	test.end()
+})
+
+tape('empty values', test => {
+	const params: UrlJsonRaw = { a: null, b: undefined, c: 0 }
+	const encodedParams = encode(structuredClone(params))
+	test.deepEqual(
+		{ a: null, c: 0 },
+		decode(preprocess(encodedParams)),
+		'should correctly encode and decode boolean values'
+	)
 	test.end()
 })
 
@@ -41,7 +55,7 @@ tape('array values', test => {
 	const encodedParams = encode(structuredClone(params))
 	// Special handling of undefined value in an array, which JSON.stringify() converts to null
 	params.a[params.a.indexOf(undefined)] = null
-	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode array values')
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correctly encode and decode array values')
 	test.end()
 })
 
@@ -52,6 +66,6 @@ tape('object values', test => {
 	for (const key in params) {
 		if (params[key] === undefined) delete params[key]
 	}
-	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode object values')
+	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correctly encode and decode object values')
 	test.end()
 })

--- a/server/shared/test/urljson.unit.spec.ts
+++ b/server/shared/test/urljson.unit.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { encode, decode } from '../urljson'
+import { encode, decode, UrlJsonRaw, UrlJsonEncoded } from '../urljson'
 
 /*************************
  reusable helper functions
@@ -16,28 +16,28 @@ function preprocess(params) {
 // Test that the original values are recovered with the expected type
 
 tape('string values', test => {
-	const params = { a: 'abc', b: '123', c: '{}', d: '[]', e: 'false', f: 'true', g: 'null', h: 'undefined' }
+	const params: UrlJsonRaw = { a: 'abc', b: '123', c: '{}', d: '[]', e: 'false', f: 'true', g: 'null', h: 'undefined' }
 	const encodedParams = encode(structuredClone(params))
 	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode string values')
 	test.end()
 })
 
 tape('numeric values', test => {
-	const params = { a: 1, b: 0.99, c: 1e2 }
+	const params: UrlJsonRaw = { a: 1, b: 0.99, c: 1e2 }
 	const encodedParams = encode(structuredClone(params))
 	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode numeric values')
 	test.end()
 })
 
 tape('boolean values', test => {
-	const params = { a: true, b: false }
+	const params: UrlJsonRaw = { a: true, b: false }
 	const encodedParams = encode(structuredClone(params))
 	test.deepEqual(params, decode(preprocess(encodedParams)), 'should correct encode and decode boolean values')
 	test.end()
 })
 
 tape('array values', test => {
-	const params = { a: ['xyz', 1, 0, true, false, null, 'null', undefined, { b: 5 }] }
+	const params: UrlJsonRaw = { a: ['xyz', 1, 0, true, false, null, 'null', undefined, { b: 5 }] }
 	const encodedParams = encode(structuredClone(params))
 	// Special handling of undefined value in an array, which JSON.stringify() converts to null
 	params.a[params.a.indexOf(undefined)] = null
@@ -46,7 +46,7 @@ tape('array values', test => {
 })
 
 tape('object values', test => {
-	const params = { a: {}, b: { 1: 'test', nested: { x: 99 } }, c: ['xyz', true], d: undefined, e: null }
+	const params: UrlJsonRaw = { a: {}, b: { 1: 'test', nested: { x: 99 } }, c: ['xyz', true], d: undefined, e: null }
 	const encodedParams = encode(structuredClone(params))
 	// special handling of undefined value in an object, which JSON.stringify deletes from the object
 	for (const key in params) {

--- a/server/shared/types/routes/termdb.getdescrstats.ts
+++ b/server/shared/types/routes/termdb.getdescrstats.ts
@@ -6,7 +6,6 @@ export type getdescrstatsRequest = {
 	/** a user-defined dataset label in the serverconfig.json, such as ClinVar, SJLife, GDC, etc */
 	dslabel: string
 	embedder: string
-	getdescrstats: number
 	/** term id string */
 	tid: string
 	filter: Filter

--- a/server/shared/urljson.ts
+++ b/server/shared/urljson.ts
@@ -15,7 +15,7 @@
 
 // a URL query parameters object with values to be encoded
 export type UrlJsonRaw = {
-	[key: string]: boolean | string | number | { [key: string]: any } | any[] | null
+	[key: string]: any //boolean | string | number | any[] | null | undefined  //| { [key: string]: any }
 }
 
 // a URL query parameters object with values to be decoded
@@ -27,7 +27,7 @@ const reserved = ['false', 'true', 'null', 'undefined']
 const delimiters = ['"', '{', '[']
 
 export function encode(rawObject: UrlJsonRaw) {
-	const params = []
+	const params: any[] = []
 	for (const [key, value] of Object.entries(rawObject)) {
 		if (typeof value == 'string' && !isNumeric(value) && !reserved.includes(value) && !delimiters.includes(value[0])) {
 			// no need to json-encode a string before percent encoding
@@ -44,12 +44,12 @@ export function decode(query: UrlJsonEncoded) {
 	const encoding = query.encoding
 	for (const [key, value] of Object.entries(query)) {
 		//const value = query[key]
-		if (value == 'undefined') {
-			// maybe better to also detect this common error
-			console.warn(`${key}="undefined" value as a string URL query parameter`)
-			query[key] = undefined
-			continue
-		}
+		// if (value == 'undefined') {
+		// 	// maybe better to also detect this common error
+		// 	console.warn(`${key}="undefined" value as a string URL query parameter`)
+		// 	query[key] = undefined
+		// 	continue
+		// }
 		if (
 			encoding == 'json' ||
 			value == 'null' || // not new, always been

--- a/server/shared/urljson.ts
+++ b/server/shared/urljson.ts
@@ -15,7 +15,7 @@
 
 // a URL query parameters object with values to be encoded
 export type UrlJsonRaw = {
-	[key: string]: string | number | { [key: string]: any } | any[] | null
+	[key: string]: boolean | string | number | { [key: string]: any } | any[] | null
 }
 
 // a URL query parameters object with values to be decoded

--- a/server/shared/urljson.ts
+++ b/server/shared/urljson.ts
@@ -1,0 +1,71 @@
+/*
+	A custom encoder-decoder for URL query parameter values
+
+	All values are strings except for the following, which
+	will are assumed to be json-encoded:
+
+	- those that correspond to JSON reserved keywords: true, false, null
+	- numeric values using the isNumeric() function below
+	- values that are wrapped by "", {}, []
+
+	In addition, a URL-payload that includes an `encoding=urljson` parameter
+	will cause all query parameter values to be processed by the decode()
+	function below. 
+*/
+
+// a URL query parameters object with values to be encoded
+export type UrlJsonRaw = {
+	[key: string]: string | number | { [key: string]: any } | any[] | null
+}
+
+// a URL query parameters object with values to be decoded
+export type UrlJsonEncoded = {
+	[key: string]: string
+}
+
+const reserved = ['false', 'true', 'null', 'undefined']
+const delimiters = ['"', '{', '[']
+
+export function encode(rawObject: UrlJsonRaw) {
+	const params = []
+	for (const [key, value] of Object.entries(rawObject)) {
+		if (typeof value == 'string' && !isNumeric(value) && !reserved.includes(value) && !delimiters.includes(value[0])) {
+			// no need to json-encode a string before percent encoding
+			// if it doesn't contain reserved JSON wrapper/delimiters
+			params.push(`${key}=${encodeURIComponent(value)}`)
+		} else if (value !== undefined) {
+			params.push(`${key}=${encodeURIComponent(JSON.stringify(value))}`)
+		}
+	}
+	return params.join('&')
+}
+
+export function decode(query: UrlJsonEncoded) {
+	const encoding = query.encoding
+	for (const [key, value] of Object.entries(query)) {
+		//const value = query[key]
+		if (value == 'undefined') {
+			// maybe better to also detect this common error
+			console.warn(`${key}="undefined" value as a string URL query parameter`)
+			query[key] = undefined
+			continue
+		}
+		if (
+			encoding == 'json' ||
+			value == 'null' || // not new, always been
+			value == 'true' || // NEED TO FIND-REPLACE CODE THAT USES value == 'true'
+			value == 'false' || // NEED TO FIND-REPLACE CODE THAT USES value == 'false'
+			isNumeric(value) || // NEED TO check
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith('{') && value.endsWith('}')) ||
+			(value.startsWith('[') && value.endsWith(']'))
+		)
+			query[key] = JSON.parse(value)
+		// else the value is already a string
+	}
+	return query
+}
+
+function isNumeric(d) {
+	return !isNaN(parseFloat(d)) && isFinite(d) && d !== ''
+}

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -85,6 +85,8 @@ import cookieParser from 'cookie-parser'
 import { authApi } from './auth.js'
 import { server_init_db_queries, listDbTables } from './termdb.server.init'
 import { versionInfo } from './health'
+import { decode as urlJsonDecode } from '../shared/urljson'
+
 export * as phewas from './termdb.phewas'
 
 export const tabixnoterror = s => {
@@ -157,27 +159,7 @@ app.use((req, res, next) => {
 	// detect URL parameter values with matching JSON start-stop encoding characters
 	try {
 		const encoding = req.query.encoding
-		for (const key in req.query) {
-			const value = req.query[key]
-			if (value == 'undefined') {
-				// maybe better to also detect this common error
-				// console.warn(`${key}="undefined" value as a string URL query parameter`)
-				delete req.query[key]
-				continue
-			}
-			if (
-				encoding == 'json' ||
-				value == 'null' || // not new, always been
-				value == 'true' || // NEED TO FIND-REPLACE CODE THAT USES value == 'true'
-				value == 'false' || // NEED TO FIND-REPLACE CODE THAT USES value == 'false'
-				isNumeric(value) || // NEED TO check
-				(value.startsWith('"') && value.endsWith('"')) ||
-				(value.startsWith('{') && value.endsWith('}')) ||
-				(value.startsWith('[') && value.endsWith(']'))
-			)
-				req.query[key] = JSON.parse(value)
-			// else the value is already a string
-		}
+		urlJsonDecode(req.query)
 	} catch (e) {
 		res.send({ error: e })
 		return

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -3104,7 +3104,6 @@ async function route_getread(genome, req) {
 }
 
 async function query_oneread(req, r) {
-	console.log(req.query)
 	const [_file, dir] = await getFilefullpathOrUrl(req)
 	let firstseg, lastseg, readstart, readstop, lst // array of reads to be returned
 
@@ -3128,11 +3127,13 @@ async function query_oneread(req, r) {
 			if (line.split('\t')[0] != req.query.qname) return
 			const s = parse_one_segment({ sam_info: line, keepallboxes: true, keepmatepos: true, keepunmappedread: true }, r)
 			if (!s) return
-
 			if (req.query.show_unmapped && s.discord_unmapped2) return // Make sure the read being parse is mapped, especially in cases where the umapped mate is missing
-
-			if ((req.query.start != s.segstart_original || req.query.stop != s.segstop) && !req.query.paired) return
-
+			if (
+				(req.query.start != s.segstart_original || req.query.stop != s.segstop) &&
+				!req.query.paired &&
+				!req.query.show_unmapped
+			)
+				return
 			if (req.query.show_unmapped && req.query.getfirst) {
 				// In case first read is mapped and second unmapped
 				if (s.islast) {

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -3131,7 +3131,11 @@ async function query_oneread(req, r) {
 			const s = parse_one_segment({ sam_info: line, keepallboxes: true, keepmatepos: true, keepunmappedread: true }, r)
 			if (!s) return
 			else if (req.query.show_unmapped && s.discord_unmapped2) return // Make sure the read being parse is mapped, especially in cases where the umapped mate is missing
-			if ((req.query.start != s.segstart_original || req.query.stop != s.segstop) && req.query.paired == 'false') return
+			if (
+				(req.query.start != s.segstart_original || req.query.stop != s.segstop) &&
+				(!req.query.paired || req.query.paired == 'false')
+			)
+				return
 			if (req.query.show_unmapped && req.query.getfirst) {
 				// In case first read is mapped and second unmapped
 				if (s.islast) {

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -1,6 +1,5 @@
 import serverconfig from './serverconfig'
 import fs from 'fs'
-import path from 'path'
 import pkg from '../package.json'
 import { VersionInfo, GenomeBuildInfo, HealthCheckResponse } from '../shared/types/routes/healthcheck.js'
 

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -1,5 +1,6 @@
 import serverconfig from './serverconfig'
 import fs from 'fs'
+import path from 'path'
 import pkg from '../package.json'
 import { VersionInfo, GenomeBuildInfo, HealthCheckResponse } from '../shared/types/routes/healthcheck.js'
 
@@ -42,24 +43,28 @@ export async function getStat(genomes) {
 	return health
 }
 
-const sjcrh = `${process.cwd()}/node_modules/@sjcrh/proteinpaint`
-const serverPkg = JSON.parse(fs.readFileSync(`${sjcrh}-server/package.json`, { encoding: 'utf8' }))
-
 export const versionInfo: VersionInfo = {
 	pkgver: pkg.version,
 	codedate: get_codedate(),
 	launchdate: new Date(Date.now()).toString().split(' ').slice(0, 5).join(' '),
-	deps: {
-		'@sjcrh/proteinpaint-server': {
-			installed: serverPkg.version
-		}
+	deps: {}
+}
+
+// not  `${process.cwd()}/node_modules/@sjcrh/proteinpaint`
+const sjcrhServer = serverconfig.binpath
+const serverPkg = `${sjcrhServer}/package.json`
+if (fs.existsSync(serverPkg)) {
+	const pkg = JSON.parse(fs.readFileSync(serverPkg, { encoding: 'utf8' }))
+	versionInfo.deps['@sjcrh/proteinpaint-server'] = {
+		installed: pkg.version
 	}
 }
 
-if (fs.existsSync(`${sjcrh}-client/package.json`)) {
-	const client = JSON.parse(fs.readFileSync(`${sjcrh}-client/package.json`, { encoding: 'utf8' }))
+const clientPkg = serverPkg.replace('server', 'client')
+if (fs.existsSync(clientPkg)) {
+	const pkg = JSON.parse(fs.readFileSync(clientPkg, { encoding: 'utf8' }))
 	versionInfo.deps['@sjcrh/proteinpaint-client'] = {
-		installed: client.version
+		installed: pkg.version
 	}
 }
 

--- a/server/test/webpack.config.js
+++ b/server/test/webpack.config.js
@@ -70,9 +70,9 @@ const commonConfig = {
 }
 
 module.exports = env => {
-	const NODE_ENV = env.NODE_ENV || 'production'
+	const mode = env.NODE_ENV || 'development'
 	return merge(commonConfig, {
-		mode: 'production',
+		mode,
 		entry: path.join(__dirname, './emitPrepFiles.js'),
 		output: {
 			path: __dirname,


### PR DESCRIPTION
## Description

This update detects `"true"`, `"false"`, `"undefined"`, and numeric values for json-decoding, even though these URL param values are `string` by default when processed as `req.query` by expressjs. This fixes the mismatch that the server processing has not been fully updated to match the `init.body` conversion to URL params, and also catches typical encoding errors that don't get processes as init.body in `mayAdjustRequest()` in `dofetch.js`.

To test
- http://localhost:3000/testrun.html?dir=shared&name=urljson.unit
- run all unit and integration tests
- all other auto and manual tests that you are familiar with

NOTE: This PR requires lots of testing since it impacts all server routes/handlers.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
