### PR TITLE
fix: GDC bam slice ui requires hitting Enter to search and no longer …

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC bam slice ui requires hitting Enter to search and no longer auto search to avoid showing duplicate ssm table


### PR DESCRIPTION
…auto search to avoid showing duplicate ssm table

## Description

you did mention this issue before and i finally found out how to replicate it

please test at http://localhost:3000/?gdcbamslice=1, copy paste "TCGA-06-0211" and quickly hit ENTER. ssm tables shows once, but on master it shows twice

[all ui tests](http://localhost:3000/testrun.html?dir=src&name=block.tk.bam.gdc) pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
