### PR TITLE
Fix to unhide a survival series by clicking its corresponding legend

### DIFF
--- a/client/plots/survival.js
+++ b/client/plots/survival.js
@@ -62,7 +62,7 @@ class TdbSurvival {
 			},
 			handlers: {
 				legend: {
-					click: e => this.legendClick(e.target.data, e.clientX, e.clientY)
+					click: e => this.legendClick(e.target.__data__, e.clientX, e.clientY)
 				}
 			}
 		})
@@ -72,7 +72,7 @@ class TdbSurvival {
 			},
 			handlers: {
 				legend: {
-					click: e => this.legendClick(e.target.data, e.clientX, e.clientY)
+					click: e => this.legendClick(e.target.__data__, e.clientX, e.clientY)
 				}
 			}
 		})

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Fix to unhide a survival series by clicking its corresponding legend entry


### PR DESCRIPTION
## Description

Fixes https://github.com/stjude/proteinpaint/issues/1448

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
