### PR TITLE
delete searchfield-cancel-button styling as instructed by chrome

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -143,10 +143,6 @@ h2 {
     -webkit-appearance: searchfield;
 }
 
-.sja_root_holder input[type="search"].tree_search::-webkit-search-cancel-button {
-    -webkit-appearance: searchfield-cancel-button;
-}
-
 .sja_root_holder ul {
     display: block;
     list-style-type: disc;


### PR DESCRIPTION
## Description

remove the err constantly showing on chrome console. i tested a few search boxes and they're fine

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
