### PR TITLE
fix: client always set mode=continuous when querying violin route

### DIFF
--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -73,18 +73,15 @@ async function showBinsMenu(self, div: any) {
 	div.selectAll('*').remove()
 	div.append('div').style('padding', '10px').style('text-align', 'center').html('Getting distribution data ...<br/>')
 	try {
-		if (!self.vocabApi) throw `Missing .vocabApi{} [numeric.discrete showBinsMenu()]`
-		const tw = await fillTermWrapper({ term: self.term, q: self.q }, self.vocabApi) //the q for the discrete mode may need to be initialized
 		const d = await self.vocabApi.getViolinPlotData(
 			{
-				term: tw,
+				term: { term: self.term, q: { mode: 'continuous' } },
 				filter: self.filter,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,
 				strokeWidth: 0.2
 			},
 			self.opts.getBodyParams?.()
 		)
-		self.q = JSON.parse(JSON.stringify(tw.q)) //copy the q from the termwrapper to be able to change it, the tw q is readonly
 		self.num_obj.density_data = convertViolinData(d)
 	} catch (err) {
 		console.log(err)


### PR DESCRIPTION
## Description

at [gdc map](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22case.disease_type%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}],%22divideBy%22:{%22id%22:%22case.demographic.gender%22}}]}), changing Age to continuous works
all mds3 tests work
all CI passes

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
