### PR TITLE
reenable the option to create a single sample cohort from a lollipop

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -284,13 +284,7 @@ function printSampleName(sample, tk, div, block, thisMutation) {
 
 	const extraRow = div.append('div') // row under sample name to show optional info about the sample
 
-	/* !!! temporary change !!!
-	hides button to disable selecting a single sample
-	required for gdc not wanting to create single-case cohort, and shouldn't break non-gdc ds too much
-	reenable when gdc offer a modal to select existing cohort and add to it
-	also revert test change
-	*/
-	if (0 && tk.allow2selectSamples) {
+	if (tk.allow2selectSamples) {
 		// display button for selecting this sample alone
 		const t = tk.allow2selectSamples.buttonText
 		const btn = extraRow

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -430,11 +430,7 @@ must use a gene with both single and multi occurrence mutations to test
 		singletonMutationDisc.dispatchEvent(new Event('click'))
 		await whenVisible(tk.itemtip.d)
 
-		/*** !!! temporarily disabled test.
-		mds3 no longer shows select button for single sample
-		reenable when mds3 change is reverted
-		*/
-		if (0) {
+		{
 			const button = await detectOne({ elem: tk.itemtip.dnode, selector: '.' + buttonClass })
 			test.equal(button.innerHTML, buttonText, buttonText + ' button created in single-sample menu')
 			// TODO trigger click on selection button

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Reenable the option to create a single sample cohort from a lollipop sample table/menu


### PR DESCRIPTION
## Description

… sample table/menu. This addresses https://gdc-ctds.atlassian.net/browse/SV-2417, and works with https://github.com/NCI-GDC/gdc-frontend-framework/pull/1031.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
