### PR TITLE
speed up gdc query by deleting use of empty case_filters

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- In GDC query, do not supply empty "case_filters{content[]}" that will slow down API. lollipop and oncomatrix are now faster when there's no cohort

--- a/server/routes/gdc.maf.ts
+++ b/server/routes/gdc.maf.ts
@@ -97,7 +97,6 @@ async function listMafFiles(q: GdcMafRequest, ds) {
 
 	const data = {
 		filters,
-		case_filters,
 		size: maxFileNumber,
 		fields: [
 			'id',
@@ -108,6 +107,7 @@ async function listMafFiles(q: GdcMafRequest, ds) {
 			// may add diagnosis and primary site
 		].join(',')
 	}
+	if (case_filters.content.length) data.case_filters = case_filters
 
 	const response = await got.post(path.join(host.rest, 'files'), { headers, body: JSON.stringify(data) })
 

--- a/server/routes/gdc.maf.ts
+++ b/server/routes/gdc.maf.ts
@@ -95,7 +95,7 @@ async function listMafFiles(q: GdcMafRequest, ds) {
 
 	const { host, headers } = ds.getHostHeaders(q)
 
-	const data = {
+	const data: any = {
 		filters,
 		size: maxFileNumber,
 		fields: [

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -51,14 +51,14 @@ export function validate_query_TopVariablyExpressedGenes(ds: any, genome: any) {
 	if (q.src == 'gdcapi') {
 		gdcValidateQuery(ds, genome)
 	} else if (q.src == 'native') {
-		nativeValidateQuery(ds, genome)
+		nativeValidateQuery(ds)
 	} else {
 		throw 'unknown topVariablyExpressedGenes.src'
 	}
 	// added getter: q.getGenes()
 }
 
-function nativeValidateQuery(ds: any, genome: any) {
+function nativeValidateQuery(ds: any) {
 	const gE = ds.queries.geneExpression // a separate query required to supply data for computing top genes
 	if (!gE) throw 'topVariablyExpressedGenes query given but geneExpression missing'
 	if (gE.src != 'native') throw 'topVariablyExpressedGenes is native but geneExpression.src is not native'

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -2,7 +2,7 @@ import {
 	TermdbTopVariablyExpressedGenesRequest,
 	TermdbTopVariablyExpressedGenesResponse
 } from '#shared/types/routes/termdb.topVariablyExpressedGenes.ts'
-import { gdcGetCasesWithExressionDataFromCohort } from '../src/mds3.gdc.js'
+import { gdcGetCasesWithExpressionDataFromCohort } from '../src/mds3.gdc.js'
 import path from 'path'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
 import got from 'got'
@@ -135,7 +135,7 @@ function gdcValidateQuery(ds: any, genome: any) {
 		if (!ds.__gdc.doneCaching) throw 'The server has not finished caching the case IDs: try again in ~2 minutes'
 
 		// based on current cohort, get list of cases with exp data, as input of next api query
-		const caseLst = await gdcGetCasesWithExressionDataFromCohort(q, ds)
+		const caseLst = await gdcGetCasesWithExpressionDataFromCohort(q, ds)
 		if (caseLst.length == 0) {
 			// there are no cases with gene exp data
 			return [] as string[]

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -938,7 +938,13 @@ async function snvindel_byisoform(opts, ds) {
 			json: Object.assign({ size: query2.size, fields: query2.fields.join(',') }, query2.filters(opts, ds))
 		})
 		.json()
+
+	const starttime = Date.now()
+
 	const [re_ssms, re_cases] = await Promise.all([p1, p2])
+
+	if (serverconfig.debugmode) console.log('gdc snvindel tandem queries', Date.now() - starttime)
+
 	if (!Array.isArray(re_ssms?.data?.hits) || !Array.isArray(re_cases?.data?.hits))
 		throw 'ssm tandem query not returning data.hits[]'
 
@@ -2125,6 +2131,7 @@ const isoform2ssm_query1_getvariant = {
 		if (p.filterObj) {
 			f.case_filters.content.push(filter2GDCfilter(p.filterObj))
 		}
+		if (!f.case_filters.content.length) delete f.case_filters
 		return f
 	}
 }
@@ -2254,6 +2261,7 @@ const isoform2ssm_query2_getcase = {
 			f.case_filters.content.push(filter2GDCfilter(p.filterObj))
 		}
 		addTid2value_to_filter(p.tid2value, f.case_filters.content, ds)
+		if (!f.case_filters.content.length) delete f.case_filters // do not use empty case_filters to speed up query (Jason Stiles 3/28/24)
 		return f
 	}
 }


### PR DESCRIPTION
## Description

closes #1474
mds3 tests pass. now lollipop tk loads 10x fast when there's no cohort -- if there's cohort it's slow as before
oncomatrix is fast too
should be safe -- please help test in GFF
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
