### PR TITLE
Use `roundValue` instead

### DIFF
--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -1,7 +1,7 @@
 import { filterJoin, getFilterItemByTag } from '#filter'
 import { renderTable } from '../dom/table'
 import { to_svg } from '#src/client'
-import { roundValueAuto } from '../shared/roundValue'
+import { roundValue, roundValueAuto } from '../shared/roundValue'
 import { rgb } from 'd3'
 
 export function setInteractivity(self) {
@@ -98,7 +98,7 @@ export function setInteractivity(self) {
 		//For testing and debugging
 		self.app.tip.d.classed('sjpp-violin-brush-tip', true)
 
-		self.app.tip.d.append('div').text(`From ${roundValueAuto(start, 2)} to ${roundValueAuto(end, 2)}`)
+		self.app.tip.d.append('div').text(`From ${roundValue(start, 2)} to ${roundValue(end, 2)}`)
 
 		//show menu options for label clicking and brush selection
 		self.app.tip.d


### PR DESCRIPTION
## Description

Test links: 
1. [Brush with integers](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22hrtavg%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D,%22nav%22:%7B%22activeTab%22:1%7D%7D)
2. [Brush with decimels](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22MB_meta_analysis%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22Confidence%20Score%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D%7D)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
