### PR TITLE
Fix disco plot cnv issue

### DIFF
--- a/client/plots/disco/cnv/CnvArcsMapper.ts
+++ b/client/plots/disco/cnv/CnvArcsMapper.ts
@@ -140,7 +140,7 @@ export default class CnvArcsMapper {
 
 		if (this.lossOnly) {
 			const outerRadius = this.cnvInnerRadius + this.cnvWidth
-			return outerRadius - this.capMinValue((this.cnvWidth * this.capMaxValue(data.value)) / this.maxAbsValue)
+			return outerRadius + this.capMinValue((this.cnvWidth * this.capMaxValue(data.value)) / this.maxAbsValue)
 		}
 
 		const centerRadius = this.cnvInnerRadius + this.cnvWidth / 2


### PR DESCRIPTION
## Description

 In case all CNV values are negative, the disco plot is not rendered properly. 
<img width="527" alt="Screenshot 2024-02-16 at 11 27 31 AM" src="https://github.com/stjude/proteinpaint/assets/32873451/56211c87-069b-4746-98c5-f2597cb39416">

This issue is fixed the CNVs are rendered properly now:

<img width="617" alt="Screenshot 2024-02-16 at 11 22 41 AM" src="https://github.com/stjude/proteinpaint/assets/32873451/fbf36bc6-cf0c-4903-9bcf-9860d111557f">


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
