### PR TITLE
fix: COSMIC mds3 track bug fix, number of variants will go down in su…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- COSMIC mds3 track bug fix, number of variants will go down in subtrack with sample filtering

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -672,7 +672,7 @@ function mayAdd_refseq2ensembl(ds, genome) {
 
 /* generate getter as ds.queries.snvindel.byrange.get() when both bcffile(no samples) and maffile are provided
 
-Called to initiate official dataset, in sthis script 
+Called to initiate official dataset, in this script 
 
 getter input:
 .rglst=[ {chr, start, stop} ] (required)
@@ -853,15 +853,13 @@ export async function snvindelByRangeGetter_bcfMaf(ds, genome) {
 					pos = Number(l[1]) - 1,
 					refallele = l[2],
 					altallele = l[3]
-				const ssm_id = [chr, pos, refallele, altallele].join(ssmIdFieldsSeparator)
-				if (!variantSamples.hasOwnProperty(ssm_id)) {
-					variantSamples[ssm_id] = []
-				}
 				const sample = l[sampleIdx]
 				const sampleInt = ds.sampleName2Id.get(sample)
-				if (limitSamples && !limitSamples.has(sampleInt)) {
-					return // Skip this line if sampleInt is not found in limitSamples
-				}
+				if (limitSamples && !limitSamples.has(sampleInt)) return // this sample is filtered out
+
+				// this same passes filter, associate with a ssm_id
+				const ssm_id = [chr, pos, refallele, altallele].join(ssmIdFieldsSeparator)
+				if (!variantSamples.hasOwnProperty(ssm_id)) variantSamples[ssm_id] = []
 
 				const sampleObj = { sample_id: sampleInt }
 				if (param.addFormatValues) {


### PR DESCRIPTION
…btrack with sample filtering

## Description

Karishma noticed this
test at http://localhost:3000/?genome=hg38&gene=hoxb1&mds3=COSMIC, filter by `primary site=skin`. subtk has 74 variants compared to 212 total

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
