### PR TITLE
PP code to handle 'hideTitle' flag from dataset

### DIFF
--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -88,7 +88,7 @@ function make(q, res, ds, genome) {
 		isGeneSetTermdb: tdb.isGeneSetTermdb,
 		lollipop: tdb.lollipop,
 		urlTemplates: tdb.urlTemplates,
-		title: ds.cohort.title || ds.label
+		title: ds.cohort.hideTitle ? '' : ds.cohort.title || ds.label
 	}
 	// optional attributes
 	// when missing, the attribute will not be present as "key:undefined"

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -88,7 +88,7 @@ function make(q, res, ds, genome) {
 		isGeneSetTermdb: tdb.isGeneSetTermdb,
 		lollipop: tdb.lollipop,
 		urlTemplates: tdb.urlTemplates,
-		title: ds.cohort.hideTitle ? '' : ds.cohort.title || ds.label
+		title: 'title' in ds.cohort ? ds.cohort.title : ds.label
 	}
 	// optional attributes
 	// when missing, the attribute will not be present as "key:undefined"

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -757,7 +757,6 @@ export type Cohort = {
 	scatterplots?: Scatterplots
 	// optional title of this ds, if missing use ds.label. shown on mass nav header
 	title?: string
-	hideTitle?: boolean // optional flag to hide title
 	cumburden?: {
 		files: {
 			fit: string

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -757,6 +757,7 @@ export type Cohort = {
 	scatterplots?: Scatterplots
 	// optional title of this ds, if missing use ds.label. shown on mass nav header
 	title?: string
+	hideTitle?: boolean // optional flag to hide title
 	cumburden?: {
 		files: {
 			fit: string


### PR DESCRIPTION
## Description

New PP code to handle the 'hideTitle' flag from dataset file.

Can test by comparing navigation bar between [SJLife](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22}) dataset and [PNET](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg19%22,%22dslabel%22:%22PNET%22}) dataset

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
