### PR TITLE
DE filter

### DIFF
--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -54,6 +54,24 @@ class DEanalysis {
 		this.dom.controlsDiv.selectAll('*').remove()
 		const inputs = [
 			{
+				label: 'Min count',
+				type: 'number',
+				chartType: 'DEanalysis',
+				settingsKey: 'min_count',
+				title: 'Min count',
+				min: 0,
+				max: 100
+			},
+			{
+				label: 'Min total count',
+				type: 'number',
+				chartType: 'DEanalysis',
+				settingsKey: 'min_total_count',
+				title: 'Min total count',
+				min: 0,
+				max: 100
+			},
+			{
 				label: 'P-value significance (linear scale)',
 				type: 'number',
 				chartType: 'DEanalysis',
@@ -115,6 +133,7 @@ class DEanalysis {
 			this.settings.method = output.method
 			this.state.config = output.method
 		}
+
 		if (this.app.opts.genome.termdbs) {
 			// Check if genome build contains termdbs, only then enable gene ora
 			inputs.push({
@@ -170,24 +189,10 @@ class DEanalysis {
 	async main() {
 		this.config = JSON.parse(JSON.stringify(this.state.config))
 		this.settings = this.config.settings.DEanalysis
-		const output = await this.app.vocabApi.runDEanalysis(this.state.config)
+		const output = await this.app.vocabApi.runDEanalysis(this.config) // "this.config" was changed from "this.state.config". Hope this does not create any problems.
 		output.mid_sample_size_cutoff = 8 // mid sample size cutoff for method toggle to appear
 		output.high_sample_size_cutoff = 30 // high sample size cutoff for method toggle to not appear, so that very high sample-size groups are not analyzed by edgeR. The exact cutoff value will need to be determined with more examples.
 		await this.setControls(output)
-		//const state = this.app.getState()
-		//console.log('state:', state)
-		//if (state.customTerms[0].name) {
-		//	const headerText = state.customTerms[0].name
-		//	this.dom.header
-		//		.append('span')
-		//		.style('color', '#999999')
-		//		.text(headerText)
-		//		.append('span')
-		//		.style('font-size', '0.75em')
-		//		.style('opacity', 0.6)
-		//		.style('padding-left', '10px')
-		//		.text('DIFFERENTIAL EXPRESSION')
-		//} else {
 		this.dom.header
 			.style('opacity', 0.6)
 			.style('padding-left', '10px')
@@ -266,6 +271,9 @@ add:
 			d.vo_g = this
 		})
 	const fold_change_cutoff = self.settings.foldchange
+	//console.log("self.settings:",self.settings)
+	//self.config.settings.DEanalysis.min_count = self.settings.min_count
+	//self.config.settings.DEanalysis.min_total_count = self.settings.min_total_count
 	if (self.settings.pvalue == 0) throw 'p-value significance cannot be zero'
 	const p_value_cutoff = -Math.log10(self.settings.pvalue)
 	const p_value_adjusted_original = self.settings.adjusted_original_pvalue
@@ -531,6 +539,8 @@ export async function getPlotConfig(opts, app) {
 				DEanalysis: {
 					pvalue: 0.05,
 					foldchange: 2,
+					min_count: 10,
+					min_total_count: 15,
 					pvaluetable: false,
 					adjusted_original_pvalue: 'adjusted',
 					method: undefined,

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -189,7 +189,7 @@ class DEanalysis {
 	async main() {
 		this.config = JSON.parse(JSON.stringify(this.state.config))
 		this.settings = this.config.settings.DEanalysis
-		const output = await this.app.vocabApi.runDEanalysis(this.config) // "this.config" was changed from "this.state.config". Hope this does not create any problems.
+		const output = await runDEanalysis(this) // "this.config" was changed from "this.state.config". Hope this does not create any problems.
 		output.mid_sample_size_cutoff = 8 // mid sample size cutoff for method toggle to appear
 		output.high_sample_size_cutoff = 30 // high sample size cutoff for method toggle to not appear, so that very high sample-size groups are not analyzed by edgeR. The exact cutoff value will need to be determined with more examples.
 		await this.setControls(output)
@@ -626,5 +626,20 @@ export async function openHiercluster(term, samplelstTW, app, id, newId) {
 	await app.dispatch({
 		type: 'plot_create',
 		config
+	})
+}
+
+async function runDEanalysis(self) {
+	console.log('self:', self)
+	return await dofetch3('termdb', {
+		body: {
+			for: 'DEanalysis',
+			genome: self.app.vocabApi.vocab.genome,
+			dslabel: self.app.vocabApi.vocab.dslabel,
+			samplelst: self.config.samplelst,
+			min_count: self.settings.min_count,
+			min_total_count: self.settings.min_total_count,
+			method: self.settings.method
+		}
 	})
 }

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -468,6 +468,8 @@ add:
 				maxHeight: '150vh',
 				resize: true
 			})
+		} else {
+			self.dom.tableDiv.selectAll('*').remove()
 		}
 
 		if (self.settings.gene_ora && self.app.opts.genome.termdbs) {

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -60,7 +60,7 @@ class DEanalysis {
 				settingsKey: 'min_count',
 				title: 'Min count',
 				min: 0,
-				max: 100
+				max: 10000
 			},
 			{
 				label: 'Min total count',
@@ -69,7 +69,7 @@ class DEanalysis {
 				settingsKey: 'min_total_count',
 				title: 'Min total count',
 				min: 0,
-				max: 100
+				max: 10000
 			},
 			{
 				label: 'P-value significance (linear scale)',
@@ -430,6 +430,10 @@ add:
 			{
 				label: 'Number of significant genes',
 				value: num_significant_genes
+			},
+			{
+				label: 'Number of total genes',
+				value: num_significant_genes + num_non_significant_genes
 			},
 			{
 				label: 'Group1 sample size',

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -54,21 +54,20 @@ class DEanalysis {
 		this.dom.controlsDiv.selectAll('*').remove()
 		const inputs = [
 			{
-				label: 'Min count',
+				label: 'Minimum read count',
 				type: 'number',
 				chartType: 'DEanalysis',
 				settingsKey: 'min_count',
-				title:
-					'Parameter for filtering genes based on relative read counts of a gene with respect to others in the same sample',
+				title: 'Relative cpm cutoff for filtering a gene compared to all samples and genes in dataset',
 				min: 0,
 				max: 10000
 			},
 			{
-				label: 'Min total count',
+				label: 'Minimum total read count',
 				type: 'number',
 				chartType: 'DEanalysis',
 				settingsKey: 'min_total_count',
-				title: 'Cutoff for filtering genes based on absolute total read counts for a gene across all samples',
+				title: 'Minimum total read count required for each sample',
 				min: 0,
 				max: 10000
 			},

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -58,7 +58,8 @@ class DEanalysis {
 				type: 'number',
 				chartType: 'DEanalysis',
 				settingsKey: 'min_count',
-				title: 'Min count',
+				title:
+					'Parameter for filtering genes based on relative read counts of a gene with respect to others in the same sample',
 				min: 0,
 				max: 10000
 			},
@@ -67,7 +68,7 @@ class DEanalysis {
 				type: 'number',
 				chartType: 'DEanalysis',
 				settingsKey: 'min_total_count',
-				title: 'Min total count',
+				title: 'Cutoff for filtering genes based on absolute total read counts for a gene across all samples',
 				min: 0,
 				max: 10000
 			},
@@ -630,7 +631,6 @@ export async function openHiercluster(term, samplelstTW, app, id, newId) {
 }
 
 async function runDEanalysis(self) {
-	console.log('self:', self)
 	return await dofetch3('termdb', {
 		body: {
 			for: 'DEanalysis',

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1159,20 +1159,6 @@ export class TermdbVocab extends Vocab {
 		await Promise.all(promises)
 		return bySample
 	}
-
-	async runDEanalysis(config) {
-		return await dofetch3('termdb', {
-			body: {
-				for: 'DEanalysis',
-				genome: this.state.vocab.genome,
-				dslabel: this.state.vocab.dslabel,
-				samplelst: config.samplelst,
-				min_count: config.settings.DEanalysis.min_count,
-				min_total_count: config.settings.DEanalysis.min_total_count,
-				method: config.settings.DEanalysis.method
-			}
-		})
-	}
 }
 
 /*

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1167,6 +1167,8 @@ export class TermdbVocab extends Vocab {
 				genome: this.state.vocab.genome,
 				dslabel: this.state.vocab.dslabel,
 				samplelst: config.samplelst,
+				min_count: config.settings.DEanalysis.min_count,
+				min_total_count: config.settings.DEanalysis.min_total_count,
 				method: config.settings.DEanalysis.method
 			}
 		})

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -1611,6 +1611,8 @@ async function validate_query_rnaseqGeneCount(ds, genome) {
 			case: cases_string,
 			control: controls_string,
 			input_file: q.file,
+			min_count: param.min_count,
+			min_total_count: param.min_total_count,
 			output_path: path.join(serverconfig.binpath, 'utils')
 		}
 		//console.log("expression_input:",expression_input)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -6,6 +6,7 @@ import { Readable } from 'stream'
 import { scaleLinear } from 'd3-scale'
 import { createCanvas } from 'canvas'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
+import run_R from './run_R'
 import * as gdc from './mds3.gdc.js'
 import { initGDCdictionary } from './termdb.gdc.js'
 import { validate_variant2samples, ssmIdFieldsSeparator } from './mds3.variant2samples.js'
@@ -1629,28 +1630,13 @@ async function validate_query_rnaseqGeneCount(ds, genome) {
 		) {
 			// edgeR will be used for DE analysis
 			const time1 = new Date()
-			const r_output = await run_edgeR(
-				path.join(serverconfig.binpath, 'utils', 'edge.R'),
-				JSON.stringify(expression_input)
+			result = JSON.parse(
+				await run_R(path.join(serverconfig.binpath, 'utils', 'edge.R'), JSON.stringify(expression_input))
 			)
 			const time2 = new Date()
 			console.log('Time taken to run edgeR:', time2 - time1, 'ms')
 			param.method = 'edgeR'
-			//console.log("r_output:",r_output)
-
-			//for (const line of r_output.split('\n')) {
-			//    console.log("line:",line)
-			//    if (line.includes("output_json:")) {
-			//	     //console.log(line.replace(",output_json:",""))
-			//  	     result=JSON.parse(line.replace(",output_json:",""))
-			//      } else {
-			//          //console.log(line)
-			//      }
-			//}
-
-			const tmpfile = path.join(serverconfig.binpath, 'utils', 'r_output.txt')
-			result = JSON.parse(fs.readFileSync(tmpfile, 'utf8'))
-			fs.unlink(tmpfile, () => {})
+			//console.log("result:",result)
 		} else if (param.method == 'wilcoxon') {
 			// Wilcoxon test will be used for DE analysis
 			const time1 = new Date()
@@ -1698,43 +1684,6 @@ function getFirstLine(file) {
 		ps.on('close', code => {
 			if (code != 0) reject('head command exited with non-zero status and this error: ' + out2.join(''))
 			resolve(out1.join(''))
-		})
-	})
-}
-async function run_edgeR(Rscript, input_data) {
-	return new Promise((resolve, reject) => {
-		const binpath = path.join(serverconfig.Rscript, Rscript)
-		const ps = spawn(serverconfig.Rscript, [Rscript])
-		const stdout = []
-		const stderr = []
-
-		try {
-			Readable.from(input_data).pipe(ps.stdin)
-		} catch (error) {
-			ps.kill()
-			let errmsg = error
-			if (stderr.length) errmsg += `killed edgeR('${Rscript}'), stderr: ${stderr.join('').trim()}`
-			reject(errmsg)
-		}
-
-		ps.stdout.on('data', data => stdout.push(data))
-		ps.stderr.on('data', data => stderr.push(data))
-		ps.on('error', err => {
-			if (stderr.length) console.log(`edgeR('${Rscript}') ps.on('error') stderr:`, stderr)
-			reject(err)
-		})
-		ps.on('close', code => {
-			if (code !== 0) reject(`spawned '${Rscript}' exited with a non-zero status and this stderr:\n${stderr.join('')}`)
-			//else if (stderr.length) {
-			//	// handle rust stderr
-			//	const err = stderr.join('').trim()
-			//	const errmsg = `edgeR('${Rscript}') emitted standard error\n stderr: ${err}`
-			//	//reject(errmsg)
-			//}
-			else {
-				//console.log("stdout:",stdout)
-				resolve(stdout.toString())
-			}
 		})
 	})
 }

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -1,3 +1,9 @@
+# Usage: echo <in_json> | Rscript edge.R > <out_json>
+
+#   in_json: [string] input data in JSON format. Streamed through stdin.
+#   out_json: [string] clustering results in JSON format. Streamed to stdout.
+
+
 # json='{"case":"SJMB066856,SJMB069601,SJMB030827,SJMB030838,SJMB031131,SJMB031227,SJMB077221,SJMB077223","control":"SJMB069596,SJMB069587,SJMB074736,SJMB030488,SJMB030825,SJMB031110,SJMB032998,SJMB033002","input_file":"/Users/rpaul1/pp_data/files/hg38/sjmb12/rnaseq/geneCounts.txt"}' && time echo $json | Rscript edge.R
 
 # json='{"case":"SJMB030827,SJMB030838,SJMB064540,SJMB064538,SJMB064520,SJMB064535,SJMB031131,SJMB031227","control":"SJMB030488,SJMB030825,SJMB064537,SJMB064510,SJMB064533,SJMB064534,SJMB031110","input_file":"/Users/rpaul1/pp_data/files/hg38/sjmb12/rnaseq/geneCounts.txt"}' && time echo $json | Rscript edge.R
@@ -28,21 +34,28 @@ suppressWarnings({
     suppressPackageStartupMessages(library(dplyr))
 })
 
-infile <- file("stdin")
-input <- fromJSON(infile)
-print (input$output_path)
+con <- file("stdin", "r")
+json <- readLines(con, warn=FALSE)
+close(con)
+input <- fromJSON(json)
+#print (input)
+#print (input$output_path)
 cases <- unlist(strsplit(input$case, ","))
 controls <- unlist(strsplit(input$control, ","))
 combined <- c("geneID","geneSymbol",cases,controls)
 #data %>% select(all_of(combined))
-read_file_time_start <- Sys.time()
+#read_file_time_start <- Sys.time()
+suppressWarnings({
+  suppressMessages({
 read_counts <- read_tsv(input$input_file, col_names = TRUE, col_select = combined)
+  })
+})
 geneIDs <- unlist(read_counts[1])
 geneSymbols <- unlist(read_counts[2])
 read_counts <- select(read_counts, -geneID)
 read_counts <- select(read_counts, -geneSymbol)
-read_file_time_stop <- Sys.time()
-print (read_file_time_stop - read_file_time_start)
+#read_file_time_stop <- Sys.time()
+#print (read_file_time_stop - read_file_time_start)
 
 diseased <- rep("Diseased", length(cases))
 control <- rep("Control", length(controls))
@@ -50,16 +63,20 @@ conditions <- c(diseased, control)
 tabs <- rep("\t",length(geneIDs))
 gene_id_symbols <- paste0(geneIDs,tabs,geneSymbols)
 y <- DGEList(counts = as.matrix(read_counts), group = conditions, genes = gene_id_symbols)
-keep <- filterByExpr(y)
+keep <- filterByExpr(y, min.count = input$min_count, min.total.count = input$min_total_count)
 y <- y[keep, keep.lib.sizes = FALSE]
 y <- calcNormFactors(y, method = "TMM")
 #print (y)
-calculate_DE_time_start <- Sys.time()
-dge <- estimateDisp(y = y)
+#calculate_DE_time_start <- Sys.time()
+suppressWarnings({
+  suppressMessages({
+      dge <- estimateDisp(y = y)
+  })
+})
 et <- exactTest(object = dge)
 calculate_DE_time_stop <- Sys.time()
-print ("Time to calculate DE")
-print (calculate_DE_time_stop - calculate_DE_time_start)
+#print ("Time to calculate DE")
+#print (calculate_DE_time_stop - calculate_DE_time_start)
 #print (et)
 logfc <- et$table$logFC
 logcpm <- et$table$logCPM
@@ -76,11 +93,13 @@ names(output)[3] <- "fold_change"
 names(output)[4] <- "original_p_value"
 names(output)[5] <- "adjusted_p_value"
 
-output_json <- toJSON(output)
-print ("output_json")
-output_file <- paste0(input$output_path,"/r_output.txt")
-print (output_file)
-cat(output_json, file = output_file)
+toJSON(output)
+#output_json <- toJSON(output)
+#print ("output_json")
+#output_file <- paste0(input$output_path,"/r_output.txt")
+#print (output_file)
+#cat(output_json, file = output_file)
+
 #top_degs = topTags(object = et, n = "Inf")
 #print ("top_degs")
 #print (top_degs)


### PR DESCRIPTION
## Description

In this PR, now min_count and min_total_count can now be controlled through the UI. min_count is used to calculate the cpm cutoff and min_total_count is an absolute cutoff. For more details, see the filterByExpr [source code ](https://rdrr.io/bioc/edgeR/src/R/filterByExpr.R)in edgeR.

For testing, may use this sessions file
[sjmb12_DE.txt](https://github.com/stjude/proteinpaint/files/15381858/sjmb12_DE.txt)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
