### PR TITLE
fix: At oncomatrix, allow gene expression term to pull data on all cases

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- At oncomatrix, allow gene expression term to pull data on all cases

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -15,8 +15,7 @@ import { mayLimitSamples } from '#src/mds3.filter.js'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
 import { getResult as getResultGene } from '#src/gene.js'
 import { TermTypes } from '#shared/terms.js'
-import { Term } from '#shared/types/terms/term.ts'
-import { GeneVariantCoordTerm, GeneVariantGeneTerm } from '#types'
+import { GeneVariantGeneTerm } from '#types'
 
 export const api = {
 	endpoint: 'termdb/cluster',
@@ -223,7 +222,7 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any, genome: any
 		const term2sample2value = new Map() // k: gene symbol, v: { sampleId : value }
 
 		for (const g of param.terms!) {
-			const geneTerm = g as GeneVariantGeneTerm
+			const geneTerm = g as GeneVariantGeneTerm // FIXME wrong
 			if (!geneTerm.gene) continue
 
 			if (!geneTerm.chr) {

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -61,7 +61,8 @@ function init({ genomes }) {
 }
 
 async function getResult(q: TermdbClusterRequest, ds: any) {
-	let _q = q
+	let _q: any = q // may assign adhoc flag, use "any" to avoid tsc err and no need to include the flag in the type doc
+
 	if (q.dataType == TermTypes.GENE_EXPRESSION) {
 		// gdc gene exp clustering analysis is restricted to max 1000 cases, this is done at ds.queries.geneExpression.get() in mds3.gdc.js. the same getter also serves non-clustering requests and that should not limit cases. add this flag to be able to conditionally limit cases in get()
 		_q = JSON.parse(JSON.stringify(q))

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -169,10 +169,7 @@ async function getSampleData(q) {
 				dataType: tw.term.type,
 				terms: [tw.term],
 				filter: q.filter,
-				filter0: q.filter0,
-				/* quick fix for gdc dataset!
-				 */
-				geneExpUseAllSamples: true
+				filter0: q.filter0
 			}
 			const data = await q.ds.queries[tw.term.type].get(args)
 			for (const sampleId in data.term2sample2value.get(tw.term.name)) {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -166,12 +166,13 @@ async function getSampleData(q) {
 			const args = {
 				genome: q.ds.genome,
 				dslabel: q.ds.label,
-				clusterMethod: 'hierarchical',
-				distanceMethod: 'euclidean', // TODO refactor get() and remove these arg
 				dataType: tw.term.type,
 				terms: [tw.term],
 				filter: q.filter,
-				filter0: q.filter0
+				filter0: q.filter0,
+				/* quick fix for gdc dataset!
+				 */
+				geneExpUseAllSamples: true
 			}
 			const data = await q.ds.queries[tw.term.type].get(args)
 			for (const sampleId in data.term2sample2value.get(tw.term.name)) {


### PR DESCRIPTION
## Description

please test on [adhoc map with genexp already added](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22HOXA1%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22EGFR%22,%22type%22:%22geneExpression%22},%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22case.disease_type%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}],%22divideBy%22:{%22id%22:%22case.demographic.gender%22}}]}) note that the term shows exp values for 219 cases

very slow! 100 seconds. it queries gene exp data twice, each 50 seconds. first time is fillTw() getting binning. 2nd time is to pull data

in next pr may apply a hardcoded dummy default bin for gdc gene exp terms. for local ds this is not an issue and won't do this

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
