### PR TITLE
Genome url fix

### DIFF
--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -7,6 +7,7 @@ import * as mdsjson from './app.mdsjson'
 import urlmap from '#common/urlmap'
 import { first_genetrack_tolist } from '#common/1stGenetk'
 import { corsMessage } from '#common/embedder-helpers'
+import { sayerror } from '../dom/sayerror'
 /*
 ********************** EXPORTED
 parse()
@@ -225,6 +226,16 @@ upon error, throw err message as a string
 		const n = urlp.get('genome')
 		const genome_options = [...arg.selectgenome.node().childNodes]
 		const selectedIndex = genome_options.findIndex(d => d.value == n)
+		if (selectedIndex == -1) {
+			sayerror(
+				arg.holder,
+				`Invalid genome: ${n}. Please provide an available genome from this list: ${genome_options
+					.map(d => d.value)
+					.join(', ')
+					.replace(/,(?=[^,]*$)/, ', or')}`
+			)
+			return
+		}
 		arg.selectgenome.node().selectedIndex = selectedIndex
 		arg.selectgenome.node().dispatchEvent(new Event('change'))
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes: 
+- Show user error message for an invalid genome provided in a URL. Error message contains the list of available genomes from that server.


### PR DESCRIPTION
## Description
I provided the list of genomes in the error message so 1) it's crystal clear what went wrong (e.g. a typo, genome unavailable, etc.) and, 2) the user can copy/paste the desired genome into the URL (useful for genomes with longer names). 

See fix with http://localhost:3000/?genome=xx vs. http://localhost:3000/?genome=hg19.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
