### PR TITLE
create a gdc cohort-level MAF launcher

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -701,6 +701,9 @@ async function parseEmbedThenUrl(arg, app) {
 	if (arg.launchGdcHierCluster) {
 		return await launchGdcHierCluster(arg, app)
 	}
+	if (arg.launchGdcMaf) {
+		return await launchGdcMaf(arg, app)
+	}
 
 	if (arg.parseurl && location.search.length) {
 		/*
@@ -1320,16 +1323,21 @@ async function launchSelectGenomeWithTklst(arg, app) {
 }
 
 async function launchGeneSearch4GDCmds3(arg, app) {
-	const _ = await import('./geneSearch4GDCmds3')
+	const _ = await import('./geneSearch4GDCmds3.js')
 	return await _.init(arg, app.holder0, app.genomes)
 }
 async function launchGdcMatrix(arg, app) {
-	const _ = await import('./launchGdcMatrix')
+	const _ = await import('./launchGdcMatrix.js')
 	return await _.init(arg, app.holder0, app.genomes)
 }
-async function launchGdcHierCluster(arg, app) {
-	const _ = await import('./launchGdcHierCluster')
-	return await _.init(arg, app.holder0, app.genomes)
+async function launchGdcMaf(arg, app) {
+	const _ = await import('./gdc.maf.js')
+	return await _.gdcMAFui({
+		holder: app.holder0,
+		filter0: arg.filter0,
+		callbacks: arg.callbacks || {},
+		debugmode: arg.debugmode
+	})
 }
 
 function launchmavb(arg, app) {

--- a/client/src/gdc.maf.js
+++ b/client/src/gdc.maf.js
@@ -162,15 +162,7 @@ const mafColumns = [
 	{ column: 'callers', selected: true }
 ]
 
-export async function gdcMAFui({ holder, filter0, callbackOnRender, debugmode = false }) {
-	// public api obj to be returned
-	const publicApi = {}
-
-	if (typeof callbackOnRender == 'function') {
-		// ?
-		callbackOnRender(publicApi)
-	}
-
+export async function gdcMAFui({ holder, filter0, callbacks, debugmode = false }) {
 	try {
 		{
 			// validate column names in case of human err
@@ -181,6 +173,14 @@ export async function gdcMAFui({ holder, filter0, callbackOnRender, debugmode = 
 				cn.add(c.column)
 			}
 		}
+		update({ filter0 })
+	} catch (e) {
+		console.log(e)
+		sayerror(holder, e.message || e)
+	}
+
+	async function update({ filter0 }) {
+		holder.selectAll('*').remove()
 		const obj = {
 			// old habit of wrapping everything
 			errDiv: holder.append('div'),
@@ -193,11 +193,13 @@ export async function gdcMAFui({ holder, filter0, callbackOnRender, debugmode = 
 		}
 		makeControls(obj)
 		await getFilesAndShowTable(obj)
-	} catch (e) {
-		console.log(e)
-		sayerror(holder, e.message || e)
+		if (typeof callbacks?.postRender == 'function') {
+			callbacks.postRender(publicApi)
+		}
 	}
 
+	// public api obj to be returned
+	const publicApi = { update }
 	return publicApi // ?
 }
 


### PR DESCRIPTION
## Description

To test:
- pull `sjpp` master
- can test http://localhost:3000/GDC/maf.html, which does not use a URL param
- @congyu-lu pull `gdc-frontend-framework` `maf-card` branch, should see a `Cohort Level MAF` card. In the MAF app, changing the cohort should cause the list of files to re-render.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
