### PR TITLE
Support groupsetting for geneVariant term

### DIFF
--- a/client/plots/controls.divide.js
+++ b/client/plots/controls.divide.js
@@ -28,6 +28,8 @@ class Divide {
 		if (!o.holder) throw 'opts.holder missing'
 	}
 	initPill() {
+		if (!this.opts.defaultQ4fillTW) this.opts.defaultQ4fillTW = {}
+		this.opts.defaultQ4fillTW['geneVariant'] = { groupsetting: { inuse: true } } // geneVariant term should always use groupsetting when used as divide term
 		this.pill = termsettingInit({
 			vocabApi: this.app.vocabApi,
 			vocab: this.state.vocab,

--- a/client/plots/controls.overlay.js
+++ b/client/plots/controls.overlay.js
@@ -31,6 +31,8 @@ class Overlay {
 		if (!o.holder) throw 'opts.holder missing'
 	}
 	initPill() {
+		if (!this.opts.defaultQ4fillTW) this.opts.defaultQ4fillTW = {}
+		this.opts.defaultQ4fillTW['geneVariant'] = { groupsetting: { inuse: true } } // geneVariant term should always use groupsetting when used as overlay term
 		this.pill = termsettingInit({
 			vocabApi: this.app.vocabApi,
 			vocab: this.state.vocab,

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -128,6 +128,7 @@ function setRenderers(self) {
 			case 'survival':
 				break
 			case 'geneVariant':
+				self.dom.td1.text('Group variants')
 				break
 			case 'samplelst':
 				break

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -74,7 +74,7 @@ function setCategoricalCellProps(cell, tw, anno, value, s, t, self, width, heigh
 export function setGeneVariantCellProps(cell, tw, anno, value, s, t, self, width, height, dx, dy, i) {
 	const values = anno.renderedValues || anno.filteredValues || anno.values || [anno.value]
 	const colorFromq = tw.q?.values && tw.q?.values[value.class]?.color // TODO: may fill in tw.q.values{} based on groupsetting
-	if (tw.q.groupsetting.inuse) {
+	if (tw.q?.groupsetting?.inuse) {
 		// groupsetting in use
 		// value is name of group assignment
 		cell.label = value

--- a/client/plots/matrix.groups.js
+++ b/client/plots/matrix.groups.js
@@ -228,7 +228,7 @@ export function classifyValues(anno, tw, grp, s, sample) {
 		: values.filter(v => sample_match_termvaluesetting(v, isSpecific[0], tw.term, sample))
 
 	const renderedValues = []
-	if (tw.term.type != 'geneVariant' || tw.q.groupsetting.inuse) renderedValues.push(...filteredValues)
+	if (tw.term.type != 'geneVariant' || tw.q?.groupsetting?.inuse) renderedValues.push(...filteredValues)
 	else {
 		// filteredValues.sort((a, b) => getMclassOrder(a) - getMclassOrder(b))
 		filteredValues.sort(this.mclassSorter)
@@ -262,7 +262,7 @@ export function classifyValues(anno, tw, grp, s, sample) {
 		filteredValues,
 		countedValues: filteredValues.filter(v => {
 			if (tw.term.type == 'geneVariant') {
-				if (!tw.q.groupsetting.inuse) {
+				if (!tw.q?.groupsetting?.inuse) {
 					// groupsetting not in use
 					// values are mutation classes
 					// do not count WT, blank, or skipped classes

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -484,8 +484,8 @@ function setTermActions(self) {
 				if (tw && !tw.q) throw 'data.q{} missing from pill callback'
 				const t = self.activeLabel || self.lastactiveLabel
 				if (tw) {
-					// users could midify the term label, need to update tw.label to the latest label
-					tw.label = t.label
+					// users could modify the term label, need to update tw.label to the latest label
+					tw.label = t.tw.label
 					if (t && t.tw) tw.$id = t.tw.$id
 					const legendValueFilter = self.mayRemoveTvsEntry(tw)
 					self.pill.main(tw)

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -199,7 +199,7 @@ export function setInteractivity(self) {
 					let fontColor = 'black'
 					const whiteColor = rgb('white').toString()
 
-					if (tw?.term.type == 'geneVariant') {
+					if (tw?.term.type == 'geneVariant' && !tw.q.groupsetting.inuse) {
 						for (const id in mclass) {
 							const class_info = mclass[id]
 							if (node.value.includes(class_info.label)) {
@@ -288,7 +288,7 @@ export function setInteractivity(self) {
 		function getCategoryValue(category, d, tw) {
 			if (category == '') return ''
 			let value = d[category]
-			if (tw?.term.type == 'geneVariant') {
+			if (tw?.term.type == 'geneVariant' && !tw.q.groupsetting.inuse) {
 				const mutation = value.split(', ')[0]
 				for (const id in mclass) {
 					const class_info = mclass[id]
@@ -409,7 +409,7 @@ export function setInteractivity(self) {
 						legendG,
 						tw,
 						mapKey,
-						tw.term.type == 'geneVariant' ? !mapKey.startsWith(key) : mapKey != key
+						tw.term.type == 'geneVariant' && !tw.q.groupsetting.inuse ? !mapKey.startsWith(key) : mapKey != key
 					)
 
 				menu.hide()
@@ -467,7 +467,10 @@ export function setInteractivity(self) {
 			})
 		}
 		if (!tw.q.hiddenValues) tw.q.hiddenValues = {}
-		const value = tw.term.type != 'geneVariant' && tw.term.values[key] ? tw.term.values[key] : { key: key, label: key }
+		const value =
+			!(tw.term.type == 'geneVariant' && !tw.q.groupsetting.inuse) && tw.term.values[key]
+				? tw.term.values[key]
+				: { key: key, label: key }
 		const items = legendG.selectAll(`text[name="sjpp-scatter-legend-label"]`).nodes()
 		const itemG = items.find(item => key.startsWith(item.innerHTML))?.parentElement
 
@@ -478,7 +481,8 @@ export function setInteractivity(self) {
 
 	self.changeColor = async function (key, color) {
 		const tw = self.config.colorTW
-		if (tw.term.type != 'geneVariant' && tw.term.values[key]) tw.term.values[key].color = color
+		if (!(tw.term.type == 'geneVariant' && !tw.q.groupsetting.inuse) && tw.term.values[key])
+			tw.term.values[key].color = color
 		else {
 			if (!tw.term.values) tw.term.values = {}
 			tw.term.values[key] = { key: key, label: key, color }

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -690,7 +690,7 @@ export function setRenderers(self) {
 			)}`
 			const colorRefCategory = chart.colorLegend.get('Ref')
 
-			if (self.config.colorTW?.term?.type == 'geneVariant')
+			if (self.config.colorTW?.term?.type == 'geneVariant' && !self.config.colorTW?.q.groupsetting.inuse)
 				offsetY = self.renderGeneVariantLegend(
 					chart,
 					offsetX,
@@ -792,10 +792,14 @@ export function setRenderers(self) {
 			self.drawScaleDotLegend(chart)
 		}
 		if (self.config.shapeTW) {
-			offsetX = !self.config.colorTW ? 0 : self.config.colorTW.term.type == 'geneVariant' ? 300 : 200
+			offsetX = !self.config.colorTW
+				? 0
+				: self.config.colorTW.term.type == 'geneVariant' && !self.config.colorTW.q.groupsetting.inuse
+				? 300
+				: 200
 			offsetY = 60
 			title = `${getTitle(self.config.shapeTW.term.name)}`
-			if (self.config.shapeTW.term.type == 'geneVariant')
+			if (self.config.shapeTW.term.type == 'geneVariant' && !self.config.shapeTW.q.groupsetting.inuse)
 				self.renderGeneVariantLegend(chart, offsetX, offsetY, legendG, self.config.shapeTW, 'shape', chart.shapeLegend)
 			else {
 				const shapeG = legendG.append('g')

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -89,6 +89,11 @@ class ViolinPlot {
 				// TODO: when used under the summary chart, this.opts.usecase may replace the usecase here
 
 				usecase: { target: 'violin', detail: 'term2' },
+				defaultQ4fillTW: {
+					geneVariant: {
+						groupsetting: { inuse: true }
+					}
+				},
 				callback: value => (this.settings.plotThickness = undefined)
 			},
 			{

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -89,11 +89,6 @@ class ViolinPlot {
 				// TODO: when used under the summary chart, this.opts.usecase may replace the usecase here
 
 				usecase: { target: 'violin', detail: 'term2' },
-				defaultQ4fillTW: {
-					geneVariant: {
-						groupsetting: { inuse: true }
-					}
-				},
 				callback: value => (this.settings.plotThickness = undefined)
 			},
 			{

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -144,22 +144,17 @@ export class Vocab {
 	// for better GET caching by the browser
 	getTwMinCopy(tw) {
 		const copy = { $id: tw.$id, term: {}, q: tw.q }
-		copy.term.id = tw.term?.id
-		copy.term.name = tw.term?.name
-		copy.term.type = tw.term?.type
 		if (isDictionaryType(tw.term?.type)) {
+			copy.term.id = tw.term?.id
+			copy.term.name = tw.term?.name
+			copy.term.type = tw.term?.type
 			copy.term.values = tw.term?.values
 		} else {
-			if (tw.term.gene) {
-				copy.term.gene = tw.term.gene
-			} else if (tw.term.type.startsWith('gene')) {
-				//quick fix that should be fixed later
-				copy.term.chr = tw.term.chr
-				copy.term.start = tw.term.start
-				copy.term.stop = tw.term.stop
-			} /* else {
-				// TODO: minimize other non-dictionary term types
-			}*/
+			// passing whole tw.term for non-dictionary term because
+			// different term types need different term properties passed
+			// to backend (e.g., geneVariant term needs term.groupsetting,
+			// geneExpression term needs term.chr, term.start, and term.stop)
+			copy.term = tw.term
 		}
 		return copy
 	}

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -134,7 +134,7 @@ export function fillTW(tw: GeneVariantTW, vocabApi: VocabApi) {
 	// fill tw.q.groupsetting
 	if (!tw.q.groupsetting) tw.q.groupsetting = {}
 	delete tw.q.groupsetting.disabled
-	if (!('inuse' in tw.q.groupsetting)) tw.q.groupsetting.inuse = true
+	if (!('inuse' in tw.q.groupsetting)) tw.q.groupsetting.inuse = false
 	if (tw.q.groupsetting.inuse) {
 		// groupsetting is active
 		const gs = tw.q.groupsetting as PredefinedGroupSetting
@@ -149,7 +149,7 @@ export function fillTW(tw: GeneVariantTW, vocabApi: VocabApi) {
 		) {
 			gs.predefined_groupset_idx = gs.useIndex
 		}*/
-		gs.predefined_groupset_idx = 1
+		gs.predefined_groupset_idx = 0
 
 		// specify a single dt
 		const ds_dts = [] // dts specified in dataset
@@ -207,8 +207,6 @@ export function fillTW(tw: GeneVariantTW, vocabApi: VocabApi) {
 	} else {
 		tw.q.cnvLossCutoff = -0.2
 	}
-
-	console.log('tw:', structuredClone(tw))
 }
 
 function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -1,7 +1,7 @@
 import { select } from 'd3-selection'
 import { mclass, dt2label, dtsnvindel, dtcnv, dtsv, dtfusionrna } from '../../shared/common'
 import { VocabApi, GeneVariantTermSettingInstance, GeneVariantTW } from '../../shared/types/index'
-import { PredefinedGroupSetting } from '../../shared/types/terms/term'
+import { make_radios } from '#dom/radiobutton'
 
 /* 
 instance attributes
@@ -135,44 +135,6 @@ export function fillTW(tw: GeneVariantTW, vocabApi: VocabApi) {
 	if (!tw.q.groupsetting) tw.q.groupsetting = {}
 	delete tw.q.groupsetting.disabled
 	if (!('inuse' in tw.q.groupsetting)) tw.q.groupsetting.inuse = false
-	if (tw.q.groupsetting.inuse) {
-		// groupsetting is active
-		const gs = tw.q.groupsetting as PredefinedGroupSetting
-		/* is the following necessary? (copied from client/termsetting/handlers/categorical.ts). useIndex does not seem to be used in the codebase.
-		if (
-			gs.lst &&
-			//Typescript emits error that .useIndex could be undefined
-			gs.useIndex &&
-			//Fix checks if property is present
-			gs.useIndex >= 0 &&
-			gs.lst[gs.useIndex]
-		) {
-			gs.predefined_groupset_idx = gs.useIndex
-		}*/
-		gs.predefined_groupset_idx = 0
-
-		// specify a single dt
-		const ds_dts = [] // dts specified in dataset
-		for (const query of Object.keys(vocabApi.termdbConfig.queries)) {
-			if (query == 'snvindel') ds_dts.push(dtsnvindel)
-			else if (query == 'cnv') ds_dts.push(dtcnv)
-			else if (query == 'svfusion') ds_dts.push(dtfusionrna)
-			else if (query == 'sv') ds_dts.push(dtsv) // TODO: is this correct?
-			else continue
-		}
-		if (!tw.q.dt) tw.q.dt = ds_dts[0] // default dt will be first in dataset
-		if (!(tw.q.dt in dt2label)) throw 'invalid dt'
-		if (!ds_dts.includes(tw.q.dt)) throw 'dt not supported in dataset'
-
-		// specify a single origin
-		// TODO: verify that 'vocabApi.termdbConfig.assayAvailability.byDt[dt].byOrigin' will always be defined in dataset when dt has multiple origins
-		if (vocabApi.termdbConfig.assayAvailability?.byDt[tw.q.dt]?.byOrigin) {
-			// dt has multiple origins in dataset
-			// so an origin must be specified
-			if (!tw.q.origin) tw.q.origin = 'somatic' /*'germline'*/
-			if (!(tw.q.origin in vocabApi.termdbConfig.assayAvailability.byDt[tw.q.dt].byOrigin)) throw 'invalid dt origin'
-		}
-	}
 
 	{
 		// apply optional ds-level configs for this specific term
@@ -213,6 +175,130 @@ function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 	const div = _div.append('div').style('padding', '5px').style('cursor', 'pointer')
 
 	div.append('div').style('font-size', '1.2rem').text(self.term.name)
+
+	const optsDiv = div.append('div').style('margin-top', '10px')
+	const groupsDiv = div.append('div').style('margin-left', '30px').style('display', 'none')
+	const dtDiv = groupsDiv.append('div').style('margin-top', '15px')
+	const originDiv = groupsDiv.append('div').style('margin-top', '15px')
+	const groupsetDiv = groupsDiv.append('div').style('margin-top', '15px')
+
+	// TODO: add apply button. Try to implement in barchart.
+
+	// radio buttons for whether or not to group variants
+	optsDiv.append('div').style('font-weight', 'bold').text('Group variants')
+	const radios = make_radios({
+		holder: optsDiv,
+		options: [
+			{ label: 'No variant grouping', value: false, checked: !self.q.groupsetting.inuse },
+			{ label: 'Assign variants to groups', value: true, checked: self.q.groupsetting.inuse }
+		],
+		callback: v => {
+			if (v) {
+				self.q.groupsetting.inuse = true
+				makeRadiosForGrouping()
+			} else {
+				self.q.groupsetting.inuse = false
+				delete self.q.dt
+				delete self.q.origin
+				groupsDiv.style('display', 'none')
+			}
+		}
+	})
+	if (radios.inputs.filter(':checked').datum().value) makeRadiosForGrouping()
+
+	// make radio buttons for grouping variants
+	function makeRadiosForGrouping() {
+		groupsDiv.style('display', 'block')
+		makeDtRadios()
+		mayMakeOriginRadios()
+		makeGroupsetRadios()
+	}
+
+	// radio buttons for data type
+	function makeDtRadios() {
+		dtDiv.selectAll('*').remove()
+		dtDiv.append('div').style('font-weight', 'bold').text('Variant type')
+		const ds_dts = getDsDts(self.vocabApi.termdbConfig.queries)
+		if (!self.q.dt) self.q.dt = ds_dts[0]
+		make_radios({
+			holder: dtDiv,
+			options: ds_dts.map(dt => ({ label: dt2label[dt], value: dt, checked: dt == self.q.dt })),
+			callback: v => {
+				self.q.dt = v
+				mayMakeOriginRadios()
+				makeGroupsetRadios()
+			}
+		})
+	}
+
+	// radio buttons for variant origin
+	function mayMakeOriginRadios() {
+		const byOrigin = self.vocabApi.termdbConfig.assayAvailability?.byDt[self.q.dt]?.byOrigin
+		if (!byOrigin) {
+			originDiv.style('display', 'none')
+			return
+		}
+		if (!self.q.origin || !(self.q.origin in byOrigin)) self.q.origin = Object.keys(byOrigin)[0]
+		originDiv.style('display', 'block')
+		originDiv.selectAll('*').remove()
+		originDiv.append('div').style('font-weight', 'bold').text('Variant origin')
+		make_radios({
+			holder: originDiv,
+			options: Object.keys(byOrigin).map(origin => ({
+				label: byOrigin[origin].label,
+				value: origin,
+				checked: origin == self.q.origin
+			})),
+			callback: v => {
+				self.q.origin = v
+			}
+		})
+	}
+
+	// radio buttons for variant grouping
+	function makeGroupsetRadios() {
+		// specify the indices of the predefined groupsets that are
+		// relevant to the dt, for example the 'Protein-changing vs. rest'
+		// groupset is relevant to SNV/indel and SV mutations but not
+		// to CNV mutations
+		const groupset_idxs =
+			self.q.dt == dtsnvindel || self.q.dt == dtsv
+				? [0, 1, 2]
+				: self.q.dt == dtcnv
+				? [0]
+				: self.q.dt == dtfusionrna
+				? [0, 1]
+				: null
+		// render the relevant predefined groupsets as radio buttons
+		if (
+			!self.q.groupsetting.predefined_groupset_idx ||
+			!groupset_idxs.includes(self.q.groupsetting.predefined_groupset_idx)
+		)
+			self.q.groupsetting.predefined_groupset_idx = groupset_idxs[0]
+		groupsetDiv.selectAll('*').remove()
+		groupsetDiv.append('div').style('font-weight', 'bold').text('Variant grouping')
+		make_radios({
+			holder: groupsetDiv,
+			options: groupset_idxs.map(i => {
+				const groupset = self.term.groupsetting.lst[i]
+				return { label: groupset.name, value: i, checked: i == self.q.groupsetting.predefined_groupset_idx }
+			}),
+			callback: v => {
+				self.q.groupsetting.predefined_groupset_idx = v
+			}
+		})
+	}
+
+	// Apply button
+	div
+		.append('button')
+		.style('margin-top', '10px')
+		.text('Apply')
+		.on('click', () => {
+			self.runCallback()
+		})
+
+	/*
 	const applyBtn = div
 		.append('button')
 		.property('disabled', true)
@@ -291,5 +377,18 @@ function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 						.style('cursor', 'pointer')
 						.text(d.label)
 				})
-		})
+		})*/
+}
+
+// get dts specified in dataset
+function getDsDts(ds_queries) {
+	const ds_dts = []
+	for (const query of Object.keys(ds_queries)) {
+		if (query == 'snvindel') ds_dts.push(dtsnvindel)
+		else if (query == 'cnv') ds_dts.push(dtcnv)
+		else if (query == 'svfusion') ds_dts.push(dtfusionrna)
+		else if (query == 'sv') ds_dts.push(dtsv) // TODO: is this correct?
+		else continue
+	}
+	return ds_dts
 }

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -23,7 +23,17 @@ export function getHandler(self: GeneVariantTermSettingInstance) {
 		},
 
 		getPillStatus() {
-			return { text: self.q.exclude?.length ? 'matching variants' : 'any variant class' }
+			if (self.q.groupsetting.inuse) {
+				const labels = []
+				labels.push(dt2label[self.q.dt])
+				const byOrigin = self.vocabApi.termdbConfig.assayAvailability?.byDt[self.q.dt]?.byOrigin
+				if (byOrigin) labels.push(byOrigin[self.q.origin]?.label || self.q.origin)
+				const groupset = self.term.groupsetting.lst[self.q.groupsetting.predefined_groupset_idx]
+				labels.push(groupset.name)
+				return { text: labels.join(' - ') }
+			} else {
+				return { text: self.q.exclude?.length ? 'matching variants' : 'any variant class' }
+			}
 		},
 
 		//validateQ(data: Q) {},
@@ -181,8 +191,6 @@ function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 	const dtDiv = groupsDiv.append('div').style('margin-top', '15px')
 	const originDiv = groupsDiv.append('div').style('margin-top', '15px')
 	const groupsetDiv = groupsDiv.append('div').style('margin-top', '15px')
-
-	// TODO: add apply button. Try to implement in barchart.
 
 	// radio buttons for whether or not to group variants
 	optsDiv.append('div').style('font-weight', 'bold').text('Group variants')

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -201,7 +201,7 @@ export class TermSetting {
 		the override tw serves the "atypical" termsetting usage
 		as used in snplocus block pan/zoom update in regression.results.js
 		*/
-		const arg: any = this.term ? { id: this.term.id, term: this.term, q: this.q, isAtomic: true } : {}
+		const arg: any = this.term ? { term: this.term, q: this.q, isAtomic: true } : {}
 		if ('$id' in this) arg.$id = this.$id
 		if (arg.q?.reuseId && arg.q.reuseId === this.data.q?.reuseId) {
 			if (!deepEqual(arg.q, this.data.q)) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- geneVariant term now supports grouping variants into predefined groups

--- a/server/shared/types/terms/geneVariant.ts
+++ b/server/shared/types/terms/geneVariant.ts
@@ -17,6 +17,7 @@ export type GeneVariantQ = BaseQ & {
 	cnvMinAbsValue?: number
 	cnvLossCutoff?: number
 	exclude: any //an array maybe?
+	dts: object
 }
 
 export type GeneVariantTW = TermWrapper & {

--- a/server/shared/types/terms/geneVariant.ts
+++ b/server/shared/types/terms/geneVariant.ts
@@ -17,7 +17,7 @@ export type GeneVariantQ = BaseQ & {
 	cnvMinAbsValue?: number
 	cnvLossCutoff?: number
 	exclude: any //an array maybe?
-	dt: number
+	dt?: number
 	origin?: string
 }
 

--- a/server/shared/types/terms/geneVariant.ts
+++ b/server/shared/types/terms/geneVariant.ts
@@ -1,5 +1,5 @@
 import { TermWrapper } from './tw.ts'
-import { BaseQ, BaseTerm } from './term.ts'
+import { BaseQ, BaseTerm, PredefinedGroupSetting } from './term.ts'
 import { TermSettingInstance } from '../termsetting.ts'
 
 /*
@@ -17,6 +17,7 @@ export type GeneVariantQ = BaseQ & {
 	cnvMinAbsValue?: number
 	cnvLossCutoff?: number
 	exclude: any //an array maybe?
+	groupsetting: PredefinedGroupSetting
 	dt?: number
 	origin?: string
 }

--- a/server/shared/types/terms/geneVariant.ts
+++ b/server/shared/types/terms/geneVariant.ts
@@ -17,7 +17,8 @@ export type GeneVariantQ = BaseQ & {
 	cnvMinAbsValue?: number
 	cnvLossCutoff?: number
 	exclude: any //an array maybe?
-	dts: object
+	dt: number
+	origin?: string
 }
 
 export type GeneVariantTW = TermWrapper & {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2299,7 +2299,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		if (tw.term.type != 'geneVariant') throw 'tw.term.type is not geneVariant'
 		if (!tw.term.gene && !(tw.term.chr && Number.isInteger(tw.term.start) && Number.isInteger(tw.term.stop)))
 			throw 'no gene or position specified'
-		if (tw.q.groupsetting?.inuse) {
+		if (tw.q?.groupsetting?.inuse) {
 			if (!Number.isInteger(tw.q.dt)) throw 'dt is not an integer value'
 			if (!Number.isInteger(tw.q.groupsetting.predefined_groupset_idx))
 				throw 'predefined_groupset_idx is not an integer value'
@@ -2347,7 +2347,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		// otherwise, query all dts in dataset
 		const sample2mlst = new Map()
 		const dts = []
-		if (tw.q.groupsetting?.inuse) {
+		if (tw.q?.groupsetting?.inuse) {
 			dts.push(tw.q.dt)
 		} else {
 			if (ds.queries.snvindel) dts.push(dtsnvindel)
@@ -2408,7 +2408,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 
 					if (s.formatK2v) {
 						// sample has format values
-						if (tw.q.origin) {
+						if (tw.q?.origin) {
 							// origin specified
 							if (!Object.keys(s.formatK2v).includes('origin')) throw 'format does not include origin'
 							if (s.formatK2v['origin'] != tw.q.origin) {
@@ -2441,7 +2441,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				}
 			}
 
-			await mayAddDataAvailability(sample2mlst, dt, ds, tw.q.origin, q.filter)
+			await mayAddDataAvailability(sample2mlst, dt, ds, tw.q?.origin, q.filter)
 		}
 
 		const groupset = get_active_groupset(tw.term, tw.q)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2369,8 +2369,6 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					? await getGenecnvByTerm(ds, tw.term, genome, q)
 					: []
 
-			if (!mlst.length) throw 'unable to retrieve mutation data'
-
 			for (const m of mlst) {
 				/*
 				m={

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2299,7 +2299,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		if (tw.term.type != 'geneVariant') throw 'tw.term.type is not geneVariant'
 		if (!tw.term.gene && !(tw.term.chr && Number.isInteger(tw.term.start) && Number.isInteger(tw.term.stop)))
 			throw 'no gene or position specified'
-		if (tw.q.groupsetting.inuse) {
+		if (tw.q.groupsetting?.inuse) {
 			if (!Number.isInteger(tw.q.dt)) throw 'dt is not an integer value'
 			if (!Number.isInteger(tw.q.groupsetting.predefined_groupset_idx))
 				throw 'predefined_groupset_idx is not an integer value'
@@ -2347,7 +2347,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		// otherwise, query all dts in dataset
 		const sample2mlst = new Map()
 		const dts = []
-		if (tw.q.groupsetting.inuse) {
+		if (tw.q.groupsetting?.inuse) {
 			dts.push(tw.q.dt)
 		} else {
 			if (ds.queries.snvindel) dts.push(dtsnvindel)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2337,16 +2337,17 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 			// has some code duplication with mds3.load.js query_snvindel() etc
 			// primary concern is tw.term may be missing coord/isoform to perform essential query
 
-			if (ds.queries.snvindel) {
+			if (ds.queries.snvindel && tw.q.dts[dtsnvindel]) {
 				const lst = await getSnvindelByTerm(ds, tw.term, genome, q)
 				mlst.push(...lst)
 			}
 
-			if (ds.queries.svfusion) {
+			if (ds.queries.svfusion && (tw.q.dts[dtfusionrna] || tw.q.dts[dtsv])) {
 				const lst = await getSvfusionByTerm(ds, tw.term, genome, q)
 				mlst.push(...lst)
 			}
-			if (ds.queries.cnv) {
+
+			if (ds.queries.cnv && tw.q.dts[dtcnv]) {
 				const lst = await getCnvByTw(ds, tw, genome, q)
 				mlst.push(...lst)
 			}
@@ -2428,24 +2429,24 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 			}
 		}
 
-		await mayAddDataAvailability(q, ds, data, tw.term.name)
+		await mayAddDataAvailability(q, ds, data, tw)
 
 		return data
 	}
 }
 
-async function mayAddDataAvailability(q, ds, data, tname) {
+async function mayAddDataAvailability(q, ds, data, tw) {
 	if (!ds.assayAvailability?.byDt) return
 	// get samples passing filter if filter is in use
 	const sampleFilter = q.filter ? new Set((await get_samples(q.filter, ds)).map(i => i.id)) : null
-	for (const dtKey in ds.assayAvailability.byDt) {
+	for (const dtKey in tw.q.dts) {
 		const dt = ds.assayAvailability.byDt[dtKey]
 		if (dt.byOrigin) {
 			for (const origin in dt.byOrigin) {
 				const sub_dt = dt.byOrigin[origin]
-				addDataAvailability(dtKey, sub_dt, data, tname, origin, sampleFilter)
+				addDataAvailability(dtKey, sub_dt, data, tw.term.name, origin, sampleFilter)
 			}
-		} else addDataAvailability(dtKey, dt, data, tname, false, sampleFilter)
+		} else addDataAvailability(dtKey, dt, data, tw.term.name, false, sampleFilter)
 	}
 }
 

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2299,7 +2299,11 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		if (tw.term.type != 'geneVariant') throw 'tw.term.type is not geneVariant'
 		if (!tw.term.gene && !(tw.term.chr && Number.isInteger(tw.term.start) && Number.isInteger(tw.term.stop)))
 			throw 'no gene or position specified'
-		if (tw.q.groupsetting.inuse && !tw.q.dt) throw 'tw.q.dt must be defined when groupsetting is used'
+		if (tw.q.groupsetting.inuse) {
+			if (!Number.isInteger(tw.q.dt)) throw 'dt is not an integer value'
+			if (!Number.isInteger(tw.q.groupsetting.predefined_groupset_idx))
+				throw 'predefined_groupset_idx is not an integer value'
+		}
 
 		if (tw.term.subtype == 'snp') throw 'not supported'
 		/* the 'mlst' in this 'if' code block is no longer supported due

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2368,7 +2368,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					? await getCnvByTw(ds, tw, genome, q)
 					: dt == 'geneCnv'
 					? await getGenecnvByTerm(ds, tw.term, genome, q)
-					: null
+					: []
 
 			if (!mlst.length) throw 'unable to retrieve mutation data'
 
@@ -2462,28 +2462,16 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					return group.values.some(v => mclasses.includes(v.key))
 				})
 				if (!group) throw 'unable to assign sample to group'
-				// assign sample to group
+				// .key will be the name of the assigned group
 				data.set(sample, {
 					sample,
 					[tw.$id]: { key: group.name, label: group.name, values: mlst }
 				})
 			} else {
 				// groupsetting is not active
-				// cannot assign sample to a specific key because .values[]
-				// contains mutations from multiple dts and origins
-				// will handle classification of samples in a different script
-				// by setting key0 to be the dt/origin of the term (in order
-				// to divide the plot by dt/origin) and setting key1 to be the
-				// mutation class of the term. Note that this key1 should
-				// discriminate between samples that only have a certain
-				// mutation from samples that have multiple mutations,
-				// for example: samples with only missense mutations should
-				// have the key 'Missense only' and samples with both missense
-				// and frameshift mutations should have the key 'Missense and
-				// frameshift'
 				data.set(sample, {
 					sample,
-					[tw.$id]: { label: tw.term.name, values: mlst }
+					[tw.$id]: { key: tw.term.name, label: tw.term.name, values: mlst }
 				})
 			}
 		}

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2299,6 +2299,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		if (tw.term.type != 'geneVariant') throw 'tw.term.type is not geneVariant'
 		if (!tw.term.gene && !(tw.term.chr && Number.isInteger(tw.term.start) && Number.isInteger(tw.term.stop)))
 			throw 'no gene or position specified'
+		if (tw.q.groupsetting.inuse && !tw.q.dt) throw 'tw.q.dt must be defined when groupsetting is used'
 
 		if (tw.term.subtype == 'snp') throw 'not supported'
 		/* the 'mlst' in this 'if' code block is no longer supported due
@@ -2343,7 +2344,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		// otherwise, query all dts in dataset
 		const sample2mlst = new Map()
 		const dts = []
-		if (tw.q.dt) {
+		if (tw.q.groupsetting.inuse) {
 			dts.push(tw.q.dt)
 		} else {
 			if (ds.queries.snvindel) dts.push(dtsnvindel)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2305,10 +2305,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				throw 'predefined_groupset_idx is not an integer value'
 		}
 
-		if (tw.term.subtype == 'snp') throw 'not supported'
-		/* the 'mlst' in this 'if' code block is no longer supported due
-		to the new code changes introduced below
 		if (tw.term.subtype == 'snp') {
+			throw 'subtype snp not supported'
 			// query term is one snp; it should only work for snvindel
 			if (!ds.queries.snvindel?.allowSNPs) throw 'snvindel does not allow snp'
 			const lst = await getSnvindelByTerm(ds, tw.term, genome, q)
@@ -2337,7 +2335,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				}
 				mlst.push(_m)
 			}
-		}*/
+		}
+
 		// query term is not snp
 		// should be either gene or region, and will work for all data types
 		// has some code duplication with mds3.load.js query_snvindel() etc
@@ -2465,7 +2464,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				// .key will be the name of the assigned group
 				data.set(sample, {
 					sample,
-					[tw.$id]: { key: group.name, label: group.name, values: mlst }
+					[tw.$id]: { key: group.name, label: group.name, value: group.name, values: mlst }
 				})
 			} else {
 				// groupsetting is not active

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -158,8 +158,9 @@ export async function barchart_data(q, ds, tdb) {
 								// value{} will have a .key property (group assignment) and
 								// a .values[] property (mutation data)
 								// only value.key should be used for plotting
-								// FIXME: since value.values[] is not considered for plotting,
-								// item.dedupkey cannot be supported for geneVariant term
+								// NOTE: item.dedupkey is not necessary because
+								// geneVariant groupsetting assignment will
+								// never be ambiguous
 								item[`key${i}`] = i != 1 ? value.key : [value.key]
 								item[`val${i}`] = value.key
 							} else {

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -155,14 +155,15 @@ export async function barchart_data(q, ds, tdb) {
 						} else {
 							if (tw.term.type == 'geneVariant') {
 								// geneVariant term using groupsetting
-								// value{} will have a .key property (group assignment) and
-								// a .values[] property (mutation data)
-								// only value.key should be used for plotting
-								// NOTE: item.dedupkey is not necessary because
-								// geneVariant groupsetting assignment will
-								// never be ambiguous
+								// value{} will have .key, .value, and .values[]
+								// .key and .value are both the group
+								// assignment of the sample and should be
+								// used for plotting
+								// .values[] contains the mutation data of
+								// the sample and should not be used for
+								// plotting/dedpulication
 								item[`key${i}`] = i != 1 ? value.key : [value.key]
-								item[`val${i}`] = value.key
+								item[`val${i}`] = value.value
 							} else {
 								// this series key will not deduplicate multi-valued samples (those that belong to multiple groups)
 								item[`key${i}`] = i != 1 ? value.key : value.values?.map(v => v.key) || [value.key]

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -168,7 +168,7 @@ function get_samplelst(tvs, CTEname) {
 }
 
 async function get_geneVariant(tvs, CTEname, ds) {
-	const tw = { term: tvs.term, q: {} }
+	const tw = { $id: Math.random().toString(), term: tvs.term, q: {} }
 	const data = await ds.mayGetGeneVariantData(tw, { genome: ds.genomename })
 	/*
 	data here is map of sampleId-mutationData pairs, e.g.
@@ -177,7 +177,7 @@ async function get_geneVariant(tvs, CTEname, ds) {
 	*/
 	const samplenames = []
 	for (const [key, value] of data) {
-		const sampleValues = value[tvs.term.name].values
+		const sampleValues = value[tw.$id].values
 		/*
 		sampleVlaues here is an array of results for each available dt for the sampleID. e.g.
 		[

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -119,14 +119,14 @@ async function getSampleData(q) {
 			const data = await q.ds.mayGetGeneVariantData(tw, q)
 
 			for (const [sampleId, value] of data.entries()) {
-				if (!(tw.term.name in value)) continue
+				if (!(tw.$id in value)) continue
 				if (!dictTerms.length) {
 					// only create a sample entry/row when it is not already filtered out by not having any dictionary term values
 					// FIXME invalid assumption for data downloading
 					if (!(sampleId in samples)) samples[sampleId] = { sample: sampleId }
 				}
 				if (samples[sampleId]) {
-					samples[sampleId][tw.$id] = value[tw.term.name]
+					samples[sampleId][tw.$id] = value[tw.$id]
 				}
 			}
 		} else if (tw.term.type == 'snplst' || tw.term.type == 'snplocus') {

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -221,7 +221,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 		let divideBy = 'Default'
 		if (q.divideByTW && q.divideByTW.q.mode != 'continuous') {
 			sample.z = 0
-			if (q.divideByTW.term.type == 'geneVariant') {
+			if (q.divideByTW.term.type == 'geneVariant' && !q.divideByTW.q.groupsetting.inuse) {
 				divideBy = getMutation(true, dbSample, q.divideByTW)
 				if (divideBy == null) {
 					divideBy = getMutation(false, dbSample, q.divideByTW)
@@ -286,7 +286,8 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 						value.color = scheme[i]
 						i--
 					}
-				} else if (q.colorTW.term.type != 'geneVariant') value.color = k2c(category)
+				} else if (!(q.colorTW.term.type == 'geneVariant' && !q.colorTW.q.groupsetting.inuse))
+					value.color = k2c(category)
 			}
 		}
 		let i = 1
@@ -320,7 +321,8 @@ function hasValue(dbSample, tw) {
 
 function processSample(dbSample, sample, tw, categoryMap, category) {
 	let value = null
-	if (tw.term.type == 'geneVariant') assignGeneVariantValue(dbSample, sample, tw, categoryMap, category)
+	if (tw.term.type == 'geneVariant' && !tw.q.groupsetting.inuse)
+		assignGeneVariantValue(dbSample, sample, tw, categoryMap, category)
 	else {
 		value = dbSample?.[tw.$id]?.key
 		if (tw.term.values?.[value]?.label) {
@@ -390,7 +392,7 @@ function getCategory(mutation) {
 function order(map, tw, refs) {
 	let entries = []
 	if (!tw || map.size == 0) return entries
-	if (tw.term.type == 'geneVariant') {
+	if (tw.term.type == 'geneVariant' && !tw.q.groupsetting.inuse) {
 		entries = Object.entries(map)
 		entries.sort((a, b) => {
 			if (a[0] < b[0]) return -1

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -580,7 +580,7 @@ function makesql_survival(tablename, term, q, values, filter) {
 }
 
 export function get_active_groupset(term, q) {
-	if (!q.groupsetting || q.groupsetting.disabled || !q.groupsetting.inuse) return
+	if (!q?.groupsetting || q.groupsetting.disabled || !q.groupsetting.inuse) return
 	if (Number.isInteger(q.groupsetting.predefined_groupset_idx)) {
 		if (q.groupsetting.predefined_groupset_idx < 0) throw 'q.predefined_groupset_idx out of bound'
 		if (!term.groupsetting) throw 'term.groupsetting missing when q.predefined_groupset_idx in use'

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -579,7 +579,7 @@ function makesql_survival(tablename, term, q, values, filter) {
 	}
 }
 
-function get_active_groupset(term, q) {
+export function get_active_groupset(term, q) {
 	if (!q.groupsetting || q.groupsetting.disabled || !q.groupsetting.inuse) return
 	if (Number.isInteger(q.groupsetting.predefined_groupset_idx)) {
 		if (q.groupsetting.predefined_groupset_idx < 0) throw 'q.predefined_groupset_idx out of bound'


### PR DESCRIPTION
## Description

geneVariant term can now use groupsetting to divide samples into predefined groups: `Mutated vs. wildtype`, `Protein-changing vs. rest`, and `Truncating vs. rest`. Dividing samples into groups requires specification of a single data type and a single origin.

The geneVariant edit UI has been updated to allow user to divide samples into these groups.

geneVariant groupsetting is now supported in barchart, violin plot, scatter plot, and survival plot. Groupsetting is disabled by default when used as term1 and enabled by default when used as term2/term0 (see barchart, violin plot, and survival plot). For scatter plot, groupsetting is always disabled by default. Will support groupsetting in regression and matrix plots later.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
