### PR TITLE
Untrack public bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ server/src/hicstat.js
 server/package*/*
 
 **/public/bin/*
-!public/bin/proteinpaint.js
-!public/bin/dist
 public/tmp/*
 /container/deps/public/cards/
 public/data/*

--- a/client/dev.sh
+++ b/client/dev.sh
@@ -3,7 +3,12 @@
 set -euxo pipefail
 
 rm -rf ./dist
-
 node emitImports.mjs > ./test/internals-dev.js
+
+if [[ ! -d ../public/bin ]]; then
+	mkdir ../public/bin
+fi
 ln -sf $(pwd)/dist ../public/bin/
+ln -sf $(pwd)/../front/src/app.js ../public/bin/proteinpaint.js
+
 ENV=dev node esbuild.config.mjs

--- a/public/bin/proteinpaint.js
+++ b/public/bin/proteinpaint.js
@@ -1,1 +1,0 @@
-../../front/src/app.js


### PR DESCRIPTION
## Description

This update will reinstate the pre-esbuild `gitignore` of `public/bin` dir and all files under it. Tracking `public/bin/proteinpaint.js` has caused a bit of confusion with the need to track changes to this file, while not automatically restoring the symlink can create stale `proteinpaint.js` code from an outdated bundle.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
