### PR TITLE
Draft PR supporting geneExpression

### DIFF
--- a/client/common/termutils.js
+++ b/client/common/termutils.js
@@ -118,6 +118,7 @@ export function sample_match_termvaluesetting(row, filter, geneVariant$ids) {
 							if (v.dt == f.dt && (!v.origin || v.origin == f.origin) && f.mclasslst.includes(v.class)) return true
 						}
 					}) && true
+			} else if (t.term.type == 'geneExpression') {
 			} else {
 				throw 'unknown term type'
 			}

--- a/client/dom/violinRenderer.js
+++ b/client/dom/violinRenderer.js
@@ -3,7 +3,7 @@ import { line, curveMonotoneX } from 'd3-shape'
 import { rgb, brushX, axisTop } from 'd3'
 
 export class violinRenderer {
-	constructor(holder, plot, width = 500, height = 100, shiftx = 20, shifty = 20, callback = null, scaleFactor = 1) {
+	constructor(holder, plot, width = 500, height = 100, shiftx = 20, shifty = 30, callback = null, scaleFactor = 1) {
 		this.holder = holder
 		this.plot = plot
 		this.width = width

--- a/client/filter/test/filter.integration.spec.js
+++ b/client/filter/test/filter.integration.spec.js
@@ -452,7 +452,6 @@ tape('+NEW button interaction', async test => {
 	)
 	// simulate creating the initial filter
 	await addDemographicSexFilter(opts, opts.holder.node().querySelector('.sja_new_filter_btn'))
-	return
 	test.equal(opts.filterData.lst.length, 1, 'should create a one-entry filter.lst[]')
 	test.equal(
 		opts.holder.select('.sja_new_filter_btn').style('display'),

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -124,7 +124,6 @@ async function fillMenu(self, div, tvs) {
 				},
 				self.opts.getCategoriesArguments
 			)
-			console.log('data', data)
 			self.num_obj.density_data = convertViolinData(data)
 		} catch (err) {
 			console.log(err)

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -118,11 +118,13 @@ async function fillMenu(self, div, tvs) {
 			const data = await self.opts.vocabApi.getViolinPlotData(
 				{
 					termid: tvs.term.id,
+					termType: tvs.term.type,
 					filter: self.filter,
 					svgw: self.num_obj.plot_size.width / window.devicePixelRatio
 				},
 				self.opts.getCategoriesArguments
 			)
+			console.log('data', data)
 			self.num_obj.density_data = convertViolinData(data)
 		} catch (err) {
 			console.log(err)

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -589,6 +589,8 @@ function validatePlotTerm(t, vocabApi) {
 			break
 		case 'samplelst':
 			break
+		case 'geneExpression':
+			break
 		default:
 			if (t.term.isgenotype) {
 				// don't do anything for now

--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -1229,7 +1229,8 @@ tape('avoid race condition', function (test) {
 		matrix.Inner.app.vocabApi.getAnnotatedSampleData = async (opts, _refs = {}) => {
 			await sleep(i)
 			i = 0
-			return await matrix.Inner.app.vocabApi.origGetAnnotatedSampleData(opts, _refs)
+			const data = await matrix.Inner.app.vocabApi.origGetAnnotatedSampleData(opts, _refs)
+			return data
 		}
 		// set up the postRender callback before triggering rerenders via app.dispatch
 		matrix.on('postRender.test', async () => {
@@ -1263,8 +1264,8 @@ tape('avoid race condition', function (test) {
 							{
 								name: '',
 								lst: [
-									{ term: { gene: 'KRAS', name: 'KRAS', type: 'geneVariant', isleaf: true } },
-									{ term: { gene: 'AKT1', name: 'AKT1', type: 'geneVariant', isleaf: true } }
+									{ $id: 0, term: { gene: 'KRAS', name: 'KRAS', type: 'geneVariant', isleaf: true } },
+									{ $id: 1, term: { gene: 'AKT1', name: 'AKT1', type: 'geneVariant', isleaf: true } }
 								]
 							}
 						]
@@ -1279,7 +1280,7 @@ tape('avoid race condition', function (test) {
 							termgroups: [
 								{
 									name: '',
-									lst: [{ term: { gene: 'BCR', name: 'BCR', type: 'geneVariant', isleaf: true } }]
+									lst: [{ $id: 3, term: { gene: 'BCR', name: 'BCR', type: 'geneVariant', isleaf: true } }]
 								}
 							]
 						}

--- a/client/mass/test/sampleScatter.spec.js
+++ b/client/mass/test/sampleScatter.spec.js
@@ -148,7 +148,7 @@ tape('PNET plot + filter + colorTW=gene', function (test) {
 			lst: [{ type: 'tvs', tvs: { term: { id: 'Gender' }, values: [{ key: 'M', label: 'Male' }] } }]
 		}
 	}
-	s2.plots[0].colorTW = { term: { type: 'geneVariant', name: 'TP53' } }
+	s2.plots[0].colorTW = { term: { type: 'geneVariant', name: 'TP53', gene: 'TP53' } }
 
 	runpp({
 		state: s2,

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -89,14 +89,14 @@ class Term1ui {
 export const term1uiInit = getCompInit(Term1ui)
 
 function setRenderers(self) {
-	self.initUI = function() {
+	self.initUI = function () {
 		// label to be updated later after getting plot state via api.main()
 		// <td> left
 		self.dom.td1 = self.dom.tr.append('td').attr('class', 'sja-termdb-config-row-label')
 		// <td> right
 		self.dom.td2 = self.dom.tr.append('td')
 	}
-	self.render = async function() {
+	self.render = async function () {
 		/* state and plot are frozen from app.state
 		 */
 		const plot = this.state.plot
@@ -130,6 +130,8 @@ function setRenderers(self) {
 			case 'geneVariant':
 				break
 			case 'samplelst':
+				break
+			case 'geneExpression':
 				break
 			default:
 				throw 'unknown term type'

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -159,6 +159,7 @@ class Scatter {
 		if (reqOpts.coordTWs.length == 1) return //To allow removing a term in the controls, though nothing is rendered (summary tab with violin active)
 
 		const results = await this.app.vocabApi.getScatterData(reqOpts)
+		console.log(results)
 		if (results.error) throw results.error
 		this.charts = []
 		let i = 0

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -159,7 +159,6 @@ class Scatter {
 		if (reqOpts.coordTWs.length == 1) return //To allow removing a term in the controls, though nothing is rendered (summary tab with violin active)
 
 		const results = await this.app.vocabApi.getScatterData(reqOpts)
-		console.log(results)
 		if (results.error) throw results.error
 		this.charts = []
 		let i = 0

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -73,7 +73,7 @@ export function setRenderers(self) {
 			self.config.stopColor[chart.id] = rgb(gradientColor).darker().toString()
 		}
 
-		if (self.config.colorTW?.q.mode === 'continuous' || self.config.colorTW.term.type == TermTypes.GENE_EXPRESSION) {
+		if (self.config.colorTW?.q.mode === 'continuous') {
 			const [min, max] = chart.cohortSamples
 				.filter(s => !self.config.colorTW.term.values || !(s.category in self.config.colorTW.term.values))
 				.reduce(
@@ -330,10 +330,7 @@ export function setRenderers(self) {
 	}
 
 	self.getColor = function (c, chart) {
-		if (
-			(self.config.colorTW?.q.mode == 'continuous' || self.config.colorTW.term.type == TermTypes.GENE_EXPRESSION) &&
-			'sampleId' in c
-		) {
+		if (self.config.colorTW?.q.mode == 'continuous' && 'sampleId' in c) {
 			const color = chart.colorGenerator(c.category)
 			return color
 		}
@@ -721,10 +718,7 @@ export function setRenderers(self) {
 					.style('font-weight', 'bold')
 				offsetY += step
 
-				if (
-					self.config.colorTW?.q?.mode === 'continuous' ||
-					self.config.colorTW.term.type == TermTypes.GENE_EXPRESSION
-				) {
+				if (self.config.colorTW?.q?.mode === 'continuous') {
 					const gradientWidth = 150
 					const [min, max] = chart.colorGenerator.domain()
 					const gradientScale = d3Linear().domain([min, max]).range([0, gradientWidth])

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -802,7 +802,7 @@ export function setRenderers(self) {
 			}
 		}
 		if (self.config.scaleDotTW) {
-			chart.scaleG = legendG.append('g').attr('transform', `translate(${offsetX},${self.legendHeight})`)
+			chart.scaleG = legendG.append('g').attr('transform', `translate(${offsetX},${self.legendHeight - 100})`)
 			self.drawScaleDotLegend(chart)
 		}
 		if (self.config.shapeTW) {

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -14,7 +14,6 @@ import { getId } from '#mass/nav'
 import { minDotSize, maxDotSize } from './sampleScatter.js'
 import { addNewGroup } from '../mass/groups.js'
 import { setRenderersThree } from './sampleScatter.rendererThree.js'
-import { TermTypes } from '../shared/common.js'
 
 const defaultSize = 64
 export function setRenderers(self) {

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -7,6 +7,7 @@ import { getDefaultViolinSettings } from './violin.js'
 import { getDefaultBarSettings } from './barchart.js'
 import { getDefaultScatterSettings } from './sampleScatter.js'
 import { Tabs } from '../dom/toggleButtons'
+import { isNumeric } from '../shared/common.js'
 
 //import {  } from ''
 
@@ -62,7 +63,6 @@ class SummaryPlot {
 	async main() {
 		this.dom.errdiv.style('display', 'none')
 		this.config = structuredClone(this.state.config)
-
 		if (!this.components.plots[this.config.childType]) {
 			await this.setComponent(this.config)
 		}
@@ -166,14 +166,12 @@ function setRenderers(self) {
 						const term = self.config?.term
 						const term2 = self.config?.term2
 						if (term) {
-							const mode =
-								term?.term.type == 'float' || term?.term.type == 'integer' ? 'discrete' : term?.q.mode || 'discrete'
+							const mode = isNumeric(term?.term) ? 'discrete' : term?.q.mode || 'discrete'
 							config.term = await self.getWrappedTermCopy(term, mode)
 						}
 
 						if (term2) {
-							const mode =
-								term2.term.type == 'float' || term2.term.type == 'integer' ? 'discrete' : term2.q.mode || 'discrete'
+							const mode = isNumeric(term2.term) ? 'discrete' : term2.q.mode || 'discrete'
 							config.term2 = await self.getWrappedTermCopy(term2, mode)
 						}
 						return config
@@ -185,19 +183,13 @@ function setRenderers(self) {
 					childType: 'violin',
 					label: 'Violin',
 					disabled: d => false,
-					isVisible: () =>
-						self.config?.term.term.type === 'integer' ||
-						self.config?.term.term.type === 'float' ||
-						self.config?.term2?.term.type === 'integer' ||
-						self.config?.term2?.term.type === 'float',
+					isVisible: () => isNumeric(self.config?.term?.term) || isNumeric(self.config?.term2?.term),
 					getConfig: async () => {
 						const term = self.config?.term
 						const term2 = self.config.term2
 
 						let _term, _term2
-						term.term.type === 'integer' || term.term.type === 'float'
-							? (self.violinContTerm = 'term')
-							: (self.violinContTerm = 'term2')
+						isNumeric(term?.term) ? (self.violinContTerm = 'term') : (self.violinContTerm = 'term2')
 
 						//If the first term was continuous or is coming as continuous
 						if ((self.violinContTerm && self.violinContTerm === 'term') || term.q?.mode == 'continuous') {

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -311,7 +311,6 @@ class ViolinPlot {
 		const { term, term2, settings } = this.config
 		const s = this.settings
 		const arg = {
-			tw: term,
 			filter: this.state.termfilter.filter,
 			svgw: s.svgw / window.devicePixelRatio,
 			orientation: s.orientation,

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -263,7 +263,6 @@ class ViolinPlot {
 		await this.getDescrStats()
 
 		const args = this.validateArgs()
-
 		this.data = await this.app.vocabApi.getViolinPlotData(args)
 
 		if (this.settings.plotThickness == undefined) {

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -343,7 +343,7 @@ class ViolinPlot {
 				arg.scale = term.q.scale
 			}
 		} else if ((term.term.type === 'float' || term.term.type === 'integer') && term.q.mode === 'continuous') {
-			arg.termid = term.id
+			arg.term = term
 			if (term2) arg.divideTw = term2
 		} else if ((term2?.term?.type === 'float' || term2?.term?.type === 'integer') && term2.q.mode === 'continuous') {
 			if (term2) arg.termid = term2.id
@@ -351,6 +351,7 @@ class ViolinPlot {
 		} else {
 			throw 'both term1 and term2 are not numeric/continuous'
 		}
+		arg.termType = term.type
 		return arg
 	}
 }

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -4,7 +4,7 @@ import setViolinRenderer from './violin.renderer'
 import htmlLegend from '../dom/html.legend'
 import { fillTermWrapper } from '#termsetting'
 import { setInteractivity } from './violin.interactivity'
-import { plotColor } from '../shared/common'
+import { plotColor, isNumeric } from '../shared/common'
 
 /*
 when opts.mode = 'minimal', a minimal violin plot will be rendered that will have a single term and minimal features (i.e. no controls, legend, labels, brushing, transitions, etc.)
@@ -299,7 +299,7 @@ class ViolinPlot {
 		if (this.config.term2) terms.push(this.config.term2)
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
-			if (t.term.type == 'integer' || t.term.type == 'float') {
+			if (isNumeric(t.term)) {
 				const data = await this.app.vocabApi.getDescrStats(t.id, this.state.termfilter.filter, this.config.settings)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
@@ -311,6 +311,7 @@ class ViolinPlot {
 		const { term, term2, settings } = this.config
 		const s = this.settings
 		const arg = {
+			tw: term,
 			filter: this.state.termfilter.filter,
 			svgw: s.svgw / window.devicePixelRatio,
 			orientation: s.orientation,
@@ -341,10 +342,10 @@ class ViolinPlot {
 				// scale the data on the server-side
 				arg.scale = term.q.scale
 			}
-		} else if ((term.term.type === 'float' || term.term.type === 'integer') && term.q.mode === 'continuous') {
+		} else if (isNumeric(term.term) && term.q.mode === 'continuous') {
 			arg.term = term
 			if (term2) arg.divideTw = term2
-		} else if ((term2?.term?.type === 'float' || term2?.term?.type === 'integer') && term2.q.mode === 'continuous') {
+		} else if (isNumeric(term2?.term) && term2.q.mode === 'continuous') {
 			if (term2) arg.termid = term2.id
 			arg.divideTw = term
 		} else {

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -18,7 +18,7 @@ const useCases = {
 	summary: [TermTypeGroups.DICTIONARY_VARIABLES],
 	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION, TermTypeGroups.GENE_EXPRESSION],
 	violin: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
-	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION], //This case covers dynamic scatters with coordinates from numeric terms
+	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION], //This case covers scaleBy and dynamic scatters with coordinates from numeric terms
 	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],
 	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES], //Later on can support other term types like snplocus, snplst, geneVariant
 	survival: [TermTypeGroups.DICTIONARY_VARIABLES],

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -18,7 +18,7 @@ const useCases = {
 	summary: [TermTypeGroups.DICTIONARY_VARIABLES],
 	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	violin: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
-	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES], //This case covers dynamic scatters with coordinates from numeric terms
+	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION], //This case covers dynamic scatters with coordinates from numeric terms
 	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],
 	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES], //Later on can support other term types like snplocus, snplst, geneVariant
 	survival: [TermTypeGroups.DICTIONARY_VARIABLES],
@@ -37,7 +37,8 @@ export const typeGroup = {
 	survival: TermTypeGroups.DICTIONARY_VARIABLES,
 	geneVariant: TermTypeGroups.MUTATION_CNV_FUSION,
 	snplst: TermTypeGroups.SNP_LIST,
-	snplocus: TermTypeGroups.SNP_LOCUS
+	snplocus: TermTypeGroups.SNP_LOCUS,
+	geneExpression: TermTypeGroups.GENE_EXPRESSION
 }
 
 export class TermTypeSearch {
@@ -134,39 +135,37 @@ export class TermTypeSearch {
 				// }
 				if (state.usecase.target == 'regression' && type == TermTypes.GENE_VARIANT) {
 					if (state.usecase.detail == 'independent')
-						this.tabs.push({ label, callback: () => this.setTermTypeGroup(termTypeGroup), termTypeGroup })
+						this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
 					continue
 				}
 				//In sampleScatter geneVariant is only allowed if detail is not numeric, like when building a dynamic scatter
 				if (state.usecase.target == 'sampleScatter' && type == TermTypes.GENE_VARIANT) {
 					if (state.usecase.detail != 'numeric')
-						this.tabs.push({ label, callback: () => this.setTermTypeGroup(termTypeGroup), termTypeGroup })
+						this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
 					continue
 				}
 				if (state.usecase.target == 'matrix' && state.usecase.detail == 'termgroups' && type == TermTypes.GENE_VARIANT)
 					continue //Not supported yet to select multiple geneVariants
 				//In most cases the target is enough to know what terms are allowed
 				if (!state.usecase.target || useCases[state.usecase.target]?.includes(termTypeGroup))
-					this.tabs.push({ label, callback: () => this.setTermTypeGroup(termTypeGroup), termTypeGroup })
+					this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
 			}
 		}
 	}
 
-	async setTermTypeGroup(termTypeGroup) {
+	async setTermTypeGroup(type, termTypeGroup) {
 		await this.app.dispatch({ type: 'set_term_type_group', value: termTypeGroup })
 		const tab = this.tabs.find(tab => tab.termTypeGroup == termTypeGroup)
 		const holder = tab.contentHolder
 		holder.selectAll('*').remove()
 
 		if (tab.termTypeGroup != TermTypeGroups.DICTIONARY_VARIABLES) {
-			const handler = this.handlerByType['geneVariant']
-			if (tab.termTypeGroup == TermTypeGroups.MUTATION_CNV_FUSION)
-				await handler.init({
-					holder,
-					genomeObj: this.genomeObj,
-					callback: term => this.selectTerm(term)
-				})
-			//Add other cases here like snplst, snplocus, etc
+			const handler = this.handlerByType[type]
+			await handler.init({
+				holder,
+				genomeObj: this.genomeObj,
+				callback: term => this.selectTerm(term)
+			})
 		}
 	}
 	//This callback will be called by the handlers when a term is selected

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -16,7 +16,7 @@ const useCases = {
 	filter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	dictionary: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	summary: [TermTypeGroups.DICTIONARY_VARIABLES],
-	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION, TermTypeGroups.GENE_EXPRESSION],
+	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	violin: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION], //This case covers scaleBy and dynamic scatters with coordinates from numeric terms
 	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -23,7 +23,7 @@ const useCases = {
 	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES], //Later on can support other term types like snplocus, snplst, geneVariant
 	survival: [TermTypeGroups.DICTIONARY_VARIABLES],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
-	default: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION, TermTypeGroups.GENE_EXPRESSION],
+	default: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	regression: [TermTypeGroups.DICTIONARY_VARIABLES]
 }
 

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -98,12 +98,7 @@ export class TermTypeSearch {
 		return {
 			termTypeGroup: appState.termTypeGroup,
 			usecase: appState.tree.usecase,
-			isVisible: !appState.submenu.term,
-			selectedTerms: appState.selectedTerms,
-			cohortStr:
-				appState.activeCohort == -1 || !appState.termdbConfig.selectCohort
-					? ''
-					: appState.termdbConfig.selectCohort.values[appState.activeCohort].keys.slice().sort().join(',')
+			isVisible: !appState.submenu.term
 		}
 	}
 

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -16,14 +16,14 @@ const useCases = {
 	filter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	dictionary: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	summary: [TermTypeGroups.DICTIONARY_VARIABLES],
-	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
+	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION, TermTypeGroups.GENE_EXPRESSION],
 	violin: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
 	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION], //This case covers dynamic scatters with coordinates from numeric terms
 	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],
 	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES], //Later on can support other term types like snplocus, snplst, geneVariant
 	survival: [TermTypeGroups.DICTIONARY_VARIABLES],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
-	default: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
+	default: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION, TermTypeGroups.GENE_EXPRESSION],
 	regression: [TermTypeGroups.DICTIONARY_VARIABLES]
 }
 
@@ -107,7 +107,7 @@ export class TermTypeSearch {
 			const termTypeGroup = typeGroup[type]
 			let label = termTypeGroup
 			if (type == TermTypes.GENE_VARIANT) {
-				const labels = []
+				const labels: string[] = []
 				if (this.app.vocabApi.termdbConfig.queries.snvindel) labels.push('Mutation')
 				if (this.app.vocabApi.termdbConfig.queries.cnv) labels.push('CNV')
 				if (this.app.vocabApi.termdbConfig.queries.svfusion) labels.push('Fusion')
@@ -158,6 +158,7 @@ export class TermTypeSearch {
 			const handler = this.handlerByType[type]
 			await handler.init({
 				holder,
+				app: this.app,
 				genomeObj: this.genomeObj,
 				callback: term => this.selectTerm(term)
 			})

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -447,7 +447,6 @@ export class TermdbVocab extends Vocab {
 			arg,
 			_body
 		)
-		console.log('getViolinPlotData', body)
 		if (body.filter) body.filter = getNormalRoot(body.filter)
 		const d = await dofetch3('termdb/violin', { headers, body })
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -453,6 +453,28 @@ export class TermdbVocab extends Vocab {
 		return d
 	}
 
+	async getGeneExpViolinPlotData(arg, _body = {}) {
+		// the violin plot may still render when not in session,
+		// but not have an option to list samples
+		const headers = this.mayGetAuthHeaders('termdb')
+		const body = Object.assign(
+			{
+				getGeneExpressionData: 1,
+				genome: this.vocab.genome,
+				dslabel: this.vocab.dslabel,
+				isKDE: arg.isKDE || true,
+				ticks: arg.ticks || 20,
+				svgw: arg.svgw || 200
+			},
+			arg,
+			_body
+		)
+		if (body.filter) body.filter = getNormalRoot(body.filter)
+		const d = await dofetch3('termdb/geneExpViolin', { headers, body })
+
+		return d
+	}
+
 	async getPercentile(term_id, percentile_lst, filter) {
 		// for a numeric term, convert a percentile to an actual value, with respect to a given filter
 		if (percentile_lst.find(p => !Number.isInteger(p))) throw 'non-integer percentiles found'

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -447,6 +447,7 @@ export class TermdbVocab extends Vocab {
 			arg,
 			_body
 		)
+		console.log('getViolinPlotData', body)
 		if (body.filter) body.filter = getNormalRoot(body.filter)
 		const d = await dofetch3('termdb/violin', { headers, body })
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -433,6 +433,7 @@ export class TermdbVocab extends Vocab {
 		const body = Object.assign(
 			{
 				getViolinPlotData: 1,
+				termid: arg.term?.id,
 				genome: this.vocab.genome,
 				dslabel: this.vocab.dslabel,
 				embedder: window.location.hostname,

--- a/client/termdb/handlers/geneExpression.ts
+++ b/client/termdb/handlers/geneExpression.ts
@@ -1,11 +1,12 @@
 import { Menu } from '#dom/menu'
 import { addGeneSearchbox } from '#dom/genesearch'
-import { TermTypes } from '../../shared/common.js'
+import { TermTypes } from '#shared/common.js'
 export class SearchHandler {
 	callback: any
-
+	app: any
 	init(opts) {
 		this.callback = opts.callback
+		this.app = opts.app
 		const geneSearch = addGeneSearchbox({
 			tip: new Menu({ padding: '0px' }),
 			genome: opts.genomeObj,
@@ -17,7 +18,8 @@ export class SearchHandler {
 		})
 	}
 
-	async selectGene(name) {
-		if (name) this.callback({ id: name, name, gene: name, type: TermTypes.GENE_EXPRESSION })
+	async selectGene(gene) {
+		if (!gene) throw new Error('No gene selected')
+		this.callback({ gene, type: TermTypes.GENE_EXPRESSION, name: gene })
 	}
 }

--- a/client/termdb/handlers/geneExpression.ts
+++ b/client/termdb/handlers/geneExpression.ts
@@ -20,6 +20,6 @@ export class SearchHandler {
 
 	async selectGene(gene) {
 		if (!gene) throw new Error('No gene selected')
-		this.callback({ gene, type: TermTypes.GENE_EXPRESSION, name: gene })
+		this.callback({ id: gene, gene, type: TermTypes.GENE_EXPRESSION, name: gene })
 	}
 }

--- a/client/termdb/handlers/geneExpression.ts
+++ b/client/termdb/handlers/geneExpression.ts
@@ -1,0 +1,23 @@
+import { Menu } from '#dom/menu'
+import { addGeneSearchbox } from '#dom/genesearch'
+import { TermTypes } from '../../shared/common.js'
+export class SearchHandler {
+	callback: any
+
+	init(opts) {
+		this.callback = opts.callback
+		const geneSearch = addGeneSearchbox({
+			tip: new Menu({ padding: '0px' }),
+			genome: opts.genomeObj,
+			row: opts.holder,
+			geneOnly: true,
+			callback: () => this.selectGene(geneSearch.geneSymbol),
+			hideHelp: true,
+			focusOff: true
+		})
+	}
+
+	async selectGene(name) {
+		if (name) this.callback({ id: name, name, gene: name, type: TermTypes.GENE_EXPRESSION })
+	}
+}

--- a/client/termdb/handlers/geneVariant.ts
+++ b/client/termdb/handlers/geneVariant.ts
@@ -1,9 +1,6 @@
 import { Menu } from '#dom/menu'
 import { addGeneSearchbox } from '#dom/genesearch'
 
-const idPrefix = `_geneVariant_AUTOID_${+new Date()}_`
-let id = 0
-
 export class SearchHandler {
 	callback: any
 
@@ -20,11 +17,9 @@ export class SearchHandler {
 	}
 
 	async selectGene(geneSearch) {
-		// TODO: set term.id=term.name
-		// TODO: term.id should be required
 		if (geneSearch.geneSymbol) {
 			this.callback({
-				id: idPrefix + id++,
+				id: geneSearch.geneSymbol,
 				gene: geneSearch.geneSymbol,
 				name: geneSearch.geneSymbol,
 				type: 'geneVariant'
@@ -32,7 +27,8 @@ export class SearchHandler {
 		} else if (geneSearch.chr && geneSearch.start && geneSearch.stop) {
 			const { chr, start, stop } = geneSearch
 			// name should be 1-based coordinate
-			this.callback({ id: idPrefix + id++, chr, start, stop, name: `${chr}:${start + 1}-${stop}`, type: 'geneVariant' })
+			const name = `${chr}:${start + 1}-${stop}`
+			this.callback({ id: name, chr, start, stop, name, type: 'geneVariant' })
 		} else {
 			throw 'no gene or position specified'
 		}

--- a/client/termdb/search.js
+++ b/client/termdb/search.js
@@ -66,15 +66,23 @@ class TermSearch {
 		}
 	}
 
-	async main() {
-		// show/hide search input from the tree
+	isTermTypeSupported() {
 		const termTypeGroup = this.state.termTypeGroup
+
 		if (
 			termTypeGroup == TermTypeGroups.SNP_LIST ||
 			termTypeGroup == TermTypeGroups.SNP_LOCUS ||
 			termTypeGroup == TermTypeGroups.MUTATION_SIGNATURE ||
-			termTypeGroup == TermTypeGroups.MUTATION_CNV_FUSION
-		) {
+			termTypeGroup == TermTypeGroups.MUTATION_CNV_FUSION ||
+			termTypeGroup == TermTypeGroups.GENE_EXPRESSION
+		)
+			return false
+		return true
+	}
+
+	async main() {
+		// show/hide search input from the tree
+		if (!this.isTermTypeSupported()) {
 			this.dom.holder.style('display', 'none') //These views will have their own UI
 			return
 		}

--- a/client/termdb/test/vocabulary.integration.spec.js
+++ b/client/termdb/test/vocabulary.integration.spec.js
@@ -402,7 +402,7 @@ tape('getTdbDataUrl()', async test => {
 	result = termdbVocabApi.getTdbDataUrl(opts)
 	test.equal(
 		result,
-		`/termdb?embedder=${window.location.hostname}&term1_id=agedx&term1_q=%7B%22id%22%3A%22agedx%22%2C%22name%22%3A%22Age%20at%20Cancer%20Diagnosis%22%2C%22unit%22%3A%22Years%22%2C%22type%22%3A%22float%22%2C%22bins%22%3A%7B%22label_offset%22%3A1%2C%22default%22%3A%7B%22type%22%3A%22regular-bin%22%2C%22label_offset%22%3A1%2C%22bin_size%22%3A3%2C%22startinclusive%22%3Atrue%2C%22first_bin%22%3A%7B%22startunbounded%22%3Atrue%2C%22stop%22%3A2%7D%7D%2C%22less%22%3A%7B%22type%22%3A%22regular-bin%22%2C%22label_offset%22%3A1%2C%22bin_size%22%3A5%2C%22startinclusive%22%3Atrue%2C%22first_bin%22%3A%7B%22startunbounded%22%3Atrue%2C%22stop%22%3A5%7D%2C%22last_bin%22%3A%7B%22stopunbounded%22%3Atrue%2C%22start%22%3A15%7D%7D%7D%2C%22isleaf%22%3Atrue%7D&genome=hg38-test&dslabel=TermdbTest`,
+		`/termdb?embedder=${window.location.hostname}&term1_$id=undefined&term1_id=agedx&term1_q=%7B%22id%22%3A%22agedx%22%2C%22name%22%3A%22Age%20at%20Cancer%20Diagnosis%22%2C%22unit%22%3A%22Years%22%2C%22type%22%3A%22float%22%2C%22bins%22%3A%7B%22label_offset%22%3A1%2C%22default%22%3A%7B%22type%22%3A%22regular-bin%22%2C%22label_offset%22%3A1%2C%22bin_size%22%3A3%2C%22startinclusive%22%3Atrue%2C%22first_bin%22%3A%7B%22startunbounded%22%3Atrue%2C%22stop%22%3A2%7D%7D%2C%22less%22%3A%7B%22type%22%3A%22regular-bin%22%2C%22label_offset%22%3A1%2C%22bin_size%22%3A5%2C%22startinclusive%22%3Atrue%2C%22first_bin%22%3A%7B%22startunbounded%22%3Atrue%2C%22stop%22%3A5%7D%2C%22last_bin%22%3A%7B%22stopunbounded%22%3Atrue%2C%22start%22%3A15%7D%7D%7D%2C%22isleaf%22%3Atrue%7D&genome=hg38-test&dslabel=TermdbTest`,
 		message
 	)
 

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -26,16 +26,14 @@ export async function getHandler(self) {
 }
 
 export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
-	if (!tw.q.mode) {
-		if (!(defaultQ as null) || (defaultQ as NumericQ).mode) (tw.q as NumericQ).mode = 'continuous'
-	}
 	if (!tw.term.bins) {
 		const d = await vocabApi.getGeneExpViolinPlotData({ gene: tw.term.gene })
-		tw.q = structuredClone(d.bins.default)
+		tw.q = structuredClone(d.bins.default) //we should not overwrite the default
+		tw.q.mode = 'continuous'
 		tw.term.bins = d.bins
-	}
-	tw.term.id = tw.term.gene //solve id!!
+	} else if (!tw.q.mode) tw.q.mode = 'continuous'
 
+	tw.term.id = tw.term.gene //solve id!!
 	return tw
 }
 

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -18,6 +18,24 @@ importSubtype()
     resuable try/catch block for import statement
 */
 
+const bins = {
+	default: {
+		mode: 'discrete',
+		type: 'regular-bin',
+		bin_size: 10,
+		startinclusive: false,
+		stopinclusive: true,
+		first_bin: {
+			startunbounded: true,
+			stop: 10
+		},
+		last_bin: {
+			start: 100,
+			stopunbounded: true
+		}
+	}
+}
+
 export async function getHandler(self) {
 	const numEditVers = self.opts.numericEditMenuVersion as string[]
 	const subtype = numEditVers.length > 1 ? 'toggle' : numEditVers[0] // defaults to 'discrete'
@@ -30,26 +48,11 @@ export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ:
 		if (!(defaultQ as null) || (defaultQ as NumericQ).mode) (tw.q as NumericQ).mode = 'discrete'
 	}
 	const subtype = tw.term.type == TermTypes.GENE_EXPRESSION ? 'toggle' : tw.q.mode
-	tw.term.bins = {
-		default: {
-			mode: 'discrete',
-			type: 'regular-bin',
-			bin_size: 10,
-			startinclusive: false,
-			stopinclusive: true,
-			first_bin: {
-				startunbounded: true,
-				stop: 10
-			},
-			last_bin: {
-				start: 100,
-				stopunbounded: true
-			}
-		}
-	}
-	console.log(tw)
-	//const _ = await importSubtype(subtype)
-	return tw //await _.fillTW(tw, vocabApi, defaultQ)
+	tw.q.bin_size = 10
+	tw.term.bins = bins
+	tw.term.id = tw.term.gene //the id should be the gene so that the edit works when generating the density plot
+	tw.id = tw.term.gene
+	return tw
 }
 
 async function importSubtype(subtype: string | undefined) {

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -27,7 +27,7 @@ export async function getHandler(self) {
 
 export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
 	if (!tw.term.bins) {
-		const d = await vocabApi.getGeneExpViolinPlotData({ gene: tw.term.gene })
+		const d = await vocabApi.getGeneExpViolinPlotData({ termid: tw.term.id }) //the id it is the gene
 		tw.q = structuredClone(d.bins.default) //we should not overwrite the default
 		tw.q.mode = 'continuous'
 		tw.term.bins = d.bins

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -22,16 +22,12 @@ const bins = {
 	default: {
 		mode: 'discrete',
 		type: 'regular-bin',
-		bin_size: 10,
+		bin_size: 1,
 		startinclusive: false,
 		stopinclusive: true,
 		first_bin: {
 			startunbounded: true,
-			stop: 10
-		},
-		last_bin: {
-			start: 100,
-			stopunbounded: true
+			stop: 0
 		}
 	}
 }
@@ -48,7 +44,7 @@ export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ:
 		if (!(defaultQ as null) || (defaultQ as NumericQ).mode) (tw.q as NumericQ).mode = 'discrete'
 	}
 	const subtype = tw.term.type == TermTypes.GENE_EXPRESSION ? 'toggle' : tw.q.mode
-	tw.q.bin_size = 10
+	tw.q = bins
 	tw.term.bins = bins
 	tw.term.id = tw.term.gene //the id should be the gene so that the edit works when generating the density plot
 	tw.id = tw.term.gene

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -31,7 +31,8 @@ export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ:
 		tw.q = structuredClone(d.bins.default) //we should not overwrite the default
 		tw.q.mode = 'continuous'
 		tw.term.bins = d.bins
-	} else if (!tw.q.mode) tw.q.mode = 'continuous'
+	}
+	tw.q.mode = 'continuous'
 
 	tw.term.id = tw.term.gene //solve id!!
 	return tw

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -18,20 +18,6 @@ importSubtype()
     resuable try/catch block for import statement
 */
 
-const bins = {
-	default: {
-		mode: 'discrete',
-		type: 'regular-bin',
-		bin_size: 1,
-		startinclusive: false,
-		stopinclusive: true,
-		first_bin: {
-			startunbounded: true,
-			stop: 0
-		}
-	}
-}
-
 export async function getHandler(self) {
 	const numEditVers = self.opts.numericEditMenuVersion as string[]
 	const subtype = numEditVers.length > 1 ? 'toggle' : numEditVers[0] // defaults to 'discrete'
@@ -41,13 +27,15 @@ export async function getHandler(self) {
 
 export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
 	if (!tw.q.mode) {
-		if (!(defaultQ as null) || (defaultQ as NumericQ).mode) (tw.q as NumericQ).mode = 'discrete'
+		if (!(defaultQ as null) || (defaultQ as NumericQ).mode) (tw.q as NumericQ).mode = 'continuous'
 	}
-	const subtype = tw.term.type == TermTypes.GENE_EXPRESSION ? 'toggle' : tw.q.mode
-	tw.q = bins
-	tw.term.bins = bins
-	tw.term.id = tw.term.gene //the id should be the gene so that the edit works when generating the density plot
-	tw.id = tw.term.gene
+	if (!tw.term.bins) {
+		const d = await vocabApi.getGeneExpViolinPlotData({ gene: tw.term.gene })
+		tw.q = structuredClone(d.bins.default)
+		tw.term.bins = d.bins
+	}
+	tw.term.id = tw.term.gene //solve id!!
+
 	return tw
 }
 

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -1,0 +1,165 @@
+import { select } from 'd3-selection'
+import { mclass, dt2label } from '#shared/common'
+import { VocabApi, GeneExpressionTermSettingInstance, GeneExpressionTW } from '#shared/types/index'
+
+/* 
+instance attributes
+
+self.term{}
+	.name: str, not really used
+	.type: "geneExpression"
+*/
+
+//TODO move to common.ts??? Corresponds to client/shared/common.js
+type MClassEntry = { label: string; color: string; dt: number; desc: string; key: string }
+type GroupsEntry = { name: string; items: MClassEntry[] }
+
+// self is the termsetting instance
+export function getHandler(self: GeneExpressionTermSettingInstance) {
+	return {
+		getPillName() {
+			return self.term.name
+		},
+
+		getPillStatus() {
+			return { text: self.q.exclude?.length ? 'matching variants' : 'any variant class' }
+		},
+
+		//validateQ(data: Q) {},
+
+		async showEditMenu(div: Element) {
+			await makeEditMenu(self, div)
+		}
+	}
+}
+
+const idPrefix = `_geneExpression_AUTOID_${+new Date()}_`
+let id = 0
+const namePrefix = `_geneExpression_AUTONAME_${+new Date()}_`
+let name = 0
+
+export function fillTW(tw: GeneExpressionTW, vocabApi?: VocabApi) {
+	if (!('id' in tw)) tw.id = idPrefix + id++
+	if (!tw.term.name) tw.term.name = namePrefix + name++
+	if (!tw.term.gene && !(tw.term.chr && tw.term.start && tw.term.stop)) throw 'no gene or position specified'
+
+	{
+		// TODO: how should 'tw.term.name' be handled here?
+		// apply optional ds-level configs for this specific term
+		const c = vocabApi?.termdbConfig.customTwQByType?.geneExpression
+		if (c && tw.term.name) {
+			//if (c) valid js code but `&& tw.term.name` required to avoid type error
+			// order of overide: 1) do not override existing settings in tw.q{} 2) c.byGene[thisGene] 3) c.default{}
+			Object.assign(tw.q, c.default || {}, c.byGene?.[tw.term.name] || {}, tw.q)
+		}
+	}
+
+	// cnv cutoffs; if the attributes are missing from q{}, add
+	if ('cnvMaxLength' in tw.q) {
+		// has cutoff
+		if (!Number.isInteger(tw.q.cnvMaxLength)) throw 'cnvMaxLength is not integer'
+		// cnvMaxLength value<=0 will not filter by length
+	} else {
+		tw.q.cnvMaxLength = 2000000
+	}
+	// cutoffs on cnv quantifications, subject to change!
+	if ('cnvGainCutoff' in tw.q) {
+		if (!Number.isFinite(tw.q.cnvGainCutoff)) throw 'cnvGainCutoff is not finite'
+		if (tw.q.cnvGainCutoff && tw.q.cnvGainCutoff < 0) throw 'cnvGainCutoff is not positive'
+		// =0 for no filtering gains
+	} else {
+		tw.q.cnvGainCutoff = 0.2
+	}
+	if ('cnvLossCutoff' in tw.q) {
+		if (!Number.isFinite(tw.q.cnvLossCutoff)) throw 'cnvLossCutoff is not finite'
+		if (tw.q.cnvLossCutoff && tw.q.cnvLossCutoff > 0) throw 'cnvLossCutoff is not negative'
+		// =0 for not filtering losses
+	} else {
+		tw.q.cnvLossCutoff = -0.2
+	}
+}
+
+function makeEditMenu(self: GeneExpressionTermSettingInstance, _div: any) {
+	const div = _div.append('div').style('padding', '5px').style('cursor', 'pointer')
+
+	div.append('div').style('font-size', '1.2rem').text(self.term.name)
+	const applyBtn = div
+		.append('button')
+		.property('disabled', true)
+		.style('margin-top', '3px')
+		.text('Apply')
+		.on('click', () => {
+			self.runCallback({
+				term: JSON.parse(JSON.stringify(self.term)),
+				q: { exclude }
+			})
+		})
+
+	const exclude = self.q?.exclude?.slice().sort() || []
+	const origExclude = JSON.stringify(exclude)
+	const mclasses = Object.values(mclass)
+
+	const dtNums = [...new Set(mclasses.map((c: any) => c.dt))].sort() as number[] // must add type "any" to avoid tsc err
+
+	const groups: GroupsEntry[] = []
+	for (const dt of dtNums) {
+		const items = mclasses.filter((c: any) => c.dt === dt) as MClassEntry[] // must add type "any" to avoid tsc err
+
+		if (items.length) {
+			groups.push({
+				name: dt2label[dt],
+				items
+			})
+		}
+	}
+
+	div
+		.append('div')
+		.selectAll(':scope>div')
+		.data(groups, (d: GroupsEntry) => d.name)
+		.enter()
+		.append('div')
+		.style('max-width', '500px')
+		.style('margin', '5px')
+		.style('padding-left', '5px')
+		.style('text-align', 'left')
+		.each(function (this: any, grp: GroupsEntry) {
+			const div = select(this)
+			div.append('div').style('font-weight', 600).html(grp.name)
+			//.on('click', )
+
+			div
+				.selectAll(':scope>div')
+				.data(grp.items, (d: any) => d.label)
+				.enter()
+				.append('div')
+				.style('margin', '5px')
+				.style('display', 'inline-block')
+				.on('click', function (this: any, event: Event, d: MClassEntry) {
+					const i = exclude.indexOf(d.key)
+					if (i == -1) exclude.push(d.key)
+					else exclude.splice(i, 1)
+					select(this.lastChild).style('text-decoration', i == -1 ? 'line-through' : '')
+					applyBtn.property('disabled', JSON.stringify(exclude) === origExclude)
+				})
+				.each(function (this: any, d: MClassEntry) {
+					const itemDiv = select(this)
+					itemDiv
+						.append('div')
+						.style('display', 'inline-block')
+						.style('width', '1rem')
+						.style('height', '1rem')
+						.style('border', '1px solid #ccc')
+						.style('background-color', d.color)
+						.html('&nbsp;')
+
+					itemDiv
+						.append('div')
+						.style('display', 'inline-block')
+						.style('margin-left', '3px')
+						.style('text-decoration', exclude.includes(d.key) ? 'line-through' : '')
+						.style('cursor', 'pointer')
+						.text(d.label)
+				})
+		})
+}

--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -57,7 +57,7 @@ export function getHandler(self) {
 				.html('Getting distribution data ...<br/>')
 			const d = await self.vocabApi.getViolinPlotData(
 				{
-					termid: self.term.id,
+					term: self.term,
 					filter: self.filter,
 					svgw: self.num_obj.plot_size.width
 				},

--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -57,7 +57,7 @@ export function getHandler(self) {
 				.html('Getting distribution data ...<br/>')
 			const d = await self.vocabApi.getViolinPlotData(
 				{
-					term: self.term,
+					termid: self.term.id,
 					filter: self.filter,
 					svgw: self.num_obj.plot_size.width
 				},

--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -58,7 +58,7 @@ export function getHandler(self) {
 			const d = await self.vocabApi.getViolinPlotData(
 				{
 					termid: self.term.id,
-					gene: self.term.gene,
+					termType: self.term.type,
 					filter: self.filter,
 					svgw: self.num_obj.plot_size.width
 				},

--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -58,6 +58,7 @@ export function getHandler(self) {
 			const d = await self.vocabApi.getViolinPlotData(
 				{
 					termid: self.term.id,
+					gene: self.term.gene,
 					filter: self.filter,
 					svgw: self.num_obj.plot_size.width
 				},

--- a/client/termsetting/handlers/numeric.continuous.ts
+++ b/client/termsetting/handlers/numeric.continuous.ts
@@ -45,7 +45,7 @@ export function getHandler(self) {
 			const d = await self.vocabApi.getViolinPlotData(
 				{
 					termid: self.term.id,
-					tw: { id: self.id, term: self.term, q: self.q },
+					tw: { $id: self.$id, id: self.id, term: self.term, q: self.q },
 					filter: self.filter,
 					svgw: plot_size.width / window.devicePixelRatio
 				},

--- a/client/termsetting/handlers/numeric.continuous.ts
+++ b/client/termsetting/handlers/numeric.continuous.ts
@@ -45,6 +45,7 @@ export function getHandler(self) {
 			const d = await self.vocabApi.getViolinPlotData(
 				{
 					termid: self.term.id,
+					termType: self.term.type,
 					filter: self.filter,
 					svgw: plot_size.width / window.devicePixelRatio
 				},

--- a/client/termsetting/handlers/numeric.continuous.ts
+++ b/client/termsetting/handlers/numeric.continuous.ts
@@ -45,7 +45,7 @@ export function getHandler(self) {
 			const d = await self.vocabApi.getViolinPlotData(
 				{
 					termid: self.term.id,
-					gene: self.term.gene,
+					tw: { id: self.id, term: self.term, q: self.q },
 					filter: self.filter,
 					svgw: plot_size.width / window.devicePixelRatio
 				},

--- a/client/termsetting/handlers/numeric.continuous.ts
+++ b/client/termsetting/handlers/numeric.continuous.ts
@@ -45,7 +45,7 @@ export function getHandler(self) {
 			const d = await self.vocabApi.getViolinPlotData(
 				{
 					termid: self.term.id,
-					termType: self.term.type,
+					gene: self.term.gene,
 					filter: self.filter,
 					svgw: plot_size.width / window.devicePixelRatio
 				},

--- a/client/termsetting/handlers/numeric.continuous.ts
+++ b/client/termsetting/handlers/numeric.continuous.ts
@@ -45,7 +45,7 @@ export function getHandler(self) {
 			const d = await self.vocabApi.getViolinPlotData(
 				{
 					termid: self.term.id,
-					tw: { $id: self.$id, id: self.id, term: self.term, q: self.q },
+					termType: self.term.type,
 					filter: self.filter,
 					svgw: plot_size.width / window.devicePixelRatio
 				},

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -76,7 +76,7 @@ async function showBinsMenu(self, div: any) {
 		if (!self.vocabApi) throw `Missing .vocabApi{} [numeric.discrete showBinsMenu()]`
 		const d = await self.vocabApi.getViolinPlotData(
 			{
-				termid: self.termid,
+				termid: self.term.id,
 				termType: self.term.type,
 				filter: self.filter,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -76,7 +76,8 @@ async function showBinsMenu(self, div: any) {
 		if (!self.vocabApi) throw `Missing .vocabApi{} [numeric.discrete showBinsMenu()]`
 		const d = await self.vocabApi.getViolinPlotData(
 			{
-				termid: self.term.id,
+				termid: self.termid,
+				termType: self.term.type,
 				filter: self.filter,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,
 				strokeWidth: 0.2

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -74,11 +74,11 @@ async function showBinsMenu(self, div: any) {
 	div.append('div').style('padding', '10px').style('text-align', 'center').html('Getting distribution data ...<br/>')
 	try {
 		if (!self.vocabApi) throw `Missing .vocabApi{} [numeric.discrete showBinsMenu()]`
-		console.log(self)
+
 		const d = await self.vocabApi.getViolinPlotData(
 			{
 				termid: self.term.id,
-				tw: { $id: self.$id, id: self.id, term: self.term, q: self.q },
+				termType: self.term.type,
 				filter: self.filter,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,
 				strokeWidth: 0.2

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -77,7 +77,7 @@ async function showBinsMenu(self, div: any) {
 		const d = await self.vocabApi.getViolinPlotData(
 			{
 				termid: self.term.id,
-				gene: self.term.gene,
+				tw: { id: self.id, term: self.term, q: self.q },
 				filter: self.filter,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,
 				strokeWidth: 0.2

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -74,10 +74,11 @@ async function showBinsMenu(self, div: any) {
 	div.append('div').style('padding', '10px').style('text-align', 'center').html('Getting distribution data ...<br/>')
 	try {
 		if (!self.vocabApi) throw `Missing .vocabApi{} [numeric.discrete showBinsMenu()]`
+		console.log(self)
 		const d = await self.vocabApi.getViolinPlotData(
 			{
 				termid: self.term.id,
-				tw: { id: self.id, term: self.term, q: self.q },
+				tw: { $id: self.$id, id: self.id, term: self.term, q: self.q },
 				filter: self.filter,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,
 				strokeWidth: 0.2

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -77,7 +77,7 @@ async function showBinsMenu(self, div: any) {
 		const d = await self.vocabApi.getViolinPlotData(
 			{
 				termid: self.term.id,
-				termType: self.term.type,
+				gene: self.term.gene,
 				filter: self.filter,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,
 				strokeWidth: 0.2

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -57,7 +57,7 @@ export function getHandler(self) {
 				const d = await self.vocabApi.getViolinPlotData(
 					{
 						termid: self.term.id,
-						termType: self.term.type,
+						gene: self.term.gene,
 						filter: self.filter,
 						svgw: self.num_obj.plot_size.width
 					},

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -56,7 +56,7 @@ export function getHandler(self) {
 			try {
 				const d = await self.vocabApi.getViolinPlotData(
 					{
-						termid: self.term.id,
+						tw: { $id: self.$id, id: self.id, term: self.term, q: self.q },
 						gene: self.term.gene,
 						filter: self.filter,
 						svgw: self.num_obj.plot_size.width

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -57,7 +57,7 @@ export function getHandler(self) {
 				const d = await self.vocabApi.getViolinPlotData(
 					{
 						termid: self.term.id,
-						gene: self.term.gene,
+						termType: self.term.type,
 						filter: self.filter,
 						svgw: self.num_obj.plot_size.width
 					},

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -56,7 +56,7 @@ export function getHandler(self) {
 			try {
 				const d = await self.vocabApi.getViolinPlotData(
 					{
-						termid: self.termid,
+						termid: self.term.id,
 						termType: self.term.type,
 						filter: self.filter,
 						svgw: self.num_obj.plot_size.width

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -56,7 +56,7 @@ export function getHandler(self) {
 			try {
 				const d = await self.vocabApi.getViolinPlotData(
 					{
-						tw: { $id: self.$id, id: self.id, term: self.term, q: self.q },
+						termid: self.term.id,
 						gene: self.term.gene,
 						filter: self.filter,
 						svgw: self.num_obj.plot_size.width

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -56,7 +56,8 @@ export function getHandler(self) {
 			try {
 				const d = await self.vocabApi.getViolinPlotData(
 					{
-						termid: self.term.id,
+						termid: self.termid,
+						termType: self.term.type,
 						filter: self.filter,
 						svgw: self.num_obj.plot_size.width
 					},

--- a/client/termsetting/handlers/numeric.ts
+++ b/client/termsetting/handlers/numeric.ts
@@ -28,7 +28,6 @@ export async function fillTW(tw: NumericTW, vocabApi: VocabApi, defaultQ: Numeri
 		if (!(defaultQ as null) || (defaultQ as NumericQ).mode) (tw.q as NumericQ).mode = 'discrete'
 	}
 	const subtype = tw.term.type == 'float' || tw.term.type == 'integer' ? 'toggle' : tw.q.mode
-
 	const _ = await importSubtype(subtype)
 	return await _.fillTW(tw, vocabApi, defaultQ)
 }

--- a/client/termsetting/handlers/samplelst.ts
+++ b/client/termsetting/handlers/samplelst.ts
@@ -126,11 +126,9 @@ export function getSamplelstTW(groups: any, name = 'groups', notIn = true) {
 			values: samples
 		})
 	}
-	const $id = get$id()
 	const tw = {
-		$id,
 		isAtomic: true,
-		term: { $id, name, type: 'samplelst', values },
+		term: { name, type: 'samplelst', values },
 		q: {
 			groups: qgroups,
 			groupsetting: { disabled }
@@ -165,11 +163,9 @@ export function getSamplelstTWFromIds(ids: number[]) {
 		values
 	}
 
-	const $id = get$id()
 	const tw = {
-		$id,
 		isAtomic: true,
-		term: { $id, name, type: 'samplelst', values: { [name]: { key: name, list: values } } },
+		term: { name, type: 'samplelst', values: { [name]: { key: name, list: values } } },
 		q: {
 			groups: [qgroup]
 		}

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -41,7 +41,7 @@ opts{}
 //let $id = 0
 
 export async function get$id(minTwCopy) {
-	if (!minTwCopy) return <string>`${$id++}${idSuffix}`
+	if (!minTwCopy) return null
 	delete minTwCopy.$id
 	return await digestMessage(JSON.stringify(minTwCopy))
 }

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -697,7 +697,7 @@ tape('Numerical term.bins.default.type=custom-bin', async test => {
 	}
 })
 
-tape.only('Numerical term: toggle menu - 4 options', async test => {
+tape('Numerical term: toggle menu - 4 options', async test => {
 	test.timeoutAfter(3000)
 	test.plan(9)
 

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -697,7 +697,7 @@ tape('Numerical term.bins.default.type=custom-bin', async test => {
 	}
 })
 
-tape('Numerical term: toggle menu - 4 options', async test => {
+tape.only('Numerical term: toggle menu - 4 options', async test => {
 	test.timeoutAfter(3000)
 	test.plan(9)
 

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -122,13 +122,13 @@ async function trigger_getcategories(
 	} else {
 		term = tdb.q.termjsonByOneid(q.tid)
 	}
-
+	const tw =
+		q.type == 'geneVariant'
+			? { term, q: { isAtomic: true } }
+			: { id: q.tid, term, q: q.term1_q || getDefaultQ(term, q) }
 	const arg = {
 		filter: q.filter,
-		terms:
-			q.type == 'geneVariant'
-				? [{ term, q: { isAtomic: true } }]
-				: [{ id: q.tid, term, q: q.term1_q || getDefaultQ(term, q) }],
+		terms: [tw],
 		currentGeneNames: q.currentGeneNames, // optional, from mds3 mayAddGetCategoryArgs()
 		rglst: q.rglst // optional, from mds3 mayAddGetCategoryArgs()
 	}
@@ -149,7 +149,7 @@ async function trigger_getcategories(
 		}
 		const sampleCountedFor = new Set() // if the sample is counted
 		for (const [sampleId, sampleData] of Object.entries(samples)) {
-			const key = (q.tid || q.name)! //as the request is done from the server side the results are indexed by term id or name
+			const key = tw.$id //getData indexes terms by tw.$id, that may be $id or the term id or the name
 			const values = sampleData[key].values
 			sampleCountedFor.clear()
 			/* values here is an array of result entires, one or more entries for each dt. e.g.

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -111,7 +111,7 @@ async function trigger_getcategories(
 	if (!q.tid) throw '.tid missing'
 	let term
 	if (q.type == 'geneVariant') {
-		term = { name: q.name, type: 'geneVariant', isleaf: true }
+		term = { id: q.name, name: q.name, type: 'geneVariant', isleaf: true }
 		if (q.gene) {
 			term.gene = q.gene
 		} else {
@@ -149,7 +149,8 @@ async function trigger_getcategories(
 		}
 		const sampleCountedFor = new Set() // if the sample is counted
 		for (const [sampleId, sampleData] of Object.entries(samples)) {
-			const values = sampleData[q.name].values
+			const key = (q.tid || q.name)! //as the request is done from the server side the results are indexed by term id or name
+			const values = sampleData[key].values
 			sampleCountedFor.clear()
 			/* values here is an array of result entires, one or more entries for each dt. e.g.
 			[

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -152,6 +152,7 @@ function getZscore(l: number[]) {
 export async function validate_query_geneExpression(ds: any, genome: any) {
 	const q: GeneExpressionQuery = ds.queries.geneExpression
 	if (!q) return
+	q.gene2density = {}
 
 	if (q.src == 'gdcapi') {
 		gdc_validate_query_geneExpression(ds as GeneExpressionQueryGdc, genome)

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -249,6 +249,7 @@ function getAllowedTermTypes(ds) {
 		// same logic in trigger_findterm()
 		typeSet.add('geneVariant')
 	}
+	if (ds?.queries?.geneExpression) typeSet.add('geneExpression')
 
 	return [...typeSet]
 }

--- a/server/routes/termdb.geneExpViolin.ts
+++ b/server/routes/termdb.geneExpViolin.ts
@@ -1,0 +1,53 @@
+import { trigger_getGeneExpViolinPlotData } from '#src/termdb.violin.js'
+import { getGeneExpViolinRequest, getGeneExpViolinResponse } from '#shared/types/routes/termdb.geneExpViolin.ts'
+
+export const api: any = {
+	endpoint: 'termdb/geneExpViolin',
+	methods: {
+		get: {
+			init,
+			request: {
+				typeId: 'getGeneExpViolinRequest'
+			},
+			response: {
+				typeId: 'getGeneEspViolinResponse'
+			},
+			examples: [
+				{
+					request: {
+						body: {
+							genome: 'hg38-test',
+							dslabel: 'TermdbTest',
+							gene: 'TP53'
+						}
+					},
+					response: {
+						header: { status: 200 }
+					}
+				}
+			]
+		},
+		post: {
+			alternativeFor: 'get',
+			init
+		}
+	}
+}
+
+function init({ genomes }) {
+	return async (req: any, res: any): Promise<void> => {
+		const q = req.query as getGeneExpViolinRequest
+		try {
+			const g = genomes[req.query.genome]
+			const ds = g.datasets[req.query.dslabel]
+			if (!g) throw 'invalid genome name'
+			const data = await trigger_getGeneExpViolinPlotData(req.query, null, ds, g) // as getViolinResponse
+			res.send(data as getGeneExpViolinResponse)
+		} catch (e) {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			res.send({ error: e?.message || e })
+			if (e instanceof Error && e.stack) console.log(e)
+		}
+	}
+}

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -1125,3 +1125,8 @@ export const TermTypeGroups = {
 	SNP_LIST: 'SNP List',
 	SNP_LOCUS: 'SNP Locus'
 }
+
+export function isNumeric(term) {
+	if (!term) return false
+	return term.type == TermTypes.INTEGER || term.type == TermTypes.FLOAT || term.type == TermTypes.GENE_EXPRESSION
+}

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -1130,3 +1130,9 @@ export function isNumeric(term) {
 	if (!term) return false
 	return term.type == TermTypes.INTEGER || term.type == TermTypes.FLOAT || term.type == TermTypes.GENE_EXPRESSION
 }
+
+export function isNonDictionary(type) {
+	if (!type) throw new Error('Type is not defined')
+	const types = [TermTypes.SNP_LIST, TermTypes.SNP_LOCUS, TermTypes.GENE_EXPRESSION, TermTypes.GENE_VARIANT]
+	return types.includes(type)
+}

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -1095,7 +1095,8 @@ export const CNVClasses = Object.values(mclass)
 	.filter(m => m.dt == dtcnv)
 	.map(m => m.key)
 
-//Term types should be used gradually using these constants instead of hardcoding the values, eg: type == TermTypes.CATEGORICAL instead of type == 'categorical'
+//Term types should be used gradually using these constants instead of hardcoding the values,
+// eg: type == TermTypes.CATEGORICAL instead of type == 'categorical'
 export const TermTypes = {
 	GENE_VARIANT: 'geneVariant',
 	GENE_EXPRESSION: 'geneExpression',
@@ -1105,7 +1106,8 @@ export const TermTypes = {
 	SNP_LIST: 'snplst',
 	SNP_LOCUS: 'snplocus',
 	CONDITION: 'condition',
-	SURVIVAL: 'survival'
+	SURVIVAL: 'survival',
+	SAMPLELST: 'samplelst'
 }
 
 export const TermTypeGroups = {

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -9,7 +9,8 @@ export const graphableTypes = new Set([
 	'snplst',
 	'snplocus',
 	'geneVariant',
-	'samplelst'
+	'samplelst',
+	'geneExpression'
 ])
 /*
 	isUsableTerm() will

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -306,6 +306,7 @@ type RnaseqGeneCount = {
 // the geneExpression query
 export type GeneExpressionQueryGdc = {
 	src: 'gdcapi' | string
+	gene2density?: { [index: string]: any }
 }
 
 export type GeneExpressionQueryNative = {
@@ -315,6 +316,7 @@ export type GeneExpressionQueryNative = {
 	samples?: number[]
 	nochr?: boolean
 	get?: (param: any) => void
+	gene2density?: { [index: string]: any }
 }
 export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNative
 

--- a/server/shared/types/terms/geneExpression.ts
+++ b/server/shared/types/terms/geneExpression.ts
@@ -26,6 +26,7 @@ export type GeneExpressionTW = TermWrapper & {
 
 export type GeneExpressionTerm = Term & {
 	gene?: string
+	bins?: any
 }
 
 export type GeneExpressionTermSettingInstance = TermSettingInstance & {

--- a/server/shared/types/terms/geneExpression.ts
+++ b/server/shared/types/terms/geneExpression.ts
@@ -1,0 +1,34 @@
+import { TermWrapper, BaseQ, Term } from '../termdb.ts'
+import { TermSettingInstance } from '../termsetting.ts'
+
+/*
+--------EXPORTED--------
+GeneExpressionQ
+GeneExpressionTermWrapper
+GeneExpressionTermSettingInstance
+
+*/
+
+export type GeneExpressionQ = BaseQ & {
+	// termType: 'GeneExpression'
+	cnvGainCutoff?: number
+	cnvMaxLength?: number
+	cnvMinAbsValue?: number
+	cnvLossCutoff?: number
+	exclude: any //an array maybe?
+	mode: 'continuous'
+}
+
+export type GeneExpressionTW = TermWrapper & {
+	q: GeneExpressionQ
+	term: GeneExpressionTerm
+}
+
+export type GeneExpressionTerm = Term & {
+	gene?: string
+}
+
+export type GeneExpressionTermSettingInstance = TermSettingInstance & {
+	q: GeneExpressionQ
+	term: GeneExpressionTerm
+}

--- a/server/shared/types/terms/geneExpression.ts
+++ b/server/shared/types/terms/geneExpression.ts
@@ -25,8 +25,8 @@ export type GeneExpressionTW = TermWrapper & {
 }
 
 export type GeneExpressionTerm = Term & {
-	gene?: string
-	bins?: any
+	gene: string
+	bins: any
 }
 
 export type GeneExpressionTermSettingInstance = TermSettingInstance & {

--- a/server/shared/types/terms/geneVariant.ts
+++ b/server/shared/types/terms/geneVariant.ts
@@ -23,12 +23,15 @@ export type GeneVariantTW = TermWrapper & {
 	term: GeneVariantTerm
 }
 
-export type GeneVariantTerm = Term & {
-	gene?: string
-	chr?: string
-	start?: number
-	stop?: number
-}
+export type GeneVariantTerm =
+	| (Term & {
+			chr: string
+			start: number
+			stop: number
+	  })
+	| (Term & {
+			gene: string
+	  })
 
 export type GeneVariantTermSettingInstance = TermSettingInstance & {
 	q: GeneVariantQ

--- a/server/shared/types/vocab.ts
+++ b/server/shared/types/vocab.ts
@@ -22,6 +22,7 @@ export type VocabApi = {
 	getTerms: (f: any) => any
 	getTermdbConfig: () => any
 	getViolinPlotData: (f: any, params: any) => void
+	getGeneExpViolinPlotData: (f: any) => any
 	uncacheTermQ: (term: Term, q: any) => any
 	hasVerifiedToken: () => boolean
 	tokenVerificationMessage: string

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -22,6 +22,7 @@ export function handle_request_closure(genomes) {
 		for (const i of [0, 1, 2]) {
 			const termnum = 'term' + i
 			const termnum_id = termnum + '_id'
+			const termnum_type = termnum + '_type'
 			if (typeof q[termnum_id] == 'string') {
 				q[termnum_id] = decodeURIComponent(q[termnum_id])
 			} else if (typeof q[termnum] == 'string') {

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -122,7 +122,7 @@ export async function barchart_data(q, ds, tdb) {
 				const q = map.get(i)?.q
 				const tw = map.get(i)
 				const term = tw?.term || null
-				const id = tw?.$id ? tw.$id : term?.id ? term.id : term?.name
+				const id = tw?.$id
 				if (id && data.refs.byTermId[id]?.bins) bins.push(data.refs.byTermId[id]?.bins)
 				else bins.push([])
 				if (q?.binColored) {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -353,7 +353,6 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 			// add next term value to .values[]
 			samples[sample][term_id].values.push({ key, value })
 		}
-		console.log(samples[sample])
 	}
 
 	return [samples, byTermId]

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -61,7 +61,6 @@ Returns:
 */
 
 export async function getData(q, ds, genome) {
-	console.log('terms', q.terms)
 	try {
 		validateArg(q, ds, genome)
 		return await getSampleData(q)
@@ -163,10 +162,24 @@ async function getSampleData(q) {
 				genes: [{ gene: tw.term.gene }]
 			}
 			const data = await q.ds.queries.geneExpression.get(args)
+			const bins = tw.q
 			for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
 				if (!(sampleId in samples)) samples[sampleId] = { sample: sampleId }
 				const values = data.gene2sample2value.get(tw.term.gene)
-				const value = Number(values[sampleId])
+				let value = Number(values[sampleId]).toFixed(2)
+				if (tw.q.mode == 'discrete') {
+					let bin
+					if (value < bins.first_bin.stop) bin = 0
+					else bin = parseInt((value - bins.first_bin.stop) / bins.bin_size) + 1
+					if (bin == 0) value = (bins.startinclusive ? '<= ' : '< ') + bins.first_bin.stop
+					else if (bins.startinclusive ? value >= bins.last_bin.start : value > bins.last_bin.start)
+						value = (bins.startinclusive ? '>= ' : '> ') + bins.last_bin.start
+					else {
+						const start = (bins.first_bin.stop + (bin - 1) * bins.bin_size).toFixed(2)
+						const stop = (bins.first_bin.stop + bin * bins.bin_size).toFixed(2)
+						value = start + ` to ${bins.stopinclusive ? '<= ' : '< '}` + stop
+					}
+				}
 				samples[sampleId][tw.term.id] = { key: value, value }
 			}
 			/** pp filter */

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -112,7 +112,7 @@ async function getSampleData(q) {
 	const sampleFilterSet = await mayGetSampleFilterSet(q, nonDictTerms) // conditionally returns a set of sample ids
 
 	for (const tw of nonDictTerms) {
-		const $id = tw.$id || tw.term.id
+		if (!tw.$id) tw.$id = tw.term.id || tw.term.name //for tests and backwards compatibility
 		// for each non dictionary term type
 		// query sample data with its own method and append results to "samples"
 		if (tw.term.type == 'geneVariant') {
@@ -148,7 +148,7 @@ async function getSampleData(q) {
 				const snp2value = {}
 				for (const [snp, o] of value.id2value) snp2value[snp] = o.value
 
-				samples[sampleId][tw.$id || tw.term.id] = snp2value
+				samples[sampleId][tw.$id] = snp2value
 			}
 		} else if (tw.term.type == TermTypes.GENE_EXPRESSION) {
 			const args = {
@@ -317,7 +317,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	).catch(console.error)
 
 	// for "samplelst" term, term.id is missing and must use term.name
-	values.push(...termWrappers.map(tw => tw.$id))
+	values.push(...termWrappers.map(tw => tw.$id || tw.term.id || tw.term.name))
 	const sql = `WITH
 		${filter ? filter.filters + ',' : ''}
 		${CTEs.map(t => t.sql).join(',\n')}
@@ -353,6 +353,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 			// add next term value to .values[]
 			samples[sample][term_id].values.push({ key, value })
 		}
+		console.log(samples[sample])
 	}
 
 	return [samples, byTermId]

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -61,6 +61,7 @@ Returns:
 */
 
 export async function getData(q, ds, genome) {
+	console.log('terms', q.terms)
 	try {
 		validateArg(q, ds, genome)
 		return await getSampleData(q)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -180,7 +180,7 @@ async function getSampleData(q) {
 						value = start + ` to ${bins.stopinclusive ? '<= ' : '< '}` + stop
 					}
 				}
-				samples[sampleId][tw.term.id] = { key: value, value }
+				samples[sampleId][tw.$id] = { key: value, value }
 			}
 			/** pp filter */
 		} else {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -151,7 +151,6 @@ async function getSampleData(q) {
 				samples[sampleId][tw.$id || tw.term.id] = snp2value
 			}
 		} else if (tw.term.type == TermTypes.GENE_EXPRESSION) {
-			const getGeneExpression = q.ds.queries.geneExpression.get
 			const args = {
 				genome: q.ds.genome,
 				dslabel: q.ds.label,
@@ -162,7 +161,7 @@ async function getSampleData(q) {
 				dataType: 3,
 				genes: [{ gene: tw.term.gene }]
 			}
-			const data = await getGeneExpression(args)
+			const data = await q.ds.queries.geneExpression.get(args)
 			for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
 				if (!(sampleId in samples)) samples[sampleId] = { sample: sampleId }
 				const values = data.gene2sample2value.get(tw.term.gene)

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -225,7 +225,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 					isLast = true
 				}
 			} else {
-				const field = q.divideByTW.$id || q.divideByTW.term.id
+				const field = q.divideByTW.$id
 				const key = dbSample[field]?.key
 				if (key == null) continue
 				divideBy = q.divideByTW.term.values?.[key]?.label || key
@@ -249,7 +249,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 			sample.category = 'Default'
 		} else {
 			if (q.colorTW?.q?.mode === 'continuous') {
-				if (dbSample) sample.category = dbSample[q.colorTW.$id || q.colorTW.term.id].value
+				if (dbSample) sample.category = dbSample[q.colorTW.$id].value
 			} else processSample(dbSample, sample, q.colorTW, results[divideBy].colorMap, 'category')
 		}
 
@@ -308,7 +308,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 }
 
 function hasValue(dbSample, tw) {
-	const key = dbSample?.[tw?.$id || tw?.term.id]?.key
+	const key = dbSample?.[tw?.$id]?.key
 	const hasKey = key !== undefined
 	if (!hasKey) console.log(JSON.stringify(dbSample) + ' missing value for the term ' + JSON.stringify(tw))
 	return hasKey
@@ -318,7 +318,7 @@ function processSample(dbSample, sample, tw, categoryMap, category) {
 	let value = null
 	if (tw.term.type == 'geneVariant') assignGeneVariantValue(dbSample, sample, tw, categoryMap, category)
 	else {
-		value = dbSample?.[tw.$id || tw.term.id]?.key
+		value = dbSample?.[tw.$id]?.key
 		if (tw.term.values?.[value]?.label) {
 			value = tw.term.values?.[value]?.label
 			sample.hidden[category] = tw.q.hiddenValues ? value in tw.q.hiddenValues : false

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -239,7 +239,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 		if (!q.divideByTW) sample.z = 0
 		if (!q.scaleDotTW) sample.scale = 1
 		else {
-			const value = dbSample?.[q.scaleDotTW.id]?.key
+			const value = dbSample?.[q.scaleDotTW.id || q.scaleDotTW.term.name]?.key
 			if (!value || !isComputable(q.scaleDotTW.term, value)) continue
 			sample.scale = value
 		}
@@ -392,6 +392,22 @@ function order(map, tw, refs) {
 		entries.sort((a, b) => {
 			if (a[0] < b[0]) return -1
 			if (a[0] > b[0]) return 1
+			return 0
+		})
+	} else if (tw.term.type == TermTypes.GENE_EXPRESSION) {
+		entries = Object.entries(map)
+		const floatRegex = /^[+-]?\d+(\.\d+)?/
+		entries.sort((a, b) => {
+			if (a[0].startsWith('<')) return -1
+			if (a[0].startsWith('>')) return 1
+			let num1 = a[0].match(floatRegex)
+			let num2 = b[0].match(floatRegex)
+			if (!num1 || !num2) return -1
+			num1 = parseFloat(num1[0])
+			num2 = parseFloat(num2[0])
+
+			if (num1 < num2) return -1
+			if (num1 > num2) return 1
 			return 0
 		})
 	} else if (!refs?.byTermId[tw.term.id]?.bins) {

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -3,12 +3,11 @@ import path from 'path'
 import serverconfig from './serverconfig.js'
 import { schemeCategory20, getColors } from '#shared/common.js'
 import { interpolateSqlValues } from './termdb.sql.js'
-import { mclass, dt2label, morigin } from '#shared/common.js'
+import { mclass, dt2label, morigin, TermTypes } from '#shared/common.js'
 import { getFilterCTEs } from './termdb.filter.js'
 import { authApi } from './auth.js'
 import run_R from './run_R.js'
 import { write_file, read_file } from './utils.js'
-import { listTableColumns } from './termdb.server.init.js'
 
 /*
 works with "canned" scatterplots in a dataset, e.g. data from a text file of tSNE coordinates from a pre-analyzed cohort (contrary to on-the-fly analysis)
@@ -250,7 +249,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 		if (!q.colorTW) {
 			sample.category = 'Default'
 		} else {
-			if (q.colorTW?.q?.mode === 'continuous') {
+			if (q.colorTW?.q?.mode === 'continuous' || q.colorTW?.term.type === TermTypes.GENE_EXPRESSION) {
 				if (dbSample) sample.category = dbSample[q.colorTW.term.id || q.colorTW.term.name].value
 			} else processSample(dbSample, sample, q.colorTW, results[divideBy].colorMap, 'category')
 		}

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -249,7 +249,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 		if (!q.colorTW) {
 			sample.category = 'Default'
 		} else {
-			if (q.colorTW?.q?.mode === 'continuous' || q.colorTW?.term.type === TermTypes.GENE_EXPRESSION) {
+			if (q.colorTW?.q?.mode === 'continuous') {
 				if (dbSample) sample.category = dbSample[q.colorTW.term.id || q.colorTW.term.name].value
 			} else processSample(dbSample, sample, q.colorTW, results[divideBy].colorMap, 'category')
 		}

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -238,7 +238,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 		if (!q.divideByTW) sample.z = 0
 		if (!q.scaleDotTW) sample.scale = 1
 		else {
-			const value = dbSample?.[q.scaleDotTW.id || q.scaleDotTW.term.name]?.key
+			const value = dbSample?.[q.scaleDotTW.$id]?.key
 			if (!value || !isComputable(q.scaleDotTW.term, value)) continue
 			sample.scale = value
 		}

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -209,7 +209,6 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 	const results = {}
 	for (const sample of cohortSamples) {
 		const dbSample = data.samples[sample.sampleId.toString()]
-
 		if (!dbSample) {
 			//console.log(JSON.stringify(sample) + ' not in the database or filtered')
 			continue
@@ -226,7 +225,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 					isLast = true
 				}
 			} else {
-				const field = q.divideByTW.term.id || q.divideByTW.term.name
+				const field = q.divideByTW.$id || q.divideByTW.term.id
 				const key = dbSample[field]?.key
 				if (key == null) continue
 				divideBy = q.divideByTW.term.values?.[key]?.label || key
@@ -250,7 +249,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 			sample.category = 'Default'
 		} else {
 			if (q.colorTW?.q?.mode === 'continuous') {
-				if (dbSample) sample.category = dbSample[q.colorTW.term.id || q.colorTW.term.name].value
+				if (dbSample) sample.category = dbSample[q.colorTW.$id || q.colorTW.term.id].value
 			} else processSample(dbSample, sample, q.colorTW, results[divideBy].colorMap, 'category')
 		}
 
@@ -309,7 +308,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 }
 
 function hasValue(dbSample, tw) {
-	const key = dbSample?.[`${tw?.term?.id && tw?.term?.type != 'geneVariant' ? tw?.term?.id : tw?.term?.name}`]?.key
+	const key = dbSample?.[tw?.$id || tw?.term.id]?.key
 	const hasKey = key !== undefined
 	if (!hasKey) console.log(JSON.stringify(dbSample) + ' missing value for the term ' + JSON.stringify(tw))
 	return hasKey
@@ -319,7 +318,7 @@ function processSample(dbSample, sample, tw, categoryMap, category) {
 	let value = null
 	if (tw.term.type == 'geneVariant') assignGeneVariantValue(dbSample, sample, tw, categoryMap, category)
 	else {
-		value = dbSample?.[tw.id || tw.term.name]?.key
+		value = dbSample?.[tw.$id || tw.term.id]?.key
 		if (tw.term.values?.[value]?.label) {
 			value = tw.term.values?.[value]?.label
 			sample.hidden[category] = tw.q.hiddenValues ? value in tw.q.hiddenValues : false
@@ -334,7 +333,7 @@ function processSample(dbSample, sample, tw, categoryMap, category) {
 
 function assignGeneVariantValue(dbSample, sample, tw, categoryMap, category) {
 	if (tw.term.type == 'geneVariant') {
-		const mutations = dbSample?.[tw.term.name]?.values
+		const mutations = dbSample?.[tw.$id]?.values
 		sample.cat_info[category] = []
 
 		for (const mutation of mutations) {
@@ -360,7 +359,7 @@ function assignGeneVariantValue(dbSample, sample, tw, categoryMap, category) {
 }
 
 function getMutation(strict, dbSample, tw) {
-	const mutations = dbSample?.[tw.term.name]?.values
+	const mutations = dbSample?.[tw.$id]?.values
 
 	for (const [dt, label] of Object.entries(dt2label)) {
 		const mutation = mutations.find(mutation => {

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -115,7 +115,7 @@ export async function trigger_getViolinPlotData(q, res, ds, genome) {
 	if (q.tw?.term.type == TermTypes.GENE_EXPRESSION)
 		//to support new types we pass the termwrapper object
 		return await trigger_getGeneExpViolinPlotData(q, res, ds, genome)
-	console.log('q', q)
+
 	const term = ds.cohort.termdb.q.termjsonByOneid(q.termid)
 	if (!term) throw '.termid invalid'
 	//term on backend should always be an integer term

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -54,7 +54,7 @@ q = {
 */
 
 export async function trigger_getGeneExpViolinPlotData(q, res, ds, genome) {
-	const gene = q.gene
+	const gene = q.tw?.term.gene || q.gene
 	if (!gene) throw 'gene is required'
 	if (ds.queries.geneExpression.gene2density[gene]) return ds.queries.geneExpression.gene2density[gene]
 	const args = {
@@ -112,14 +112,16 @@ export async function trigger_getGeneExpViolinPlotData(q, res, ds, genome) {
 }
 
 export async function trigger_getViolinPlotData(q, res, ds, genome) {
-	if (q.gene) return await trigger_getGeneExpViolinPlotData(q, res, ds, genome)
+	if (q.tw?.term.type == TermTypes.GENE_EXPRESSION)
+		//to support new types we pass the termwrapper object
+		return await trigger_getGeneExpViolinPlotData(q, res, ds, genome)
+	console.log('q', q)
 	const term = ds.cohort.termdb.q.termjsonByOneid(q.termid)
-	const termid = term.id
 	if (!term) throw '.termid invalid'
 	//term on backend should always be an integer term
 	if (term.type != 'integer' && term.type != 'float') throw 'term type is not integer/float.'
 
-	const twLst = [{ id: termid, term, q: { mode: 'continuous' } }]
+	const twLst = [{ id: q.termid, term, q: { mode: 'continuous' } }]
 
 	if (q.divideTw) {
 		if (q.divideTw !== null && q.divideTw !== undefined && typeof q.divideTw === 'object' && !('id' in q.divideTw)) {

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -76,7 +76,7 @@ export async function getGeneExpViolinPlotData(q, res, ds, genome) {
 		if (max < value) max = value
 		samples.push(value)
 	}
-	const plot = { label: 'All samples', values: samples, plotValueCount: samples.length }
+	const plot = { label: 'All samples', values: samples, plotValueCount: samples.length, minvalue: min, maxvalue: max }
 	const axisScale = scaleLinear().domain([min, max]).range([0, q.svgw])
 	plot.density = getBinsDensity(axisScale, plot, true, q.ticks)
 	const result = {


### PR DESCRIPTION
 Description

This PR adds support to geneExpression, and as it is on top of the geneVariant PR, it also supports the changes in this type, like using coordinates to search. It also does a major refactor to solve the problems related to accessing sample term values. It can be tested using the [TermdbTest](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg19%22,%22dslabel%22:%22panallMds3%22}](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38-test%22,%22dslabel%22:%22TermdbTest%22})) dataset. To test the geneExpression term, from the scatter plot, do overlay and select the gene expression tab, then select  a gene expression. You would see something like this:

<img width="1054" alt="Screenshot 2024-04-17 at 10 08 53 PM" src="https://github.com/stjude/proteinpaint/assets/12271391/181e22d8-b375-468e-a2f8-5a745ce7a340">

We also require further testing of all the functionalities, as the refactoring updated the way the data is returned by the getData method, which is central to most plots. So please check everything works as expected.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
