### PR TITLE
fix: Do not trim text returned by gdc gene expression /values API to …

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Do not trim text returned by gdc gene expression /values API to handle the case of missing value cases at the end

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -281,7 +281,12 @@ async function getExpressionData(q, gene_ids, case_ids, ensg2symbol, gene2sample
 			}
 		})
 		.text()
-	const lines = re.trim().split('\n')
+
+	/* do not trim on any line!
+	had ran into a scenario that /values endpoint may return blank columns for missing exp values, and when those columns are at the end of each line, trim() will cause the last line to have mismatching number of columns
+	(blank column may be explained by pp cache is mismatching with a new data release, awaiting further confirmation)
+	*/
+	const lines = re.split('\n')
 	if (lines.length <= 1) throw 'less than 1 line from tsv response.body'
 
 	// header line:
@@ -300,6 +305,9 @@ async function getExpressionData(q, gene_ids, case_ids, ensg2symbol, gene2sample
 
 	// each line is data from one gene
 	for (let i = 1; i < lines.length; i++) {
+		// since it no longer trims, this detects when text ends with a newline character and escapes it
+		if (!lines[i]) continue
+
 		const l = lines[i].split('\t')
 		if (l.length != caseHeader.length + 1) throw 'number of fields in gene line does not equal header'
 		const ensg = l[0]


### PR DESCRIPTION
…handle the case of missing value cases at the end

## Description

local gene exp views work
awaiting for Edgar to test 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
