### PR TITLE
Remove plotBrainImaging from serverconfig.json.

### DIFF
--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -1737,7 +1737,14 @@ async function validate_query_NIdata(ds, genome) {
 				}
 
 				return new Promise((resolve, reject) => {
-					const ps = spawn('python3', [serverconfig.plotBrainImaging, refFile, sampleFile, l, f, t])
+					const ps = spawn('python3', [
+						`${serverconfig.binpath}/utils/plotBrainImaging.py`,
+						refFile,
+						sampleFile,
+						l,
+						f,
+						t
+					])
 					let imgData = []
 					ps.stdout.on('data', data => {
 						imgData.push(data)

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -104,8 +104,6 @@ if (!serverconfig.binpath) {
 		}
 	}
 }
-// defaults tool paths, for those that require binpath
-if (!serverconfig.plotBrainImaging) serverconfig.plotBrainImaging = `${serverconfig.binpath}/utils/plotBrainImaging.py`
 
 if (serverconfig.debugmode) {
 	// only apply optional routeSetters in debugmode


### PR DESCRIPTION
## Description

A small refactor, plotBrainImaging is removed from `serverconfig.json` options.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
