### PR TITLE
fix tsc errors

### DIFF
--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run tsc
         run: |
-          cd server && npm run checkers # && cd .. # TODO: enable type check at proteinpaint root dir
+          cd server && npm run checkers && cd ..
           npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions
           cd ..
 

--- a/client/dom/genesetEdit.ts
+++ b/client/dom/genesetEdit.ts
@@ -10,6 +10,7 @@ type API = {
 		loadBtn: any
 		clearBtn: any
 		submitBtn: any
+		restoreBtn: any
 		geneHoldingDiv: any | null // gene holding area, shows bunch of gene buttons pending submission
 		statLegendDiv: any // legend area, to show available stats legend on genes
 	}
@@ -28,11 +29,12 @@ type showGenesetEditArg = {
 	holder: any
 	genome: any
 	mode?: 'expression' // if provided, allow to load top variably expressed genes; later can be union of multiple mode strings
-	callback: () => void
+	callback: (arg: CallbackArg) => void
 	vocabApi: any
 	geneList?: {
 		gene: string
 	}[]
+	titleText?: string
 }
 
 export function showGenesetEdit(arg: showGenesetEditArg) {
@@ -139,7 +141,7 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 				.text('Load top variably expressed genes')
 				.on('click', async event => {
 					event.target.disabled = true
-					const args = {
+					const args: any = {
 						genome: vocabApi.state.vocab.genome,
 						dslabel: vocabApi.state.vocab.dslabel,
 						maxGenes: 50
@@ -305,7 +307,7 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 		if (hasChanged) submitBtn.node().focus()
 	}
 
-	function renderGene(gene) {
+	function renderGene(this: any, gene) {
 		const div = select(this).style('border-radius', '5px')
 
 		if (gene.mutationStat) {

--- a/client/dom/ssmLink.ts
+++ b/client/dom/ssmLink.ts
@@ -23,7 +23,10 @@ separateUrls[]: array of html links (if ssm_urls is array) or html string (if ss
 */
 export function makeSsmLink(
 	ssm_urls: UrlTemplateSsm | UrlTemplateSsm[],
-	m: object,
+	m: {
+		chr?: string
+		pos?: number
+	},
 	variantNameDom: any,
 	genome: string
 ) {
@@ -35,7 +38,7 @@ export function makeSsmLink(
 		for (const ssm_url of ssm_urls) {
 			if (ssm_url.namekey == 'regulomedb') {
 				// this key corresponds to hardcoded logic to build regulomedb link with special requirements that also include genome
-				if (typeof m.chr == 'string' && Number.isInteger(m.pos)) {
+				if (typeof m.chr == 'string' && m.pos !== undefined && Number.isInteger(m.pos)) {
 					const coord = `${m.chr}%3A${m.pos}-${m.pos + 1}`
 					separateUrls.push(
 						`<a href="${ssm_url.base}regions=${coord}&genome=${genome == 'hg38' ? 'GRCh38' : genome}" target="_blank">${

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -40,10 +40,10 @@ export type TableArgs = {
 	maxWidth?: string //The max width of the table, 90vw by default.
 	maxHeight?: string //The max height of the table, 40vh by default
 
-	selectedRows: number[] //Preselect rows specified
+	selectedRows?: number[] //Preselect rows specified
 	selectAll: boolean //Preselect all rows
-	resize: boolean //Allow to resize the table height dragging the border
-	selectedRowStyle: any //An object of arbitrary css key-values on how to style selected rows,
+	resize?: boolean //Allow to resize the table height dragging the border
+	selectedRowStyle?: any //An object of arbitrary css key-values on how to style selected rows,
 	//for example `{text-decoration: 'line-through'}`. If a row is not
 	//selected, each css property will be set to an empty string ''
 	inputName?: any //For testing purposes

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -295,6 +295,7 @@ export function renderTable({
 	}
 
 	function updateButtons() {
+		if (!buttons) return
 		const idxlst = getCheckedRowIndex()
 		for (const b of buttons) {
 			b.button.node().disabled = idxlst.length == 0
@@ -320,7 +321,7 @@ export function renderTable({
 				_selectedRowStyle = opts.selectedRowStyle
 				const trs = tbody.selectAll('tr')
 				for (const key in _selectedRowStyle) {
-					const value = trs.style(key, function () {
+					const value = trs.style(key, function (this: any) {
 						return select(this).select('td input').property('checked') ? _selectedRowStyle[key] : ''
 					})
 				}

--- a/client/termsetting/handlers/samplelst.ts
+++ b/client/termsetting/handlers/samplelst.ts
@@ -35,7 +35,8 @@ export function getHandler(self: SampleLstTermSettingInstance) {
 				const e = self.vocabApi.tokenVerificationPayload
 				const missingAccess =
 					e?.error == 'Missing access' && self.vocabApi.termdbConfig.dataDownloadCatch?.missingAccess
-				const message = missingAccess?.message?.replace('MISSING-ACCESS-LINK', missingAccess?.links[e?.linkKey])
+				const message =
+					e && missingAccess?.message?.replace('MISSING-ACCESS-LINK', missingAccess?.links[e.linkKey || ''])
 				const helpLink = self.vocabApi.termdbConfig?.dataDownloadCatch?.helpLink
 				div
 					.append('div')

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -869,7 +869,12 @@ export async function fillTwLst(
 	const dictTerms = await getDictTerms(twlst, vocabApi)
 	const promises: Promise<TermWrapper>[] = []
 	for (const tw of twlst) {
-		if (!tw.term) tw.term = dictTerms[tw.id]
+		if (!tw.term) {
+			// maybe already fill-in tw.term in getDictTerms() and rename that function to maySetMissingTwTerm(),
+			// since the results from getDictTerms() is always used to fill-in tw.term anyway
+			if (tw.id === undefined || tw.id === '') throw 'missing both .id and .term'
+			tw.term = dictTerms[tw.id]
+		}
 		promises.push(fillTermWrapper(tw, vocabApi, defaultQByTsHandler))
 	}
 	await Promise.all(promises)
@@ -880,7 +885,7 @@ async function getDictTerms(twlst: TwLst, vocabApi: VocabApi) {
 	for (const tw of twlst) {
 		// non-dictionary tw would always have a tw.term, so only dictionary tw will be tracked here
 		if (!tw.term) {
-			if (tw.id == undefined || tw.id === '') throw 'missing both .id and .term'
+			if (tw.id === undefined || tw.id === '') throw 'missing both .id and .term'
 			ids.push(tw.id)
 		}
 	}
@@ -899,7 +904,7 @@ export async function fillTermWrapper(
 ): Promise<TermWrapper> {
 	tw.isAtomic = true
 	if (!tw.$id) tw.$id = get$id()
-	if (!tw.term) {
+	if (!tw.term && tw.id) {
 		const terms = await getDictTerms([tw], vocabApi)
 		tw.term = terms[tw.id]
 	}

--- a/client/termsetting/types.ts
+++ b/client/termsetting/types.ts
@@ -85,6 +85,7 @@ export type PillData = BaseTermSettingOpts & {
 	q?: Q
 	sampleCounts?: SampleCountsEntry[]
 	term?: Term
+	menuOptions?: string
 }
 
 export type TermSettingOpts = BaseTermSettingOpts & {
@@ -95,7 +96,7 @@ export type TermSettingOpts = BaseTermSettingOpts & {
 	$id?: string
 	buttons?: string[] //replace, delete, info
 	defaultQ4fillTW?: DefaultQ4fillTW
-	menuOptions: string //all, edit, replace, remove
+	menuOptions?: string //all, edit, replace, remove
 	menuLayout?: string //horizonal, all
 	numericEditMenuVersion?: string[]
 	numericContinuousEditOptions?: NumericContEditOptsEntry[]

--- a/client/types/d3.d.ts
+++ b/client/types/d3.d.ts
@@ -13,18 +13,21 @@ import { Selection } from 'd3-selection'
 	vs 
 
 	import { Selection } from '../types/d3.d.ts'
-	const holder: Selection<HTMLDivElement, any, any, any> = ...
+	const holder: Sel.Div = ...
 */
 
 // most code can use these general element selection types,
 // it has the most used methods like .attr(), .style(), .on(), .node(), etc
-export type Elem = Selection<HTMLElement, any, HTMLElement, any>
-export type Svg = Selection<SVGElement, any, HTMLElement, any>
-export type SvgG = Selection<SVGGElement, any, HTMLElement, any>
+export type _Element_ = Selection<Element, any, any, any>
+export type Elem = Selection<HTMLElement, any, any, any>
+export type Div = Selection<HTMLDivElement, any, any, any>
+export type Svg = Selection<SVGElement, any, any, any>
+export type SvgG = Selection<SVGGElement, any, any, any>
+export type SvgSvg = Selection<SVGSVGElement, any, any, any>
 
 // this is meant to easily type all properties of the this.dom object in an rx component
 export type Dom = {
-	[selectionName: string]: Elem | Svg | SvgG
+	[selectionName: string]: Div | Svg | SvgG | SvgSvg | Span | Input
 }
 
 /*
@@ -47,7 +50,7 @@ export type Dom = {
 		- etc)
 */
 
-export type Div = Selection<HTMLDivElement, any, HTMLElement, any>
 export type Span = Selection<HTMLSpanElement, any, any, any>
-export type Input = Selection<HTMLInputElement, any, HTMLElement, any>
-export type Table = Selection<HTMLTableElement, any, HTMLElement, any>
+export type Button = Selection<HTMLButtonElement, any, any, any>
+export type Input = Selection<HTMLInputElement, any, any, any>
+export type Table = Selection<HTMLTableElement, any, any, any>

--- a/client/types/test/d3.type.spec.ts
+++ b/client/types/test/d3.type.spec.ts
@@ -9,14 +9,14 @@
 */
 
 import { Selection, select } from 'd3-selection'
-import * as Sel from '../d3'
+import * as Sel from '../d3.d'
 
 // ------------
 // Declarations
 // ------------
 
 // ok
-const elem: Sel.Elem = select('body').append('div')
+const elem: Sel.Div = select('body').append('div')
 // ok
 const div: Sel.Div = elem.append('div')
 // ok
@@ -25,7 +25,10 @@ const span: Sel.Span = elem.append('span')
 const spanAsDiv: Sel.Div = elem.append('span')
 // ok
 const spanGen = <Sel.Span>elem.append('span')
-// ok - should have caught this non-sensical syntax ???
+// tsc does not catch this error when called directly on this spec file
+// e.g. npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions client/types/test/d3.type.spec.ts
+// but calling tsc on a directory (without a filename) works as expected
+// @ts-expect-error, span is not a div
 const spanGen2: Sel.Span = <Sel.Div>elem.append('span')
 
 const dom: Sel.Dom = {
@@ -47,7 +50,10 @@ function abc(arg: Sel.Div) {
 abc(div)
 // @ts-expect-error, mismatched argument type
 abc(span)
-// ok, should be an error !!! this forced type syntax should not be used for generics !!!
+// tsc does not catch this error when called directly on this spec file
+// e.g. npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions client/types/test/d3.type.spec.ts
+// but calling tsc on a directory (without a filename) works as expected
+// @ts-expect-error, this forced type syntax should not be used for generics !!!
 abc(span as Sel.Div)
 // ok - should have been prevented if the @ts-expect-error comment was removed above this variable's declaration
 abc(spanAsDiv)

--- a/server/shared/types/vocab.ts
+++ b/server/shared/types/vocab.ts
@@ -23,4 +23,10 @@ export type VocabApi = {
 	getTermdbConfig: () => any
 	getViolinPlotData: (f: any, params: any) => void
 	uncacheTermQ: (term: Term, q: any) => any
+	hasVerifiedToken: () => boolean
+	tokenVerificationMessage: string
+	tokenVerificationPayload?: {
+		error?: string
+		linkKey?: string
+	}
 }


### PR DESCRIPTION
## Description

... for genesetEdit, ssmLink, table, d3.d + spec, table.ts, handlerts/samplelist.ts, termsetting.ts, vocabApi types

to test: 
- from the proteinpaint dir, run `npx tsc --noEmit --esModuleInterop --allowImportingTsExtensions`
- also check the CI run for this PR, should be passing

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
