### PR TITLE
bug fix to pass missing filter0 to compute sunburst total size

### DIFF
--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1780,6 +1780,7 @@ input:
 		.tid2value={ termid: v}
 		.ssm_id_lst=str
 		.filterObj={}
+		.filter0
 	combination={}
 		if provided, return alongside map; needed for sunburst, see get_crosstabCombinations()
 	ds

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -687,6 +687,7 @@ export async function get_crosstabCombinations(twLst, ds, q, nodes) {
 		// must not directly submit q{} to .get([], q), this will filter to only those mutated samples rather than category total size
 		const _q = {}
 		if (q.filterObj) _q.filterObj = q.filterObj
+		if (q.filter0) _q.filter0 = q.filter0
 
 		const tv2counts = await ds.cohort.termdb.termid2totalsize2.get([twLst[0]], _q)
 		for (const [v, count] of tv2counts.get(id0)) {
@@ -711,6 +712,7 @@ export async function get_crosstabCombinations(twLst, ds, q, nodes) {
 			// make new q with filters
 			const _q = { tid2value: { [id0]: v0 } }
 			if (q.filterObj) _q.filterObj = q.filterObj
+			if (q.filter0) _q.filter0 = q.filter0
 
 			promises.push(ds.cohort.termdb.termid2totalsize2.get([twLst[1]], _q, v0))
 		}
@@ -740,6 +742,7 @@ export async function get_crosstabCombinations(twLst, ds, q, nodes) {
 				// make new q with filters
 				const _q = { tid2value: { [id0]: v0, [id1]: v1 } }
 				if (q.filterObj) _q.filterObj = q.filterObj
+				if (q.filter0) _q.filter0 = q.filter0
 
 				promises.push(ds.cohort.termdb.termid2totalsize2.get([twLst[2]], _q, { v0, v1 }))
 			}


### PR DESCRIPTION
## Description

can test at http://localhost:3000/example.gdc.html. see Adenoma total diff from sample summary and sunburst ring

<img width="648" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/6a92b683-3ba7-4ce9-aef8-6b34deaa76b2">


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
