### PR TITLE
fix: In querying gene expression data, allow a gene not to have defau…

### DIFF
--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -14,6 +14,7 @@ import { gdc_validate_query_geneExpression } from '#src/mds3.gdc.js'
 import { mayLimitSamples } from '#src/mds3.filter.js'
 import { dtgeneexpression } from '#shared/common.js'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
+import { getResult as getResultGene } from '#src/gene.js'
 
 export const api = {
 	endpoint: 'termdb/cluster',
@@ -213,17 +214,16 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any, genome: any
 		const gene2sample2value = new Map() // k: gene symbol, v: { sampleId : value }
 
 		for (const g of param.genes) {
-			// FIXME newly added geneVariant terms from client to be changed to {gene} but not {name}
 			if (!g.gene) continue
 
 			if (!g.chr) {
 				// quick fix: newly added gene from client will lack chr/start/stop
-				const lst = genome.genedb.getjsonbyname.all(g.gene)
-				if (lst.length == 0) continue
-				const j = JSON.parse(lst.find(i => i.isdefault).genemodel || lst[0].genemodel)
-				g.start = j.start
-				g.stop = j.stop
-				g.chr = j.chr
+				const re = getResultGene(genome, { input: g.gene, deep: 1 })
+				if (!re.gmlst || re.gmlst.length == 0) throw 'unknown gene'
+				const i = re.gmlst.find(i => i.isdefault) || re.gmlst[0]
+				g.start = i.start
+				g.stop = i.stop
+				g.chr = i.chr
 			}
 
 			const s2v = {}


### PR DESCRIPTION
…lt isoform

## Description

closes #1604 
[Pax1](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22redomics%22,%22genome%22:%22mm10%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22Pax1%22,%22name%22:%22Pax1%22},%22q%22:{%22mode%22:%22continuous%22}}}]}) breaks but [Myc](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22redomics%22,%22genome%22:%22mm10%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22Myc%22,%22name%22:%22Myc%22},%22q%22:{%22mode%22:%22continuous%22}}}]}) works.
seems the gene exp file lacks Pax1 and our code doesn't handle such. can fix later

gdc also works

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
