### PR TITLE
Removing `host: window.location.origin` from app drawer

### DIFF
--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -177,7 +177,12 @@ function renderContent(ppcalls, div, card, pageArgs) {
 
 	const runpp_arg = {
 		holder: div.append('div').style('margin', '20px').node(),
-		host: window.location.origin
+		/* Do not use window.location.origin
+		Will break the embedder (/genomes will be requested from https:/embedder.site.org/genomes, 
+		for example). It's very rare for an embedder to want to show this default "portal" header 
+		because external portals usually have their own headers, but it will affect simple html 
+		pages that embed a runpp() call where the app header is not hidden. */
+		host: sessionStorage.getItem('hostURL')
 	}
 
 	const callpp = JSON.parse(JSON.stringify(ppcalls.runargs))
@@ -201,7 +206,7 @@ function makeTopTabs(ppcalls, card, sandboxDiv, pageArgs) {
 					const runpp_arg = {
 						holder: tab.contentHolder.append('div').style('margin', '20px').node(),
 						sandbox_header: tab.contentHolder,
-						host: window.location.origin
+						host: sessionStorage.getItem('hostURL')
 					}
 
 					const callpp = JSON.parse(JSON.stringify(ppcalls[ui].runargs))
@@ -477,7 +482,7 @@ async function showCode(ppcalls, btns) {
 	//Leave the weird spacing below. Otherwise the lines won't display the same identation in the sandbox
 	const runppCode = hljs.highlight(
 		`runproteinpaint({
-    host: "${window.location.origin}",
+    host: "${sessionStorage.getItem('hostURL')}",
     holder: document.getElementById('a'),
     ` + // Fix for first argument not properly appearing underneath holder
 			JSON.stringify(ppcalls.runargs, '', 4)
@@ -665,7 +670,7 @@ async function openDatasetButtonSandbox(pageArgs, res, sandboxDiv) {
 		// Call mass UI without search bar
 		const runppArg = {
 			holder: sandboxDiv.body.append('div').style('margin', '20px').style('overflow-x', 'auto').node(),
-			host: par.runargs.host || window.location.origin
+			host: par.runargs.host || sessionStorage.getItem('hostURL')
 		}
 
 		const callpp = JSON.parse(JSON.stringify(par.runargs))
@@ -708,7 +713,7 @@ async function openDatasetButtonSandbox(pageArgs, res, sandboxDiv) {
 			// Render the search parameters as a track
 			const runppArg = {
 				holder: resultDiv.append('div').style('margin', '20px').node(),
-				host: window.location.origin,
+				host: sessionStorage.getItem('hostURL'),
 				genome: par.genome.name
 			}
 			// Return only position or gene; avoid returning undefined values to runpp()

--- a/client/appdrawer/test/_x_.cards.spec.js
+++ b/client/appdrawer/test/_x_.cards.spec.js
@@ -152,7 +152,7 @@ async function runTests(data, test) {
 
 	function runCallbackTest(t) {
 		const holder = getHolder()
-		const arg = { holder, host: window.location.origin }
+		const arg = { holder, host: sessionStorage.getItem('hostURL') }
 		const callback = tkInstance => {
 			numCallsTested++
 			for (const selector in t.call.testSpec.expected) {
@@ -179,7 +179,7 @@ async function runTests(data, test) {
 
 	function runTimedTest(t) {
 		const holder = getHolder()
-		const arg = { holder, host: window.location.origin }
+		const arg = { holder, host: sessionStorage.getItem('hostURL') }
 		const wait = t.call?.testSpec?.timeout || 5000
 
 		setTimeout(() => {

--- a/client/src/block.tk.bigwig.ui.js
+++ b/client/src/block.tk.bigwig.ui.js
@@ -178,7 +178,8 @@ function submitButton(div, obj, holder, genomes) {
 		.on('click', () => {
 			const runpp_arg = {
 				holder: holder.append('div').style('margin', '20px').node(),
-				host: window.location.origin
+				/** Do not use window.location.origin. See comment: line 180, renderContent(), client/appdrawer/adSandbox.js*/
+				host: sessionStorage.getItem('hostURL')
 			}
 			const bigwig_arg = validateInput(obj, genomes)
 			if (!bigwig_arg) return

--- a/client/src/genefusion/genefusion.ui.js
+++ b/client/src/genefusion/genefusion.ui.js
@@ -107,7 +107,8 @@ function makeSubmit(div, obj, holder) {
 		} else {
 			d3select('.sjpp-app-ui').remove()
 			const runpp_arg = {
-				host: window.location.origin,
+				/** Do not use window.location.origin. See comment: line 180, renderContent(), client/appdrawer/adSandbox.js*/
+				host: sessionStorage.getItem('hostURL'),
 				nobox: true,
 				noheader: true,
 				parseurl: false,


### PR DESCRIPTION
## Description
`host: window.location.origin` will break for an embedder. Removed from app drawer and UIs code. 

Test with: 
1. [All cards pass](http://localhost:3000/testrun.html?dir=appdrawer&name=_x_.cards&time=1719326004731)
2. [Bigwig UI](http://localhost:3000/?appcard=bigwig)
3. [Gene fusion UI](http://localhost:3000/?appcard=genefusion)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
