### PR TITLE
fix: switching GDC mds3 track from gene to genomic mode it can proper…

### DIFF
--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -237,12 +237,8 @@ function loadTk_finish_closure(tk, block) {
 				if (data.cnv) totalCount += data.cnv.length
 				if (totalCount == 0) {
 					// show blank tk with msg
-					let context
-					if (block.pannedpx != undefined || block.zoomedin == true) {
-						context = 'view range'
-					} else if (block.usegm && block.gmmode != 'genomic') {
-						context = block.usegm.name || block.usegm.isoform
-					}
+					let context = 'view range'
+					if (block.usegm && block.gmmode != 'genomic') context = block.usegm.name || block.usegm.isoform
 					tk.skewer.g
 						.append('text')
 						.text('No mutation in ' + context)

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -223,11 +223,11 @@ export function rangequery_rglst(tk, block, par) {
 			r.stop = r.stop == null ? j.stop : Math.max(r.stop, j.stop)
 		}
 		rglst.push(r)
-		par.isoform = block.usegm.isoform
-		par.gene = block.usegm.name
 		if (block.gmmode == 'genomic') {
-			// TODO if can delete the isoform parameter to simply make the query by genomic pos
-			par.atgenomic = 1
+			// in genomic mode for a gene. do not pass isoform and force backend to query via "byrange{}" rather than byisoform which incorrectly limits result to those on isoform but not region
+		} else {
+			par.isoform = block.usegm.isoform
+			par.gene = block.usegm.name
 		}
 	} else {
 		rglst = block.tkarg_rglst(tk)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- switching GDC mds3 track from gene to genomic mode it can properly display ssm now

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -278,11 +278,6 @@ async function load_driver(q, ds) {
 async function query_snvindel(q, ds) {
 	if (q.isoform) {
 		// client supplies isoform, see if isoform query is supported
-		if (q.atgenomic) {
-			// in genomic mode
-			if (!ds.queries.snvindel.byrange) throw '.atgenomic but missing byrange query method'
-			return await ds.queries.snvindel.byrange.get(q)
-		}
 		if (ds.queries.snvindel.byisoform) {
 			// querying by isoform is supported
 			return await ds.queries.snvindel.byisoform.get(q)


### PR DESCRIPTION
…ly display ssm now

## Description

test at http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC. switch from protein to genomic mode. pan and mutation can show for neighboring gene. previously it wasn't
deleted old code from mds3.gdc.js involved in graphql range query

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
