### PR TITLE
Enable survival use cases

### DIFF
--- a/client/plots/controls.divide.js
+++ b/client/plots/controls.divide.js
@@ -1,7 +1,8 @@
 import { getCompInit } from '../rx'
 import { termsettingInit } from '#termsetting'
-import { Menu } from '../src/client'
+import { Menu } from '../dom/menu'
 import { getNormalRoot } from '#filter'
+import { TermTypes } from '#shared/terms.js'
 
 /*
 model after overlay2.js
@@ -29,7 +30,11 @@ class Divide {
 	}
 	initPill() {
 		if (!this.opts.defaultQ4fillTW) this.opts.defaultQ4fillTW = {}
-		this.opts.defaultQ4fillTW['geneVariant'] = { groupsetting: { inuse: true } } // geneVariant term should always use groupsetting when used as divide term
+
+		// default settings by term type
+		this.opts.defaultQ4fillTW[TermTypes.GENE_VARIANT] = { groupsetting: { inuse: true } } // geneVariant term should always use groupsetting when used as divide term
+		this.opts.defaultQ4fillTW[TermTypes.GENE_EXPRESSION] = { mode: 'discrete' } // will be nice to use smaller number of bins even binary
+
 		this.pill = termsettingInit({
 			vocabApi: this.app.vocabApi,
 			vocab: this.state.vocab,

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -34,13 +34,7 @@ const useCasesExcluded = {
 		TermTypeGroups.GENE_EXPRESSION,
 		TermTypeGroups.METABOLITE_INTENSITY
 	], //Later on can support other term types like snplocus, snplst, geneVariant, non dictionary terms
-	survival: [
-		TermTypeGroups.SNP_LOCUS,
-		TermTypeGroups.SNP_LIST,
-		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	],
+	survival: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
 	default: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	regression: [
@@ -230,6 +224,10 @@ export class TermTypeSearch {
 				//In sampleScatter geneVariant is only allowed if detail is not numeric, like when building a dynamic scatter
 				if (state.usecase.target == 'sampleScatter' && type == TermTypes.GENE_VARIANT) {
 					if (state.usecase.detail == 'numeric') continue
+				}
+
+				if (state.usecase.target == 'survival' && termTypeGroup != TermTypeGroups.DICTIONARY_VARIABLES) {
+					if (state.usecase.detail == 'term') continue
 				}
 
 				if (state.usecase.target && useCasesExcluded[state.usecase.target]?.includes(termTypeGroup)) continue

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -29,7 +29,7 @@ export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ:
 	if (typeof tw.term.gene != 'string' || !tw.term.gene) throw 'geneExpression tw.term.gene must be non-empty string'
 	if (!tw.term.name) tw.term.name = tw.term.gene // auto fill if .name is missing
 
-	if (!tw.q?.mode) tw.q = { mode: 'discrete' } // supply default q if missing
+	if (!tw.q?.mode) tw.q = { mode: 'continuous' } // supply default q if missing
 	if (defaultQ) copyMerge(tw.q, defaultQ) // override if default is given
 
 	if (!tw.term.bins) {

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -29,7 +29,7 @@ export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ:
 	if (typeof tw.term.gene != 'string' || !tw.term.gene) throw 'geneExpression tw.term.gene must be non-empty string'
 	if (!tw.term.name) tw.term.name = tw.term.gene // auto fill if .name is missing
 
-	if (!tw.q?.mode) tw.q = { mode: 'continuous' } // supply default q if missing
+	if (!tw.q?.mode) tw.q = { mode: 'discrete' } // supply default q if missing
 	if (defaultQ) copyMerge(tw.q, defaultQ) // override if default is given
 
 	if (!tw.term.bins) {

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -4,6 +4,7 @@ import { write_file } from './utils'
 import fs from 'fs'
 import serverconfig from './serverconfig'
 import run_R from './run_R'
+import { TermTypes } from '#shared/terms.js'
 
 export async function get_survival(q, ds) {
 	try {
@@ -183,9 +184,8 @@ function getSeriesKey(ot, d) {
 		if (d[n].values.length > tested.length) return 'Not tested'
 		// TODO: more helpful message or throw
 		return 'Not sure'
-	}
-
-	throw `cannot get series key for term='${n}'`
+	} else if (d[ot.name]) return d[ot.name].key
+	else throw `cannot get series key for term='${n}'`
 }
 
 function getOrderedLabels(term, bins = []) {

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -4,7 +4,6 @@ import { write_file } from './utils'
 import fs from 'fs'
 import serverconfig from './serverconfig'
 import run_R from './run_R'
-import { TermTypes } from '#shared/terms.js'
 
 export async function get_survival(q, ds) {
 	try {


### PR DESCRIPTION
## Description

This PR enables the survival cases missing. Closes #1651. It also changes the default mode used in geneExpression to discrete. I felt at the barchart/summary and the scatter, we always start using numeric terms in discrete mode when doing overlays, so it made more sense to use it as the default mode. If so, we may want to do this for all numeric non dict terms when filling the term wrapper.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
