### PR TITLE
De fix4 review

### DIFF
--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -153,8 +153,8 @@ class DEanalysis {
 		this.config = JSON.parse(JSON.stringify(this.state.config))
 		this.settings = this.config.settings.DEanalysis
 		const output = await this.app.vocabApi.runDEanalysis(this.state.config)
-		output.mid_sample_size_cutoff = 30 // mid sample size cutoff for method toggle to appear
-		output.high_sample_size_cutoff = 50 // high sample size cutoff for method toggle to not appear, so that very high sample-size groups are not analyzed by edgeR. The exact cutoff value will need to be determined with more examples.
+		output.mid_sample_size_cutoff = 8 // mid sample size cutoff for method toggle to appear
+		output.high_sample_size_cutoff = 30 // high sample size cutoff for method toggle to not appear, so that very high sample-size groups are not analyzed by edgeR. The exact cutoff value will need to be determined with more examples.
 		await this.setControls(output)
 		//const state = this.app.getState()
 		//console.log('state:', state)


### PR DESCRIPTION
## Description

1) Passed an entire object into render_volcano() instead of fields inside output.
2) Changed mid and high sample size cutoff.
Use session loaded here for testing
[low_high_sample_DE.txt](https://github.com/stjude/proteinpaint/files/14251614/low_high_sample_DE.txt)
3) Now the volcano plot details are on the right side instead of bottom. This is easier to view as it user does not need to scroll.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
