### PR TITLE
fix: GDC bam slicing ui show actual number of available bam files whi…

### DIFF
--- a/client/gdc/bam.js
+++ b/client/gdc/bam.js
@@ -577,7 +577,7 @@ export async function bamsliceui({
 		if (data.total < data.loaded) handle.text(`Or, browse ${data.total} BAM files`)
 		else handle.text(`Or, browse first ${data.loaded} BAM files out of ${data.total} total`)
 		*/
-		handle.text(`Or, Browse ${data.loaded} Available BAM Files`)
+		handle.text(`Or, Browse ${data.total} Available BAM Files`)
 
 		// count number of bams per assay, allow checkbox to alter true/false for each assay here
 		const assays = new Map() // k: assay, v: {count:int, checked:bool}
@@ -621,7 +621,7 @@ export async function bamsliceui({
 				const tableDiv = tip.d
 					.append('div')
 					.style('margin', '10px')
-					.style('overflow-y', 'scroll')
+					.attr('class', 'sjpp_show_scrollbar')
 					.style('height', '300px')
 					.style('resize', 'vertical')
 				makeTable(tableDiv)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC bam slicing ui show actual number of available bam files which can be lower than 1000, fix scrollbar appearance

--- a/server/src/bam.gdc.js
+++ b/server/src/bam.gdc.js
@@ -83,7 +83,7 @@ const entityTypes = [
 
 const skip_workflow_type = 'STAR 2-Pass Transcriptome'
 
-const maxCaseNumber = 100 // max number of cases to request based on cohort, setting to 200 doesn't work
+const maxCaseNumber = 150 // max number of cases to request based on cohort
 const listCaseFileSize = 1000 // max number of bam files to request based on case ids
 
 let queryApi
@@ -440,8 +440,7 @@ async function getCaseFiles(filter0, q, ds) {
 	}
 	return {
 		case2files,
-		total: re.data?.pagination?.total,
-		loaded: listCaseFileSize,
+		total: Math.min(listCaseFileSize, re.data?.pagination?.total), // actual number of bam files pulled from api and returned to client. asks api to return up to listCaseFileSize number of files. due to filtering may return less than that
 		// in bam slice download app (versus sequence reads viz) client calls api directly thus need the rest host. since client always makes this request, send the host url to client
 		restapihost: ds.getHostHeaders(q).host.rest
 	}


### PR DESCRIPTION
…ch can be lower than 1000, fix scrollbar appearance

## Description

please pull sjpp master first
at http://localhost:3000/example.gdc.bam.html, due to cohort filter use, it shows `68 available bams` instead of 1000 as before which is wrong
please help me test it in localGFF to see when applying cohort filter (has to be a very restrictive filter), the number of bams can go down below 1000

nothing else should break 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
