### PR TITLE
feat: GDC bam app can visualize truncated bam slice when streaming is…

### DIFF
--- a/client/gdc/bam.js
+++ b/client/gdc/bam.js
@@ -990,22 +990,24 @@ export async function bamsliceui({
 
 			// when clicking "Back To" button and resubmit another region, the same file info will be reused and must avoid inserting duplicating entries here
 			{
-				// update file size
 				const i = file.about.find(i => i.k == 'Slice file size')
-				if (i) {
-					// this file has been sliced before and already has the record; do not add duplicate record
-					i.v = fileStat.size
-				} else {
-					// this file does not have the record
-					file.about.push({ k: 'Slice file size', v: fileStat.size })
-				}
+				if (i) i.v = fileStat.size
+				else file.about.push({ k: 'Slice file size', v: fileStat.size })
 			}
 			if (fileStat.time) {
 				const i = file.about.find(i => i.k == 'Stream time')
 				if (i) i.v = Math.round(fileStat.time) + ' seconds'
 				else file.about.push({ k: 'Stream time', v: Math.round(fileStat.time) + ' seconds' })
 			}
-			if (fileStat.truncated) file.about.push({ k: 'Truncated', v: 'BAM slice size exceeds limit and is truncated' })
+			if (fileStat.truncated) {
+				// insert entry if not found
+				if (!file.about.find(i => i.k == 'Truncated'))
+					file.about.push({ k: 'Truncated', v: 'BAM slice size exceeds limit and is truncated' })
+			} else {
+				// delete entry if found
+				const i = file.about.findIndex(i => i.k == 'Truncated')
+				if (i > 0) file.about.splice(i, 1)
+			}
 		}
 
 		formdiv.style('display', 'none')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GDC bam app can visualize truncated bam slice when streaming is terminated due to hitting max size


### PR DESCRIPTION
… terminated due to hitting max size

## Description

 please pull sjpp. gdc bam max cache size is set to be 20MB

try this wgs: http://localhost:3000/?gdcbamslice=1&gdc_id=31b08021-8de8-47d3-8741-79e556bb925b

slicing over HOXA1 results in a bam slice of 0.5MB

slicing over ALK results in truncated file and still browsable. zooming and panning and loading single read all works, but are slower since backend now will call "samtools view" without using position arg (otherwise breaks with file lacking EOF and unindexable), and each request starts from beginning of the bam slice. truncated bam is also indicated in the track info menu as below

<img width="493" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/a4777e0e-2a61-4b81-80d6-6f456c8596a8">


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
