### PR TITLE
Tentative prototype of gene set over representation analysis

### DIFF
--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -447,7 +447,7 @@ add:
 			//console.log('output.data:', output.data)
 			const sample_genes = []
 			const background_genes = []
-			console.log('self:', self)
+			//console.log('self:', self)
 			//console.log('fold_change_cutoff:', fold_change_cutoff)
 
 			// Need to handle those genes which do not have a name
@@ -457,9 +457,8 @@ add:
 						// Do not include blank rows
 						if (fold_change_cutoff < Math.abs(gene.fold_change) && gene.fold_change > 0) {
 							sample_genes.push(gene.gene_symbol)
-						} else {
-							background_genes.push(gene.gene_symbol)
 						}
+						background_genes.push(gene.gene_symbol)
 					}
 				}
 			} else if (self.settings.gene_ora == 'downregulated') {
@@ -468,9 +467,8 @@ add:
 						// Do not include blank rows
 						if (fold_change_cutoff < Math.abs(gene.fold_change) && gene.fold_change < 0) {
 							sample_genes.push(gene.gene_symbol)
-						} else {
-							background_genes.push(gene.gene_symbol)
 						}
+						background_genes.push(gene.gene_symbol)
 					}
 				}
 			} else if (self.settings.gene_ora == 'both') {
@@ -479,9 +477,8 @@ add:
 						// Do not include blank rows
 						if (fold_change_cutoff < Math.abs(gene.fold_change)) {
 							sample_genes.push(gene.gene_symbol)
-						} else {
-							background_genes.push(gene.gene_symbol)
 						}
+						background_genes.push(gene.gene_symbol)
 					}
 				}
 			} else {

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -448,6 +448,7 @@ add:
 			console.log('self:', self)
 			console.log('fold_change_cutoff:', fold_change_cutoff)
 
+			// Need to handle those genes which do not have a name
 			if (self.settings.gene_ora == 'upregulated') {
 				for (const gene of output.data) {
 					if (fold_change_cutoff < Math.abs(gene.fold_change) && gene.fold_change > 0) {
@@ -480,7 +481,6 @@ add:
 			const body = {
 				sample_genes: sample_genes.toString(),
 				background_genes: background_genes.toString(),
-				dbfile: self.app.opts.genome.termdbs.msigdb.label,
 				genome: self.app.vocabApi.opts.state.vocab.genome,
 				geneSetGroup: 'BP: subset of GO'
 			}

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -78,18 +78,6 @@ class DEanalysis {
 				boxLabel: ''
 			},
 			{
-				label: 'Gene overrepresentation analysis',
-				type: 'radio',
-				chartType: 'DEanalysis',
-				settingsKey: 'gene_ora',
-				title: 'Toggle between analyzing upregulated, downregulated or both genes',
-				options: [
-					{ label: 'upregulated', value: 'upregulated' },
-					{ label: 'downregulated', value: 'downregulated' },
-					{ label: 'both', value: 'both' }
-				]
-			},
-			{
 				label: 'P-value',
 				type: 'radio',
 				chartType: 'DEanalysis',
@@ -125,7 +113,21 @@ class DEanalysis {
 			this.settings.method = output.method
 			this.state.config = output.method
 		}
-
+		if (this.app.opts.genome.termdbs) {
+			// Check if genome build contains termdbs, only then enable gene ora
+			inputs.push({
+				label: 'Gene overrepresentation analysis',
+				type: 'radio',
+				chartType: 'DEanalysis',
+				settingsKey: 'gene_ora',
+				title: 'Toggle between analyzing upregulated, downregulated or both genes',
+				options: [
+					{ label: 'upregulated', value: 'upregulated' },
+					{ label: 'downregulated', value: 'downregulated' },
+					{ label: 'both', value: 'both' }
+				]
+			})
+		}
 		if (this.settings.pvaluetable == true) {
 			// This currently does not work as hierarchial clustering code needs to be changed
 			inputs.push({
@@ -440,12 +442,12 @@ add:
 			})
 		}
 
-		if (self.settings.gene_ora) {
+		if (self.settings.gene_ora && self.app.opts.genome.termdbs) {
 			//console.log('Run gene ora:', self.settings.gene_ora)
 			//console.log('output.data:', output.data)
 			const sample_genes = []
 			const background_genes = []
-			//console.log('self:', self)
+			console.log('self:', self)
 			//console.log('fold_change_cutoff:', fold_change_cutoff)
 
 			// Need to handle those genes which do not have a name

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -441,12 +441,12 @@ add:
 		}
 
 		if (self.settings.gene_ora) {
-			console.log('Run gene ora:', self.settings.gene_ora)
-			console.log('output.data:', output.data)
+			//console.log('Run gene ora:', self.settings.gene_ora)
+			//console.log('output.data:', output.data)
 			const sample_genes = []
 			const background_genes = []
-			console.log('self:', self)
-			console.log('fold_change_cutoff:', fold_change_cutoff)
+			//console.log('self:', self)
+			//console.log('fold_change_cutoff:', fold_change_cutoff)
 
 			// Need to handle those genes which do not have a name
 			if (self.settings.gene_ora == 'upregulated') {
@@ -485,6 +485,32 @@ add:
 				geneSetGroup: 'BP: subset of GO'
 			}
 			const data = await dofetch3('genesetOverrepresentation', { body })
+			//console.log("data:",data)
+
+			// Generating the table
+			self.gene_ora_table_cols = [
+				{ label: 'Pathway name' },
+				{ label: 'Original p-value (linear scale)' },
+				{ label: 'Adjusted p-value (linear scale)' }
+			]
+			self.gene_ora_table_rows = []
+			for (const pathway of data) {
+				self.gene_ora_table_rows.push([
+					{ value: pathway.pathway_name },
+					{ value: pathway.p_value_original },
+					{ value: pathway.p_value_adjusted }
+				])
+			}
+
+			const d_ora = self.dom.tableDiv.append('div').html(`<br>Gene over-representation results`)
+			renderTable({
+				columns: self.gene_ora_table_cols,
+				rows: self.gene_ora_table_rows,
+				div: d_ora,
+				showLines: true,
+				maxHeight: '30vh',
+				resize: true
+			})
 		}
 	}
 	return svg

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -451,33 +451,41 @@ add:
 			// Need to handle those genes which do not have a name
 			if (self.settings.gene_ora == 'upregulated') {
 				for (const gene of output.data) {
-					if (fold_change_cutoff < Math.abs(gene.fold_change) && gene.fold_change > 0) {
-						sample_genes.push(gene.gene_symbol)
-					} else {
-						background_genes.push(gene.gene_symbol)
+					if (gene.gene_symbol.length > 0) {
+						// Do not include blank rows
+						if (fold_change_cutoff < Math.abs(gene.fold_change) && gene.fold_change > 0) {
+							sample_genes.push(gene.gene_symbol)
+						} else {
+							background_genes.push(gene.gene_symbol)
+						}
 					}
 				}
 			} else if (self.settings.gene_ora == 'downregulated') {
 				for (const gene of output.data) {
-					if (fold_change_cutoff < Math.abs(gene.fold_change) && gene.fold_change < 0) {
-						sample_genes.push(gene.gene_symbol)
-					} else {
-						background_genes.push(gene.gene_symbol)
+					if (gene.gene_symbol.length > 0) {
+						// Do not include blank rows
+						if (fold_change_cutoff < Math.abs(gene.fold_change) && gene.fold_change < 0) {
+							sample_genes.push(gene.gene_symbol)
+						} else {
+							background_genes.push(gene.gene_symbol)
+						}
 					}
 				}
 			} else if (self.settings.gene_ora == 'both') {
 				for (const gene of output.data) {
-					if (fold_change_cutoff < Math.abs(gene.fold_change)) {
-						sample_genes.push(gene.gene_symbol)
-					} else {
-						background_genes.push(gene.gene_symbol)
+					if (gene.gene_symbol.length > 0) {
+						// Do not include blank rows
+						if (fold_change_cutoff < Math.abs(gene.fold_change)) {
+							sample_genes.push(gene.gene_symbol)
+						} else {
+							background_genes.push(gene.gene_symbol)
+						}
 					}
 				}
 			} else {
 				console.log('Unrecognized option')
 			}
-			console.log('sample_genes:', sample_genes.length)
-			console.log('background_genes:', background_genes.length)
+
 			const body = {
 				sample_genes: sample_genes.toString(),
 				background_genes: background_genes.toString(),
@@ -486,6 +494,15 @@ add:
 			}
 			const data = await dofetch3('genesetOverrepresentation', { body })
 			//console.log("data:",data)
+
+			self.dom.detailsDiv
+				.append('div')
+				.html(
+					'Number of sample genes used for gene over representation analysis:' +
+						sample_genes.length +
+						'<br>Number of background genes used for gene over representation analysis:' +
+						background_genes.length
+				)
 
 			// Generating the table
 			self.gene_ora_table_cols = [
@@ -502,6 +519,7 @@ add:
 				])
 			}
 
+			self.dom.tableDiv.selectAll('*').remove()
 			const d_ora = self.dom.tableDiv.append('div').html(`<br>Gene over-representation results`)
 			renderTable({
 				columns: self.gene_ora_table_cols,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ kodama = "0.3"
 rayon = "1.7.0"
 bgzip = "0.3.1"
 petgraph = "0.6.3"
+rusqlite="0.31.0"
 ndarray = "0.15.6"
 nalgebra = {version = "0.32.2", features = ["serde-serialize"]}
 plotters = "0.3.4"
@@ -31,8 +32,6 @@ tokio = { version="1", features = ["full"] }
 reqwest = "0.11"
 flate2 = "1"
 futures = "0.3"
-
-
 
 [profile.release]
 lto = "fat"
@@ -83,3 +82,7 @@ path="src/wilcoxon.rs"
 [[bin]]
 name="DEanalysis"
 path="src/DEanalysis.rs"
+
+[[bin]]
+name="genesetORA"
+path="src/genesetORA.rs"

--- a/rust/src/genesetORA.rs
+++ b/rust/src/genesetORA.rs
@@ -1,3 +1,4 @@
+// The hypergeometric distribution is computed based on the implementation in https://rdrr.io/github/GuangchuangYu/DOSE/src/R/enricher_internal.R
 // Syntax: cd .. && cargo build --release && cat ~/sjpp/test.txt | target/release/genesetORA
 #![allow(non_snake_case)]
 use json::JsonValue;

--- a/rust/src/genesetORA.rs
+++ b/rust/src/genesetORA.rs
@@ -1,0 +1,168 @@
+// Syntax: cd .. && cargo build --release && cat ~/sjpp/test.txt | target/release/genesetORA
+#![allow(non_snake_case)]
+use json::JsonValue;
+use r_mathlib;
+use rusqlite::{Connection, Result};
+use std::io;
+
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[derive(Debug)]
+struct GO_pathway {
+    GO_id: String,
+}
+
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[derive(Debug)]
+struct pathway_genes {
+    symbol: String,
+    _ensg: String,
+    _enstCanonical: String,
+}
+
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct pathway_p_value {
+    GO_id: String,
+    p_value: f64,
+}
+
+fn calculate_hypergeometric_p_value(
+    sample_genes: &Vec<&str>,
+    background_genes: &Vec<&str>,
+    genes_in_pathway: Vec<pathway_genes>,
+) -> f64 {
+    let matching_sample_genes_counts: f64 = sample_genes
+        .iter()
+        .zip(&genes_in_pathway)
+        .filter(|&(a, b)| *a.to_string() == b.symbol)
+        .count() as f64;
+    //println!("k-1:{}", matching_sample_genes_counts - 1.0);
+    //println!("M:{}", genes_in_pathway.len() as f64);
+    //println!(
+    //    "N-M:{}",
+    //    background_genes.len() as f64 - genes_in_pathway.len() as f64
+    //);
+    //println!("n:{}", sample_genes.len() as f64);
+    let p_value = r_mathlib::hypergeometric_cdf(
+        matching_sample_genes_counts - 1.0,
+        genes_in_pathway.len() as f64,
+        background_genes.len() as f64 - genes_in_pathway.len() as f64,
+        sample_genes.len() as f64,
+        false,
+        false,
+    );
+    //println!("p_value:{}", p_value);
+    p_value
+}
+
+fn main() -> Result<()> {
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        // Accepting the piped input from nodejs (or command line from testing)
+        Ok(_n) => {
+            let input_json = json::parse(&input);
+            match input_json {
+                Ok(json_string) => {
+                    let db_input: &JsonValue = &json_string["db"];
+                    let db;
+                    match db_input.as_str() {
+                        Some(db_string) => db = db_string.to_string(),
+                        None => panic!("db file path is missing"),
+                    }
+                    let sample_genes_input: &JsonValue = &json_string["sample_genes"];
+                    let sample_genes: Vec<&str> =
+                        sample_genes_input.as_str().unwrap().split(",").collect();
+                    let mut pathway_p_values: Vec<pathway_p_value> = Vec::with_capacity(10000);
+                    let background_genes_input: &JsonValue = &json_string["background_genes"];
+                    let background_genes: Vec<&str> = background_genes_input
+                        .as_str()
+                        .unwrap()
+                        .split(",")
+                        .collect();
+                    //println!("sample_genes:{:?}", sample_genes);
+                    //println!("background_genes:{:?}", background_genes);
+                    let conn = Connection::open(db)?;
+                    let stmt_result =
+                        conn.prepare("select id from terms where parent_id='BP: subset of GO'");
+                    match stmt_result {
+                        Ok(mut stmt) => {
+                            #[allow(non_snake_case)]
+                            let GO_iter =
+                                stmt.query_map([], |row| Ok(GO_pathway { GO_id: row.get(0)? }))?;
+                            let mut iter = 0;
+                            #[allow(non_snake_case)]
+                            for GO_term in GO_iter {
+                                iter += 1;
+                                match GO_term {
+                                    Ok(n) => {
+                                        //println!("GO term {:?}", n);
+                                        let sql_statement =
+                                            "select genes from term2genes where id='".to_owned()
+                                                + &n.GO_id
+                                                + &"'";
+                                        //println!("sql_statement:{}", sql_statement);
+                                        let mut gene_stmt = conn.prepare(&(sql_statement))?;
+                                        //println!("gene_stmt:{:?}", gene_stmt);
+
+                                        let mut rows = gene_stmt.query([])?;
+                                        let mut names = Vec::<pathway_genes>::new();
+                                        while let Some(row) = rows.next()? {
+                                            let a: String = row.get(0)?;
+                                            let input_gene_json = json::parse(&a);
+                                            match input_gene_json {
+                                                Ok(json_genes) => {
+                                                    for json_iter in 0..json_genes.len() {
+                                                        let item = pathway_genes {
+                                                            symbol: json_genes[json_iter]["symbol"]
+                                                                .to_string(),
+                                                            _ensg: json_genes[json_iter]["ensg"]
+                                                                .to_string(),
+                                                            _enstCanonical: json_genes[json_iter]
+                                                                ["enstCanonical"]
+                                                                .to_string(),
+                                                        };
+                                                        //println!("item:{:?}", item);
+                                                        names.push(item);
+                                                    }
+                                                }
+                                                Err(_) => {
+                                                    panic!(
+                                                "Symbol, ensg, enstCanonical structure is missing!"
+                                            )
+                                                }
+                                            }
+                                        }
+                                        let p_value = calculate_hypergeometric_p_value(
+                                            &sample_genes,
+                                            &background_genes,
+                                            names,
+                                        );
+                                        if p_value.is_nan() == false {
+                                            pathway_p_values.push(pathway_p_value {
+                                                GO_id: n.GO_id,
+                                                p_value: p_value,
+                                            })
+                                        }
+                                    }
+                                    Err(_) => {
+                                        println!("GO term not found!")
+                                    }
+                                }
+                            }
+                            println!("Number of pathway entries:{}", iter);
+                        }
+                        Err(_) => panic!("sqlite database file not found"),
+                    }
+                    println!("pathway_p_values:{:?}", pathway_p_values);
+                }
+                Err(error) => println!("Incorrect json:{}", error),
+            }
+        }
+        Err(error) => println!("Piping error: {}", error),
+    }
+    Ok(())
+}

--- a/rust/src/genesetORA.rs
+++ b/rust/src/genesetORA.rs
@@ -30,7 +30,7 @@ struct pathway_genes {
 #[derive(Debug, Serialize, Deserialize)]
 //#[allow(dead_code)]
 struct pathway_p_value {
-    GO_id: String,
+    pathway_name: String,
     p_value_original: f64,
     p_value_adjusted: Option<f64>,
 }
@@ -149,7 +149,7 @@ fn main() -> Result<()> {
                                         );
                                         if p_value.is_nan() == false {
                                             pathway_p_values.push(pathway_p_value {
-                                                GO_id: n.GO_id,
+                                                pathway_name: n.GO_id,
                                                 p_value_original: p_value,
                                                 p_value_adjusted: None,
                                             })
@@ -211,7 +211,7 @@ fn adjust_p_values(mut original_p_values: Vec<pathway_p_value>) -> String {
         rank -= 1.0;
 
         adjusted_p_values.push(pathway_p_value {
-            GO_id: original_p_values[i].GO_id.clone(),
+            pathway_name: original_p_values[i].pathway_name.clone(),
             p_value_original: original_p_values[i].p_value_original,
             p_value_adjusted: Some(adjusted_p_val),
         });

--- a/server/routes/genesetOverrepresentation.ts
+++ b/server/routes/genesetOverrepresentation.ts
@@ -59,4 +59,13 @@ async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentati
 	const rust_output = await run_rust('genesetORA', JSON.stringify(gene_overrepresentation_input))
 	const time2 = new Date()
 	console.log('rust_output:', rust_output)
+	let result
+	for (const line of rust_output.split('\n')) {
+		if (line.startsWith('pathway_p_values:')) {
+			result = JSON.parse(line.replace('pathway_p_values:', ''))
+		} else {
+			console.log(line)
+		}
+	}
+	console.log('result:', result)
 }

--- a/server/routes/genesetOverrepresentation.ts
+++ b/server/routes/genesetOverrepresentation.ts
@@ -1,3 +1,4 @@
+//import fs from 'fs'
 import {
 	genesetOverrepresentationRequest,
 	genesetOverrepresentationResponse
@@ -27,7 +28,6 @@ export const api = {
 function init({ genomes }) {
 	return async (req: any, res: any): Promise<void> => {
 		try {
-			console.log('Hello')
 			//console.log("req.query:",req.query)
 			const results = await run_genesetOverrepresentation_analysis(
 				req.query as genesetOverrepresentationRequest,
@@ -40,7 +40,23 @@ function init({ genomes }) {
 	}
 }
 
-async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentationRequest, genomes: Any) {
-	console.log('genomes:', genomes[q.genome].termdbs)
+async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentationRequest, genomes: any) {
+	console.log('genomes:', genomes[q.genome].termdbs.msigdb.cohort.db.connection.name)
 	console.log('q:', q.genome)
+	if (!genomes[q.genome].termdbs) throw 'termdb database is not available for ' + q.genome
+	const gene_overrepresentation_input = {
+		sample_genes: q.sample_genes,
+		background_genes: q.background_genes,
+		db: genomes[q.genome].termdbs.msigdb.cohort.db.connection.name
+	}
+
+	//fs.writeFile('test.txt', JSON.stringify(gene_overrepresentation_input), function (err) {
+	//	// For catching input to rust pipeline, in case of an error
+	//	if (err) return console.log(err)
+	//})
+
+	const time1 = new Date()
+	const rust_output = await run_rust('genesetORA', JSON.stringify(gene_overrepresentation_input))
+	const time2 = new Date()
+	console.log('rust_output:', rust_output)
 }

--- a/server/routes/genesetOverrepresentation.ts
+++ b/server/routes/genesetOverrepresentation.ts
@@ -4,9 +4,6 @@ import {
 	genesetOverrepresentationResponse
 } from '#shared/types/routes/genesetOverrepresentation.ts'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
-import path from 'path'
-import got from 'got'
-import serverconfig from '#src/serverconfig.js'
 
 export const api = {
 	endpoint: 'genesetOverrepresentation',
@@ -41,8 +38,8 @@ function init({ genomes }) {
 }
 
 async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentationRequest, genomes: any) {
-	console.log('genomes:', genomes[q.genome].termdbs.msigdb.cohort.db.connection.name)
-	console.log('q:', q.genome)
+	//console.log('genomes:', genomes[q.genome].termdbs.msigdb.cohort.db.connection.name)
+	//console.log('q:', q.genome)
 	if (!genomes[q.genome].termdbs) throw 'termdb database is not available for ' + q.genome
 	const gene_overrepresentation_input = {
 		sample_genes: q.sample_genes,
@@ -55,10 +52,10 @@ async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentati
 	//	if (err) return console.log(err)
 	//})
 
-	const time1 = new Date()
+	const time1 = new Date().valueOf()
 	const rust_output = await run_rust('genesetORA', JSON.stringify(gene_overrepresentation_input))
-	const time2 = new Date()
-	console.log('rust_output:', rust_output)
+	const time2 = new Date().valueOf()
+	console.log('Time taken to run rust gene over representation pipeline:', time2 - time1, 'ms')
 	let result
 	for (const line of rust_output.split('\n')) {
 		if (line.startsWith('pathway_p_values:')) {
@@ -67,5 +64,6 @@ async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentati
 			console.log(line)
 		}
 	}
-	console.log('result:', result)
+	//console.log('result:', result)
+	return result as genesetOverrepresentationResponse
 }

--- a/server/routes/genesetOverrepresentation.ts
+++ b/server/routes/genesetOverrepresentation.ts
@@ -1,0 +1,46 @@
+import {
+	genesetOverrepresentationRequest,
+	genesetOverrepresentationResponse
+} from '#shared/types/routes/genesetOverrepresentation.ts'
+import { run_rust } from '@sjcrh/proteinpaint-rust'
+import path from 'path'
+import got from 'got'
+import serverconfig from '#src/serverconfig.js'
+
+export const api = {
+	endpoint: 'genesetOverrepresentation',
+	methods: {
+		all: {
+			init,
+			request: {
+				typeId: 'genesetOverrepresentationRequest'
+			},
+			response: {
+				typeId: 'genesetOverrepresentationResponse'
+				// will combine this with type checker
+				//valid: (t) => {}
+			}
+		}
+	}
+}
+
+function init({ genomes }) {
+	return async (req: any, res: any): Promise<void> => {
+		try {
+			console.log('Hello')
+			//console.log("req.query:",req.query)
+			const results = await run_genesetOverrepresentation_analysis(
+				req.query as genesetOverrepresentationRequest,
+				genomes
+			)
+			res.send(results)
+		} catch (e: any) {
+			res.send({ status: 'error', error: e.message || e })
+		}
+	}
+}
+
+async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentationRequest, genomes: Any) {
+	console.log('genomes:', genomes[q.genome].termdbs)
+	console.log('q:', q.genome)
+}

--- a/server/routes/genesetOverrepresentation.ts
+++ b/server/routes/genesetOverrepresentation.ts
@@ -62,7 +62,7 @@ async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentati
 		if (line.startsWith('pathway_p_values:')) {
 			result = JSON.parse(line.replace('pathway_p_values:', ''))
 		} else {
-			console.log(line)
+			//console.log(line)
 		}
 	}
 	//console.log('result:', result)

--- a/server/routes/genesetOverrepresentation.ts
+++ b/server/routes/genesetOverrepresentation.ts
@@ -44,7 +44,8 @@ async function run_genesetOverrepresentation_analysis(q: genesetOverrepresentati
 	const gene_overrepresentation_input = {
 		sample_genes: q.sample_genes,
 		background_genes: q.background_genes,
-		db: genomes[q.genome].termdbs.msigdb.cohort.db.connection.name
+		db: genomes[q.genome].termdbs.msigdb.cohort.db.connection.name,
+		gene_set_group: q.geneSetGroup
 	}
 
 	//fs.writeFile('test.txt', JSON.stringify(gene_overrepresentation_input), function (err) {

--- a/server/shared/types/routes/genesetOverrepresentation.ts
+++ b/server/shared/types/routes/genesetOverrepresentation.ts
@@ -1,12 +1,12 @@
 export type genesetOverrepresentationRequest = {
-	sample_genes: string
-	background_genes: string
-	genome: string
-	geneSetGroup: string
+	sample_genes: string // Sample genes to be queried
+	background_genes: string // Background genes against which the sample genes will be queried
+	genome: string // Genome build
+	geneSetGroup: string // Type of GO to be queried e.g MF, CC, BP
 }
 
 export type genesetOverrepresentationResponse = {
-	pathway_name: string
-	p_value_original: number
-	p_value_adjusted: number
+	pathway_name: string // Name of pathway
+	p_value_original: number // Original p-value
+	p_value_adjusted: number // Adjusted p-value
 }

--- a/server/shared/types/routes/genesetOverrepresentation.ts
+++ b/server/shared/types/routes/genesetOverrepresentation.ts
@@ -1,7 +1,3 @@
-//export type genesetOverrepresentationResponse = {
-//
-//}
-
 export type genesetOverrepresentationRequest = {
 	sample_genes: string
 	background_genes: string
@@ -10,5 +6,7 @@ export type genesetOverrepresentationRequest = {
 }
 
 export type genesetOverrepresentationResponse = {
-	pathways: string
+	pathway_name: string
+	p_value_original: number
+	p_value_adjusted: number
 }

--- a/server/shared/types/routes/genesetOverrepresentation.ts
+++ b/server/shared/types/routes/genesetOverrepresentation.ts
@@ -5,7 +5,6 @@
 export type genesetOverrepresentationRequest = {
 	sample_genes: string
 	background_genes: string
-	dbfile: string
 	genome: string
 	geneSetGroup: string
 }

--- a/server/shared/types/routes/genesetOverrepresentation.ts
+++ b/server/shared/types/routes/genesetOverrepresentation.ts
@@ -1,0 +1,15 @@
+//export type genesetOverrepresentationResponse = {
+//
+//}
+
+export type genesetOverrepresentationRequest = {
+	sample_genes: string
+	background_genes: string
+	dbfile: string
+	genome: string
+	geneSetGroup: string
+}
+
+export type genesetOverrepresentationResponse = {
+	pathways: string
+}


### PR DESCRIPTION
## Description
This is a rough implementation of gene set over representation analysis. The user may select upregulated/downregulated/both genes from the DE analysis. On clicking any of the buttons a server side request is invoked which queries the sql database file which searches for all the pathways under the given gene ontology term. For each pathway, the rust script runs a hypergeometric test to get a pvalue. It then adjusts the p-values for multiple-testing correction using the B-H method and send results to the client side.

The method used to compute the p-values are based on how its implemented in the [enricher_internal.R ](https://rdrr.io/github/GuangchuangYu/DOSE/src/R/enricher_internal.R) function.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
