### PR TITLE
Allow to query for tw.id in interaction terms

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- bug fix to allow for interactions with molecular variables in regression analysis 

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -197,7 +197,8 @@ function parse_q(q, ds) {
 		if (!i.interactions) i.interactions = []
 		for (const x of i.interactions) {
 			// TODO allow tw.interactions[] array to contain snpid instead of snplst term id
-			if (!q.independent.find(y => y.term.id == x)) throw 'interacting term id missing from independent[]: ' + x
+			if (!q.independent.find(y => y.term?.id == x || y.id == x))
+				throw 'interacting term id missing from independent[]: ' + x
 		}
 	}
 }
@@ -404,7 +405,7 @@ function makeRvariable_dictionaryTerm(tw, independent, q) {
 	if (tw.interactions.length > 0) {
 		thisTerm.interactions = []
 		for (const id of tw.interactions) {
-			const tw2 = q.independent.find(i => i.term.id == id)
+			const tw2 = q.independent.find(i => i.term?.id == id || i.id == id)
 			if (tw2.type == 'snplst') {
 				// this term is interacting with a snplst term, fill in all snps from this list into thisTerm.interactions
 				for (const s of tw2.highAFsnps.keys()) thisTerm.interactions.push(s)


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/1668

Fix for interactions with non-dictionary terms in regression analysis. Can now query for `tw.id` in interaction terms to support non-dictionary terms. This change is needed because `tw.term` is not defined in backend for non-dictionary terms. In future, will pass `tw.term` to backend for non-dictionary terms in regression analysis and will refactor backend to always use `tw.term`.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
