### PR TITLE
fix: allow to use a simplified filterObj on mds3 tk that will be hydr…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- allow to use a simplified filterObj on mds3 tk that will be hydrated on launch


### PR DESCRIPTION
…ated on launch

## Description

small fix to make it easier to create examples

test with [female](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.demographic.gender%22},%22values%22:[{%22key%22:%22female%22}],%22isnot%22:true}}]}) and [age](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.diagnoses.age_at_diagnosis%22},%22ranges%22:[{%22start%22:10000,%22stop%22:20000,%22startinclusive%22:false,%22stopinclusive%22:true}],%22isnot%22:true}}]}) link. both uses {id} for the term rather than full obj

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
