### PR TITLE
fix: add missing jsonwebtoken import

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- add missing jsonwebtoken import

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -9,6 +9,7 @@ import serverconfig from './serverconfig.js'
 import { authApi } from './auth.js'
 import * as validator from './validator.js'
 import { decode as urlJsonDecode } from '#shared/urljson.ts'
+import jsonwebtoken from 'jsonwebtoken'
 
 const basepath = serverconfig.basepath || ''
 


### PR DESCRIPTION
## Description

To test, add to serverconfig.json:
```
  "jwt": {
    "secret": "XXX",
    "permissioncheck": "clinical_permission"
  },
```
In `app.middlewares.js` add to the line 35:

```
j.jwt = "XXX"
```

Load: http://localhost:3000

You should see:

`Cannot get genomes: Invalid token`



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
