### PR TITLE
show basic and advanced options in the matrix sorter controls

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -231,7 +231,7 @@ export function setComputedConfig(config) {
 	const s = config.settings.matrix
 	const allClasses = [...s.mutationClasses, ...s.CNVClasses]
 
-	s.filterByClass = {}
+	s.filterByClass = { isAtomic: true }
 	for (const f of config.legendGrpFilter.lst) {
 		if (!f.dt) continue
 		allClasses
@@ -253,7 +253,7 @@ export function setComputedConfig(config) {
 			})
 		else throw `unhandled tvs from legendValueFilter`
 	}
-	s.hiddenVariants = Object.keys(s.filterByClass)
+	s.hiddenVariants = Object.keys(s.filterByClass).filter(c => c !== 'isAtomic')
 
 	const hiddenCNVs = new Set(s.hiddenVariants.filter(key => mclass[key]?.dt === dtcnv))
 	s.hiddenCNVs = [...hiddenCNVs]

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -65,8 +65,8 @@ export async function getPlotConfig(opts = {}, app) {
 				sampleNameFilter: '',
 				sortSamplesBy: 'a',
 				sortPriority: undefined, // will be filled-in
-				sortByMutation: 'consequence', // TODO: deprecate and instead set the matching sortOptions.a.sortPriority[*].tiebreakers[*].isOrdered
-				sortByCNV: true, // TODO: deprecate and instead set the matching sortOptions.a.sortPriority[*].tiebreakers[*].isOrdered
+				sortByMutation: 'consequence', // TODO: compute from the matching sortOptions.a.sortPriority[*].tiebreakers[*].isOrdered
+				sortByCNV: true, // TODO: compute from the matching sortOptions.a.sortPriority[*].tiebreakers[*].isOrdered
 				//sortOptions: getSortOptions(app.vocabApi.termdbConfig, controlLabels),
 				sortSampleGrpsBy: 'name', // 'hits' | 'name' | 'sampleCount'
 				sortSamplesTieBreakers: [{ $id: 'sample', sortSamples: {} /*split: {char: '', index: 0}*/ }],
@@ -276,4 +276,11 @@ export function setComputedConfig(config) {
 		? 'onlyTruncating'
 		: 'bySelection'
 	s.allMatrixMutationHidden = hiddenMutations.size == s.mutationClasses.length
+
+	const tiebreakers =
+		s.sortOptions.a?.sortPriority.find(sp => sp.types.length == 1 && sp.types[0] == 'geneVariant')?.tiebreakers || []
+
+	s.sortByMutation = tiebreakers.find(tb => tb.filter?.values[0]?.dt === 1).isOrdered ? 'consequence' : 'presence'
+
+	s.sortByCNV = tiebreakers.find(tb => tb.filter?.values[0]?.dt === 4).disabled !== true
 }

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -432,6 +432,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 					},
 					{
 						label: 'Cases with CNV data > without',
+						mayToggle: true,
 						filter: {
 							values: [
 								{
@@ -446,6 +447,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 					},
 					{
 						disabled: true,
+						mayToggle: true,
 						label: 'Cases with consequence data',
 						filter: {
 							values: [

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -405,7 +405,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 						order: ['Fuserna' /*'WT', 'Blank'*/]
 					},
 					{
-						label: 'Cases with protein changing mutations > without',
+						label: 'Cases with truncating mutations > without',
 						filter: {
 							values: [
 								{
@@ -416,7 +416,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 						by: 'class',
 						isOrdered: false,
 						order: [
-							...s.proteinChangingMutations
+							...s.truncatingMutations
 							// // truncating
 							// 'F', // FRAMESHIFT
 							// 'N', // NONSENSE
@@ -430,7 +430,10 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 
 							// // point
 							// 'M' // MISSENSE
-						]
+						],
+						// do not have the option to add unused protein-changing mutations,
+						// because the "truncating" label for this tiebreaker will not make sense
+						notUsed: []
 					},
 					{
 						label: 'Cases with CNV data > without',
@@ -448,9 +451,9 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 						order: ['CNV_amp', 'CNV_loss']
 					},
 					{
-						disabled: true,
+						disabled: false,
 						mayToggle: true,
-						label: 'Cases with consequence data',
+						label: 'Cases with protein-changing mutations > without',
 						filter: {
 							values: [
 								{
@@ -459,30 +462,11 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 							]
 						},
 						by: 'class',
-						isOrdered: true,
-						order: [
-							// truncating
-							'F', // FRAMESHIFT
-							'N', // NONSENSE
-							'L', // SPLICE
-							'P', // SPLICE_REGION
-
-							// indel
-							'D', // PROTEINDEL
-							'I', // PROTEININS
-							'ProteinAltering',
-
-							// point
-							'M' // MISSENSE
-						],
-						notUsed: [
-							// noncoding
-							'Utr3',
-							'Utr5',
-							'S', //SILENT
-							'Intron',
-							'noncoding'
-						]
+						isOrdered: false,
+						// by default, do not include truncating mutations here since they may
+						// already be used in the tiebreaker with truncating mutations
+						order: s.proteinChangingMutations.filter(mcls => !s.truncatingMutations.includes(mcls)),
+						notUsed: s.truncatingMutations
 					}
 				]
 			},

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -289,19 +289,21 @@ function getSortSamplesByClass(st, self, rows, s) {
 			cls.set(row.sample, nextRound)
 			return
 		}
+
 		const vals = values.map(v => v.class)
-		let str = sortSamples.isOrdered ? '' : 'x'
-		for (const mcls of order) {
-			if (sortSamples.isOrdered) str += vals.includes(mcls) ? '1' : 'x'
-			else if (vals.includes(mcls)) {
-				str = '1'
-				break
-			}
+		if (!order.find(mcls => vals.includes(mcls))) {
+			// there is no matching values, force the sorting to the next round of tiebreakers
+			cls.set(row.sample, nextRound)
+			return
+		} else if (!sortSamples.isOrdered) {
+			cls.set(row.sample, '1')
+		} else {
+			// each sample will be mapped to a sortable string (for ease of sorting comparison),
+			// derived from concatenating an array of characters equivalent to indicate
+			// natching or not matching an ordered mclass
+			const str = order.map(mcls => (vals.includes(mcls) ? '1' : 'x'))
+			cls.set(row.sample, str)
 		}
-		// each sample will be mapped to a sortable string (for ease of sorting comparison),
-		// derived from concatenating an array of numbers equivalent to values that match
-		// the mclass sortPriority
-		cls.set(row.sample, str)
 	}
 
 	// not calling setSortIndex in advance based on the benchmark notes above

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -34,7 +34,7 @@ export function getSorterUi(opts) {
 		type: 'custom',
 		expanded: opts.expanded || false,
 		expandedSection: opts.expandedSection || '',
-		init(overrides = {}) {
+		init(overrides = {}, _opts = {}) {
 			tip.clear().hide()
 			const s = copyMerge(`{}`, parent.config.settings.matrix, overrides)
 			self.settings = s
@@ -54,7 +54,7 @@ export function getSorterUi(opts) {
 					tiebreakers: []
 				}
 			]
-
+			Object.assign(opts, _opts) // on update, new opts, such as a new holder dom element, may be provided
 			opts.holder.selectAll('*').remove()
 			const topDiv = opts.holder.append('div').style('text-align', 'right')
 			topDiv.append('button').html('Apply').on('click', apply)

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -214,11 +214,13 @@ export function getSorterUi(opts) {
 
 					const td3 = tr.append('td').style('text-align', 'center').style('vertical-align', 'top')
 
-					const btn = td3
-						.append('button')
-						.datum(tb)
-						.html(tb.disabled ? 'Enable' : 'Disable')
-						.on('click', toggleTieBreakerDisabled)
+					if (tb.mayToggle) {
+						td3
+							.append('button')
+							.datum(tb)
+							.html(tb.disabled ? 'Enable' : 'Disable')
+							.on('click', toggleTieBreakerDisabled)
+					}
 				}
 
 				const lastTr = tbody.append('tr').attr('draggable', true).on('mouseover', undoMouseoverHighlights)
@@ -422,7 +424,7 @@ export function getSorterUi(opts) {
 			.append('span')
 			.style('cursor', 'pointer')
 			.style('text-decoration', d.filterByClass[d.key] == 'case' ? 'line-through' : '')
-			.html((d.filterByClass[d.key] ? '(<i>not used</i>) ' : '') + d.cls.label)
+			.html(d.cls.label + (d.filterByClass[d.key] ? ' (<i>not used since this value is hidden</i>)' : ''))
 
 		const toggle = div
 			.append('div')

--- a/client/plots/matrix.sorterUi.js
+++ b/client/plots/matrix.sorterUi.js
@@ -16,7 +16,7 @@ const alphabet = `ABCDEFGHIJKLMNOPQRSTUVWXYZ`.split('')
 export function getSorterUi(opts) {
 	const { controls, holder } = opts
 	const parent = controls.parent
-	const s = parent.config.settings.matrix
+	const s = structuredClone(parent.config.settings.matrix)
 	const l = s.controlLabels
 	const tip = new Menu({ padding: '', parent_menu: parent.app.tip?.d.node() })
 
@@ -36,7 +36,8 @@ export function getSorterUi(opts) {
 		expandedSection: opts.expandedSection || '',
 		init(overrides = {}, _opts = {}) {
 			tip.clear().hide()
-			const s = copyMerge(`{}`, parent.config.settings.matrix, overrides)
+			if (parent.config.settings.matrix != s) copyMerge(s, parent.config.settings.matrix)
+			if (s !== overrides) copyMerge(s, overrides)
 			self.settings = s
 			self.activeOption = structuredClone(s.sortOptions[s.sortSamplesBy])
 
@@ -58,7 +59,10 @@ export function getSorterUi(opts) {
 			opts.holder.selectAll('*').remove()
 			const topDiv = opts.holder.append('div').style('text-align', 'right')
 			topDiv.append('button').html('Apply').on('click', apply)
-			topDiv.append('button').html('Reset').on('click', self.init)
+			topDiv
+				.append('button')
+				.html('Reset')
+				.on('click', (event, d) => self.init())
 
 			const table = opts.holder.append('table')
 
@@ -77,7 +81,7 @@ export function getSorterUi(opts) {
 				const thead = table
 					.append('thead')
 					.datum(sd)
-					.attr('draggable', !sd.notDraggable)
+					.property('draggable', !sd.notDraggable)
 					.attr('droppable', true) //!sd.notDraggable)
 					.on('dragstart', trackDraggedSection)
 					.on('dragover', highlightSection)
@@ -129,8 +133,8 @@ export function getSorterUi(opts) {
 						.append('tr')
 						.on('mouseover', undoMouseoverHighlights)
 						.datum(tb)
-						.attr('draggable', !tb.disabled && sd.types?.length)
-						.attr('droppable', !tb.disabled && sd.types?.length)
+						.attr('draggable', !tb.disabled && sd.types?.length !== 0)
+						.attr('droppable', !tb.disabled && sd.types?.length !== 0)
 						.on('dragstart', trackDraggedTieBreaker)
 						.on('dragover', highlightTieBreaker)
 						.on('dragleave', unhighlightTieBreaker)
@@ -160,7 +164,7 @@ export function getSorterUi(opts) {
 
 					if (!tb.disabled) {
 						const label = td2.append('label')
-						label.append('span').html(' (use data list order ')
+						label.append('span').html('<br>(use data list order ')
 						if (!tb.isOrdered) tb.isOrdered = false
 						const checkbox = label
 							.append('input')
@@ -383,9 +387,10 @@ export function getSorterUi(opts) {
 			//.on('mouseover', () => )
 			.on('click', () => {
 				if (title.length) {
-					const div = tip.clear().d.append('div').style('max-width', '200px').style('padding', '5px')
-					div.append('div').html(title.join('<br>'))
-					tip.showunder(this)
+					const cls = 'sjpp-matrix-sorter-value-note'
+					div.selectAll(`.${cls}`).remove()
+					const note = div.append('div').attr('class', cls).style('max-width', '200px').style('padding', '5px')
+					note.html(title.join('<br>'))
 					if (d.filterByClass[d.key]) return
 				}
 

--- a/client/plots/test/matrix.sort.unit.spec.js
+++ b/client/plots/test/matrix.sort.unit.spec.js
@@ -247,7 +247,11 @@ tape('sortPriority by Mutation categories, default no value sorting, that uses a
 	test.deepEqual(
 		sampleNames,
 		[
-			[2, 3, 1],
+			// NOTE on 5/29/2024:
+			// When prioritizing truncating mutations, samples with F (truncating)
+			// will be sorted before samples with only M (non-truncating)
+			// for a given gene row
+			[3, 2, 1],
 			[5, 4]
 		],
 		'should sort the samples by dt then value'
@@ -256,9 +260,9 @@ tape('sortPriority by Mutation categories, default no value sorting, that uses a
 		simpleMatrix(sampleNames, self.termOrder, rows),
 		// prettier-ignore
 		[ 
-			[ '2', '3', ' ', '5', ' ' ], 
-			[ '2', ' ', '1', '5', ' ' ], 
-			[ ' ', '3', '1', ' ', '4' ] 
+			[ '3', '2', ' ', '5', ' ' ], 
+			[ ' ', '2', '1', '5', ' ' ], 
+			[ '3', ' ', '1', ' ', '4' ] 
 		],
 		'should sort sample and rows in the expected order'
 	)
@@ -373,7 +377,7 @@ tape('custom sortPriority, without filter', async test => {
 	test.deepEqual(
 		sampleNames,
 		[
-			[2, 3, 1],
+			[3, 2, 1],
 			[5, 4]
 		],
 		'should sort the samples by dt then value'
@@ -382,9 +386,9 @@ tape('custom sortPriority, without filter', async test => {
 		simpleMatrix(sampleNames, self.termOrder, rows),
 		// prettier-ignore
 		[ 
-			[ '2', '3', ' ', '5', ' ' ], 
-			[ '2', ' ', '1', '5', ' ' ], 
-			[ ' ', '3', '1', ' ', '4' ] 
+			[ '3', '2', ' ', '5', ' ' ], 
+			[ ' ', '2', '1', '5', ' ' ], 
+			[ '3', ' ', '1', ' ', '4' ] 
 		],
 		'should sort sample and rows in the expected order'
 	)

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -223,9 +223,9 @@ tape('tiebreaker disabled', async test => {
 	const trs = thead1.nextSibling.querySelectorAll('tr')
 
 	test.equal(
-		select(trs[0].lastChild).select('button').html(),
-		'Disable',
-		'should indicate that the protein-changing tiebreaker is active'
+		select(trs[0].lastChild).select('button').node(),
+		null,
+		`should not have an enable/disable toggle button for the protein-changing tiebreaker that is not configured with 'mayToggle: true'`
 	)
 
 	test.equal(

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -231,18 +231,18 @@ tape('tiebreaker disabled', async test => {
 	)
 
 	test.equal(
-		select(trs[2].lastChild).select('button').html(),
+		select(trs[1].lastChild).select('button').html(),
 		'Enable',
 		'should indicate that the CNV tiebreaker is not active'
 	)
 
-	select(trs[2].lastChild).select('button').node().click()
+	select(trs[1].lastChild).select('button').node().click()
 	const activeTieBreakers = ui.activeOption.sortPriority[0].tiebreakers
 	ui.apply()
 
 	test.deepEqual(
-		activeTieBreakers[2].disabled,
-		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority[0].tiebreakers[2]?.disabled,
+		activeTieBreakers[1].disabled,
+		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority[0].tiebreakers[1]?.disabled,
 		'should adjust the CNV tiebreaker disabled after clicking apply'
 	)
 

--- a/client/plots/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/test/matrix.sorterUi.unit.spec.js
@@ -102,6 +102,7 @@ tape('section visibility toggling', async test => {
 tape('simulated section drag/drop', async test => {
 	const { uiApi, controls, config, parent, opts } = await getControls()
 	const s = config.settings.matrix
+	const prevSettings = structuredClone(s)
 	const ui = uiApi.Inner
 	const activeOptionBeforeDrag = structuredClone(ui.activeOption)
 	const th = opts.holder
@@ -124,7 +125,7 @@ tape('simulated section drag/drop', async test => {
 
 	test.deepEqual(
 		activeOptionBeforeDrag.sortPriority,
-		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority,
+		prevSettings.sortOptions[s.sortSamplesBy].sortPriority,
 		'should not adjust the sortPriority/table before clicking apply, after drag/drop'
 	)
 
@@ -143,6 +144,7 @@ tape('simulated section drag/drop', async test => {
 tape('simulated tiebreaker drag/drop', async test => {
 	const { uiApi, controls, config, parent, opts } = await getControls()
 	const s = config.settings.matrix
+	const prevSettings = structuredClone(s)
 	const ui = uiApi.Inner
 	const activeOptionBeforeDrag = structuredClone(ui.activeOption)
 	const thead0 = opts.holder
@@ -187,7 +189,7 @@ tape('simulated tiebreaker drag/drop', async test => {
 
 	test.deepEqual(
 		activeOptionBeforeDrag.sortPriority[0].tiebreakers,
-		config.settings.matrix.sortOptions[s.sortSamplesBy].sortPriority[0].tiebreakers,
+		prevSettings.sortOptions[s.sortSamplesBy].sortPriority[0].tiebreakers,
 		'should not adjust the tiebreakers before clicking apply, after drag/drop'
 	)
 


### PR DESCRIPTION
## Description

This update keeps the current, simpler matrix sorter UI with minimal inputs under a "Basic" tab. Under an "Advanced" tab, the new sorter UI is intended for super users, and includes more detailed rendering of the sorting rules/logic, with drag/drop interactivity to edit the matrix sort priority and tiebreaker rules.

Tested with all the unit and integration tests as usual, including http://localhost:3000/testrun.html?dir=plots&name=matrix.sort.unit and http://localhost:3000/testrun.html?dir=plots&name=matrix.sorterUi.unit.

Also tested manually to ensure that the basic and advanced inputs/status are synchronized, that is, changing an input in the advanced tab should update the input status in the basic tab, and vice-versa. I manually tested in http://localhost:3000/example.gdc.matrix.html?maxGenes=3&cohort=Gliomas.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
