### PR TITLE
do not force the sample table to be positioned relative to screen bot…

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -188,8 +188,8 @@ export class Menu {
 		const p = this.dnode.getBoundingClientRect()
 
 		//does not fit to the right
-		if (/*width - x < middlex &&*/ x + p.width > width) this.d.style('left', 0)
-		else this.d.style('left', x + 'px')
+		if (x + p.width > width) this.d.style('left', null).style('right', width - x + 'px')
+		else this.d.style('left', x + 'px').style('right', null)
 
 		this.d.style('top', y + 'px').style('bottom', null)
 		this.d.transition().style('opacity', 1)

--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -167,6 +167,35 @@ export class Menu {
 		return this
 	}
 
+	// simplified alternative to show(), with less arguments
+	show2(_x, _y) {
+		let x = _x
+		let y = _y
+		this.prevX = _x
+		this.prevY = _y
+
+		// show around a given point
+		document.body.appendChild(this.dnode)
+		this.d.style('display', 'block')
+
+		x = x + window.scrollX + this.offsetX
+		y = y + window.scrollY + this.offsetY
+
+		const width = window.innerWidth
+		const height = window.innerHeight
+		const middlex = width / 2
+		const middley = height / 2
+		const p = this.dnode.getBoundingClientRect()
+
+		//does not fit to the right
+		if (/*width - x < middlex &&*/ x + p.width > width) this.d.style('left', 0)
+		else this.d.style('left', x + 'px')
+
+		this.d.style('top', y + 'px').style('bottom', null)
+		this.d.transition().style('opacity', 1)
+		return this
+	}
+
 	showunder(dom) {
 		// route to .show()
 		const p = dom.getBoundingClientRect()

--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -178,7 +178,10 @@ export class Menu {
 		document.body.appendChild(this.dnode)
 		this.d.style('display', 'block')
 
-		x = x + window.scrollX + this.offsetX
+		// the event.clientX and event.clientY are already veiwport positions.
+		// when position == absolute, (what we have now) the scroll position has to be considered.
+		// when position == fixed, relative to the viewport, the scroll could be ignored, but the menu doesn't follow the scroll
+		x = x + window.scrollX + this.offsetX // by adding the scroll, the postion of menu becomes relative to document.body
 		y = y + window.scrollY + this.offsetY
 
 		const width = window.innerWidth
@@ -188,10 +191,13 @@ export class Menu {
 		const p = this.dnode.getBoundingClientRect()
 
 		//does not fit to the right
-		if (x + p.width > width) this.d.style('left', null).style('right', width - x + 'px')
-		else this.d.style('left', x + 'px').style('right', null)
+		// "right" is relative to the right side of menu and window
+		if (x + p.width > width) this.d.style('left', '').style('right', '5px')
+		else this.d.style('left', x + 'px').style('right', '')
 
-		this.d.style('top', y + 'px').style('bottom', null)
+		// for now, the users have to scroll down to see the entire menu if there is not enough height for the menu
+		// TODO: reposition the menu to make it at least partially visible.
+		this.d.style('top', y + 'px').style('bottom', '')
 		this.d.transition().style('opacity', 1)
 		return this
 	}

--- a/client/mds3/clickVariant.js
+++ b/client/mds3/clickVariant.js
@@ -134,7 +134,7 @@ async function click2sunburst(d, tk, block, tippos) {
 			// positioned relative to the bottom of the div, which may not be visible
 			// relative to the screen/window bottom and so the sample table is rendered
 			// below the screen and not visible unless the user scrolls down
-			tk.itemtip.show(x, y) //, false, false)
+			tk.itemtip.show2(x, y)
 		}
 	}
 	if (d.aa) {

--- a/client/mds3/clickVariant.js
+++ b/client/mds3/clickVariant.js
@@ -130,7 +130,11 @@ async function click2sunburst(d, tk, block, tippos) {
 			only need to show sample display
 			*/
 			await init_sampletable(param)
-			tk.itemtip.show(x, y, false, false)
+			// the last 2 boolean arguments causes the sample table to be
+			// positioned relative to the bottom of the div, which may not be visible
+			// relative to the screen/window bottom and so the sample table is rendered
+			// below the screen and not visible unless the user scrolls down
+			tk.itemtip.show(x, y) //, false, false)
 		}
 	}
 	if (d.aa) {

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -156,7 +156,7 @@ export function setInteractivity(self) {
 		}
 		self.dom.matrixCellHoverOver.clear()
 		self.dom.matrixCellHoverOver.d.append('div').html(`<table class='sja_simpletable'>${rows.join('\n')}</table>`)
-		self.dom.matrixCellHoverOver.show(event.clientX, event.clientY)
+		self.dom.matrixCellHoverOver.show2(event.clientX, event.clientY)
 		self.dom.mainG.on('mouseout', self.mouseout)
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Do not force the sample table to be positioned relative to screen bottom after a sunburst click


### PR DESCRIPTION
## Description
…tom after a sunburst click

Fixes https://gdc-ctds.atlassian.net/browse/SV-2437.

Tested in GFF SSM lollipop track, and also in localhost:3000, after clicking a sunburst the sample table should be near the click.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
