### PR TITLE
option to notify subcomponents of an action, but skip the plot itself

### DIFF
--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -115,7 +115,13 @@ function setInteractivity(self) {
 					controls: { isOpen }
 				}
 			},
-			_scope_: 'none'
+			_scope_: 'none',
+			// TODO: may combine _scope_ with _skipNotification_, optimal approach tbd
+			_skipNotification_(componentApi) {
+				// do not notify a plot of this dispatched action, to avoid unnecessary rerender
+				// but all child components of a plot will still be notified
+				return self.app.getState().plots.find(p => p.type === componentApi.type || p.chartType === componentApi.type)
+			}
 		})
 	}
 }

--- a/client/rx/index.js
+++ b/client/rx/index.js
@@ -445,13 +445,11 @@ export function getComponentApi(self) {
 		type: self.type,
 		id: self.id,
 		async update(current) {
-			if (current.action && self.reactsTo) {
-				const affected = self.reactsTo(current.action)
+			if (current.action) {
+				const affected = self.reactsTo ? self.reactsTo(current.action) : true
 				if (!affected) return
-				if (current.action._scope_ === 'none') {
-					// _scope_ = 'none' indicates a state change that should not be tracked,
-					// assume that this also indicates that the main component itself will not
-					// be visibly affected, but should notify children which may be visibly affected
+				if (current.action._skipNotification_?.(api)) {
+					// option to skip notification of a parent component, but still nofify subcomponents
 					await notifyComponents(self.components, current)
 					return
 				}


### PR DESCRIPTION
## Description

Assume that dispatched `action._scope_ = 'none'`  should be dispatched to child components.



Tested with:
- any plot that uses the burger menu: should still open and close as usual
- http://localhost:3000/testrun.html?name=*.unit 
- http://localhost:3000/testrun.html?name=*.integration.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
