### PR TITLE
replace got with ky in topmgene route

### DIFF
--- a/server/routes/gdc.topMutatedGenes.ts
+++ b/server/routes/gdc.topMutatedGenes.ts
@@ -1,6 +1,6 @@
 import { GdcTopMutatedGeneRequest, GdcTopMutatedGeneResponse, Gene } from '#shared/types/routes/gdc.topMutatedGenes.ts'
 import { mclasscnvgain, mclasscnvloss, dtsnvindel } from '#shared/common.js'
-import got from 'got'
+import ky from 'ky'
 
 // TODO change to /termdb/topMutatedGenes
 
@@ -247,12 +247,14 @@ async function getGenesGraphql(q: GdcTopMutatedGeneRequest, ds) {
 	const query: string = queryV2.query
 	const variables: object = queryV2.getVariables(q)
 
-	const response = await got.post(host.graphql, {
-		headers,
-		body: JSON.stringify({ query, variables })
-	})
+	const re: any = await ky
+		.post(host.graphql, {
+			timeout: false, // do not let ky timeout
+			headers,
+			json: { query, variables }
+		})
+		.json()
 
-	const re: any = JSON.parse(response.body)
 	const genes: Gene[] = []
 	for (const g of re.data.genesTableViewer.explore.genes.hits.edges) {
 		/* g.node is:


### PR DESCRIPTION
## Description

[local works](http://localhost:3000/example.gdc.matrix.html?cohort=Gliomas). please test with localGFF+logging in+oncomatrix which uses the wrong api url, to see if it can catch the error?

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
