### PR TITLE
Disable the geneset submit button when the number of genes

### DIFF
--- a/client/dom/genesetEdit.ts
+++ b/client/dom/genesetEdit.ts
@@ -29,6 +29,7 @@ type showGenesetEditArg = {
 	holder: any
 	genome: any
 	mode?: 'expression' // if provided, allow to load top variably expressed genes; later can be union of multiple mode strings
+	minNumGenes?: number
 	callback: (arg: CallbackArg) => void
 	vocabApi: any
 	geneList?: {
@@ -38,7 +39,7 @@ type showGenesetEditArg = {
 }
 
 export function showGenesetEdit(arg: showGenesetEditArg) {
-	const { holder, genome, mode, callback, vocabApi, titleText } = arg
+	const { holder, genome, mode, callback, vocabApi, titleText, minNumGenes } = arg
 	let geneList = structuredClone(arg.geneList || [])
 	const tip2 = new Menu({ padding: '0px', parent_menu: holder.node(), test: 'test' })
 	holder.selectAll('*').remove()
@@ -306,7 +307,8 @@ export function showGenesetEdit(arg: showGenesetEditArg) {
 		const hasChanged = origNames !== JSON.stringify(geneList.map(t => t.gene).sort())
 		api.dom.restoreBtn?.property('disabled', !hasChanged)
 		// disable submit button when gene list not changed or is empty in expression mode
-		api.dom.submitBtn.property('disabled', !hasChanged || (mode == 'expression' && !geneList?.length))
+		const minNum = minNumGenes || 0
+		api.dom.submitBtn.property('disabled', !hasChanged || geneList?.length < minNum)
 		if (hasChanged) submitBtn.node().focus()
 	}
 

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -27,10 +27,10 @@ export class MatrixControls {
 		this.setVariablesBtn(s)
 		this.setDimensionsBtn(s)
 		this.setLegendBtn(s)
-		if (state.termdbConfig.matrix?.settings?.addMutationCNVButtons && this.parent.chartType !== 'hierCluster')
+		if (s.addMutationCNVButtons && this.parent.chartType !== 'hierCluster') {
 			this.setCNVBtn()
-		if (state.termdbConfig.matrix?.settings?.addMutationCNVButtons && this.parent.chartType !== 'hierCluster')
 			this.setMutationBtn()
+		}
 		this.setDownloadBtn(s)
 		this.setZoomInput()
 		this.setDragToggle({
@@ -888,6 +888,7 @@ export class MatrixControls {
 				genome: app.opts.genome,
 				geneList,
 				mode: selectedGroup.mode,
+				minNumGenes: selectedGroup.mode == 'expression' ? 3 : 1,
 				vocabApi: this.opts.app.vocabApi,
 				callback: ({ geneList, groupName }) => {
 					if (!selectedGroup) throw `missing selectedGroup`

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Disable the geneset submit button when there there is less than a minNumGenes option (3 for hier cluster, 1 for matrix)


### PR DESCRIPTION
## Description

....  is less than a minNumGenes option (3 for hier cluster, 1 for matrix)

To test:
- http://localhost:3000/example.gdc.matrix.html?maxGenes=3:  clearing the geneset edit UI should disable the submit button
- http://localhost:3000/example.gdc.exp.html?&cohort=APOLLO,EAGLE: the submit button should only be enabled when the list has changed and there is >= 3 genes

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
