### PR TITLE
Fix for broken custom data example in data browser card

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -181,7 +181,7 @@ function setRenderers(self) {
 			.style('float', 'right')
 			.style('font-size', '1.1em')
 			.style('margin-top', '50px')
-			.text(appState.termdbConfig.title.text)
+			.text(appState.termdbConfig?.title?.text || '')
 
 		const tabDiv = header.append('div').style('display', 'none').style('vertical-align', 'bottom')
 		const controlsDiv = header


### PR DESCRIPTION
## Description
The example and UI for the data browser is breaking. See https://proteinpaint.stjude.org/?appcard=databrowser. 
Test with: http://localhost:3000/?appcard=databrowser


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
