### PR TITLE
fix: numeric setdefaultq() will default to term's own default bin typ…

### DIFF
--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -257,7 +257,12 @@ function setqDefaults(self) {
 	//if (self.q && self.q.type && Object.keys(self.q).length>1) return
 	if (self.q && !self.q.mode) self.q.mode = 'discrete'
 	if (!self.q || self.q.mode !== 'discrete') self.q = {}
-	if (!self.q.type) self.q.type = 'regular-bin'
+
+	if (!self.q.type) {
+		// supply default q.type when missing. important not to always hardcode to "regular-bin". e.g. in gdc, agedx default binning is custom but not regular; for such term defaulting to regular will confuse termsetting ui
+		self.q.type = self.term.bins?.default?.type || 'regular-bin'
+	}
+
 	const cacheCopy = JSON.parse(JSON.stringify(cache[t.id].discrete[self.q.type]))
 	self.q = Object.assign(cacheCopy, self.q)
 	const bin_size = 'bin_size' in self.q && self.q.bin_size!.toString()

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- numeric setdefaultq() will default to term's own default bin type rather than always hardcoding to regular-bin


### PR DESCRIPTION
…e rather than always hardcoding to regular-bin

## Description

[test here](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22settings%22:{%22matrix%22:{%22numGenes%22:3}},%22termgroups%22:[{%22lst%22:[{%22term%22:{%22name%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22case.diagnoses.age_at_diagnosis%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22case.demographic.days_to_birth%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22case.demographic.year_of_birth%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22case.demographic.year_of_death%22,%22q%22:{%22mode%22:%22continuous%22}}]}]}]}). click on Age at diagnosis > Edit > Discrete. on master it breaks

all CI pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
