### PR TITLE
fix: Filter mutations checkbox is not shown if there is no CGC

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Filter mutations checkbox is not shown for if there is no CGC


### PR DESCRIPTION
## Description

Fixes the issues that Cancer Gene census option was  hardcoded and shows up for [pnet](http://localhost:3000/?genome=hg19&dslabel=PNET&disco=1&sample=SJBT032239_D1) which is based on hg19 but hg19 doesn't have CGC..


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
