### PR TITLE
fix the dispatched matrix sorter isOrdered value for mutation tiebreaker

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -64,8 +64,8 @@ export async function getPlotConfig(opts = {}, app) {
 				sampleNameFilter: '',
 				sortSamplesBy: 'a',
 				sortPriority: undefined, // will be filled-in
-				sortByMutation: 'consequence',
-				sortByCNV: true,
+				sortByMutation: 'consequence', // TODO: deprecate and instead set the matching sortOptions.a.sortPriority[*].tiebreakers[*].isOrdered
+				sortByCNV: true, // TODO: deprecate and instead set the matching sortOptions.a.sortPriority[*].tiebreakers[*].isOrdered
 				//sortOptions: getSortOptions(app.vocabApi.termdbConfig, controlLabels),
 				sortSampleGrpsBy: 'name', // 'hits' | 'name' | 'sampleCount'
 				sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: {} /*split: {char: '', index: 0}*/ }],

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -235,7 +235,6 @@ export class MatrixControls {
 							const sortOptions = parent.config.settings.matrix.sortOptions
 							const activeOption = sortOptions.a
 							const cnvTb = activeOption.sortPriority[0].tiebreakers[2]
-							console.log(244, cnvTb, activeOption)
 							cnvTb.disabled = !sortByCNV
 							cnvTb.isOrdered = sortByCNV
 

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -202,9 +202,9 @@ export class MatrixControls {
 						callback: sortByMutation => {
 							const sortOptions = parent.config.settings.matrix.sortOptions
 							const activeOption = sortOptions.a
-							const mutTb = activeOption.sortPriority[0].tiebreakers[1] //; console.log(244, mutTb, activeOption)
+							const mutTb = activeOption.sortPriority[0].tiebreakers[1]
 							mutTb.disabled = !sortByMutation
-							mutTb.isOrdered = sortByMutation
+							mutTb.isOrdered = sortByMutation === 'consequence'
 
 							parent.app.dispatch({
 								type: 'plot_edit',

--- a/client/plots/test/matrix.controls.unit.spec.js
+++ b/client/plots/test/matrix.controls.unit.spec.js
@@ -1,0 +1,150 @@
+import tape from 'tape'
+import { MatrixControls } from '../matrix.controls'
+import { select } from 'd3-selection'
+import { getPlotConfig } from '../matrix.config'
+import { Menu } from '#dom/menu'
+import * as helpers from '../../test/test.helpers'
+
+/*************************
+ reusable helper functions
+**************************/
+
+// return unique copies so that each test does not reuse
+// the same data rows that are already sorted in another test
+async function getArgs(_settings = {}) {
+	const app = { vocabApi: { termdbConfig: {} }, tip: new Menu(), opts: {} }
+	const config = await getPlotConfig(
+		{
+			settings: {
+				matrix: {
+					sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: { by: 'sample' } }],
+					sortByMutation: 'presence',
+					sortByCNV: false,
+					hiddenVariants: [],
+					..._settings
+				}
+			}
+		},
+		app
+	)
+
+	const holder = select('body').append('div')
+	const controlsDiv = holder.append('div')
+	const svg = holder.append('svg')
+
+	return new MatrixControls(
+		{
+			id: 1,
+			app,
+			parent: {
+				app,
+				dom: {
+					holder,
+					svg,
+					seriesesG: svg.append('g'),
+					scroll: holder.append('div')
+				},
+				getState() {
+					return {
+						//isVisible: true,
+						config
+						// filter: appState.termfilter.filter,
+						// filter0, // read-only, invisible filter currently only used for gdc dataset
+						// hasVerifiedToken: this.app.vocabApi.hasVerifiedToken(),
+						// tokenVerificationMessage: this.app.vocabApi.tokenVerificationMessage,
+						// vocab: appState.vocab,
+						// termdbConfig: appState.termdbConfig,
+						// clusterMethod: config.settings.hierCluster?.clusterMethod,
+						// distanceMethod: config.settings.hierCluster?.distanceMethod,
+						// nav: appState.nav
+					}
+				},
+				config,
+				settings: config.settings
+			},
+			holder: controlsDiv
+		},
+		{
+			plots: [config]
+		}
+	)
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.pass('-***- plots/matrix.controls -***-')
+	test.end()
+})
+
+// TODO: delete these tests if and when the new sorter UI is used
+tape('basic sorter UI', async test => {
+	test.timeoutAfter(1000)
+	test.plan(6)
+	const controls = await getArgs({ sortSamplesBy: 'asListed' })
+	const samplesBtn = [...controls.opts.holder.node().querySelectorAll(':scope>button')].find(
+		elem => elem.innerHTML === 'Samples'
+	)
+	samplesBtn.click()
+	const radio0 = await helpers.detectOne({
+		elem: controls.parent.app.tip.d.node(),
+		selector: 'input[value="consequence"]'
+	})
+
+	controls.parent.app.dispatch = function (action) {
+		test.equal(
+			action.type,
+			'plot_edit',
+			'should dispatch a plot_edit action on clicking Sort Sample: SSM by consequence radio button'
+		)
+
+		test.equal(
+			action.config?.settings?.matrix?.sortByMutation,
+			'consequence',
+			'should set the correct sortByMutation value when clicking Sort Sample: SSM by consequence radio button'
+		)
+
+		test.equal(
+			action.config?.settings?.matrix?.sortOptions?.a.sortPriority[0].tiebreakers[1]?.isOrdered,
+			true,
+			'should set the correct sortOptions tiebreaker to isOrdered when clicking Sort Sample: SSM by consequence radio button'
+		)
+	}
+
+	radio0.click()
+
+	const radio1 = await helpers.detectOne({
+		elem: controls.parent.app.tip.d.node(),
+		selector: 'input[value="presence"]'
+	})
+
+	controls.parent.app.dispatch = function (action) {
+		test.equal(
+			action.type,
+			'plot_edit',
+			'should dispatch a plot_edit action on clicking Sort Sample: SSM by presence radio button'
+		)
+
+		test.equal(
+			action.config?.settings?.matrix?.sortByMutation,
+			'presence',
+			'should set the correct sortByMutation value when clicking Sort Sample: SSM by presence radio button'
+		)
+
+		test.equal(
+			action.config?.settings?.matrix?.sortOptions?.a.sortPriority[0].tiebreakers[1]?.isOrdered,
+			false,
+			'should set the correct sortOptions tiebreaker to isOrdered when clicking Sort Sample: SSM by presence radio button'
+		)
+
+		if (test._ok) {
+			controls.parent.app.tip.clear().hide()
+			controls.opts.holder.remove()
+		}
+	}
+
+	radio1.click()
+	test.end()
+})


### PR DESCRIPTION
## Description
closes https://github.com/stjude/proteinpaint/issues/1558

To test:
- http://localhost:3000/testrun.html?dir=plots&name=matrix.controls.unit
- http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=Gliomas: open the Samples menu and click on SSM by consequence and then presence and back, the matrix should change the sorting.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
