### PR TITLE
fix: when parsing phenotree, enforce uncomputable categories to be numb…

### DIFF
--- a/client/src/databrowser/dictionary.parse.js
+++ b/client/src/databrowser/dictionary.parse.js
@@ -114,8 +114,10 @@ export function parseDictionary(input) {
 					// term is numeric. keys declared in .values{} should be uncomputable categories
 					for (const k in terms[termId].values) {
 						const tmp = Number(k)
-						if (Number.isNaN(tmp))
-							throw `Uncomputable category of a numeric term is required to be a number (here uses non-numeric value of ${k}, at line ${lineNum}). This is by design so that all such values can be kept in anno_float table etc`
+						if (Number.isNaN(tmp)) {
+							// this is by design so that all values in the db to match the column type for that value, otherwise the generated SQL statements would always have to include
+							throw `Uncomputable category of a numeric term is required to be a number (here uses non-numeric value of ${k}).`
+						}
 						terms[termId].values[k].uncomputable = true
 					}
 				}

--- a/client/src/databrowser/dictionary.parse.js
+++ b/client/src/databrowser/dictionary.parse.js
@@ -97,10 +97,7 @@ export function parseDictionary(input) {
 					terms[termId].values = {}
 					terms[termId].groupsetting = { inuse: false }
 				}
-				const values = cols[valuesIndex]
-					.trim()
-					.replace(/"/g, '')
-					.split(';')
+				const values = cols[valuesIndex].trim().replace(/"/g, '').split(';')
 
 				for (const x of values) {
 					const v = x.trim()
@@ -114,7 +111,13 @@ export function parseDictionary(input) {
 				}
 
 				if (type == 'integer' || type == 'float') {
-					for (const k in terms[termId].values) terms[termId].values[k].uncomputable = true
+					// term is numeric. keys declared in .values{} should be uncomputable categories
+					for (const k in terms[termId].values) {
+						const tmp = Number(k)
+						if (Number.isNaN(tmp))
+							throw `Uncomputable category of a numeric term is required to be a number (here uses non-numeric value of ${k}, at line ${lineNum}). This is by design so that all such values can be kept in anno_float table etc`
+						terms[termId].values[k].uncomputable = true
+					}
 				}
 			} catch (e) {
 				throw `Line ${lineNum} error: ${e}`

--- a/client/src/databrowser/dictionary.parse.js
+++ b/client/src/databrowser/dictionary.parse.js
@@ -292,13 +292,17 @@ function validateNumericTermCategories(term) {
 	// term is numeric
 	if (!term.values) return // .values{} is optional
 	if (typeof term.values != 'object') throw 'numeric .values{} is not object'
-	// values{} keys should be uncomputable categories, auto-assign the flag here. also make sure keys can be cast into numbers
-	for (const k in term.values) {
-		const tmp = Number(k)
+	// values{} keys should be uncomputable categories, auto-assign the flag here
+	// also make sure keys can be cast into numbers
+	for (const key in term.values) {
+		if (key == '') throw 'Cannot use empty string as an uncomputable category'
+		// key is not empty string
+		const tmp = Number(key)
 		if (Number.isNaN(tmp)) {
 			// this is by design so that all values in the db to match the column type for that value, otherwise the generated SQL statements would always have to include
-			throw `Uncomputable category of a numeric term is required to be a number (here uses non-numeric value of ${k}).`
+			throw `Uncomputable category of a numeric term is required to be a number (here uses non-numeric value of ${key}).`
 		}
-		term.values[k].uncomputable = true
+		// key is a valid category because it can be casted into a number
+		term.values[key].uncomputable = true
 	}
 }

--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -2,21 +2,28 @@ import tape from 'tape'
 import { parseDictionary } from '../dictionary.parse'
 import * as d3s from 'd3-selection'
 
-/***********************************
- reusable helper vars and functions
-************************************/
-
-function getHolder() {
-	return d3s
-		.select('body')
-		.append('div')
-		.style('border', '1px solid #aaa')
-		.style('padding', '5px')
-		.style('margin', '5px')
-}
-
 /****************
  Dictionary Tests
+
+levels before variable, type, and categories - no gaps
+levels after variable, type, categories - with gap
+empty variable
+extra, non essential column
+no level columns
+repeated level names, same line
+dash between levels
+missing type
+repeated intermediate terms for diff branches, whole dataset
+missing Variable header
+missing Type header
+missing parent_id header
+missing name header
+missing type header
+missing values header
+blank or dash in required data column
+missing k=v in values (dictionary format)
+uncomputable category is not number
+
 *****************/
 
 tape('\n', function (test) {
@@ -497,11 +504,6 @@ tape('missing Type header', function (test) {
 	test.end()
 })
 
-tape('\n', function (test) {
-	test.pass('-***- dictionary.ui, data dictionary parsing-***-')
-	test.end()
-})
-
 tape('missing parent_id header', function (test) {
 	test.timeoutAfter(100)
 	const tsv = [
@@ -625,3 +627,31 @@ tape('missing k=v in values (dictionary format)', function (test) {
 	}
 	test.end()
 })
+
+tape('uncomputable category is not number', function (test) {
+	test.timeoutAfter(100)
+	// user can totally encode missing numeric values with words like "unk". our system requires those to be coded as number instead otherwise it crashes our sql query. in below "unk" key is rejected
+	const tsv = [`variable\ttype\tcategories`, `A1a\tinteger\t{ "unk": { "label": "unknown" } }`].join('\n')
+
+	const message = 'Should throw on uncomputable category not being number'
+	try {
+		parseDictionary(tsv)
+		test.fail(message)
+	} catch (e) {
+		test.pass(message + ': ' + e)
+	}
+	test.end()
+})
+
+/***********************************
+ reusable helper vars and functions
+************************************/
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+}

--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -22,7 +22,8 @@ missing type header
 missing values header
 blank or dash in required data column
 missing k=v in values (dictionary format)
-uncomputable category is not number
+uncomputable category is a string but not number
+uncomputable category is empty string but not number
 
 *****************/
 
@@ -628,10 +629,24 @@ tape('missing k=v in values (dictionary format)', function (test) {
 	test.end()
 })
 
-tape('uncomputable category is not number', function (test) {
+tape('uncomputable category is a string but not number', function (test) {
 	test.timeoutAfter(100)
 	// user can totally encode missing numeric values with words like "unk". our system requires those to be coded as number instead otherwise it crashes our sql query. in below "unk" key is rejected
 	const tsv = [`variable\ttype\tcategories`, `A1a\tinteger\t{ "unk": { "label": "unknown" } }`].join('\n')
+
+	const message = 'Should throw on uncomputable category not being number'
+	try {
+		parseDictionary(tsv)
+		test.fail(message)
+	} catch (e) {
+		test.pass(message + ': ' + e)
+	}
+	test.end()
+})
+
+tape('uncomputable category is empty string but not number', function (test) {
+	test.timeoutAfter(100)
+	const tsv = [`variable\ttype\tcategories`, `A1a\tinteger\t{ "": { "label": "empty!!" } }`].join('\n')
 
 	const message = 'Should throw on uncomputable category not being number'
 	try {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- when parsing phenotree, enforce uncomputable categories are numbers also


### PR DESCRIPTION
…ers also

## Description

handles a case i didn't know about before
using non-numeric value as uncomputable category breaks our sql code
databrowser tests pass (nice unit tests)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
