### PR TITLE
violin: Use nice number labels in the violin brush menu

### DIFF
--- a/client/dom/niceNumLabels.ts
+++ b/client/dom/niceNumLabels.ts
@@ -1,0 +1,23 @@
+import { decimalPlacesUntilFirstNonZero } from '../shared/roundValue'
+
+/**
+ * Correct an array of numbers with the appropriate number of decimal places
+ * based on the range of numeric distribution for scales, axes, etc.
+ * @param nums array of numbers to be sorted and corrected
+ * @returns array of sorted numbers with corrected decimal places
+ */
+export function niceNumLabels(nums: number[]) {
+	// Sort array and find the difference in distribution
+	const sorted = nums.sort((a, b) => a - b)
+	const abs = Math.abs(sorted[0] - sorted[sorted.length - 1])
+
+	// Find the number of decimals
+	const zeroDecimalNum = decimalPlacesUntilFirstNonZero(abs)
+	/** > 10, no decimals
+	 *  10 - 1, 1 decimal
+	 * <= 1, 1 decimal past the first non-zero
+	 */
+	const decimals2Show = abs >= 10 ? 0 : abs >= 1 ? 1 : zeroDecimalNum + 2
+
+	return nums.map(num => Number(num.toFixed(decimals2Show)))
+}

--- a/client/dom/test/numLabel.unit.spec.ts
+++ b/client/dom/test/numLabel.unit.spec.ts
@@ -1,0 +1,32 @@
+import tape from 'tape'
+import { niceNumLabels } from '../niceNumLabels'
+
+tape('\n', test => {
+	test.pass('-***- dom/niceNumberLabels -***-')
+	test.end()
+})
+
+tape('niceNumLabels', test => {
+	test.timeoutAfter(100)
+	test.plan(3)
+
+	let nums: number[], result: number[], expected: number[]
+
+	//No decimals, >=10
+	nums = [0, 1, 2, 3.4, 4, 5, 6.36, 7, 8, 9, 10]
+	result = niceNumLabels(nums)
+	expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+	test.deepEqual(result, expected, `Should return a corrected number array with no decimals: ${expected}`)
+
+	//1 decimal, 10-1
+	nums = [0, 0.002, 1, 0.23, 0.4]
+	result = niceNumLabels(nums)
+	expected = [0, 0, 0.2, 0.4, 1]
+	test.deepEqual(result, expected, `Should return a corrected number array with 1 decimal: ${expected}`)
+
+	//5 decimals
+	nums = [0, 0.0002, 0.0000173485678, 0.00023, 0.000489374598732489]
+	result = niceNumLabels(nums)
+	expected = [0, 0.00002, 0.0002, 0.00023, 0.00049]
+	test.deepEqual(result, expected, `Should return a corrected number array with a max of 5 decimals: ${expected}`)
+})

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -1,8 +1,9 @@
 import { filterJoin, getFilterItemByTag } from '#filter'
 import { renderTable } from '../dom/table'
 import { to_svg } from '#src/client'
-import { roundValue, roundValueAuto } from '../shared/roundValue'
+import { roundValueAuto } from '../shared/roundValue'
 import { rgb } from 'd3'
+import { niceNumLabels } from '../dom/niceNumLabels'
 
 export function setInteractivity(self) {
 	self.download = () => {
@@ -98,7 +99,9 @@ export function setInteractivity(self) {
 		//For testing and debugging
 		self.app.tip.d.classed('sjpp-violin-brush-tip', true)
 
-		self.app.tip.d.append('div').text(`From ${roundValue(start, 2)} to ${roundValue(end, 2)}`)
+		const [niceStart, niceEnd] = niceNumLabels([start, end])
+
+		self.app.tip.d.append('div').text(`From ${niceStart} to ${niceEnd}`)
 
 		//show menu options for label clicking and brush selection
 		self.app.tip.d


### PR DESCRIPTION
## Description
Reusable nice number labels function in `client/dom`, used in the violin brush menu. 
Test with: 
1. [3 decimals](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22MB_meta_analysis%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22Confidence%20Score%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D%7D)
2. [No decimals](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22hrtavg%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D,%22nav%22:%7B%22activeTab%22:1%7D%7D)
3. [Unit tests](http://localhost:3000/testrun.html?dir=dom&name=numLabel.unit&time=1718215103546)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
