### PR TITLE
fix: mds3 tk sample summary table will scroll if too tall

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -176,7 +176,7 @@ export function renderTable({
 				}
 			})
 		if (showLines) {
-			const lineDiv = rowtable
+			rowtable
 				.append('td')
 				.text(i + 1)
 				.style('text-align', 'center')
@@ -266,7 +266,7 @@ export function renderTable({
 						.append('input')
 						.attr('type', 'color')
 						.attr('value', cell.color)
-						.on('change', e => {
+						.on('change', () => {
 							const color = input.node().value
 							cell.color = color
 							if (column.editCallback) column.editCallback(i, cell)
@@ -289,7 +289,7 @@ export function renderTable({
 				.append('button')
 				.text(bCfg.text)
 				.style('margin', '10px 10px 0 0')
-				.on('click', e => {
+				.on('click', () => {
 					bCfg.callback(getCheckedRowIndex(), bCfg.button.node())
 				})
 			if (bCfg.class) bCfg.button.attr('class', bCfg.class)
@@ -328,7 +328,7 @@ export function renderTable({
 				_selectedRowStyle = opts.selectedRowStyle
 				const trs = tbody.selectAll('tr')
 				for (const key in _selectedRowStyle) {
-					const value = trs.style(key, function (this: any) {
+					trs.style(key, function (this: any) {
 						return select(this).select('td input').property('checked') ? _selectedRowStyle[key] : ''
 					})
 				}
@@ -341,7 +341,6 @@ export function renderTable({
 
 export async function downloadTable(rows, cols) {
 	const filename = `table.tsv`
-	const data = {}
 	let lines = ''
 	for (const column of cols) {
 		lines += `${column.label}\t`

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -2,6 +2,7 @@ import { makelabel } from './leftlabel'
 import { Tabs } from '../dom/toggleButtons'
 import { displaySampleTable } from './sampletable'
 import { fillbar } from '#dom/fillbar'
+import { renderTable } from '../dom/table'
 import { filterInit, getNormalRoot } from '#filter'
 import { convertUnits } from '#shared/helpers'
 import { violinRenderer } from '../dom/violinRenderer'
@@ -252,38 +253,33 @@ function showSummary4oneTerm(termid, div, numbycategory, tk, block) {
 	const tw = tk.mds.variant2samples.twLst.find(i => i.id == termid)
 	if (!tw) throw 'showSummary4oneTerm(): tw not found from variant2samples.twLst'
 
-	const grid_div = div
-		.append('div')
-		.style('display', 'inline-grid')
-		.style('grid-template-columns', 'auto auto auto')
-		.style('grid-row-gap', '3px')
-		.style('align-items', 'center')
-		.style('justify-items', 'left')
-
+	const rows = []
 	for (const [category_key, count, total] of numbycategory) {
 		// in future tw may be in groupsetting mode
-		grid_div
-			.append('div')
-			.style('padding-right', '10px')
-			.attr('class', 'sja_clbtext2')
-			.text(tw.term.values?.[category_key]?.label || category_key)
-			.on('click', () => clickCategory(category_key))
-
-		const percent_div = grid_div.append('div')
-		if (total != undefined) {
-			// show percent bar
-			percent_div.on('click', () => clickCategory(category_key))
-
-			fillbar(percent_div, { f: count / total, v1: count, v2: total }, { fillbg: '#ECE5FF', fill: '#9F80FF' })
-		}
-
-		grid_div
-			.append('div')
-			.style('margin-left', '10px')
-			.attr('class', 'sja_clbtext2')
-			.on('click', () => clickCategory(category_key))
-			.html(count + (total ? ' <span style="font-size:.8em">/ ' + total + '</span>' : ''))
+		const row = [
+			{ value: tw.term.values?.[category_key]?.label || category_key },
+			{ html: total == undefined ? '' : fillbar(null, { f: count / total, v1: count, v2: total }) },
+			{ html: count + (total ? ' <span style="font-size:.8em">/ ' + total + '</span>' : '') }
+		]
+		rows.push(row)
 	}
+	renderTable({
+		div,
+		rows,
+		columns: [
+			{
+				nowrap: true // to force all category values to show in one line without wrap. otherwise they wrap and column width appears fixed
+			},
+			{},
+			{}
+		],
+		showHeader: false,
+		singleMode: true,
+		noRadioBtn: true,
+		noButtonCallback: i => {
+			clickCategory(numbycategory[i][0])
+		}
+	})
 
 	async function clickCategory(category) {
 		// for a selected category, launch subtrack

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -37,7 +37,7 @@ export function makeVariantLabel(data, tk, block, laby) {
 		totalcount = tk.custom_variants.length
 	} else {
 		// no custom data but server returned data, get total from it
-		totalcount = tk.skewer.rawmlst.length + data.cnv?.length
+		totalcount = tk.skewer.rawmlst.length + (data.cnv?.length || 0)
 	}
 
 	if (totalcount == 0) {

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -172,7 +172,7 @@ export async function testSampleSummary2subtrack(genome, gene, dslabel, test) {
 		tk.leftlabels.doms.samples.node().dispatchEvent(new Event('click'))
 		await whenVisible(tk.menutip.d, 10000)
 
-		const div = await detectOne({ elem: tk.menutip.d.node(), selector: '.sja_mds3samplesummarydiv', maxTime: 10000 })
+		const div = await detectOne({ elem: tk.menutip.d.node(), selector: '.sja_mds3samplesummarydiv' })
 		test.ok(div, 'Sample summary table rendered in menutip')
 
 		for (const tw of tk.mds.variant2samples.twLst) {
@@ -233,7 +233,7 @@ export async function testSampleSummary2subtrack(genome, gene, dslabel, test) {
 			test.end()
 		}
 
-		const categoryDiv = tk.menutip.d.select('.sja_clbtext2')
+		const categoryDiv = tk.menutip.d.select('.sjpp_row_wrapper')
 		categoryDiv.node().dispatchEvent(new Event('click'))
 	}
 }
@@ -443,7 +443,7 @@ must use a gene with both single and multi occurrence mutations to test
 		multiMutationDisc.dispatchEvent(new Event('click'))
 		await whenVisible(tk.itemtip.d)
 		{
-			const button = await detectOne({ elem: tk.itemtip.dnode, selector: '.' + buttonClass, maxTime: 10000 })
+			const button = await detectOne({ elem: tk.itemtip.dnode, selector: '.' + buttonClass })
 			test.equal(button.innerHTML, buttonText, buttonText + ' button created in multi-sample menu')
 			test.ok(button.disabled, 'button is also disabled (when no checkbox is checked)')
 			// must check one checkbox first to
@@ -455,7 +455,7 @@ must use a gene with both single and multi occurrence mutations to test
 		{
 			const btn = await detectOne({ elem: tk.menutip.dnode, selector: '.sja_mds3_slb_sampletablebtn' })
 			btn.dispatchEvent(new Event('click'))
-			const button = await detectOne({ elem: tk.menutip.dnode, selector: '.' + buttonClass, maxTime: 10000 })
+			const button = await detectOne({ elem: tk.menutip.dnode, selector: '.' + buttonClass })
 			test.equal(button.innerHTML, buttonText, buttonText + ' button is created in leftlabel sample table')
 			test.ok(button.disabled, 'button is also disabled (when no checkbox is checked)')
 		}

--- a/client/test/test.helpers.js
+++ b/client/test/test.helpers.js
@@ -45,6 +45,7 @@ export function sleep(ms) {
     .matcher()   optional, a function that signals the end of the observer 
                              passed (mutationsList, observer) as arguments
                              must return an array of zero or more elements to trigger observer.disconnect() 
+    .maxTime     optional, max time to wait
 
     // only used when opts.matcher is not supplied
     .count       optional, the expected number of detected matching elements to stop the observer
@@ -58,7 +59,7 @@ export async function detectLst(_opts = {}) {
 	const defaults = {
 		target: _opts.target || _opts.elem,
 		selector: _opts.selector,
-		maxTime: 5000,
+		maxTime: 12000, // default is increased from 5 to 12 specifically for gdc live tests with high latency
 		observe: {
 			childList: true,
 			subtree: true,

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- mds3 tk sample summary table will scroll if too tall


### PR DESCRIPTION
## Description

test feature change at [here](http://localhost:3000/?genome=hg38&gene=ENST00000256078&mds3=GDC), or [here](http://localhost:3000/?genome=hg38&gene=notch1&mds3=pantallMds3), or the GATA2 dataset. click on samples leftlabel, and switch to a term with many categories. the summary table is now shown in consistent look by table.ts and scrolls

fixed a bug in mds3 genomic mode that can show `0 variants of NaN` at variant leftlabel

changed table.ts to hide radio buttons (Airen should evaluate)

changed test helper to increase maxTime to 12 seconds so all gdc tests can pass

all mds3 and table tests pass


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
