### PR TITLE
Enable new type cases

### DIFF
--- a/client/dom/dynamicScatter.js
+++ b/client/dom/dynamicScatter.js
@@ -48,8 +48,8 @@ export function addDynamicScatterForm(tip, app) {
 		const state = { tree: { usecase: { detail: 'numeric', target: 'sampleScatter' } } }
 		//state.nav = {header_mode: 'hide_search'}
 		const disable_terms = []
-		if (xterm) disable_terms.push(xterm.id)
-		if (yterm) disable_terms.push(yterm.id)
+		if (xterm) disable_terms.push(xterm)
+		if (yterm) disable_terms.push(yterm)
 		showTermsTree(
 			div,
 			term => {

--- a/client/mass/search.js
+++ b/client/mass/search.js
@@ -106,7 +106,7 @@ function setRenderers(self) {
 		// add disabled terms to opts.disable_terms
 		if (self.opts.disable_terms)
 			data.lst.forEach(t => {
-				if (t.disabled) self.opts.disable_terms.push(t.id)
+				if (t.disabled) self.opts.disable_terms.push(t)
 			})
 		self.clear({ hide: !data.lst.length })
 		if (data.lst.length) {

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -656,6 +656,7 @@ tape('term1 as numeric and term2 numeric, change median size', function (test) {
 })
 
 tape('term1=categorical, term2=numeric', function (test) {
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			plots: [
@@ -692,6 +693,7 @@ tape('term1=categorical, term2=numeric', function (test) {
 })
 
 tape('term1=numeric, term2=survival', function (test) {
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			plots: [
@@ -727,6 +729,7 @@ tape('term1=numeric, term2=survival', function (test) {
 })
 
 tape('term1=numeric, term2=condition', function (test) {
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			nav: { header_mode: 'hide_search' },
@@ -770,6 +773,7 @@ tape('term1=numeric, term2=condition', function (test) {
 })
 
 tape('term1=geneExp, term2=categorical', function (test) {
+	test.timeoutAfter(1000)
 	runpp({
 		state: {
 			plots: [
@@ -804,6 +808,7 @@ tape('term1=geneExp, term2=categorical', function (test) {
 	}
 })
 tape('term1=geneExp, term2=survival', function (test) {
+	test.timeoutAfter(1000)
 	runpp({
 		state: {
 			plots: [

--- a/client/plots/controls.divide.js
+++ b/client/plots/controls.divide.js
@@ -78,14 +78,14 @@ class Divide {
 		const a = {
 			activeCohort: this.state.activeCohort,
 			filter: this.state.filter,
-			disable_terms: [plot.term.id]
+			disable_terms: [plot.term]
 		}
 		if (plot.term0) {
 			a.term = plot.term0.term
 			a.q = plot.term0.q
-			a.disable_terms.push(plot.term0.id)
+			a.disable_terms.push(plot.term0)
 		}
-		if (plot.term2) a.disable_terms.push(plot.term2.id)
+		if (plot.term2) a.disable_terms.push(plot.term2)
 		if (!this.pill) this.initPill()
 		this.pill.main(a)
 	}

--- a/client/plots/controls.overlay.js
+++ b/client/plots/controls.overlay.js
@@ -91,7 +91,7 @@ class Overlay {
 		const a = {
 			activeCohort: this.state.activeCohort,
 			filter: this.state.filter,
-			disable_terms: [plot.term.id]
+			disable_terms: [plot.term]
 		}
 		{
 			// if cohort selection is enabled
@@ -104,9 +104,9 @@ class Overlay {
 		if (plot.term2) {
 			a.term = plot.term2.term
 			a.q = plot.term2.q
-			a.disable_terms.push(plot.term2.id)
+			a.disable_terms.push(plot.term2)
 		}
-		if (plot.term0) a.disable_terms.push(plot.term0.id)
+		if (plot.term0) a.disable_terms.push(plot.term0)
 		if (!this.pill) this.initPill()
 		this.pill.main(a)
 	}

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -1,5 +1,6 @@
 import { convertUnits } from '#shared/helpers'
 import { dtsnvindel, dtcnv, dtfusionrna, dtgeneexpression, dtsv } from '#shared/common'
+import { TermTypes } from '../shared/terms'
 /*
 	cell: a matrix cell data
 	tw: termwrapper
@@ -230,6 +231,8 @@ export const setCellProps = {
 	categorical: setCategoricalCellProps,
 	integer: setNumericCellProps,
 	float: setNumericCellProps,
+	[TermTypes.GENE_EXPRESSION]: setNumericCellProps,
+	[TermTypes.METABOLITE_INTENSITY]: setNumericCellProps,
 	/* !!! TODO: later, may allow survival terms as a matrix row in server/shared/termdb.usecase.js, 
 	   but how - quantitative, categorical, etc? */
 	//survival: setNumericCellProps,

--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -207,6 +207,7 @@ export async function getPlotConfig(opts = {}, app) {
 
 	const promises = []
 	for (const grp of config.termgroups) {
+		grp.lst = JSON.parse(JSON.stringify(grp.lst))
 		for (const tw of grp.lst) {
 			// may force the saved session to request the most up-to-data dictionary term data from server
 			// TODO: should skip samplelst term here

--- a/client/plots/regression.inputs.js
+++ b/client/plots/regression.inputs.js
@@ -137,10 +137,10 @@ export class RegressionInputs {
 
 	setDisableTerms() {
 		this.disable_terms = []
-		if (this.config.outcome && this.config.outcome.term) this.disable_terms.push(this.config.outcome.term.id)
+		if (this.config.outcome && this.config.outcome.term) this.disable_terms.push(this.config.outcome.term)
 		if (this.config.independent) {
 			for (const vb of this.config.independent) {
-				this.disable_terms.push(vb.term.id)
+				this.disable_terms.push(vb.term)
 			}
 		}
 	}

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -478,6 +478,7 @@ function getQSetter4outcome(regressionType) {
 	return {
 		integer: regressionType == 'logistic' ? maySetTwoBins : setContMode,
 		float: regressionType == 'logistic' ? maySetTwoBins : setContMode,
+		geneExpression: regressionType == 'logistic' ? maySetTwoBins : setContMode, //Added geneExpression, but still breaks, need to fix
 		categorical: maySetTwoGroups,
 		condition: setQ4tteOutcome,
 		survival: setQ4tteOutcome

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -30,15 +30,34 @@ const useCases = {
 		TermTypeGroups.GENE_EXPRESSION,
 		TermTypeGroups.METABOLITE_INTENSITY
 	],
-	summary: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION],
-	barchart: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION, TermTypeGroups.GENE_EXPRESSION],
-	violin: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION, TermTypeGroups.GENE_EXPRESSION],
-	sampleScatter: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION], //This case covers scaleBy and dynamic scatters with coordinates from numeric terms
+	summary: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION, TermTypeGroups.METABOLITE_INTENSITY],
+	barchart: [
+		TermTypeGroups.DICTIONARY_VARIABLES,
+		TermTypeGroups.MUTATION_CNV_FUSION,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	],
+	violin: [
+		TermTypeGroups.DICTIONARY_VARIABLES,
+		TermTypeGroups.MUTATION_CNV_FUSION,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	],
+	sampleScatter: [
+		TermTypeGroups.DICTIONARY_VARIABLES,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	], //This case covers scaleBy and dynamic scatters with coordinates from numeric terms
 	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],
 	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES], //Later on can support other term types like snplocus, snplst, geneVariant
-	survival: [TermTypeGroups.DICTIONARY_VARIABLES],
+	survival: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION, TermTypeGroups.METABOLITE_INTENSITY],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
-	default: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
+	default: [
+		TermTypeGroups.DICTIONARY_VARIABLES,
+		TermTypeGroups.MUTATION_CNV_FUSION,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	],
 	regression: [TermTypeGroups.DICTIONARY_VARIABLES]
 }
 

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -27,6 +27,8 @@ const useCasesExcluded = {
 		TermTypeGroups.METABOLITE_INTENSITY
 	],
 	dataDownload: [
+		//TermTypeGroups.SNP_LOCUS, //this tabs require that the handler for this term type to be implemented
+		//TermTypeGroups.SNP_LIST, //this tabs require that the handler for this term type to be implemented
 		TermTypeGroups.MUTATION_CNV_FUSION,
 		TermTypeGroups.GENE_EXPRESSION,
 		TermTypeGroups.METABOLITE_INTENSITY

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -19,15 +19,27 @@ const useCasesExcluded = {
 	barchart: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	violin: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	sampleScatter: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
-	cuminc: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST, TermTypeGroups.GENE_VARIANT],
+	cuminc: [
+		TermTypeGroups.SNP_LOCUS,
+		TermTypeGroups.SNP_LIST,
+		TermTypeGroups.MUTATION_CNV_FUSION,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	],
 	dataDownload: [
 		TermTypeGroups.SNP_LOCUS,
 		TermTypeGroups.SNP_LIST,
-		TermTypeGroups.GENE_VARIANT,
+		TermTypeGroups.MUTATION_CNV_FUSION,
 		TermTypeGroups.GENE_EXPRESSION,
 		TermTypeGroups.METABOLITE_INTENSITY
 	], //Later on can support other term types like snplocus, snplst, geneVariant, non dictionary terms
-	survival: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	survival: [
+		TermTypeGroups.SNP_LOCUS,
+		TermTypeGroups.SNP_LIST,
+		TermTypeGroups.MUTATION_CNV_FUSION,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
 	default: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	regression: [TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS]
@@ -129,8 +141,8 @@ export class TermTypeSearch {
 				if (state.usecase.target == 'sampleScatter' && type == TermTypes.GENE_VARIANT) {
 					if (state.usecase.detail == 'numeric') continue
 				}
-				//In most cases the target is enough to know what terms are allowed
-				if (!state.usecase.target || useCasesExcluded[state.usecase.target]?.includes(termTypeGroup)) continue
+
+				if (state.usecase.target && useCasesExcluded[state.usecase.target]?.includes(termTypeGroup)) continue
 
 				this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
 			}

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -11,54 +11,26 @@ When searching for terms, depending on the use case, only certain types of terms
 The tree target is used to determine the allowed term types.
  */
 
-const useCases = {
-	matrix: [
-		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.MUTATION_CNV_FUSION,
+const useCasesExcluded = {
+	matrix: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	filter: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	dictionary: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	summary: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	barchart: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	violin: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	sampleScatter: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	cuminc: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST, TermTypeGroups.GENE_VARIANT],
+	dataDownload: [
+		TermTypeGroups.SNP_LOCUS,
+		TermTypeGroups.SNP_LIST,
+		TermTypeGroups.GENE_VARIANT,
 		TermTypeGroups.GENE_EXPRESSION,
 		TermTypeGroups.METABOLITE_INTENSITY
-	],
-	filter: [
-		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	],
-	dictionary: [
-		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	],
-	summary: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION, TermTypeGroups.METABOLITE_INTENSITY],
-	barchart: [
-		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	],
-	violin: [
-		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	],
-	sampleScatter: [
-		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	], //This case covers scaleBy and dynamic scatters with coordinates from numeric terms
-	cuminc: [TermTypeGroups.DICTIONARY_VARIABLES],
-	dataDownload: [TermTypeGroups.DICTIONARY_VARIABLES], //Later on can support other term types like snplocus, snplst, geneVariant
-	survival: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.GENE_EXPRESSION, TermTypeGroups.METABOLITE_INTENSITY],
+	], //Later on can support other term types like snplocus, snplst, geneVariant, non dictionary terms
+	survival: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
-	default: [
-		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	],
-	regression: [TermTypeGroups.DICTIONARY_VARIABLES]
+	default: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
+	regression: [TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS]
 }
 
 export class TermTypeSearch {
@@ -149,26 +121,18 @@ export class TermTypeSearch {
 				throw `error with handler='./handlers/${type}.ts': ${e}`
 			}
 			if (termTypeGroup && !this.tabs.some(tab => tab.label == termTypeGroup)) {
-				//In regression snplocus and snplst are only allowed for the input variable, disabled for now
-				// if (state.usecase.target == 'regression' && (type == 'snplocus' || type == 'snplst' || type == TermTypes.GENE_VARIANT)) {
-				// 	if (state.usecase.detail == 'independent')
-				// 		this.tabs.push({ label, callback: () => this.setTermTypeGroup(termTypeGroup), termTypeGroup })
-				// 	continue
-				// }
+				//regression snp cases will be handled when the search handler is added
 				if (state.usecase.target == 'regression' && type == TermTypes.GENE_VARIANT) {
-					if (state.usecase.detail == 'independent')
-						this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
-					continue
+					if (state.usecase.detail != 'independent') continue
 				}
 				//In sampleScatter geneVariant is only allowed if detail is not numeric, like when building a dynamic scatter
 				if (state.usecase.target == 'sampleScatter' && type == TermTypes.GENE_VARIANT) {
-					if (state.usecase.detail != 'numeric')
-						this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
-					continue
+					if (state.usecase.detail == 'numeric') continue
 				}
 				//In most cases the target is enough to know what terms are allowed
-				if (!state.usecase.target || useCases[state.usecase.target]?.includes(termTypeGroup))
-					this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
+				if (!state.usecase.target || useCasesExcluded[state.usecase.target]?.includes(termTypeGroup)) continue
+
+				this.tabs.push({ label, callback: () => this.setTermTypeGroup(type, termTypeGroup), termTypeGroup })
 			}
 		}
 	}

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -27,8 +27,6 @@ const useCasesExcluded = {
 		TermTypeGroups.METABOLITE_INTENSITY
 	],
 	dataDownload: [
-		TermTypeGroups.SNP_LOCUS,
-		TermTypeGroups.SNP_LIST,
 		TermTypeGroups.MUTATION_CNV_FUSION,
 		TermTypeGroups.GENE_EXPRESSION,
 		TermTypeGroups.METABOLITE_INTENSITY
@@ -42,7 +40,12 @@ const useCasesExcluded = {
 	],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
 	default: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
-	regression: [TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS]
+	regression: [
+		TermTypeGroups.SNP_LIST,
+		TermTypeGroups.SNP_LOCUS,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	]
 }
 
 export class TermTypeSearch {

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -1,7 +1,6 @@
-import { Term } from '#shared/types/terms/term.ts'
 import { Tabs } from '../dom/toggleButtons'
 import { getCompInit } from '../rx'
-import { TermTypeGroups, TermTypes, typeGroup } from '#shared/terms'
+import { TermTypeGroups, TermTypes, typeGroup, Term } from '#shared/terms'
 
 type Dict = {
 	[key: string]: any
@@ -13,7 +12,12 @@ The tree target is used to determine the allowed term types.
  */
 
 const useCases = {
-	matrix: [TermTypeGroups.DICTIONARY_VARIABLES, TermTypeGroups.MUTATION_CNV_FUSION],
+	matrix: [
+		TermTypeGroups.DICTIONARY_VARIABLES,
+		TermTypeGroups.MUTATION_CNV_FUSION,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.METABOLITE_INTENSITY
+	],
 	filter: [
 		TermTypeGroups.DICTIONARY_VARIABLES,
 		TermTypeGroups.MUTATION_CNV_FUSION,

--- a/client/termdb/search.js
+++ b/client/termdb/search.js
@@ -5,7 +5,7 @@ import { debounce } from 'debounce'
 import { root_ID } from './tree'
 import { isUsableTerm } from '#shared/termdb.usecase'
 import { keyupEnter } from '#src/client'
-import { TermTypeGroups, isNonDictionaryType } from '#shared/terms'
+import { TermTypeGroups, isNonDictionaryType, equals } from '#shared/terms'
 
 /*
 steps:
@@ -190,7 +190,7 @@ function setRenderers(self) {
 		// add disabled terms to opts.disable_terms
 		if (self.opts.disable_terms) {
 			data.lst.forEach(t => {
-				if (t.disabled) self.opts.disable_terms.push(t.id)
+				if (t.disabled) self.opts.disable_terms.push(t)
 			})
 		}
 		self.clear()
@@ -222,7 +222,6 @@ function setRenderers(self) {
 		const tr = select(this)
 		const button = tr.append('td').text(term.name)
 		const uses = isUsableTerm(term, self.state.usecase)
-
 		/*
 		below, both callbacks are made in app.js validateOpts()
 		1. self.opts.click_term() is for selecting to tvs
@@ -230,7 +229,7 @@ function setRenderers(self) {
 		*/
 		if ((self.opts.click_term || self.app.opts?.tree?.click_term_wrapper) && uses.has('plot')) {
 			// to click a graphable term, show as blue button
-			if (self.opts.disable_terms?.includes(term.id)) {
+			if (self.opts.disable_terms?.find(term2 => equals(term, term2))) {
 				// but it's disabled
 				button
 					.attr('class', 'sja_tree_click_term_disabled')

--- a/client/termdb/search.js
+++ b/client/termdb/search.js
@@ -188,6 +188,7 @@ function setRenderers(self) {
 	}
 	self.showTerms = data => {
 		// add disabled terms to opts.disable_terms
+
 		if (self.opts.disable_terms) {
 			data.lst.forEach(t => {
 				if (t.disabled) self.opts.disable_terms.push(t)
@@ -229,7 +230,7 @@ function setRenderers(self) {
 		*/
 		if ((self.opts.click_term || self.app.opts?.tree?.click_term_wrapper) && uses.has('plot')) {
 			// to click a graphable term, show as blue button
-			if (self.opts.disable_terms?.find(term2 => equals(term, term2))) {
+			if (term && self.opts.disable_terms?.find(term2 => equals(term, term2))) {
 				// but it's disabled
 				button
 					.attr('class', 'sja_tree_click_term_disabled')

--- a/client/termdb/test/search.integration.spec.js
+++ b/client/termdb/test/search.integration.spec.js
@@ -25,12 +25,12 @@ const runpp = helpers.getRunPp('termdb', {
  test sections
 ***************/
 
-tape('\n', function(test) {
+tape('\n', function (test) {
 	test.pass('-***- termdb/search -***-')
 	test.end()
 })
 
-tape('term search, default behavior with barchart usecase', function(test) {
+tape('term search, default behavior with barchart usecase', function (test) {
 	test.timeoutAfter(5000)
 	runpp({
 		state: {
@@ -115,7 +115,7 @@ tape('click_term', test => {
 	runpp({
 		tree: {
 			click_term: modifier_callback,
-			disable_terms: ['Cardiomyopathy']
+			disable_terms: [{ id: 'Cardiomyopathy' }]
 		},
 		search: {
 			callbacks: {
@@ -168,7 +168,7 @@ tape('tree.click_term2select_tvs', test => {
 	runpp({
 		tree: {
 			click_term2select_tvs: () => {},
-			disable_terms: ['Cardiomyopathy']
+			disable_terms: [{ id: 'Cardiomyopathy' }]
 		},
 		search: {
 			callbacks: {

--- a/client/termdb/test/search.integration.spec.js
+++ b/client/termdb/test/search.integration.spec.js
@@ -115,7 +115,7 @@ tape('click_term', test => {
 	runpp({
 		tree: {
 			click_term: modifier_callback,
-			disable_terms: [{ id: 'Cardiomyopathy' }]
+			disable_terms: [{ id: 'Cardiomyopathy', type: 'condition' }]
 		},
 		search: {
 			callbacks: {
@@ -168,7 +168,7 @@ tape('tree.click_term2select_tvs', test => {
 	runpp({
 		tree: {
 			click_term2select_tvs: () => {},
-			disable_terms: [{ id: 'Cardiomyopathy' }]
+			disable_terms: [{ id: 'Cardiomyopathy', type: 'condition' }]
 		},
 		search: {
 			callbacks: {

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -260,7 +260,7 @@ function setRenderers(self) {
 		// add disabled terms to opts.disable_terms
 		if (self.opts.disable_terms) {
 			term.terms.forEach(t => {
-				if (t.disabled) self.opts.disable_terms.push(t.id)
+				if (t.disabled) self.opts.disable_terms.push(t)
 			})
 		}
 

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -30,6 +30,7 @@ export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ:
 
 	if (!tw.term.bins) {
 		const defaultBins = await vocabApi.getDefaultBins({ tw })
+		if ('error' in defaultBins) throw defaultBins.error
 		tw.term.bins = defaultBins
 		tw.q = JSON.parse(JSON.stringify(tw.term.bins.default))
 	}

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -153,7 +153,6 @@ function getZscore(l: number[]) {
 export async function validate_query_geneExpression(ds: any, genome: any) {
 	const q: GeneExpressionQuery = ds.queries.geneExpression
 	if (!q) return
-	q.gene2bins = {}
 
 	if (q.src == 'gdcapi') {
 		gdc_validate_query_geneExpression(ds as GeneExpressionQueryGdc, genome)

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -250,6 +250,7 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any, genome: any
 		}
 		// pass blank byTermId to match with expected output structure
 		const byTermId = {}
+		if (gene2sample2value.size == 0) throw 'no data available for ' + param.genes.map(g => g.gene).join(', ')
 		return { gene2sample2value, byTermId, bySampleId }
 	}
 }

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -153,6 +153,7 @@ function getZscore(l: number[]) {
 export async function validate_query_geneExpression(ds: any, genome: any) {
 	const q: GeneExpressionQuery = ds.queries.geneExpression
 	if (!q) return
+	q.geneExpression2bins = {} //this dict is used to store the default bin config for each gene searched, so it doesn't have to be recalculated each time
 
 	if (q.src == 'gdcapi') {
 		gdc_validate_query_geneExpression(ds as GeneExpressionQueryGdc, genome)

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -250,7 +250,7 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any, genome: any
 		}
 		// pass blank byTermId to match with expected output structure
 		const byTermId = {}
-		if (gene2sample2value.size == 0) throw 'no data available for ' + param.genes.map(g => g.gene).join(', ')
+		if (gene2sample2value.size == 0) throw 'no data available for the input ' + param.genes?.map(g => g.gene).join(', ')
 		return { gene2sample2value, byTermId, bySampleId }
 	}
 }

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -1,4 +1,4 @@
-import { TermTypes } from './terms.js'
+import { TermTypes, isNumericTerm } from './terms.js'
 
 export const graphableTypes = new Set([
 	'categorical',
@@ -85,7 +85,7 @@ export function isUsableTerm(term, _usecase, ds) {
 
 		case 'sampleScatter':
 			if (usecase.detail == 'numeric') {
-				if (term.type == 'float' || term.type == 'integer') {
+				if (isNumericTerm(term)) {
 					uses.add('plot')
 				}
 				if (hasNumericChild(child_types)) uses.add('branch')

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -72,3 +72,20 @@ export function isNonDictionaryType(type) {
 	if (!type) throw new Error('Type is not defined')
 	return nonDictTypes.has(type)
 }
+
+export function equals(t1, t2) {
+	if (!t1) throw new Error('Term is not defined ' + t1)
+	if (!t2) throw new Error('Term is not defined ' + t2)
+	if (t1.type !== t2.type) return false //term types are different
+	if (isDictionaryType(t1.type) && isDictionaryType(t2.type)) return t1.id === t2.id
+	switch (t1.type) {
+		case TermTypes.GENE_EXPRESSION:
+			return t1.gene == t2.gene
+		case TermTypes.METABOLITE_INTENSITY:
+			return t1.name == t2.name
+		case TermTypes.GENE_VARIANT:
+			return t1.gene == t2.gene || (t1.chr == t2.chr && t1.start == t2.start && t1.stop == t2.stop)
+		default:
+			return false
+	}
+}

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -74,8 +74,8 @@ export function isNonDictionaryType(type) {
 }
 
 export function equals(t1, t2) {
-	if (!t1) throw new Error('Term is not defined ' + t1)
-	if (!t2) throw new Error('Term is not defined ' + t2)
+	if (!t1) throw new Error('First term is not defined ')
+	if (!t2) throw new Error('Second term is not defined ')
 	if (t1.type !== t2.type) return false //term types are different
 	if (isDictionaryType(t1.type) && isDictionaryType(t2.type) && t1.type != TermTypes.SAMPLELST) return t1.id === t2.id
 	switch (t1.type) {

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -53,15 +53,15 @@ const nonDictTypes = new Set([
 	TermTypes.GENE_VARIANT,
 	TermTypes.METABOLITE_INTENSITY
 ])
-
+export const numericTypes = new Set([
+	TermTypes.INTEGER,
+	TermTypes.FLOAT,
+	TermTypes.GENE_EXPRESSION,
+	TermTypes.METABOLITE_INTENSITY
+])
 export function isNumericTerm(term) {
 	if (!term) return false
-	return (
-		term.type == TermTypes.INTEGER ||
-		term.type == TermTypes.FLOAT ||
-		term.type == TermTypes.GENE_EXPRESSION ||
-		term.type == TermTypes.METABOLITE_INTENSITY
-	)
+	return numericTypes.has(term.type)
 }
 
 export function isDictionaryType(type) {

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -77,7 +77,7 @@ export function equals(t1, t2) {
 	if (!t1) throw new Error('Term is not defined ' + t1)
 	if (!t2) throw new Error('Term is not defined ' + t2)
 	if (t1.type !== t2.type) return false //term types are different
-	if (isDictionaryType(t1.type) && isDictionaryType(t2.type)) return t1.id === t2.id
+	if (isDictionaryType(t1.type) && isDictionaryType(t2.type) && t1.type != TermTypes.SAMPLELST) return t1.id === t2.id
 	switch (t1.type) {
 		case TermTypes.GENE_EXPRESSION:
 			return t1.gene == t2.gene
@@ -85,6 +85,12 @@ export function equals(t1, t2) {
 			return t1.name == t2.name
 		case TermTypes.GENE_VARIANT:
 			return t1.gene == t2.gene || (t1.chr == t2.chr && t1.start == t2.start && t1.stop == t2.stop)
+
+		// TO DO: Add more cases
+		// case TermTypes.SNP_LIST:
+		// case TermTypes.SNP_LOCUS:
+		// case TermTypes.SAMPLELST:
+
 		default:
 			return false
 	}

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -312,14 +312,13 @@ export type MetaboliteIntensityQueryNative = {
 	_metabolites?: string[]
 	get?: (param: any) => void
 	find?: (param: string[]) => void
-	metabolite2bins?: { [index: string]: any }
+	metaboliteIntensity2bins?: { [index: string]: any }
 }
 export type MetaboliteIntensityQuery = MetaboliteIntensityQueryNative
 
 // the geneExpression query
 export type GeneExpressionQueryGdc = {
 	src: 'gdcapi' | string
-	gene2bins?: { [index: string]: any }
 }
 
 export type GeneExpressionQueryNative = {
@@ -330,7 +329,6 @@ export type GeneExpressionQueryNative = {
 	nochr?: boolean
 	get?: (param: any) => void
 	//This dictionary is used to store/cache the default bins calculated for a geneExpression term when initialized in the fillTermWrapper
-	gene2bins?: { [index: string]: any }
 }
 export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNative
 

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -319,6 +319,7 @@ export type MetaboliteIntensityQuery = MetaboliteIntensityQueryNative
 // the geneExpression query
 export type GeneExpressionQueryGdc = {
 	src: 'gdcapi' | string
+	geneExpression2bins?: { [index: string]: any }
 }
 
 export type GeneExpressionQueryNative = {
@@ -328,6 +329,7 @@ export type GeneExpressionQueryNative = {
 	samples?: number[]
 	nochr?: boolean
 	get?: (param: any) => void
+	geneExpression2bins?: { [index: string]: any }
 	//This dictionary is used to store/cache the default bins calculated for a geneExpression term when initialized in the fillTermWrapper
 }
 export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNative

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -1419,7 +1419,7 @@ async function validate_query_ld(ds, genome) {
 export async function validate_query_metaboliteIntensity(ds, genome) {
 	const q = ds.queries.metaboliteIntensity
 	if (!q) return
-	q.metabolite2bins = {}
+	q.metaboliteIntensity2bins = {}
 
 	if (q.src == 'native') {
 		await validateMetaboliteIntensityNative(q, ds, genome)

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -465,10 +465,8 @@ async function trigger_getDefaultBins(q, ds, res) {
 	const lst = []
 	let min = Infinity
 	let max = -Infinity
-	if (tw.term.type == TermTypes.GENE_EXPRESSION) {
-		if (ds.queries.geneExpression.gene2bins[tw.term.gene])
-			return { default: ds.queries.geneExpression.gene2bins[tw.term.gene] }
 
+	if (tw.term.type == TermTypes.GENE_EXPRESSION) {
 		const args = {
 			genome: q.genome,
 			dslabel: q.dslabel,

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -323,9 +323,10 @@ async function get_matrix(q, req, res, ds, genome) {
 	}
 	const data = await getData(q, ds, genome)
 	if (authApi.canDisplaySampleIds(req, ds)) {
-		for (const sample of Object.values(data.samples)) {
-			sample.sampleName = ds.sampleId2Name.get(sample.sample)
-		}
+		if (data.samples)
+			for (const sample of Object.values(data.samples)) {
+				sample.sampleName = ds.sampleId2Name.get(sample.sample)
+			}
 	}
 	res.send(data)
 }

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -469,48 +469,52 @@ async function trigger_getDefaultBins(q, ds, res) {
 	let max = -Infinity
 	const binsCache = ds.queries[tw.term.type][`${tw.term.type}2bins`]
 	if (binsCache[tw.term.name]) return binsCache[tw.term.name]
+	try {
+		if (tw.term.type == TermTypes.GENE_EXPRESSION) {
+			const args = {
+				genome: q.genome,
+				dslabel: q.dslabel,
+				clusterMethod: 'hierarchical',
+				/** distance method */
+				distanceMethod: 'euclidean',
+				/** Data type */
+				dataType: dtgeneexpression,
+				genes: [{ gene: tw.term.gene }]
+			}
+			const data = await ds.queries.geneExpression.get(args)
 
-	if (tw.term.type == TermTypes.GENE_EXPRESSION) {
-		const args = {
-			genome: q.genome,
-			dslabel: q.dslabel,
-			clusterMethod: 'hierarchical',
-			/** distance method */
-			distanceMethod: 'euclidean',
-			/** Data type */
-			dataType: dtgeneexpression,
-			genes: [{ gene: tw.term.gene }]
+			for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
+				const values = data.gene2sample2value.get(tw.term.gene)
+				const value = Number(values[sampleId])
+				if (value < min) min = value
+				if (value > max) max = value
+				lst.push(value)
+			}
+		} else if (tw.term.type == TermTypes.METABOLITE_INTENSITY) {
+			const args = {
+				genome: q.genome,
+				dslabel: q.dslabel,
+				clusterMethod: 'hierarchical',
+				/** distance method */
+				distanceMethod: 'euclidean',
+				/** Data type */
+				dataType: dtmetaboliteintensity, //metabolite intensity type defined for the dataset???
+				metabolites: [tw.term.name]
+			}
+			const data = await ds.queries.metaboliteIntensity.get(args)
+			const termData = data.metabolite2sample2value.get(tw.term.name)
+			for (const sample in termData) {
+				const value = termData[sample]
+				if (value < min) min = value
+				if (value > max) max = value
+				lst.push(value)
+			}
 		}
-		const data = await ds.queries.geneExpression.get(args)
-
-		for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
-			const values = data.gene2sample2value.get(tw.term.gene)
-			const value = Number(values[sampleId])
-			if (value < min) min = value
-			if (value > max) max = value
-			lst.push(value)
-		}
-	} else if (tw.term.type == TermTypes.METABOLITE_INTENSITY) {
-		const args = {
-			genome: q.genome,
-			dslabel: q.dslabel,
-			clusterMethod: 'hierarchical',
-			/** distance method */
-			distanceMethod: 'euclidean',
-			/** Data type */
-			dataType: dtmetaboliteintensity, //metabolite intensity type defined for the dataset???
-			metabolites: [tw.term.name]
-		}
-		const data = await ds.queries.metaboliteIntensity.get(args)
-		const termData = data.metabolite2sample2value.get(tw.term.name)
-		for (const sample in termData) {
-			const value = termData[sample]
-			if (value < min) min = value
-			if (value > max) max = value
-			lst.push(value)
-		}
+		let binconfig = initBinConfig(lst)
+		binsCache[tw.term.name] = { default: binconfig, min, max }
+		res.send({ default: binconfig, min, max })
+	} catch (e) {
+		console.log(e)
+		res.send({ error: e.message || e })
 	}
-	let binconfig = initBinConfig(lst)
-	binsCache[tw.term.name] = { default: binconfig, min, max }
-	res.send({ default: binconfig, min, max })
 }

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -462,12 +462,13 @@ async function LDoverlay(q, ds, res) {
 
 async function trigger_getDefaultBins(q, ds, res) {
 	const tw = q.tw
+	if (!ds.queries[tw.term.type]) throw 'term type not supported by this dataset'
+
 	const lst = []
 	let min = Infinity
 	let max = -Infinity
 	const binsCache = ds.queries[tw.term.type][`${tw.term.type}2bins`]
 	if (binsCache[tw.term.name]) return binsCache[tw.term.name]
-	if (!ds.queries[tw.term.type]) throw 'term type not supported by this dataset'
 
 	if (tw.term.type == TermTypes.GENE_EXPRESSION) {
 		const args = {

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -467,47 +467,48 @@ async function trigger_getDefaultBins(q, ds, res) {
 	let max = -Infinity
 	const binsCache = ds.queries[tw.term.type][`${tw.term.type}2bins`]
 	if (binsCache[tw.term.name]) return binsCache[tw.term.name]
-	if (ds.queries[tw.term.type])
-		if (tw.term.type == TermTypes.GENE_EXPRESSION) {
-			const args = {
-				genome: q.genome,
-				dslabel: q.dslabel,
-				clusterMethod: 'hierarchical',
-				/** distance method */
-				distanceMethod: 'euclidean',
-				/** Data type */
-				dataType: dtgeneexpression,
-				genes: [{ gene: tw.term.gene }]
-			}
-			const data = await ds.queries.geneExpression.get(args)
+	if (!ds.queries[tw.term.type]) throw 'term type not supported by this dataset'
 
-			for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
-				const values = data.gene2sample2value.get(tw.term.gene)
-				const value = Number(values[sampleId])
-				if (value < min) min = value
-				if (value > max) max = value
-				lst.push(value)
-			}
-		} else if (tw.term.type == TermTypes.METABOLITE_INTENSITY) {
-			const args = {
-				genome: q.genome,
-				dslabel: q.dslabel,
-				clusterMethod: 'hierarchical',
-				/** distance method */
-				distanceMethod: 'euclidean',
-				/** Data type */
-				dataType: dtmetaboliteintensity, //metabolite intensity type defined for the dataset???
-				metabolites: [tw.term.name]
-			}
-			const data = await ds.queries.metaboliteIntensity.get(args)
-			const termData = data.metabolite2sample2value.get(tw.term.name)
-			for (const sample in termData) {
-				const value = termData[sample]
-				if (value < min) min = value
-				if (value > max) max = value
-				lst.push(value)
-			}
+	if (tw.term.type == TermTypes.GENE_EXPRESSION) {
+		const args = {
+			genome: q.genome,
+			dslabel: q.dslabel,
+			clusterMethod: 'hierarchical',
+			/** distance method */
+			distanceMethod: 'euclidean',
+			/** Data type */
+			dataType: dtgeneexpression,
+			genes: [{ gene: tw.term.gene }]
 		}
+		const data = await ds.queries.geneExpression.get(args)
+
+		for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
+			const values = data.gene2sample2value.get(tw.term.gene)
+			const value = Number(values[sampleId])
+			if (value < min) min = value
+			if (value > max) max = value
+			lst.push(value)
+		}
+	} else if (tw.term.type == TermTypes.METABOLITE_INTENSITY) {
+		const args = {
+			genome: q.genome,
+			dslabel: q.dslabel,
+			clusterMethod: 'hierarchical',
+			/** distance method */
+			distanceMethod: 'euclidean',
+			/** Data type */
+			dataType: dtmetaboliteintensity, //metabolite intensity type defined for the dataset???
+			metabolites: [tw.term.name]
+		}
+		const data = await ds.queries.metaboliteIntensity.get(args)
+		const termData = data.metabolite2sample2value.get(tw.term.name)
+		for (const sample in termData) {
+			const value = termData[sample]
+			if (value < min) min = value
+			if (value > max) max = value
+			lst.push(value)
+		}
+	}
 	let binconfig = initBinConfig(lst)
 	binsCache[tw.term.name] = { default: binconfig, min, max }
 	res.send({ default: binconfig, min, max })

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -465,48 +465,50 @@ async function trigger_getDefaultBins(q, ds, res) {
 	const lst = []
 	let min = Infinity
 	let max = -Infinity
+	const binsCache = ds.queries[tw.term.type][`${tw.term.type}2bins`]
+	if (binsCache[tw.term.name]) return binsCache[tw.term.name]
+	if (ds.queries[tw.term.type])
+		if (tw.term.type == TermTypes.GENE_EXPRESSION) {
+			const args = {
+				genome: q.genome,
+				dslabel: q.dslabel,
+				clusterMethod: 'hierarchical',
+				/** distance method */
+				distanceMethod: 'euclidean',
+				/** Data type */
+				dataType: dtgeneexpression,
+				genes: [{ gene: tw.term.gene }]
+			}
+			const data = await ds.queries.geneExpression.get(args)
 
-	if (tw.term.type == TermTypes.GENE_EXPRESSION) {
-		const args = {
-			genome: q.genome,
-			dslabel: q.dslabel,
-			clusterMethod: 'hierarchical',
-			/** distance method */
-			distanceMethod: 'euclidean',
-			/** Data type */
-			dataType: dtgeneexpression,
-			genes: [{ gene: tw.term.gene }]
+			for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
+				const values = data.gene2sample2value.get(tw.term.gene)
+				const value = Number(values[sampleId])
+				if (value < min) min = value
+				if (value > max) max = value
+				lst.push(value)
+			}
+		} else if (tw.term.type == TermTypes.METABOLITE_INTENSITY) {
+			const args = {
+				genome: q.genome,
+				dslabel: q.dslabel,
+				clusterMethod: 'hierarchical',
+				/** distance method */
+				distanceMethod: 'euclidean',
+				/** Data type */
+				dataType: dtmetaboliteintensity, //metabolite intensity type defined for the dataset???
+				metabolites: [tw.term.name]
+			}
+			const data = await ds.queries.metaboliteIntensity.get(args)
+			const termData = data.metabolite2sample2value.get(tw.term.name)
+			for (const sample in termData) {
+				const value = termData[sample]
+				if (value < min) min = value
+				if (value > max) max = value
+				lst.push(value)
+			}
 		}
-		const data = await ds.queries.geneExpression.get(args)
-
-		for (const sampleId in data.gene2sample2value.get(tw.term.gene)) {
-			const values = data.gene2sample2value.get(tw.term.gene)
-			const value = Number(values[sampleId])
-			if (value < min) min = value
-			if (value > max) max = value
-			lst.push(value)
-		}
-	} else if (tw.term.type == TermTypes.METABOLITE_INTENSITY) {
-		const args = {
-			genome: q.genome,
-			dslabel: q.dslabel,
-			clusterMethod: 'hierarchical',
-			/** distance method */
-			distanceMethod: 'euclidean',
-			/** Data type */
-			dataType: dtmetaboliteintensity, //metabolite intensity type defined for the dataset???
-			metabolites: [tw.term.name]
-		}
-		const data = await ds.queries.metaboliteIntensity.get(args)
-		const termData = data.metabolite2sample2value.get(tw.term.name)
-		for (const sample in termData) {
-			const value = termData[sample]
-			if (value < min) min = value
-			if (value > max) max = value
-			lst.push(value)
-		}
-	}
 	let binconfig = initBinConfig(lst)
-
+	binsCache[tw.term.name] = { default: binconfig, min, max }
 	res.send({ default: binconfig, min, max })
 }

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -505,9 +505,14 @@ export function server_init_db_queries(ds) {
 				}
 			}
 			if (ds.queries.geneExpression) {
-				for (const cohort in supportedChartTypes) supportedChartTypes[cohort].push('hierCluster')
+				for (const cohort in supportedChartTypes) {
+					supportedChartTypes[cohort].push('hierCluster')
+					supportedChartTypes[cohort].push('sampleScatter')
+				}
 				// TODO support clustering on dict terms
 			}
+			if (ds.queries.metaboliteIntensity)
+				for (const cohort in supportedChartTypes) supportedChartTypes[cohort].push('sampleScatter')
 			if (ds.queries.rnaseqGeneCount) {
 				for (const cohort in supportedChartTypes) supportedChartTypes[cohort].push('DEanalysis')
 			}

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -2,6 +2,7 @@ import serverconfig from './serverconfig'
 import { connect_db } from './utils'
 import { isUsableTerm } from '../shared/termdb.usecase'
 import { authApi } from './auth'
+import { numericTypes } from '#shared/terms.js'
 
 /*
 server_init_db_queries()
@@ -471,7 +472,7 @@ export function server_init_db_queries(ds) {
 				supportedChartTypes[r.cohort].add('survival')
 			if (r.type == 'condition' && !supportedChartTypes[r.cohort].has('cuminc'))
 				supportedChartTypes[r.cohort].add('cuminc')
-			if (r.type == 'float' || r.type == 'integer') numericTypeCount[r.cohort] += r.samplecount
+			if (numericTypes.has(r.type)) numericTypeCount[r.cohort] += r.samplecount
 		}
 
 		/*

--- a/server/test/tp/files/hg38/TermdbTest/TermdbTest_matrix.json
+++ b/server/test/tp/files/hg38/TermdbTest/TermdbTest_matrix.json
@@ -360,6 +360,7 @@
                 {
                     "term": {
                         "name": "TP53",
+                        "gene": "TP53",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -374,6 +375,7 @@
                 {
                     "term": {
                         "name": "KRAS",
+                        "gene": "KRAS",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -403,6 +405,7 @@
                 {
                     "term": {
                         "name": "TP53",
+                        "gene": "TP53",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -417,6 +420,7 @@
                 {
                     "term": {
                         "name": "AKT1",
+                        "gene": "AKT1",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -431,6 +435,7 @@
                 {
                     "term": {
                         "name": "KRAS",
+                        "gene": "KRAS",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -445,6 +450,7 @@
                 {
                     "term": {
                         "name": "BCR",
+                        "gene": "BCR",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -478,6 +484,7 @@
                 {
                     "term": {
                         "name": "TP53",
+                        "gene": "TP53",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -492,6 +499,7 @@
                 {
                     "term": {
                         "name": "KRAS",
+                        "gene": "KRAS",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -522,6 +530,7 @@
                 {
                     "term": {
                         "name": "TP53",
+                        "gene": "TP53",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,
@@ -536,6 +545,7 @@
                 {
                     "term": {
                         "name": "KRAS",
+                        "gene": "KRAS",
                         "type": "geneVariant"
                     },
                     "isAtomic": true,


### PR DESCRIPTION
## Description

This PR adds support to geneExpression and metaboliteIntensity in all the use cases allowed. Now we list the use cases excluded in TermTypeSearch, instead of included cases. Also we disable terms in the dictionary passing the term and not the id, so we can disable non dict terms. As there are many use cases and files affected, please check if the tree looks as expected in the different use cases and check selecting terms. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
