### PR TITLE
Fixed term search sorting

### DIFF
--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -332,6 +332,17 @@ export class TermdbVocab extends Vocab {
 		if (targetType) body.targetType = targetType
 		const data = await dofetch3('termdb', { body })
 		if (data.error) throw data.error
+		// sort results
+		const n = str.toUpperCase()
+		const r = { equals: [], startsWith: [], startsWord: [], includes: [] }
+		for (const i of data.lst) {
+			const name = i.name.toUpperCase()
+			if (name === n) r.equals.push(i)
+			else if (name.startsWith(n)) r.startsWith.push(i)
+			else if (name.includes(' ' + n)) r.startsWord.push(i)
+			else r.includes.push(i)
+		}
+		data.lst = [...r.equals, ...r.startsWith, ...r.startsWord, ...r.includes]
 		return data
 	}
 

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -232,7 +232,7 @@ async function trigger_findterm(q, res, termdb, ds, genome) {
 			}
 		}
 
-		const _terms = await termdb.q.findTermByName(str, q.cohortStr, q.treeFilter, q.usecase, matches)
+		const _terms = await termdb.q.findTermByName(str, q.cohortStr, q.treeFilter, q.usecase)
 
 		terms.push(..._terms.map(copy_term))
 

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -300,27 +300,19 @@ export function server_init_db_queries(ds) {
 			JOIN subcohort_terms s ON s.term_id = t.id AND s.cohort=?
 			WHERE name LIKE ?`
 		)
-		q.findTermByName = (n, cohortStr = '', treeFilter = null, usecase = null, matches = null) => {
-			const vals = []
+		q.findTermByName = (n, cohortStr = '', treeFilter = null, usecase = null) => {
 			const tmp = sql.all([cohortStr, '%' + n + '%'])
 			if (tmp) {
-				const r = matches || { equals: [], startsWith: [], startsWord: [], includes: [] }
-				const lst = []
+				const r = []
 				for (const i of tmp) {
 					if (!i.jsondata) continue
-					const name = i.name.toUpperCase()
 					const j = JSON.parse(i.jsondata)
 					j.id = i.id
 					j.name = i.name || j.name
 					j.included_types = i.included_types ? i.included_types.split(',') : []
-					if (!usecase || isUsableTerm(j, usecase).has('plot')) {
-						if (name === n) r.equals.push(j)
-						else if (name.startsWith(n)) r.startsWith.push(j)
-						else if (name.includes(' ' + n)) r.startsWord.push(j)
-						else r.includes.push(j)
-					}
+					if (!usecase || isUsableTerm(j, usecase).has('plot')) r.push(j)
 				}
-				return [...r.equals, ...r.startsWith, ...r.startsWord, ...r.includes]
+				return r
 			}
 			return undefined
 		}

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -308,7 +308,7 @@ export function server_init_db_queries(ds) {
 				const lst = []
 				for (const i of tmp) {
 					if (!i.jsondata) continue
-					const name = i.name.toLowerCase()
+					const name = i.name.toUpperCase()
 					const j = JSON.parse(i.jsondata)
 					j.id = i.id
 					j.name = i.name || j.name


### PR DESCRIPTION
## Description

Term search results have not been properly sorted because of case mismatch. Sorting has been fixed by converting all strings to uppercase. Sorting code has now also been moved from server side to client side.

Can test by using search keyword `card` in [sjlife](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22}). Top results in this branch better match the keyword than top results in master.
Can also test keyword `diagn` in [GDC](http://localhost:3000/?termdb=%7B%22vocab%22:%7B%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22%7D%7D) and compare with master.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
