### PR TITLE
Added overlay/divide case

### DIFF
--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -18,11 +18,11 @@ const useCases = {
 	summary: [TermTypeGroups.DICTIONARY_VARIABLES],
 	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	violin: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
-	//sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES],//Commented out as it is covered by the overlayOrDivide use case
+	//sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES],//Commented out as it is covered by the default use case
 	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],
 	survival: [TermTypeGroups.DICTIONARY_VARIABLES],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
-	overlayOrDivide: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
+	default: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	regression: [TermTypeGroups.DICTIONARY_VARIABLES],
 	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS]
 }

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -18,11 +18,11 @@ const useCases = {
 	summary: [TermTypeGroups.DICTIONARY_VARIABLES],
 	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	violin: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
-	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES],
+	//sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES],//Commented out as it is covered by the overlayOrDivide use case
 	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],
 	survival: [TermTypeGroups.DICTIONARY_VARIABLES],
-	overlay: [TermTypeGroups.DICTIONARY_VARIABLES],
-	divideBy: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
+	//Used from the termsetting when searching for a term, as any term with categories is allowed
+	overlayOrDivide: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	regression: [TermTypeGroups.DICTIONARY_VARIABLES],
 	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS]
 }

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -550,7 +550,7 @@ function setInteractivity(self) {
 				holder instanceof Element ? holder : this instanceof Element ? this : self.dom.holder.node()
 			)
 		else self.dom.tip.show(event!.clientX, event!.clientY)
-
+		if (!self.usecase) self.usecase = { target: 'overlayOrDivide' }
 		const termdb = await import('../termdb/app.js')
 		termdb.appInit({
 			holder: self.dom.tip.d,
@@ -558,7 +558,6 @@ function setInteractivity(self) {
 			state: {
 				activeCohort: self.activeCohort,
 				tree: {
-					target: 'overlay',
 					usecase: self.usecase
 				}
 			},

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -550,7 +550,7 @@ function setInteractivity(self) {
 				holder instanceof Element ? holder : this instanceof Element ? this : self.dom.holder.node()
 			)
 		else self.dom.tip.show(event!.clientX, event!.clientY)
-		if (!self.usecase) self.usecase = { target: 'overlayOrDivide' }
+		if (!self.usecase) self.usecase = { target: 'default' }
 		const termdb = await import('../termdb/app.js')
 		termdb.appInit({
 			holder: self.dom.tip.d,


### PR DESCRIPTION
## Description

Overlay and divide can allow dictionary terms or geneVariant terms as they have categories. By default this use case can be specified in the termsetting. When a use case is not set, this case is set.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
