### PR TITLE
server caps gdc bam slice max size

### DIFF
--- a/client/src/block.tk.bam.gdc.js
+++ b/client/src/block.tk.bam.gdc.js
@@ -934,7 +934,7 @@ export async function bamsliceui({
 					sayerror(
 						saydiv,
 						`BAM slice exceeds
-						${fileSize(JSON.parse(sessionStorage.getItem('optionalFeatures')).gdcBamStreamMaxSize)}
+						${fileSize(JSON.parse(sessionStorage.getItem('optionalFeatures')).gdcBam.streamMaxSize)}
 						and is truncated. Please use with caution, or reduce query region size and try again.`
 					)
 					// still let it download

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC BAM slicing will be terminated if slice file size exceeds a limit (user is informed)

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -97,7 +97,7 @@ export const tabixnoterror = s => {
 const ch_genemcount = {} // genome name - gene name - ds name - mutation class - count
 const ch_dbtable = new Map() // k: db path, v: db stuff
 
-export const features = Object.freeze(serverconfig.features || {})
+export const features = serverconfig.features
 
 //////////////////////////////
 // Global variable (storing things in memory)

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -3,7 +3,7 @@ import path from 'path'
 import * as utils from './utils'
 import serverconfig from './serverconfig'
 import { spawn } from 'child_process'
-import { Readable, pipeline, PassThrough } from 'stream'
+import { Readable, pipeline } from 'stream'
 import { createCanvas } from 'canvas'
 import * as bamcommon from './bam.common'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
@@ -3545,8 +3545,6 @@ async function downloadGdcBam2cacheFile_withDenial(req) {
 	return gdc_bam_filenames
 }
 
-const maxStreamSize = 50000 // fixme change to real size before merging
-
 async function streamGdcBam2response(req, res) {
 	const { host, headers } = getGdcDs(req.query.__genomes).getHostHeaders(req.query)
 	headers.compression = false // see comments in get_gdc_bam()
@@ -3560,13 +3558,11 @@ async function streamGdcBam2response(req, res) {
 		let totalBytes = 0
 		sourceStream.on('data', chunk => {
 			totalBytes += chunk.length
-			if (totalBytes > maxStreamSize) {
-				res.destroy()
-				res.end(
-					`BAM slice size exceeds ${fileSize(
-						maxStreamSize
-					)} and is terminated. Please reduce the size of your query region and try again.`
-				)
+			// 200mb
+			if (totalBytes > (serverconfig.features.gdcBamStreamMaxSize || 200000000)) {
+				sourceStream.destroy()
+				res.end()
+				// no need to add further text in end() or try to signal to client in any other means, client will detect missing BAM EOF
 			}
 		})
 

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -83,11 +83,26 @@ mayAdd_mayGetGeneVariantData
 	getProbe2cnvByTw
 	mayAddDataAvailability
 		addDataAvailability
+
+
+arguments:
+	_servconfig
+		bootstrap object for this ds
 */
 
 const unannotatedKey = 'Unannotated' // this duplicates the same string in mds3/legend.js
 
 export async function init(ds, genome, _servconfig, app = null, basepath = null) {
+	// optional features/settings supplied by ds, when missing from serverconfig.features{}, are centralized here.
+	// overwrite not allowed! to prevent hard-to-trace error that 2nd ds changes value set by 1st ds etc...
+	for (const k in ds.serverconfigFeatures || {}) {
+		if (k in serverconfig.features) {
+			console.warn(`!!! NO OVERWRITING SERVERCONFIG.FEATURES.${k} (from ${ds.label}) !!!`)
+		} else {
+			serverconfig.features[k] = ds.serverconfigFeatures[k]
+		}
+	}
+
 	// must validate termdb first
 	await validate_termdb(ds)
 

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -178,6 +178,14 @@ if (!serverconfig.features) {
 	// mdjsonform: true, healthcheck_keys: ["w", "rs"], etc.
 	serverconfig.features = {}
 }
+
+/////////////////////////////////////////////////////////////////////
+//        mandatory settings! set default if missing               //
+/////////////////////////////////////////////////////////////////////
+
+if (!serverconfig.features.gdcBamStreamMaxSize) serverconfig.features.gdcBamStreamMaxSize = 200 * 1000000 // allow to stream a bam slice up to this size. 200mb default. need this on both server and client
+if (!serverconfig.features.gdcBamCacheMaxSize) serverconfig.features.gdcBamCacheMaxSize = 100 * 1000000 // allow to cache a bam slice up to this size. 100mb default. only used on server
+
 if (process.argv.find(a => a == 'validate')) {
 	// issues in the GDC API (like its servers being under maintenance) should not affect
 	// the ability of the PP server to launch itself, so skip GDC-caching during validation

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -173,18 +173,16 @@ if (process.env.PP_MODE?.startsWith('container')) {
 }
 
 if (!serverconfig.features) {
-	// default to having an empty object value for
-	// examples of end-user-accessible features are:
-	// mdjsonform: true, healthcheck_keys: ["w", "rs"], etc.
+	/*
+	default to having an empty object value for end-user-accessible features
+	necessary to ensure features{} object is set, as later when bootstraping a dataset, ds.serverconfigFeatures{} will be copied over
+	NOTE  serverconfig.json settings takes highest priority!! these are instance-level setting, e.g. on your dev computer
+	and overwrites default values from ds.serverconfigFeatures{} to assist e.g. dev work
+	*/
 	serverconfig.features = {}
 }
 
-/////////////////////////////////////////////////////////////////////
-//        mandatory settings! set default if missing               //
-/////////////////////////////////////////////////////////////////////
-
-if (!serverconfig.features.gdcBamStreamMaxSize) serverconfig.features.gdcBamStreamMaxSize = 200 * 1000000 // allow to stream a bam slice up to this size. 200mb default. need this on both server and client
-if (!serverconfig.features.gdcBamCacheMaxSize) serverconfig.features.gdcBamCacheMaxSize = 100 * 1000000 // allow to cache a bam slice up to this size. 100mb default. only used on server
+// when a mandatory setting is not defined in any ds, declare its default here
 
 if (process.argv.find(a => a == 'validate')) {
 	// issues in the GDC API (like its servers being under maintenance) should not affect
@@ -218,5 +216,4 @@ if (fs.existsSync('./package.json')) {
 	serverconfig.version = JSON.parse(pkg).version
 }
 
-//Object.freeze(serverconfig)
 module.exports = serverconfig


### PR DESCRIPTION
## Description

to test, set these in serverconfig (limiting to 50kb):
 "gdcBam":{"cacheMaxSize":50000,"streamMaxSize":50000},

test at [stream to download](http://localhost:3000/?gdcbamslice=1&gdc_id=00493087-9d9d-40ca-86d5-936f1b951c93_wxs_gdc_realn.bam&gdc_ssm=R132H&stream2download=1) and [slice to view](http://localhost:3000/?gdcbamslice=1&gdc_id=00493087-9d9d-40ca-86d5-936f1b951c93_wxs_gdc_realn.bam&gdc_ssm=R132H) which both indicates err to user

please pull sjpp master and help test it in GFF
features.gdcBam{} defaults are now declared in gdc ds file and is copied over on launch by mds3.init.js 
bamCache{} is not moved to gdc!!
tested that bam tk still works by removing gdc ds from instance

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
