### PR TITLE
Bam fix4

### DIFF
--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -1930,9 +1930,14 @@ async function click_groupheader_showMultiReadAlign(tk, group, block) {
 
 	try {
 		const data = await align_reads_to_allele(tk, group, block) // Sending server side bam request for aligning reads to ref/alt
-		if (data.error) throw data.error
-		wait.remove()
+		if (data.error) {
+			wait.remove()
+			sayerror(tk.multiAlignMenu.d, 'Realignment of reads in ambiguous group is not currently implemented.')
+			setTimeout(() => tk.multiAlignMenu.d.remove(), 3000)
+			return
+		}
 
+		wait.remove()
 		let alt_var_idx = 0 // Contains the index of the alternate allele (if queried) of the selected alternate allele
 		// If one of the alternate alles are clicked, determine which alternate allele
 		let ref_start_stops = []
@@ -2296,7 +2301,6 @@ async function getReadInfo(tk, block, box, ridx) {
 			: { start: box.start, stop: box.stop, paired: tk.asPaired }
 	)
 	const data = await dofetch3('tkbam', param)
-	console.log('data:', data)
 	if (data.error) {
 		sayerror(wait, data.error)
 		return

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -1350,10 +1350,6 @@ function makeGroup(gd, tk, block, data) {
 							.attr('transform', 'translate(' + cx1 + ',' + t.y1 + ')')
 						getReadInfo(tk, block, t, region_idx)
 						readNotShown = false
-					} else if (tk.asPaired && mx > cx1 && mx < cx2 && my > t.y1 && my < t.y2 && t.multi_region) {
-						// In case of templates extending into multiple regions
-						getReadInfo(tk, block, t, region_idx)
-						readNotShown = false
 					}
 					// must not return here because ...
 				}
@@ -2300,6 +2296,7 @@ async function getReadInfo(tk, block, box, ridx) {
 			: { start: box.start, stop: box.stop, paired: tk.asPaired }
 	)
 	const data = await dofetch3('tkbam', param)
+	console.log('data:', data)
 	if (data.error) {
 		sayerror(wait, data.error)
 		return

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -2396,6 +2396,7 @@ async function getReadInfo(tk, block, box, ridx) {
 			.append('button')
 			.style('margin-left', '10px')
 			.text('Show gene model')
+			.property('disabled', !r.seq || r.seq == '*')
 			.on('click', async () => {
 				gene_button.property('disabled', true) // disable this button
 				// Determine how many calls to bedj track need to be made. This depends on whether the read has insertions/deletions or spliced. In these cases, each part of the read will need a separate bedj track


### PR DESCRIPTION
## Description

1) Read spanning multiple region showed each template twice. This is fixed. [Test link](http://localhost:3000/?genome=hg19&block=1&bamfile=inversion_example,proteinpaint_demo/hg19/bam/CBFB-MYH11.bam&position=chr16:67116100-67116900;chr16:15814303-15816118)

2) In ambiguous group, when realignment panel is clicked the error message is shown. But when the error message is removed, the div still stayed open. Now a fix has been added where the div is automatically removed after 3s.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
