### PR TITLE
Fix the rollup bundling of shared typescript code

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -51,7 +51,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-terser": "^0.4.3",
-    "@rollup/plugin-typescript": "^11.1.2",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/d3": "^7.4.3",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "babel-loader": "^8.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -51,7 +51,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-terser": "^0.4.3",
-    "@rollup/plugin-typescript": "^11.1.1",
+    "@rollup/plugin-typescript": "^11.1.2",
     "@types/d3": "^7.4.3",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "babel-loader": "^8.2.2",

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -36,7 +36,8 @@ export default [
 				filterRoot: '../'
 			}),
 			commonjs({
-				extensions: ['.js', '.ts']
+				// ts files are expected to use esm only
+				extensions: ['.js']
 			}),
 			postcss({
 				plugins: [postcssImport()]

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -32,15 +32,15 @@ export default [
 				extensions: ['.js', '.ts']
 			}),
 			json(),
-			typescript({
-				filterRoot: '../'
-			}),
 			commonjs({
 				// ts files are expected to use esm only
 				extensions: ['.js']
 			}),
 			postcss({
 				plugins: [postcssImport()]
+			}),
+			typescript({
+				filterRoot: '../'
 			}),
 			dynamicImportVars(),
 			// for GDC webpack 3 use case: do not use terser by running

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -32,14 +32,14 @@ export default [
 				extensions: ['.js', '.ts']
 			}),
 			json(),
+			typescript({
+				filterRoot: '../'
+			}),
 			commonjs({
 				extensions: ['.js', '.ts']
 			}),
 			postcss({
 				plugins: [postcssImport()]
-			}),
-			typescript({
-				filterRoot: '../'
 			}),
 			dynamicImportVars(),
 			// for GDC webpack 3 use case: do not use terser by running

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,5 +4,5 @@
     "baseUrl": "./",
     "target": "es2016"
   },
-  "include": ["./**/*.ts", "../server/shared/*.ts"]
+  "include": ["./**/*.ts"]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,5 +4,5 @@
     "baseUrl": "./",
     "target": "es2016"
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts", "../server/shared/*.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-terser": "^0.4.3",
-        "@rollup/plugin-typescript": "^11.1.1",
+        "@rollup/plugin-typescript": "^11.1.2",
         "@types/d3": "^7.4.3",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "babel-loader": "^8.2.2",
@@ -2455,19 +2455,19 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.1.tgz",
-      "integrity": "sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==",
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
+        "@rollup/pluginutils": "^5.1.0",
         "resolve": "^1.22.1"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.14.0||^3.0.0",
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
         "tslib": "*",
         "typescript": ">=3.7.0"
       },
@@ -2481,9 +2481,9 @@
       }
     },
     "node_modules/@rollup/plugin-typescript/node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -2494,7 +2494,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -16098,19 +16098,19 @@
       }
     },
     "@rollup/plugin-typescript": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.1.tgz",
-      "integrity": "sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==",
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^5.0.1",
+        "@rollup/pluginutils": "^5.1.0",
         "resolve": "^1.22.1"
       },
       "dependencies": {
         "@rollup/pluginutils": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+          "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
           "dev": true,
           "requires": {
             "@types/estree": "^1.0.0",
@@ -16191,7 +16191,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-terser": "^0.4.3",
-        "@rollup/plugin-typescript": "^11.1.1",
+        "@rollup/plugin-typescript": "^11.1.2",
         "@types/d3": "^7.4.3",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "babel-loader": "^8.2.2",


### PR DESCRIPTION
## Description

This branch fixes `npm pack` in the client workspace, which was breaking on unprocessed shared/*.ts code file.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
