### PR TITLE
Remove .id from termwrapper

### DIFF
--- a/client/dom/dynamicScatter.js
+++ b/client/dom/dynamicScatter.js
@@ -36,8 +36,8 @@ export function addDynamicScatterForm(tip, app) {
 				type: 'plot_create',
 				config: {
 					chartType: 'sampleScatter',
-					term: { id: xterm.id, term: xterm, q: { mode: 'continuous' } },
-					term2: { id: yterm.id, term: yterm, q: { mode: 'continuous' } },
+					term: { term: xterm, q: { mode: 'continuous' } },
+					term2: { term: yterm, q: { mode: 'continuous' } },
 					name: 'Dynamic scatter'
 				}
 			})

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -117,16 +117,16 @@ async function fillMenu(self, div, tvs) {
 		try {
 			const data = await self.opts.vocabApi.getViolinPlotData(
 				{
-					termid: tvs.term.id,
-					term: { id: tvs.term.id, term: tvs.term, q: { mode: 'continuous' } },
+					term: { term: tvs.term, q: { mode: 'continuous' } },
 					filter: self.filter,
 					svgw: self.num_obj.plot_size.width / window.devicePixelRatio
 				},
 				self.opts.getCategoriesArguments
 			)
+			if (data.error) throw data.error
 			self.num_obj.density_data = convertViolinData(data)
 		} catch (err) {
-			console.log(err)
+			throw err
 		}
 	} else {
 		// frontend vocab lacks this method, return no density data so ui will not show the plot

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -494,7 +494,7 @@ export async function openSummaryPlot(term, samplelstTW, app, id, newId) {
 	// barchart config.term{} name is confusing, as it is actually a termsetting object, not term
 	// thus convert the given term into a termwrapper
 	// tw.q can be missing and will be filled in with default setting
-	const tw = term.term ? term : { id: term.id, term }
+	const tw = term.term ? term : { term }
 
 	let config = {
 		chartType: 'summary',

--- a/client/mass/search.js
+++ b/client/mass/search.js
@@ -127,7 +127,7 @@ function setRenderers(self) {
 						type: 'plot_create',
 						config: {
 							chartType: term.type == 'survival' ? 'survival' : 'summary',
-							term: { id: term.id, term }
+							term: { term }
 						}
 					})
 					self.clear({ hide: true })

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -517,7 +517,7 @@ function validateGenericPlot(p, vocabApi) {
 		} catch (e) {
 			throw 'plot.term2 error: ' + e
 		}
-		if (p.term.term.type == 'condition' && p.term.id == p.term2.id) {
+		if (p.term.term.type == 'condition' && p.term.term.id == p.term2.term.id) {
 			// term and term2 are the same CHC, potentially allows grade-subcondition overlay
 			if (p.term.q.bar_by_grade && p.term2.q.bar_by_grade)
 				throw 'plot error: term2 is the same CHC, but both cannot be using bar_by_grade'
@@ -559,8 +559,6 @@ function validatePlotTerm(t, vocabApi) {
 	if (!t.term) throw '.term{} missing'
 	if (!vocabApi.graphable(t.term)) throw '.term is not graphable (not a valid type)'
 	if (!t.term.name) throw '.term.name missing'
-	t.id = t.term.id
-
 	if (!t.q) throw '.q{} missing'
 	// term-type specific validation of q
 	switch (t.term.type) {

--- a/client/mass/test/summary.integration.spec.js
+++ b/client/mass/test/summary.integration.spec.js
@@ -419,6 +419,10 @@ tape('Overlay continuity, term: "aaclassic_5", term2: "sex"', test => {
 		// NOTE: detect a rendered violin viz element, not the holder which may still be empty
 		// by the time test.equal is called below
 		await detectOne({ elem: summary.Inner.dom.holder.body.node(), selector: '.sjpp-violin-plot' })
-		test.equal(plots.violin.Inner.config.term2.id, testTerm, `Overlay term = ${testTerm} carried over to violin plot`)
+		test.equal(
+			plots.violin.Inner.config.term2.term.id,
+			testTerm,
+			`Overlay term = ${testTerm} carried over to violin plot`
+		)
 	}
 })

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -361,7 +361,7 @@ tape('test basic controls', function (test) {
 				term2
 			}
 		})
-		test.true(violin.Inner.app.Inner.state.plots[0].term2.id === 'genetic_race', 'Overlay term changed')
+		test.true(violin.Inner.app.Inner.state.plots[0].term2.term.id === 'genetic_race', 'Overlay term changed')
 	}
 
 	async function changeScaleToLog(violin, violinDiv) {

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -195,7 +195,7 @@ async function showSummary4terms(data, div, tk, block) {
 	for (const { termid, numbycategory } of data) {
 		tabs.push({
 			label:
-				tk.mds.variant2samples.twLst.find(i => i.id == termid).term.name +
+				tk.mds.variant2samples.twLst.find(i => i.term.id == termid).term.name +
 				(numbycategory
 					? `<span style="opacity:.8;font-size:.8em;float:right;margin-left: 5px;">n=${numbycategory.length}</span>`
 					: '')
@@ -250,7 +250,7 @@ numbycategory = []
 	[2] = total number of cases from this category
 */
 function showSummary4oneTerm(termid, div, numbycategory, tk, block) {
-	const tw = tk.mds.variant2samples.twLst.find(i => i.id == termid)
+	const tw = tk.mds.variant2samples.twLst.find(i => i.term.id == termid)
 	if (!tw) throw 'showSummary4oneTerm(): tw not found from variant2samples.twLst'
 
 	const rows = []

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -188,6 +188,7 @@ async function make_singleSampleTable(s, arg) {
 			const [cell1, cell2] = table.addRow()
 			cell1.text(tw.term.name).style('text-overflow', 'ellipsis')
 			cell2.style('text-overflow', 'ellipsis')
+			// TODO: use tw.$id to accomodate non-dictionary terms
 			if (tw.term.id in s) {
 				if (Array.isArray(s[tw.term.id])) {
 					if (tw.baseURL) {

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -188,13 +188,13 @@ async function make_singleSampleTable(s, arg) {
 			const [cell1, cell2] = table.addRow()
 			cell1.text(tw.term.name).style('text-overflow', 'ellipsis')
 			cell2.style('text-overflow', 'ellipsis')
-			if (tw.id in s) {
-				if (Array.isArray(s[tw.id])) {
+			if (tw.term.id in s) {
+				if (Array.isArray(s[tw.term.id])) {
 					if (tw.baseURL) {
 						// TODO convert to display value
-						cell2.html(s[tw.id].map(i => `<a href=${tw.baseURL + i} target=_blank>${i}</a>`).join('<br>'))
+						cell2.html(s[tw.term.id].map(i => `<a href=${tw.baseURL + i} target=_blank>${i}</a>`).join('<br>'))
 					} else {
-						cell2.html(s[tw.id].join('<br>'))
+						cell2.html(s[tw.term.id].join('<br>'))
 					}
 				} else {
 					// single value
@@ -254,8 +254,8 @@ async function make_singleSampleTable(s, arg) {
 
 // get display value for a tw from a sample
 function twDisplayValueFromSample(s, tw) {
-	if (!(tw.id in s)) return ''
-	const v = s[tw.id]
+	if (!(tw.term.id in s)) return ''
+	const v = s[tw.term.id]
 	if (tw.term.values?.[v]?.label) return tw.term.values[v].label
 
 	const vc = tw.term.valueConversion

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -608,7 +608,7 @@ export async function openHiercluster(term, samplelstTW, app, id, newId) {
 	// barchart config.term{} name is confusing, as it is actually a termsetting object, not t    erm
 	// thus convert the given term into a termwrapper
 	// tw.q can be missing and will be filled in with default setting
-	const tw = term.term ? term : { id: term.id, term }
+	const tw = term.term ? term : { term }
 
 	let config = {
 		chartType: 'hierCluster',

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -24,7 +24,6 @@ export default function getHandlers(self) {
 			config: {
 				term: {
 					isAtomic: true,
-					id: term.id,
 					term: term.term,
 					q: getUpdatedQfromClick(d, term, true)
 				}
@@ -263,7 +262,6 @@ function handleColorClick(d, self, color) {
 		config: {
 			[termNum]: {
 				isAtomic: true,
-				id: term.id,
 				term: term.term,
 				q: getUpdatedQfromClick(d, term, d.isHidden, binColored)
 			}
@@ -336,7 +334,6 @@ export function hideCategory(d, self, isHidden) {
 		config: {
 			[termNum]: {
 				isAtomic: true,
-				id: term.id,
 				term: term.term,
 				q: getUpdatedQfromClick(d, term, isHidden)
 			}
@@ -395,7 +392,6 @@ function handle_click(event, self, chart) {
 					config: {
 						term: {
 							isAtomic: true,
-							id: term.id,
 							term: term.term,
 							q: getUpdatedQfromClick({ id: d.seriesId, type: 'col' }, term, true)
 						}
@@ -416,7 +412,6 @@ function handle_click(event, self, chart) {
 						config: {
 							term2: {
 								isAtomic: true,
-								id: term2.id,
 								term: term2.term,
 								q: getUpdatedQfromClick({ id: d.dataId, type: 'row' }, term2, true)
 							}

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -716,7 +716,7 @@ function getTermValues(d, self) {
 			}
 			termValues.push(tvs)
 		} else if (term.term.type == 'condition') {
-			if (!t2 || t1.id != t2.id) {
+			if (!t2 || t1.term.id != t2.term.id) {
 				termValues.push(
 					Object.assign(
 						{
@@ -728,7 +728,7 @@ function getTermValues(d, self) {
 				)
 			}
 
-			if (term == t1 && t2 && term.term.id == t2.id) {
+			if (term == t1 && t2 && term.term.id == t2.term.id) {
 				const q2 = t2.q
 				const term2Label =
 					t2.term.values && d.dataId in t2.term.values ? self.config.term2.values[d.dataId].label : d.dataId

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -269,7 +269,7 @@ class Barchart {
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
 			if (isNumericTerm(t)) {
-				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter.filter)
+				const data = await this.app.vocabApi.getDescrStats(t.term.id, this.state.termfilter.filter)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
 			}

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -11,7 +11,7 @@ import { controlsInit } from './controls'
 import { to_svg } from '../src/client'
 import { renderTable } from '../dom/table'
 import { fillTermWrapper } from '#termsetting'
-import { getColors, mclass, isNumericTerm, plotColor } from '#shared/common'
+import { getColors, mclass, isNumericTerm, plotColor } from '../shared/common'
 
 class Barchart {
 	constructor(opts) {
@@ -268,8 +268,8 @@ class Barchart {
 		if (this.config.term2) terms.push(this.config.term2)
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
-			if (isNumericTerm(t)) {
-				const data = await this.app.vocabApi.getDescrStats(t.term.id, this.state.termfilter.filter)
+			if (isNumericTerm(t.term)) {
+				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter.filter)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
 			}
@@ -319,7 +319,7 @@ class Barchart {
 	}
 
 	mayResetHidden(term, term2, term0) {
-		const combinedTermIds = (term && term.id) + ';;' + (term2 && term2.id) + ';;' + (term0 && term0.id)
+		const combinedTermIds = (term && term.term.id) + ';;' + (term2 && term2.term.id) + ';;' + (term0 && term0.term.id)
 		if (combinedTermIds === this.currCombinedTermIds) return
 		// only reset hidden if terms have changed
 		for (const chart of this.currServerData.charts) {

--- a/client/plots/controls.divide.js
+++ b/client/plots/controls.divide.js
@@ -41,9 +41,6 @@ class Divide {
 			getBodyParams: this.opts.getBodyParams,
 			callback: term0 => {
 				// term0 is {term,q} and can be null
-				if (term0) {
-					term0.id = term0.term.id
-				}
 				this.app.dispatch({
 					type: 'plot_edit',
 					id: this.opts.id,
@@ -97,20 +94,14 @@ class Divide {
 export const divideInit = getCompInit(Divide)
 
 function setRenderers(self) {
-	self.initUI = function() {
-		self.dom.tr
-			.append('td')
-			.text('Divide by')
-			.attr('class', 'sja-termdb-config-row-label')
+	self.initUI = function () {
+		self.dom.tr.append('td').text('Divide by').attr('class', 'sja-termdb-config-row-label')
 		const td = self.dom.tr.append('td')
-		self.dom.menuBtn = td
-			.append('div')
-			.attr('class', 'sja_clbtext2')
-			.on('click', self.showMenu)
+		self.dom.menuBtn = td.append('div').attr('class', 'sja_clbtext2').on('click', self.showMenu)
 		self.dom.pilldiv = td.append('div')
 		self.dom.tip = new Menu({ padding: '0px' })
 	}
-	self.updateUI = function() {
+	self.updateUI = function () {
 		const plot = this.state.config
 		self.dom.tr.style('display', '')
 
@@ -133,7 +124,7 @@ function setRenderers(self) {
 		self.dom.pilldiv.style('display', 'inline-block')
 		self.updatePill()
 	}
-	self.showMenu = function() {
+	self.showMenu = function () {
 		self.pill.showTree(self.dom.menuBtn.node())
 	}
 }

--- a/client/plots/controls.overlay.js
+++ b/client/plots/controls.overlay.js
@@ -47,9 +47,6 @@ class Overlay {
 
 			callback: term2 => {
 				// term2 is {term,q} and can be null
-				if (term2) {
-					term2.id = term2.term.id
-				}
 				this.app.dispatch({
 					type: 'plot_edit',
 					id: this.opts.id,
@@ -118,20 +115,14 @@ class Overlay {
 export const overlayInit = getCompInit(Overlay)
 
 function setRenderers(self) {
-	self.initUI = function() {
-		self.dom.tr
-			.append('td')
-			.text('Overlay')
-			.attr('class', 'sja-termdb-config-row-label')
+	self.initUI = function () {
+		self.dom.tr.append('td').text('Overlay').attr('class', 'sja-termdb-config-row-label')
 		const td = self.dom.tr.append('td')
-		self.dom.menuBtn = td
-			.append('div')
-			.attr('class', 'sja_clbtext2')
-			.on('click', self.showMenu)
+		self.dom.menuBtn = td.append('div').attr('class', 'sja_clbtext2').on('click', self.showMenu)
 		self.dom.pilldiv = td.append('div')
 		self.dom.tip = new Menu({ padding: '0px' })
 	}
-	self.updateUI = function() {
+	self.updateUI = function () {
 		if (this.state.ssid) {
 			/*
 			quick fix --
@@ -179,7 +170,7 @@ function setRenderers(self) {
 		self.dom.pilldiv.style('display', 'inline-block')
 		self.updatePill()
 	}
-	self.showMenu = function() {
+	self.showMenu = function () {
 		self.pill.showTree(self.dom.menuBtn.node())
 	}
 }

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -75,7 +75,6 @@ class Term1ui {
 							will replace plot.term with {q}
 							*/
 							isAtomic: true,
-							id: this.state.plot.term.term.id,
 							term: JSON.parse(JSON.stringify(this.state.plot.term.term)),
 							q: data.q
 						}

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -22,7 +22,7 @@ class MassDict {
 						type: 'plot_create',
 						config: {
 							chartType: term.type == 'survival' ? 'survival' : 'summary',
-							term: _term.term ? _term : 'id' in term ? { id: term.id, term } : { term }
+							term: _term.term ? _term : { term }
 						}
 					})
 

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -208,8 +208,12 @@ export async function getPlotConfig(opts = {}, app) {
 	const promises = []
 	for (const grp of config.termgroups) {
 		for (const tw of grp.lst) {
-			// force the saved session to request the most up-to-data dictionary term data from server
-			if (!tw.term?.type || isDictionaryType(tw.term.type)) delete tw.term
+			// may force the saved session to request the most up-to-data dictionary term data from server
+			if (!tw.term?.type || isDictionaryType(tw.term.type)) {
+				// NOTE: some test or demo cases may hardcode a dictionary tw.term and not have a tw.id,
+				//       in that case should not replace the tw.term with data from server
+				if (tw.id) delete tw.term
+			}
 			promises.push(fillTermWrapper(tw, app.vocabApi))
 		}
 	}

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -209,10 +209,11 @@ export async function getPlotConfig(opts = {}, app) {
 	for (const grp of config.termgroups) {
 		for (const tw of grp.lst) {
 			// may force the saved session to request the most up-to-data dictionary term data from server
+			// TODO: should skip samplelst term here
 			if (!tw.term?.type || isDictionaryType(tw.term.type)) {
 				if (!tw.id) {
 					if (!tw.term.id) throw `missing tw.id and tw.term.id`
-					tw.id = tw.term.id // will allow tw to be rehydrated with new term data from server
+					tw.id = tw.term.id // tw.id will be used to rehydrate tw with new term data from server. tw.id will be deleted following rehydration.
 				}
 				delete tw.term
 			}

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -210,9 +210,11 @@ export async function getPlotConfig(opts = {}, app) {
 		for (const tw of grp.lst) {
 			// may force the saved session to request the most up-to-data dictionary term data from server
 			if (!tw.term?.type || isDictionaryType(tw.term.type)) {
-				// NOTE: some test or demo cases may hardcode a dictionary tw.term and not have a tw.id,
-				//       in that case should not replace the tw.term with data from server
-				if (tw.id) delete tw.term
+				if (!tw.id) {
+					if (!tw.term.id) throw `missing tw.id and tw.term.id`
+					tw.id = tw.term.id // will allow tw to be rehydrated with new term data from server
+				}
+				delete tw.term
 			}
 			promises.push(fillTermWrapper(tw, app.vocabApi))
 		}

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -209,8 +209,7 @@ export async function getPlotConfig(opts = {}, app) {
 	for (const grp of config.termgroups) {
 		for (const tw of grp.lst) {
 			// force the saved session to request the most up-to-data dictionary term data from server
-			// TODO: should generalize to any dictionary term
-			if (tw.id && (!tw.term?.type || !isDictionaryType(tw.term.type))) delete tw.term
+			if (!tw.term?.type || isDictionaryType(tw.term.type)) delete tw.term
 			promises.push(fillTermWrapper(tw, app.vocabApi))
 		}
 	}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -1430,10 +1430,10 @@ function setSampleGroupActions(self) {
 		const term = tw.term
 		if (term.type == 'categorical') {
 			term.$id = tw.$id
-			const filterGrpIndex = self.config.legendValueFilter.lst.findIndex(l => l.legendGrpName == tw.id)
+			const filterGrpIndex = self.config.legendValueFilter.lst.findIndex(l => l.legendGrpName == tw.term.id)
 			if (filterGrpIndex == -1) {
 				const filterNew = {
-					legendGrpName: tw.id,
+					legendGrpName: tw.term.id,
 					type: 'tvs',
 					tvs: {
 						isnot: true,
@@ -1449,7 +1449,7 @@ function setSampleGroupActions(self) {
 		} else if (term.type == 'integer' || term.type == 'float') {
 			term.$id = tw.$id
 			const filterNew = {
-				legendGrpName: tw.id,
+				legendGrpName: tw.term.id,
 				type: 'tvs',
 				tvs: {
 					isnot: true,
@@ -1473,7 +1473,7 @@ function setSampleGroupActions(self) {
 		if (!self.config.divideBy) return
 
 		const tw = self.activeLabel?.grp?.tw || self.config.divideBy
-		self.config.legendValueFilter.lst = self.config.legendValueFilter.lst.filter(l => l.legendGrpName !== tw.id)
+		self.config.legendValueFilter.lst = self.config.legendValueFilter.lst.filter(l => l.legendGrpName !== tw.term.id)
 
 		self.app.dispatch({
 			type: 'plot_edit',

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -1,4 +1,4 @@
-import { isNonDictionary } from '#shared/common'
+import { isDictionaryType } from '../shared/common'
 
 export function getSampleSorter(self, settings, rows, opts = {}) {
 	const s = settings
@@ -72,7 +72,7 @@ export function getSampleSorter(self, settings, rows, opts = {}) {
 						// sort against only dictionary terms in this tie-breaker
 						.filter(
 							t =>
-								!t.tw.sortSamples && !isNonDictionary(t.tw.term.type) && !selectedTerms.find(tw => tw.$id === t.tw.$id)
+								!t.tw.sortSamples && isDictionaryType(t.tw.term.type) && !selectedTerms.find(tw => tw.$id === t.tw.$id)
 						)
 						.map(t => Object.assign({ sortSamples: { by: 'values' } }, t.tw))
 
@@ -83,7 +83,7 @@ export function getSampleSorter(self, settings, rows, opts = {}) {
 						// sort against only non-dictionary terms in this tie-breaker
 						.filter(
 							t =>
-								!t.tw.sortSamples && isNonDictionary(t.tw.term.type) && !selectedTerms.find(tw => tw.$id === t.tw.$id)
+								!t.tw.sortSamples && !isDictionaryType(t.tw.term.type) && !selectedTerms.find(tw => tw.$id === t.tw.$id)
 						)
 						.map(t => Object.assign({ sortSamples: { by: 'hits' } }, t.tw))
 

--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -1,6 +1,4 @@
-/*
-	
-*/
+import { isNonDictionary } from '#shared/common'
 
 export function getSampleSorter(self, settings, rows, opts = {}) {
 	const s = settings
@@ -72,7 +70,10 @@ export function getSampleSorter(self, settings, rows, opts = {}) {
 				? []
 				: self.termOrder
 						// sort against only dictionary terms in this tie-breaker
-						.filter(t => !t.tw.sortSamples && t.tw.id && !selectedTerms.find(tw => tw.$id === t.tw.$id))
+						.filter(
+							t =>
+								!t.tw.sortSamples && !isNonDictionary(t.tw.term.type) && !selectedTerms.find(tw => tw.$id === t.tw.$id)
+						)
 						.map(t => Object.assign({ sortSamples: { by: 'values' } }, t.tw))
 
 		const unSelectedNonDictTerms =
@@ -80,7 +81,10 @@ export function getSampleSorter(self, settings, rows, opts = {}) {
 				? []
 				: self.termOrder
 						// sort against only non-dictionary terms in this tie-breaker
-						.filter(t => !t.tw.sortSamples && !t.tw.id && !selectedTerms.find(tw => tw.$id === t.tw.$id))
+						.filter(
+							t =>
+								!t.tw.sortSamples && isNonDictionary(t.tw.term.type) && !selectedTerms.find(tw => tw.$id === t.tw.$id)
+						)
 						.map(t => Object.assign({ sortSamples: { by: 'hits' } }, t.tw))
 
 		sorterTerms.push(...unSelectedNonDictTerms, ...unSelectedDictTerms)

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -72,7 +72,9 @@ export class profilePlot {
 
 	getList(tw) {
 		const values = Object.values(tw.term.values)
-		const data = this.filtersData.lst.filter(sample => this.samplesPerFilter[tw.id].includes(parseInt(sample.sample)))
+		const data = this.filtersData.lst.filter(sample =>
+			this.samplesPerFilter[tw.term.id].includes(parseInt(sample.sample))
+		)
 		const sampleValues = Array.from(new Set(data.map(sample => sample[tw.$id]?.value)))
 
 		for (const value of values) {
@@ -80,7 +82,7 @@ export class profilePlot {
 			value.disabled = !sampleValues.includes(value.label)
 		}
 		values.unshift({ label: '', value: '' })
-		if (!(tw.id in this.settings)) this.settings[tw.id] = values[0].label
+		if (!(tw.term.id in this.settings)) this.settings[tw.term.id] = values[0].label
 		return values
 	}
 
@@ -109,7 +111,7 @@ export class profilePlot {
 		const filters = {}
 		for (const tw of this.config.filterTWs) {
 			const filter = this.getFilter(tw)
-			if (filter) filters[tw.id] = filter
+			if (filter) filters[tw.term.id] = filter
 		}
 
 		//Dictionary with samples applying all the filters but not the one from the current term id
@@ -390,7 +392,7 @@ export class profilePlot {
 	}
 
 	clearFiltersExcept(ids) {
-		for (const tw of this.config.filterTWs) if (!ids.includes(tw.id)) this.settings[tw.id] = ''
+		for (const tw of this.config.filterTWs) if (!ids.includes(tw.term.id)) this.settings[tw.term.id] = ''
 		if (this.config.chartType != 'profileRadarFacility') this.settings.site = ''
 	}
 
@@ -404,7 +406,7 @@ export class profilePlot {
 		const excluded = []
 		if (tw) excluded.push(tw.$id)
 		const lst = []
-		for (const tw of this.config.filterTWs) this.processTW(tw, this.settings[tw.id], excluded, lst)
+		for (const tw of this.config.filterTWs) this.processTW(tw, this.settings[tw.term.id], excluded, lst)
 
 		const tvslst = {
 			type: 'tvslst',
@@ -429,7 +431,7 @@ export class profilePlot {
 
 	addFilterLegend() {
 		if (!this.settings.site || this.config.chartType == 'profileRadarFacility') {
-			const hasFilters = this.config.filterTWs.some(tw => this.settings[tw.id])
+			const hasFilters = this.config.filterTWs.some(tw => this.settings[tw.term.id])
 			this.filterG
 				.attr('font-size', '0.9em')
 				.append('text')
@@ -437,7 +439,7 @@ export class profilePlot {
 				.style('font-weight', 'bold')
 				.text(hasFilters ? 'Filters' : 'No filter applied')
 				.attr('transform', `translate(0, -5)`)
-			for (const tw of this.config.filterTWs) this.addFilterLegendItem(tw.term.name, this.settings[tw.id])
+			for (const tw of this.config.filterTWs) this.addFilterLegendItem(tw.term.name, this.settings[tw.term.id])
 		}
 		if (this.settings.site && this.config.chartType != 'profileRadarFacility') {
 			const label = this.sites.find(s => s.value == this.settings.site).label

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -187,7 +187,7 @@ export class profilePlot {
 						type: 'dropdown',
 						chartType,
 						options: this.regions,
-						settingsKey: this.config.regionTW.id,
+						settingsKey: this.config.regionTW.term.id,
 						callback: value => this.setRegion(value)
 					},
 					{
@@ -195,64 +195,64 @@ export class profilePlot {
 						type: 'dropdown',
 						chartType,
 						options: this.countries,
-						settingsKey: this.config.countryTW.id,
-						callback: value => this.setFilterValue(this.config.countryTW.id, value)
+						settingsKey: this.config.countryTW.term.id,
+						callback: value => this.setFilterValue(this.config.countryTW.term.id, value)
 					},
 					{
 						label: 'Income group',
 						type: 'dropdown',
 						chartType,
 						options: this.incomes,
-						settingsKey: this.config.incomeTW.id,
-						callback: value => this.setFilterValue(this.config.incomeTW.id, value)
+						settingsKey: this.config.incomeTW.term.id,
+						callback: value => this.setFilterValue(this.config.incomeTW.term.id, value)
 					},
 					{
 						label: 'Facility type',
 						type: 'dropdown',
 						chartType,
 						options: this.types,
-						settingsKey: this.config.typeTW.id,
-						callback: value => this.setFilterValue(this.config.typeTW.id, value)
+						settingsKey: this.config.typeTW.term.id,
+						callback: value => this.setFilterValue(this.config.typeTW.term.id, value)
 					},
 					{
 						label: this.config.teachingStatusTW.term.name,
 						type: 'dropdown',
 						chartType,
 						options: this.teachingStates,
-						settingsKey: this.config.teachingStatusTW.id,
-						callback: value => this.setFilterValue(this.config.teachingStatusTW.id, value)
+						settingsKey: this.config.teachingStatusTW.term.id,
+						callback: value => this.setFilterValue(this.config.teachingStatusTW.term.id, value)
 					},
 					{
 						label: this.config.referralStatusTW.term.name,
 						type: 'dropdown',
 						chartType,
 						options: this.referralStates,
-						settingsKey: this.config.referralStatusTW.id,
-						callback: value => this.setFilterValue(this.config.referralStatusTW.id, value)
+						settingsKey: this.config.referralStatusTW.term.id,
+						callback: value => this.setFilterValue(this.config.referralStatusTW.term.id, value)
 					},
 					{
 						label: this.config.fundingSourceTW.term.name,
 						type: 'dropdown',
 						chartType,
 						options: this.fundingSources,
-						settingsKey: this.config.fundingSourceTW.id,
-						callback: value => this.setFilterValue(this.config.fundingSourceTW.id, value)
+						settingsKey: this.config.fundingSourceTW.term.id,
+						callback: value => this.setFilterValue(this.config.fundingSourceTW.term.id, value)
 					},
 					{
 						label: this.config.hospitalVolumeTW.term.name,
 						type: 'dropdown',
 						chartType,
 						options: this.hospitalVolumes,
-						settingsKey: this.config.hospitalVolumeTW.id,
-						callback: value => this.setFilterValue(this.config.hospitalVolumeTW.id, value)
+						settingsKey: this.config.hospitalVolumeTW.term.id,
+						callback: value => this.setFilterValue(this.config.hospitalVolumeTW.term.id, value)
 					},
 					{
 						label: this.config.yearOfImplementationTW.term.name,
 						type: 'dropdown',
 						chartType,
 						options: this.yearsOfImplementation,
-						settingsKey: this.config.yearOfImplementationTW.id,
-						callback: value => this.setFilterValue(this.config.yearOfImplementationTW.id, value)
+						settingsKey: this.config.yearOfImplementationTW.term.id,
+						callback: value => this.setFilterValue(this.config.yearOfImplementationTW.term.id, value)
 					}
 				]
 			)
@@ -385,8 +385,8 @@ export class profilePlot {
 
 	setRegion(region) {
 		const config = this.config
-		this.settings[config.regionTW.id] = region
-		this.clearFiltersExcept([config.regionTW.id])
+		this.settings[config.regionTW.term.id] = region
+		this.clearFiltersExcept([config.regionTW.term.id])
 		config.filter = this.getFilter()
 		this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 	}
@@ -487,9 +487,11 @@ export class profilePlot {
 
 	getDownloadFilename() {
 		this.downloadCount++
-		let filename = `${this.type}${this.component ? this.component : ''}${this.settings[this.config.regionTW.id]}${
-			this.settings[this.config.countryTW.id]
-		}${this.settings[this.config.incomeTW.id]}${this.settings[this.config.typeTW.id]}${this.downloadCount}.svg`
+		let filename = `${this.type}${this.component ? this.component : ''}${this.settings[this.config.regionTW.term.id]}${
+			this.settings[this.config.countryTW.term.id]
+		}${this.settings[this.config.incomeTW.term.id]}${this.settings[this.config.typeTW.term.id]}${
+			this.downloadCount
+		}.svg`
 		filename = filename.split(' ').join('_')
 		return filename
 	}

--- a/client/plots/regression.inputs.js
+++ b/client/plots/regression.inputs.js
@@ -137,10 +137,10 @@ export class RegressionInputs {
 
 	setDisableTerms() {
 		this.disable_terms = []
-		if (this.config.outcome && this.config.outcome.term) this.disable_terms.push(this.config.outcome.id)
+		if (this.config.outcome && this.config.outcome.term) this.disable_terms.push(this.config.outcome.term.id)
 		if (this.config.independent) {
 			for (const vb of this.config.independent) {
-				this.disable_terms.push(vb.id)
+				this.disable_terms.push(vb.term.id)
 			}
 		}
 	}
@@ -259,7 +259,7 @@ function setRenderers(self) {
 		const inputs = section.dom.inputsDiv
 			.selectAll(':scope > div')
 			// key function (2nd arg) uses a function to determine how datum and element are joined by variable id
-			.data(section.inputLst, input => input.term && input.term.id)
+			.data(section.inputLst, input => input.term && input.term.term.id)
 
 		inputs.exit().each(removeInput)
 
@@ -279,14 +279,14 @@ function setRenderers(self) {
 			if (section.configKey == 'independent') {
 				if (!variable.interactions) variable.interactions = []
 				for (const id of variable.interactions) {
-					const tw = selected.find(i => i.id == id)
+					const tw = selected.find(i => i.term.id == id)
 					if (!tw) throw 'interacting partner not found in independents: ' + id
 					if (!tw.interactions) tw.interactions = []
-					if (!tw.interactions.includes(variable.id)) tw.interactions.push(variable.id)
+					if (!tw.interactions.includes(variable.term.id)) tw.interactions.push(variable.term.id)
 				}
 			}
 
-			const input = section.inputLst.find(input => input.term && input.term.id == variable.id)
+			const input = section.inputLst.find(input => input.term && input.term.term.id == variable.term.id)
 			if (!input) {
 				section.inputLst.push(
 					new InputTerm({
@@ -347,14 +347,12 @@ function setInteractivity(self) {
 				// delete this term.id from those other input term.interactions
 				for (const other of input.section.inputLst) {
 					if (!other.term || !other.term.interactions) continue
-					const i = other.term.interactions.indexOf(input.term.id)
+					const i = other.term.interactions.indexOf(input.term.term.id)
 					if (i != -1) other.term.interactions.splice(i, 1)
 				}
 			}
 		} else {
 			// variable is selected for this input
-
-			variable.id = variable.term.id // when switching between continuous/discrete for independent, variable.id missing (termsetting issue?)
 
 			const prevTerm = input.term
 
@@ -367,7 +365,7 @@ function setInteractivity(self) {
 				for example adjusting a group other than the refGrp, the refGrp may be 
 				reused if there happen to be sample counts for it.
 			*/
-			if (prevTerm && variable.id === prevTerm.id) {
+			if (prevTerm && variable.term.id === prevTerm.term.id) {
 				for (const k in prevTerm) {
 					// reapply any unedited key-values to the variable, such as refGrp
 					if (!(k in variable)) variable[k] = prevTerm[k]
@@ -379,7 +377,7 @@ function setInteractivity(self) {
 				// this is a spline term, delete existing interactions with this term
 				for (const other of input.section.inputLst) {
 					if (!other.term || !other.term.interactions) continue
-					const i = other.term.interactions.indexOf(input.term.id)
+					const i = other.term.interactions.indexOf(input.term.term.id)
 					if (i != -1) other.term.interactions.splice(i, 1)
 				}
 				variable.interactions = []

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -199,7 +199,7 @@ export class InputTerm {
 
 		// get term categories
 		const data = await this.parent.app.vocabApi.getCategories(tw.term, this.parent.parent.filter, body)
-		if (!data) throw `no data for term.id='${tw.id}'`
+		if (!data) throw `no data for term.id='${tw.term.id}'`
 		if (data.error) throw data.error
 
 		mayRunSnplstTask(tw, data)
@@ -434,7 +434,9 @@ export class InputTerm {
 		self.dom.tip.d
 			.append('div')
 			.selectAll('div')
-			.data(self.parent.config.independent.filter(tw => tw && tw.id !== self.term.id && tw.q.mode != 'spline'))
+			.data(
+				self.parent.config.independent.filter(tw => tw && tw.term.id !== self.term.term.id && tw.q.mode != 'spline')
+			)
 			.enter()
 			.append('div')
 			.style('margin', '5px')
@@ -443,7 +445,7 @@ export class InputTerm {
 				const checkbox = elem
 					.append('input')
 					.attr('type', 'checkbox')
-					.property('checked', self.term.interactions.includes(tw.id))
+					.property('checked', self.term.interactions.includes(tw.term.id))
 
 				elem.append('span').text(' ' + tw.term.name)
 			})
@@ -456,12 +458,12 @@ export class InputTerm {
 				self.dom.tip.hide()
 				self.term.interactions = []
 				self.dom.tip.d.selectAll('input').each(function (tw) {
-					if (select(this).property('checked')) self.term.interactions.push(tw.id)
+					if (select(this).property('checked')) self.term.interactions.push(tw.term.id)
 				})
 				for (const tw of self.parent.config.independent) {
-					const i = tw.interactions.indexOf(self.term.id)
-					if (self.term.interactions.includes(tw.id)) {
-						if (i == -1) tw.interactions.push(self.term.id)
+					const i = tw.interactions.indexOf(self.term.term.id)
+					if (self.term.interactions.includes(tw.term.id)) {
+						if (i == -1) tw.interactions.push(self.term.term.id)
 					} else if (i != -1) {
 						tw.interactions.splice(i, 1)
 					}
@@ -491,7 +493,7 @@ async function maySetTwoBins(tw, vocabApi, filter, state) {
 		return
 	}
 
-	const data = await vocabApi.getPercentile(tw.id, [50], filter)
+	const data = await vocabApi.getPercentile(tw.term.id, [50], filter)
 	if (data.error || !data.values.length || !Number.isFinite(data.values[0]))
 		throw 'cannot get median value: ' + (data.error || 'no data')
 	const median = tw.term.type == 'integer' ? Math.round(data.values[0]) : Number(data.values[0].toFixed(2))

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -152,7 +152,7 @@ export class RegressionResults {
 		*/
 		for (const i of this.parent.inputs.independent.inputLst) {
 			if (!i.term) continue
-			if (i.term.id == tid) return i
+			if (i.term.term.id == tid) return i
 			if (i.term.term && i.term.term.snps) {
 				// is a snplst or snplocus term with .snps[]
 				for (const snp of i.term.term.snps) {

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -49,7 +49,6 @@ export function setInteractivity(self) {
 						config: {
 							[label]: {
 								isAtomic: true,
-								id: term.id,
 								term: term.term,
 								q: getUpdatedQfromClick(plot, term, isHidden)
 							}
@@ -141,7 +140,6 @@ export function setInteractivity(self) {
 					config: {
 						term2: {
 							isAtomic: true,
-							id: self.config.term2.id,
 							term: self.config.term2.term,
 							q: getUpdatedQfromClick(plot, self.config.term2, false)
 						}
@@ -221,7 +219,6 @@ export function setInteractivity(self) {
 						config: {
 							[termNum]: {
 								isAtomic: true,
-								id: term.id,
 								term: term.term,
 								q: getUpdatedQfromClick(plot, term, isHidden)
 							}

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -300,11 +300,7 @@ class ViolinPlot {
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
 			if (isNumericTerm(t.term)) {
-				const data = await this.app.vocabApi.getDescrStats(
-					t.term.id,
-					this.state.termfilter.filter,
-					this.config.settings
-				)
+				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter.filter, this.config.settings)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
 			}

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -300,7 +300,11 @@ class ViolinPlot {
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
 			if (isNumericTerm(t.term)) {
-				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter.filter, this.config.settings)
+				const data = await this.app.vocabApi.getDescrStats(
+					t.term.id,
+					this.state.termfilter.filter,
+					this.config.settings
+				)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
 			}

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -263,7 +263,8 @@ export class TermdbVocab extends Vocab {
         .independent[ {id, term, q, refGrp}, ... ]
     */
 	async getRegressionData(opts) {
-		const outcome = { id: opts.outcome.id, q: JSON.parse(JSON.stringify(opts.outcome.q)) }
+		if (nonDictionaryTermTypes.has(opts.outcome.term.type)) throw 'outcome must be dictionary term'
+		const outcome = { id: opts.outcome.term.id, q: JSON.parse(JSON.stringify(opts.outcome.q)) }
 		if (!outcome.q.mode && opts.regressionType == 'linear') outcome.q.mode = 'continuous'
 		const contQkeys = ['mode', 'scale']
 		outcome.refGrp = outcome.q.mode == 'continuous' ? 'NA' : opts.outcome.refGrp
@@ -292,7 +293,7 @@ export class TermdbVocab extends Vocab {
 					}
 				}
 				return {
-					id: t.id,
+					id: t.term.id,
 					q,
 					type: t.term.type,
 					refGrp: t.q.mode == 'continuous' ? 'NA' : t.refGrp,

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -263,7 +263,7 @@ export class TermdbVocab extends Vocab {
         .independent[ {id, term, q, refGrp}, ... ]
     */
 	async getRegressionData(opts) {
-		if (nonDictionaryTermTypes.has(opts.outcome.term.type)) throw 'outcome must be dictionary term'
+		if (!isDictionaryType(opts.outcome.term.type)) throw 'outcome must be dictionary term'
 		const outcome = { id: opts.outcome.term.id, q: JSON.parse(JSON.stringify(opts.outcome.q)) }
 		if (!outcome.q.mode && opts.regressionType == 'linear') outcome.q.mode = 'continuous'
 		const contQkeys = ['mode', 'scale']

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -140,7 +140,7 @@ export class Vocab {
 		})
 	}
 
-	// get a tw copy with the correct identifier and without $id
+	// get a minimum copy of tw
 	// for better GET caching by the browser
 	getTwMinCopy(tw) {
 		const copy = { $id: tw.$id, term: {}, q: tw.q }
@@ -168,7 +168,17 @@ export class Vocab {
 		} else {
 			copy.term.name = tw.term?.name
 			copy.term.type = tw.term?.type
-			copy.term.values = tw.term?.values
+			if (tw.term?.type == 'geneVariant') {
+				if (tw.term.gene) {
+					copy.term.gene = tw.term.gene
+				} else {
+					copy.term.chr = tw.term.chr
+					copy.term.start = tw.term.start
+					copy.term.stop = tw.term.stop
+				}
+			} else {
+				copy.term.values = tw.term?.values
+			}
 		}
 
 		return copy

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -143,6 +143,7 @@ export class Vocab {
 	// get a minimum copy of tw
 	// for better GET caching by the browser
 	getTwMinCopy(tw) {
+		if (!tw.id && !tw.term) throw `missing both tw.id && tw.term for ${JSON.stringify(tw)}`
 		const copy = { $id: tw.$id, term: {}, q: tw.q }
 		if (!isDictionaryType(tw.term?.type)) {
 			if (tw.term.id) copy.term.id = tw.term.id

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -143,12 +143,13 @@ export class Vocab {
 	// get a minimum copy of tw
 	// for better GET caching by the browser
 	getTwMinCopy(tw) {
-		if (!tw.id && !tw.term) throw `missing both tw.id && tw.term for ${JSON.stringify(tw)}`
 		const copy = { $id: tw.$id, term: {}, q: tw.q }
-		if (!isDictionaryType(tw.term?.type)) {
-			if (tw.term.id) copy.term.id = tw.term.id
-			copy.term.name = tw.term.name
-			copy.term.type = tw.term.type
+		copy.term.id = tw.term?.id
+		copy.term.name = tw.term?.name
+		copy.term.type = tw.term?.type
+		if (isDictionaryType(tw.term?.type)) {
+			copy.term.values = tw.term?.values
+		} else {
 			if (tw.term.gene) {
 				copy.term.gene = tw.term.gene
 			} else if (tw.term.type.startsWith('gene')) {
@@ -159,29 +160,7 @@ export class Vocab {
 			} /* else {
 				// TODO: minimize other non-dictionary term types
 			}*/
-		} else if ('id' in tw || (tw.term && 'id' in tw.term)) {
-			copy.term.id = tw.id || tw.term.id
-			if (tw.term?.type == 'snplst' || tw.term?.type == 'snplocus') {
-				// added following so getData will not break
-				copy.term.type = tw.term.type
-				copy.term.name = tw.term.name
-			}
-		} else {
-			copy.term.name = tw.term?.name
-			copy.term.type = tw.term?.type
-			if (tw.term?.type == 'geneVariant') {
-				if (tw.term.gene) {
-					copy.term.gene = tw.term.gene
-				} else {
-					copy.term.chr = tw.term.chr
-					copy.term.start = tw.term.start
-					copy.term.stop = tw.term.stop
-				}
-			} else {
-				copy.term.values = tw.term?.values
-			}
 		}
-
 		return copy
 	}
 

--- a/client/termdb/test/vocabulary.integration.spec.js
+++ b/client/termdb/test/vocabulary.integration.spec.js
@@ -587,6 +587,7 @@ tape('getRegressionData()', async test => {
 			id: 'agedx',
 			isAtomic: true,
 			term: {
+				id: 'agedx',
 				name: 'Age (years) at Cancer Diagnosis',
 				type: 'float',
 				bins: {
@@ -607,7 +608,7 @@ tape('getRegressionData()', async test => {
 				refGrp: '2',
 				term: {
 					groupsetting: { inuse: false },
-					id: 'genetic_race',
+					id: 'sex',
 					name: 'Sex',
 					type: 'categorical',
 					values: { 1: { label: 'Male' }, 2: { label: 'Female' } }
@@ -678,6 +679,7 @@ tape('getRegressionData()', async test => {
 	opts.independent[0] = opts.outcome
 	opts.outcome = {
 		id: 'hrtavg',
+		term: termjson['hrtavg'],
 		q: {
 			mode: 'binary',
 			type: 'custom-bin',
@@ -699,6 +701,7 @@ tape('getRegressionData()', async test => {
 	opts.regressionType = type
 	opts.outcome = {
 		id: 'Arrhythmias',
+		term: termjson['Arrhythmias'],
 		q: {
 			mode: 'cox',
 			bar_by_grade: true,

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -928,28 +928,16 @@ export async function fillTermWrapper(
 ): Promise<TermWrapper> {
 	tw.isAtomic = true
 	if (!tw.term && tw.id) {
+		// hydrate tw.term using tw.id
 		await mayHydrateDictTwLst([tw], vocabApi)
 	}
-
-	// tw.term{} is now valid
-
-	// TODO: should strip tw.id because it is no longer necessary
-	// TODO: should remove usage of tw.id in the codebase after hydration
-
-	if (!tw.$id) tw.$id = await get$id(vocabApi.getTwMinCopy(tw))
-	if ((tw.id == undefined || tw.id === '') && tw.term.id) {
-		tw.id = tw.term.id
-	}
-	if (tw.id && tw.term.id) {
-		if (tw.id != tw.term.id) throw 'the given ids (tw.id and tw.term.id) are different'
-	}
-
+	// tw.id is no longer needed
+	delete tw.id
 	if (!tw.q) tw.q = {}
+	if (!tw.$id) tw.$id = await get$id(vocabApi.getTwMinCopy(tw))
 	tw.q.isAtomic = true
-
 	// call term-type specific logic to fill tw
 	await call_fillTW(tw, vocabApi, defaultQByTsHandler)
-
 	mayValidateQmode(tw)
 	return tw
 }
@@ -961,8 +949,6 @@ async function call_fillTW(tw: TermWrapper, vocabApi: VocabApi, defaultQByTsHand
 	let _
 	if (tw.term.type) {
 		try {
-			// TODO: in the fillTW() of each term type handler, should specify
-			// whether the term is a dictionary term (possibly by setting an .isDictionary flag)
 			_ = await import(`./handlers/${type}.ts`)
 		} catch (error) {
 			throw `Type ${type} does not exist`

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -590,7 +590,7 @@ function setInteractivity(self) {
 					if (t.term) tw = t as TermWrapper
 					else {
 						const term = t as Term
-						tw = { id: term.id, term, q: { isAtomic: true }, isAtomic: true }
+						tw = { term, q: { isAtomic: true }, isAtomic: true }
 					}
 
 					if (self.opts.customFillTw) self.opts.customFillTw(tw)

--- a/client/test/testdata/termjson.js
+++ b/client/test/testdata/termjson.js
@@ -108,13 +108,13 @@ exports.termjson = {
 			}
 		},
 		values: {
-			'0': { label: '0: No condition' },
-			'1': { label: '1: Mild' },
-			'2': { label: '2: Moderate' },
-			'3': { label: '3: Severe' },
-			'4': { label: '4: Life-threatening' },
-			'5': { label: '5: Death' },
-			'9': { label: 'Unknown status', uncomputable: true }
+			0: { label: '0: No condition' },
+			1: { label: '1: Mild' },
+			2: { label: '2: Moderate' },
+			3: { label: '3: Severe' },
+			4: { label: '4: Life-threatening' },
+			5: { label: '5: Death' },
+			9: { label: 'Unknown status', uncomputable: true }
 		}
 	},
 	aaclassic_5: {
@@ -172,10 +172,30 @@ exports.termjson = {
 			}
 		},
 		values: {
-			'0': { label: 'Not exposed', uncomputable: true },
+			0: { label: 'Not exposed', uncomputable: true },
 			'-8888': { label: 'Exposed but dose unknown', uncomputable: true },
 			'-9999': { label: 'Unknown treatment record', uncomputable: true }
 		}
+	},
+	hrtavg: {
+		type: 'float',
+		bins: {
+			default: {
+				type: 'regular-bin',
+				startinclusive: true,
+				bin_size: 500,
+				first_bin: { stop: 500 },
+				last_bin: { start: 3500 }
+			}
+		},
+		values: {
+			'-8888': { label: 'exposed, dose unknown', uncomputable: true },
+			'-9999': { label: 'unknown exposure', uncomputable: true }
+		},
+		name: 'Average dose to heart + TBI, cGy',
+		skip0forPercentile: true,
+		id: 'hrtavg',
+		isleaf: true
 	},
 	'Cardiac dysrhythmia': {
 		id: 'Cardiac dysrhythmia',
@@ -213,13 +233,13 @@ exports.termjson = {
 			}
 		},
 		values: {
-			'0': { label: '0: No condition' },
-			'1': { label: '1: Mild' },
-			'2': { label: '2: Moderate' },
-			'3': { label: '3: Severe' },
-			'4': { label: '4: Life-threatening' },
-			'5': { label: '5: Death' },
-			'9': { label: 'Unknown status', uncomputable: true }
+			0: { label: '0: No condition' },
+			1: { label: '1: Mild' },
+			2: { label: '2: Moderate' },
+			3: { label: '3: Severe' },
+			4: { label: '4: Life-threatening' },
+			5: { label: '5: Death' },
+			9: { label: 'Unknown status', uncomputable: true }
 		}
 	}
 }

--- a/server/routes/termdb.getdescrstats.ts
+++ b/server/routes/termdb.getdescrstats.ts
@@ -78,6 +78,7 @@ function init({ genomes }) {
 async function trigger_getdescrstats(q: any, res: any, ds: any, genome: any) {
 	const terms = [q.tw] //pass
 	const data = await getData({ filter: q.filter, terms }, ds, genome)
+	if (data.error) throw data.error
 
 	const values: number[] = []
 	for (const key in data.samples) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -423,7 +423,7 @@ async function call_barchart_data(twLst, q, combination, ds) {
 		if (!tw.term) continue
 		if (tw.term.type == 'categorical') {
 			const _q = {
-				term1_id: tw.id,
+				term1_id: tw.term.id,
 				term1_q: { type: 'values' },
 				filter
 			}
@@ -439,7 +439,7 @@ async function call_barchart_data(twLst, q, combination, ds) {
 			for (const s of out.data.charts[0].serieses) {
 				lst.push([s.seriesId, s.total])
 			}
-			termid2values.set(tw.id, lst)
+			termid2values.set(tw.term.id, lst)
 		}
 	}
 	if (combination) return [termid2values, combination]

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -297,8 +297,6 @@ async function getSampleData_dictionaryTerms(q, termWrappers) {
 export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	const samples = {} // to return
 	const byTermId = {} // to return
-	//const twBy$id = {}
-	const tw$IdByIndex = {}
 	const filter = await getFilterCTEs(q.filter, q.ds)
 	// must copy filter.values as its copy may be used in separate SQL statements,
 	// for example get_rows or numeric min-max, and each CTE generator would
@@ -307,9 +305,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	const CTEs = await Promise.all(
 		termWrappers.map(async (tw, i) => {
 			if (!tw.$id) tw.$id = tw.term.id || tw.term.name
-			tw$IdByIndex[i] = tw.$id
 			const CTE = await get_term_cte(q, values, i, filter, tw)
-			const $id = tw.$id || tw.term.id
 			if (CTE.bins) {
 				byTermId[tw.$id] = { bins: CTE.bins }
 			}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -304,7 +304,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	const values = filter ? filter.values.slice() : []
 	const CTEs = await Promise.all(
 		termWrappers.map(async (tw, i) => {
-			if (!tw.$id) tw.$id = tw.term.id || tw.term.name
+			if (!tw.$id) throw 'tw.$id is missing'
 			const CTE = await get_term_cte(q, values, i, filter, tw)
 			if (CTE.bins) {
 				byTermId[tw.$id] = { bins: CTE.bins }

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -304,7 +304,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	const values = filter ? filter.values.slice() : []
 	const CTEs = await Promise.all(
 		termWrappers.map(async (tw, i) => {
-			if (!tw.$id) throw 'tw.$id is missing'
+			if (!tw.$id) tw.$id = tw.term.id || tw.term.name
 			const CTE = await get_term_cte(q, values, i, filter, tw)
 			if (CTE.bins) {
 				byTermId[tw.$id] = { bins: CTE.bins }

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -322,7 +322,7 @@ function processSample(dbSample, sample, tw, categoryMap, category) {
 		if (tw.term.values?.[value]?.label) {
 			value = tw.term.values?.[value]?.label
 			sample.hidden[category] = tw.q.hiddenValues ? value in tw.q.hiddenValues : false
-		} else sample.hidden[category] = tw.q.hiddenValues ? dbSample?.[tw.id]?.key in tw.q.hiddenValues : false
+		} else sample.hidden[category] = tw.q.hiddenValues ? dbSample?.[tw.term.id]?.key in tw.q.hiddenValues : false
 		if (value) {
 			sample[category] = value.toString()
 			if (categoryMap[value] == undefined) categoryMap[value] = { sampleCount: 1 }

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -58,10 +58,6 @@ export async function trigger_getViolinPlotData(q, res, ds, genome) {
 	const twLst = [q.term]
 
 	if (q.divideTw) {
-		if (q.divideTw !== null && q.divideTw !== undefined && typeof q.divideTw === 'object' && !('id' in q.divideTw)) {
-			q.divideTw.id = q.divideTw.term.name
-			q.divideTw.term.id = q.divideTw.term.name
-		}
 		twLst.push(q.divideTw)
 		q.term2_q = q.divideTw.q
 	}
@@ -69,10 +65,10 @@ export async function trigger_getViolinPlotData(q, res, ds, genome) {
 	const data = await getData({ terms: twLst, filter: q.filter, currentGeneNames: q.currentGeneNames }, ds, genome)
 	if (data.error) throw data.error
 	//get ordered labels to sort keys in key2values
-	if (q.divideTw && data.refs.byTermId[q.divideTw?.id]) {
-		data.refs.byTermId[q.divideTw?.id].orderedLabels = getOrderedLabels(
+	if (q.divideTw && data.refs.byTermId[q.divideTw.term.id]) {
+		data.refs.byTermId[q.divideTw.term.id].orderedLabels = getOrderedLabels(
 			q.divideTw,
-			data.refs.byTermId[q.divideTw?.id]?.bins,
+			data.refs.byTermId[q.divideTw.term.id]?.bins,
 			undefined,
 			q.divideTw.q
 		)


### PR DESCRIPTION
## Description

This PR removes the `.id` property from termwrapper (tw) after hydration of `tw.term`.

`tw.id` is now no longer used in the codebase, except for hydrating `tw.term`.

All unit tests and integration tests pass, but please test as many features as possible because this PR includes changes to many files.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
