### PR TITLE
Do not persist highlighted dendrogram branch selection

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Do not persist highlighted dendrogram branch selection when the hier. cluster data changes due to changes to cohort, clustering method, etc.


### PR DESCRIPTION
 ## Description
... when the hierchical cluster data changes due to changes to cohort, clustering method, etc.

To test:
- open http://localhost:3000/example.gdc.exp.html?&cohort=APOLLO,EAGLE
- click on a dendrogram line to highlight in red the corresponding branch
- zoom in, the highlighted branch should persist
- change the cohort, there should not be any lines in red (previously there would have been scattered red lines)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
