### PR TITLE
Update instruction for custom data UI

### DIFF
--- a/client/mds3/customdata.inputui.js
+++ b/client/mds3/customdata.inputui.js
@@ -180,7 +180,7 @@ function parsePositionFromGm(selecti, str, gm) {
 	if (selecti == 2) {
 		return [gm.chr, value - 1]
 	}
-	throw 'unknown selecti'
+	throw 'unknown selection'
 }
 // instructions for mutation
 function showSnvindelHelp(div) {
@@ -253,7 +253,7 @@ function showSvfusionHelp(div) {
 		Break-end position types:
 		<ul><li>Codon position: integer, 1-based</li>
 		<li>RNA position: integer, 1-based, beginning from transcription start site</li>
-		<li>Genomic position: chromosome name and 1-based coordinate joined by colon, e.g. chr1:2345</li></ul>
+		<li>Genomic position: 1-based coordinate</li></ul>
 		Either one of the isoforms must be already displayed.`
 		)
 }


### PR DESCRIPTION
## Description
Addressing a user identified issue from google groups (https://groups.google.com/g/proteinpaint/c/UQLDuQist6M). `parsePositionFromGm` already retrieves the chr from `genelookup`. Updated directions to reflect that change. 

Test with: http://localhost:3000/?gene=TMPRSS2&genome=hg19 and add a custom data from the '+' button with `Tmprss2,NM_005656,42870592,erg,NM_001243428,39876806` as a genomic position. Note the error message when trying to use `Tmprss2,NM_005656,chr21:42870592,erg,NM_001243428,chr21:39876806`. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
