### PR TITLE
Format tvs pill number labels

### DIFF
--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -4,7 +4,7 @@ import { addBrushes, addNewBrush } from './tvs.density'
 import { NumericRangeInput } from '#dom/numericRangeInput'
 import { convertUnits } from '#shared/helpers'
 import { violinRenderer } from '../dom/violinRenderer'
-import { niceNumLabels } from '#dom/niceNumLabels'
+import { niceNumLabels } from '../dom/niceNumLabels.ts'
 
 /*
 ********************** EXPORTED

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -1,10 +1,10 @@
 import { select } from 'd3-selection'
 import { scaleLinear } from 'd3'
-import { keyupEnter } from '#src/client'
 import { addBrushes, addNewBrush } from './tvs.density'
 import { NumericRangeInput } from '#dom/numericRangeInput'
 import { convertUnits } from '#shared/helpers'
 import { violinRenderer } from '../dom/violinRenderer'
+import { niceNumLabels } from '#dom/niceNumLabels'
 
 /*
 ********************** EXPORTED
@@ -74,8 +74,8 @@ function format_val_text(range, term) {
 		if ('start' in range) startName = convertUnits(range.start, vc.fromUnit, vc.toUnit, vc.scaleFactor)
 		if ('stop' in range) stopName = convertUnits(range.stop, vc.fromUnit, vc.toUnit, vc.scaleFactor)
 	} else {
-		startName = range.start
-		stopName = range.stop
+		//Rms excessive number of decimals
+		;[startName, stopName] = niceNumLabels([range.start, range.stop])
 	}
 	if (range.startunbounded) return `${x} ${range.stopinclusive ? '&le;' : '&lt;'} ${stopName}`
 


### PR DESCRIPTION
## Description
Fixed this whilst investigating the brush issue. 

Numbers in the tvs pills should appear in the new 'nice' format. 

Test with: http://localhost:3000/?genome=hg38-test&gene=p53&mds3=TermdbTest. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
