### PR TITLE
include auth tests in server healthcheck

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -232,7 +232,7 @@ function mayAdjustRequest(url, init) {
 		// assume a minimal URL path + parameters for a POST request
 		// since the payload will be in the request body
 		if (typeof init.body == 'string') init.body = JSON.parse(init.body)
-		if (!init.body.embedder) init.body.embedder = hostname
+		if (!init.body.embedder && includeEmbedder) init.body.embedder = hostname
 		init.body = JSON.stringify(init.body)
 		return url
 	}
@@ -245,14 +245,14 @@ function mayAdjustRequest(url, init) {
 		// init.body should be an object, to be converted to either
 		// (a) GET URL search parameter strings, OR
 		// (b) POST body, JSON-encoded
-		if (!init.body.embedder) init.body.embedder = hostname
+		if (!init.body.embedder && includeEmbedder) init.body.embedder = hostname
 
 		const params = encode(init.body)
 		if (!url.includes('?')) url += '?'
 		url += params
 	}
 
-	if (!url.includes('embedder=')) {
+	if (!url.includes('embedder=') && includeEmbedder) {
 		const sep = url.includes('?') ? '&' : '?'
 		url += `${sep}embedder=${hostname}`
 	}
@@ -286,7 +286,7 @@ function mayAdjustRequest(url, init) {
 					params[k] = decodedVal
 				}
 			})
-		if (!params.embedder) params.embedder = hostname
+		if (!params.embedder && includeEmbedder) params.embedder = hostname
 		init.body = JSON.stringify(params)
 	}
 
@@ -294,7 +294,10 @@ function mayAdjustRequest(url, init) {
 }
 
 const dsAuthOk = new Set()
-let dsAuth, authUi, authUiHolder
+let dsAuth,
+	authUi,
+	authUiHolder,
+	includeEmbedder = false
 
 /*
 	opts{}
@@ -311,6 +314,7 @@ export function setAuth(opts) {
 		// so that an unnecessary login form will not be shown
 		if (auth.insession) dsAuthOk.add(auth)
 	}
+	includeEmbedder = opts.dsAuth?.length > 0 || false
 }
 
 export function isInSession(dslabel, route) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- include auth test status in server healthcheck

--- a/server/shared/types/routes/healthcheck.ts
+++ b/server/shared/types/routes/healthcheck.ts
@@ -46,6 +46,9 @@ export type HealthCheckResponse = {
 	status: 'ok' | 'error'
 	genomes: BuildByGenome
 	versionInfo: VersionInfo
+	auth?: {
+		errors?: string[]
+	}[]
 	w?: number[]
 	rs?: number
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -50,7 +50,6 @@ export async function launch() {
 			routeFiles
 				//.filter(file => file.includes('health'))
 				.map(async file => {
-					console.log('route: ', file)
 					const _ = await import(`../routes/${file}`)
 					const route = Object.assign({}, _)
 					route.file = file
@@ -58,7 +57,6 @@ export async function launch() {
 				})
 		)
 
-		const augen = await import('@sjcrh/augen')
 		const __dirname = import.meta.dirname
 		augen.setRoutes(app, routes, {
 			app,

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -2,7 +2,7 @@ import serverconfig from './serverconfig.js'
 import fs from 'fs'
 import pkg from '../package.json'
 import { VersionInfo, GenomeBuildInfo, HealthCheckResponse } from '../shared/types/routes/healthcheck.js'
-import { authApi } from './auth'
+import { authApi } from './auth.js'
 
 let auth
 

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -122,17 +122,18 @@ tape(`initialization`, async test => {
 		const app = appInit()
 		await authApi.maySetAuthRoutes(app, '', { cachedir })
 		test.deepEqual(
+			Object.keys(authApi).sort(),
 			[
 				'canDisplaySampleIds',
 				'getDsAuth',
 				'getForbiddenRoutesForDsEmbedder',
+				'getHealth',
 				'getJwtPayload',
 				'getPayloadFromHeaderAuth',
 				'getRequiredCredForDsEmbedder',
 				'maySetAuthRoutes',
 				'userCanAccess'
 			],
-			Object.keys(authApi).sort(),
 			'should set the expected methods with an empty dsCredentials'
 		)
 		test.deepEqual(

--- a/server/test/fake-jwt.js
+++ b/server/test/fake-jwt.js
@@ -5,19 +5,30 @@ import jsonwebtoken from 'jsonwebtoken'
 
 const time = Math.floor(Date.now() / 1000)
 const dslabel = process.argv[2] || 'TermdbTest'
-const embedder = process.argv[3] || 'localhost'
-const secret = serverconfig.dsCredentials[dslabel].termdb[embedder].secret
-//for testing only
-console.log(
-	//secret,
-	jsonwebtoken.sign(
-		{
-			iat: time,
-			exp: time + 3600,
-			datasets: ['TermdbTest', 'SJLife', 'PNET', 'sjlife', 'ccss', 'ABC', 'XYZ', 'abc', 'xyz'],
-			email: 'username@test.tld',
-			ip: '127.0.0.1'
-		},
-		secret
-	)
-)
+const dsCred = serverconfig.dsCredentials[dslabel]
+const embedder = process.argv[3] || (dsCred.termdb['*'] ? '*' : 'localhost')
+const cred = dsCred.termdb[embedder]
+const data = {
+	iat: time,
+	exp: time + 3600,
+	datasets: ['TermdbTest', 'SJLife', 'PNET', 'sjlife', 'ccss', 'ABC', 'XYZ', 'abc', 'xyz'],
+	email: 'username@test.tld',
+	ip: '127.0.0.1'
+}
+
+// for testing only
+if (cred?.processor) {
+	;(async () => {
+		const _ = await import(cred.processor)
+		const { generatePayload, test } = _.default
+		const url = process.argv[4] ? `${serverconfig.URL}${process.argv[4]}` : ''
+		if (url) {
+			console.log(await test(cred, url, 'viz.stjude.cloud'))
+		} else {
+			const payload = generatePayload(data, cred)
+			console.log(payload)
+		}
+	})()
+} else {
+	console.log(jsonwebtoken.sign(data, cred.secret))
+}


### PR DESCRIPTION
## Description

This update tests auth credentials once in the first request to healthcheck, then the same auth status is reused afterwards. The goal is to reliably authentication issues on server startup post-deployment.

To test: 
Must pull `sjpp/auth-health`

A. From proteinpaint/server, `npm run test:unit`

B. Simulated login/session
- load http://localhost:3000/example.auth.html?dslabel=SJLife&route=termdb
- follow the NOTES to create serverconfig entries and fake jwt, Login, then try to download data

C. Server response
Load http://localhost:3000/healthcheck
-  with no code changes, should return `{"status": "ok", ..., "auth": {"errors": []}}`
- Assuming that in `sjpp/serverconfig.json`, you have a `dsCredentials` entry with type: 'basic' (not jwt): Edit line 588 inside the `authApi.getHealth()` function in `server/src/auth.js`, to 
```js
authorization: `Basic ${btoa(cred.password + 'x')}`
```
, to force an error. The healtheck should return `{"status": "error", ..., "auth": {"errors": [ /*not empty*/ ]}}`

D. Command-line
This should log `status: ok`
- `./proteinpaint/server/test/fake-jwt.js SJLife '*' /jwt-status`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
