### PR TITLE
fix: address mds3 mclass legend error by not setting uninitiated flag…

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -62,7 +62,6 @@ export function makeSampleFilterLabel(data, tk, block, laby) {
 			vocab: tk.mds.termdb.vocabApi.state.vocab,
 			callback: f => {
 				tk.filterObj = f
-				tk.uninitialized = true
 				tk.load()
 			}
 		}

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -299,7 +299,6 @@ function may_update_formatFilter(data, tk) {
 
 function reload(tk) {
 	tk.legend.tip.hide()
-	tk.uninitialized = true
 	tk.load()
 }
 
@@ -539,9 +538,7 @@ function update_mclass(tk) {
 					.text('Hide')
 					.on('click', () => {
 						tk.legend.mclass.hiddenvalues.add(c.k)
-						tk.legend.tip.hide()
-						tk.uninitialized = true
-						tk.load()
+						reload(tk)
 					})
 
 				tk.legend.tip.d
@@ -553,9 +550,7 @@ function update_mclass(tk) {
 							tk.legend.mclass.hiddenvalues.add(c2.k)
 						}
 						tk.legend.mclass.hiddenvalues.delete(c.k)
-						tk.legend.tip.hide()
-						tk.uninitialized = true
-						tk.load()
+						reload(tk)
 					})
 
 				if (hiddenlst.length) {
@@ -565,9 +560,7 @@ function update_mclass(tk) {
 						.text('Show all')
 						.on('click', () => {
 							tk.legend.mclass.hiddenvalues.clear()
-							tk.legend.tip.hide()
-							tk.uninitialized = true
-							tk.load()
+							reload(tk)
 						})
 				}
 
@@ -608,7 +601,6 @@ function update_mclass(tk) {
 				loading = true
 				tk.legend.mclass.hiddenvalues.delete(c.k)
 				event.target.innerHTML = 'Updating...'
-				tk.uninitialized = true
 				await tk.load()
 			})
 	}
@@ -708,7 +700,6 @@ function may_update_skewerRim(data, tk) {
 				loading = true
 				sk.hiddenvaluelst.splice(sk.hiddenvaluelst.indexOf(c), 1)
 				event.target.innerHTML = 'Updating...'
-				tk.uninitialized = true
 				await tk.load()
 			})
 	}

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -3,7 +3,7 @@ import { dofetch3 } from '#common/dofetch'
 import { initLegend, updateLegend } from './legend'
 import { loadTk, rangequery_rglst } from './tk'
 import urlmap from '#common/urlmap'
-import { mclass } from '#shared/common'
+import { mclass, dtsnvindel, dtsv, dtfusionrna } from '#shared/common'
 import { vcfparsemeta } from '#shared/vcf'
 import { getFilterName } from './leftlabel.sample'
 import { fillTermWrapper } from '#termsetting'
@@ -757,11 +757,11 @@ makes no return
 */
 function validateCustomVariants(tk, block) {
 	for (const m of tk.custom_variants) {
-		if (m.dt == 1) {
+		if (m.dt == dtsnvindel) {
 			validateCustomSnvindel(m)
 			continue
 		}
-		if (m.dt == 2 || m.dt == 5) {
+		if (m.dt == dtfusionrna || m.dt == dtsv) {
 			validateCustomSvfusion(m, block)
 			continue
 		}
@@ -873,13 +873,16 @@ function mayDeriveSkewerOccurrence4samples(tk) {
 		// at least one m{} has occurrence, presumably all m{} should have it. no need to group
 		return
 	}
+
 	// sample_id is hardcoded, change "sample" to "sample_id"
+
 	for (const i of tk.custom_variants) {
 		if (i.sample) {
 			i.sample_id = i.sample
 			delete i.sample
 		}
 	}
+
 	if (!tk.custom_variants.find(i => i.sample_id)) {
 		// no m{} has sample, cannot derive occurrence
 		// usecase: for displaying variant-only info, e.g. regression-snplocus, dbsnp, clinvar

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -622,7 +622,7 @@ tape('Custom variants WITH samples (allows some to be without)', test => {
 		{ chr: 'chr17', pos: 7676520, mname: 'point 2', class: 'M', dt: 1, sample: 'sample 2' },
 		// 2nd variant has no sample and should be allowed
 		{ chr: 'chr17', pos: 7675993, mname: 'point 1', class: 'M', dt: 1 },
-		{ chr: 'chr17', pos: 7676381, mname: 'point 3', class: 'M', dt: 1, sample: 'sample 1' }
+		{ chr: 'chr17', pos: 7676381, mname: 'point 3', class: 'F', dt: 1, sample: 'sample 1' }
 	]
 
 	runproteinpaint({

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- address mds3 mclass legend error by not setting uninitiated flag to true


### PR DESCRIPTION
… to true

## Description

closes #1510
for both official and custom tk, hiding an item from mclass legend will no longer duplicate the legend:
http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC
http://localhost:3000/?genome=hg38-test&gene=p53&mds3bcffile=custom,files/hg38/TermdbTest/TermdbTest.bcf.gz

there's still a known issue that from the `Tracks` menu, hide and show the custom track will cause the samples of the custom track to be "lost" (clicking "samples" leftlabel errors out). at least this doesn't impact official tk e.g. gdc and only applies to adhoc ones

all mds3 tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
