### PR TITLE
Matrix sorter UI

### DIFF
--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -120,7 +120,7 @@ export const icons = {
 			.on('click', o.handler)
 	},
 	left: (elem, o) => {
-		const fill = o.disabled ? disabled.color : 'rgb(100,100,255)'
+		const fill = o.fill ? o.fill : o.disabled ? disabled.color : 'rgb(100,100,255)'
 		return elem
 			.attr('title', o.title)
 			.style('padding', '0 3px')

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -622,7 +622,8 @@ function setCustomInput(opts) {
 				.append('td')
 				.html(opts.label)
 				.attr('class', 'sja-termdb-config-row-label')
-				.attr('title', opts.title),
+				.attr('title', opts.title)
+				.style('vertical-align', 'top'),
 			inputTd: opts.holder.append('td')
 		}
 	}

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -190,10 +190,9 @@ export async function getPlotConfig(opts = {}, app) {
 	// may apply term-specific changes to the default object
 	copyMerge(config, opts)
 	const m = config.settings.matrix
-
-	;(m.sortOptions = getSortOptions(app.vocabApi.termdbConfig, controlLabels, m)),
-		// harcode these overrides for now
-		(m.duration = 0)
+	m.sortOptions = getSortOptions(app.vocabApi.termdbConfig, controlLabels, m)
+	// harcode these overrides for now
+	m.duration = 0
 	// force auto-dimensions for colw
 	m.colw = 0
 	// support deprecated sortSamplesBy value from a saved session

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -66,7 +66,7 @@ export async function getPlotConfig(opts = {}, app) {
 				sortPriority: undefined, // will be filled-in
 				sortByMutation: 'consequence',
 				sortByCNV: true,
-				sortOptions: getSortOptions(app.vocabApi.termdbConfig, controlLabels),
+				//sortOptions: getSortOptions(app.vocabApi.termdbConfig, controlLabels),
 				sortSampleGrpsBy: 'name', // 'hits' | 'name' | 'sampleCount'
 				sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: {} /*split: {char: '', index: 0}*/ }],
 				sortTermsBy: 'sampleCount', // or 'as listed'
@@ -190,12 +190,14 @@ export async function getPlotConfig(opts = {}, app) {
 	// may apply term-specific changes to the default object
 	copyMerge(config, opts)
 	const m = config.settings.matrix
-	// harcode these overrides for now
-	m.duration = 0
+
+	;(m.sortOptions = getSortOptions(app.vocabApi.termdbConfig, controlLabels, m)),
+		// harcode these overrides for now
+		(m.duration = 0)
 	// force auto-dimensions for colw
 	m.colw = 0
 	// support deprecated sortSamplesBy value from a saved session
-	if (!m.sortOptions?.[m.sortSamplesBy]) m.sortSamplesBy = 'a'
+	if (m.sortSamplesBy != 'asListed' && !m.sortOptions?.[m.sortSamplesBy]) m.sortSamplesBy = 'a'
 	else if (['selectedTerms', 'class', 'dt', 'hits'].includes(m.sortSamplesBy)) m.sortSamplesBy = 'a'
 	if (m.samplecount4gene === true || m.samplecount4gene === 1) m.samplecount4gene = 'abs'
 	// support overrides in localhost

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1,12 +1,11 @@
 import { initByInput } from './controls.config'
 import { to_svg } from '../src/client'
+import { getSorterUi } from './matrix.sorterUi'
 import { fillTermWrapper, get$id } from '#termsetting'
 import { Menu } from '#dom/menu'
 import { zoom } from '#dom/zoom'
 import { icons } from '#dom/control.icons'
 import { svgScroll } from '#dom/svg.scroll'
-import { make_radios } from '#dom/radiobutton'
-import { make_one_checkbox } from '#dom/checkbox'
 import { showGenesetEdit } from '../dom/genesetEdit.ts' // cannot use '#dom/', breaks
 import { select } from 'd3-selection'
 import { mclass, dt2label, dtsnvindel, dtcnv, dtfusionrna, dtgeneexpression, dtsv } from '#shared/common'
@@ -80,77 +79,7 @@ export class MatrixControls {
 				getCount: () =>
 					'sampleCount' in this.overrides ? this.overrides.sampleCount : this.parent.sampleOrder?.length || 0,
 				rows: [
-					{
-						label: `Sort ${l.Sample} Priority`,
-						title: `Set how to sort ${l.samples}`,
-						type: 'custom',
-						init(self) {
-							const ssmDiv = self.dom.inputTd.append('div')
-							ssmDiv.append('span').html('SSM')
-							const { inputs } = make_radios({
-								// holder, options, callback, styles
-								holder: ssmDiv.append('span'),
-								options: [
-									{ label: 'by consequence', value: 'consequence' },
-									{ label: 'by presence', value: 'presence', checked: true }
-								],
-								styles: {
-									display: 'inline-block'
-								},
-								callback: value => {
-									parent.app.dispatch({
-										type: 'plot_edit',
-										id: parent.id,
-										config: {
-											settings: {
-												matrix: {
-													sortByMutation: value
-												}
-											}
-										}
-									})
-								}
-							})
-
-							inputs.style('margin', '2px 0 0 2px').style('vertical-align', 'top')
-
-							const cnvDiv = self.dom.inputTd.append('div')
-							cnvDiv.append('span').html('CNV')
-							// holder, labeltext, callback, checked, divstyle
-							const input = make_one_checkbox({
-								holder: cnvDiv.append('span'),
-								divstyle: { display: 'inline-block' },
-								checked: false,
-								labeltext: 'sort by CNV',
-								callback: () => {
-									parent.app.dispatch({
-										type: 'plot_edit',
-										id: parent.id,
-										config: {
-											settings: {
-												matrix: {
-													sortByCNV: input.property('checked')
-												}
-											}
-										}
-									})
-								}
-							})
-
-							//self.dom.inputTd.append('div').append('span').html('By case name')
-
-							return {
-								main: plot => {
-									const s = plot.settings.matrix
-									// ssm
-									inputs.property('checked', d => d.value == s.sortByMutation)
-									// cnv
-									input.property('checked', s.sortByCNV)
-									cnvDiv.style('display', s.showMatrixCNV != 'none' && !s.allMatrixCNVHidden ? 'block' : 'none')
-								}
-							}
-						}
-					},
+					getSorterUi(this, s),
 					{
 						label: `Maximum # ${l.Samples}`,
 						title: `Limit the number of displayed ${l.samples}`,

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -24,6 +24,7 @@ export class MatrixControls {
 		const s = state.config.settings.matrix
 		if (this.parent.setClusteringBtn)
 			this.parent.setClusteringBtn(this.opts.holder, (event, data) => this.callback(event, data))
+		this.setSortFilterBtn(s)
 		this.setSamplesBtn(s)
 		this.setGenesBtn(s)
 		if (s.addMutationCNVButtons && this.parent.chartType !== 'hierCluster') {
@@ -66,6 +67,22 @@ export class MatrixControls {
 			.selectAll(':scope>button')
 			.filter(d => d && d.label)
 			.on(`keyup.matrix-${this.parent.id}`, this.keyboardNavHandler)
+	}
+
+	setSortFilterBtn(s) {
+		this.opts.holder
+			.append('button')
+			.html('Sort and Filter')
+			.on('click', () => {
+				const tip = this.parent.app.tip
+				tip.clear()
+				console.log(this)
+				const ui = getSorterUi({ controls: this, holder: tip.d })
+				//ui.init({
+
+				//})
+				tip.showunder(event.target)
+			})
 	}
 
 	setSamplesBtn(s) {
@@ -186,8 +203,7 @@ export class MatrixControls {
 								.map(t => t.tw.term.gene || t.tw.term.name) // TODO term.gene replaces term.name
 							return { currentGeneNames }
 						}
-					},
-					getSorterUi(this, s)
+					}
 				]
 			})
 			.html(d => d.label)

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -79,7 +79,6 @@ export class MatrixControls {
 				getCount: () =>
 					'sampleCount' in this.overrides ? this.overrides.sampleCount : this.parent.sampleOrder?.length || 0,
 				rows: [
-					getSorterUi(this, s),
 					{
 						label: `Maximum # ${l.Samples}`,
 						title: `Limit the number of displayed ${l.samples}`,
@@ -162,7 +161,33 @@ export class MatrixControls {
 						type: 'number',
 						chartType: 'matrix',
 						settingsKey: 'collabelmaxchars'
-					}
+					},
+					{
+						label: `Group ${l.Samples} By`,
+						title: `Select a variable with discrete values to group ${l.samples}`,
+						type: 'term',
+						chartType: 'matrix',
+						configKey: 'divideBy',
+						vocabApi: this.opts.app.vocabApi,
+						state: {
+							vocab: this.opts.vocab
+							//activeCohort: appState.activeCohort
+						},
+						getDisplayStyle(plot) {
+							return plot.chartType == 'hierCluster' ? 'none' : 'table-row'
+						},
+						processInput: tw => {
+							if (tw) fillTermWrapper(tw)
+							return tw
+						},
+						getBodyParams: () => {
+							const currentGeneNames = this.parent.termOrder
+								.filter(t => t.tw.term.type === 'geneVariant')
+								.map(t => t.tw.term.gene || t.tw.term.name) // TODO term.gene replaces term.name
+							return { currentGeneNames }
+						}
+					},
+					getSorterUi(this, s)
 				]
 			})
 			.html(d => d.label)

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -85,35 +85,6 @@ export class MatrixControls {
 				}
 			},
 			{
-				label: `Group ${l.Samples} By`,
-				title: `Select a variable with discrete values to group ${l.samples}`,
-				type: 'term',
-				chartType: 'matrix',
-				configKey: 'divideBy',
-				vocabApi: this.opts.app.vocabApi,
-				state: {
-					vocab: this.opts.vocab
-					//activeCohort: appState.activeCohort
-				},
-				getDisplayStyle(plot) {
-					return plot.chartType == 'hierCluster' ? 'none' : 'table-row'
-				},
-				processInput: tw => {
-					if (tw) fillTermWrapper(tw)
-					return tw
-				},
-				processConfig: config => {
-					if (this.parent.config.divideBy)
-						config.legendValueFilter = this.parent.mayRemoveTvsEntry(this.parent.config.divideBy)
-				},
-				getBodyParams: () => {
-					const currentGeneNames = this.parent.termOrder
-						.filter(t => t.tw.term.type === 'geneVariant')
-						.map(t => t.tw.term.gene || t.tw.term.name) // TODO term.gene replaces term.name
-					return { currentGeneNames }
-				}
-			},
-			{
 				label: `Sort ${l.Sample} Groups`,
 				title: `Set how to sort ${l.sample} groups`,
 				type: 'radio',
@@ -174,6 +145,10 @@ export class MatrixControls {
 				processInput: tw => {
 					if (tw) fillTermWrapper(tw)
 					return tw
+				},
+				processConfig: config => {
+					if (this.parent.config.divideBy)
+						config.legendValueFilter = this.parent.mayRemoveTvsEntry(this.parent.config.divideBy)
 				},
 				getBodyParams: () => {
 					const currentGeneNames = this.parent.termOrder

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -70,13 +70,22 @@ export class MatrixControls {
 	}
 
 	setSortFilterBtn(s) {
+		let ui
+
 		this.opts.holder
 			.append('button')
 			.html('Sort')
 			.on('click', () => {
 				const tip = this.parent.app.tip
 				tip.clear()
-				const ui = getSorterUi({ controls: this, holder: tip.d, tip })
+				if (ui) ui.main()
+				else
+					ui = getSorterUi({
+						controls: this,
+						holder: tip.d,
+						tip
+						//expandedSection: this.parent.config.settings.matrix.sortOptions.a?.sortPriority[0]?.label || ''
+					})
 				tip.showunder(event.target)
 			})
 	}

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -72,7 +72,7 @@ export class MatrixControls {
 	setSortFilterBtn(s) {
 		this.opts.holder
 			.append('button')
-			.html('Sort and Filter')
+			.html('Sort')
 			.on('click', () => {
 				const tip = this.parent.app.tip
 				tip.clear()

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -77,7 +77,7 @@ export class MatrixControls {
 				const tip = this.parent.app.tip
 				tip.clear()
 				console.log(this)
-				const ui = getSorterUi({ controls: this, holder: tip.d })
+				const ui = getSorterUi({ controls: this, holder: tip.d, tip })
 				//ui.init({
 
 				//})

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -24,7 +24,7 @@ export class MatrixControls {
 		const s = state.config.settings.matrix
 		if (this.parent.setClusteringBtn)
 			this.parent.setClusteringBtn(this.opts.holder, (event, data) => this.callback(event, data))
-		this.setSortFilterBtn(s)
+		//this.setSortBtn(s)
 		this.setSamplesBtn(s)
 		this.setGenesBtn(s)
 		if (s.addMutationCNVButtons && this.parent.chartType !== 'hierCluster') {
@@ -69,7 +69,7 @@ export class MatrixControls {
 			.on(`keyup.matrix-${this.parent.id}`, this.keyboardNavHandler)
 	}
 
-	setSortFilterBtn(s) {
+	setSortBtn(s) {
 		let ui
 
 		this.opts.holder
@@ -207,6 +207,25 @@ export class MatrixControls {
 								.filter(t => t.tw.term.type === 'geneVariant')
 								.map(t => t.tw.term.gene || t.tw.term.name) // TODO term.gene replaces term.name
 							return { currentGeneNames }
+						}
+					},
+					{
+						label: `Sort ${l.Samples} By`,
+						title: ``,
+						type: 'custom',
+						init(self) {
+							//const opts = { controls, holder, debug: true, setComputedConfig }
+							self.dom.row.on('mouseover', function () {
+								this.style.backgroundColor = '#fff'
+								this.style.textShadow = 'none'
+							})
+
+							return getSorterUi({
+								controls: this,
+								holder: self.dom.inputTd,
+								tip: this.parent.app.tip
+								//expandedSection: this.parent.config.settings.matrix.sortOptions.a?.sortPriority[0]?.label || ''
+							})
 						}
 					}
 				]

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -76,11 +76,7 @@ export class MatrixControls {
 			.on('click', () => {
 				const tip = this.parent.app.tip
 				tip.clear()
-				console.log(this)
 				const ui = getSorterUi({ controls: this, holder: tip.d, tip })
-				//ui.init({
-
-				//})
 				tip.showunder(event.target)
 			})
 	}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -3078,9 +3078,7 @@ function showNone(menuGrp, targetData, self, target) {
 	})
 }
 
-function showAll(menuGrp, targetData, self, target) {
-	menuGrp.hide()
-
+export function getConfigForShowAll(self, targetData, target) {
 	if (targetData) {
 		// there are  data
 		const byOrigin = self.state.termdbConfig.assayAvailability?.byDt?.[parseInt(targetData.dt)]?.byOrigin
@@ -3106,18 +3104,26 @@ function showAll(menuGrp, targetData, self, target) {
 			)
 	}
 
+	const s = self.config.settings.matrix
 	if (
-		self.state.config.settings.matrix.addMutationCNVButtons &&
+		s.addMutationCNVButtons &&
 		self.chartType !== 'hierCluster' &&
 		(target == 'CNV' || targetData?.dt?.includes(dtcnv)) &&
-		self.config.settings.matrix.cellEncoding !== ''
+		s.cellEncoding !== ''
 	) {
-		self.config.settings.matrix.cellEncoding = 'oncoprint'
+		s.cellEncoding = 'oncoprint'
 	}
+
+	return self.config
+}
+
+export function showAll(menuGrp, targetData, self, target) {
+	menuGrp.hide()
+
 	self.app.dispatch({
 		type: 'plot_edit',
 		id: self.id,
-		config: self.config
+		config: getConfigForShowAll(self, targetData, target)
 	})
 }
 

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -11,7 +11,8 @@ import * as matrixLayout from './matrix.layout'
 import * as matrixSerieses from './matrix.serieses'
 import * as matrixLegend from './matrix.legend'
 import * as matrixGroups from './matrix.groups'
-export { getPlotConfig, setComputedConfig } from './matrix.config'
+import { setComputedConfig } from './matrix.config'
+export { getPlotConfig } from './matrix.config'
 
 export class Matrix {
 	constructor(opts) {

--- a/client/plots/matrix.js
+++ b/client/plots/matrix.js
@@ -249,15 +249,12 @@ export class Matrix {
 
 	setComputedConfig() {
 		const s = this.config.settings.matrix
-		const mutationClasses = s.mutationClasses
-		const CNVClasses = s.CNVClasses
+		const allClasses = [...s.mutationClasses, ...s.CNVClasses]
 
 		const hiddenVariants = new Set()
 		for (const f of this.config.legendGrpFilter.lst) {
 			if (!f.dt) continue
-			;[...mutationClasses, ...CNVClasses]
-				.filter(m => f.dt.includes(mclass[m].dt))
-				.forEach(key => hiddenVariants.add(key))
+			allClasses.filter(m => f.dt.includes(mclass[m].dt)).forEach(key => hiddenVariants.add(key))
 		}
 		for (const f of this.config.legendValueFilter.lst) {
 			if (!f.legendGrpName || !f.tvs?.term?.type.startsWith('gene')) continue
@@ -270,8 +267,8 @@ export class Matrix {
 		const hiddenCNVs = new Set(s.hiddenVariants.filter(key => mclass[key]?.dt === dtcnv))
 		s.hiddenCNVs = [...hiddenCNVs]
 
-		s.showMatrixCNV = !hiddenCNVs.size ? 'all' : hiddenCNVs.size == CNVClasses.length ? 'none' : 'bySelection'
-		s.allMatrixCNVHidden = hiddenCNVs.size == CNVClasses.length
+		s.showMatrixCNV = !hiddenCNVs.size ? 'all' : hiddenCNVs.size == s.CNVClasses.length ? 'none' : 'bySelection'
+		s.allMatrixCNVHidden = hiddenCNVs.size == s.CNVClasses.length
 
 		const hiddenMutations = new Set(s.hiddenVariants.filter(key => s.mutationClasses.find(k => k === key)))
 		s.hiddenMutations = [...hiddenMutations]

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -368,7 +368,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 		order: 1, // this is used for list order as a sorter option in a dropdown
 		sortPriority: [
 			{
-				label: 'For each gene mutation row from top to bottom, sort cases by matching data',
+				label: 'For each gene mutation, sort cases by matching data',
 				types: ['geneVariant'],
 				tiebreakers: [
 					{
@@ -462,7 +462,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 				]
 			},
 			{
-				label: 'For each dictionary variable from top to bottom, sort cases by matching data',
+				label: 'For each dictionary variable, sort cases by matching data',
 				types: ['categorical', 'integer', 'float', 'survival'],
 				tiebreakers: [
 					{

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -359,7 +359,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 	}
 
 	// Similar to Oncoprint sorting
-	sortOptions.a = {
+	sortOptions.a = s.sortOptions?.a || {
 		//label: l.Mutation + ' categories', //'CNV+SSM > SSM-only > CNV-only',
 		// altLabels: {
 		// 	mutationOnly: 'SSM',
@@ -534,8 +534,12 @@ function defaultSorter(a, b) {
 
 export function getMclassSorter(self) {
 	const s = self.settings.matrix
+	// subsequent code does not work when s.sortSamplesBy == 'name', but a mclass sorter function
+	// may still be needed for non-matrix-column-sorting use cases such as for legend entries.
+	// In that case, use a default sorting option that is known to sort by mutation classes
+	const activeOption = s.sortOptions[s.sortSamplesBy].sortPriority ? s.sortOptions[s.sortSamplesBy] : s.sortOptions.a
 	const mclassPriority = []
-	s.sortOptions[s.sortSamplesBy].sortPriority.forEach(obj => {
+	activeOption.sortPriority.forEach(obj => {
 		if (obj.types.includes('geneVariant')) {
 			// Extract 'order' arrays from each tiebreaker and filter 'WT' and 'Blank'
 			obj.tiebreakers.forEach(tiebreaker => {

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -361,7 +361,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 		order: 1, // this is used for list order as a sorter option in a dropdown
 		sortPriority: [
 			{
-				label: 'For each gene mutation row from top to bottom, sort cases by',
+				label: 'For each gene mutation row from top to bottom, sort cases by matching data',
 				types: ['geneVariant'],
 				tiebreakers: [
 					{
@@ -454,7 +454,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 				]
 			},
 			{
-				label: 'For each dictionary variable from top to bottom, sort cases by',
+				label: 'For each dictionary variable from top to bottom, sort cases by matchin data',
 				types: ['categorical', 'integer', 'float', 'survival'],
 				tiebreakers: [
 					{
@@ -619,7 +619,6 @@ export function getMclassSorter(self) {
 	const s = self.settings.matrix
 	const mclassPriority = []
 	s.sortOptions[s.sortSamplesBy].sortPriority.forEach(obj => {
-		console.log(627, obj)
 		if (obj.types.includes('geneVariant')) {
 			// Extract 'order' arrays from each tiebreaker and filter 'WT' and 'Blank'
 			obj.tiebreakers.forEach(tiebreaker => {

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -421,7 +421,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 							]
 						},
 						by: 'class',
-						isOrdered: false,
+						isOrdered: true,
 						disabled: true,
 						order: ['CNV_amp', 'CNV_loss']
 					},

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -374,7 +374,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 							]
 						},
 						by: 'class',
-						applyOrder: false,
+						isOrdered: false,
 						order: ['Fuserna' /*'WT', 'Blank'*/]
 					},
 					{
@@ -387,7 +387,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 							]
 						},
 						by: 'class',
-						applyOrder: false,
+						isOrdered: false,
 						order: [
 							// truncating
 							'F', // FRAMESHIFT
@@ -414,7 +414,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 							]
 						},
 						by: 'class',
-						applyOrder: true,
+						isOrdered: true,
 						order: ['CNV_amp', 'CNV_loss']
 					},
 					{
@@ -427,7 +427,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 							]
 						},
 						by: 'class',
-						applyOrder: false,
+						isOrdered: false,
 						order: [
 							// truncating
 							'F', // FRAMESHIFT
@@ -454,7 +454,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 				]
 			},
 			{
-				label: 'For each dictionary variable from top to bottom, sort cases by matchin data',
+				label: 'For each dictionary variable from top to bottom, sort cases by matching data',
 				types: ['categorical', 'integer', 'float', 'survival'],
 				tiebreakers: [
 					{
@@ -486,7 +486,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, self) {
 			{
 				label: 'Cases with protein changing mutations > without',
 				filter: '',
-				applyOrder: false,
+				isOrdered: false,
 				order: [
 					// truncating
 					'F', // FRAMESHIFT

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -44,9 +44,6 @@ export function getSorterUi(opts) {
 				{
 					label: 'For each selected row, sort cases by matching data',
 					notDraggable: true,
-					handler(div) {
-						//div.append('button').html('Select a row')
-					},
 					tiebreakers: [],
 					handler: handleSelectedTerms
 				},
@@ -75,6 +72,8 @@ export function getSorterUi(opts) {
 				j = 0
 
 			for (const sd of sectionData) {
+				const hasTbOrder = sd.tiebreakers?.[0]?.order || sd.handler
+
 				const thead = table
 					.append('thead')
 					.datum(sd)
@@ -93,13 +92,14 @@ export function getSorterUi(opts) {
 					.style('vertical-align', 'top')
 					.style('font-weight', 400)
 					.html(alphabet[j++])
-					.on('click', toggleSection)
+					.on('click', hasTbOrder ? toggleSection : null)
 				const td2 = tr
 					.append('th')
 					.style('padding', '5px')
 					.style('vertical-align', 'top')
 					.style('text-align', 'left')
-					.on('click', toggleSection)
+					.style('cursor', hasTbOrder ? 'pointer' : '')
+					.on('click', hasTbOrder ? toggleSection : null)
 				td2.append('span').style('margin-right', '12px').style('font-weight', 400).html(sd.label)
 
 				tr.append('th')
@@ -107,10 +107,10 @@ export function getSorterUi(opts) {
 					.style('vertical-align', 'top')
 					.style('text-align', 'center')
 					.style('font-weight', 400)
-					.style('cursor', 'pointer')
+					.style('cursor', hasTbOrder ? 'pointer' : '')
 					.append('span')
-					.html('Details')
-					.on('click', toggleSection)
+					.html(hasTbOrder ? 'Details' : '&nbsp;')
+					.on('click', hasTbOrder ? toggleSection : null)
 
 				const tbody = table
 					.append('tbody')
@@ -118,14 +118,19 @@ export function getSorterUi(opts) {
 					.style('display', self.expandedSection == 'all' || self.expandedSection == sd.label ? '' : 'none')
 
 				for (const tb of sd.tiebreakers) {
-					// TODO: should handle dictionary variables
-					if (!sd.types?.includes('geneVariant') || tb.skip) continue
+					if (tb.skip) continue
+					if (!sd.types?.includes('geneVariant')) {
+						// TODO: display inputs to customize sorting of dictionary variable values,
+						// currently the value order is arbitrary
+						continue
+					}
+
 					const tr = tbody
 						.append('tr')
 						.on('mouseover', undoMouseoverHighlights)
 						.datum(tb)
-						.attr('draggable', !tb.disabled)
-						.attr('droppable', !tb.disabled)
+						.attr('draggable', !tb.disabled && sd.types?.length)
+						.attr('droppable', !tb.disabled && sd.types?.length)
 						.on('dragstart', trackDraggedTieBreaker)
 						.on('dragover', highlightTieBreaker)
 						.on('dragleave', unhighlightTieBreaker)
@@ -142,7 +147,7 @@ export function getSorterUi(opts) {
 						)
 						.datum(tb)
 					td1.style('padding', '5px').style('vertical-align', 'top').style('text-align', 'center')
-					td1.append('span').html(!tb.disabled ? i : '') // TODO: show pr
+					td1.append('span').html(!tb.disabled ? i : '') // TODO: show priority
 					//td1.append('br')
 
 					const td2 = tr

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -141,26 +141,48 @@ export function getSorterUi(opts) {
 						.datum(tb)
 						.attr('draggable', true)
 						.attr('droppable', true)
+						.style('opacity', tb.disabled ? 0.5 : 1)
 						.on('dragstart', trackDraggedTieBreaker)
 						.on('dragover', highlightTieBreaker)
 						.on('dragleave', unhighlightTieBreaker)
 						.on('drop', adjustTieBreakers)
 
 					if (!tb.disabled) i++
-					tr.append('td')
-						.style('padding', '5px')
-						.style('vertical-align', 'top')
-						.html(!tb.disabled ? i : '&nbsp;') // TODO: show pr
+					const td1 = tr
+						.append('td')
+						.attr(
+							'title',
+							tb.disabled
+								? `This tiebreaker is currently not being used to sort ${l.cases}. Check the box to use.`
+								: `The number indicates the order in which this tiebreaker is used. Unched the box to skip.`
+						)
+					td1.style('padding', '5px').style('vertical-align', 'top').style('text-align', 'center')
+
+					td1.append('span').html(!tb.disabled ? i + '<br>' : '') // TODO: show pr
+					//td1.append('br')
+					const disabled = td1
+						.append('input')
+						.attr('type', 'checkbox')
+						.property('checked', !tb.disabled)
+						.on('change', () => {
+							tb.disabled = !disabled.property('checked')
+							tr.style('opacity', tb.disabled ? 0.5 : 1)
+						})
+
 					const td2 = tr.append('td').style('padding', '5px').style('vertical-align', 'top').style('max-width', '500px')
 					td2.append('span').html(tb.label || '')
 
 					const label = td2.append('label')
 					label.append('span').html(' (in listed order ')
-					label
+					if (!tb.isOrdered) tb.isOrdered = false
+					const checkbox = label
 						.append('input')
 						.attr('type', 'checkbox')
+						.property('checked', tb.isOrdered)
 						.style('vertical-align', 'bottom') //.html('(in listed order ')
-						.on('change')
+						.on('change', () => {
+							tb.isOrdered = checkbox.property('checked')
+						})
 
 					label.append('span').html(')')
 					td2

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -1,0 +1,82 @@
+import { make_radios } from '#dom/radiobutton'
+import { make_one_checkbox } from '#dom/checkbox'
+
+/*
+	self: matrix controls component instance
+	s: settings.matrix 
+*/
+export function getSorterUi(self, s) {
+	const l = s.controlLabels
+	const parent = self.parent
+	return {
+		label: `Sort ${l.Sample} Priority`,
+		title: `Set how to sort ${l.samples}`,
+		type: 'custom',
+		init(self) {
+			const ssmDiv = self.dom.inputTd.append('div')
+			ssmDiv.append('span').html('SSM')
+			const { inputs } = make_radios({
+				// holder, options, callback, styles
+				holder: ssmDiv.append('span'),
+				options: [
+					{ label: 'by consequence', value: 'consequence' },
+					{ label: 'by presence', value: 'presence', checked: true }
+				],
+				styles: {
+					display: 'inline-block'
+				},
+				callback: value => {
+					parent.app.dispatch({
+						type: 'plot_edit',
+						id: parent.id,
+						config: {
+							settings: {
+								matrix: {
+									sortByMutation: value
+								}
+							}
+						}
+					})
+				}
+			})
+
+			inputs.style('margin', '2px 0 0 2px').style('vertical-align', 'top')
+
+			const cnvDiv = self.dom.inputTd.append('div')
+			cnvDiv.append('span').html('CNV')
+			// holder, labeltext, callback, checked, divstyle
+			const input = make_one_checkbox({
+				holder: cnvDiv.append('span'),
+				divstyle: { display: 'inline-block' },
+				checked: false,
+				labeltext: 'sort by CNV',
+				callback: () => {
+					parent.app.dispatch({
+						type: 'plot_edit',
+						id: parent.id,
+						config: {
+							settings: {
+								matrix: {
+									sortByCNV: input.property('checked')
+								}
+							}
+						}
+					})
+				}
+			})
+
+			//self.dom.inputTd.append('div').append('span').html('By case name')
+
+			return {
+				main: plot => {
+					const s = plot.settings.matrix
+					// ssm
+					inputs.property('checked', d => d.value == s.sortByMutation)
+					// cnv
+					input.property('checked', s.sortByCNV)
+					cnvDiv.style('display', s.showMatrixCNV != 'none' && !s.allMatrixCNVHidden ? 'block' : 'none')
+				}
+			}
+		}
+	}
+}

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -1,9 +1,14 @@
+import { select } from 'd3-selection'
 import { deepEqual, copyMerge } from '#rx'
 import { make_radios } from '#dom/radiobutton'
 import { make_one_checkbox } from '#dom/checkbox'
+import { Menu } from '#dom/menu'
 import { mclass } from '#shared/common'
-import { select } from 'd3-selection'
 import { getConfigForShowAll } from './matrix.interactivity'
+import { setComputedConfig } from './matrix.config'
+
+const tip = new Menu({ padding: '' })
+const alphabet = `ABCDEFGHIJKLMNOPQRSTUVWXYZ`.split('')
 
 /*
 	controls: matrix controls component instance
@@ -14,6 +19,7 @@ export function getSorterUi(opts) {
 	const parent = controls.parent
 	const s = parent.config.settings.matrix
 	const l = s.controlLabels
+	const unusedDisplayByLabel = new Map()
 
 	let input,
 		theads = [],
@@ -27,10 +33,10 @@ export function getSorterUi(opts) {
 		title: `Set how to sort ${l.samples}`,
 		type: 'custom',
 		expanded: opts.expanded || false,
-		expandedSection: '',
+		expandedSection: opts.expandedSection || '',
 		init(overrides = {}) {
-			//console.log(32, 'self.init')
 			const s = copyMerge(`{}`, parent.config.settings.matrix, overrides)
+			self.settings = s
 			self.activeOption = structuredClone(s.sortOptions[s.sortSamplesBy])
 
 			sectionData = [
@@ -53,25 +59,18 @@ export function getSorterUi(opts) {
 			opts.holder.selectAll('*').remove()
 			const topDiv = opts.holder.append('div')
 			topDiv.append('button').html('Apply').on('click', apply)
-			topDiv.append('button').html('Reset')
+			topDiv.append('button').html('Reset').on('click', self.init)
 
 			const table = opts.holder.append('table')
 
 			const tr = table.append('thead')
 			tr.append('th').html('Priority').style('text-align', 'left').style('max-width', '0px')
-			tr.append('th').html('Data used of sorting')
-			tr.append('th')
-				.style('text-align', 'center')
-				.style('cursor', 'pointer')
-				.html(self.expandedSection == 'all' ? '&lt;&lt;' : '...')
-				.on('click', toggleSection)
-			tr.append('th')
-				.attr('colspan', 3)
-				.style('display', self.expandedSection ? '' : 'none')
-				.html('Data not used for sorting')
+			tr.append('th').html('Description')
+			tr.append('th').html('Action')
 
 			// to track sort priority number
-			let i = 0
+			let i = 0,
+				j = 0
 
 			for (const sd of sectionData) {
 				const thead = table
@@ -87,15 +86,19 @@ export function getSorterUi(opts) {
 				theads.push(select(thead))
 
 				const tr = thead.append('tr').style('background-color', '#eee')
-
-				const td12 = tr
+				tr.append('th')
+					.style('padding', '5px')
+					.style('vertical-align', 'top')
+					.style('font-weight', 400)
+					.html(alphabet[j++])
+					.on('click', toggleSection)
+				const td2 = tr
 					.append('th')
-					.attr('colspan', 2)
 					.style('padding', '5px')
 					.style('vertical-align', 'top')
 					.style('text-align', 'left')
 					.on('click', toggleSection)
-				td12.append('span').style('margin-right', '12px').style('font-weight', 400).html(sd.label)
+				td2.append('span').style('margin-right', '12px').style('font-weight', 400).html(sd.label)
 
 				tr.append('th')
 					.style('padding', '5px')
@@ -103,30 +106,9 @@ export function getSorterUi(opts) {
 					.style('text-align', 'center')
 					.style('font-weight', 400)
 					.style('cursor', 'pointer')
-					.html(self.expandedSection == 'all' || self.expandedSection == sd.label ? '&lt;&lt;' : '...')
+					.append('button')
+					.html('Add')
 					.on('click', toggleSection)
-
-				tr.append('th')
-					.style('padding', '5px')
-					.style('vertical-align', 'top')
-					.style('font-weight', 400)
-					.style('display', self.expandedSection ? '' : 'none')
-					.html('Visible')
-					.on('click', toggleSection)
-
-				tr.append('th')
-					.style('padding', '5px')
-					.style('vertical-align', 'top')
-					.style('font-weight', 400)
-					.style('display', self.expandedSection ? '' : 'none')
-					.html('Hidden')
-
-				tr.append('th')
-					.style('padding', '5px')
-					.style('vertical-align', 'top')
-					.style('font-weight', 400)
-					.style('display', self.expandedSection ? '' : 'none')
-					.html('Case Filter')
 
 				const tbody = table
 					.append('tbody')
@@ -138,8 +120,13 @@ export function getSorterUi(opts) {
 					if (!sd.types?.includes('geneVariant')) continue
 					const tr = tbody
 						.append('tr')
-						.style('opacity', tb.disabled ? 0.5 : 1)
 						.datum(tb)
+						.attr('draggable', true)
+						.attr('droppable', true)
+						.on('dragstart', trackDraggedTieBreaker)
+						.on('dragover', highlightTieBreaker)
+						.on('dragleave', unhighlightTieBreaker)
+						.on('drop', adjustTieBreakers)
 
 					if (!tb.disabled) i++
 					const td1 = tr
@@ -151,81 +138,118 @@ export function getSorterUi(opts) {
 								: `The number indicates the order in which this tiebreaker is used. Unched the box to skip.`
 						)
 						.datum(tb)
-						.attr('draggable', true)
-						.attr('droppable', true)
-						.on('dragstart', trackDraggedTieBreaker)
-						.on('dragover', highlightTieBreaker)
-						.on('dragleave', unhighlightTieBreaker)
-						.on('drop', adjustTieBreakers)
 					td1.style('padding', '5px').style('vertical-align', 'top').style('text-align', 'center')
-					td1.append('span').html(!tb.disabled ? i + '<br>' : '') // TODO: show pr
+					td1.append('span').html(!tb.disabled ? i : '') // TODO: show pr
 					//td1.append('br')
-					const disabled = td1
-						.append('input')
-						.attr('type', 'checkbox')
-						.property('checked', !tb.disabled)
-						.on('change', () => {
-							tb.disabled = !disabled.property('checked')
-							tr.style('opacity', tb.disabled ? 0.5 : 1)
-						})
 
-					const td2 = tr.append('td').style('padding', '5px').style('vertical-align', 'top').style('max-width', '500px')
+					const td2 = tr
+						.append('td')
+						.style('opacity', tb.disabled ? 0.5 : 1)
+						.style('padding', '5px')
+						.style('vertical-align', 'top')
+						.style('max-width', '500px')
 					td2.append('span').html(tb.label || '')
 
 					const label = td2.append('label')
-					label.append('span').html(' (in listed order ')
+					label.append('span').html(' (use data list order ')
 					if (!tb.isOrdered) tb.isOrdered = false
 					const checkbox = label
 						.append('input')
+						.datum(tb)
 						.attr('type', 'checkbox')
 						.property('checked', tb.isOrdered)
 						.style('vertical-align', 'bottom') //.html('(in listed order ')
-						.on('change', () => {
-							tb.isOrdered = checkbox.property('checked')
-						})
+						.on('change', toggleTieBreakerIsOrdered)
 
 					label.append('span').html(')')
+
+					const order = tb.order //.filter(cls => !s.hiddenVariants.includes(cls))
 					td2
 						.append('div')
 						.attr('class', 'sjpp-matrix-sorter-ui-value')
 						.selectAll('div')
-						.data(tb.order)
+						.data(
+							order.map((key, index) => ({
+								lstName: 'order',
+								key,
+								cls: mclass[key],
+								tb,
+								dragstart: trackDraggedValue,
+								dragover: highlightValue,
+								dragleave: unhighlightValue,
+								drop: adjustValueOrder,
+								filterByClass: s.filterByClass,
+								index
+							}))
+						)
 						.enter()
 						.append('div')
-						.style('display', 'inline-block')
-						.each(function (key) {
-							const div = select(this)
-								.attr('draggable', true)
-								.attr('droppable', true)
-								.style('margin-right', '10px')
-								.style('opacity', tb.disabled ? 0.5 : 1)
-								.on('dragstart', trackDraggedValue)
-								.on('dragover', highlightValue)
-								.on('dragleave', unhighlightValue)
-								.on('drop', adjustValueOrder)
+						.style('display', tb.isOrdered ? 'block' : 'inline-block')
+						.each(setValueDiv)
 
-							const cls = mclass[key]
-							div
-								.append('div')
-								.style('display', 'inline-block')
-								.style('width', '12px')
-								.style('height', '12px')
-								.style('margin-right', '3px')
-								.style('background-color', cls.color)
-							div.append('span').html(cls.label)
-						})
+					if (tb.notUsed?.length) {
+						const notUsed = td2.append('div')
+						if (!unusedDisplayByLabel.has(tb.label)) unusedDisplayByLabel.set(tb.label, 'none')
 
-					tr.append('td').style('text-align', 'center').html('&nbsp;') //.on('click', toggleSection)
-					tr.append('td') //.style('display', 'none')
-					tr.append('td') //.style('display', 'none')
-					tr.append('td') //.style('display', 'none')
+						notUsed //.append('td')
+							.append('div')
+							.attr('data-testid', 'sjpp-matrix-sorter-ui-hidden-add')
+							.style('display', 'inline-block')
+							.style('padding', '5x')
+							.style('vertical-align', 'top')
+							.style('padding', '3px 5px')
+							.style('cursor', 'pointer')
+							.html(`+Add`)
+							.on('click', () => {
+								unusedDisplayByLabel.set(
+									tb.label,
+									unusedDisplayByLabel.get(tb.label) == 'inline-block' ? 'none' : 'inline-block'
+								)
+								availDiv.style('display', unusedDisplayByLabel.get(tb.label))
+							})
+
+						const availDiv = notUsed
+							.append('div')
+							.attr('data-testid', 'sjpp-matrix-sorter-ui-hidden-vals')
+							.style('margin-top', '3px')
+							.style('vertical-align', 'top')
+							.style('padding-left', '12px')
+							.style('display', unusedDisplayByLabel.get(tb.label))
+
+						availDiv
+							.selectAll('div')
+							.data(
+								tb.notUsed.map((key, index) => ({
+									lstName: 'notUsed',
+									key,
+									cls: mclass[key],
+									tb,
+									dragstart: trackDraggedValue,
+									dragover: highlightValue,
+									dragleave: unhighlightValue,
+									drop: adjustValueOrder,
+									filterByClass: s.filterByClass,
+									index
+								}))
+							)
+							.enter()
+							.append('div')
+							.style('display', 'inline-block')
+							.each(setValueDiv)
+					}
+
+					const td3 = tr.append('td').style('text-align', 'center').style('vertical-align', 'top')
+
+					const btn = td3
+						.append('button')
+						.datum(tb)
+						.html(tb.disabled ? 'Enable' : 'Disable')
+						.on('click', toggleTieBreakerDisabled)
 				}
 
 				const lastTr = tbody.append('tr').attr('draggable', true)
 				lastTr.append('td').html('&nbsp;')
-				lastTr.append('td').style('text-align', 'left').append('button').html('Add a tiebreaker')
-				lastTr.append('td').html('&nbsp;')
-				lastTr.append('td').html('&nbsp;')
+				lastTr.append('td').style('text-align', 'left') //.append('button').html('Add')
 				lastTr.append('td').html('&nbsp;')
 			}
 		},
@@ -312,6 +336,26 @@ export function getSorterUi(opts) {
 		select(this).selectAll('td:nth-child(2)').style('border', 'none')
 	}
 
+	function toggleTieBreakerIsOrdered(event, tb) {
+		event.stopPropagation()
+		tb.isOrdered = !tb.isOrdered
+		self.init({
+			sortOptions: {
+				[s.sortSamplesBy]: self.activeOption
+			}
+		})
+	}
+
+	function toggleTieBreakerDisabled(event, tb) {
+		event.stopPropagation()
+		tb.disabled = !tb.disabled
+		self.init({
+			sortOptions: {
+				[s.sortSamplesBy]: self.activeOption
+			}
+		})
+	}
+
 	function adjustTieBreakers(event, d) {
 		if (dragged.type != 'tiebreaker' || d == dragged.data) return
 		event.preventDefault()
@@ -326,7 +370,77 @@ export function getSorterUi(opts) {
 		})
 	}
 
+	function setValueDiv(d) {
+		const title = []
+		if (d.tb.notUsed?.includes(d.key)) title.push(`Click to use for sorting ${l.samples}.`)
+		if (d.filterByClass[d.key] == 'value') title.push('Hidden value')
+		if (d.filterByClass[d.key] == 'case') title.push('Case filter')
+
+		const skipped = d.tb.notUsed?.includes(d.key)
+		const opacity = d.filterByClass[d.key] == 'value' ? 0.5 : 1
+		const div = select(this)
+			.attr('title', title.join(','))
+			.attr('draggable', d.tb.isOrdered ? true : false)
+			.attr('droppable', d.tb.isOrdered ? true : false)
+			.style('width', 'fit-content')
+			.style('margin-right', '10px')
+			.style('overflow', 'hidden')
+			.style('white-space', 'nowrap')
+			.style('opacity', opacity)
+			.style('cursor', 'pointer')
+			.on('dragstart', d.dragstart)
+			.on('dragover', d.dragover)
+			.on('dragleave', d.dragleave)
+			.on('drop', d.drop)
+			.on('mouseenter', () => toggle.style('opacity', 1))
+			.on('mouseleave', () => toggle.style('opacity', 0))
+			.on('click', () => {
+				const targetLstName = d.lstName == 'order' ? 'notUsed' : 'order'
+				if (!d.tb[targetLstName]) d.tb[targetLstName] = []
+				const targetLst = d.tb[targetLstName]
+				d.tb[d.lstName].splice(d.index, 1)
+				if (d.lstName == 'order') targetLst.unshift(d.key)
+				else targetLst.push(d.key)
+				self.init({
+					sortOptions: {
+						[s.sortSamplesBy]: self.activeOption
+					}
+				})
+			})
+		//.on('click', showValueMenu)
+		// .on('mouseenter', () => {
+		// 	div.style(wh, '')//.style('opacity', '')
+		// })
+		// .on('mouseleave', (event, d) => {
+		// 	div.style(wh, d.tb.skipped?.includes(d.key) ? '12px' : '')//.style('opacity', 0.5)
+		// })
+
+		div
+			.append('div')
+			.style('display', 'inline-block')
+			.style('cursor', 'pointer')
+			.style('width', '12px')
+			.style('height', '12px')
+			.style('margin-right', '3px')
+			.style('background-color', d.cls.color)
+		div
+			.append('span')
+			.style('cursor', 'pointer')
+			.style('text-decoration', d.filterByClass[d.key] == 'case' ? 'line-through' : '')
+			.html((d.filterByClass[d.key] ? '(<i>not used</i>) ' : '') + d.cls.label)
+
+		const toggle = div
+			.append('div')
+			.style('display', 'inline-block')
+			.style('width', '12px')
+			.style('cursor', 'pointer')
+			.style('opacity', 0)
+			.style('color', d.lstName == 'order' ? 'red' : 'green')
+			.html(d.lstName == 'order' ? '&cross;' : '&check;')
+	}
+
 	function trackDraggedValue(event, d) {
+		event.stopPropagation?.()
 		dragged.type = 'value'
 		dragged.data = d
 		dragged.sectionData = event.target.closest('tbody').__data__
@@ -334,51 +448,127 @@ export function getSorterUi(opts) {
 		dragged.tiebreaker = event.target.closest('tr').__data__
 		dragged.tbIndex = dragged.sectionData.tiebreakers.indexOf(dragged.priorityIndex)
 		dragged.order = dragged.tiebreaker.order
-		dragged.index = dragged.order.indexOf(d)
 	}
 
 	function highlightValue(event, d) {
+		event.stopPropagation?.()
 		if (dragged.type != 'value' || d == dragged.data) return
+		if (d.tb != dragged.data.tb) return
 		event.preventDefault()
 		const i = dragged.order.indexOf(d)
-		const borderSide = i < dragged.index ? 'border-right' : i > dragged.index ? 'border-left' : ''
-		if (!borderSide) return
-		select(this).style(borderSide, '2px solid blue')
+		select(this).style('border', '2px solid blue')
 	}
 
 	function unhighlightValue(event, d) {
+		event.stopPropagation?.()
 		if (dragged.type != 'value') return
 		event.preventDefault()
 		select(this).style('border', 'none')
 	}
 
 	function adjustValueOrder(event, d) {
+		event.stopPropagation?.()
 		if (dragged.type != 'value' || d == dragged.data) return
 		event.preventDefault()
-		const i = dragged.order.indexOf(d)
-		const s = parent.config.settings.matrix
-		dragged.order.splice(dragged.index, 1)
-		dragged.order.splice(i, 0, dragged.data)
+
+		const s = self.settings
+		dragged.data.tb[dragged.data.lstName].splice(dragged.data.index, 1)
+		d.tb[d.lstName].splice(d.index, 0, dragged.data.key)
+		// if (dragged.data.lstName == d.lstName) {
+		// 	const i = dragged.order.indexOf(d.key)
+		// 	dragged.order.splice(i, 0, dragged.data.key)
+		// } else { console.log(44, d, d.tb[d.lstName])
+		// 	d.tb[d.lstName].push(dragged.data.key)
+		// }
+
+		const j = s.hiddenVariants.indexOf(dragged.data.key)
+		const hiddenVariants = structuredClone(s.hiddenVariants)
+		const filterByClass = structuredClone(s.filterByClass)
+		if (j != -1) {
+			hiddenVariants.splice(j, 1)
+			filterByClass[dragged.data.key] = false
+		}
 		self.init({
+			hiddenVariants,
+			filterByClass,
 			sortOptions: {
 				[s.sortSamplesBy]: self.activeOption
 			}
 		})
 	}
 
-	function apply() {
+	// function showValueMenu(event, d) {
+	// 	event.stopPropagation?.()
+	// 	tip.clear()
+	// 	const s = parent.config.settings.matrix
+	// 	const l = s.controlLabels
+	// 	make_one_checkbox({
+	// 		holder: tip.d.append('div'),
+	// 			labeltext: 'Do not use this data value to sort cases',
+	// 			checked: d.tb.skipped.includes(d.key),
+	// 			style: {padding: '5px'},
+	// 			callback: checked => {
+	// 				tip.hide()
+	// 				if (!d.tb.skipped) d.tb.skipped = []
+	// 				const i = d.tb.skipped.indexOf(d.key)
+	// 				if (checked && i == -1) d.tb.skipped.push(d.key)
+	// 				else if (!checked && i != -1) d.tb.skipped.splice(i, 1)
+	// 				self.init({
+	//  				sortOptions: {
+	// 					[s.sortSamplesBy]: self.activeOption
+	// 				}
+	// 			})
+	// 			}
+	// 	})
+
+	// 	const fbk = s.filterByClass[d.key] || ''
+	// 	make_radios({
+	// 		holder: tip.d.append('div'),
+	// 			options: [{
+	// 				label: `Show ${d.cls.label}, do not use to filter ${l.samples}`,
+	// 				value: '',
+	// 				checked: fbk != 'value' && fbk != 'case'
+	// 			},{
+	// 				label: `Do not show ${d.cls.label}`,
+	// 				value: 'value',
+	// 				checked: fbk == 'value'
+	// 			},{
+	// 				label: `Hide ${l.samples} with ${d.cls.label}`,
+	// 				value: 'case',
+	// 				checked: fbk == 'case'
+	// 			}],
+	// 			// checked: d.tb.skipped.includes(d.key),
+	// 			style: {padding: '5px'},
+	// 			callback: value => {
+	// 				tip.hide()
+	// 				//const config = structuredClone(parent.config)
+	// 				self.init({
+	//  				sortOptions: {
+	// 					[s.sortSamplesBy]: self.activeOption
+	// 				}
+	// 			})
+	// 			}
+	// 	})
+
+	// 	tip.showunder(this)
+	// }
+
+	function apply(edits = {}) {
 		parent.app.tip?.hide()
 		parent.app.dispatch({
 			type: 'plot_edit',
 			id: parent.id,
 			config: {
-				settings: {
-					matrix: {
-						sortOptions: {
-							[s.sortSamplesBy]: self.activeOption
+				settings: copyMerge(
+					{
+						matrix: {
+							sortOptions: {
+								[s.sortSamplesBy]: self.activeOption
+							}
 						}
-					}
-				}
+					},
+					edits
+				)
 			}
 		})
 	}

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -5,196 +5,118 @@ import { select } from 'd3-selection'
 import { getConfigForShowAll } from './matrix.interactivity'
 
 /*
-	self: matrix controls component instance
+	controls: matrix controls component instance
 	s: settings.matrix 
 */
-export function getSorterUi(self, s) {
-	console.log(10, s)
+export function getSorterUi(opts) {
+	const { controls, holder } = opts
+	const parent = controls.parent
+	const s = parent.config.settings.matrix
 	const l = s.controlLabels
-	const parent = self.parent
-	return {
+
+	let input
+	const self = {
 		highlightColor: 'none',
 		label: `Sort ${l.Samples}`,
 		title: `Set how to sort ${l.samples}`,
 		type: 'custom',
-		init(self) {
-			self.dom.row.on('mouseover', function () {
-				this.style.backgroundColor = '#fff'
-				this.style.textShadow = 'none'
-			})
-			self.dom.row.select(':first-child').style('vertical-align', 'top')
-			self.dom.inputTd.style('max-width', '600px')
+		init() {
+			const s = parent.config.settings.matrix
+			const activeOption = s.sortOptions[s.sortSamplesBy]
+			console.log(22, opts, activeOption)
+			const sectionData = [
+				{
+					label: 'By data for each selected row',
+					handler(div) {
+						//div.append('button').html('Select a row')
+					},
+					tiebreakers: []
+				},
+				...activeOption.sortPriority,
+				{
+					label: 'By case name, alphabetically',
+					tiebreakers: []
+				}
+			]
 
-			// TODO: input for selected matrix row
-			const selRowsDiv = self.dom.inputTd
-				.append('div')
-				.style('margin', '0 10px 5px 5px')
-				.style('padding', '5px')
-				.style('border-left', '2px solid #ccc')
-			selRowsDiv.append('div').style('font-weight', 600).html('By data for each selected row')
-			selRowsDiv.append('button').html('Select a row')
+			opts.holder.selectAll('*').remove()
+			opts.holder.append('div').append('button').html('Apply')
+			const table = opts.holder.append('table')
 
-			const div2 = self.dom.inputTd
-				.append('div')
-				.style('margin', '10px 5px')
-				.style('padding', '5px')
-				.style('border-left', '2px solid #ccc')
-			div2.append('div').style('font-weight', 600).html('By data for each gene mutation row, from top to bottom')
+			const tr = table.append('thead')
+			tr.append('th').html('Priority')
+			tr.append('th').html('Data used of sorting')
+			tr.append('th').attr('colspan', 3).html('Data not used for sorting')
 
-			const presenceDiv = div2.append('div').style('margin', '5px')
-			const presenceInput = presenceDiv
-				.append('input')
-				.attr('type', 'checkbox')
-				.style('width', '18px')
-				.style('opacity', 0)
-			const presenceLabel = presenceDiv.append('div').style('display', 'inline-block')
-			presenceLabel.append('div').style('display', 'inline-block').style('width', '18px').html('1. ')
-			presenceLabel.append('div').style('display', 'inline-block').html('Has SSM > No SSM')
+			let i = 0
+			for (const sd of sectionData) {
+				const thead = table.append('thead')
+				const tr = thead.append('tr')
 
-			const cnvDiv = div2.append('div').style('margin', '5px')
-			const cnvInput = cnvDiv
-				.append('input')
-				.attr('type', 'checkbox')
-				.style('width', '18px')
-				.on('change', () => {
-					const s = parent.config.settings.matrix
-					const checked = cnvInput.property('checked')
-					const config =
-						checked && s.showMatrixCNV == 'none'
-							? getConfigForShowAll(
-									parent,
-									parent.legendData.find(l => l.dt?.includes(4)),
-									'CNV'
-							  )
-							: { settings: { matrix: {} } }
-					config.settings.matrix.sortByCNV = checked
+				tr.style('background-color', '#eee')
+				const td12 = tr
+					.append('th')
+					.attr('colspan', 2)
+					.style('padding', '5px')
+					.style('vertical-align', 'top')
+					.style('text-align', 'left')
+				td12.append('span').style('margin-right', '12px').html(sd.label)
+				td12.append('button').style('height', '20px').style('float', 'right').html('+').on('click', sd.handler)
+				tr.append('th').style('padding', '5px').style('vertical-align', 'top').html('Visible')
+				tr.append('th').style('padding', '5px').style('vertical-align', 'top').html('Hidden')
+				tr.append('th').style('padding', '5px').style('vertical-align', 'top').html('Case Filter')
 
-					parent.app.dispatch({
-						type: 'plot_edit',
-						id: parent.id,
-						config
-					})
-				})
-
-			const cnvLabel = cnvDiv.append('div').style('display', 'inline-block')
-			const cnvNum = cnvLabel.append('div').style('display', 'inline-block').style('width', '18px').html('2. ')
-			cnvLabel
-				.append('div')
-				.style('display', 'inline-block')
-				.html('CNV <i style="color: #aaa">(drag to change sort order)</i>')
-			const cnvClasses = cnvDiv
-				.append('div')
-				//.style('display', 'inline-block')
-				.style('margin-left', '42px')
-				.selectAll('div')
-				.data(s.CNVClasses)
-				.enter()
-				.append('div')
-				.attr('draggable', true)
-				.style('display', 'inline-block')
-				.style('padding', '2px 3px')
-				.style('margin-left', '3px')
-				.each(function (d) {
-					const div = select(this)
-					div
+				const tbody = table.append('tbody')
+				if (!sd.tiebreakers?.length || !sd.types?.includes('geneVariant')) continue
+				for (const tb of sd.tiebreakers) {
+					const tr = tbody.append('tr')
+					if (!tb.disabled) i++
+					tr.append('td')
+						.style('padding', '5px')
+						.style('vertical-align', 'top')
+						.html(!tb.disabled ? i : '&nbsp;') // TODO: show pr
+					const td2 = tr.append('td').style('padding', '5px').style('vertical-align', 'top').style('max-width', '500px')
+					td2.append('span').html(tb.label || '')
+					const label = td2.append('label')
+					label.append('span').html(' (in listed order ')
+					label.append('input').attr('type', 'checkbox').style('vertical-align', 'bottom') //.html('(in listed order ')
+					label.append('span').html(')')
+					console.log(75, tb)
+					td2
+						.append('div')
+						.selectAll('div')
+						.data(tb.order)
+						.enter()
 						.append('div')
 						.style('display', 'inline-block')
-						.style('width', '12px')
-						.style('height', '12px')
-						.style('margin-right', '3px')
-						.style('background-color', key => mclass[key].color)
-
-					div.append('span').html(key => mclass[key].label)
-				})
-
-			const ssmDiv = div2.append('div').style('margin', '5px')
-			const ssmInput = ssmDiv
-				.append('input')
-				.attr('type', 'checkbox')
-				.style('width', '18px')
-				.on('change', () => {
-					const s = parent.config.settings.matrix
-					const checked = ssmInput.property('checked')
-					console.log(98, checked)
-					const config =
-						checked && s.showMatrixMutation == 'none'
-							? getConfigForShowAll(
-									parent,
-									parent.legendData.find(l => l.dt?.includes(1), 'mutation')
-							  )
-							: { settings: { matrix: {} } }
-					config.settings.matrix.sortByMutation = checked ? 'consequence' : 'presence'
-
-					parent.app.dispatch({
-						type: 'plot_edit',
-						id: parent.id,
-						config
-					})
-				})
-			const ssmLabel = ssmDiv.append('div').style('display', 'inline-block')
-			const ssmNum = ssmLabel.append('div').style('display', 'inline-block').style('width', '18px').html('3. ')
-			ssmLabel
-				.append('div')
-				.style('display', 'inline-block')
-				.html('Consequence <i style="color: #aaa">(drag to change sort order)</i>')
-
-			const ssmClasses = ssmDiv
-				.append('div')
-				.style('margin-left', '42px')
-				.selectAll('div')
-				.data(s.mutationClasses)
-				.enter()
-				.append('div')
-				.attr('draggable', true)
-				.style('display', 'inline-block')
-				.style('padding', '2px 3px')
-				.style('margin-left', '3px')
-				.each(function (d) {
-					const div = select(this)
-					div
-						.append('div')
-						.style('display', 'inline-block')
-						.style('width', '12px')
-						.style('height', '12px')
-						.style('margin-right', '3px')
-						.style('background-color', key => mclass[key].color)
-
-					div.append('span').html(key => mclass[key].label)
-				})
-
-			const div3 = self.dom.inputTd
-				.append('div')
-				.style('margin', '10px 5px')
-				.style('padding', '5px')
-				.style('border-left', '2px solid #ccc')
-			div3.append('div').style('font-weight', 600).html('By data for each dictionary term row, from top to bottom')
-
-			// const dictDiv = div3.append('div').style('margin', '5px')
-			// const dictInput = dictDiv.append('input')
-			// 	.attr('type', 'checkbox')
-			// 	.style('width', '18px')
-			// 	.style('opacity', 0)
-			// const dictLabel = dictDiv.append('div').style('display', 'inline-block')
-			// const dictNum = dictLabel.append('div').style('display', 'inline-block').style('width', '18px').html('4. ')
-			// dictLabel.append('div').style('display', 'inline-block').html('Dictionary term values')
-
-			const div4 = self.dom.inputTd
-				.append('div')
-				.style('margin', '10px 5px')
-				.style('padding', '5px')
-				.style('border-left', '2px solid #ccc')
-			div4.append('div').style('font-weight', 600).html('By case name, alphabetically')
+						.each(function (key) {
+							const div = select(this).attr('draggable', true).style('margin-right', '10px')
+							const cls = mclass[key]
+							div
+								.append('div')
+								.style('display', 'inline-block')
+								.style('width', '12px')
+								.style('height', '12px')
+								.style('margin-right', '3px')
+								.style('background-color', cls.color)
+							div.append('span').html(cls.label)
+						})
+				}
+			}
 
 			return {
 				main: plot => {
 					const s = plot.settings.matrix
 					// ssm
-					ssmInput.property('checked', s.sortByMutation == 'consequence')
+					// ssmInput.property('checked', s.sortByMutation == 'consequence')
 					// cnv
-					cnvInput.property('checked', s.sortByCNV)
+					// cnvInput.property('checked', s.sortByCNV)
 					//cnvDiv.style('display', s.showMatrixCNV != 'none' && !s.allMatrixCNVHidden ? 'block' : 'none')
 				}
 			}
 		}
 	}
+
+	self.init()
+	return self
 }

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -1,80 +1,198 @@
 import { make_radios } from '#dom/radiobutton'
 import { make_one_checkbox } from '#dom/checkbox'
+import { mclass } from '#shared/common'
+import { select } from 'd3-selection'
+import { getConfigForShowAll } from './matrix.interactivity'
 
 /*
 	self: matrix controls component instance
 	s: settings.matrix 
 */
 export function getSorterUi(self, s) {
+	console.log(10, s)
 	const l = s.controlLabels
 	const parent = self.parent
 	return {
-		label: `Sort ${l.Sample} Priority`,
+		highlightColor: 'none',
+		label: `Sort ${l.Samples}`,
 		title: `Set how to sort ${l.samples}`,
 		type: 'custom',
 		init(self) {
-			const ssmDiv = self.dom.inputTd.append('div')
-			ssmDiv.append('span').html('SSM')
-			const { inputs } = make_radios({
-				// holder, options, callback, styles
-				holder: ssmDiv.append('span'),
-				options: [
-					{ label: 'by consequence', value: 'consequence' },
-					{ label: 'by presence', value: 'presence', checked: true }
-				],
-				styles: {
-					display: 'inline-block'
-				},
-				callback: value => {
+			self.dom.row.on('mouseover', function () {
+				this.style.backgroundColor = '#fff'
+				this.style.textShadow = 'none'
+			})
+			self.dom.row.select(':first-child').style('vertical-align', 'top')
+			self.dom.inputTd.style('max-width', '600px')
+
+			// TODO: input for selected matrix row
+			const selRowsDiv = self.dom.inputTd
+				.append('div')
+				.style('margin', '0 10px 5px 5px')
+				.style('padding', '5px')
+				.style('border-left', '2px solid #ccc')
+			selRowsDiv.append('div').style('font-weight', 600).html('By data for each selected row')
+			selRowsDiv.append('button').html('Select a row')
+
+			const div2 = self.dom.inputTd
+				.append('div')
+				.style('margin', '10px 5px')
+				.style('padding', '5px')
+				.style('border-left', '2px solid #ccc')
+			div2.append('div').style('font-weight', 600).html('By data for each gene mutation row, from top to bottom')
+
+			const presenceDiv = div2.append('div').style('margin', '5px')
+			const presenceInput = presenceDiv
+				.append('input')
+				.attr('type', 'checkbox')
+				.style('width', '18px')
+				.style('opacity', 0)
+			const presenceLabel = presenceDiv.append('div').style('display', 'inline-block')
+			presenceLabel.append('div').style('display', 'inline-block').style('width', '18px').html('1. ')
+			presenceLabel.append('div').style('display', 'inline-block').html('Has SSM > No SSM')
+
+			const cnvDiv = div2.append('div').style('margin', '5px')
+			const cnvInput = cnvDiv
+				.append('input')
+				.attr('type', 'checkbox')
+				.style('width', '18px')
+				.on('change', () => {
+					const s = parent.config.settings.matrix
+					const checked = cnvInput.property('checked')
+					const config =
+						checked && s.showMatrixCNV == 'none'
+							? getConfigForShowAll(
+									parent,
+									parent.legendData.find(l => l.dt?.includes(4)),
+									'CNV'
+							  )
+							: { settings: { matrix: {} } }
+					config.settings.matrix.sortByCNV = checked
+
 					parent.app.dispatch({
 						type: 'plot_edit',
 						id: parent.id,
-						config: {
-							settings: {
-								matrix: {
-									sortByMutation: value
-								}
-							}
-						}
+						config
 					})
-				}
-			})
+				})
 
-			inputs.style('margin', '2px 0 0 2px').style('vertical-align', 'top')
+			const cnvLabel = cnvDiv.append('div').style('display', 'inline-block')
+			const cnvNum = cnvLabel.append('div').style('display', 'inline-block').style('width', '18px').html('2. ')
+			cnvLabel
+				.append('div')
+				.style('display', 'inline-block')
+				.html('CNV <i style="color: #aaa">(drag to change sort order)</i>')
+			const cnvClasses = cnvDiv
+				.append('div')
+				//.style('display', 'inline-block')
+				.style('margin-left', '42px')
+				.selectAll('div')
+				.data(s.CNVClasses)
+				.enter()
+				.append('div')
+				.attr('draggable', true)
+				.style('display', 'inline-block')
+				.style('padding', '2px 3px')
+				.style('margin-left', '3px')
+				.each(function (d) {
+					const div = select(this)
+					div
+						.append('div')
+						.style('display', 'inline-block')
+						.style('width', '12px')
+						.style('height', '12px')
+						.style('margin-right', '3px')
+						.style('background-color', key => mclass[key].color)
 
-			const cnvDiv = self.dom.inputTd.append('div')
-			cnvDiv.append('span').html('CNV')
-			// holder, labeltext, callback, checked, divstyle
-			const input = make_one_checkbox({
-				holder: cnvDiv.append('span'),
-				divstyle: { display: 'inline-block' },
-				checked: false,
-				labeltext: 'sort by CNV',
-				callback: () => {
+					div.append('span').html(key => mclass[key].label)
+				})
+
+			const ssmDiv = div2.append('div').style('margin', '5px')
+			const ssmInput = ssmDiv
+				.append('input')
+				.attr('type', 'checkbox')
+				.style('width', '18px')
+				.on('change', () => {
+					const s = parent.config.settings.matrix
+					const checked = ssmInput.property('checked')
+					console.log(98, checked)
+					const config =
+						checked && s.showMatrixMutation == 'none'
+							? getConfigForShowAll(
+									parent,
+									parent.legendData.find(l => l.dt?.includes(1), 'mutation')
+							  )
+							: { settings: { matrix: {} } }
+					config.settings.matrix.sortByMutation = checked ? 'consequence' : 'presence'
+
 					parent.app.dispatch({
 						type: 'plot_edit',
 						id: parent.id,
-						config: {
-							settings: {
-								matrix: {
-									sortByCNV: input.property('checked')
-								}
-							}
-						}
+						config
 					})
-				}
-			})
+				})
+			const ssmLabel = ssmDiv.append('div').style('display', 'inline-block')
+			const ssmNum = ssmLabel.append('div').style('display', 'inline-block').style('width', '18px').html('3. ')
+			ssmLabel
+				.append('div')
+				.style('display', 'inline-block')
+				.html('Consequence <i style="color: #aaa">(drag to change sort order)</i>')
 
-			//self.dom.inputTd.append('div').append('span').html('By case name')
+			const ssmClasses = ssmDiv
+				.append('div')
+				.style('margin-left', '42px')
+				.selectAll('div')
+				.data(s.mutationClasses)
+				.enter()
+				.append('div')
+				.attr('draggable', true)
+				.style('display', 'inline-block')
+				.style('padding', '2px 3px')
+				.style('margin-left', '3px')
+				.each(function (d) {
+					const div = select(this)
+					div
+						.append('div')
+						.style('display', 'inline-block')
+						.style('width', '12px')
+						.style('height', '12px')
+						.style('margin-right', '3px')
+						.style('background-color', key => mclass[key].color)
+
+					div.append('span').html(key => mclass[key].label)
+				})
+
+			const div3 = self.dom.inputTd
+				.append('div')
+				.style('margin', '10px 5px')
+				.style('padding', '5px')
+				.style('border-left', '2px solid #ccc')
+			div3.append('div').style('font-weight', 600).html('By data for each dictionary term row, from top to bottom')
+
+			// const dictDiv = div3.append('div').style('margin', '5px')
+			// const dictInput = dictDiv.append('input')
+			// 	.attr('type', 'checkbox')
+			// 	.style('width', '18px')
+			// 	.style('opacity', 0)
+			// const dictLabel = dictDiv.append('div').style('display', 'inline-block')
+			// const dictNum = dictLabel.append('div').style('display', 'inline-block').style('width', '18px').html('4. ')
+			// dictLabel.append('div').style('display', 'inline-block').html('Dictionary term values')
+
+			const div4 = self.dom.inputTd
+				.append('div')
+				.style('margin', '10px 5px')
+				.style('padding', '5px')
+				.style('border-left', '2px solid #ccc')
+			div4.append('div').style('font-weight', 600).html('By case name, alphabetically')
 
 			return {
 				main: plot => {
 					const s = plot.settings.matrix
 					// ssm
-					inputs.property('checked', d => d.value == s.sortByMutation)
+					ssmInput.property('checked', s.sortByMutation == 'consequence')
 					// cnv
-					input.property('checked', s.sortByCNV)
-					cnvDiv.style('display', s.showMatrixCNV != 'none' && !s.allMatrixCNVHidden ? 'block' : 'none')
+					cnvInput.property('checked', s.sortByCNV)
+					//cnvDiv.style('display', s.showMatrixCNV != 'none' && !s.allMatrixCNVHidden ? 'block' : 'none')
 				}
 			}
 		}

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -148,11 +148,10 @@ tape('simulated tiebreaker drag/drop', async test => {
 		.filter(d => d?.types?.includes('geneVariant'))
 		.node()
 
-	const trs = thead1.nextSibling.querySelectorAll('tr') //thead.__data__.tiebreakers // select(thead.nextSibling).selectAll('tr').each(d => )
+	const trs = thead1.nextSibling.querySelectorAll('tr')
 
 	// since this simulated test does not trigger actual drag and drop,
 	// must make sure that the correct event handler is tested here
-
 	test.equal(
 		select(trs[0]).on('drop'),
 		ui.adjustTieBreakers,
@@ -193,5 +192,50 @@ tape('simulated tiebreaker drag/drop', async test => {
 	)
 
 	if (test._ok) uiApi.destroy()
+	test.end()
+})
+
+tape.only('tiebreaker disabled', async test => {
+	const { uiApi, controls, config, parent, opts } = await getControls()
+	const s = config.settings.matrix
+	const ui = uiApi.Inner
+	const activeOptionBeforeDrag = structuredClone(ui.activeOption)
+	const thead0 = opts.holder
+		.selectAll('thead')
+		.filter(d => d?.types?.includes('geneVariant'))
+		.node()
+
+	thead0.firstChild.firstChild.click()
+
+	const thead1 = opts.holder
+		.selectAll('thead')
+		.filter(d => d?.types?.includes('geneVariant'))
+		.node()
+
+	const trs = thead1.nextSibling.querySelectorAll('tr')
+
+	test.equal(
+		select(trs[1].firstChild).select('input').property('checked'),
+		true,
+		'should not check the row for protein-changing tiebreaker'
+	)
+
+	test.equal(
+		select(trs[2].firstChild).select('input').property('checked'),
+		false,
+		'should not check the row for CNV tiebreaker'
+	)
+
+	select(trs[2].firstChild).select('input').node().click()
+	const activeTieBreakers = ui.activeOption.sortPriority[0].tiebreakers
+	ui.apply()
+
+	test.deepEqual(
+		activeTieBreakers[2].disabled,
+		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority[0].tiebreakers[2]?.disabled,
+		'should adjust the CNV tiebreaker disabled after clicking apply'
+	)
+
+	// if (test._ok) uiApi.destroy()
 	test.end()
 })

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -59,6 +59,37 @@ tape('default setup', async test => {
 	test.end()
 })
 
+tape('section visibility toggling', async test => {
+	const { uiApi, controls, config, parent, opts } = await getControls()
+	const s = config.settings.matrix
+	const ui = uiApi.Inner
+	const activeOptionBeforeDrag = structuredClone(ui.activeOption)
+	const thead = opts.holder
+		.selectAll('thead')
+		.filter(d => d?.types?.includes('geneVariant'))
+		.node()
+
+	test.equal(
+		thead.nextSibling.style.display,
+		'none',
+		'should have a hiddden table section for gene mutation before toggling'
+	)
+
+	thead.firstChild.firstChild.click()
+
+	test.equal(
+		opts.holder
+			.selectAll('thead')
+			.filter(d => d?.types?.includes('geneVariant'))
+			.node().nextSibling.style.display,
+		'',
+		'should have a visible table section for gene mutation after toggling'
+	)
+
+	if (test._ok) uiApi.destroy()
+	test.end()
+})
+
 tape('simulated section drag/drop', async test => {
 	const { uiApi, controls, config, parent, opts } = await getControls()
 	const s = config.settings.matrix
@@ -70,6 +101,14 @@ tape('simulated section drag/drop', async test => {
 		.node()
 	const sectionData = th.__data__
 	ui.trackDraggedSection.call(th, {}, sectionData)
+
+	// since this simulated test does not trigger actual drag and drop,
+	// must make sure that the correct event handler is tested here
+	test.equal(
+		select(th.parentNode.parentNode).on('drop'),
+		ui.adjustSortPriority,
+		'should attach the correct drop handler for section thead'
+	)
 
 	const i = ui.activeOption.sortPriority.indexOf(sectionData)
 	ui.adjustSortPriority({}, ui.activeOption.sortPriority[i + 1])
@@ -86,6 +125,71 @@ tape('simulated section drag/drop', async test => {
 		activeOptionBeforeDrag.sortPriority.reverse(),
 		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority,
 		'should adjust the sortPriority/table after clicking apply'
+	)
+
+	if (test._ok) uiApi.destroy()
+	test.end()
+})
+
+tape('simulated tiebreaker drag/drop', async test => {
+	const { uiApi, controls, config, parent, opts } = await getControls()
+	const s = config.settings.matrix
+	const ui = uiApi.Inner
+	const activeOptionBeforeDrag = structuredClone(ui.activeOption)
+	const thead0 = opts.holder
+		.selectAll('thead')
+		.filter(d => d?.types?.includes('geneVariant'))
+		.node()
+
+	thead0.firstChild.firstChild.click()
+
+	const thead1 = opts.holder
+		.selectAll('thead')
+		.filter(d => d?.types?.includes('geneVariant'))
+		.node()
+
+	const trs = thead1.nextSibling.querySelectorAll('tr') //thead.__data__.tiebreakers // select(thead.nextSibling).selectAll('tr').each(d => )
+
+	// since this simulated test does not trigger actual drag and drop,
+	// must make sure that the correct event handler is tested here
+
+	test.equal(
+		select(trs[0]).on('drop'),
+		ui.adjustTieBreakers,
+		'should attach the correct drop handler for tiebreaker label'
+	)
+
+	const tbData = trs[0].__data__
+	ui.trackDraggedTieBreaker.call(trs[0], { target: trs[0].firstChild.nextSibling }, tbData)
+
+	const activeTieBreakers = ui.activeOption.sortPriority[0].tiebreakers
+	const i = activeTieBreakers.indexOf(tbData)
+	console.log(activeTieBreakers[i + 1].label)
+	ui.adjustTieBreakers({ preventDefault: () => undefined }, activeTieBreakers[i + 1])
+
+	const thead2 = opts.holder
+		.selectAll('thead')
+		.filter(d => d?.types?.includes('geneVariant'))
+		.node()
+	const trs2 = [...thead2.nextSibling.querySelectorAll('tr')]
+	test.deepEqual(
+		trs2.slice(0, 2).map(elem => elem.__data__),
+		activeOptionBeforeDrag.sortPriority[0].tiebreakers.slice(0, 2).reverse(),
+		'should visibly switch the first two tiebreaker rows'
+	)
+
+	test.deepEqual(
+		activeOptionBeforeDrag.sortPriority[0].tiebreakers,
+		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority[0].tiebreakers,
+		'should not adjust the tiebreakers before clicking apply, after drag/drop'
+	)
+
+	ui.apply()
+
+	test.deepEqual(
+		activeTieBreakers,
+		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority[0].tiebreakers,
+		'should adjust the tiebreakers after clicking apply'
 	)
 
 	if (test._ok) uiApi.destroy()

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -48,6 +48,11 @@ async function getControls(_opts = {}) {
  test sections
 ***************/
 
+tape('\n', function (test) {
+	test.pass('-***- plots/matrix.sorterUi -***-')
+	test.end()
+})
+
 tape('default setup', async test => {
 	const { uiApi, controls, config, parent, opts } = await getControls()
 	const s = parent.config.settings.matrix
@@ -167,7 +172,6 @@ tape('simulated tiebreaker drag/drop', async test => {
 
 	const activeTieBreakers = ui.activeOption.sortPriority[0].tiebreakers
 	const i = activeTieBreakers.indexOf(tbData)
-	console.log(activeTieBreakers[i + 1].label)
 	ui.adjustTieBreakers({ preventDefault: () => undefined }, activeTieBreakers[i + 1])
 
 	const thead2 = opts.holder
@@ -177,7 +181,7 @@ tape('simulated tiebreaker drag/drop', async test => {
 	const trs2 = [...thead2.nextSibling.querySelectorAll('tr')]
 	test.deepEqual(
 		trs2.slice(0, 2).map(elem => elem.__data__),
-		activeOptionBeforeDrag.sortPriority[0].tiebreakers.slice(0, 2).reverse(),
+		activeOptionBeforeDrag.sortPriority[0].tiebreakers.slice(1, 3).reverse(),
 		'should visibly switch the first two tiebreaker rows'
 	)
 
@@ -219,7 +223,7 @@ tape('tiebreaker disabled', async test => {
 	const trs = thead1.nextSibling.querySelectorAll('tr')
 
 	test.equal(
-		select(trs[1].lastChild).select('button').html(),
+		select(trs[0].lastChild).select('button').html(),
 		'Disable',
 		'should indicate that the protein-changing tiebreaker is active'
 	)
@@ -227,7 +231,7 @@ tape('tiebreaker disabled', async test => {
 	test.equal(
 		select(trs[2].lastChild).select('button').html(),
 		'Enable',
-		'should indicate that the CNV tiebreaker is active'
+		'should indicate that the CNV tiebreaker is not active'
 	)
 
 	select(trs[2].lastChild).select('button').node().click()
@@ -260,7 +264,7 @@ tape('simulated value drag/drop', async test => {
 		.selectAll('thead')
 		.filter(d => d?.types?.includes('geneVariant'))
 		.node()
-	const valuesDiv = thead1.nextSibling.querySelectorAll('tr')[1].querySelector('.sjpp-matrix-sorter-ui-value')
+	const valuesDiv = thead1.nextSibling.querySelectorAll('tr')[0].querySelector('.sjpp-matrix-sorter-ui-value')
 	const lastVal = select(valuesDiv.lastChild)
 
 	// since this simulated test does not trigger actual drag and drop,
@@ -277,7 +281,7 @@ tape('simulated value drag/drop', async test => {
 		.selectAll('thead')
 		.filter(d => d?.types?.includes('geneVariant'))
 		.node()
-	const valuesDiv2 = thead2.nextSibling.querySelectorAll('tr')[1].querySelector('.sjpp-matrix-sorter-ui-value')
+	const valuesDiv2 = thead2.nextSibling.querySelectorAll('tr')[0].querySelector('.sjpp-matrix-sorter-ui-value')
 	const lastVal2 = select(valuesDiv2.lastChild)
 	const n = activeOrderBeforeDrag.length
 
@@ -355,7 +359,7 @@ tape('hidden values', async test => {
 		.selectAll('thead')
 		.filter(d => d?.types?.includes('geneVariant'))
 		.node()
-	const tr1 = thead1.nextSibling.querySelectorAll('tr')[1]
+	const tr1 = thead1.nextSibling.querySelectorAll('tr')[0]
 	const valuesDiv = tr1.querySelector('.sjpp-matrix-sorter-ui-value')
 	const m = valuesDiv.querySelectorAll(':scope>div').length
 	//const valueDivsBeforeDrop = valuesDiv.querySelectorAll(':scope > div')
@@ -375,7 +379,7 @@ tape('hidden values', async test => {
 		.selectAll('thead')
 		.filter(d => d?.types?.includes('geneVariant'))
 		.node()
-		.nextSibling.querySelectorAll('tr')[1]
+		.nextSibling.querySelectorAll('tr')[0]
 
 	const valuesDiv_a = tr1_a.querySelector('.sjpp-matrix-sorter-ui-value')
 	const unusedVals_a = tr1_a.querySelector('[data-testid=sjpp-matrix-sorter-ui-hidden-vals]')

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -345,6 +345,7 @@ tape('hidden values', async test => {
 	// config is a reference to the mutable object
 	const s = config.settings.matrix
 	const ui = uiApi.Inner
+	const tipNode = ui.dom.tip.d.node()
 	const a = config.settings.matrix.sortOptions.a
 	ui.expandedSection = a.sortPriority[0].label
 	a.sortPriority[0].tiebreakers[1].isOrdered = true
@@ -366,7 +367,7 @@ tape('hidden values', async test => {
 	const hiddenBtn = tr1.querySelector('[data-testid=sjpp-matrix-sorter-ui-hidden-add]')
 	hiddenBtn.click()
 
-	const unusedVals = tr1.querySelector('[data-testid=sjpp-matrix-sorter-ui-hidden-vals]')
+	const unusedVals = tipNode.querySelector('[data-testid=sjpp-matrix-sorter-ui-hidden-vals]')
 	const n = 1
 	test.equal(
 		unusedVals.querySelectorAll(':scope>div').length,
@@ -382,7 +383,9 @@ tape('hidden values', async test => {
 		.nextSibling.querySelectorAll('tr')[0]
 
 	const valuesDiv_a = tr1_a.querySelector('.sjpp-matrix-sorter-ui-value')
-	const unusedVals_a = tr1_a.querySelector('[data-testid=sjpp-matrix-sorter-ui-hidden-vals]')
+	const hiddenBtn_a = tr1_a.querySelector('[data-testid=sjpp-matrix-sorter-ui-hidden-add]')
+	hiddenBtn_a.click()
+	const unusedVals_a = tipNode.querySelector('[data-testid=sjpp-matrix-sorter-ui-hidden-vals]')
 	test.deepEqual(
 		[valuesDiv_a.querySelectorAll(':scope>div').length, unusedVals_a.querySelectorAll(':scope>div').length],
 		[m - 1, n + 1],

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -1,0 +1,46 @@
+import tape from 'tape'
+import { getSorterUi } from '../matrix.sorterUi.js'
+import { getPlotConfig } from '../matrix.config'
+import { initByInput } from '../controls.config'
+import { select } from 'd3-selection'
+
+/*************************
+ reusable helper functions
+**************************/
+
+let i = 0
+
+async function getControls({ dispatch }) {
+	const holder = select('body').append('div').attr('class', 'sja_root_holder').append('table').append('tr')
+	const controls = {
+		parent: {
+			id: `_${i++}_${Math.random()}`,
+			app: {
+				dispatch,
+				vocabApi: {
+					termdbConfig: {}
+				}
+			},
+			dom: {
+				holder
+			}
+		}
+	}
+
+	const config = await getPlotConfig({}, controls.parent.app)
+	controls.parent.config = config
+	const ui = getSorterUi({ controls, holder })
+	//const input = initByInput.custom(uiOpts)
+	return { ui, controls, config, parent: controls.parent }
+}
+
+/**************
+ test sections
+***************/
+
+tape('default setup', async test => {
+	const { ui, controls, config, parent } = await getControls({ dispatch: () => {} })
+	const s = parent.config.settings.matrix
+	console.log(s)
+	test.end()
+})

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -3,6 +3,7 @@ import { getSorterUi } from '../matrix.sorterUi.js'
 import { getPlotConfig } from '../matrix.config'
 import { initByInput } from '../controls.config'
 import { select } from 'd3-selection'
+import { copyMerge } from '#rx'
 
 /*************************
  reusable helper functions
@@ -10,28 +11,33 @@ import { select } from 'd3-selection'
 
 let i = 0
 
-async function getControls({ dispatch }) {
+async function getControls(_opts = {}) {
 	const holder = select('body').append('div').attr('class', 'sja_root_holder').append('table').append('tr')
-	const controls = {
-		parent: {
-			id: `_${i++}_${Math.random()}`,
-			app: {
-				dispatch,
-				vocabApi: {
-					termdbConfig: {}
-				}
-			},
-			dom: {
-				holder
+	const parent = {
+		id: `_${i++}_${Math.random()}`,
+		app: {
+			dispatch:
+				_opts.dispatch ||
+				(action => {
+					copyMerge(config, action.config)
+					uiApi.main()
+				}),
+			vocabApi: {
+				termdbConfig: {}
 			}
+		},
+		dom: {
+			holder
 		}
 	}
 
-	const config = await getPlotConfig({}, controls.parent.app)
-	controls.parent.config = config
-	const ui = getSorterUi({ controls, holder })
+	const config = await getPlotConfig({}, parent.app)
+	parent.config = config
+	const controls = { parent }
+	const opts = { controls, holder, debug: true }
+	const uiApi = getSorterUi(opts)
 	//const input = initByInput.custom(uiOpts)
-	return { ui, controls, config, parent: controls.parent }
+	return { uiApi, controls, config, parent: controls.parent, opts }
 }
 
 /**************
@@ -39,8 +45,49 @@ async function getControls({ dispatch }) {
 ***************/
 
 tape('default setup', async test => {
-	const { ui, controls, config, parent } = await getControls({ dispatch: () => {} })
+	const { uiApi, controls, config, parent, opts } = await getControls()
 	const s = parent.config.settings.matrix
-	console.log(s)
+	const activeOption = s.sortOptions[s.sortSamplesBy]
+	test.equal(
+		opts.holder.node().querySelectorAll('thead').length,
+		// 2 theads, 1 for hardcoded manual selected rows + 1 for sort by case names
+		// 1 thead for main table heading
+		activeOption.sortPriority.length + 2 + 1,
+		'should have the expected number of thead'
+	)
+	if (test._ok) uiApi.destroy()
+	test.end()
+})
+
+tape('simulated section drag/drop', async test => {
+	const { uiApi, controls, config, parent, opts } = await getControls()
+	const s = config.settings.matrix
+	const ui = uiApi.Inner
+	const activeOptionBeforeDrag = structuredClone(ui.activeOption)
+	const th = opts.holder
+		.selectAll('th')
+		.filter(d => d?.types?.includes('geneVariant'))
+		.node()
+	const sectionData = th.__data__
+	ui.trackDraggedSection.call(th, {}, sectionData)
+
+	const i = ui.activeOption.sortPriority.indexOf(sectionData)
+	ui.adjustSortPriority({}, ui.activeOption.sortPriority[i + 1])
+
+	test.deepEqual(
+		activeOptionBeforeDrag.sortPriority,
+		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority,
+		'should not adjust the sortPriority/table before clicking apply, after drag/drop'
+	)
+
+	ui.apply()
+
+	test.deepEqual(
+		activeOptionBeforeDrag.sortPriority.reverse(),
+		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority,
+		'should adjust the sortPriority/table after clicking apply'
+	)
+
+	if (test._ok) uiApi.destroy()
 	test.end()
 })

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -832,10 +832,10 @@ h2 {
   margin-bottom: 10px;
 }
 
-.sjpp-controls-table tr:hover {
+.sjpp-controls-table > tr:hover {
   /*font-weight: 600;*/
   text-shadow:0px 0px 0.5px black;
-background-color: rgba(239, 236, 149, 0.389);
+  background-color: rgba(239, 236, 149, 0.389);
 }
 
 .sja_edit_btn {

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -27,6 +27,8 @@ export const graphableTypes = new Set([
 		.target (REQUIRED): 'barchart', 'regression', etc
 			- used as a switch-case "router" for additional use-specific logic
 			- other parameters, if applicable, are described in the route "handler" 
+		.detail 
+		  - a more specific detailed use case
 	
 	ds 
 	- a bootstrapped dataset object that can supply overrides to the use case logic,


### PR DESCRIPTION
## Description

NOTE: The new sorter UI requires a dataset matrix settings option to be set to true (see manual testing B below). We can remove this feature/settings flag once the feature is approved.

To test:
A. Automated (does not require setting a dataset settings option)
- http://localhost:3000/testrun.html?dir=plots&name=matrix.sort.unit
- http://localhost:3000/testrun.html?dir=plots&name=matrix.sorterUi.unit
- http://localhost:3000/testrun.html?dir=mass&name=matrix.integration

B. Manual:
- in `sjpp/gdc/active/dataset/gdc.hg38.ts`, add `useSorterUi: true`  in `termdb.matrix.settings`
- you should see the new UI in http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=Gliomas
- you can open a table row in the sorter UI and then enable, check "Use Order", or drag entries to change the order of  tiebreakers/values.

![Screenshot 2024-04-24 at 4 43 37 PM](https://github.com/stjude/proteinpaint/assets/411031/5e21cc13-d53e-42ad-9a65-129ecd25d037)

 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
