### PR TITLE
Fix for user identified issue with `.bcf:{url}` in `runproteinpaint()`

### DIFF
--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -604,6 +604,17 @@ export async function get_tklst(urlp, genomeobj) {
 			})
 		}
 	}
+	if (urlp.has('mds3bcfurl')) {
+		// "name,url,indexURL" to remote file. indexURL is optional when the index file is not co-locating with the bcf file
+		const [tkname, url, indexURL] = urlp.get('mds3bcfurl').split(',')
+		if (tkname && url) {
+			tklst.push({
+				type: client.tkt.mds3,
+				name: tkname,
+				bcf: { url, indexURL }
+			})
+		}
+	}
 
 	if (urlp.has('arcfile')) {
 		const lst = urlp.get('arcfile').split(',')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- Bcf url argument for mds3 tracks fixed.

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -937,7 +937,7 @@ export async function snvindelByRangeGetter_bcf(ds, genome) {
 	.
 	*/
 
-	if (q._tk.file) {
+	if (q._tk.file || q._tk.url) {
 		await utils.init_one_vcf(q._tk, genome, true) // "true" to indicate file is bcf but not vcf
 	} else if (q._tk.chr2files) {
 		// record stringified sample json array from first chr

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -222,7 +222,7 @@ export async function init_one_vcf(tk, genome, isbcf) {
 		await validate_tabixfile(tk.file)
 	} else if (tk.url) {
 		filelocation = tk.url
-		tk.dir = await utils.cache_index(tk.url, tk.indexURL)
+		tk.dir = await cache_index(tk.url, tk.indexURL)
 	} else {
 		throw 'no file or url given for vcf file'
 	}


### PR DESCRIPTION
## Description
User identified issue with mds3 track not accepting bcf urls. This corrects issue. 

To test: Create a html file with:
```
<!DOCTYPE html>
<html>
<head>
	 <meta charset="utf-8">
</head>
<body>

<script src="bin/proteinpaint.js" charset="utf-8"></script>

<div id=aaa style="margin:10px"></div>

<script>
runproteinpaint({
  holder:document.getElementById('aaa'),
  genome:"hg38",
  gene:"TP53",
  tracks:[
    {
      type: "mds3",
      name: "BCF with samples",
      bcf: {
         url: "https://proteinpaint.stjude.org/ppdemo/hg38/bcf/test.bcf.gz",
         //file: "proteinpaint_demo/hg38/bcf/test.bcf.gz"
      }
    }
  ]
})
</script>
</body>
</html>
```
Check by switching between`file` and `url`. Also works with `.bcf{.url, .indexURL}`. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
