### PR TITLE
Handle custom matrix geneset input option

### DIFF
--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -54,6 +54,11 @@ export type CallbackArg = {
 	geneList: Gene[]
 }
 
+type CustomInputs = {
+	label: string
+	showInput: (arg: any) => void
+}[]
+
 export type GeneSetEditArg = {
 	holder: Elem
 	genome: ClientCopyGenome
@@ -71,6 +76,7 @@ export type GeneSetEditArg = {
 	geneList?: Gene[]
 	/** Title appearing above the UI */
 	titleText?: string
+	customInputs?: CustomInputs
 }
 
 export class GeneSetEditUI {
@@ -85,12 +91,16 @@ export class GeneSetEditUI {
 	api: API
 	geneSearch: any //cheating
 	/** Objects detailing the menus to create above the api.dom.geneHoldingDiv as clickable links  */
-	menuList: { label: string; callback: (f?: any) => void }[]
+	menuList: {
+		label: string
+		callback: (f?: any) => void
+		tagName?: string
+	}[]
 	mode?: 'geneVariant' | 'geneExpression'
 	minNumGenes: number
 	geneList: Gene[]
 	titleText?: string
-	customInputs?: any
+	customInputs?: CustomInputs
 
 	constructor(opts: GeneSetEditArg) {
 		this.holder = opts.holder

--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -54,8 +54,11 @@ export type CallbackArg = {
 	geneList: Gene[]
 }
 
+/** optional instruction to add new button(s) and pull in gene sets by custom-designed means. used by gdc oncomatrix react wrapper to call the GFF gene set modal */
 type CustomInputs = {
+	/** button name */
 	label: string
+	/** callback to trigger upon clicking this button. should show some ui to collect gene names and bring them into holding box */
 	showInput: (arg: any) => void
 }[]
 

--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -90,12 +90,14 @@ export class GeneSetEditUI {
 	minNumGenes: number
 	geneList: Gene[]
 	titleText?: string
+	customInputs?: any
 
 	constructor(opts: GeneSetEditArg) {
 		this.holder = opts.holder
 		this.genome = opts.genome
 		this.callback = opts.callback
 		this.vocabApi = opts.vocabApi
+		this.customInputs = opts.customInputs
 		this.geneList = structuredClone(opts.geneList || [])
 		this.tip2 = new Menu({ padding: '0px', parent_menu: opts.holder.node(), test: 'test' })
 		this.minNumGenes = opts.minNumGenes || 0
@@ -388,6 +390,15 @@ export class GeneSetEditUI {
 				})
 			}
 		}
+		if (this.customInputs) {
+			for (const btn of this.customInputs) {
+				this.menuList.push({
+					label: btn.label,
+					callback: btn.showInput,
+					arg: 'callback'
+				})
+			}
+		}
 	}
 
 	renderTextControls(div: Div) {
@@ -399,7 +410,8 @@ export class GeneSetEditUI {
 				.style('color', 'black')
 				.html(`${menu.label} &#9660;`)
 				.on('click', async (event: Event) => {
-					await menu.callback(event)
+					if (menu.arg == 'callback') menu.callback({ callback: this.callback })
+					else await menu.callback(event)
 				})
 		}
 	}

--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -394,8 +394,15 @@ export class GeneSetEditUI {
 			for (const btn of this.customInputs) {
 				this.menuList.push({
 					label: btn.label,
-					callback: btn.showInput,
-					arg: 'callback'
+					callback: () => {
+						btn.showInput({
+							callback: ({ geneList }) => {
+								this.geneList = geneList
+								this.renderGenes()
+							}
+						})
+					},
+					tagName: 'button'
 				})
 			}
 		}
@@ -403,16 +410,22 @@ export class GeneSetEditUI {
 
 	renderTextControls(div: Div) {
 		for (const menu of this.menuList) {
-			div
-				.append('a')
-				.style('text-decoration', 'underline')
-				.style('padding', '0px 10px')
-				.style('color', 'black')
-				.html(`${menu.label} &#9660;`)
-				.on('click', async (event: Event) => {
-					if (menu.arg == 'callback') menu.callback({ callback: this.callback })
-					else await menu.callback(event)
+			if (menu.tagName == 'button')
+				addButton({
+					div,
+					text: menu.label,
+					callback: menu.callback
 				})
+			else
+				div
+					.append('a')
+					.style('text-decoration', 'underline')
+					.style('padding', '0px 10px')
+					.style('color', 'black')
+					.html(`${menu.label} &#9660;`)
+					.on('click', async (event: Event) => {
+						await menu.callback(event)
+					})
 		}
 	}
 

--- a/client/gdc/geneExpClustering.js
+++ b/client/gdc/geneExpClustering.js
@@ -219,7 +219,6 @@ export async function init(arg, holder, genomes) {
 		const api = {
 			type: 'hierCluster',
 			update: async _arg => {
-				console.log(214, _arg)
 				const plotConfig = plotAppApi.getState().plots.find(p => p.chartType == 'hierCluster')
 				if (!hierClusterApi) {
 					if (plotConfig) hierClusterApi = plotAppApi.getComponents(`plots.${plotConfig.id}`)

--- a/client/gdc/oncomatrix.js
+++ b/client/gdc/oncomatrix.js
@@ -292,7 +292,29 @@ export async function init(arg, holder, genomes) {
 					if (plotConfig) matrixApi = plotAppApi.getComponents(`plots.${plotConfig.id}`)
 				}
 
-				if ('filter0' in arg) {
+				if (arg.genes) {
+					// user geneset as saved and reused from GFF, reshaped to be {gene: string}[]
+					plotAppApi.dispatch({
+						type: 'plot_edit',
+						id: matrixApi.id,
+						config: {
+							termgroups: [
+								{
+									lst: await Promise.all(
+										arg.genes.map(async g => {
+											return await fillTermWrapper(
+												{
+													term: { gene: g.gene, type: 'geneVariant', name: g.gene }
+												},
+												vocabApi
+											)
+										})
+									)
+								}
+							]
+						}
+					})
+				} else if ('filter0' in arg) {
 					plotAppApi.dispatch({
 						type: 'filter_replace',
 						filter0: arg.filter0

--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -151,7 +151,6 @@ class GenesetComp {
 	}
 
 	async getTwLst(genes) {
-		// mode should equates to term type. if not the case then fix here
 		return await Promise.all(
 			// do tempfix of "data.genes.slice(0,3).map" for faster testing
 			genes.map(async i =>

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1263,7 +1263,7 @@ export class MatrixControls {
 				triggerGenesetEdit(tip.d.append('div'))
 			})
 
-		if (parent.opts.customInputs.geneset) {
+		if (parent.opts.customInputs?.geneset) {
 			for (const btn of parent.opts.customInputs.geneset) {
 				td.append('button')
 					.html(btn.label)

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1262,6 +1262,48 @@ export class MatrixControls {
 				}
 				triggerGenesetEdit(tip.d.append('div'))
 			})
+
+		if (parent.opts.customInputs.geneset) {
+			for (const btn of parent.opts.customInputs.geneset) {
+				td.append('button')
+					.html(btn.label)
+					.on('click', () => {
+						tip.hide()
+						btn.showInput({
+							callback: genesArr => {
+								const geneLst = genesArr.map(gene => ({ gene }))
+								// TODO: this may not be the first term group
+								let group = tg.find(g => g.lst.find(tw => tw.term?.type == 'geneVariant'))
+								if (!group) group = tg[0]
+								const lst = group.lst.filter(tw => tw.term.type != 'geneVariant')
+								const tws = geneLst.map(d => {
+									//if it was present use the previous term, genomic range terms require chr, start and stop fields, found in the original term
+									let tw = group.lst.find(tw => tw.term.name == d.symbol || tw.term.name == d.gene)
+									if (!tw)
+										tw = {
+											$id: get$id(),
+											term: {
+												name: d.symbol || d.gene,
+												type: 'geneVariant'
+											},
+											q: {}
+										}
+									return tw
+								})
+								group.lst = [...lst, ...tws]
+								if (!group.lst.length) tg.splice(selectedGroup.index, 1)
+								app.dispatch({
+									type: 'plot_edit',
+									id: this.parent.id,
+									config: {
+										termgroups: tg
+									}
+								})
+							}
+						})
+					})
+			}
+		}
 	}
 
 	setMenuBackBtn(holder, callback) {

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1160,21 +1160,23 @@ export class MatrixControls {
 			}) //To do, selectedGroup.lst may replace name with gene as well
 			new GeneSetEditUI({
 				holder,
+				genome: app.opts.genome,
+				geneList,
+				customInputs: this.parent.opts.customInputs?.geneset,
 				/* running hier clustering and the editing group is the group used for clustering
 			pass this mode value to inform ui to support the optional button "top variably exp gene"
 			this is hardcoded for the purpose of gene expression and should be improved
 			*/
-				genome: app.opts.genome,
-				geneList,
+
 				mode: selectedGroup.mode,
-				minNumGenes: selectedGroup.mode == 'expression' ? 3 : 1,
+				minNumGenes: selectedGroup.mode == 'geneExpression' ? 3 : 1,
 				vocabApi: this.opts.app.vocabApi,
 				callback: async ({ geneList, groupName }) => {
 					if (!selectedGroup) throw `missing selectedGroup`
 					tip.hide()
 					const group = selectedGroup.status == 'new' ? { name: groupName, lst: [] } : tg[selectedGroup.index]
 					if (selectedGroup.status == 'new') tg.push(group)
-					const targetTermType = selectedGroup.mode == 'expression' ? 'geneExpression' : 'geneVariant'
+					const targetTermType = selectedGroup.mode // == 'expression' ? 'geneExpression' : 'geneVariant'
 					// remove gene terms to be replaced by the new lst, keep all other term types in the group
 					const lst = group.lst.filter(tw => tw.term.type != targetTermType)
 					const tws = await Promise.all(
@@ -1263,47 +1265,47 @@ export class MatrixControls {
 				triggerGenesetEdit(tip.d.append('div'))
 			})
 
-		if (parent.opts.customInputs?.geneset) {
-			for (const btn of parent.opts.customInputs.geneset) {
-				td.append('button')
-					.html(btn.label)
-					.on('click', () => {
-						tip.hide()
-						btn.showInput({
-							callback: genesArr => {
-								const geneLst = genesArr.map(gene => ({ gene }))
-								// TODO: this may not be the first term group
-								let group = tg.find(g => g.lst.find(tw => tw.term?.type == 'geneVariant'))
-								if (!group) group = tg[0]
-								const lst = group.lst.filter(tw => tw.term.type != 'geneVariant')
-								const tws = geneLst.map(d => {
-									//if it was present use the previous term, genomic range terms require chr, start and stop fields, found in the original term
-									let tw = group.lst.find(tw => tw.term.name == d.symbol || tw.term.name == d.gene)
-									if (!tw)
-										tw = {
-											$id: get$id(),
-											term: {
-												name: d.symbol || d.gene,
-												type: 'geneVariant'
-											},
-											q: {}
-										}
-									return tw
-								})
-								group.lst = [...lst, ...tws]
-								if (!group.lst.length) tg.splice(selectedGroup.index, 1)
-								app.dispatch({
-									type: 'plot_edit',
-									id: this.parent.id,
-									config: {
-										termgroups: tg
-									}
-								})
-							}
-						})
-					})
-			}
-		}
+		// if (parent.opts.customInputs?.geneset) {
+		// 	for (const btn of parent.opts.customInputs.geneset) {
+		// 		td.append('button')
+		// 			.html(btn.label)
+		// 			.on('click', () => {
+		// 				tip.hide()
+		// 				btn.showInput({
+		// 					callback: genesArr => {
+		// 						const geneLst = genesArr.map(gene => ({ gene }))
+		// 						// TODO: this may not be the first term group
+		// 						let group = tg.find(g => g.lst.find(tw => tw.term?.type == 'geneVariant'))
+		// 						if (!group) group = tg[0]
+		// 						const lst = group.lst.filter(tw => tw.term.type != 'geneVariant')
+		// 						const tws = geneLst.map(d => {
+		// 							//if it was present use the previous term, genomic range terms require chr, start and stop fields, found in the original term
+		// 							let tw = group.lst.find(tw => tw.term.name == d.symbol || tw.term.name == d.gene)
+		// 							if (!tw)
+		// 								tw = {
+		// 									$id: get$id(),
+		// 									term: {
+		// 										name: d.symbol || d.gene,
+		// 										type: 'geneVariant'
+		// 									},
+		// 									q: {}
+		// 								}
+		// 							return tw
+		// 						})
+		// 						group.lst = [...lst, ...tws]
+		// 						if (!group.lst.length) tg.splice(selectedGroup.index, 1)
+		// 						app.dispatch({
+		// 							type: 'plot_edit',
+		// 							id: this.parent.id,
+		// 							config: {
+		// 								termgroups: tg
+		// 							}
+		// 						})
+		// 					}
+		// 				})
+		// 			})
+		// 	}
+		// }
 	}
 
 	setMenuBackBtn(holder, callback) {

--- a/client/src/notify.ts
+++ b/client/src/notify.ts
@@ -31,9 +31,12 @@ let sse,
 	initialLoad = 0
 setSse()
 
+const host = sessionStorage.getItem('hostURL') || window.testHost || ''
+const sseUrl = host.endsWith('/') ? `${host}sse` : `${host}/sse`
+
 function setSse() {
 	// server-sent events
-	sse = new EventSource('/sse')
+	sse = new EventSource(sseUrl)
 
 	let lastReload = 0
 

--- a/client/src/notify.ts
+++ b/client/src/notify.ts
@@ -30,7 +30,7 @@ const notifyDiv = select('body')
 let sse,
 	initialLoad = 0
 
-const host = sessionStorage.getItem('hostURL') || window.testHost || ''
+const host = sessionStorage.getItem('hostURL') || (window as any).testHost || ''
 const sseUrl = host.endsWith('/') ? `${host}sse` : `${host}/sse`
 setSse()
 

--- a/client/src/notify.ts
+++ b/client/src/notify.ts
@@ -29,10 +29,10 @@ const notifyDiv = select('body')
 
 let sse,
 	initialLoad = 0
-setSse()
 
 const host = sessionStorage.getItem('hostURL') || window.testHost || ''
 const sseUrl = host.endsWith('/') ? `${host}sse` : `${host}/sse`
+setSse()
 
 function setSse() {
 	// server-sent events

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Handle custom matrix geneset input option

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Features:
 - Handle custom matrix geneset input option
+- In GDC gene exp clustering, when screening user-defined gene sets, use a close-to-zero min_median_log2_uqfpkm parameter to keep more genes expressed at low level


### PR DESCRIPTION
## Description

This features addresses https://gdc-ctds.atlassian.net/browse/FEAT-766. 
```text
Upload User custom gene sets:

Similar to v1, GDC 2.0 allows users to create gene sets using the Manage Sets feature. 

See https://docs.gdc.cancer.gov/Data_Portal/Users_Guide/getting_started/#manage-sets 

In OncoMatrix and Gene Expression Clustering tools, under Genes button, 

Under Edit Genes & Create Genes, add “Load Gene Sets” option.

If the user has already created a gene set using the “Manage Sets” feature, then similar to MSigDB, display the gene sets
```

To test with `example.gdc.*.html`:
- pull sjpp/master
- open http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=CDDP_EAGLE-1
- open `Genes -> Gene Sets: Edit Group -> Load Gene Set` 
- Enter `KRAS, MYCN` or other gene list in the popup modal and enter
- the gene text input div should be filled-in, click Submit
- the matrix should update with the new gene set
- can repeast the test using `example.gdc.exp.html`

To test in GFF (@congyu-lu )
- open OncoMatrix or Gene Expression Clustering tool
- open `Genes -> Gene Sets: Edit Group -> Load Gene Set` 
- click on the first tab to enter comma-separated gene list then submit, or click on second tab to `USE A PREVIOUSLY SAVED GENE SET`
- the OncoMatrix or GEC should update directly. Pre-filling the gene input div will require the geneset edit UI to be reactive (updatable by external code), will require more work in a separate PR

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
