### PR TITLE
fix: Reload page while streaming/downloading gdc bam slice to client …

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Reload page while streaming/downloading gdc bam slice to client will not crash server

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -351,8 +351,13 @@ export default function (genomes) {
 
 			if (serverconfig.debugmode) console.log('bam.js time ms', new Date() - starttime)
 		} catch (e) {
-			res.send({ error: e.message || e })
+			if (e?.code == 'ERR_STREAM_PREMATURE_CLOSE') {
+				// happens when client refreshed page in the mid of streaming bam data from backend. somehow the response header is already set. this check help avoid ERR_HTTP_HEADERS_SENT that crashes server
+				return
+			}
+
 			if (e.stack) console.log(e.stack)
+			res.send({ error: e.message || e })
 		}
 	}
 }


### PR DESCRIPTION
…will not crash server

## Description

test [here](http://localhost:3000/?gdcbamslice=1&gdc_id=TCGA-06-0211-02A-02D-A922-36.WholeGenome.RP-1657.bam&gdc_pos=chr7:55153818-55156225&stream2download=1). use your token, at Gene or position, enter EGFR and download. it will start streaming data to client after a few seconds and it will streams hundreds of MB without stopping. reload page. pp continue to work. on master server crashes with the reload

i know Jian doesn't have token so cannot test. but please see if this fix is valid or is there a better way

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
