### PR TITLE
Reduced font size on scatter tooltip svg to avoid clipping

### DIFF
--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -196,7 +196,7 @@ export function setInteractivity(self) {
 					const svg = td.append('svg').attr('width', width).attr('height', '25px')
 					const g = svg.append('g').attr('transform', 'translate(10, 14)')
 					g.append('path').attr('d', shape).attr('fill', color).attr('stroke', '#aaa')
-					const text = g.append('text').attr('x', 12).attr('y', 6)
+					const text = g.append('text').attr('x', 12).attr('y', 6).attr('font-size', '0.9em')
 
 					const span2 = text.append('tspan').text(node.value).attr('fill', fontColor)
 				} else td.style('padding', '2px').text(`${node.value}`)


### PR DESCRIPTION
## Description

During giles meeting I noticed the scatter tooltip had some text clipping. Fixed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
