### PR TITLE
handle spawn error in blat route

### DIFF
--- a/server/src/blat.js
+++ b/server/src/blat.js
@@ -50,6 +50,7 @@ function server_stat(name, g) {
 			}
 			resolve(name + ' ON, ' + c + ' requests')
 		})
+		ps.on('error', e => reject(e.message || 'Error calling gfServer'))
 	})
 }
 
@@ -226,5 +227,6 @@ function run_blat2(genome, infile) {
 			}
 			resolve(outfile)
 		})
+		ps.on('error', e => reject(e.message || 'Error calling gfClient'))
 	})
 }


### PR DESCRIPTION
## Description

now nodejs will no longer crash due to missing binaries. apologize for the sloppy code i wrote before. should do `ps.on('error',e=>reject())` on all spawn uses?

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
