### PR TITLE
Fix for path error appearing for hic genome files from url

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -723,6 +723,7 @@ async function parseEmbedThenUrl(arg, app) {
 			})
 		} catch (e) {
 			app.error0(e)
+			console.error(e.stack || e)
 		}
 	}
 

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -241,11 +241,13 @@ upon error, throw err message as a string
 
 	if (urlp.has('hicfile') || urlp.has('hicurl')) {
 		// whole-genome view
-		let file, url
+		let file, url, name
 		if (urlp.has('hicfile')) {
 			file = urlp.get('hicfile')
+			name = file.split('/').pop()
 		} else {
 			url = urlp.get('hicurl')
+			name = url.split('/').pop()
 		}
 		const gn = urlp.get('genome')
 		if (!gn) throw 'genome is required for hic'
@@ -255,7 +257,7 @@ upon error, throw err message as a string
 			genome,
 			file,
 			url,
-			name: path.split('/').pop(), //.basename(file || url),
+			name, //.basename(file || url),
 			hostURL: arg.hostURL,
 			enzyme: urlp.get('enzyme'),
 			holder: arg.holder


### PR DESCRIPTION
## Description
Fix for path variable causing issues with whole genome files run from a url. 

Test with: 
1. [Hicfile](http://localhost:3000/?genome=hg19&hicfile=proteinpaint_demo/hg19/hic/hic_demo.hic)
2. [Hicurl](http://localhost:3000/?genome=hg19&hicurl=https://proteinpaint.stjude.org/ppdemo/hg19/hic/hic_demo.hic)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
