### PR TITLE
fix for uncomputable values, if values in hiddenValues obj then skip …

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- fixed rendering of barchart and violin when terms have uncomputable categories

--- a/server/routes/termdb.getdescrstats.ts
+++ b/server/routes/termdb.getdescrstats.ts
@@ -84,7 +84,7 @@ async function trigger_getdescrstats(q: any, res: any, ds: any, genome: any) {
 	for (const key in data.samples) {
 		const sample = data.samples[key]
 		const value = sample[q.tw.$id].value
-		if (q.tw.values?.[value]?.uncomputable) {
+		if (q.tw.q.hiddenValues?.[value]) {
 			// skip uncomputable values
 			continue
 		}

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -159,9 +159,9 @@ function divideValues(q, data, tw) {
 
 		if (!Number.isFinite(value?.value)) continue
 
-		if (tw.term.values?.[value.key]?.uncomputable) {
+		if (tw.term.values?.[value.value]?.uncomputable) {
 			//skip these values from rendering in plot but show in legend as uncomputable categories
-			const label = tw.term.values[value.key].label // label of this uncomputable category
+			const label = tw.term.values[value.value].label // label of this uncomputable category
 			uncomputableValueObj[label] = (uncomputableValueObj[label] || 0) + 1
 			continue
 		}


### PR DESCRIPTION
…from computing through descriptive stats

## Description

Hi @gavrielm can you check now and see if those plots still show uncomputable categories? 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
