### PR TITLE
Improve the matrix sorting options to easily toggle sorting 

### DIFF
--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -591,7 +591,7 @@ tape('sort samples by sample name', function (test) {
 	}
 })
 
-tape('sort samples by CNV+SSM > SSM-only > CNV-only', function (test) {
+tape('sort samples by Mutation categories', function (test) {
 	test.timeoutAfter(5000)
 	test.plan(4)
 	runpp({

--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -1,7 +1,7 @@
 const tape = require('tape')
 const termjson = require('../../test/testdata/termjson').termjson
 const helpers = require('../../test/front.helpers.js')
-const { sleep, detectLst } = require('../../test/test.helpers.js')
+const { sleep, detectLst, detectGte } = require('../../test/test.helpers.js')
 
 /*************************
  reusable helper functions
@@ -1993,11 +1993,12 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 			`third option should be "Do not show Somatic Mutations"`
 		)
 		test.equal(options.length, 3, `Should show three options`)
-		const rects = await detectLst({
+		const rects = await detectGte({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 181,
+			count: 180,
 			trigger: () => {
+				console.log(2000, options)
 				options[0].dispatchEvent(
 					new MouseEvent('click', {
 						bubbles: true,
@@ -2038,10 +2039,10 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 			`fourth option should be "Show all Somatic Mutations"`
 		)
 		test.equal(options2.length, 4, `Should show four options`)
-		const rects2 = await detectLst({
+		const rects2 = await detectGte({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 183,
+			count: 180,
 			trigger: () => {
 				options2[1].dispatchEvent(
 					new MouseEvent('click', {
@@ -2079,7 +2080,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		)
 
 		test.equal(options3.length, 4, `Should show four options`)
-		const rects3 = await detectLst({
+		const rects3 = await detectGte({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
 			count: 180,
@@ -2120,7 +2121,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		)
 
 		test.equal(options4.length, 1, `Should show one option`)
-		const rects4 = await detectLst({
+		const rects4 = await detectGte({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
 			count: 240,

--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -1993,12 +1993,11 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 			`third option should be "Do not show Somatic Mutations"`
 		)
 		test.equal(options.length, 3, `Should show three options`)
-		const rects = await detectGte({
+		const rects = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 180,
+			count: 181,
 			trigger: () => {
-				console.log(2000, options)
 				options[0].dispatchEvent(
 					new MouseEvent('click', {
 						bubbles: true,
@@ -2039,10 +2038,10 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 			`fourth option should be "Show all Somatic Mutations"`
 		)
 		test.equal(options2.length, 4, `Should show four options`)
-		const rects2 = await detectGte({
+		const rects2 = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 180,
+			count: 183,
 			trigger: () => {
 				options2[1].dispatchEvent(
 					new MouseEvent('click', {
@@ -2080,7 +2079,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		)
 
 		test.equal(options3.length, 4, `Should show four options`)
-		const rects3 = await detectGte({
+		const rects3 = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
 			count: 180,
@@ -2121,7 +2120,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		)
 
 		test.equal(options4.length, 1, `Should show one option`)
-		const rects4 = await detectGte({
+		const rects4 = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
 			count: 240,

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -614,6 +614,25 @@ function setMultiCheckbox(opts) {
 	return Object.freeze(api)
 }
 
+function setCustomInput(opts) {
+	const self = {
+		dom: {
+			row: opts.holder.style('display', 'table-row'),
+			labelTd: opts.holder
+				.append('td')
+				.html(opts.label)
+				.attr('class', 'sja-termdb-config-row-label')
+				.attr('title', opts.title),
+			inputTd: opts.holder.append('td')
+		}
+	}
+
+	self.api = opts.init(self)
+
+	if (opts.debug) self.api.Inner = self
+	return Object.freeze(self.api)
+}
+
 /*
 	this is a generalized control wrapper for termsetting pill,
 	intended to eventually replace the more specific term1, overlay, and divide components
@@ -690,6 +709,7 @@ export const initByInput = {
 	dropdown: setDropdownInput,
 	checkbox: setCheckboxInput,
 	multiCheckbox: setMultiCheckbox,
+	custom: setCustomInput,
 	term: setTermInput
 }
 

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -150,7 +150,7 @@ export async function getPlotConfig(opts = {}, app) {
 	const overrides = app.vocabApi.termdbConfig.matrix || {}
 	copyMerge(config.settings.matrix, overrides.settings)
 	if (overrides.legendGrpFilter) config.legendGrpFilter = overrides.legendGrpFilter
-	if (overrides.legendValueFilter) config.legendGrpFilter = overrides.legendValueFilter
+	if (overrides.legendValueFilter) config.legendValueFilter = overrides.legendValueFilter
 
 	if (opts.name) {
 		// name should be identifier of a premade plot from the datase; load data of the premade plot and override into config{}
@@ -176,53 +176,6 @@ export async function getPlotConfig(opts = {}, app) {
 
 	// may apply term-specific changes to the default object
 	copyMerge(config, opts)
-
-	if (
-		config.settings.matrix.cellEncoding == 'single' &&
-		!config.legendGrpFilter.lst.find(l => l.dt?.length == 1 && l.dt[0] == 4)
-	) {
-		// add the default CNV legend group value filter
-		config.legendGrpFilter.lst.push({ dt: [4] })
-	}
-
-	if (config.settings.matrix.showMatrixMutation == 'onlyPC' && !config.legendValueFilter.lst.length) {
-		// add the default synonymous legend value filters
-		const proteinChangingM = s.matrix.proteinChangingMutations
-
-		const controlLabels = config.settings.matrix.controlLabels
-		const origin = app.vocabApi.termdbConfig.assayAvailability?.byDt?.[dtsnvindel]?.byOrigin
-
-		for (const [k, v] of Object.entries(mclass)) {
-			if (proteinChangingM.includes(k) || v.dt != dtsnvindel) continue
-			if (origin) {
-				for (const o of ['somatic', 'germline']) {
-					const filterNew = {
-						legendGrpName: controlLabels.Mutations,
-						type: 'tvs',
-						tvs: {
-							isnot: true,
-							legendFilterType: 'geneVariant_soft',
-							term: { type: 'geneVariant' },
-							values: [{ dt: dtsnvindel, origin: o, mclasslst: [k] }]
-						}
-					}
-					config.legendValueFilter.lst.push(filterNew)
-				}
-			} else {
-				const filterNew = {
-					legendGrpName: controlLabels.Mutations,
-					type: 'tvs',
-					tvs: {
-						isnot: true,
-						legendFilterType: 'geneVariant_soft',
-						term: { type: 'geneVariant' },
-						values: [{ dt: dtsnvindel, mclasslst: [k] }]
-					}
-				}
-				config.legendValueFilter.lst.push(filterNew)
-			}
-		}
-	}
 	const m = config.settings.matrix
 	// harcode these overrides for now
 	m.duration = 0

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -39,7 +39,7 @@ export async function getPlotConfig(opts = {}, app) {
 			matrix: {
 				svgCanvasSwitch: 1000, // the number of samples to trigger switching between svg and canvas
 				useMinPixelWidth: true, // canvas may be hazy if false, but more accurately reflects column density
-				cellEncoding: '', // can be oncoprint
+				cellEncoding: '', // can be "oncoprint" | "stacked" | "single"
 				margin: {
 					top: 10,
 					right: 5,
@@ -51,6 +51,7 @@ export async function getPlotConfig(opts = {}, app) {
 				maxGenes: opts.settings?.maxGenes || 50,
 				maxSample: opts.settings?.maxSample || 1000,
 				sortPriority: undefined,
+				variantSortBy: ['ssm', 'cnv'],
 
 				sampleNameFilter: '',
 				sortSamplesBy: 'a',
@@ -66,8 +67,8 @@ export async function getPlotConfig(opts = {}, app) {
 				// whether to show these controls buttons
 				addMutationCNVButtons: false,
 				// used for the radio inputs in the CNV/Mutation control menus
-				showMatrixMutation: opts.chartType !== 'hierCluster' ? '' : 'all',
-				showMatrixCNV: opts.chartType !== 'hierCluster' ? '' : 'all',
+				showMatrixMutation: opts.chartType !== 'hierCluster' ? '' : 'all', // all | none | onlyTruncating | onlyPC | bySelection
+				showMatrixCNV: opts.chartType !== 'hierCluster' ? '' : 'all', // all | none | bySelection
 				allMatrixCNVHidden: false,
 				allMatrixMutationHidden: false,
 				gridStroke: '#fff',

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -50,11 +50,12 @@ export async function getPlotConfig(opts = {}, app) {
 				// put in settings, so that later may be overridden by a user
 				maxGenes: opts.settings?.maxGenes || 50,
 				maxSample: opts.settings?.maxSample || 1000,
-				sortPriority: undefined,
-				variantSortBy: ['ssm', 'cnv'],
 
 				sampleNameFilter: '',
 				sortSamplesBy: 'a',
+				sortPriority: undefined, // will be filled-in
+				sortByMutation: 'presence',
+				sortByCNV: false,
 				sortOptions: getSortOptions(app.vocabApi.termdbConfig, controlLabels),
 				sortSampleGrpsBy: 'name', // 'hits' | 'name' | 'sampleCount'
 				sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: {} /*split: {char: '', index: 0}*/ }],

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -54,8 +54,8 @@ export async function getPlotConfig(opts = {}, app) {
 				sampleNameFilter: '',
 				sortSamplesBy: 'a',
 				sortPriority: undefined, // will be filled-in
-				sortByMutation: 'presence',
-				sortByCNV: false,
+				sortByMutation: 'consequence',
+				sortByCNV: true,
 				sortOptions: getSortOptions(app.vocabApi.termdbConfig, controlLabels),
 				sortSampleGrpsBy: 'name', // 'hits' | 'name' | 'sampleCount'
 				sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: {} /*split: {char: '', index: 0}*/ }],

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -1,7 +1,7 @@
 import { copyMerge } from '../rx'
 import { getSortOptions } from './matrix.sort'
 import { fillTermWrapper } from '#termsetting'
-import { mclass, proteinChangingMutations, dtsnvindel } from '#shared/common'
+import { mclass, proteinChangingMutations, truncatingMutations, dtsnvindel } from '#shared/common'
 
 export async function getPlotConfig(opts = {}, app) {
 	const controlLabels = {
@@ -67,11 +67,8 @@ export async function getPlotConfig(opts = {}, app) {
 				showGrid: '', // false | 'pattern' | 'rect'
 				// whether to show these controls buttons
 				addMutationCNVButtons: false,
-				// used for the radio inputs in the CNV/Mutation control menus
-				showMatrixMutation: opts.chartType !== 'hierCluster' ? '' : 'all', // all | none | onlyTruncating | onlyPC | bySelection
-				showMatrixCNV: opts.chartType !== 'hierCluster' ? '' : 'all', // all | none | bySelection
-				allMatrixCNVHidden: false,
-				allMatrixMutationHidden: false,
+				truncatingMutations,
+				proteinChangingMutations,
 				gridStroke: '#fff',
 				outlineStroke: '#ccc',
 				beamStroke: '#f00',
@@ -152,6 +149,8 @@ export async function getPlotConfig(opts = {}, app) {
 
 	const overrides = app.vocabApi.termdbConfig.matrix || {}
 	copyMerge(config.settings.matrix, overrides.settings)
+	if (overrides.legendGrpFilter) config.legendGrpFilter = overrides.legendGrpFilter
+	if (overrides.legendValueFilter) config.legendGrpFilter = overrides.legendValueFilter
 
 	if (opts.name) {
 		// name should be identifier of a premade plot from the datase; load data of the premade plot and override into config{}
@@ -188,7 +187,7 @@ export async function getPlotConfig(opts = {}, app) {
 
 	if (config.settings.matrix.showMatrixMutation == 'onlyPC' && !config.legendValueFilter.lst.length) {
 		// add the default synonymous legend value filters
-		const proteinChangingM = config.settings.matrix.proteinChangingMutations || proteinChangingMutations
+		const proteinChangingM = s.matrix.proteinChangingMutations
 
 		const controlLabels = config.settings.matrix.controlLabels
 		const origin = app.vocabApi.termdbConfig.assayAvailability?.byDt?.[dtsnvindel]?.byOrigin

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -1,7 +1,13 @@
 import { copyMerge } from '../rx'
 import { getSortOptions } from './matrix.sort'
 import { fillTermWrapper } from '#termsetting'
-import { proteinChangingMutations, truncatingMutations, synonymousMutations, mclasses } from '#shared/common'
+import {
+	proteinChangingMutations,
+	truncatingMutations,
+	synonymousMutations,
+	mutationClasses,
+	CNVClasses
+} from '#shared/common'
 
 export async function getPlotConfig(opts = {}, app) {
 	const controlLabels = {
@@ -70,7 +76,8 @@ export async function getPlotConfig(opts = {}, app) {
 				truncatingMutations,
 				proteinChangingMutations,
 				synonymousMutations,
-				mclasses,
+				mutationClasses,
+				CNVClasses,
 				gridStroke: '#fff',
 				outlineStroke: '#ccc',
 				beamStroke: '#f00',

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -1,7 +1,7 @@
 import { copyMerge } from '../rx'
 import { getSortOptions } from './matrix.sort'
 import { fillTermWrapper } from '#termsetting'
-import { mclass, proteinChangingMutations, truncatingMutations, dtsnvindel } from '#shared/common'
+import { proteinChangingMutations, truncatingMutations, synonymousMutations, mclasses } from '#shared/common'
 
 export async function getPlotConfig(opts = {}, app) {
 	const controlLabels = {
@@ -69,6 +69,8 @@ export async function getPlotConfig(opts = {}, app) {
 				addMutationCNVButtons: false,
 				truncatingMutations,
 				proteinChangingMutations,
+				synonymousMutations,
+				mclasses,
 				gridStroke: '#fff',
 				outlineStroke: '#ccc',
 				beamStroke: '#f00',

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -26,13 +26,13 @@ export class MatrixControls {
 			this.parent.setClusteringBtn(this.opts.holder, (event, data) => this.callback(event, data))
 		this.setSamplesBtn(s)
 		this.setGenesBtn(s)
+		if (s.addMutationCNVButtons && this.parent.chartType !== 'hierCluster') {
+			this.setMutationBtn()
+			this.setCNVBtn()
+		}
 		this.setVariablesBtn(s)
 		this.setDimensionsBtn(s)
 		this.setLegendBtn(s)
-		if (s.addMutationCNVButtons && this.parent.chartType !== 'hierCluster') {
-			this.setCNVBtn()
-			this.setMutationBtn()
-		}
 		this.setDownloadBtn(s)
 		this.setZoomInput()
 		this.setDragToggle({

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -68,7 +68,7 @@ export class MatrixControls {
 
 	setSamplesBtn(s) {
 		const l = s.controlLabels
-
+		const parent = this.parent
 		this.opts.holder
 			.append('button')
 			//.property('disabled', d => d.disabled)
@@ -84,9 +84,54 @@ export class MatrixControls {
 						chartType: 'matrix',
 						settingsKey: 'sortSamplesBy',
 						options: Object.values(s.sortOptions).sort((a, b) => a.order - b.order),
-						labelDisplay: 'block',
+						//labelDisplay: 'block',
 						getDisplayStyle(plot) {
 							return plot.chartType == 'hierCluster' ? 'none' : 'table-row'
+						}
+						// setRadioLabel(d) {
+						// 	if (!d.altLabels) return '&nbsp;' + d.label
+						// 	const s = parent.config.settings.matrix
+						// 	// show in label
+						// 	const showSSM = (s.showMatrixMutation != 'none' && !s.allMatrixMutationHidden) && s.variantSortBy.includes('ssm')
+						// 	const showCNV = (s.showMatrixCNV != 'none' && !s.allMatrixCNVHidden) && s.variantSortBy.includes('cnv')
+						// 	const label = showSSM && showCNV
+						// 		? d.label
+						// 		: !showSSM && !showCNV
+						// 		? d.label
+						// 		: showCNV
+						// 		? d.altLabels.mutationOnly
+						// 		: d.altLabels.cnvOnly
+
+						// 	return '&nbsp;' + label
+						// }
+					},
+					{
+						label: `Sort by values`,
+						type: 'multiCheckbox',
+						chartType: 'matrix',
+						settingsKey: 'variantSortBy',
+						options: [
+							{
+								label: 'CNV',
+								value: 'cnv',
+								getDisplayStyle(plot) {
+									const s = plot.settings.matrix
+									return s.showMatrixCNV == 'none' || s.allMatrixCNVHidden ? 'none' : ''
+								}
+							},
+							{
+								label: l.Mutation,
+								value: 'ssm',
+								getDisplayStyle(plot) {
+									const s = plot.settings.matrix
+									return s.showMatrixMutation == 'none' || s.allMatrixMutationHidden ? 'none' : ''
+								}
+							}
+						],
+						getDisplayStyle(plot) {
+							return plot.chartType == 'hierCluster' || plot.settings.matrix.sortSamplesBy == 'name'
+								? 'none'
+								: 'table-row'
 						}
 					},
 					{

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -111,6 +111,8 @@ export class MatrixControls {
 								}
 							})
 
+							inputs.style('margin', '2px 0 0 2px').style('vertical-align', 'top')
+
 							const cnvDiv = self.dom.inputTd.append('div')
 							cnvDiv.append('span').html('CNV')
 							// holder, labeltext, callback, checked, divstyle

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -717,15 +717,10 @@ export class MatrixControls {
 			.datum({
 				label: 'Mutation',
 				updateBtn: btn => {
-					const matrixSetting = this.parent.config.settings.matrix
-					btn.style(
-						'text-decoration',
-						matrixSetting.showMatrixMutation == 'none' || matrixSetting.allMatrixMutationHidden ? 'line-through' : ''
-					)
-					btn.style(
-						'text-decoration-thickness',
-						matrixSetting.showMatrixMutation == 'none' || matrixSetting.allMatrixMutationHidden ? '2px' : ''
-					)
+					const s = this.parent.config.settings.matrix
+					btn
+						.style('text-decoration', s.allMatrixMutationHidden ? 'line-through' : '')
+						.style('text-decoration-thickness', s.allMatrixMutationHidden ? '2px' : '')
 				},
 				rows: [
 					{
@@ -763,7 +758,7 @@ export class MatrixControls {
 				label: 'CNV',
 				updateBtn: btn => {
 					const s = this.parent.config.settings.matrix
-					const notRendered = s.showMatrixCNV == 'none' || s.allMatrixCNVHidden
+					const notRendered = s.allMatrixCNVHidden
 					btn
 						.style('text-decoration', notRendered ? 'line-through' : '')
 						.style('text-decoration-thickness', notRendered ? '2px' : '')

--- a/client/plots/matrix.data.js
+++ b/client/plots/matrix.data.js
@@ -156,10 +156,8 @@ export function applyLegendValueFilter() {
 		}
 	}
 
-	const onlySoftFilter = structuredClone(self.config.legendValueFilter)
-	onlySoftFilter.lst = onlySoftFilter.lst.filter(l => l.tvs.legendFilterType == 'geneVariant_soft')
-	const validSoftFilterLst = []
-	for (const valFilter of onlySoftFilter.lst) {
+	for (const valFilter of self.config.legendValueFilter.lst) {
+		if (valFilter.tvs.legendFilterType !== 'geneVariant_soft') continue
 		// applying each soft filter
 		const tvsV = valFilter.tvs.values[0]
 		const filteredOutCats = new Set() // the classes removed by the grpFilter
@@ -178,10 +176,7 @@ export function applyLegendValueFilter() {
 				}
 			}
 		}
-		if (filteredOutCats.size !== 0) {
-			valFilter.filteredOutCats = [...filteredOutCats]
-			validSoftFilterLst.push(valFilter)
-		}
+		valFilter.filteredOutCats = [...filteredOutCats]
 		for (const oneSampleData of Object.values(data.samples)) {
 			for (const annoForOneTerm of Object.values(oneSampleData)) {
 				if (annoForOneTerm.values)
@@ -191,7 +186,6 @@ export function applyLegendValueFilter() {
 			}
 		}
 	}
-	self.config.legendValueFilter.lst = [...onlyHardFilter.lst, ...validSoftFilterLst]
 	if (self.chartType !== 'hierCluster' && geneVariant$ids.length && self.app.vocabApi.vocab?.dslabel == 'GDC')
 		remove_empty_sample(data, geneVariant$ids)
 	self.data = data

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -3080,7 +3080,7 @@ function showByLegendFilter(menuGrp, targetData, self, target) {
 	const checkboxName = Math.random().toString()
 	const mClassDiv = classDiv
 		.selectAll(':scope>div')
-		.data(target == 'mutation' ? s.snvIndelClasses : s.CNVClasses)
+		.data(target == 'mutation' ? s.mutationClasses : s.CNVClasses)
 		.enter()
 		.append('label')
 		.style('margin', '5px')
@@ -3132,7 +3132,7 @@ function showByLegendFilter(menuGrp, targetData, self, target) {
 				f => !((f.dt.includes(1) && targetData.dt.includes(1)) || (f.dt.includes(4) && targetData.dt.includes(4)))
 			)
 
-			for (const item of target == 'mutation' ? s.snvIndelClasses : s.CNVClasses) {
+			for (const item of target == 'mutation' ? s.mutationClasses : s.CNVClasses) {
 				if (checkedItems.includes(item)) continue
 				// add a new "soft filter" to filter out the legend's origin + legend's dt + legend's class
 				// add a new "soft filter" to filter out samples that only have mutation match with (the legend's origin + legend's dt + legend's class) and no other mutation

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -2905,7 +2905,9 @@ function showOnlyTrunc(menuGrp, targetData, self) {
 		for (const [k, v] of Object.entries(mclass)) {
 			if (truncatingM.includes(k) || v.dt != dtsnvindel) continue
 			const filterNew = {
-				legendGrpName: controlLabels.Mutations,
+				legendGrpName: targetData.origin
+					? `${targetData.origin[0].toUpperCase() + targetData.origin.slice(1)} ${controlLabels.Mutations}`
+					: controlLabels.Mutations,
 				type: 'tvs',
 				tvs: {
 					isnot: true,
@@ -2946,7 +2948,9 @@ function showOnlyPC(menuGrp, targetData, self) {
 		for (const [k, v] of Object.entries(mclass)) {
 			if (proteinChangingMutations.includes(k) || v.dt != dtsnvindel) continue
 			const filterNew = {
-				legendGrpName: controlLabels.Mutations,
+				legendGrpName: targetData.origin
+					? `${targetData.origin[0].toUpperCase() + targetData.origin.slice(1)} ${controlLabels.Mutations}`
+					: controlLabels.Mutations,
 				type: 'tvs',
 				tvs: {
 					isnot: true,

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -3150,6 +3150,18 @@ function showByLegendFilter(menuGrp, targetData, self, target) {
 				self.config.legendValueFilter.lst.push(filterNew)
 			}
 
+			if (
+				self.state.config.settings.matrix.addMutationCNVButtons &&
+				self.chartType !== 'hierCluster' &&
+				(target == 'CNV' || targetData?.dt?.includes(4))
+			) {
+				if (checkedItems.length == 0 && self.config.settings.matrix.cellEncoding == 'oncoprint') {
+					//when all CNV items are hidden by applying legend value filter
+					self.config.settings.matrix.cellEncoding = 'single'
+				} else if (checkedItems.length > 0 && self.config.settings.matrix.cellEncoding == 'single') {
+					self.config.settings.matrix.cellEncoding = 'oncoprint'
+				}
+			}
 			self.app.dispatch({
 				type: 'plot_edit',
 				id: self.id,

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -2,14 +2,7 @@ import { select, pointer } from 'd3-selection'
 import { fillTermWrapper, termsettingInit } from '#termsetting'
 import { icons } from '#dom/control.icons'
 import { newSandboxDiv } from '../dom/sandbox.ts'
-import {
-	mclass,
-	dt2label,
-	truncatingMutations,
-	proteinChangingMutations,
-	mclasscnvgain,
-	mclasscnvloss
-} from '#shared/common'
+import { mclass, dt2label, dtsnvindel } from '#shared/common'
 import { format as d3format } from 'd3-format'
 import { Menu } from '#dom/menu'
 import { renderTable } from '../dom/table.ts'
@@ -2906,18 +2899,23 @@ function showOnlyTrunc(menuGrp, targetData, self) {
 
 		// remove the grp legend filter for the group
 		self.config.legendGrpFilter.lst = self.config.legendGrpFilter.lst.filter(f => !f.dt.includes(1))
-		const item = targetData.items[0]
-		const filterNew = {
-			legendGrpName: targetData.name,
-			type: 'tvs',
-			tvs: {
-				isnot: true,
-				legendFilterType: 'geneVariant_soft', // indicates this matrix legend filter is soft filter
-				term: { type: 'geneVariant' },
-				values: [{ dt: item.dt, origin: item.origin, mclasslst: [...self.config.settings.matrix.truncatingMutations] }]
+
+		const truncatingM = self.config.settings.matrix.truncatingMutations
+		const controlLabels = self.config.settings.matrix.controlLabels
+		for (const [k, v] of Object.entries(mclass)) {
+			if (truncatingM.includes(k) || v.dt != dtsnvindel) continue
+			const filterNew = {
+				legendGrpName: controlLabels.Mutations,
+				type: 'tvs',
+				tvs: {
+					isnot: true,
+					legendFilterType: 'geneVariant_soft',
+					term: { type: 'geneVariant' },
+					values: [{ dt: dtsnvindel, origin: targetData.origin, mclasslst: [k] }]
+				}
 			}
+			self.config.legendValueFilter.lst.push(filterNew)
 		}
-		self.config.legendValueFilter.lst.push(filterNew)
 	}
 
 	self.app.dispatch({
@@ -2942,20 +2940,23 @@ function showOnlyPC(menuGrp, targetData, self) {
 
 		// remove the grp legend filter for the group
 		self.config.legendGrpFilter.lst = self.config.legendGrpFilter.lst.filter(f => !f.dt.includes(1))
-		const item = targetData.items[0]
-		const filterNew = {
-			legendGrpName: item.termid,
-			type: 'tvs',
-			tvs: {
-				isnot: true,
-				legendFilterType: 'geneVariant_soft', // indicates this matrix legend filter is soft filter
-				term: { type: 'geneVariant' },
-				values: [
-					{ dt: item.dt, origin: item.origin, mclasslst: [...self.config.settings.matrix.proteinChangingMutations] }
-				]
+
+		const proteinChangingMutations = self.config.settings.matrix.proteinChangingMutations
+		const controlLabels = self.config.settings.matrix.controlLabels
+		for (const [k, v] of Object.entries(mclass)) {
+			if (proteinChangingMutations.includes(k) || v.dt != dtsnvindel) continue
+			const filterNew = {
+				legendGrpName: controlLabels.Mutations,
+				type: 'tvs',
+				tvs: {
+					isnot: true,
+					legendFilterType: 'geneVariant_soft',
+					term: { type: 'geneVariant' },
+					values: [{ dt: dtsnvindel, origin: targetData.origin, mclasslst: [k] }]
+				}
 			}
+			self.config.legendValueFilter.lst.push(filterNew)
 		}
-		self.config.legendValueFilter.lst.push(filterNew)
 	}
 
 	self.app.dispatch({

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -249,7 +249,6 @@ export class Matrix {
 	setComputedConfig() {
 		const s = this.config.settings.matrix
 		const mclasses = s.mclasses
-		const synonymousMutations = s.synonymousMutations
 
 		const hiddenVariants = new Set()
 		for (const f of this.config.legendGrpFilter.lst) {
@@ -264,13 +263,16 @@ export class Matrix {
 		}
 		s.hiddenVariants = [...hiddenVariants]
 
+		s.CNVClasses = mclasses.filter(m => mclass[m]?.dt === dtcnv)
 		const hiddenCNVs = new Set(s.hiddenVariants.filter(key => mclass[key]?.dt === dtcnv))
+		s.hiddenCNVs = [...hiddenCNVs]
 		// TODO: hiddenCNVs.size comparison should not be hardcoded against 2
 		s.showMatrixCNV = !hiddenCNVs.size ? 'all' : hiddenCNVs.size >= 2 ? 'none' : 'bySelection'
 		s.allMatrixCNVHidden = hiddenCNVs.size >= 2
 
 		s.snvIndelClasses = mclasses.filter(m => mclass[m]?.dt === dtsnvindel)
 		const hiddenMutations = new Set(s.hiddenVariants.filter(key => s.snvIndelClasses.find(k => k === key)))
+		s.hiddenMutations = [...hiddenMutations]
 		const PCset = new Set(s.proteinChangingMutations)
 		const TMset = new Set(s.truncatingMutations)
 
@@ -278,9 +280,9 @@ export class Matrix {
 			? 'all'
 			: hiddenMutations.size >= s.snvIndelClasses.length
 			? 'none'
-			: hiddenMutations.size === PCset.size && [...hiddenMutations].every(m => PCset.has(m))
+			: hiddenMutations.size === s.snvIndelClasses.length - PCset.size && [...hiddenMutations].every(m => !PCset.has(m))
 			? 'onlyPC'
-			: hiddenMutations.size === TMset.size && [...hiddenMutations].every(m => TMset.has(m))
+			: hiddenMutations.size === s.snvIndelClasses.length - TMset.size && [...hiddenMutations].every(m => !TMset.has(m))
 			? 'onlyTruncating'
 			: 'bySelection'
 		s.allMatrixMutationHidden = hiddenMutations.size >= s.snvIndelClasses.length

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -272,7 +272,6 @@ export class Matrix {
 		s.showMatrixCNV = !hiddenCNVs.size ? 'all' : hiddenCNVs.size == CNVClasses.length ? 'none' : 'bySelection'
 		s.allMatrixCNVHidden = hiddenCNVs.size == CNVClasses.length
 
-		console.log('what is s.allMatrixCNVHidden', s.allMatrixCNVHidden)
 		const hiddenMutations = new Set(s.hiddenVariants.filter(key => s.mutationClasses.find(k => k === key)))
 		s.hiddenMutations = [...hiddenMutations]
 		const PCset = new Set(s.proteinChangingMutations)

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -248,16 +248,13 @@ export class Matrix {
 
 	setComputedConfig() {
 		const s = this.config.settings.matrix
-		const mclasses = Object.values(mclass)
-		// by mclass
-		const hiddenVariants = new Set()
+		const mclasses = s.mclasses
+		const synonymousMutations = s.synonymousMutations
 
+		const hiddenVariants = new Set()
 		for (const f of this.config.legendGrpFilter.lst) {
 			if (!f.dt) continue
-			mclasses
-				.filter(c => f.dt.includes(c.dt))
-				.map(c => c.key)
-				.forEach(key => hiddenVariants.add(key))
+			mclasses.filter(m => f.dt.includes(mclass[m].dt)).forEach(key => hiddenVariants.add(key))
 		}
 		for (const f of this.config.legendValueFilter.lst) {
 			if (!f.legendGrpName || !f.tvs?.term?.type.startsWith('gene')) continue
@@ -272,12 +269,11 @@ export class Matrix {
 		s.showMatrixCNV = !hiddenCNVs.size ? 'all' : hiddenCNVs.size >= 2 ? 'none' : 'bySelection'
 		s.allMatrixCNVHidden = hiddenCNVs.size >= 2
 
-		s.snvIndelClasses = Object.values(mclass)
-			.filter(m => m.dt != dtcnv && m.key !== 'Blank' && m.key != 'WT')
-			.map(m => m.key)
+		s.snvIndelClasses = mclasses.filter(m => mclass[m]?.dt === dtsnvindel)
 		const hiddenMutations = new Set(s.hiddenVariants.filter(key => s.snvIndelClasses.find(k => k === key)))
 		const PCset = new Set(s.proteinChangingMutations)
 		const TMset = new Set(s.truncatingMutations)
+
 		s.showMatrixMutation = !hiddenMutations.size
 			? 'all'
 			: hiddenMutations.size >= s.snvIndelClasses.length

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -260,17 +260,20 @@ export class Matrix {
 				.forEach(key => hiddenVariants.add(key))
 		}
 		for (const f of this.config.legendValueFilter.lst) {
-			if (!f.legendGrpName) continue
-			f.tvs.values[0].mclasslst.forEach(key => hiddenVariants.add(key))
+			if (!f.legendGrpName || !f.tvs?.term?.type.startsWith('gene')) continue
+			if (f.tvs.values?.[0].mclasslst) f.tvs.values[0].mclasslst.forEach(key => hiddenVariants.add(key))
+			else if (f.tvs.values) f.tvs.values.forEach(v => hiddenVariants.add(v.key))
+			else throw `unhandled tvs from legendValueFilter`
 		}
 		s.hiddenVariants = [...hiddenVariants]
 
-		const hiddenCNVs = new Set(s.hiddenVariants.filter(d => d.startsWith('CNV_')))
+		const hiddenCNVs = new Set(s.hiddenVariants.filter(key => mclass[key]?.dt === dtcnv))
+		// TODO: hiddenCNVs.size comparison should not be hardcoded against 2
 		s.showMatrixCNV = !hiddenCNVs.size ? 'all' : hiddenCNVs.size >= 2 ? 'none' : 'bySelection'
 		s.allMatrixCNVHidden = hiddenCNVs.size >= 2
 
 		s.snvIndelClasses = Object.values(mclass)
-			.filter(m => m.dt === dtsnvindel)
+			.filter(m => m.dt != dtcnv && m.key !== 'Blank' && m.key != 'WT')
 			.map(m => m.key)
 		const hiddenMutations = new Set(s.hiddenVariants.filter(key => s.snvIndelClasses.find(k => k === key)))
 		const PCset = new Set(s.proteinChangingMutations)

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -269,20 +269,22 @@ export class Matrix {
 		s.showMatrixCNV = !hiddenCNVs.size ? 'all' : hiddenCNVs.size >= 2 ? 'none' : 'bySelection'
 		s.allMatrixCNVHidden = hiddenCNVs.size >= 2
 
-		const snvIndelClasses = Object.values(mclass).filter(m => m.dt === dtsnvindel)
-		const hiddenMutations = new Set(s.hiddenVariants.filter(key => snvIndelClasses.find(c => c.key === key)))
+		s.snvIndelClasses = Object.values(mclass)
+			.filter(m => m.dt === dtsnvindel)
+			.map(m => m.key)
+		const hiddenMutations = new Set(s.hiddenVariants.filter(key => s.snvIndelClasses.find(k => k === key)))
 		const PCset = new Set(s.proteinChangingMutations)
 		const TMset = new Set(s.truncatingMutations)
 		s.showMatrixMutation = !hiddenMutations.size
 			? 'all'
-			: hiddenMutations.size >= snvIndelClasses.length
+			: hiddenMutations.size >= s.snvIndelClasses.length
 			? 'none'
 			: hiddenMutations.size === PCset.size && [...hiddenMutations].every(m => PCset.has(m))
 			? 'onlyPC'
 			: hiddenMutations.size === TMset.size && [...hiddenMutations].every(m => TMset.has(m))
 			? 'onlyTruncating'
 			: 'bySelection'
-		s.allMatrixMutationHidden = hiddenMutations.size >= snvIndelClasses.length
+		s.allMatrixMutationHidden = hiddenMutations.size >= s.snvIndelClasses.length
 	}
 
 	showNoMatchingDataMessage() {

--- a/client/plots/matrix.legend.js
+++ b/client/plots/matrix.legend.js
@@ -14,6 +14,10 @@ export function getLegendData(legendGroups, refs, self) {
 			for (const f of this.config.legendValueFilter.lst) {
 				if (f.tvs.term.type !== 'geneVariant') continue
 				if (f.legendGrpName != $id) continue
+				if (f.tvs.legendFilterType == 'geneVariant_soft' && f.filteredOutCats.length == 0) {
+					// when the soft legend filter doesn't filter out any value, do not generate the greyed-out legend for it
+					continue
+				}
 				for (const v of f.tvs.values) {
 					for (const key of v.mclasslst) {
 						const legendk = v.origin ? v.origin + key : key

--- a/client/plots/matrix.legend.js
+++ b/client/plots/matrix.legend.js
@@ -83,6 +83,10 @@ export function getLegendData(legendGroups, refs, self) {
 				for (const v of f.tvs.values) {
 					// need to push all the dt to legend group, even when the legend item is hidden or filtered out
 					if (legend.dt && !legend.dt.includes(v.dt)) legend.dt.push(v.dt)
+					if (f.tvs.legendFilterType == 'geneVariant_soft' && f.filteredOutCats.length == 0) {
+						// when the soft legend filter doesn't filter out any value, do not generate the greyed-out legend for it
+						continue
+					}
 					for (const key of v.mclasslst) {
 						const legendk = v.origin ? v.origin + key : key
 						legend.values[legendk] = {

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -234,7 +234,7 @@ function getSortSamplesByClass(st, self, rows, s) {
 			: !sortBySSM && !sortByCNV
 			? () => false
 			: sortBySSM
-			? v => m.snvIndelClasses.includes(v) && !m.hiddenVariants.includes(v)
+			? v => m.mutationClasses.includes(v) && !m.hiddenVariants.includes(v)
 			: sortByCNV
 			? v => v.startsWith('CNV_') && !m.hiddenVariants.includes(v)
 			: v => !v.startsWith('CNV_')

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -230,12 +230,14 @@ function getSortSamplesByClass(st, self, rows, s) {
 	const sortByCNV = m.showMatrixCNV != 'none' && !m.allMatrixCNVHidden && m.sortByCNV
 	const order = sortSamples.order.filter(
 		sortBySSM && sortByCNV
-			? () => true // TODO: handle showMatrixMutation, showMatrixCNV == 'bySelection', if self.config.legendValueFilter.lst.includes(order[*])
+			? v => !m.hiddenVariants.includes(v)
 			: !sortBySSM && !sortByCNV
 			? () => false
-			: !sortByCNV
-			? v => !v.startsWith('CNV_') // TODO: handle showMatrixMutation, showMatrixCNV == 'bySelection'
-			: v => v.startsWith('CNV_') // TODO: handle showMatrixMutation, showMatrixCNV == 'bySelection'
+			: sortBySSM
+			? v => s.snvIndelClasses.includes(v) && !m.hiddenVariants.includes(v)
+			: sortByCNV
+			? v => v.startsWith('CNV_') && !m.hiddenVariants.includes(v)
+			: v => !v.startsWith('CNV_')
 	)
 
 	if (!order.length && sortSamples.ignoreEmptyFilteredOrder) return () => 0

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -226,8 +226,8 @@ function getSortSamplesByDt(st, self, rows, s) {
 function getSortSamplesByClass(st, self, rows, s) {
 	const { $id, sortSamples } = st
 	const m = self.config.settings.matrix
-	const sortBySSM = m.showMatrixMutation != 'none' && !m.allMatrixMutationHidden && m.variantSortBy.includes('ssm')
-	const sortByCNV = m.showMatrixCNV != 'none' && !m.allMatrixCNVHidden && m.variantSortBy.includes('cnv')
+	const sortBySSM = m.showMatrixMutation != 'none' && !m.allMatrixMutationHidden && m.sortByMutation == 'consequence'
+	const sortByCNV = m.showMatrixCNV != 'none' && !m.allMatrixCNVHidden && m.sortByCNV
 	const order = sortSamples.order.filter(
 		sortBySSM && sortByCNV
 			? () => true // TODO: handle showMatrixMutation, showMatrixCNV == 'bySelection', if self.config.legendValueFilter.lst.includes(order[*])
@@ -431,99 +431,6 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 				tiebreakers: [{ by: 'values' }]
 			}
 		]
-	}
-
-	// sortOptions.b = {
-	// 	label: 'CNV+SSM > SSM-only',
-	// 	altLabels: {
-	// 		mutationOnly: 'SSM',
-	// 		cnvOnly: 'CNV'
-	// 	},
-	// 	value: 'b',
-	// 	order: 1,
-	// 	sortPriority: [
-	// 		{
-	// 			types: ['geneVariant'],
-	// 			tiebreakers: [
-	// 				{
-	// 					filter: {
-	// 						values: [
-	// 							{
-	// 								dt: 2
-	// 							}
-	// 						]
-	// 					},
-	// 					by: 'class',
-	// 					order: ['Fuserna' /* 'WT', 'Blank'*/]
-	// 				}
-	// 			]
-	// 		},
-
-	// 		{
-	// 			types: ['geneVariant'],
-	// 			tiebreakers: [
-	// 				{
-	// 					filter: {
-	// 						values: [{ dt: 1 }]
-	// 					},
-	// 					by: 'class',
-	// 					order: [
-	// 						// copy-number
-	// 						'CNV_amp',
-	// 						'CNV_loss',
-
-	// 						// truncating
-	// 						'F', // FRAMESHIFT
-	// 						'N', // NONSENSE
-	// 						'L', // SPLICE
-	// 						'P', // SPLICE_REGION
-
-	// 						// indel
-	// 						'D', // PROTEINDEL
-	// 						'I', // PROTEININS
-	// 						'ProteinAltering',
-
-	// 						// point
-	// 						'M', // MISSENSE
-
-	// 						// noncoding
-	// 						'Utr3',
-	// 						'Utr5',
-	// 						'S', //SILENT
-	// 						'Intron',
-	// 						'noncoding'
-	// 					]
-	// 				}
-	// 			]
-	// 		},
-	// 		// {
-	// 		// 	types: ['geneVariant'],
-	// 		// 	tiebreakers: [
-	// 		// 		{
-	// 		// 			by: 'dt',
-	// 		// 			order: [4] // snvindel, cnv,
-	// 		// 			// other dt values will be ordered last
-	// 		// 			// for the sorter to not consider certain dt values,
-	// 		// 			// need to explicitly not use such values for sorting
-	// 		// 			// ignore: [4]
-	// 		// 		},
-	// 		// 		{
-	// 		// 			by: 'class',
-	// 		// 			order: ['CNV_amp', 'CNV_loss']
-	// 		// 		}
-	// 		// 	]
-	// 		// },
-	// 		{
-	// 			types: ['categorical', 'integer', 'float', 'survival'],
-	// 			tiebreakers: [{ by: 'values' }]
-	// 		}
-	// 	]
-	// }
-
-	sortOptions.name = {
-		label: `By ${l.sample} name, ID, or label`,
-		value: 'name',
-		order: Object.values(sortOptions).length
 	}
 
 	return sortOptions

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -234,7 +234,7 @@ function getSortSamplesByClass(st, self, rows, s) {
 			: !sortBySSM && !sortByCNV
 			? () => false
 			: sortBySSM
-			? v => s.snvIndelClasses.includes(v) && !m.hiddenVariants.includes(v)
+			? v => m.snvIndelClasses.includes(v) && !m.hiddenVariants.includes(v)
 			: sortByCNV
 			? v => v.startsWith('CNV_') && !m.hiddenVariants.includes(v)
 			: v => !v.startsWith('CNV_')
@@ -433,6 +433,13 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 				tiebreakers: [{ by: 'values' }]
 			}
 		]
+	}
+
+	// legacy support for testing, do not display in a control UI
+	sortOptions.name = {
+		label: `By ${l.sample} name, ID, or label`,
+		value: 'name',
+		order: Object.values(sortOptions).length
 	}
 
 	return sortOptions

--- a/client/plots/test/matrix.sort.unit.spec.js
+++ b/client/plots/test/matrix.sort.unit.spec.js
@@ -90,6 +90,7 @@ function getArgs(_settings = {}) {
 			sortOptions: ms.getSortOptions(),
 			sortByMutation: 'presence',
 			sortByCNV: false,
+			hiddenVariants: [],
 			..._settings
 		}
 	}

--- a/client/plots/test/matrix.sort.unit.spec.js
+++ b/client/plots/test/matrix.sort.unit.spec.js
@@ -88,7 +88,8 @@ function getArgs(_settings = {}) {
 		matrix: {
 			sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: { by: 'sample' } }],
 			sortOptions: ms.getSortOptions(),
-			variantSortBy: [],
+			sortByMutation: 'presence',
+			sortByCNV: false,
 			..._settings
 		}
 	}
@@ -244,7 +245,8 @@ tape('sortPriority by Mutation categories, default no value sorting, that uses a
 tape('sortPriority by Mutation categories with value sorting, that uses a filter', test => {
 	const { self, settings, rows } = getArgs({
 		sortSamplesBy: 'a',
-		variantSortBy: ['cnv', 'ssm']
+		sortByMutation: 'consequence',
+		sortByCNV: true
 	})
 	const sorter = ms.getSampleSorter(self, settings, rows)
 	const sampleNames = self.sampleGroups.map(g => g.lst.sort(sorter).map(s => s.sample))

--- a/client/plots/test/matrix.sort.unit.spec.js
+++ b/client/plots/test/matrix.sort.unit.spec.js
@@ -88,6 +88,7 @@ function getArgs(_settings = {}) {
 		matrix: {
 			sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: { by: 'sample' } }],
 			sortOptions: ms.getSortOptions(),
+			variantSortBy: [],
 			..._settings
 		}
 	}
@@ -213,9 +214,37 @@ tape('sortSamplesBy = asListed', test => {
 	test.end()
 })
 
-tape('sortPriority by CNV+SSM > SSM-only > CNV-only that uses a filter', test => {
+tape('sortPriority by Mutation categories, default no value sorting, that uses a filter', test => {
 	const { self, settings, rows } = getArgs({
 		sortSamplesBy: 'a'
+	})
+	const sorter = ms.getSampleSorter(self, settings, rows)
+	const sampleNames = self.sampleGroups.map(g => g.lst.sort(sorter).map(s => s.sample))
+	test.deepEqual(
+		sampleNames,
+		[
+			[2, 3, 1],
+			[5, 4]
+		],
+		'should sort the samples by dt then value'
+	)
+	test.deepEqual(
+		simpleMatrix(sampleNames, self.termOrder, rows),
+		// prettier-ignore
+		[ 
+			[ '2', '3', ' ', '5', ' ' ], 
+			[ '2', ' ', '1', '5', ' ' ], 
+			[ ' ', '3', '1', ' ', '4' ] 
+		],
+		'should sort sample and rows in the expected order'
+	)
+	test.end()
+})
+
+tape('sortPriority by Mutation categories with value sorting, that uses a filter', test => {
+	const { self, settings, rows } = getArgs({
+		sortSamplesBy: 'a',
+		variantSortBy: ['cnv', 'ssm']
 	})
 	const sorter = ms.getSampleSorter(self, settings, rows)
 	const sampleNames = self.sampleGroups.map(g => g.lst.sort(sorter).map(s => s.sample))

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,5 @@
 Features:
 - Improve the matrix sorting options to easily toggle sorting by cnv and/or consequence
+
+Fixes:
+- Add to GDC oncoMatrix mutation/cnv buttons all available mutation/cnv classes in GDC instead of all available mutation/cnv classes in the current matrix

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Improve the matrix sorting options to easily toggle sorting by cnv and/or consequence

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -1087,3 +1087,5 @@ export function getColors(number) {
 
 export const truncatingMutations = ['F', 'N', 'L', 'P']
 export const proteinChangingMutations = ['F', 'N', 'L', 'P', 'D', 'I', 'ProteinAltering', 'M']
+export const mclasses = Object.keys(mclass)
+export const synonymousMutations = ['S', 'Intron', 'Utr3', 'Utr5', 'noncoding', 'E']

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -1087,5 +1087,10 @@ export function getColors(number) {
 
 export const truncatingMutations = ['F', 'N', 'L', 'P']
 export const proteinChangingMutations = ['F', 'N', 'L', 'P', 'D', 'I', 'ProteinAltering', 'M']
-export const mclasses = Object.keys(mclass)
 export const synonymousMutations = ['S', 'Intron', 'Utr3', 'Utr5', 'noncoding', 'E']
+export const mutationClasses = Object.values(mclass)
+	.filter(m => m.dt == dtsnvindel)
+	.map(m => m.key)
+export const CNVClasses = Object.values(mclass)
+	.filter(m => m.dt == dtcnv)
+	.map(m => m.key)

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -570,12 +570,12 @@ type MatrixSettings = {
 	sortSamplesBy?: string
 	sortPriority?: SortPriorityEntry[]
 	ignoreCnvValues?: boolean
-	geneVariantCountSamplesSkipMclass?: Array<string>
-	truncatingMutations?: Array<string> // all the truncating mutations exist in the dataset
-	proteinChangingMutations?: Array<string> // all the protein-changing mutations mutations exist in the dataset
-	mutationClasses?: Array<string> // all the mutation classes exist in the dataset
-	CNVClasses?: Array<string> // all the CNV classes exist in the dataset
-	synonymousMutations?: Array<string> // all the synonymous mutations exist in the dataset
+	geneVariantCountSamplesSkipMclass?: string[]
+	truncatingMutations?: string[] // all the truncating mutations exist in the dataset
+	proteinChangingMutations?: string[] // all the protein-changing mutations mutations exist in the dataset
+	mutationClasses?: string[] // all the mutation classes exist in the dataset
+	CNVClasses?: string[] // all the CNV classes exist in the dataset
+	synonymousMutations?: string[] // all the synonymous mutations exist in the dataset
 	showHints?: string[]
 	displayDictRowWithNoValues?: boolean
 	addMutationCNVButtons?: boolean // allow to add two buttons (CNV and mutation) to control panel for selecting mclasses displayed on oncoMatrix

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -571,8 +571,10 @@ type MatrixSettings = {
 	sortPriority?: SortPriorityEntry[]
 	ignoreCnvValues?: boolean
 	geneVariantCountSamplesSkipMclass?: Array<string>
-	truncatingMutations?: Array<string>
-	proteinChangingMutations?: Array<string>
+	truncatingMutations?: Array<string> // all the truncating mutations exist in the dataset
+	proteinChangingMutations?: Array<string> // all the protein-changing mutations mutations exist in the dataset
+	mclasses?: Array<string> // all the mclasses exist in the dataset
+	synonymousMutations?: Array<string> // all the synonymous mutations exist in the dataset
 	showHints?: string[]
 	displayDictRowWithNoValues?: boolean
 	addMutationCNVButtons?: boolean // allow to add two buttons (CNV and mutation) to control panel for selecting mclasses displayed on oncoMatrix

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -573,7 +573,8 @@ type MatrixSettings = {
 	geneVariantCountSamplesSkipMclass?: Array<string>
 	truncatingMutations?: Array<string> // all the truncating mutations exist in the dataset
 	proteinChangingMutations?: Array<string> // all the protein-changing mutations mutations exist in the dataset
-	mclasses?: Array<string> // all the mclasses exist in the dataset
+	mutationClasses?: Array<string> // all the mutation classes exist in the dataset
+	CNVClasses?: Array<string> // all the CNV classes exist in the dataset
 	synonymousMutations?: Array<string> // all the synonymous mutations exist in the dataset
 	showHints?: string[]
 	displayDictRowWithNoValues?: boolean


### PR DESCRIPTION
## Description

… by cnv and/or consequence.

![Screenshot 2024-03-29 at 6 34 51 PM](https://github.com/stjude/proteinpaint/assets/411031/e3115564-7cc3-4b21-81f5-1ec0c37f7a37)

@congyu-lu Please check this branch in the neuroonc datasets

To test:
1. http://localhost:3000/testrun.html?dir=mass&name=matrix.integration
2. http://localhost:3000/testrun.html?dir=plots&name=matrix.sort.unit
3. GDC:
- Load http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=Gliomas
- `Cases -> Sort by values` should not have a `CNV` checkbox, when the `CNV` button is crossed out
- Click on the CNV button to show all CNV, then the `Cases -> Sort by values : CNV` checkbox should appear in the Cases menu
- Clicking on the `Cases -> Sort by values` CNV and Consequence checkboxes should intuitively re-sort the case columns 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
