### PR TITLE
Support survival term in cox regression

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Support survival term as outcome variable in regression analysis

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -9,7 +9,7 @@ export const graphableTypes = new Set([
 	'snplst',
 	'snplocus',
 	'geneVariant',
-	'samplelst',
+	'samplelst'
 ])
 /*
 	isUsableTerm() will
@@ -151,8 +151,8 @@ export function isUsableTerm(term, _usecase, ds) {
 					if (hasNonSurvivalTermChild(child_types)) uses.add('branch')
 					return uses
 				} else if (usecase.regressionType == 'cox') {
-					if (term.type == 'condition') uses.add('plot')
-					if (child_types.includes('condition')) uses.add('branch')
+					if (term.type == 'condition' || term.type == 'survival') uses.add('plot')
+					if (child_types.includes('condition') || child_types.includes('survival')) uses.add('branch')
 					return uses
 				}
 			}

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -348,11 +348,15 @@ function makeRinput(q, sampledata) {
 			// cox regression, therefore time-to-event outcome
 			// use both key (event status) and value (time)
 			entry[outcome.timeToEvent.eventId] = out.key
-			const { age_start, age_end } = out.value
-			entry[outcome.timeToEvent.timeId] = age_end - age_start
-			if (q.outcome.q.timeScale == 'age') {
-				entry[outcome.timeToEvent.agestartId] = age_start
-				entry[outcome.timeToEvent.ageendId] = age_end
+			if (q.outcome.term.type == 'condition') {
+				const { age_start, age_end } = out.value
+				entry[outcome.timeToEvent.timeId] = age_end - age_start
+				if (q.outcome.q.timeScale == 'age') {
+					entry[outcome.timeToEvent.agestartId] = age_start
+					entry[outcome.timeToEvent.ageendId] = age_end
+				}
+			} else {
+				entry[outcome.timeToEvent.timeId] = out.value
 			}
 		}
 
@@ -1177,48 +1181,16 @@ async function getSampleData_dictionaryTerms(q, terms) {
 			`
 		).join(`UNION ALL`)}`
 
-	const rows = q.ds.cohort.db.connection.prepare(sql).all(values)
+	const _rows = q.ds.cohort.db.connection.prepare(sql).all(values)
 
 	// process rows
-	const prows = []
-	const ageEndOffset = q.ds.cohort.termdb.ageEndOffset
-	if (!ageEndOffset) throw 'missing age end offset'
-	for (const row of rows) {
-		if (q.regressionType == 'cox' && row.term_id == q.outcome.id) {
-			// cox outcome row
-
-			// event: event status code
-			// age_start: age at beginning of follow-up
-			// age_end: age at event or at censoring
-			const event = row.key
-			const { age_start, age_end } = JSON.parse(row.value)
-
-			// discard samples that had events before follow-up
-			if (event == -1) continue
-
-			// for timeScale='age', add a small offset to age_end
-			// to prevent age_end = age_start (which would cause
-			// R to error out)
-			const value = {
-				age_start,
-				age_end: q.outcome.q.timeScale == 'age' ? age_end + ageEndOffset : age_end
-			}
-
-			prows.push({
-				sample: row.sample,
-				key: event,
-				value,
-				term_id: row.term_id
-			})
-		} else {
-			// not cox outcome row
-			// no need to process row
-			prows.push(row)
-		}
-	}
+	const rows =
+		q.regressionType == 'cox' && q.outcome.term.type == 'condition'
+			? processCoxConditionOutcomeRows(_rows, q.outcome, q.ds.cohort.termdb.ageEndOffset)
+			: _rows
 
 	// parse the processed rows
-	for (const { sample, term_id, key, value } of prows) {
+	for (const { sample, term_id, key, value } of rows) {
 		const term = terms.find(term => term.id == term_id)
 
 		if (!samples.has(sample)) {
@@ -1255,6 +1227,45 @@ async function getSampleData_dictionaryTerms(q, terms) {
 	}
 
 	return samples
+}
+
+function processCoxConditionOutcomeRows(rows, outcome, ageEndOffset) {
+	if (!ageEndOffset) throw 'missing age end offset'
+	const prows = []
+	for (const row of rows) {
+		if (row.term_id == outcome.id) {
+			// outcome row
+
+			// event: event status code
+			// age_start: age at beginning of follow-up
+			// age_end: age at event or at censoring
+			const event = row.key
+			const { age_start, age_end } = JSON.parse(row.value)
+
+			// discard samples that had events before follow-up
+			if (event == -1) continue
+
+			// for timeScale='age', add a small offset to age_end
+			// to prevent age_end = age_start (which would cause
+			// R to error out)
+			const value = {
+				age_start,
+				age_end: outcome.q.timeScale == 'age' ? age_end + ageEndOffset : age_end
+			}
+
+			prows.push({
+				sample: row.sample,
+				key: event,
+				value,
+				term_id: row.term_id
+			})
+		} else {
+			// not outcome row
+			// no need to process row
+			prows.push(row)
+		}
+	}
+	return prows
 }
 
 /*


### PR DESCRIPTION
## Description

Survival term can now be used as an outcome variable in Cox regression. Regression analysis is now active for datasets with survival terms (e.g., mbmeta, pnet, and ihg) (see [sjpp PR](https://github.com/stjude/sjpp/pull/344)). See [tutorial](https://docs.google.com/document/d/1EyPXH7kdXMiO5WNSVLvOIVE7hMCFPp5uONi29EskRmU/edit#heading=h.2lm0tp6qvrcx) for instructions on setting up a regression analysis.

Here is an example Cox regression analysis in the TermdbTest dataset, using survival as an outcome variabe: http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38-test%22,%22dslabel%22:%22TermdbTest%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22cox%22,%22outcome%22:{%22id%22:%22os%22},%22independent%22:[{%22id%22:%22sex%22},{%22id%22:%22agedx%22}]}]}


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
