### PR TITLE
Update matrix survival

### DIFF
--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -63,15 +63,22 @@ function setNumericCellProps(cell, tw, anno, value, s, t, self, width, height, d
 function setSurvivalCellProps(cell, tw, anno, value, s, t, self, width, height, dx, dy, i) {
 	const key = tw.q?.mode == 'continuous' ? anno.value : anno.key
 	cell.key = key
-	cell.label = tw.q?.mode == 'continuous' ? (tw.term.unit ? `${key}(${tw.term.unit})` : key) : 'Exit code: ' + key
-	cell.fill = key == 1 ? '#ff7f0e' : '#1f77b4'
+	cell.label =
+		tw.q?.mode == 'continuous'
+			? tw.term.unit
+				? `${key}(${tw.term.unit})`
+				: key
+			: tw.term.values?.[key].label
+			? tw.term.values?.[key].label
+			: 'Exit code: ' + key
+	cell.fill = key == 1 ? '#a1a3a6' : '#a3c88b'
 	cell.order = 0
 	if (tw.q?.mode == 'continuous') {
 		if (!tw.settings) tw.settings = {}
 		if (!tw.settings.barh) tw.settings.barh = s.barh
 		if (!('gap' in tw.settings)) tw.settings.gap = 4
-
-		cell.fill = '#555'
+		cell.exitCodeKey = tw.term.values?.[anno.key].label || 'Exit code: ' + anno.key
+		cell.fill = anno.key == 1 ? '#a1a3a6' : '#a3c88b'
 		if (s.transpose) {
 			cell.height = t.scale(cell.key)
 			cell.x = tw.settings.gap
@@ -85,6 +92,7 @@ function setSurvivalCellProps(cell, tw, anno, value, s, t, self, width, height, 
 			cell.convertedValueLabel = vc ? convertUnits(cell.key, vc.fromUnit, vc.toUnit, vc.scaleFactor) : ''
 		}
 	} else {
+		cell.timeToEventKey = anno.value
 		cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
 		cell.y = height * i
 		const group = tw.legend?.group || tw.$id

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -61,6 +61,10 @@ export function setInteractivity(self) {
 			.style('display', '')
 
 		if (d.term.type != 'geneVariant') {
+			let survivalInfo
+			if (d.term.type == 'survival' && d.exitCodeKey) {
+				survivalInfo = d.term.values?.[d.exitCodeKey]?.label || d.exitCodeKey
+			}
 			rows.push(`<tr><td>${l.Sample}:</td><td>${d.row._ref_.label}</td></tr>`)
 			rows.push(
 				`<tr>
@@ -69,10 +73,18 @@ export function setInteractivity(self) {
 						<span style="display:inline-block; width:12px; height:12px; background-color:${
 							d.fill == '#fff' || d.fill == 'transparent' ? '' : d.fill
 						}" ></span>
-						${d.convertedValueLabel || d.label}
+						${survivalInfo || d.convertedValueLabel || d.label}
 					</td>
 				</tr>`
 			)
+			if (d.term.type == 'survival') {
+				const timeToEventKey =
+					'Time to Event: ' +
+					(d.timeToEventKey
+						? d.timeToEventKey + (d.term.unit ? `(${d.term.unit})` : '')
+						: d.convertedValueLabel || d.label)
+				rows.push(`<tr><td></td><td>${timeToEventKey}</td></tr>`)
+			}
 		} else if (d.term.type == 'geneVariant') {
 			rows.push(`<tr><td>${l.Sample}:</td><td>${d.row._ref_.label || d.value?.sample}</td></tr>`)
 			rows.push(`<tr><td>Gene:</td><td>${d.term.name}</td></tr>`)

--- a/client/termsetting/handlers/numeric.toggle.ts
+++ b/client/termsetting/handlers/numeric.toggle.ts
@@ -63,7 +63,7 @@ export async function getHandler(self) {
 	if (self.opts.numericEditMenuVersion!.includes('continuous')) {
 		tabs.push({
 			mode: 'continuous',
-			label: 'Continuous',
+			label: self.term.type == 'survival' ? 'Time to Event' : 'Continuous',
 			callback: self.tabCallback
 		})
 	}
@@ -71,7 +71,7 @@ export async function getHandler(self) {
 	if (self.opts.numericEditMenuVersion!.includes('discrete')) {
 		tabs.push({
 			mode: 'discrete',
-			label: 'Discrete',
+			label: self.term.type == 'survival' ? 'Exit code' : 'Discrete',
 			callback: self.tabCallback
 		})
 	}


### PR DESCRIPTION
## Description
PNET db doesn't have exit-code label defined, so for PNET, exit code (**_Exit code: 0, Exit code: 1_**) will be shown. 
IHG, mbmeta, sjmb12, megaportal, recATRT all have exit-code label (**_deceased, alive, progressed, etc_**), which will be shown instead of exit code

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
