### PR TITLE
fix: getFilterName() treats geneExp and metabolite same as float terms

### DIFF
--- a/client/mds3/filterName.js
+++ b/client/mds3/filterName.js
@@ -1,0 +1,106 @@
+import { niceNumLabels } from '../dom/niceNumLabels.ts'
+import { convertUnits } from '../shared/helpers'
+
+/*
+try to provide a meaningful name based on filter content; 
+when filter is single-tvs, return a human-readable label.
+when there's >=2 tvs, which is hard to summarize, return a general name with total number of tvs
+
+not specific to mds3, may move to client/filter/ or even shared/ in case backend needs to do same
+*/
+
+export function getFilterName(f) {
+	if (f.lst.length == 0) {
+		// this is possible when user has deleted the only tvs
+		return 'No filter'
+	}
+
+	if (f.lst.length == 1 && f.lst[0].type == 'tvs') {
+		// has only one tvs
+		const tvs = f.lst[0].tvs
+		if (!tvs) throw 'f.lst[0].tvs{} missing'
+		const ttype = tvs?.term?.type
+		if (ttype == 'categorical') {
+			// tvs is categorical
+			if (!Array.isArray(tvs.values)) throw 'f.lst[0].tvs.values not array'
+
+			// only assess 1st category name; only use for display, not computing
+			const catKey = tvs.values[0]?.key
+			if (catKey == undefined) throw 'f.lst[0].tvs.values[0].key missing'
+			const catValue = tvs.term.values?.[catKey]?.label || catKey
+
+			if (tvs.values.length == 1) {
+				// tvs uses only 1 category
+				if ((tvs.term.name + catValue).length < 20) {
+					// term name plus category value has short length, show both
+					return tvs.term.name + (tvs.isnot ? '!=' : ': ') + catValue
+				}
+				// only show cat value
+				return (tvs.isnot ? '!' : '') + (catValue.length < 15 ? catValue : catValue.substring(0, 13) + '...')
+			}
+			// tvs uses more than 1 category, set label as "catValue (3)"
+			return `${tvs.isnot ? '!' : ''}${catValue.length < 12 ? catValue : catValue.substring(0, 10) + '...'} (${
+				tvs.values.length
+			})`
+		}
+		if (ttype == 'integer' || ttype == 'float' || ttype == 'geneExpression' || ttype == 'metaboliteIntensity') {
+			// tvs is numeric, show numeric range
+			return getNumericRangeLabel(tvs)
+		}
+
+		throw 'unknown tvs term type'
+	}
+	// more than 1 tvs, not able to generate a short name
+	// TODO count total tvs from nested list
+	return 'Filter (' + f.lst.length + ')'
+}
+
+/*
+tvs={ranges:[], term:{type}}
+only generate label with first range. if multiple, simply append '...' to indicate such
+label is always show as A<x<B
+where "x" represents the variable, no matter term type. using "AKT1 expresion" can be too long
+if needed e.g. has enough space in another setting, can allow replacing "x" with entity name based on term type
+*/
+function getNumericRangeLabel(tvs) {
+	if (!Array.isArray(tvs.ranges)) throw 'tvs.ranges not array'
+	if (!tvs.ranges[0]) throw 'tvs.ranges[] blank array'
+
+	const r = tvs.ranges[0]
+
+	let startName, stopName // logic to compute print name and use if needed
+	const vc = tvs.term.valueConversion
+	if (vc) {
+		if ('start' in r) startName = convertUnits(r.start, vc.fromUnit, vc.toUnit, vc.scaleFactor, true)
+		if ('stop' in r) stopName = convertUnits(r.stop, vc.fromUnit, vc.toUnit, vc.scaleFactor, true)
+	} else {
+		// no conversion, show numeric values
+		if (tvs.term.type == 'integer') {
+			// integer term, round to integer
+			if ('start' in r) startName = Math.round(r.start)
+			if ('stop' in r) stopName = Math.round(r.stop)
+		} else {
+			// not integer, then must be float, including geneExpression etc.
+			if ('start' in r) startName = r.start
+			if ('stop' in r) stopName = r.stop
+
+			if ('start' in r && 'stop' in r) {
+				// range has both start/stop, can apply nice label
+				;[startName, stopName] = niceNumLabels([startName, stopName])
+			}
+		}
+	}
+
+	let label
+	if (tvs.isnot) {
+		if (r.startunbounded) label = `x ${r.stopinclusive ? '>' : '>='} ${stopName}`
+		else if (r.stopunbounded) label = `x ${r.startinclusive ? '<' : '<='} ${startName}`
+		else label = `!(${startName} ${stopName})`
+	} else {
+		if (r.startunbounded) label = `x ${r.stopinclusive ? '<=' : '<'} ${stopName}`
+		else if (r.stopunbounded) label = `x ${r.startinclusive ? '>=' : '>'} ${startName}`
+		else label = `${startName}${r.startinclusive ? '<=' : '<'}x${r.stopinclusive ? '<=' : '<'}${stopName}`
+	}
+	if (tvs.ranges.length > 1) label += '...' // quick way to indicate there're more
+	return label
+}

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -5,7 +5,7 @@ import { loadTk, rangequery_rglst } from './tk'
 import urlmap from '#common/urlmap'
 import { mclass, dtsnvindel, dtsv, dtfusionrna } from '#shared/common'
 import { vcfparsemeta } from '#shared/vcf'
-import { getFilterName } from './leftlabel.sample'
+import { getFilterName } from './filterName'
 import { fillTermWrapper } from '#termsetting'
 
 /*

--- a/client/mds3/test/filterName.unit.spec.js
+++ b/client/mds3/test/filterName.unit.spec.js
@@ -1,0 +1,67 @@
+import tape from 'tape'
+import { getFilterName } from '../filterName'
+
+tape('\n', test => {
+	test.pass('-***- mds3/getFilterName-***-')
+	test.end()
+})
+
+const catTerm = { type: 'categorical', name: 'TermA', values: { A: { label: 'Aname' } } }
+
+const fCat = {
+	lst: [
+		{
+			type: 'tvs',
+			tvs: {
+				term: catTerm,
+				values: [{ key: 'A' }]
+			}
+		}
+	]
+}
+
+const fInt = {
+	lst: [
+		{
+			type: 'tvs',
+			tvs: {
+				term: { type: 'integer' },
+				ranges: [{ start: 10, stop: 20 }]
+			}
+		}
+	]
+}
+const fFloat = {
+	lst: [
+		{
+			type: 'tvs',
+			tvs: {
+				term: { type: 'float' },
+				ranges: [{ start: 1.123456, stop: 2.56778 }]
+			}
+		}
+	]
+}
+
+tape('getFilterName', test => {
+	test.timeoutAfter(100)
+	//test.plan(3)
+
+	// combined string is short enough for term name to be included
+	test.equal(getFilterName(fCat), catTerm.name + ': Aname')
+
+	catTerm.name = 'Term11111112222222' // name too long and it no longer appears
+	test.equal(getFilterName(fCat), 'Aname')
+
+	test.equal(getFilterName(fInt), '10<x<20')
+
+	test.equal(getFilterName(fFloat), '1.1<x<2.6')
+
+	fFloat.lst[0].tvs.term.type = 'geneExpression' // pretend the floating range filter is gene exp
+	test.equal(getFilterName(fFloat), '1.1<x<2.6') // and it's treated same as float
+
+	fFloat.lst[0].tvs.term.type = 'metaboliteIntensity' // pretend the floating range filter is metabolite
+	test.equal(getFilterName(fFloat), '1.1<x<2.6') // and it's treated same as float
+
+	test.end()
+})

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- getFilterName() treats geneExp and metabolite same as float terms


### PR DESCRIPTION
## Description

now a standalone function, with unit tests http://localhost:3000/testrun.html?dir=mds3&name=filterName.unit

test with dictionary term filtering works on [non-gdc](http://localhost:3000/?genome=hg38-test&gene=p53&mds3=TermdbTest) and [gdc](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC) tracks

however, unable to test gene exp filter for non-gdc track, due to unknown error possibly at data loading (seems no variants are loaded), and unrelated to this change

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
