### PR TITLE
fix: profilegenevalue track reports subtrack file error in a legible way

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- profilegenevalue track reports subtrack file error in a legible way


### PR DESCRIPTION
## Description

quick fix on a long standing problem
please pull sjpp master and test at http://localhost:3000/example.pgv.html
link is also added to url.html
this is a quick fix. haven't tested err handling on gene exp value file yet

changes are masked by eslint
i added `t.errg` and .catch(e=>tkerror(t,err)) at the end of loading each subtk

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
