### PR TITLE
fix: Bug fix for disco plot launched from sunburst shows aachange in …

### DIFF
--- a/client/mds3/clickVariant.js
+++ b/client/mds3/clickVariant.js
@@ -84,30 +84,32 @@ async function click2sunburst(d, tk, block, tippos) {
 			add the key/values to tid2value{}
 			*/
 			tk.itemtip.clear()
-			const arg = {
+			const param = {
 				mlst: d.mlst,
 				tk,
 				block,
 				div: tk.itemtip.d,
 				tid2value: {}
 			}
-			arg.tid2value[d2.data.id0] = d2.data.v0
-			if (d2.data.id1) arg.tid2value[d2.data.id1] = d2.data.v1
-			if (d2.data.id2) arg.tid2value[d2.data.id2] = d2.data.v2
+			param.tid2value[d2.data.id0] = d2.data.v0
+			if (d2.data.id1) param.tid2value[d2.data.id1] = d2.data.v1
+			if (d2.data.id2) param.tid2value[d2.data.id2] = d2.data.v2
 
 			/*
-			TEMP FIX to create a mock arg.mlst[]
-			this wedge has less samples than d.mlst will have multiple.
+			!! to create a mock param.mlst[] !!
+			(re-evaluate if this is actually temp fix)
+			this wedge has less samples than what d.mlst[] have in total
 			as mlst2samplesummary uses occurrence sum to decide what type of data to request
 			must change occurrence sum to d2.value so mlst2samplesummary() can function based on sum of this wedge
+			(by first setting .occurrence=0 for entire param.mlst[], then just set param.mlst[0].occurrence=d2.value)
 			*/
-			arg.mlst = d.mlst.map(m => {
+			param.mlst = d.mlst.map(m => {
 				if (tk.mds.variant2samples.variantkey == 'ssm_id') {
 					return { ssm_id: m.ssm_id, occurrence: 0 }
 				}
 				throw 'unknown variant2samples.variantkey'
 			})
-			arg.mlst[0].occurrence = d2.value
+			param.mlst[0].occurrence = d2.value
 
 			const x = event.clientX
 			const y = event.clientY
@@ -118,16 +120,16 @@ async function click2sunburst(d, tk, block, tippos) {
 			const middlex = width / 2
 			const middley = height / 2
 
-			arg.maxWidth = width - x > middlex ? width - x : x
-			arg.maxHeight = height - y > middley ? height - y : y
-			arg.maxWidth = arg.maxWidth - 150 + 'px'
-			arg.maxHeight = arg.maxHeight - 150 + 'px'
+			param.maxWidth = width - x > middlex ? width - x : x
+			param.maxHeight = height - y > middley ? height - y : y
+			param.maxWidth = param.maxWidth - 150 + 'px'
+			param.maxHeight = param.maxHeight - 150 + 'px'
 			*/
 
 			/* do not call variant_details() as no need to show info on variants
 			only need to show sample display
 			*/
-			await init_sampletable(arg)
+			await init_sampletable(param)
 			tk.itemtip.show(x, y, false, false)
 		}
 	}

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -166,7 +166,11 @@ async function make_singleSampleTable(s, arg) {
 		// sample_id is hardcoded
 		const [cell1, cell2] = table.addRow()
 		cell1.text(arg.tk.mds.termdbConfig?.lollipop?.sample || 'Sample')
-		printSampleName(s, arg.tk, cell2, arg.block, arg.mlst?.[0])
+		let m // mutation carried by this sample. if found, pass to createDiscoInSandbox for showing aachange on disco sandbox header for showing context
+		if (s.ssm_id_lst?.[0]) {
+			m = arg.tk.skewer.rawmlst.find(i => i.ssm_id == s.ssm_id_lst[0])
+		}
+		printSampleName(s, arg.tk, cell2, arg.block, m)
 	}
 
 	/////////////
@@ -214,9 +218,9 @@ async function make_singleSampleTable(s, arg) {
 				const m = arg.tk.skewer.rawmlst.find(i => i.ssm_id == ssmid)
 				if (m) {
 					// found m object by id, can make a better display
-					if (m.dt == 1) {
+					if (m.dt == dtsnvindel) {
 						print_snv(td, m, arg.tk, arg.block)
-					} else if (m.dt == 2 || m.dt == 5) {
+					} else if (m.dt == dtsv || m.dt == dtfusionrna) {
 						printSvPair(m.pairlst[0], td)
 					} else {
 						td.text(ssmid)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Bug fix for disco plot launched from sunburst shows aachange in sandbox header rather than undefined


### PR DESCRIPTION
…sandbox header rather than undefined

## Description

test at http://localhost:3000/?genome=hg38&gene=ENST00000345146&mds3=GDC
click R132H. at sunburst, click a slice of 1 sample. then click Disco for that sample. in plot header it shows `R132H` rather than undefined as in master

also in track, click the `500` under the stack of mutations to do above, it can still correctly show sample's mutation despite the sunburst displays `R132H etc`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
