### PR TITLE
fix: scope PP-specific css resets and styles to the root holder

### DIFF
--- a/client/generateScopedCss.js
+++ b/client/generateScopedCss.js
@@ -1,0 +1,61 @@
+const usage = `
+	usage from the client dir: 
+	
+	node ./generateScopedCss.js cssFile [ > outputFile]
+
+	- cssFile is assumed to be well-formatted, with new line after each selector and curly bracket blocks
+	- if no outputFile, the output will be logged
+	- with outputFile argument, outputFile-unscoped.css and outputFile-scoped.css will be generated
+
+	example:
+	node generateScopedCss.js ../../node_modules/normalize.css/normalize.css src/style-normalize
+`
+const cssFile = process.argv[2]
+if (!cssFile) throw usage
+
+const fs = require('fs')
+if (!fs.existsSync(cssFile)) throw `not found, file='${cssFile}'`
+
+const cssStr = fs.readFileSync(cssFile).toString('utf-8').trim()
+const lines = cssStr.split('\n')
+const unscopedRules = []
+const scopedRules = []
+
+let currTag,
+	unclosed = false,
+	currRulesArr = unscopedRules // assumed html, body are declared first in css
+for (const line of lines) {
+	const l = line.trim()
+	if (!l) {
+		currRulesArr.push(line)
+	} else if (l.includes('}')) {
+		currRulesArr.push(line)
+		// assume body is the last declared scoped rule
+		// this will allow subsequent comments to be on top of the applicable scoped rule
+		if (currTag == 'body') currRulesArr = scopedRules
+		unclosed = false
+	} else if (line.includes('{') || line.endsWith(',')) {
+		unclosed = true
+		currTag = l.split(' ')[0]
+		currRulesArr = currTag == 'html' || currTag == 'body' ? unscopedRules : scopedRules
+		currRulesArr.push(`.sja_root_holder ${line}`)
+	} else if (!currTag || currTag == 'html' || currTag == 'body') {
+		currRulesArr.push(line)
+	} else if (unclosed) {
+		currRulesArr.push(line)
+	} else {
+		currRulesArr = scopedRules
+		currRulesArr.push(line)
+	}
+}
+
+const outputFile = process.argv[3]
+if (!outputFile) {
+	console.log(unscopedRules.join('\n'))
+	console.log('@scope (.sja_root_holder) {')
+	console.log(scopedRules.join('\n'))
+	console.log('}')
+} else {
+	fs.writeFileSync(`${outputFile}-unscoped.css`, unscopedRules.join('\n'), { encoding: 'utf8' })
+	fs.writeFileSync(`${outputFile}-scoped.css`, scopedRules.join('\n'), { encoding: 'utf8' })
+}

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -181,6 +181,9 @@ export function runproteinpaint(arg) {
 				// TODO??: server-side rendered viz should see client-side arg.commonOverrides ???
 				common.applyOverrides(Object.assign(data.commonOverrides || {}, arg.commonOverrides || {}))
 			}
+			// TODO: may import(style-normalize-unscoped.css) here for pp portals
+			//       where is it certain html, body css resets will not conflict with portal styles;
+			//       will also need to remove the import of the unscoped.css file from style.css
 			if (data.targetPortal && data.targetPortal == 'gdc') await import('./style.gdc.css') // actual string value will let webpack find and bundle this optional stylesheet
 			// genome data init
 			for (const genomename in app.genomes) {

--- a/client/src/style-normalize-scoped.css
+++ b/client/src/style-normalize-scoped.css
@@ -1,0 +1,324 @@
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+.sja_root_holder main {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+.sja_root_holder h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+.sja_root_holder hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+.sja_root_holder pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+.sja_root_holder a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+.sja_root_holder abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+.sja_root_holder b,
+.sja_root_holder strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+.sja_root_holder code,
+.sja_root_holder kbd,
+.sja_root_holder samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+.sja_root_holder small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+.sja_root_holder sub,
+.sja_root_holder sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.sja_root_holder sub {
+  bottom: -0.25em;
+}
+
+.sja_root_holder sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+
+.sja_root_holder img {
+  border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+.sja_root_holder button,
+.sja_root_holder input,
+.sja_root_holder optgroup,
+.sja_root_holder select,
+.sja_root_holder textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+.sja_root_holder button,
+.sja_root_holder input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+.sja_root_holder button,
+.sja_root_holder select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+
+.sja_root_holder button,
+.sja_root_holder [type="button"],
+.sja_root_holder [type="reset"],
+.sja_root_holder [type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+.sja_root_holder button::-moz-focus-inner,
+.sja_root_holder [type="button"]::-moz-focus-inner,
+.sja_root_holder [type="reset"]::-moz-focus-inner,
+.sja_root_holder [type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+.sja_root_holder button:-moz-focusring,
+.sja_root_holder [type="button"]:-moz-focusring,
+.sja_root_holder [type="reset"]:-moz-focusring,
+.sja_root_holder [type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+
+.sja_root_holder fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+.sja_root_holder legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+.sja_root_holder progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+.sja_root_holder textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+
+.sja_root_holder [type="checkbox"],
+.sja_root_holder [type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+.sja_root_holder [type="number"]::-webkit-inner-spin-button,
+.sja_root_holder [type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+.sja_root_holder [type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+.sja_root_holder [type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+.sja_root_holder ::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+.sja_root_holder details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+.sja_root_holder summary {
+  display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10+.
+ */
+
+.sja_root_holder template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+
+.sja_root_holder [hidden] {
+  display: none;
+}

--- a/client/src/style-normalize-unscoped.css
+++ b/client/src/style-normalize-unscoped.css
@@ -1,0 +1,25 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+.sja_root_holder html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+.sja_root_holder body {
+  margin: 0;
+}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1,4 +1,12 @@
-@import 'normalize.css/normalize.css';
+/*
+    see client/generateScopedCss.js on how to generate style-normalize-*.css
+
+    also see a TODO comment in client/src/app.js, of dynamically importing
+    style-normalize-unscoped.css only if it's known to not conflict in
+    the embedder portal
+*/
+@import './style-normalize-unscoped.css';
+@import './style-normalize-scoped.css';
 @import 'highlight.js/styles/github.css';
 /*
 html {
@@ -14,13 +22,21 @@ table {
 }
 */
 
+/*
+    !!! NOTE !!!
+    FireFox does not support the @scope (selector) syntax
+    that can enclose all affected rules inside a nested block,
+    so for now, will need to prepend the .sja_root_holder scope for each selector
+*/
 
 /***************************************
 CSS properties that are not covered 
 by normalize.css are covered here
+
+!!! make sure to scope to sja_root_holder
 ****************************************/
 
-h2 {
+.sja_root_holder h2 {
     margin-block-start: 0.83em;
     margin-block-end: 0.83em;
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- scope PP-specific css resets and styles to the root holder, such as the previously unscoped h2 style


### PR DESCRIPTION
## Description
... such as the previously unscoped `h2` style

NOTE: 4 unrelated hierCluster tests are failing, will not fix in this PR

Manually test that html, example URLs looks the same as in master branch.

Testing with GFF: By removing/adding the `.sja_root_holder` scope to the `h2` element, the GFF footer will shift up/down. That footer should not be shifted by the bundled PP styles. 

```css
.sja_root_holder h2 {
    margin-block-start: 0.83em;
    margin-block-end: 0.83em;
}
```


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
