### PR TITLE
Move jwt serverconfig handling bellow the bodyParser.json handling

### DIFF
--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -28,32 +28,6 @@ export function setAppMiddlewares(app) {
 		app.use(staticDir)
 	}
 
-	if (serverconfig.jwt) {
-		console.log('JWT is activated')
-		app.use((req, res, next) => {
-			let j = {}
-			if (req.body && req.method == 'POST') {
-				// a preceding middleware assumes all POST contents are json-encoded and processed by bodyParser()
-				j = req.body
-			}
-			const jwt = j.jwt
-				? j.jwt
-				: req.headers && req.headers.authorization && req.headers.authorization.startsWith('Bearer ')
-				? req.headers.authorization.split(' ')[1]
-				: null
-			if (!jwt) return res.send({ error: 'json web token missing' })
-
-			jsonwebtoken.verify(jwt, serverconfig.jwt.secret, (err, decode) => {
-				if (err) return res.send({ error: 'Invalid token' })
-
-				// FIXME do not hardcode required attribute, replace with a list
-				if (!decode[serverconfig.jwt.permissioncheck]) return res.send({ error: 'Not authorized' })
-
-				next()
-			})
-		})
-	}
-
 	app.use(compression())
 
 	app.use((req, res, next) => {
@@ -78,6 +52,32 @@ export function setAppMiddlewares(app) {
 	app.use(bodyParser.json({ limit: '5mb' }))
 	app.use(bodyParser.text({ limit: '5mb' }))
 	app.use(bodyParser.urlencoded({ extended: true }))
+
+	if (serverconfig.jwt) {
+		console.log('JWT is activated')
+		app.use((req, res, next) => {
+			let j = {}
+			if (req.body && req.method === 'POST') {
+				// a preceding middleware assumes all POST contents are json-encoded and processed by bodyParser()
+				j = req.body
+			}
+			const jwt = j.jwt
+				? j.jwt
+				: req.headers && req.headers.authorization && req.headers.authorization.startsWith('Bearer ')
+				? req.headers.authorization.split(' ')[1]
+				: null
+			if (!jwt) return res.send({ error: 'json web token missing' })
+
+			jsonwebtoken.verify(jwt, serverconfig.jwt.secret, (err, decode) => {
+				if (err) return res.send({ error: 'Invalid token' })
+
+				// FIXME do not hardcode required attribute, replace with a list
+				if (!decode[serverconfig.jwt.permissioncheck]) return res.send({ error: 'Not authorized' })
+
+				next()
+			})
+		})
+	}
 
 	app.use((req, res, next) => {
 		if (req.method.toUpperCase() == 'POST' && req.body && req.headers['content-type'] != 'application/json') {


### PR DESCRIPTION
## Description

I moved jwt serverconfig handling bellow the bodyParser.json handling.

To test:

Add to `serverconfig.json`:

```
  "jwt": {
    "secret": "XXX",
    "permissioncheck": "clinical_permission"
  }
```

 curl -X POST http://localhost:3000/ -H "Content-Type: application/json" -d '{"jwt":"value"}'
 
 Should get:
` {"error":"Invalid token"}`

Instead of:
` {"error":"json web token missing"}`

 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
