### PR TITLE
migrate augen to node 20

### DIFF
--- a/augen/.gitignore
+++ b/augen/.gitignore
@@ -2,3 +2,4 @@ test/checkers
 test/types/*.js
 public/docs/*
 public/server-api.json
+**/*.js

--- a/augen/package.json
+++ b/augen/package.json
@@ -6,10 +6,10 @@
   "main": "src/augen.js",
   "bin": "cli.js",
   "scripts": {
-    "predev": "ts-node-esm test/prep.js",
-    "dev": "ts-node-esm test/app.js",
-    "pretest": "ts-node-esm test/prep.js && typia generate --input test/checkers-raw --output test/checkers",
-    "test": "ts-node-esm test/unit.spec.js",
+    "predev": "tsx test/prep.js",
+    "dev": "npm run doc && tsx watch test/app.js",
+    "pretest": "tsx test/prep.js && typia generate --input test/checkers-raw --output test/checkers",
+    "test": "tsx test/unit.spec.js",
     "doc": "./build.sh test/routes test/types test/checkers public/docs"
   },
   "author": "",

--- a/augen/src/augen.js
+++ b/augen/src/augen.js
@@ -50,6 +50,7 @@ export function typeCheckers(fileRoutes, fromPath) {
 	const importLines = [`import { createValidate } from 'typia'`]
 	const createLines = []
 	for (const file in typeIdsByFile) {
+		if (file.endsWith('.js')) continue
 		const typeIds = Array.from(typeIdsByFile[file])
 		importLines.push(`import { ${typeIds.join(', ')} } from '${fromPath}/${file}'`)
 		for (const typeId of typeIds) {

--- a/augen/test/app.js
+++ b/augen/test/app.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const files = readdirSync(join(__dirname, './routes'))
-const endpoints = files.filter(f => f.endsWith('.ts') || f.endsWith('.js'))
+const endpoints = files.filter(f => f.endsWith('.ts')) //|| f.endsWith('.js'))
 const port = 'PORT' in process.env ? Number(process.env.PORT) : 8999
 init({ port })
 
@@ -19,7 +19,6 @@ async function init(opts = {}) {
 			return Object.assign({ file, basepath }, route)
 		})
 	)
-	//console.log(endpoints, routes)
 
 	const app = express()
 	const staticService = express.static(join(__dirname, '../public'))

--- a/augen/test/prep.js
+++ b/augen/test/prep.js
@@ -8,7 +8,7 @@ prep()
 
 async function prep() {
 	const files = readdirSync(join(__dirname, './routes'))
-	const endpoints = files.filter(f => f.endsWith('.ts') || f.endsWith('.js'))
+	const endpoints = files.filter(f => f.endsWith('.ts')) // || f.endsWith('.js'))
 
 	const routes = await Promise.all(
 		endpoints.map(async file => {

--- a/augen/tsconfig.json
+++ b/augen/tsconfig.json
@@ -2,13 +2,15 @@
   "compilerOptions": {
     "module": "node16",
     "moduleResolution": "node16",
-    "esModuleInterop": true,
+    "target": "es2020",
     "baseUrl": "./",
-    "allowImportingTsExtensions": true,
     "strictNullChecks": true,
     "skipLibCheck": true,
     "noImplicitAny": false
   },
+  "include": [
+    "**/checkers/index.ts"
+  ],
   "exclude": [
     "node_modules",
     "**/*+(.spec|.e2e).ts"

--- a/augen/webpack.config.cjs
+++ b/augen/webpack.config.cjs
@@ -10,13 +10,22 @@ module.exports = function getPortalConfig(env = {}) {
 		mode: 'development', //env.NODE_ENV ? env.NODE_ENV : 'production',
 		target: 'web',
 		entry,
+
+		experiments: {
+	    outputModule: true,
+	  },
+
 		output: {
+			module: true,
 			path: outdir,
 			publicPath: '__PP_URL__',
 			filename: 'checkers.js',
 			chunkLoadingGlobal: 'ppCheckersJsonp',
 			// the library name exposed by this bundle
-			library: 'ppcheckers',
+			library: {
+				name: 'ppcheckers',
+				type: 'module'
+			},
 			// the target context to which the library is 'attached' or assigned
 			// e.g., window.checkers
 			libraryTarget: 'window'


### PR DESCRIPTION
## Description

Tested with:
- from the proteinpaint/augen dir: `npm run dev` then open http://localhost:8999/, should open a `Server API` docs page
- from the proteinpaint dir: `npm run doc`, then open http://localhost:3000/server.html, should see docs for server routes

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
