### PR TITLE
fix: preliminary fix for mds3 tk using custom bcf file to pull mutate…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- preliminary fix for mds3 tk using custom bcf file to pull mutated smples

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -691,7 +691,8 @@ type ChartConfig = {
 	[key: string]: any
 }
 
-type SimpleTermEntry = {
+// modified version of termwrapper
+type Tw = {
 	id: string
 	q: unknown
 	baseURL?: string //Only appears as a quick fix in SAMD9-SAMD9L.hg19?
@@ -699,8 +700,8 @@ type SimpleTermEntry = {
 
 type Variant2Samples = GdcApi & {
 	variantkey: string
-	twLst: SimpleTermEntry[]
-	sunburst_twLst?: SimpleTermEntry[]
+	twLst?: Tw[]
+	sunburst_twLst?: Tw[]
 }
 
 type MutationSet = {

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -1,5 +1,6 @@
 import { mayCopyFromCookie, fileurl } from './utils'
 import { snvindelByRangeGetter_bcf } from './mds3.init'
+import { validate_variant2samples } from './mds3.variant2samples.js'
 
 /*
 method good for somatic variants, in skewer and gp queries:
@@ -177,6 +178,12 @@ async function get_ds(q, genome) {
 		}
 		ds.queries.snvindel = { byrange: { _tk } }
 		ds.queries.snvindel.byrange.get = await snvindelByRangeGetter_bcf(ds, genome)
+		// bcf header should have been parsed, allow to know if if there's sample
+		if (ds.queries.snvindel.byrange._tk.samples?.length) {
+			// add v2s
+			ds.variant2samples = { variantkey: 'ssm_id' }
+			await validate_variant2samples(ds)
+		}
 	}
 	// add new file types
 


### PR DESCRIPTION
…d smples

## Description

closes #1063 

test at http://localhost:3000/?genome=hg38-test&gene=p53&mds3bcffile=custom,files/hg38/TermdbTest/TermdbTest.bcf.gz, click individual mutation as well as the `5 samples` leftlabel all works. please also test with other ds urls
in next pr will support FORMAT fields

all mds3 tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
