### PR TITLE
Added local sample type filter to the scatter plot, if defined for the plot in the dataset configuration

### DIFF
--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -132,7 +132,8 @@ function addScatterplots(c, ds) {
 			colorColumn: p.colorColumn,
 			sampleType: p.sampleType,
 			coordsColumns: p.coordsColumns,
-			settings: p.settings
+			settings: p.settings,
+			sampleCategory: p.sampleCategory
 		}
 	})
 }

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -466,6 +466,7 @@ type ScatterPlotsEntry = {
 	/** a plot can be colored by either a dict term termsetting (colorTW) or file column values (colorColumn) */
 	colorTW?: { id: string }
 	colorColumn?: ColorColumn
+	sampleCategory?: { tw: { id: string }; defaultValue: string; order: string[] }
 }
 
 type Scatterplots = {

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -466,7 +466,18 @@ type ScatterPlotsEntry = {
 	/** a plot can be colored by either a dict term termsetting (colorTW) or file column values (colorColumn) */
 	colorTW?: { id: string }
 	colorColumn?: ColorColumn
-	sampleCategory?: { tw: { id: string }; defaultValue: string; order: string[] }
+	/** provide a sampletype term to filter for specific type of samples for subjects with multiple samples and show in the plot.
+	e.g. to only show D samples from all patients
+	this is limited to only one term and doesn't allow switching between multiple terms
+	*/
+	sampleCategory?: {
+		/** categorical term like "sampleType" which describes types of multiple samples from the same subject */
+		tw: { id: string }
+		/** default category */
+		defaultValue: string
+		/** order of categories */
+		order: string[]
+	}
 }
 
 type Scatterplots = {


### PR DESCRIPTION
## Description

To test it from the PNET scatter set a sample type filter. See corresponding PR in sjpp


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
