### PR TITLE
do not call niceNumLabels() on integer term density/violin

### DIFF
--- a/client/dom/niceNumLabels.ts
+++ b/client/dom/niceNumLabels.ts
@@ -13,9 +13,9 @@ export function niceNumLabels(nums: number[]) {
 
 	// Find the number of decimals
 	const zeroDecimalNum = decimalPlacesUntilFirstNonZero(abs)
-	/** > 10, no decimals
-	 *  10 - 1, 1 decimal
-	 * <= 1, 1 decimal past the first non-zero
+	/** >= 10: no decimals
+	 *  10< - 1: 1 decimal
+	 *  < 1: 1 decimal past the first non-zero
 	 */
 	const decimals2Show = abs >= 10 ? 0 : abs >= 1 ? 1 : zeroDecimalNum + 2
 

--- a/client/filter/test/tvs.density.unit.spec.ts
+++ b/client/filter/test/tvs.density.unit.spec.ts
@@ -1,0 +1,117 @@
+import tape from 'tape'
+import * as d3s from 'd3-selection'
+import { NumericRangeInput } from '#dom/numericRangeInput'
+import { updateTempRanges } from '../tvs.density'
+import { scaleLinear } from 'd3-scale'
+
+/* Tests
+    updateTempRanges
+*/
+
+/**************
+ helper functions
+***************/
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+}
+
+function createTestSelf(holder) {
+	const callback = () => {
+		//comment to avoid linting error
+	}
+	const testSelf = {
+		num_obj: {
+			brushes: [
+				{
+					elem: holder,
+					orig: { start: '', stop: '', index: 0 },
+					range: {
+						start: '1962',
+						stop: '2012',
+						index: 0,
+						startunbounded: false,
+						stopunbounded: false
+					},
+					rangeInput: new NumericRangeInput(holder, [1962, 2012], callback)
+				}
+			],
+			density_data: {
+				maxvalue: 2012,
+				minvalue: 1962
+			},
+			ranges: [
+				{
+					start: 1962,
+					stop: 2012
+				}
+			],
+			plot_size: {
+				width: 500,
+				height: 100,
+				xpad: 10,
+				ypad: 20
+			},
+			xscale: scaleLinear().domain([1962, 2012]).range([0, 500])
+		}
+	}
+
+	return testSelf
+}
+
+tape('\n', test => {
+	test.pass('-***- filter/tvs.density -***-')
+	test.end()
+})
+
+tape('updateTempRanges', test => {
+	test.timeoutAfter(100)
+	test.plan(4)
+
+	const holder = getHolder()
+	const testSelf = createTestSelf(holder)
+	const s = [259, 359]
+
+	//Integer term
+	const range1 = {
+		start: '1987.3',
+		stop: '1997.8',
+		index: 0,
+		startunbounded: false,
+		stopunbounded: false
+	} as any
+	const origRange1 = structuredClone(range1)
+	updateTempRanges(testSelf.num_obj.xscale, s, range1, range1, 1962, 2012, 'integer')
+	test.ok(
+		range1.start != origRange1.start && range1.start == 1988,
+		'Should update start value in the original range and round to integer'
+	)
+	test.ok(
+		range1.stop != origRange1.stop && range1.stop == 1998,
+		'Should update stop value in the original range and round to integer'
+	)
+
+	//Non integer term
+	const range2 = {
+		start: '1987.3678',
+		stop: '1997.823476',
+		index: 0,
+		startunbounded: false,
+		stopunbounded: false
+	} as any
+	const origRange2 = structuredClone(range2)
+	updateTempRanges(testSelf.num_obj.xscale, s, range2, range2, 1962, 2012, 'discrete')
+	test.ok(
+		range2.start != origRange2.start && range2.start == 1987.9,
+		'Should update start value in the original range and include the '
+	)
+	test.ok(
+		range2.stop != origRange2.stop && range2.stop == 1997.9,
+		'Should update stop value in the original range and round to integer'
+	)
+})

--- a/client/filter/test/tvs.density.unit.spec.ts
+++ b/client/filter/test/tvs.density.unit.spec.ts
@@ -108,10 +108,7 @@ tape('updateTempRanges', test => {
 	updateTempRanges(testSelf.num_obj.xscale, s, range2, range2, 1962, 2012, 'discrete')
 	test.ok(
 		range2.start != origRange2.start && range2.start == 1987.9,
-		'Should update start value in the original range and include the '
+		'Should update start value in the original range.'
 	)
-	test.ok(
-		range2.stop != origRange2.stop && range2.stop == 1997.9,
-		'Should update stop value in the original range and round to integer'
-	)
+	test.ok(range2.stop != origRange2.stop && range2.stop == 1997.9, 'Should update stop value in the original range.')
 })

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -114,8 +114,8 @@ function applyBrush(self, elem, brush) {
 		)
 }
 
-/** Updates the range returned from the brushing into rounded values
- * or integers. Exported for testing only.
+/** Updates the number range returned from the brushing into
+ * rounded values or integers. Exported for testing only.
  */
 export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalue, type) {
 	range.start = convertRangeValue(xscale, s[0])
@@ -126,9 +126,9 @@ export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalu
 	range.startunbounded = min == range.start && inputRange.startunbounded
 	range.stopunbounded = max == range.stop && inputRange.stopunbounded
 	//Do not show decimals for integer types
-	if (!range.startunbounded && !range.stopunbounded && type == 'integer') {
-		range.start = Math.round(range.start)
-		range.stop = Math.round(range.stop)
+	if (type == 'integer') {
+		range.start = range.startunbounded ? '' : Math.round(range.start)
+		range.stop = range.stopunbounded ? '' : Math.round(range.stop)
 	}
 }
 

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -93,6 +93,10 @@ function applyBrush(self, elem, brush) {
 			max = roundValueAuto(max)
 			range.startunbounded = min == range.start && inputRange.startunbounded //Limit by the brush, not by the user
 			range.stopunbounded = max == range.stop && inputRange.stopunbounded
+			if (!range.startunbounded && !range.stopunbounded && self.tvs.term.type == 'integer') {
+				range.start = range.start.toFixed(0)
+				range.stop = range.stop.toFixed(0)
+			}
 			const start = range.startunbounded ? '' : inputRange.startinclusive ? `${range.start} <=` : `${range.start} <`
 			const stop = range.stopunbounded ? '' : inputRange.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
 			// update inputs from brush move

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -83,20 +83,8 @@ function applyBrush(self, elem, brush) {
 				return
 			}
 			//update temp_ranges
-			range.start = Number(xscale.invert(s[0]))
-			range.stop = Number(xscale.invert(s[1]))
-			let min = Number(minvalue)
-			let max = Number(maxvalue)
-			range.start = roundValueAuto(range.start)
-			range.stop = roundValueAuto(range.stop)
-			min = roundValueAuto(min)
-			max = roundValueAuto(max)
-			range.startunbounded = min == range.start && inputRange.startunbounded //Limit by the brush, not by the user
-			range.stopunbounded = max == range.stop && inputRange.stopunbounded
-			if (!range.startunbounded && !range.stopunbounded && self.tvs.term.type == 'integer') {
-				range.start = range.start.toFixed(0)
-				range.stop = range.stop.toFixed(0)
-			}
+			updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalue, self.tvs.term.type)
+
 			const start = range.startunbounded ? '' : inputRange.startinclusive ? `${range.start} <=` : `${range.start} <`
 			const stop = range.stopunbounded ? '' : inputRange.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
 			// update inputs from brush move
@@ -124,6 +112,26 @@ function applyBrush(self, elem, brush) {
 				? '#23cba7'
 				: '#777777'
 		)
+}
+
+export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalue, type) {
+	range.start = convertRangeValue(xscale, s[0])
+	range.stop = convertRangeValue(xscale, s[1])
+	const min = roundValueAuto(Number(minvalue))
+	const max = roundValueAuto(Number(maxvalue))
+	//Limit by the brush, not by the user
+	range.startunbounded = min == range.start && inputRange.startunbounded
+	range.stopunbounded = max == range.stop && inputRange.stopunbounded
+	//Do not show decimals for integer types
+	if (!range.startunbounded && !range.stopunbounded && type == 'integer') {
+		range.start = Number(range.start.toFixed(0))
+		range.stop = Number(range.stop.toFixed(0))
+	}
+}
+
+function convertRangeValue(xscale, sidx) {
+	let value = Number(xscale.invert(sidx))
+	return roundValueAuto(value)
 }
 
 //Add new blank range temporary, save after entering values

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -114,6 +114,9 @@ function applyBrush(self, elem, brush) {
 		)
 }
 
+/** Updates the range returned from the brushing into rounded values
+ * or integers. Exported for testing only.
+ */
 export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalue, type) {
 	range.start = convertRangeValue(xscale, s[0])
 	range.stop = convertRangeValue(xscale, s[1])
@@ -124,8 +127,8 @@ export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalu
 	range.stopunbounded = max == range.stop && inputRange.stopunbounded
 	//Do not show decimals for integer types
 	if (!range.startunbounded && !range.stopunbounded && type == 'integer') {
-		range.start = Number(range.start.toFixed(0))
-		range.stop = Number(range.stop.toFixed(0))
+		range.start = Math.round(range.start)
+		range.stop = Math.round(range.stop)
 	}
 }
 

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -99,7 +99,10 @@ export function setInteractivity(self) {
 		//For testing and debugging
 		self.app.tip.d.classed('sjpp-violin-brush-tip', true)
 
-		const [niceStart, niceEnd] = niceNumLabels([start, end])
+		const [niceStart, niceEnd] =
+			self.config.term.term.type == 'integer'
+				? [Number(start).toFixed(0), Number(end).toFixed(0)]
+				: niceNumLabels([start, end])
 
 		self.app.tip.d.append('div').text(`From ${niceStart} to ${niceEnd}`)
 

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -256,8 +256,9 @@ export function setInteractivity(self) {
 
 		tvslst.lst[lstIdx].tvs.ranges = [
 			{
-				start: rangeStart,
-				stop: rangeStop,
+				//Only show integers for integer terms
+				start: term.term.type == 'integer' ? Math.round(rangeStart) : rangeStart,
+				stop: term.term.type == 'integer' ? Math.round(rangeStop) : rangeStop,
 				startinclusive: true,
 				stopinclusive: true,
 				startunbounded: self.displayLabelClickMenu.called == false ? true : false,

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -100,9 +100,7 @@ export function setInteractivity(self) {
 		self.app.tip.d.classed('sjpp-violin-brush-tip', true)
 
 		const [niceStart, niceEnd] =
-			self.config.term.term.type == 'integer'
-				? [Number(start).toFixed(0), Number(end).toFixed(0)]
-				: niceNumLabels([start, end])
+			self.config.term.term.type == 'integer' ? [Math.round(start), Math.round(end)] : niceNumLabels([start, end])
 
 		self.app.tip.d.append('div').text(`From ${niceStart} to ${niceEnd}`)
 


### PR DESCRIPTION
## Description
Addresses issue #1716.

Changes: 
1. Do not pass decimals from the violin when the term type is `integer`. 
2. New unit test and file specifically for `tvs.density`
3. Filter pill only shows rounded numbers

Test with: 
1. [Edit violin](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22yeardx%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D,%22nav%22:%7B%22activeTab%22:1%7D%7D) in the control panel and filter. Also brush the plot -> Add filter -> Filter in navigation -> only rounded numbers. 
4. Other violin render plots: [Age at dx from sample label](http://localhost:3000/?genome=hg38-test&gene=p53&mds3=TermdbTest)
5. [Unit tests](http://localhost:3000/testrun.html?dir=filter&name=tvs.density.unit&time=1718729996361)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
