### PR TITLE
Sample view dzi

### DIFF
--- a/client/plots/dziviewer/DziViewer.ts
+++ b/client/plots/dziviewer/DziViewer.ts
@@ -15,7 +15,7 @@ export default class DziViewer {
 	async init() {
 		const state = this.app.getState()
 		const holder = this.opts.holder
-		holder.append('div').attr('id', 'openseadragon-viewer').style('width', ' 800px').style('height', ' 800px')
+		holder.append('div').attr('id', 'openseadragon-viewer').style('width', '80vw').style('height', ' 80vh')
 
 		const tileSources: Array<string> = []
 
@@ -29,6 +29,11 @@ export default class DziViewer {
 			prefixUrl: 'https://openseadragon.github.io/openseadragon/images/',
 			showNavigator: true,
 			sequenceMode: tileSources.length > 1
+			// gestureSettingsMouse: {
+			// 	clickToZoom: true,
+			// 	scrollToZoom: false,
+			// 	flickEnabled: true
+			//   },
 		})
 	}
 }

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -60,7 +60,7 @@ class SampleView {
 		const sampleDiv = this.dom.sampleDiv
 		if (this.dom.header) this.dom.header.html(`Sample View`)
 
-		if (config.samples) {
+		if (config.samples && config.samples.length > 1) {
 			const sampleLabel = sampleDiv.insert('label').style('vertical-align', 'top').html('Samples:')
 
 			const select = sampleDiv
@@ -250,6 +250,18 @@ class SampleView {
 				title: `Option to show/hide brain imaging`
 			})
 		}
+
+		if (q?.DZImages) {
+			inputs.push({
+				boxLabel: 'Visible',
+				label: 'Deep zoom',
+				type: 'checkbox',
+				chartType: 'sampleView',
+				settingsKey: 'showDzi',
+				title: `Option to show/hide deep zoom images`
+			})
+		}
+
 		this.components = {
 			controls: await controlsInit({
 				app: this.app,
@@ -439,19 +451,12 @@ class SampleView {
 
 	showVisiblePlots() {
 		this.dom.sampleDiv.style('display', this.settings.showDictionary ? 'inline-block' : 'none')
-		for (const div of this.discoPlots)
-			if (this.settings.showDisco) div.style('display', this.state.samples.length == 1 ? 'inline-block' : 'table-cell')
-			else div.style('display', 'none')
+		for (const div of this.discoPlots) div.style('display', this.settings.showDisco ? 'table-cell' : 'none')
 		for (const div of this.singleSamplePlots)
-			if (this.settings.showSingleSample)
-				div.style('display', this.state.samples.length == 1 ? 'inline-block' : 'table-cell')
-			else div.style('display', 'none')
-		for (const div of this.brainPlots)
-			if (this.settings.showBrain) div.style('display', this.state.samples.length == 1 ? 'inline-block' : 'table-cell')
-			else div.style('display', 'none')
-		for (const div of this.imagePlots)
-			if (this.settings.showImages) div.style('display', this.state.samples.length == 1 ? 'inline-block' : 'table-cell')
-			else div.style('display', 'none')
+			div.style('display', this.settings.showSingleSample ? 'table-cell' : 'none')
+		for (const div of this.brainPlots) div.style('display', this.settings.showBrain ? 'table-cell' : 'none')
+		for (const div of this.imagePlots) div.style('display', this.settings.showImages ? 'table-cell' : 'none')
+		for (const div of this.dziPlots) div.style('display', this.settings.showDzi ? 'table-cell' : 'none')
 	}
 
 	async renderPlots(state, samples) {
@@ -461,6 +466,7 @@ class SampleView {
 		this.singleSamplePlots = []
 		this.brainPlots = []
 		this.imagePlots = []
+		this.dziPlots = []
 
 		if (state.termdbConfig?.queries?.singleSampleMutation) {
 			let div = plotsDiv.append('div')
@@ -533,13 +539,10 @@ class SampleView {
 				imagePlotImport.renderImagePlot(state, cellDiv, sample)
 			}
 		}
-
 		if (state.termdbConfig.queries?.DZImages) {
 			let div = plotsDiv.append('div')
 
 			for (const sample of samples) {
-				const cellDiv = div.append('div').style('display', 'inline-block')
-
 				const data = await dofetch3('sampledzimages', {
 					body: {
 						genome: this.app.opts.genome.name,
@@ -548,6 +551,8 @@ class SampleView {
 					}
 				})
 				if (data.sampleDZImages?.length > 0) {
+					const cellDiv = div.append('div').style('display', 'inline-block')
+					this.dziPlots.push(cellDiv)
 					dziviewer(state.vocab.dslabel, cellDiv, this.app.opts.genome, sample.sampleName, data.sampleDZImages)
 				}
 			}
@@ -704,7 +709,14 @@ function setInteractivity(self) {
 
 export async function getPlotConfig(opts) {
 	const settings = {
-		sampleView: { showDictionary: true, showDisco: true, showSingleSample: true, showBrain: true, showImages: true }
+		sampleView: {
+			showDictionary: true,
+			showDisco: true,
+			showSingleSample: true,
+			showBrain: true,
+			showImages: true,
+			showDzi: true
+		}
 	}
 	const config = { activeCohort: 0, sample: null, expandedTermIds: [root_ID], settings }
 	return copyMerge(config, opts)

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -2,6 +2,8 @@ import { getCompInit, copyMerge } from '#rx'
 import { select } from 'd3-selection'
 import { controlsInit } from './controls'
 import { getNormalRoot } from '#filter/filter'
+import dziviewer from './dziviewer/plot.dzi'
+import { dofetch3 } from '#src/client'
 
 const root_ID = 'root'
 const samplesLimit = 15
@@ -529,6 +531,25 @@ class SampleView {
 					cellDiv.insert('div').style('font-weight', 'bold').style('padding-left', '20px').text(sample.sampleName)
 				const imagePlotImport = await import('./imagePlot.js')
 				imagePlotImport.renderImagePlot(state, cellDiv, sample)
+			}
+		}
+
+		if (state.termdbConfig.queries?.DZImages) {
+			let div = plotsDiv.append('div')
+
+			for (const sample of samples) {
+				const cellDiv = div.append('div').style('display', 'inline-block')
+
+				const data = await dofetch3('sampledzimages', {
+					body: {
+						genome: this.app.opts.genome.name,
+						dslabel: this.state.vocab.dslabel,
+						sample_id: sample.sampleName
+					}
+				})
+				if (data.sampleDZImages?.length > 0) {
+					dziviewer(state.vocab.dslabel, cellDiv, this.app.opts.genome, sample.sampleName, data.sampleDZImages)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

This draft PR integrates the dzi viewer in the sampleView. In order to test it we first need to have the vips dependencies installed as explained in the sjpp/python/README.md.  Then we can use sjmb12, that has the DZImages query linked to the path files/hg38/sjmb12/HnEData/dzimages and copy or create, for testing, fake images associated to a sample.
I have uploaded to hpc  the images associated to the first sample loaded in the sampleView (204679630075_R06C01) so if you run scp -r hpc:tp/files/hg38/sjmb12/HnEData ~/data/tp/files/hg38/sjmb12 you should be able to test the sampleView. If you already have the images you just need to copy them under the path /sjmb12/HnEData/dzimages/204679630075_R06C01

I still would like to improve some details in the UI, but I wanted to share what I have so far so we can wrap up this view today before I leave.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
