### PR TITLE
geneExpression fillTw() auto fill .name if missing, also consider defaultQ

### DIFF
--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -25,6 +25,8 @@ export async function getHandler(self) {
 }
 
 export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
+	if (typeof tw.term.gene != 'string' || !tw.term.gene) throw 'geneExpression tw.term.gene must be non-empty string'
+	if (!tw.term.name) tw.term.name = tw.term.gene // auto fill if .name is missing
 	if (!tw.q?.mode) tw.q = { mode: 'continuous' }
 	const mode = tw.q.mode || 'continuous'
 

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -1,6 +1,7 @@
 import { NumericQ } from '../../shared/types/terms/numeric'
 import { VocabApi } from '../../shared/types/index'
 import { GeneExpressionTW } from '../../shared/types/terms/geneExpression.js'
+import { copyMerge } from '../../rx'
 
 /*
 Routes numeric terms to their respective subhandlers. Functions follow the same naming convention as the other handler files and returns the results. 
@@ -27,16 +28,22 @@ export async function getHandler(self) {
 export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
 	if (typeof tw.term.gene != 'string' || !tw.term.gene) throw 'geneExpression tw.term.gene must be non-empty string'
 	if (!tw.term.name) tw.term.name = tw.term.gene // auto fill if .name is missing
-	if (!tw.q?.mode) tw.q = { mode: 'continuous' }
-	const mode = tw.q.mode || 'continuous'
+
+	if (!tw.q?.mode) tw.q = { mode: 'continuous' } // supply default q if missing
+	if (defaultQ) copyMerge(tw.q, defaultQ) // override if default is given
 
 	if (!tw.term.bins) {
+		/* gene term is missing bin definition, this is expected as it's not valid to apply same bin to genes with vastly different exp range, and not worth it to precompute each gene's default bin with its actual exp data
+		here make a request to determine default bin for this term based on its data
+		(in gdc this adds significant pause when adding gene exp term to oncomatrix)
+		*/
 		const defaultBins = await vocabApi.getDefaultBins({ tw })
 		if ('error' in defaultBins) throw defaultBins.error
 		tw.term.bins = defaultBins
-		tw.q = JSON.parse(JSON.stringify(tw.term.bins.default))
+		const currMode = tw.q.mode // record current mode before q{} is overriden
+		tw.q = structuredClone(tw.term.bins.default)
+		tw.q.mode = currMode
 	}
-	tw.q.mode = mode
 	return tw
 }
 


### PR DESCRIPTION
## Description

[test here](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22AKT1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22sex%22},{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22diaggrp%22},{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22}}]}],%22divideBy%22:{%22id%22:%22sex%22}}]}), the TP53 gene exp term is missing .name and should work

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
