### PR TITLE
Snplst snplocus changes

### DIFF
--- a/client/plots/plot.app.js
+++ b/client/plots/plot.app.js
@@ -45,13 +45,15 @@ class PlotApp {
 	constructor(opts) {
 		this.type = 'app'
 		// this will create divs in the correct order
-		const controls = opts.holder.append('div').style('white-space', 'nowrap')
+		const controls = opts.violin?.mode == 'minimal' ? null : opts.holder.append('div').style('white-space', 'nowrap')
 		this.dom = {
 			holder: opts.holder,
-			plotControls: controls.append('div').style('display', 'inline-block'),
-			recoverControls: controls.append('div').style('display', 'inline-block'),
 			errdiv: opts.holder.append('div'),
 			plotDiv: opts.holder.append('div')
+		}
+		if (controls) {
+			this.dom.plotControls = controls.append('div').style('display', 'inline-block')
+			this.dom.recoverControls = controls.append('div').style('display', 'inline-block')
 		}
 	}
 

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -215,7 +215,7 @@ export class InputTerm {
 		if (tw.q.numOfSampleWithAnyValidGT) {
 			const invalid_snps_count = tw.term.snps.reduce((i, j) => i + (j.invalid ? 1 : 0), 0)
 			this.termStatus.topInfoStatus.push(
-				`${tw.q.numOfSampleWithAnyValidGT} samples with valid genotypes.` +
+				`${tw.q.numOfSampleWithAnyValidGT} samples with valid genotypes` +
 					(invalid_snps_count > 0 ? ` ${invalid_snps_count} invalid SNP${invalid_snps_count > 1 ? 's' : ''}.` : '')
 			)
 		}
@@ -233,6 +233,11 @@ export class InputTerm {
 		}
 		if (tw.q.restrictAncestry) {
 			this.termStatus.topInfoStatus.push('Analyzing ' + tw.q.restrictAncestry.name)
+			if (tw.q.restrictAncestry.PCcount) {
+				this.termStatus.topInfoStatus.push(
+					`Adjusting for top ${tw.q.restrictAncestry.PCcount} ancestry principal components`
+				)
+			}
 		}
 		if (tw.term.reachedVariantLimit) {
 			this.termStatus.topInfoStatus.push(

--- a/client/plots/regression.inputs.values.table.js
+++ b/client/plots/regression.inputs.values.table.js
@@ -79,7 +79,7 @@ function setRenderers(self) {
 
 			top_info_div: holder.append('div').style('padding-bottom', '5px'),
 
-			violin_div: holder.append('div').style('color', 'black'),
+			violin_div: holder.append('div').style('color', 'black').style('padding-top', '5px'),
 
 			table_div: holder
 				.append('table')

--- a/client/termsetting/handlers/snplocus.ts
+++ b/client/termsetting/handlers/snplocus.ts
@@ -105,7 +105,8 @@ async function makeEditMenu(self, div0: any) {
 	if (self.usecase.target == 'dataDownload') div.select('.sjpp-snp-select').style('display', 'none')
 
 	// submit button
-	div
+	const btnRow = div.append('div').style('margin-top', '15px')
+	btnRow
 		.append('button')
 		.style('margin-top', '15px')
 		.text('Submit')
@@ -154,6 +155,15 @@ async function makeEditMenu(self, div0: any) {
 
 			self.runCallback()
 		})
+
+	btnRow
+		.append('span')
+		.style('padding-left', '15px')
+		.style('opacity', 0.8)
+		.style('font-size', '.8em')
+		.text(
+			self.usecase.target == 'dataDownload' ? '' : 'Variants will be treated individually in separate regression models'
+		)
 }
 
 /* 

--- a/client/termsetting/handlers/snplst.ts
+++ b/client/termsetting/handlers/snplst.ts
@@ -308,7 +308,11 @@ async function makeEditMenu(self, div0: any) {
 		.style('padding-left', '15px')
 		.style('opacity', 0.8)
 		.style('font-size', '.8em')
-		.text('Must press submit button to apply changes.')
+		.text(
+			self.usecase.target == 'dataDownload'
+				? ''
+				: 'Variants will be treated as separate covariates in the regression model'
+		)
 
 	// both input and edit UIs are rendered
 	// decide visibility of edit and input UIs

--- a/server/src/termdb.config.js
+++ b/server/src/termdb.config.js
@@ -78,7 +78,7 @@ export function make(q, res, ds, genome) {
 function addRestrictAncestries(c, tdb) {
 	if (!tdb.restrictAncestries) return
 	c.restrictAncestries = tdb.restrictAncestries.map(i => {
-		return { name: i.name, tvs: i.tvs }
+		return { name: i.name, tvs: i.tvs, PCcount: i.PCcount }
 	})
 }
 


### PR DESCRIPTION
## Description

- New message prompt for entering snplst input
- For snplst, `Custom allele` option is set when user inputs custom effect allele
- New hint messages to indicate: (1) how variants are analyzed for snplst term, (2) how variants are analyzed for snplocus term, (3) that top N ancestry PCs are adjusted for in analysis


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
