### PR TITLE
numeric termsetting: delete q.last_bin{} when setting auto for last bin

### DIFF
--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -501,7 +501,8 @@ function renderLastBinInputs(self, tr: any) {
 		],
 		callback: v => {
 			if (v == 'auto') {
-				delete self.q.last_bin!.start
+				delete self.q.last_bin
+				// if just deleting last_bin.start and keeps q.last_bin{}, density plot may set last_bin.bin='last' and will break bin validation
 				edit_div.style('display', 'none')
 				self.renderBinLines(self, self.q as NumericQ)
 				setDensityPlot(self)


### PR DESCRIPTION
## Description

closes #1698 
all CI passes
please help test and find any issue about it

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
