### PR TITLE
build ds.queries.metaboliteIntensity.find

### DIFF
--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -287,6 +287,30 @@ async function validateMetaboliteIntensityNative(q: MetaboliteIntensityQueryNati
 		}
 	}
 
+	q.find = async (param: TermdbClusterRequest) => {
+		// if !q.metabolites, read all metabolites from file
+		if (!q.metabolites) {
+			const metabolites = [] as string[]
+			await utils.get_lines_txtfile({
+				args: [q.file],
+				callback: line => {
+					const l = line.split('\t')
+					if (l[0].startsWith('#Metabolites')) return
+					metabolites.push(l[0])
+				}
+			} as any)
+			q.metabolites = metabolites
+		}
+		const matches = []
+		for (const m of param.metabolites!) {
+			if (!m) continue
+			for (const metabolite of q.metabolites) {
+				if (metabolite.toLowerCase().includes(m.toLowerCase())) matches.push(metabolite)
+			}
+		}
+		return { matches }
+	}
+
 	q.get = async (param: TermdbClusterRequest) => {
 		const limitSamples = await mayLimitSamples(param, q.samples, ds)
 		if (limitSamples?.size == 0) {

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -232,10 +232,10 @@ async function trigger_findterm(q, res, termdb, ds, genome) {
 				dataType: dtmetaboliteintensity, //metabolite intensity type defined for the dataset???
 				metabolites: [q.findterm]
 			}
-			const data = await ds.queries.metaboliteIntensity.get(args)
+			const data = await ds.queries.metaboliteIntensity.find(args)
 			const foundTerms = []
-			for (const metabolite of data.metabolite2sample2value) {
-				foundTerms.push({ name: metabolite[0], type: 'metaboliteIntensity' })
+			for (const metabolite of data.matches) {
+				foundTerms.push({ name: metabolite, type: 'metaboliteIntensity' })
 			}
 			terms.push(...foundTerms)
 		}


### PR DESCRIPTION
## Description
ds.queries.metaboliteIntensity.find:
   read the metabolite intensity file only once and save the metabolites into cache (q.metabolites). When you do metabolite search, the code will first check if q.metabolites is available. If not, reading through the metabolite file is needed. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
