### PR TITLE
Display message about cohort persistence

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -62,14 +62,11 @@ export async function getPlotConfig(opts = {}, app) {
 				geneVariantCountSamplesSkipMclass: [],
 				cellbg: '#ececec',
 				showGrid: '', // false | 'pattern' | 'rect'
-				showMatrixMutation:
-					app.vocabApi.termdbConfig?.matrix?.settings?.addMutationCNVButtons && opts.chartType !== 'hierCluster'
-						? 'all'
-						: '',
-				showMatrixCNV:
-					app.vocabApi.termdbConfig?.matrix?.settings?.addMutationCNVButtons && opts.chartType !== 'hierCluster'
-						? 'none'
-						: '',
+				// whether to show these controls buttons
+				addMutationCNVButtons: false,
+				// used for the radio inputs in the CNV/Mutation control menus
+				showMatrixMutation: opts.chartType !== 'hierCluster' ? '' : 'all',
+				showMatrixCNV: opts.chartType !== 'hierCluster' ? '' : 'all',
 				allMatrixCNVHidden: false,
 				allMatrixMutationHidden: false,
 				gridStroke: '#fff',

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -700,15 +700,11 @@ export class MatrixControls {
 			.datum({
 				label: 'CNV',
 				updateBtn: btn => {
-					const matrixSetting = this.parent.config.settings.matrix
-					btn.style(
-						'text-decoration',
-						matrixSetting.showMatrixCNV == 'none' || matrixSetting.allMatrixCNVHidden ? 'line-through' : ''
-					)
-					btn.style(
-						'text-decoration-thickness',
-						matrixSetting.showMatrixCNV == 'none' || matrixSetting.allMatrixCNVHidden ? '2px' : ''
-					)
+					const s = this.parent.config.settings.matrix
+					const notRendered = s.showMatrixCNV == 'none' || s.allMatrixCNVHidden
+					btn
+						.style('text-decoration', notRendered ? 'line-through' : '')
+						.style('text-decoration-thickness', notRendered ? '2px' : '')
 				},
 				rows: [
 					{

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -766,7 +766,7 @@ export class MatrixControls {
 				step: s.zoomStep || 1
 			})
 
-		if (this.svgScrollApi) {
+		if (this.svgScrollApi && d) {
 			this.svgScrollApi.update({
 				x: d.xOffset,
 				y: d.yOffset - s.scrollHeight,

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -187,10 +187,16 @@ export class Matrix {
 			this.sampleGroups = this.getSampleGroups(this.hierClusterSamples || this.data)
 			this.sampleOrder = this.getSampleOrder(this.data)
 
-			if (!this.sampleOrder?.length) {
-				// lack of data may be due to cohort filter, legend filter, and/or selected geneset
+			if (
+				!this.sampleOrder?.length &&
+				// TODO: should show empty data message when there is nothing to render
+				//       because of cohort, legend filter, and/or geneset
+				// this.config.settings.matrix.addMutationCNVButtons ||
+				!this.config.legendGrpFilter?.lst.length &&
+				!this.config.legendValueFilter?.lst.length
+			) {
 				this.showNoMatchingDataMessage()
-				this.controlsRenderer.main()
+				this.controlsRenderer.main() // to update button count or cross out button labels
 				return
 			}
 			this.setLayout()

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Display hints about persisted matrix gene set and option to unhide CNV and mutations when there is no matrix data to render


### PR DESCRIPTION
## Description

Display a message that gene sets are persisted across cohort changes. Also, display hints about persisted matrix gene set and option  to unhide CNV and mutations when there is no matrix data to render

![Screenshot 2024-03-26 at 2 44 30 PM](https://github.com/stjude/proteinpaint/assets/411031/f1e5d07a-122b-42e9-9822-ec0db5f66a19)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
