### PR TITLE
supply a ds specific health status if applicable in the healthcheck handler

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- support dataset-specific healthcheck information

--- a/server/routes/healthcheck.ts
+++ b/server/routes/healthcheck.ts
@@ -9,6 +9,16 @@ export const api = {
 				return async (req: undefined, res: any): Promise<void> => {
 					try {
 						const health = (await getStat(genomes)) as HealthCheckResponse
+						const q = req.query
+						if (q.dslabel) {
+							for (const gn in genomes) {
+								const ds = genomes[gn]?.datasets?.[q.dslabel]
+								if (!ds?.getHealth) continue
+								if (!health.byDataset) health.byDataset = {}
+								if (!health.byDataset[q.dslabel]) health.byDataset[q.dslabel] = {}
+								health.byDataset[q.dslabel][gn] = ds.getHealth(ds)
+							}
+						}
 						res.send(health)
 					} catch (e: any) {
 						res.send({ status: 'error', error: e.message || e })

--- a/server/routes/healthcheck.ts
+++ b/server/routes/healthcheck.ts
@@ -6,7 +6,7 @@ export const api = {
 	methods: {
 		get: {
 			init({ genomes }) {
-				return async (req: undefined, res: any): Promise<void> => {
+				return async (req: any, res: any): Promise<void> => {
 					try {
 						const health = (await getStat(genomes)) as HealthCheckResponse
 						const q = req.query

--- a/server/shared/types/routes/healthcheck.ts
+++ b/server/shared/types/routes/healthcheck.ts
@@ -46,6 +46,9 @@ export type HealthCheckResponse = {
 	status: 'ok' | 'error'
 	genomes: BuildByGenome
 	versionInfo: VersionInfo
+	byDataset: {
+		[dslabel: string]: any
+	}
 	auth?: {
 		errors?: string[]
 	}[]


### PR DESCRIPTION
## Description

Requires the `sjpp` health-by-ds branch.

To test, load http://localhost:3000/healthcheck?dslabel=GDC , there should be a `byDataset.gdc` object in the response.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
