### PR TITLE
fix: GDC sequence reads viz no longer limits slicing range; the only …

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC sequence reads viz no longer limits slicing range; the only limit is slice file size


### PR DESCRIPTION
…limit is slice file size

## Description

please help quickly test it on localGFF
shouldn't break any CI

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
