### PR TITLE
fix: Pass request header containing session when querying arriba file…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Pass request header containing session when querying arriba file which is controlled

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -849,8 +849,8 @@ async function getCnvFusion4oneCase(opts, ds) {
 
 	if (arribaFile) {
 		try {
-			// do not use headers here that has accept: 'application/json'
-			const re = await ky(path.join(host.rest, 'data', arribaFile), { timeout: false }).text()
+			// must use headers to access controlled fusion file
+			const re = await ky(path.join(host.rest, 'data', arribaFile), { headers, timeout: false }).text()
 			const lines = re.split('\n')
 			// first line is header
 			// #chrom1 start1  end1    chrom2  start2  end2    name    score   strand1 strand2 strand1(gene/fusion)    strand2(gene/fusion)    site1   site2   type    direction1      direction2      split_reads1    split_reads2    discordant_mates        coverage1       coverage2       closest_genomic_breakpoint1     closest_genomic_breakpoint2     filters fusion_transcript       reading_frame   peptide_sequence        read_identifiers


### PR DESCRIPTION
… which is controlled

## Description

please test this on localGFF+pp. login first. gene: DCK, mutation H218L, show Disco for this case and see if fusion shows
can't test localhost as mds3 doesn't pass token to disco

PLEASE DO NOT POST GDC FUSION SCREENSHOT. THAT DATA IS CONTROLLED

shouldn't impact anything else

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
