### PR TITLE
Backwards compatibility fix for old saved sessions missing .isOrdered…

### DIFF
--- a/client/plots/matrix.config.js
+++ b/client/plots/matrix.config.js
@@ -279,7 +279,8 @@ export function setComputedConfig(config) {
 	const tiebreakers =
 		s.sortOptions.a?.sortPriority.find(sp => sp.types.length == 1 && sp.types[0] == 'geneVariant')?.tiebreakers || []
 
-	s.sortByMutation = tiebreakers.find(tb => tb.filter?.values[0]?.dt === 1).isOrdered ? 'consequence' : 'presence'
+	//Backwards compatibility fix for old saved sessions missing .isOrdered and/or .disabled
+	s.sortByMutation = tiebreakers.find(tb => tb.filter?.values[0]?.dt === 1)?.isOrdered ? 'consequence' : 'presence'
 
-	s.sortByCNV = tiebreakers.find(tb => tb.filter?.values[0]?.dt === 4).disabled !== true
+	s.sortByCNV = tiebreakers.find(tb => tb.filter?.values[0]?.dt === 4)?.disabled !== true
 }


### PR DESCRIPTION
… and/or .disabled

## Description
PR as a suggested fix for issue found an old session file by @karishma-gangwani. Without this fix, `Error: Cannot read properties of undefined (reading 'isOrdered')` appears. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
