### PR TITLE
use term.chr, start, stop with C19MC and handle the term/variant posi…

### DIFF
--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -153,7 +153,9 @@ export class MatrixControls {
 				getBodyParams: () => {
 					const currentGeneNames = this.parent.termOrder
 						.filter(t => t.tw.term.type === 'geneVariant')
-						.map(t => t.tw.term.gene || t.tw.term.name) // TODO term.gene replaces term.name
+						.map(t =>
+							t.tw.term.chr ? `${t.tw.term.chr}:${t.tw.term.start}-${t.tw.term.stop}` : t.tw.term.gene || t.tw.term.name
+						) // TODO term.gene replaces term.name
 					return { currentGeneNames }
 				}
 			}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -399,7 +399,9 @@ function setTermActions(self) {
 				for (const g of self.config.termgroups) {
 					for (const t of g.lst) {
 						if (t.term.type == 'geneVariant') {
-							if (t.term.gene) {
+							if (t.term.chr) {
+								currentGeneNames.push(`${t.term.chr}:${t.term.start}-${t.term.stop}`)
+							} else if (t.term.gene) {
 								currentGeneNames.push(t.term.gene)
 							} else if (t.term.name) {
 								currentGeneNames.push(t.term.name)

--- a/client/plots/matrix.renderers.js
+++ b/client/plots/matrix.renderers.js
@@ -377,7 +377,9 @@ export function setRenderers(self) {
 			getBodyParams: () => {
 				const currentGeneNames = self.termOrder
 					.filter(t => t.tw.term.type === 'geneVariant')
-					.map(t => t.tw.term.gene || t.tw.term.name) // TODO term.gene replaces term.name
+					.map(t =>
+						t.tw.term.chr ? `${t.tw.term.chr}:${t.tw.term.start}-${t.tw.term.stop}` : t.tw.term.gene || t.tw.term.name
+					) // TODO term.gene replaces term.name
 				return { currentGeneNames }
 			},
 			callback: tw => {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -733,7 +733,7 @@ export class TermdbVocab extends Vocab {
 			? null
 			: opts.terms
 					.filter(tw => tw.term.type === 'geneVariant')
-					.map(tw => tw.term.name)
+					.map(tw => (tw.term.chr ? `${tw.term.chr}:${tw.term.start}-${tw.term.stop}` : tw.term.name))
 					.sort() // sort the gene names by the default alphanumeric order to improve cache reuse even when terms are resorted
 		const allTerms2update = opts.terms.slice() // make copy of array as it will be truncated to empty. do not modify original
 

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2482,6 +2482,13 @@ also returns isoform accession of the model that's used
 if the model is canonical, the isoform will be usable for screening csq annotation for mutations
 */
 async function mayMapGeneName2coord(term, genome) {
+	if (term.name.startsWith('chr') && term.name.includes(':') && term.name.includes('-')) {
+		const [chr, pos] = term.name.split(':')
+		const [start, stop] = pos.split('-').map(Number)
+		term.chr = chr
+		term.start = start
+		term.stop = stop
+	}
 	if (term.chr && Number.isInteger(term.start) && Number.isInteger(term.stop)) return
 	// coord missing, fill in chr/start/stop by querying with name
 	if (!term.name) throw 'both term.name and term.chr/start/stop missing'


### PR DESCRIPTION
…tion in the request payload

## Description
To test, open the default [pnet matrix plot](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22BCOR%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22C19MC%22,%22id%22:%22C19MC%22,%22chr%22:%22chr19%22,%22start%22:54169933,%22stop%22:54292028,%22type%22:%22geneVariant%22}},{%22id%22:%22Gender%22},{%22id%22:%22Age%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22TSNE%20Category%22}]}]}]}), then try to change the divide by term or click on the `TSNE closest cluster` row label, there should be no errors. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
