### PR TITLE
remove trailing slash from the client stored hosrURL

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -265,6 +265,9 @@ function setHostUrl(arg, app) {
 		}
 	}
 
+	// strip trailing slash
+	if (app.hostURL.endsWith('/')) app.hostURL = app.hostURL.slice(0, -1)
+
 	// store fetch parameters
 	sessionStorage.setItem('hostURL', app.hostURL)
 }


### PR DESCRIPTION
## Description

Fix the generated mass session link to not have a double-slash after the URL host

To test:
- change `proteinpaint/public/index.html ` to have `host: 'http://localhost:3000/', as an argument to runpp() 
- open http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22}
- switch to the filter or groups tab
- click Session -> Share: a new tab should open, with the URL not having a double-slash
- copy the session link and paste to another browser tab, should also not have a double-slash in the URL

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
