### PR TITLE
singleCell: support query and overlay gene-level exp value on clustering map

### DIFF
--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -108,8 +108,7 @@ function make(q, res, ds, genome) {
 	addRestrictAncestries(c, tdb)
 	addScatterplots(c, ds)
 	addMatrixplots(c, ds)
-	addGenomicQueries(c, ds, genome)
-	addImageQueries(c, ds)
+	addNonDictionaryQueries(c, ds, genome)
 
 	res.send({ termdbConfig: c })
 }
@@ -119,13 +118,6 @@ function addRestrictAncestries(c, tdb) {
 	c.restrictAncestries = tdb.restrictAncestries.map(i => {
 		return { name: i.name, tvs: i.tvs, PCcount: i.PCcount }
 	})
-}
-function addImageQueries(c, ds) {
-	const q = ds.queries
-	const q2 = c.queries
-	if (q.images) {
-		q2.images = {} //nothing to pass to the client for now, but the key must be present
-	}
 }
 function addScatterplots(c, ds) {
 	if (!ds.cohort.scatterplots) return
@@ -153,7 +145,10 @@ function addMatrixplots(c, ds) {
 	})
 }
 
-function addGenomicQueries(c, ds, genome) {
+/* ds.queries{} contains query methods for non-dictionary data types
+including genomic, molecular, imaging etc
+*/
+function addNonDictionaryQueries(c, ds, genome) {
 	const q = ds.queries
 	if (!q) return
 	// this ds supports genomic query methods
@@ -231,6 +226,7 @@ function addGenomicQueries(c, ds, genome) {
 		q2.rnaseqGeneCount = true
 	}
 	if (q.singleCell) {
+		// samples and data are required properties
 		q2.singleCell = {
 			samples: {
 				firstColumnName: q.singleCell.samples.firstColumnName,
@@ -242,6 +238,13 @@ function addGenomicQueries(c, ds, genome) {
 				refName: q.singleCell.data.refName
 			}
 		}
+		if (q.singleCell.geneExpression) {
+			// optional data type
+			q2.singleCell.geneExpression = {}
+		}
+	}
+	if (q.images) {
+		q2.images = {} //nothing to pass to the client for now, but the key must be present
 	}
 }
 

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -79,7 +79,7 @@ export async function validate_query_singleCell(ds: any, genome: any) {
 	if (q.data.src == 'gdcapi') {
 		gdc_validate_query_singleCell_data(ds, genome)
 	} else if (q.data.src == 'native') {
-		validateDataNative(q.data as SingleCellDataNative, ds)
+		validateDataNative(q.data as SingleCellDataNative)
 	} else {
 		throw 'unknown singleCell.data.src'
 	}
@@ -87,7 +87,7 @@ export async function validate_query_singleCell(ds: any, genome: any) {
 
 	if (q.geneExpression) {
 		if (q.geneExpression.src == 'native') {
-			validateGeneExpressionNative(q.geneExpression as SingleCellGeneExpressionNative, ds)
+			validateGeneExpressionNative(q.geneExpression as SingleCellGeneExpressionNative)
 		} else if (q.geneExpression.src == 'gdcapi') {
 			// TODO
 		} else {
@@ -117,7 +117,7 @@ async function validateSamplesNative(S: SingleCellSamplesNative, ds: any) {
 	}
 }
 
-function validateDataNative(D: SingleCellDataNative, ds: any) {
+function validateDataNative(D: SingleCellDataNative) {
 	const nameSet = new Set() // guard against duplicating plot names
 	for (const plot of D.plots) {
 		if (nameSet.has(plot.name)) throw 'duplicate plot.name'
@@ -168,7 +168,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 	}
 }
 
-function validateGeneExpressionNative(G: SingleCellGeneExpressionNative, ds: any) {
+function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 	G.get = async (q: any) => {
 		// q {sample:str, gene:str}
 		const tsvfile = path.join(serverconfig.tpmasterdir, G.folder, q.sample)

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -184,11 +184,11 @@ function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 
 function grepMatrix4geneExpression(tsvfile: string, gene: string, header: string[]) {
 	return new Promise((resolve, reject) => {
-		const cp = spawn('grep', ['-m', 1, gene + '\t', tsvfile])
-		const out = [],
-			err = []
-		cp.stdout.on('data', (d: any) => out.push(d))
-		cp.stderr.on('data', (d: any) => err.push(d))
+		const cp = spawn('grep', ['-m', '1', gene + '\t', tsvfile])
+		const out: string[] = [],
+			err: string[] = []
+		cp.stdout.on('data', d => out.push(d))
+		cp.stderr.on('data', d => err.push(d))
 		cp.on('close', () => {
 			const e = err.join('')
 			if (e) reject(e)

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -1,8 +1,14 @@
 import fs from 'fs'
 import path from 'path'
-import { read_file } from '#src/utils.js'
+import { spawn } from 'child_process'
+import { read_file, get_header_txt } from '#src/utils.js'
 import serverconfig from '#src/serverconfig.js'
-import { SingleCellQuery, SingleCellSamplesNative, SingleCellDataNative } from '#shared/types/dataset.ts'
+import {
+	SingleCellQuery,
+	SingleCellSamplesNative,
+	SingleCellDataNative,
+	SingleCellGeneExpressionNative
+} from '#shared/types/dataset.ts'
 import {
 	Sample,
 	TermdbSinglecellsamplesRequest,
@@ -64,7 +70,7 @@ export async function validate_query_singleCell(ds: any, genome: any) {
 	if (q.samples.src == 'gdcapi') {
 		gdc_validate_query_singleCell_samples(ds, genome)
 	} else if (q.samples.src == 'native') {
-		getSamplesNative(q.samples as SingleCellSamplesNative, ds)
+		validateSamplesNative(q.samples as SingleCellSamplesNative, ds)
 	} else {
 		throw 'unknown singleCell.samples.src'
 	}
@@ -73,14 +79,25 @@ export async function validate_query_singleCell(ds: any, genome: any) {
 	if (q.data.src == 'gdcapi') {
 		gdc_validate_query_singleCell_data(ds, genome)
 	} else if (q.data.src == 'native') {
-		getDataNative(q.data as SingleCellDataNative, ds)
+		validateDataNative(q.data as SingleCellDataNative, ds)
 	} else {
 		throw 'unknown singleCell.data.src'
 	}
 	// q.data.get() added
+
+	if (q.geneExpression) {
+		if (q.geneExpression.src == 'native') {
+			validateGeneExpressionNative(q.geneExpression as SingleCellGeneExpressionNative, ds)
+		} else if (q.geneExpression.src == 'gdcapi') {
+			// TODO
+		} else {
+			throw 'unknown singleCell.geneExpression.src'
+		}
+		// q.geneExpression.get() added
+	}
 }
 
-async function getSamplesNative(S: SingleCellSamplesNative, ds: any) {
+async function validateSamplesNative(S: SingleCellSamplesNative, ds: any) {
 	// for now use this quick fix method to pull sample ids annotated by this term
 	// to support situation where not all samples from a dataset has sc data
 	const samples = {}
@@ -100,7 +117,7 @@ async function getSamplesNative(S: SingleCellSamplesNative, ds: any) {
 	}
 }
 
-function getDataNative(D: SingleCellDataNative, ds: any) {
+function validateDataNative(D: SingleCellDataNative, ds: any) {
 	const nameSet = new Set() // guard against duplicating plot names
 	for (const plot of D.plots) {
 		if (nameSet.has(plot.name)) throw 'duplicate plot.name'
@@ -149,4 +166,43 @@ function getDataNative(D: SingleCellDataNative, ds: any) {
 			return { error: e.message || e }
 		}
 	}
+}
+
+function validateGeneExpressionNative(G: SingleCellGeneExpressionNative, ds: any) {
+	G.get = async (q: any) => {
+		// q {sample:str, gene:str}
+		const tsvfile = path.join(serverconfig.tpmasterdir, G.folder, q.sample)
+		try {
+			await fs.promises.stat(tsvfile)
+		} catch (e: any) {
+			throw 'geneExp matrix file not found or readable for this sample'
+		}
+		const header = await get_header_txt(tsvfile)
+		return await grepMatrix4geneExpression(tsvfile, q.gene, header)
+	}
+}
+
+function grepMatrix4geneExpression(tsvfile: string, gene: string, header: string[]) {
+	return new Promise((resolve, reject) => {
+		const cp = spawn('grep', ['-m', 1, gene + '\t', tsvfile])
+		const out = [],
+			err = []
+		cp.stdout.on('data', (d: any) => out.push(d))
+		cp.stderr.on('data', (d: any) => err.push(d))
+		cp.on('close', () => {
+			const e = err.join('')
+			if (e) reject(e)
+			// got data
+			const l = out.join('').split('\t')
+			if (l.length != header.length)
+				reject(`number of fields differ between data line and header: ${l.length} ${header.length}`)
+			const cell2value = {} // key: cell barcode in header, value: exp value
+			for (let i = 1; i < l.length; i++) {
+				const v = Number(l[i])
+				if (Number.isNaN(v)) continue // invalid value
+				cell2value[header[i]] = v
+			}
+			resolve(cell2value)
+		})
+	})
 }

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -350,6 +350,21 @@ export type GeneExpressionQueryNative = {
 }
 export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNative
 
+export type SingleCellGeneExpressionNative = {
+	src: 'native'
+	/** path to gene-by-cell matrices per sample
+	each matrix file:
+		- is named by sample name
+		- is a tab-delimited text file
+		- has a header line: `gene \t cell1 \t cell2 ...`
+		- each gene has a line with gene symbol at first column, and sctransform values in rest columns
+
+	note that such matrices should be available for all samples present from queries.singleCell.samples{}
+	if a sample is missing its matrix in this folder, it may cause unexpected behavior
+	*/
+	folder: string
+}
+
 export type SingleCellSamplesNative = {
 	src: 'native' | string
 	/*
@@ -406,8 +421,13 @@ export type SingleCellDataNative = {
 }
 
 export type SingleCellQuery = {
+	/** methods to identify samples with singlecell data,
+	for client to list those samples, or determine if to invoke plot in sampleView of a sample */
 	samples: SingleCellSamplesGdc | SingleCellSamplesNative
+	/** defines tsne/umap type of clustering maps for each sample */
 	data: SingleCellDataGdc | SingleCellDataNative
+	/** defines available gene-level expression values for each cell of each sample */
+	geneExpression?: SingleCellGeneExpressionNative
 }
 
 type LdQuery = {

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -363,6 +363,8 @@ export type SingleCellGeneExpressionNative = {
 	if a sample is missing its matrix in this folder, it may cause unexpected behavior
 	*/
 	folder: string
+	/** dynamically added getter */
+	get?: (q: any) => any
 }
 
 export type SingleCellSamplesNative = {


### PR DESCRIPTION
## Description

the getter at ds.queries.singleCell.geneExpression{} is added. query parameter is `{sample:str, gene:str}` and returns an object of gene-value pairs

need to add new route to query this e.g. routes/termdb.singlecellGeneExp.ts

need client app to show gene search box, query and retrieve data, and overlay on map of a sample

Note: without any indexing on the gene exp matrix, "grep" is introduced as a new dependency

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
