### PR TITLE
standardize config through termdbConfig.queries.singleCell{data,samples}

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -241,7 +241,7 @@ class singleCellPlot {
 	}
 
 	renderLegend(plot, colorMap) {
-		if (this.state.termdbConfig.singleCell.sameLegend && this.legendRendered) return
+		if (this.state.termdbConfig.queries.singleCell.data.sameLegend && this.legendRendered) return
 		this.legendRendered = true
 		const legendSVG = plot.plotDiv
 			.append('svg')
@@ -274,7 +274,7 @@ class singleCellPlot {
 				.text(
 					`${
 						cluster == 'ref'
-							? this.state.termdbConfig.singleCell.refName
+							? this.state.termdbConfig.queries.singleCell.data.refName
 							: cluster == 'query'
 							? this.state.config.sample
 							: cluster

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -51,7 +51,6 @@ function init({ genomes }) {
 			if (!ds) throw 'invalid dataset name'
 			if (!ds.queries?.singleCell) throw 'no singlecell data on this dataset'
 			result = (await ds.queries.singleCell.samples.get(q)) as TermdbSinglecellsamplesResponse
-			result.sameLegend = ds.queries.singleCell.samples.sameLegend
 		} catch (e: any) {
 			if (e.stack) console.log(e.stack)
 			result = {

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -309,7 +309,13 @@ export type SingleCellSamplesNative = {
 	*/
 	isSampleTerm: string
 
-	/** allow to change name of 1st column from "Sample" to different, e.g. "Case" for gdc */
+	/** 
+	logic to decide sample table columns:
+	a sample table will always have a sample column, to show sample.sample value
+	firstColumnName allow to change name of 1st column from "Sample" to different, e.g. "Case" for gdc
+	the other two properties allow to declare additional columns to be shown in table, that are for display only
+	when sample.experiments[] are used, a last column of experiment id will be auto added
+	*/
 	firstColumnName?: string
 	/** any other columns to be added to sample table. each is a term id */
 	sampleColumns?: { termid: string }[]

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -301,10 +301,6 @@ export type GeneExpressionQueryNative = {
 }
 export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNative
 
-export type SingleCellSamplesGdc = {
-	src: 'gdcapi'
-	get?: (q: any) => any
-}
 export type SingleCellSamplesNative = {
 	src: 'native'
 	/*
@@ -312,10 +308,23 @@ export type SingleCellSamplesNative = {
 	TODO change to hasScTerm:string
 	*/
 	isSampleTerm: string
-	fields: string[]
-	columnNames: string[]
+
+	/** allow to change name of 1st column from "Sample" to different, e.g. "Case" for gdc */
+	firstColumnName?: string
+	/** any other columns to be added to sample table. each is a term id */
+	sampleColumns?: { termid: string }[]
+	experimentColumns?: { label: string }[]
+
 	get?: (q: any) => any
 }
+export type SingleCellSamplesGdc = {
+	src: 'gdcapi'
+	get?: (q: any) => any
+	firstColumnName?: string
+	sampleColumns?: { termid: string }[]
+	experimentColumns?: { label: string }[]
+}
+
 export type SingleCellDataGdc = {
 	src: 'gdcapi'
 	sameLegend: boolean

--- a/server/shared/types/routes/termdb.singlecellSamples.ts
+++ b/server/shared/types/routes/termdb.singlecellSamples.ts
@@ -3,8 +3,17 @@ import { ErrorResponse } from './errorResponse'
 export type Sample = {
 	/** Sample name, required */
 	sample: string
-	/** optional list of sc data files available for this sample, gdc-specific */
+	/** optional list of sc data files available for this sample, gdc-specific
+	if available:
+		each row of sample table will infact be one experiment.
+		selecting one will use its experimentID as "sample" value in request parameter
+		each experiment may have additional fields that may be displayed in table. see singleCell.samples.experimentColumns[]
+
+	if no exp, then each sample will just have one experiment identifiable by its sample name, and this name is used in request
+	*/
 	experiments?: { experimentID: string }[]
+
+	// a sample may have additional fields that will be displayed in table, see singleCell.samples.sampleColumns[]
 }
 
 export type TermdbSinglecellsamplesRequest = {

--- a/server/shared/types/routes/termdb.singlecellSamples.ts
+++ b/server/shared/types/routes/termdb.singlecellSamples.ts
@@ -4,7 +4,7 @@ export type Sample = {
 	/** Sample name, required */
 	sample: string
 	/** optional list of sc data files available for this sample, gdc-specific */
-	files?: any
+	experiments?: { experimentID: string }[]
 }
 
 export type TermdbSinglecellsamplesRequest = {

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2037,7 +2037,7 @@ export function gdc_validate_query_singleCell_samples(ds, genome) {
 			fields: [
 				'id',
 				'cases.submitter_id',
-				'cases.project.project_id', // for display only
+				'cases.project.project_id', // for display only NOTE it will be replaced to 'case.project.project_id' to be consistent with dict term id and used in sample obj property
 				'cases.samples.sample_type',
 				'cases.samples.submitter_id',
 				'cases.primary_site',
@@ -2093,24 +2093,22 @@ export function gdc_validate_query_singleCell_samples(ds, genome) {
 			const caseSubmitterId = c.submitter_id
 			if (!case2files.has(caseSubmitterId)) {
 				case2files.set(caseSubmitterId, {
-					sample: caseSubmitterId, // use "sample" but not case as generic property, which is typed
-					primarySite: c.primary_site,
-					diseaseType: c.disease_type,
-					projectId: c.project?.project_id,
-					files: []
+					sample: caseSubmitterId, // "sample" is universal key, though here is actually case
+					'case.primary_site': c.primary_site,
+					'case.disease_type': c.disease_type,
+					'case.project.project_id': c.project?.project_id,
+					experiments: []
 				})
 			}
 			if (!c.samples?.[0]) throw 'h.cases[0].samples[0] missing'
-			case2files.get(caseSubmitterId).files.push({
-				fileId,
+			case2files.get(caseSubmitterId).experiments.push({
+				experimentID: fileId,
 				sampleName: c.samples[0].submitter_id,
 				sampleType: c.samples[0].sample_type
 			})
 		}
 		return {
-			samples: [...case2files.values()],
-			fields: ds.queries.singleCell.samples.fields,
-			columnNames: ds.queries.singleCell.samples.columnNames
+			samples: [...case2files.values()]
 		}
 	}
 }

--- a/server/src/termdb.config.js
+++ b/server/src/termdb.config.js
@@ -72,7 +72,6 @@ export function make(q, res, ds, genome) {
 	addScatterplots(c, ds)
 	addMatrixplots(c, ds)
 	addGenomicQueries(c, ds, genome)
-	addSinglecellData(c, ds)
 
 	res.send({ termdbConfig: c })
 }
@@ -98,12 +97,6 @@ function addMatrixplots(c, ds) {
 	c.matrixplots = ds.cohort.matrixplots.plots.map(p => {
 		return { name: p.name }
 	})
-}
-
-function addSinglecellData(c, ds) {
-	if (!ds.queries?.singleCell?.data) return
-	// this dataset has premade scatterplots. reveal to client
-	c.singleCell = ds.queries.singleCell.data
 }
 
 function addGenomicQueries(c, ds, genome) {
@@ -158,6 +151,18 @@ function addGenomicQueries(c, ds, genome) {
 	}
 	if (q.rnaseqGeneCount) {
 		q2.rnaseqGeneCount = true
+	}
+	if (q.singleCell) {
+		q2.singleCell = {
+			samples: {
+				fields: q.singleCell.samples.fields,
+				columnNames: q.singleCell.samples.fields
+			},
+			data: {
+				sameLegend: q.singleCell.data.sameLegend,
+				refName: q.singleCell.data.refName
+			}
+		}
 	}
 }
 

--- a/server/src/termdb.config.js
+++ b/server/src/termdb.config.js
@@ -155,8 +155,9 @@ function addGenomicQueries(c, ds, genome) {
 	if (q.singleCell) {
 		q2.singleCell = {
 			samples: {
-				fields: q.singleCell.samples.fields,
-				columnNames: q.singleCell.samples.fields
+				firstColumnName: q.singleCell.samples.firstColumnName,
+				sampleColumns: q.singleCell.samples.sampleColumns,
+				experimentColumns: q.singleCell.samples.experimentColumns
 			},
 			data: {
 				sameLegend: q.singleCell.data.sameLegend,

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -493,8 +493,8 @@ export function server_init_db_queries(ds) {
 			}
 		}
 
+		// determine eligible chart types based on optional genomic queries
 		if (ds.queries) {
-			// has genomic data queries
 			if (ds.queries.snvindel || ds.queries.trackLst) {
 				// suitable datatypes are present, enable genomeBrowser chart
 				for (const cohort in supportedChartTypes) {
@@ -507,6 +507,9 @@ export function server_init_db_queries(ds) {
 			}
 			if (ds.queries.rnaseqGeneCount) {
 				for (const cohort in supportedChartTypes) supportedChartTypes[cohort].push('DEanalysis')
+			}
+			if (ds.queries.singleCell) {
+				for (const cohort in supportedChartTypes) supportedChartTypes[cohort].push('singleCellPlot')
 			}
 		}
 


### PR DESCRIPTION
## Description

please pull sjpp master to test
- sample table display should follow configurations of termdbConfig.queries.singleCell.samples.fields[]
- should show box border by default
- (separate) prevent plot rerender by show/hiding edit menu

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
