### PR TITLE
fix: Updated protein domain color is applied to all instances of this…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Updated protein domain color is applied to all instances of this domain, not just first one


### PR DESCRIPTION
… domain, not just first one

## Description

please test at http://localhost:3000/?genome=hg38&gene=ENST00000269305
this isoform has two domains of `P53` type. can see the problem of changing P53 color on master

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
