### PR TITLE
Used curveBasis instead of curveMonotoneX and cleanup

### DIFF
--- a/client/dom/violinRenderer.js
+++ b/client/dom/violinRenderer.js
@@ -1,5 +1,5 @@
 import { scaleLinear } from 'd3-scale'
-import { line, curveMonotoneX } from 'd3-shape'
+import { line, curveBasis } from 'd3-shape'
 import { rgb, brushX, axisTop } from 'd3'
 
 export class violinRenderer {
@@ -60,7 +60,7 @@ export class violinRenderer {
 	renderArea(invert) {
 		if (this.plot.densityMax == 0) return
 		const areaBuilder = line()
-			.curve(curveMonotoneX)
+			.curve(curveBasis)
 			.x(d => this.axisScale(d.x0))
 			.y(d => (invert ? -this.wScale(d.density) : this.wScale(d.density)))
 

--- a/server/shared/violin.bins.js
+++ b/server/shared/violin.bins.js
@@ -82,17 +82,6 @@ function sheatherJonesBandwidth(data, kernel) {
 
 	const bandwidth = 1.06 * sigmaHat * Math.pow(n, -0.2)
 
-	if (isNaN(bandwidth) || !isFinite(bandwidth)) {
-		// console.error("Error computing bandwidth: NaN or infinite value encountered");
-		// console.log("Data:", data);
-		// console.log("Sorted Data:", sortedData);
-		// console.log("Quantiles:", q25, q75);
-		// console.log("IQR:", iqr);
-		// console.log("Std Dev:", stdDev);
-		// console.log("h0:", h0);
-		// console.log("sigmaHat:", sigmaHat);
-	}
-
 	return bandwidth
 }
 


### PR DESCRIPTION
## Description

Solves the different rendering in the violin termsetting.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
