### PR TITLE
Fixed bug reported in issue 1613

### DIFF
--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -295,11 +295,11 @@ async function updateUI(self) {
 	if (!self.filterPrompt)
 		self.filterPrompt = await filterPromptInit({
 			holder: self.dom.addNewGroupBtnHolder,
-			vocab: self.app.opts.state.vocab,
+			vocabApi: self.app.vocabApi,
 			emptyLabel: 'Add group',
 			termdbConfig: self.state.termdbConfig,
 			callback: f => {
-				addNewGroup(self.app, f, groups)
+				addNewGroup(self.app, f, self.state.groups)
 			},
 			debug: self.opts.debug
 		})

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -54,7 +54,7 @@ export async function getFilterCTEs(filter, ds, CTEname = 'f') {
 			f = await get_geneExpression(item.tvs, CTEname_i, ds)
 		} else if (
 			item.tvs.term.id &&
-			isDictionaryType(item.tvs.term.type) &&
+			(!item.tvs.term.type || isDictionaryType(item.tvs.term.type)) &&
 			!ds.cohort.termdb.q.termjsonByOneid(item.tvs.term.id)
 		) {
 			throw 'invalid term id in tvs'

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -318,29 +318,27 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	// have to independently extend its copy of filter values
 	const values = filter ? filter.values.slice() : []
 	const CTEs = await Promise.all(
-		termWrappers
-			.filter(tw => !tw.term.type || isDictionaryType(tw.term.type))
-			.map(async (tw, i) => {
-				if (!tw.$id) tw.$id = tw.term.id || tw.term.name
-				const CTE = await get_term_cte(q, values, i, filter, tw)
-				const $id = tw.$id || tw.term.id
-				if (CTE.bins) {
-					byTermId[tw.$id] = { bins: CTE.bins }
-				}
-				if (CTE.events) {
-					byTermId[tw.$id] = { events: CTE.events }
-				}
-				if (tw.term.values) {
-					const values = Object.values(tw.term.values)
-					if (values.find(v => 'order' in v)) {
-						byTermId[tw.$id] = {
-							keyOrder: values.sort((a, b) => a.order - b.order).map(v => v.key)
-						}
+		termWrappers.map(async (tw, i) => {
+			if (!tw.$id) tw.$id = tw.term.id || tw.term.name
+			const CTE = await get_term_cte(q, values, i, filter, tw)
+			const $id = tw.$id || tw.term.id
+			if (CTE.bins) {
+				byTermId[tw.$id] = { bins: CTE.bins }
+			}
+			if (CTE.events) {
+				byTermId[tw.$id] = { events: CTE.events }
+			}
+			if (tw.term.values) {
+				const values = Object.values(tw.term.values)
+				if (values.find(v => 'order' in v)) {
+					byTermId[tw.$id] = {
+						keyOrder: values.sort((a, b) => a.order - b.order).map(v => v.key)
 					}
 				}
-				//if ('id' in tw.term) twBy$id[$id] = tw
-				return CTE
-			})
+			}
+			//if ('id' in tw.term) twBy$id[$id] = tw
+			return CTE
+		})
 	).catch(console.error)
 
 	// for "samplelst" term, term.id is missing and must use term.name


### PR DESCRIPTION
## Description

Fixed bug creating new group and others found. Closes #1613. The groups list being passed to the filter was empty, so it was causing this error. It needed to use the latest state groups. I also passed the vocabApi needed to create geneVariant filters and removed changes not needed introduced in previous PR.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
