### PR TITLE
fix: always hard set tw.q.mode to continuous before fetching violin data

### DIFF
--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -51,8 +51,11 @@ q = {
 
 export async function trigger_getViolinPlotData(q, res, ds, genome) {
 	const term = q.term?.term ? q.term.term : ds.cohort.termdb.q.termjsonByOneid(q.termid)
-	if (!q.term.q?.mode) q.term.q.mode = 'continuous'
 	if (!term) throw '.termid invalid'
+
+	if (!q.term.q) throw 'q.term.q{} missing'
+	q.term.q.mode = 'continuous' // override mode in case requests by discrete. which breaks gdc term
+
 	//term on backend should always be an integer term
 	if (!isNumericTerm(term) && term.type !== 'survival') throw 'term type is not numeric or survival'
 


### PR DESCRIPTION
## Description

[test link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22case.disease_type%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}],%22divideBy%22:{%22id%22:%22case.demographic.gender%22}}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
