### PR TITLE
Legend filter updates

### DIFF
--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -203,7 +203,7 @@ export default function svgLegend(opts) {
 				.enter()
 				.append('stop')
 				.attr('offset', (c, i) => `${c * 100}%`)
-				.attr('stop-color', c => d.scale(c))
+				.attr('stop-color', c => (d.scale ? d.scale(c) : 'grey'))
 				.attr('stop-opacity', 1)
 
 			const minLabel = g

--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -109,9 +109,17 @@ tape('only dictionary terms', function (test) {
 		sg0rects.each(d => uniqueHts.add(d.height))
 		test.equal(uniqueHts.size, 45, `should render different rect heights for continuous mode bar plots`)
 
+		const legendTexts = [...matrix.Inner.dom.legendG.node().querySelectorAll('g g text')]
+			.find(d => d?.__data__?.text?.startsWith('Male'))
+			.dispatchEvent(
+				new MouseEvent('mouseup', {
+					bubbles: true,
+					cancelable: true
+				})
+			)
 		// TODO: test for matrix bar plots of continuous mode terms with allowed negative value
 
-		if (test._ok) matrix.Inner.app.destroy()
+		//if (test._ok) matrix.Inner.app.destroy()
 		test.end()
 	}
 })
@@ -1344,5 +1352,62 @@ tape('avoid race condition', function (test) {
 			test.fail('error: ' + e)
 			throw e
 		}
+	}
+})
+
+tape.only('one geneVariant term with legend filter', function (test) {
+	test.timeoutAfter(5000)
+	test.plan(1)
+	runpp({
+		state: {
+			nav: {
+				activeTab: 1
+			},
+			plots: [
+				{
+					chartType: 'matrix',
+					settings: {
+						matrix: {
+							// the matrix autocomputes the colw based on available screen width,
+							// need to set an exact screen width for consistent tests using getBBox()
+							availContentWidth: 1200
+						}
+					},
+					termgroups: [
+						{
+							name: 'Demographics',
+							lst: [
+								{
+									id: 'sex'
+									//q: { mode: 'values' } // or 'groupsetting'
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		matrix: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	function runTests(matrix) {
+		matrix.on('postRender.test', null)
+		console.log('before legendTexts')
+		const legendTexts = [...matrix.Inner.dom.legendG.node().querySelectorAll('g g text')]
+			.find(d => d?.__data__?.text?.startsWith('Male'))
+			.dispatchEvent(
+				new MouseEvent('mouseup', {
+					bubbles: true,
+					cancelable: true
+				})
+			)
+
+		console.log('what is legendTexts', legendTexts)
+		// if (test._ok) matrix.Inner.app.destroy()
+		test.end()
 	}
 })

--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -109,17 +109,9 @@ tape('only dictionary terms', function (test) {
 		sg0rects.each(d => uniqueHts.add(d.height))
 		test.equal(uniqueHts.size, 45, `should render different rect heights for continuous mode bar plots`)
 
-		const legendTexts = [...matrix.Inner.dom.legendG.node().querySelectorAll('g g text')]
-			.find(d => d?.__data__?.text?.startsWith('Male'))
-			.dispatchEvent(
-				new MouseEvent('mouseup', {
-					bubbles: true,
-					cancelable: true
-				})
-			)
 		// TODO: test for matrix bar plots of continuous mode terms with allowed negative value
 
-		//if (test._ok) matrix.Inner.app.destroy()
+		if (test._ok) matrix.Inner.app.destroy()
 		test.end()
 	}
 })
@@ -1352,62 +1344,5 @@ tape('avoid race condition', function (test) {
 			test.fail('error: ' + e)
 			throw e
 		}
-	}
-})
-
-tape.only('one geneVariant term with legend filter', function (test) {
-	test.timeoutAfter(5000)
-	test.plan(1)
-	runpp({
-		state: {
-			nav: {
-				activeTab: 1
-			},
-			plots: [
-				{
-					chartType: 'matrix',
-					settings: {
-						matrix: {
-							// the matrix autocomputes the colw based on available screen width,
-							// need to set an exact screen width for consistent tests using getBBox()
-							availContentWidth: 1200
-						}
-					},
-					termgroups: [
-						{
-							name: 'Demographics',
-							lst: [
-								{
-									id: 'sex'
-									//q: { mode: 'values' } // or 'groupsetting'
-								}
-							]
-						}
-					]
-				}
-			]
-		},
-		matrix: {
-			callbacks: {
-				'postRender.test': runTests
-			}
-		}
-	})
-
-	function runTests(matrix) {
-		matrix.on('postRender.test', null)
-		console.log('before legendTexts')
-		const legendTexts = [...matrix.Inner.dom.legendG.node().querySelectorAll('g g text')]
-			.find(d => d?.__data__?.text?.startsWith('Male'))
-			.dispatchEvent(
-				new MouseEvent('mouseup', {
-					bubbles: true,
-					cancelable: true
-				})
-			)
-
-		console.log('what is legendTexts', legendTexts)
-		// if (test._ok) matrix.Inner.app.destroy()
-		test.end()
 	}
 })

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -105,6 +105,7 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 	}
 	//if (value.origin) cell.label = `${self.morigin[value.origin].label} ${cell.label}`
 
+	const byDt = self.state.termdbConfig.assayAvailability?.byDt
 	// return the corresponding legend item data
 	const order = value.class == 'CNV_loss' ? -2 : value.class.startsWith('CNV_') ? -1 : 0
 	if (value.dt == 4) {
@@ -141,8 +142,17 @@ function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, heigh
 				entry: { key: value.class, label: cell.label, fill: cell.fill, order, dt: value.dt, origin: value.origin }
 			}
 		}
-	} else if (value.dt == 2) {
-		const group = 'Structural Variants'
+	} else if (value.dt == 2 && byDt?.[2]) {
+		const group = 'Fusion RNA'
+		return {
+			ref: t.ref,
+			group,
+			value: value.class,
+			order: -1,
+			entry: { key: value.class, label: cell.label, fill: cell.fill, order, dt: value.dt, origin: value.origin }
+		}
+	} else if (value.dt == 5 && byDt?.[5]) {
+		const group = 'Structural Variation'
 		return {
 			ref: t.ref,
 			group,

--- a/client/plots/matrix.data.js
+++ b/client/plots/matrix.data.js
@@ -113,19 +113,7 @@ export function applyLegendValueFilter() {
 				for (const annoForOneTerm of Object.values(oneSampleData)) {
 					if (annoForOneTerm.values)
 						annoForOneTerm.values = annoForOneTerm.values.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
-						)
-					if (annoForOneTerm.countedValues)
-						annoForOneTerm.countedValues = annoForOneTerm.countedValues.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
-						)
-					if (annoForOneTerm.filteredValues)
-						annoForOneTerm.filteredValues = annoForOneTerm.filteredValues.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
-						)
-					if (annoForOneTerm.renderedValues)
-						annoForOneTerm.renderedValues = annoForOneTerm.renderedValues.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
+							v => !(grpFilter.dt.includes(v.dt) && (!grpFilter.origin || v.origin == grpFilter.origin))
 						)
 				}
 			}
@@ -134,19 +122,7 @@ export function applyLegendValueFilter() {
 				for (const annoForOneTerm of Object.values(oneSampleData)) {
 					if (annoForOneTerm.values)
 						annoForOneTerm.values = annoForOneTerm.values.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
-						)
-					if (annoForOneTerm.countedValues)
-						annoForOneTerm.countedValues = annoForOneTerm.countedValues.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
-						)
-					if (annoForOneTerm.filteredValues)
-						annoForOneTerm.filteredValues = annoForOneTerm.filteredValues.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
-						)
-					if (annoForOneTerm.renderedValues)
-						annoForOneTerm.renderedValues = annoForOneTerm.renderedValues.filter(
-							v => !(v.dt == grpFilter.dt && (!grpFilter.origin || v.origin == grpFilter.origin))
+							v => !(grpFilter.dt.includes(v.dt) && (!grpFilter.origin || v.origin == grpFilter.origin))
 						)
 				}
 			}
@@ -165,8 +141,16 @@ export function applyLegendValueFilter() {
 		.map(v => v.$id)
 	const data = { samples: {}, lst: [], refs: self.data.refs }
 
+	const onlyHardFilter = structuredClone(self.config.legendValueFilter)
+	onlyHardFilter.lst = onlyHardFilter.lst.filter(
+		l => !l.tvs.legendFilterType || l.tvs.legendFilterType !== 'geneVariant_soft'
+	)
 	for (const row of self.origData.lst) {
-		const include = sample_match_termvaluesetting(row, self.config.legendValueFilter, geneVariant$ids)
+		const include = sample_match_termvaluesetting(
+			row,
+			self.app.vocabApi.vocab?.dslabel == 'GDC' ? self.config.legendValueFilter : onlyHardFilter,
+			geneVariant$ids
+		)
 		if (include || self.chartType == 'hierCluster') {
 			// for hierCluster, should not filter out any samples by sample_match_termvaluesetting
 			// samples are filtered out by joining legendValueFilter with filter in setHierClusterData
@@ -186,18 +170,6 @@ export function applyLegendValueFilter() {
 					annoForOneTerm.values = annoForOneTerm.values.filter(
 						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
 					)
-				if (annoForOneTerm.countedValues)
-					annoForOneTerm.countedValues = annoForOneTerm.countedValues.filter(
-						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
-					)
-				if (annoForOneTerm.filteredValues)
-					annoForOneTerm.filteredValues = annoForOneTerm.filteredValues.filter(
-						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
-					)
-				if (annoForOneTerm.renderedValues)
-					annoForOneTerm.renderedValues = annoForOneTerm.renderedValues.filter(
-						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
-					)
 			}
 		}
 		for (const oneSampleData of Object.values(data.samples)) {
@@ -206,22 +178,11 @@ export function applyLegendValueFilter() {
 					annoForOneTerm.values = annoForOneTerm.values.filter(
 						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
 					)
-				if (annoForOneTerm.countedValues)
-					annoForOneTerm.countedValues = annoForOneTerm.countedValues.filter(
-						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
-					)
-				if (annoForOneTerm.filteredValues)
-					annoForOneTerm.filteredValues = annoForOneTerm.filteredValues.filter(
-						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
-					)
-				if (annoForOneTerm.renderedValues)
-					annoForOneTerm.renderedValues = annoForOneTerm.renderedValues.filter(
-						v => !(v.dt == tvsV.dt && (!tvsV.origin || v.origin == tvsV.origin) && tvsV.mclasslst.includes(v.class))
-					)
 			}
 		}
 	}
-	if (self.chartType !== 'hierCluster') remove_empty_sample(data)
+	if (self.chartType !== 'hierCluster' && geneVariant$ids.length && self.app.vocabApi.vocab?.dslabel == 'GDC')
+		remove_empty_sample(data, geneVariant$ids)
 	self.data = data
 }
 

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -2307,7 +2307,7 @@ function setLengendActions(self) {
 			// for gene expression don't use legend as filter
 			return
 		}
-		if (!targetData.isLegendItem && (!targetData.dt || self.chartType == 'hierCluster')) {
+		if (!targetData.isLegendItem && !targetData.dt) {
 			// do not change color when its a non-genevariant legend group name
 			// or when its a genevariant legend group name for hierCluster
 			return
@@ -2342,7 +2342,7 @@ function setLengendActions(self) {
 
 		// When clicking a legend group name
 		if (!targetData.isLegendItem) {
-			if (!targetData.dt || self.chartType == 'hierCluster') {
+			if (!targetData.dt) {
 				// do not use as filter when its a non-genevariant legend group name
 				// or when its a genevariant legend group name for hierCluster
 				return
@@ -2350,14 +2350,16 @@ function setLengendActions(self) {
 
 			//legendGrpFilterIndex is the index of the filter that is already in self.config.legendGrpFilter.lst
 			const legendGrpFilterIndex = self.config.legendGrpFilter.lst.findIndex(
-				f => f.dt == targetData.dt && (!byOrigin || f.origin == targetData.origin)
+				f =>
+					f.dt.slice().sort().toString() === targetData.dt.slice().sort().toString() &&
+					(!byOrigin || f.origin == targetData.origin)
 			)
 
 			//legendFilterIndex is the index of the first filter (in this filter group being clicked) that is already in self.config.legendValueFilter.lst, if there's any
 			const legendFilterIndex = self.config.legendValueFilter.lst.findIndex(
 				l =>
 					l.legendGrpName == targetData.name &&
-					l.tvs.values.find(v => v.dt == targetData.dt && (!byOrigin || v.origin == targetData.origin))
+					l.tvs.values.find(v => targetData.dt.includes(v.dt) && (!byOrigin || v.origin == targetData.origin))
 			)
 			const menuGrp = new Menu({ padding: '0px' })
 			const div = menuGrp.d.append('div')
@@ -2365,7 +2367,7 @@ function setLengendActions(self) {
 			// when the legend group is not hidden
 			if (legendGrpFilterIndex == -1) {
 				// for consequences/mutations legend group
-				if (targetData.dt == 1) {
+				if (targetData.dt.includes(1)) {
 					div
 						.append('div')
 						.attr('class', 'sja_menuoption sja_sharp_border')
@@ -2453,7 +2455,7 @@ function setLengendActions(self) {
 						menuGrp.hide()
 						// when the legend group is shown and now hide it
 						// add a new "legend group filter" to filter out the legend group's origin + legend group's dt
-						const legendData = structuredClone(targetData)
+						const legendData = JSON.parse(JSON.stringify(targetData))
 						legendData.crossedOut = true
 						const filterNew = { dt: targetData.dt, legendData }
 						if (byOrigin) {

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -160,7 +160,7 @@ export class Matrix {
 				promises.push(this.setData())
 				this.dom.loadingDiv.html('Processing data ...')
 				await Promise.all(promises)
-				this.applyLegendValueFilter()
+				this.applyLegendValueFilter() // need to applyLegendValueFiter before combineData to avoid error for hierCluster
 				if (this.combineData) this.combineData()
 				// tws in the config may be filled-in based on applicable server response data;
 				// these filled-in config, such as tw.term.values|category2samplecount, will need to replace

--- a/client/plots/matrix.legend.js
+++ b/client/plots/matrix.legend.js
@@ -77,6 +77,8 @@ export function getLegendData(legendGroups, refs, self) {
 			if (f.legendGrpName != $id && f.legendGrpName != name && f.tvs.term.name != name) continue
 			if (f.tvs.term.type == 'geneVariant') {
 				for (const v of f.tvs.values) {
+					// need to push all the dt to legend group, even when the legend item is hidden or filtered out
+					if (legend.dt && !legend.dt.includes(v.dt)) legend.dt.push(v.dt)
 					for (const key of v.mclasslst) {
 						const legendk = v.origin ? v.origin + key : key
 						legend.values[legendk] = {

--- a/client/plots/matrix.serieses.js
+++ b/client/plots/matrix.serieses.js
@@ -85,10 +85,11 @@ export function getSerieses(data) {
 								values: {},
 								order: legend.order,
 								$id,
-								dt: legend.entry.dt,
+								dt: legend.entry.dt ? [legend.entry.dt] : legend.entry.dt,
 								origin: legend.entry.origin
 							}
 						const lg = l[legend.group]
+						if (lg.dt && !lg.dt.includes(legend.entry.dt)) lg.dt.push(legend.entry.dt)
 						const legendK = legend.entry.origin ? legend.entry.origin + legend.value : legend.value
 
 						if (!lg.values[legendK]) {
@@ -140,7 +141,7 @@ function addAllHiddenLegendGroups(legendGroups, self) {
 			legendGroups[valueFilter.legendGrpName] = {
 				ref: {},
 				values: {},
-				dt: valueFilter.tvs.values[0].dt,
+				dt: [valueFilter.tvs.values[0].dt],
 				origin: valueFilter.tvs.values[0].origin
 			}
 		} else if (

--- a/client/plots/matrix.serieses.js
+++ b/client/plots/matrix.serieses.js
@@ -79,15 +79,19 @@ export function getSerieses(data) {
 				if (legend) {
 					for (const l of [legendGroups, so.grp.legendGroups]) {
 						if (!l) continue
-						if (!l[legend.group])
+						if (!l[legend.group]) {
 							l[legend.group] = {
 								ref: legend.ref,
 								values: {},
 								order: legend.order,
 								$id,
-								dt: legend.entry.dt ? [legend.entry.dt] : legend.entry.dt,
 								origin: legend.entry.origin
 							}
+							// legend group dt needs to be an array because a legend group such as Mutations/Consequences
+							// could have legend items from multiple dts (dt=1, dt=2, dt=5)
+							if (legend.entry.dt) l[legend.group].dt = [legend.entry.dt]
+						}
+
 						const lg = l[legend.group]
 						if (lg.dt && !lg.dt.includes(legend.entry.dt)) lg.dt.push(legend.entry.dt)
 						const legendK = legend.entry.origin ? legend.entry.origin + legend.value : legend.value

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,4 @@
 
+Features:
+- enable geneVariant legend group filter for hierCluster
+- combine all dts (except for dt=4) into mutations/consequences legend group for dt without assay availability


### PR DESCRIPTION
## Description

Tested with:
- [pediatricMds3 gene expression](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22pediatricMds3%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22hierCluster%22,%22genes%22:[{%22gene%22:%22GAPDH%22},{%22gene%22:%22BCR%22},{%22gene%22:%22ABL1%22},{%22gene%22:%22HOXA1%22}],%22termgroups%22:[{%22name%22:%22Variables%22,%22lst%22:[{%22id%22:%22diagnosis_group_short%22}]}]}]}): add TP53 as a variable using the `Genes -> Edit Group -> Select "Variables" from the drop down` -> toggle mutation legend filters
- also test with [PNET matrix](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22BCOR%22,%22type%22:%22geneVariant%22}},{%22id%22:%22Gender%22},{%22id%22:%22Age%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22TSNE%20Category%22}]}]}]}), should list fusion transcripts and SV in separate legend groups based on assay availability

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
