### PR TITLE
Set scatter tab as visible for numeric terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+
 ## 2.65.0
 
 Features:

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -247,8 +247,12 @@ function setRenderers(self) {
 					disabled: d => false,
 					isVisible: () => {
 						return (
-							(self.config?.term.term.type === 'integer' || self.config?.term.term.type === 'float') &&
-							(self.config?.term2?.term.type === 'integer' || self.config?.term2?.term.type === 'float')
+							(self.config?.term.term.type === 'integer' ||
+								self.config?.term.term.type === 'float' ||
+								self.config?.term2?.term.type === 'geneExpression') &&
+							(self.config?.term2?.term.type === 'integer' ||
+								self.config?.term2?.term.type === 'float' ||
+								self.config?.term2?.term.type === 'geneExpression')
 						)
 					},
 					getConfig: async () => {

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -246,14 +246,7 @@ function setRenderers(self) {
 					label: 'Scatter',
 					disabled: d => false,
 					isVisible: () => {
-						return (
-							(self.config?.term.term.type === 'integer' ||
-								self.config?.term.term.type === 'float' ||
-								self.config?.term2?.term.type === 'geneExpression') &&
-							(self.config?.term2?.term.type === 'integer' ||
-								self.config?.term2?.term.type === 'float' ||
-								self.config?.term2?.term.type === 'geneExpression')
-						)
+						return isNumericTerm(self.config?.term.term) && isNumericTerm(self.config?.term2?.term)
 					},
 					getConfig: async () => {
 						const _term = await self.getWrappedTermCopy(self.config?.term, 'continuous')


### PR DESCRIPTION
## Description

Enabled the scatter tab visibility for all numeric terms. 

Test by: 
1.http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22hrtavg%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D%7D. 
2. Add 'TP53' or another gene expression term as the overlay. 
3. Scatter plot should launch with the scatter tab (bug fixed by Airen in https://github.com/stjude/proteinpaint/pull/1753). 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
