### PR TITLE
fix: mds3 tk assigns vocabApi.app.opts.genome in adhoc manner for gen…

### DIFF
--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -60,7 +60,7 @@ export function makeSampleFilterLabel(data, tk, block, laby) {
 
 		const arg = {
 			holder: tk.menutip.d.append('div').style('margin', '10px'),
-			vocab: tk.mds.termdb.vocabApi.state.vocab,
+			vocabApi: tk.mds.termdb.vocabApi,
 			callback: f => {
 				tk.filterObj = f
 				tk.load()
@@ -393,53 +393,4 @@ function menu_listSamples(buttonrow, data, tk, block) {
 				console.log(e)
 			}
 		})
-}
-
-async function unusedCode() {
-	const features = JSON.parse(sessionStorage.getItem('optionalFeatures') || `{}`)
-	if (!features.mds3barapp) {
-	}
-	// will use the "barapp" when serverconfig.features.mds3barapp evaluates to true
-	const holder = div.append('div')
-	/*.style('display', 'inline-grid')
-						.style('grid-template-columns', 'auto auto auto')
-						.style('grid-row-gap', '3px')
-						.style('align-items', 'center')
-						.style('justify-items', 'left')*/
-
-	const geneTerm = {
-		type: 'geneVariant',
-		isoform: block.usegm.isoform
-	}
-	rangequery_rglst(tk, block, geneTerm)
-
-	try {
-		const plot = await import('#plots/plot.app.js')
-		await plot.appInit({
-			holder,
-			vocab: tk.mds.termdb.vocabApi.state.vocab,
-			state: {
-				plots: [
-					{
-						chartType: 'summary',
-						childType: 'barchart',
-						term: {
-							id: termid
-						},
-						term2: {
-							term: geneTerm,
-							q: { mode: 'summary' }
-						},
-						settings: {
-							barchart: {
-								unit: 'pct'
-							}
-						}
-					}
-				]
-			}
-		})
-	} catch (e) {
-		throw e
-	}
 }

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -443,6 +443,16 @@ async function mayInitTermdb(tk, block) {
 		}
 		const _ = await import('#termdb/vocabulary')
 		tdb.vocabApi = _.vocabInit(arg)
+
+		if (!tdb.vocabApi.app) {
+			/**** Note!
+			when tk is doing sample filtering (e.g. a subtk), vocabApi will be passed to filter UI code
+			and filter UI will call termdb app with term type selector, which requires genome obj to be accessible
+			via vocabApi.app.opts.genome for gene search to function
+			here .app is missing, and since vocabApi is not frozen, this quick fix supplies it in entirely adhoc manner
+			*/
+			tdb.vocabApi.app = { opts: { genome: block.genome } }
+		}
 	}
 
 	tk.mds.termdbConfig = await tdb.vocabApi.getTermdbConfig()

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- mds3 tk assigns vocabApi.app.opts.genome in adhoc manner for gene search to work in stateless filter UI


### PR DESCRIPTION
…e search to work in stateless filter UI

## Description

test at both [non-gdc](http://localhost:3000/?genome=hg38-test&gene=p53&mds3=TermdbTest) and [gdc](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC) tk. click sample leftlabel and select a category to launch subtk. at filter leftlabel of subtk, click to show filter UI, select AND and use Mutation or gene exp tab. typing a gene will work. on master breaks for missing genome obj

all mds3 tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
