### PR TITLE
optimize to require tape bundling only in certain contexts 

### DIFF
--- a/client/dev.sh
+++ b/client/dev.sh
@@ -4,10 +4,6 @@ set -euxo pipefail
 
 rm -rf ./dist
 
-# TODO: 
-# use a good esbuild node polyfill plugin to avoid having to use webpack,
-# to bundle and supplies tape lib with missing node libs  
-npx webpack --config=./webpack.tape.config.mjs
 node emitImports.mjs > ./test/internals-dev.js
 ln -sf $(pwd)/dist ../public/bin/
 ENV=dev node esbuild.config.mjs

--- a/client/test.sh
+++ b/client/test.sh
@@ -9,11 +9,17 @@ rm -rf ../public/bin/test
 TESTFILE=test/internals-test.js
 node emitImports.mjs $NAMEPATTERN > ./$TESTFILE
 
-# TODO: 
-# use a good esbuild node polyfill plugin to avoid having to use webpack,
-# to bundle and supplies tape lib with missing node libs  
-npx webpack --config=./webpack.tape.config.mjs
-ENV=test node esbuild.config.mjs 
+if [[ ! -f "./$TESTFILE" ]]; then 
+	# assume that the tape lib rarely changes in local testing environment;
+	# this does not affect the CI environment, where the runner will install
+	# from a freshly cloned repo and will always have to create the tape.bundle
+	# TODO: 
+	# use a good esbuild node polyfill plugin to avoid having to use webpack,
+	# to bundle and supplies tape lib with missing node libs  
+	npx webpack --config=./webpack.tape.config.mjs
+fi
 
+
+ENV=test node esbuild.config.mjs 
 INITJS='window.testHost="http://localhost:3000";import("/bin/test/_.._/test/internals-test.js");'
 echo "$INITJS" | npx tape-run --static ../public

--- a/client/test.sh
+++ b/client/test.sh
@@ -9,7 +9,7 @@ rm -rf ../public/bin/test
 TESTFILE=test/internals-test.js
 node emitImports.mjs $NAMEPATTERN > ./$TESTFILE
 
-if [[ ! -f "./$TESTFILE" ]]; then 
+if [[ ! -f "./tape.bundle.js" ]]; then 
 	# assume that the tape lib rarely changes in local testing environment;
 	# this does not affect the CI environment, where the runner will install
 	# from a freshly cloned repo and will always have to create the tape.bundle


### PR DESCRIPTION
## Description

no tape bundling in dev, and only rebundle for CLI tests if the bundle is missing

To test:
- stop `npm run dev`
- `rm client/test/tape.bundle.js*`
- rerun `npm run dev`
- `http://localhost:3000/testrun.html?name=*.unit` should pass, so it works without the webpack-bundled `tape` code
- run from the client dir `npm run test:unit` or `./test.sh *tvs.unit.spec.*`, should pass
- run the same command again, the webpack bundling should not be triggered


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
