### PR TITLE
Divided by cell type geneexp violin

### DIFF
--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -595,6 +595,8 @@ function validatePlotTerm(t, vocabApi) {
 			break
 		case TermTypes.SINGLECELL_GENE_EXPRESSION:
 			break
+		case TermTypes.CELLTYPE:
+			break
 		default:
 			if (t.term.isgenotype) {
 				// don't do anything for now

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -595,7 +595,7 @@ function validatePlotTerm(t, vocabApi) {
 			break
 		case TermTypes.SINGLECELL_GENE_EXPRESSION:
 			break
-		case TermTypes.CELLTYPE:
+		case TermTypes.SINGLECELL_CELLTYPE:
 			break
 		default:
 			if (t.term.isgenotype) {

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -138,6 +138,8 @@ function setRenderers(self) {
 				break
 			case TermTypes.SINGLECELL_GENE_EXPRESSION:
 				break
+			case TermTypes.CELLTYPE:
+				break
 			default:
 				throw 'unknown term type'
 		}

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -138,7 +138,7 @@ function setRenderers(self) {
 				break
 			case TermTypes.SINGLECELL_GENE_EXPRESSION:
 				break
-			case TermTypes.CELLTYPE:
+			case TermTypes.SINGLECELL_CELLTYPE:
 				break
 			default:
 				throw 'unknown term type'

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -76,41 +76,43 @@ class singleCellPlot {
 			})
 			const violinBt = searchGeneDiv
 				.append('button')
-				.text('Open violin')
+				.text('Open violins')
 				.style('margin-left', '2px')
 				.property('disabled', state.config.gene ? false : true)
 			violinBt.on('click', () => {
 				const gene = geneSearch.geneSymbol || state.config.gene
-				const plot = this.plots[0]
-				const values = {}
-				for (const cluster of plot.clusters) {
-					values[cluster] = { key: cluster, value: cluster }
-				}
-				this.app.dispatch({
-					type: 'plot_create',
-					config: {
-						chartType: 'violin',
-						term: {
+
+				for (const plot of this.plots) {
+					const values = {}
+					for (const cluster of plot.clusters) {
+						values[cluster] = { key: cluster, value: cluster }
+					}
+					this.app.dispatch({
+						type: 'plot_create',
+						config: {
+							chartType: 'violin',
 							term: {
-								type: TermTypes.SINGLECELL_GENE_EXPRESSION,
-								id: gene,
-								gene,
-								name: gene,
-								sample: state.config.sample
-							}
-						},
-						term2: {
-							term: {
-								type: TermTypes.CELLTYPE,
-								id: TermTypes.CELLTYPE,
-								name: 'Cell type',
-								sample: state.config.sample,
-								plot: plot.name,
-								values
+								term: {
+									type: TermTypes.SINGLECELL_GENE_EXPRESSION,
+									id: gene,
+									gene,
+									name: gene,
+									sample: state.config.sample
+								}
+							},
+							term2: {
+								term: {
+									type: TermTypes.CELLTYPE,
+									id: TermTypes.CELLTYPE,
+									name: 'Cell type',
+									sample: state.config.sample,
+									plot: plot.name,
+									values
+								}
 							}
 						}
-					}
-				})
+					})
+				}
 			})
 		}
 		this.tableOnPlot = appState.nav?.header_mode == 'hidden'

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -106,8 +106,8 @@ class singleCellPlot {
 						},
 						term2: {
 							term: {
-								type: TermTypes.CELLTYPE,
-								id: TermTypes.CELLTYPE,
+								type: TermTypes.SINGLECELL_CELLTYPE,
+								id: TermTypes.SINGLECELL_CELLTYPE,
 								name: 'Cell type',
 								sample: state.config.sample,
 								plot: plot.name,

--- a/client/termdb/vocabulary.js
+++ b/client/termdb/vocabulary.js
@@ -2,7 +2,7 @@ import initBinConfig from '#shared/termdb.initbinconfig'
 import { TermdbVocab } from './TermdbVocab'
 import { FrontendVocab } from './FrontendVocab'
 import { isNumeric } from '#shared/helpers'
-import { TermTypes } from 'shared/terms'
+import { TermTypes } from '#shared/terms'
 
 export function vocabInit(opts) {
 	/*** start legacy support for state.genome, .dslabel ***/

--- a/client/termsetting/handlers/cellType.ts
+++ b/client/termsetting/handlers/cellType.ts
@@ -1,0 +1,404 @@
+import { GroupSettingMethods } from './groupsetting.ts'
+// import { filterInit } from '#filter'
+import { getPillNameDefault, set_hiddenvalues } from '../termsetting'
+import { VocabApi } from '../../shared/types/index'
+import {
+	Term,
+	TermValues,
+	PredefinedGroupSetting,
+	CustomGroupSetting,
+	BaseGroupSet,
+	GroupEntry
+} from '../../shared/types/terms/term'
+import { CategoricalQ, CategoricalTW } from '../../shared/types/terms/categorical'
+import { PillData } from '../types'
+import { copyMerge } from '../../rx'
+
+/*
+********************** EXPORTED
+getHandler(self)
+	- self: a termsetting instance
+	showEditMenu(div): // categorical edit menu
+		showGrpOpts // create first menu with basic options e.g. groupset, predefined groupset
+	getPillName() // Print term name in the pill
+	getPillStatus() // Returns {text, bgcolor} which determines whether to make right half of the pill visible and show some text. Optional bgcolor can be used to highlight an error.
+                    // Return null to hide the right half.
+	validateQ(data)
+	postMain() // update samplecount
+setCategoryMethods()
+	validateGroupsetting()
+	showGrpOpts() // show menu for available groupset options
+	grpSet2valGrp()
+fillTW(tw, vocabApi)// Can handle initiation logic specific to this term type.
+					// Must also guarantee tw.id and tw.term.id are set.
+					// Computation should be independent of state, especially filter, as that’s not provided.
+
+********************** INTERNAL
+*/
+
+export async function getHandler(self) {
+	setCategoryMethods(self)
+
+	return {
+		showEditMenu: self.showGrpOpts,
+
+		getPillName(d: PillData) {
+			return getPillNameDefault(self, d)
+		},
+
+		getPillStatus() {
+			if (self.usecase?.target == 'regression') {
+				return self.q.mode == 'binary' ? { text: 'binary' } : { text: 'categorical' }
+			}
+			return self.validateGroupsetting()
+		},
+
+		validateQ(data: PillData) {
+			const t = data.term as Term
+			const q = data.q as CategoricalQ
+			const endNote = `(${t.type}, mode='${q.mode}', type='${q.type}')`
+			// validate the configuration
+			if (q.type == 'values') {
+				if (!t.values) self.error = `no term.values defined ${endNote}`
+				if (q.mode == 'binary') {
+					if (Object.keys(t.values as TermValues).length != 2)
+						self.error = `term.values must have exactly two keys ${endNote}`
+
+					if (data.sampleCounts) {
+						for (const key in t.values) {
+							if (!data.sampleCounts.find(d => d.key === key))
+								self.error = `there are no samples for the required binary value=${key} ${endNote}`
+						}
+					}
+				}
+				return
+			}
+
+			if (q.type == 'predefined-groupset' || q.type == 'custom-groupset') {
+				const tgs = t.groupsetting as PredefinedGroupSetting
+				if (!tgs) throw `no term.groupsetting ${endNote}`
+
+				let groupset!: BaseGroupSet
+				if (q.groupsetting && q.type == 'predefined-groupset') {
+					const gs = q.groupsetting as PredefinedGroupSetting
+					const idx = gs.predefined_groupset_idx as number
+					if (tgs.lst && !tgs.lst[idx]) throw `no groupsetting[predefined_groupset_idx=${idx}] ${endNote}`
+					else if (tgs.lst) groupset = tgs.lst[idx]
+				} else if (q.groupsetting) {
+					const gs = q.groupsetting as CustomGroupSetting
+					if (!gs.customset) throw `no q.groupsetting.customset defined ${endNote}`
+					groupset = gs.customset
+				}
+
+				if (!groupset.groups.every((g: GroupEntry) => g.name !== undefined))
+					throw `every group in groupset must have 'name' defined ${endNote}`
+
+				if (q.mode == 'binary') {
+					if (groupset.groups.length != 2) throw `there must be exactly two groups ${endNote}`
+
+					if (data.sampleCounts) {
+						for (const grp of groupset.groups) {
+							if (!data.sampleCounts.find(d => d.label === grp.name))
+								throw `there are no samples for the required binary value=${grp.name} ${endNote}`
+						}
+					}
+				}
+				return
+			}
+			throw `unknown xxxx q.type='${q.type}' for categorical q.mode='${q.mode}'`
+		},
+
+		async postMain() {
+			//for rendering groupsetting menu
+			const body = self.opts.getBodyParams?.() || {}
+			const data = await self.vocabApi.getCategories(self.term, self.filter!, body)
+			/** Original code created a separate array (self.category2samplecount) and pushed only the key and label.
+			 * The new self.category2samplecount was used to create the groupsetting menu items. That logic was removed
+			 * as groupsetting.ts handles formating the data. However category2samplecount = [] is still used
+			 * in other client side code. The data shape may differ until all the code is refactored.
+			 */
+			self.category2samplecount = data.lst
+			if (!self.term.values) {
+				self.q = {}
+			} // ...
+		}
+	}
+}
+
+export function setCategoryMethods(self) {
+	self.validateGroupsetting = function () {
+		if (!self.q.groupsetting || !self.q.groupsetting.inuse) return
+		const text = self.q.name || self.q.reuseId
+		if (text) return { text }
+		if (self.q.groupsetting.predefined_groupset_idx && Number.isInteger(self.q.groupsetting.predefined_groupset_idx)) {
+			if (!self.term.groupsetting) return { text: 'term.groupsetting missing', bgcolor: 'red' }
+			if (!self.term.groupsetting.lst) return { text: 'term.groupsetting.lst[] missing', bgcolor: 'red' }
+			const i = self.term.groupsetting.lst[self.q.groupsetting.predefined_groupset_idx]
+			if (!i)
+				return {
+					text: 'term.groupsetting.lst[' + self.q.groupsetting.predefined_groupset_idx + '] missing',
+					bgcolor: 'red'
+				}
+			return { text: i.name }
+		}
+		if (self.q.groupsetting.customset) {
+			const n = self.q.groupsetting.customset.groups.length
+			return { text: 'Divided into ' + n + ' groups' }
+		}
+		return { text: 'Unknown setting for groupsetting', bgcolor: 'red' }
+	}
+
+	self.showGrpOpts = async function () {
+		// const tgs = self.term.groupsetting
+		// const qgs = self.q?.groupsetting as GroupSetting
+		// const activeGroup = qgs?.predefined_groupset_idx
+		// 	? tgs?.lst?.[qgs?.predefined_groupset_idx]
+		// 	: qgs?.inuse && qgs.customset
+
+		// if (!activeGroup) await new GroupSettingMethods(Object.assign(self, {newMenu: true})).main()
+		// else {
+		//const valGrp = self.grpSet2valGrp(activeGroup)
+		await new GroupSettingMethods(Object.assign(self, { newMenu: true })).main()
+		// }
+	}
+
+	self.getQlst = () => {
+		/********* Not used at all?? Commented out b/c of type errors *********/
+		// const values = self.q.bar_by_children ? self.term.subconditions : self.term.values
+		// const defaultGrpName = `default categories ${values ? '(n=' + Object.keys(values).length + ')' : ''}`
+		// const activeName = self.q.name || qgs?.name || activeGroup?.name || defaultGrpName
+		// //show button/s for default groups
+		// const gsLst = tgs?.lst || []
+		// const qlst = self.vocabApi.getCustomTermQLst(self.term)
+		// const lst = [...gsLst, ...qlst].sort((a, b) => (a.name === self.q.name ? -1 : 0))
+		// return lst.map(q => {
+		// 	return {
+		// 		name: q.name || defaultGrpName,
+		// 		isActive: activeName === defaultGrpName,
+		// 		callback
+		// 	}
+		// })
+		/*
+		const div = _div.append('div').style('display', 'grid')
+		div
+			.append('div')
+			.style('font-size', '.9em')
+			.style('padding', '10px')
+			.style('text-align', 'center')
+			.html(`Using ${activeName}`)
+
+		mayShowGroupDetails(tgs, qgs, activeGroup, div)
+
+		// default overlay btn - divide to n groups (n=total)
+		if (activeName != defaultGrpName) {
+			div
+				.append('div')
+				.attr('class', 'group_btn sja_menuoption')
+				// .style('padding', '7px 6px')
+				.style('margin', '5px')
+				.style('text-align', 'center')
+				.style('font-size', '.8em')
+				.style('border-radius', '13px')
+				.style('background-color', !qgs?.inuse ? '#fff' : '#eee')
+				.style('color', !qgs?.inuse ? '#888' : '#000')
+				.style('pointer-events', !qgs?.inuse ? 'none' : 'auto')
+				.text('Use ' + defaultGrpName)
+				.on('click', () => {
+					qgs.inuse = false
+					delete qgs.predefined_groupset_idx
+					delete self.q.name
+					// self.q.type = 'values' ????
+					self.dom.tip.hide()
+					self.runCallback()
+				})
+		}
+
+		//show button/s for default groups
+		const gsLst = tgs?.lst || []
+		const qlst = self.vocabApi.getCustomTermQLst(self.term)
+		const lst = [...gsLst, ...qlst].sort((a, b) => (a.name === self.q.name ? -1 : 0))
+
+		for (const [i, group] of lst.entries()) {
+			if (group.name === activeName) continue
+
+			div
+				.append('div')
+				.attr('class', 'group_btn sja_menuoption')
+				.style(
+					'display',
+					(group.is_grade && !self.q.bar_by_grade) || (group.is_subcondition && !self.q.bar_by_children)
+						? 'none'
+						: 'block'
+				)
+				// .style('padding', '7px 6px')
+				.style('grid-column', '1')
+				.style('margin', '5px')
+				.style('text-align', 'center')
+				.style('font-size', '.8em')
+				.style('border-radius', '13px')
+				.html(`Use <b>${group.name}</b>`)
+				.on('click', () => {
+					qgs.inuse = true
+					if (group.groupsetting.customset) {
+						self.q = group
+					} else {
+						qgs.predefined_groupset_idx = i
+						// used for groupsetting if one of the group is filter rahter than values,
+						// Not in use rightnow, if used in future, uncomment following line
+						// self.q.groupsetting.activeCohort = self.activeCohort
+						self.q.type = 'predefined-groupset'
+					}
+					self.dom.tip.hide()
+					self.runCallback()
+				})
+
+			if (group.name) {
+				div
+					.append('div')
+					.style('grid-column', '2/3')
+					.style('margin', '5px')
+					.style('padding', '5px')
+					.style('cursor', 'pointer')
+					.style('color', '#999')
+					.style('font-size', '.8em')
+					.text('DELETE')
+					.on('click', async () => {
+						await self.vocabApi.uncacheTermQ(self.term, group)
+						if (group.name === self.q.name) delete self.q.name
+						self.dom.tip.hide()
+					})
+			}
+		}
+
+		//redevide groups btn
+		div
+			.append('div')
+			.attr('class', 'group_btn sja_menuoption')
+			.style('display', 'block')
+			// .style('padding', '7px 6px')
+			.style('margin', '5px')
+			.style('text-align', 'center')
+			.style('font-size', '.8em')
+			.style('border-radius', '12px')
+			.html('Redivide groups')
+			.on('click', () => {
+				if (!activeGroup) self.regroupMenu()
+				else {
+					const valGrp = self.grpSet2valGrp(activeGroup)
+					self.regroupMenu(activeGroup.groups.length, valGrp)
+				}
+			})
+
+		self.renderQNameInput(div, `Grouping`)
+		*/
+	}
+
+	// function mayShowGroupDetails(tgs, qgs, groupset, div) {
+	// 	return
+	// 	const active_group_info_div = div.append('div').style('margin', '10px')
+
+	// 	//display groups and categories assigned to that group
+	// 	if (!qgs?.inuse) return
+	// 	console.log(161, groupset)
+	// 	const group_table = active_group_info_div.append('table').style('font-size', '.8em')
+
+	// 	for (const [i, g] of groupset.groups.entries()) {
+	// 		const group_tr = group_table.append('tr')
+
+	// 		//group name
+	// 		group_tr
+	// 			.append('td')
+	// 			.style('font-weight', 'bold')
+	// 			.style('vertical-align', 'top')
+	// 			.html(g.name != undefined ? g.name + ':' : 'Group ' + (i + 1) + ':')
+
+	// 		const values_td = group_tr.append('td')
+	// 		if (!g.type || g.type == 'values') {
+	// 			for (const v of g.values) {
+	// 				values_td.append('div').html(values[v.key].label)
+	// 			}
+	// 		} else if (g.type == 'filter') {
+	// 			const cohortFilter = tgs.lst[0].groups[i].filter4activeCohort
+	// 			if (!g.filter && cohortFilter) {
+	// 				const filter = JSON.parse(JSON.stringify(cohortFilter[self.activeCohort]))
+
+	// 				// show filter for predefined tvslst for activeCohort
+	// 				filterInit({
+	// 					btn: values_td.append('div'),
+	// 					btnLabel: 'Filter',
+	// 					emptyLabel: '+New Filter',
+	// 					holder: values_td.append('div').style('width', '300px'),
+	// 					vocabApi: self.vocabApi,
+	// 					callback: () => {}
+	// 				}).main(filter)
+	// 			}
+	// 		}
+	// 	}
+	// }
+
+	//No longer needed??
+	// self.grpSet2valGrp = function (groupset: BaseGroupSet) {
+	// 	const values = self.term.values || {}
+	// 	/*
+	// 	values{} is an object of key:{key,label,color}
+	// 	it is read only attribute of the term object
+	// 	duplicate it in order to introduce new attribute "group":INT to each value
+	// 	*/
+	// 	const vals_with_grp = structuredClone(values)
+	// 	if (vals_with_grp == undefined) throw `Missing group values [categorical.ts grpSet2valGrp()]`
+	// 	for (const [i, g] of groupset.groups.entries()) {
+	// 		if (!g.type || g.type == 'values') {
+	// 			for (const v of g.values) {
+	// 				if (!vals_with_grp[v.key]) {
+	// 					// **note!** gdc terms lack term.values{}, must fill in on the fly
+	// 					vals_with_grp[v.key] = { key: v.key as string, label: v.key }
+	// 				}
+
+	// 				vals_with_grp[v.key].group = i + 1
+	// 			}
+	// 		}
+	// 	}
+
+	// 	for (const key of Object.keys(vals_with_grp)) {
+	// 		if (vals_with_grp[key].group == undefined) vals_with_grp[key].group = 0
+	// 	}
+
+	// 	return vals_with_grp
+	// }
+}
+
+export function fillTW(tw: CategoricalTW, vocabApi: VocabApi, defaultQ = null) {
+	if (!('type' in tw.q)) tw.q.type = 'values' // must fill default q.type if missing
+	if (!tw.q.groupsetting) tw.q.groupsetting = {}
+	if (!tw.term.groupsetting) tw.term.groupsetting = {}
+	if (tw.term.groupsetting.disabled) {
+		tw.q.groupsetting.disabled = true
+		return
+	}
+	delete tw.q.groupsetting.disabled
+	if (!('inuse' in tw.q.groupsetting)) tw.q.groupsetting.inuse = false // do not apply by default
+
+	// inuse:false is either from automatic setup or predefined in state
+	if (tw.q.groupsetting.inuse) {
+		const gs = tw.q.groupsetting as PredefinedGroupSetting
+		if (
+			gs.lst &&
+			//Typescript emits error that .useIndex could be undefined
+			gs.useIndex &&
+			//Fix checks if property is present
+			gs.useIndex >= 0 &&
+			gs.lst[gs.useIndex]
+		) {
+			gs.predefined_groupset_idx = gs.useIndex
+		}
+	}
+
+	if (defaultQ) {
+		//TODO change when Q objects separated out
+		;(defaultQ as CategoricalQ).isAtomic = true
+		// merge defaultQ into tw.q
+		copyMerge(tw.q, defaultQ)
+	}
+
+	set_hiddenvalues(tw.q, tw.term)
+}

--- a/client/termsetting/handlers/singleCellCellType.ts
+++ b/client/termsetting/handlers/singleCellCellType.ts
@@ -1,6 +1,6 @@
 import { GroupSettingMethods } from './groupsetting.ts'
 // import { filterInit } from '#filter'
-import { getPillNameDefault, set_hiddenvalues } from '../termsetting'
+import { getPillNameDefault, set_hiddenvalues } from '../termsetting.ts'
 import { VocabApi } from '../../shared/types/index'
 import {
 	Term,
@@ -9,10 +9,10 @@ import {
 	CustomGroupSetting,
 	BaseGroupSet,
 	GroupEntry
-} from '../../shared/types/terms/term'
-import { CategoricalQ, CategoricalTW } from '../../shared/types/terms/categorical'
-import { PillData } from '../types'
-import { copyMerge } from '../../rx'
+} from '../../shared/types/terms/term.ts'
+import { CategoricalQ, CategoricalTW } from '../../shared/types/terms/categorical.ts'
+import { PillData } from '../types.ts'
+import { copyMerge } from '../../rx/index.js'
 
 /*
 ********************** EXPORTED

--- a/client/termsetting/handlers/singleCellCellType.ts
+++ b/client/termsetting/handlers/singleCellCellType.ts
@@ -10,7 +10,7 @@ import {
 	BaseGroupSet,
 	GroupEntry
 } from '../../shared/types/terms/term.ts'
-import { CategoricalQ, CategoricalTW } from '../../shared/types/terms/categorical.ts'
+import { CategoricalQ, SingleCellCellTypeTW } from '../../shared/types/terms/singleCellCellType.ts'
 import { PillData } from '../types.ts'
 import { copyMerge } from '../../rx/index.js'
 
@@ -367,7 +367,9 @@ export function setCategoryMethods(self) {
 	// }
 }
 
-export function fillTW(tw: CategoricalTW, vocabApi: VocabApi, defaultQ = null) {
+export function fillTW(tw: SingleCellCellTypeTW, vocabApi: VocabApi, defaultQ = null) {
+	if (!tw.term?.sample) throw 'missing term.sample'
+	if (!tw.term?.plot) throw 'missing term.plot'
 	if (!('type' in tw.q)) tw.q.type = 'values' // must fill default q.type if missing
 	if (!tw.q.groupsetting) tw.q.groupsetting = {}
 	if (!tw.term.groupsetting) tw.term.groupsetting = {}

--- a/client/termsetting/handlers/singleCellGeneExpression.ts
+++ b/client/termsetting/handlers/singleCellGeneExpression.ts
@@ -26,6 +26,7 @@ export async function getHandler(self) {
 }
 
 export async function fillTW(tw: SingleCellGeneExpressionTW, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
+	if (!tw.term?.sample) throw 'singleCellGeneExpression tw.term.sample must be provided'
 	if (typeof tw.term.gene != 'string' || !tw.term.gene)
 		throw 'singleCellGeneExpression tw.term.gene must be non-empty string'
 	if (!tw.term.name) tw.term.name = tw.term.gene // auto fill if .name is missing

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -4,6 +4,7 @@ import { getData } from '#src/termdb.matrix.js'
 import { Term } from '#shared/types/terms/term.ts'
 import { TermWrapper } from '#shared/types/terms/tw.ts'
 import { NumericTerm } from '#shared/types/terms/numeric.ts'
+import { TermTypes } from '#shared/terms.js'
 
 export const api: any = {
 	endpoint: 'termdb/categories',
@@ -231,5 +232,7 @@ function getDefaultQ(
 		}
 	}
 	if (term.type == 'geneVariant') return {}
+	if (term.type == TermTypes.CELLTYPE) return {}
+
 	throw 'unknown term type'
 }

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -232,7 +232,7 @@ function getDefaultQ(
 		}
 	}
 	if (term.type == 'geneVariant') return {}
-	if (term.type == TermTypes.CELLTYPE) return {}
+	if (term.type == TermTypes.SINGLECELL_CELLTYPE) return {}
 
 	throw 'unknown term type'
 }

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -231,8 +231,13 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 	}
 	if (q.singleCell) {
 		// samples and data are required properties
-		const plots: string[] =
-			'plots' in q.singleCell.data ? (q.singleCell.data as SingleCellDataNative).plots.map(p => p.name) : []
+		const plots: any[] =
+			'plots' in q.singleCell.data
+				? (q.singleCell.data as SingleCellDataNative).plots.map(p => ({
+						name: p.name,
+						colorColumn: p.colorColumn.name
+				  }))
+				: []
 		q2.singleCell = {
 			samples: {
 				firstColumnName: q.singleCell.samples.firstColumnName,

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -148,7 +148,6 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 						throw 'failed to load sc data file'
 					}
 					file2Lines[tsvfile] = (await read_file(tsvfile)).trim().split('\n')
-					console.log('read file', tsvfile)
 				}
 
 				const lines = file2Lines[tsvfile]

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -183,13 +183,12 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 }
 
 function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
-	G.singleCellGeneExpression2bins = {} // cache for binning gene expression values
+	G.sample2gene2expressionBins = {} // cache for binning gene expression values
 
 	// per-sample matrix files are not validated up front, but are verified on the fly. subject to change
 	G.get = async (q: any) => {
 		// q {sample:str, gene:str}
 		const tsvfile = path.join(serverconfig.tpmasterdir, G.folder, q.sample)
-
 		const cell2value = {} // data returned by getter. key: cell barcode in header, value: exp value
 
 		try {
@@ -225,7 +224,6 @@ function grepMatrix4geneExpression(tsvfile: string, gene: string, header: string
 			}
 
 			const l = line.split('\t')
-
 			if (l.length != header.length)
 				reject(`number of fields differ between data line and header: ${l.length} ${header.length}`)
 

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -13,7 +13,7 @@ export const graphableTypes = new Set([
 	'geneExpression',
 	TermTypes.METABOLITE_INTENSITY,
 	TermTypes.SINGLECELL_GENE_EXPRESSION,
-	TermTypes.CELLTYPE
+	TermTypes.SINGLECELL_CELLTYPE
 ])
 /*
 	isUsableTerm() will

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -12,7 +12,8 @@ export const graphableTypes = new Set([
 	'samplelst',
 	'geneExpression',
 	TermTypes.METABOLITE_INTENSITY,
-	TermTypes.SINGLECELL_GENE_EXPRESSION
+	TermTypes.SINGLECELL_GENE_EXPRESSION,
+	TermTypes.CELLTYPE
 ])
 /*
 	isUsableTerm() will

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -19,7 +19,7 @@ export const TermTypes = {
 	SAMPLELST: 'samplelst',
 	METABOLITE_INTENSITY: 'metaboliteIntensity',
 	SINGLECELL_GENE_EXPRESSION: 'singleCellGeneExpression',
-	CELLTYPE: 'cellType'
+	SINGLECELL_CELLTYPE: 'singleCellCellType'
 }
 
 export const TermTypes2Dt = {
@@ -66,7 +66,7 @@ const nonDictTypes = new Set([
 	TermTypes.GENE_VARIANT,
 	TermTypes.METABOLITE_INTENSITY,
 	TermTypes.SINGLECELL_GENE_EXPRESSION,
-	TermTypes.CELLTYPE
+	TermTypes.SINGLECELL_CELLTYPE
 ])
 export const numericTypes = new Set([
 	TermTypes.INTEGER,

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -18,7 +18,8 @@ export const TermTypes = {
 	SURVIVAL: 'survival',
 	SAMPLELST: 'samplelst',
 	METABOLITE_INTENSITY: 'metaboliteIntensity',
-	SINGLECELL_GENE_EXPRESSION: 'singleCellGeneExpression'
+	SINGLECELL_GENE_EXPRESSION: 'singleCellGeneExpression',
+	CELLTYPE: 'cellType'
 }
 
 export const TermTypes2Dt = {
@@ -64,7 +65,8 @@ const nonDictTypes = new Set([
 	TermTypes.GENE_EXPRESSION,
 	TermTypes.GENE_VARIANT,
 	TermTypes.METABOLITE_INTENSITY,
-	TermTypes.SINGLECELL_GENE_EXPRESSION
+	TermTypes.SINGLECELL_GENE_EXPRESSION,
+	TermTypes.CELLTYPE
 ])
 export const numericTypes = new Set([
 	TermTypes.INTEGER,

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -368,7 +368,7 @@ export type SingleCellGeneExpressionNative = {
 	folder: string
 	/** dynamically added getter */
 	get?: (q: any) => any
-	singleCellGeneExpression2bins?: { [sample: string]: { [gene: string]: any } }
+	sample2gene2expressionBins?: { [sample: string]: { [gene: string]: any } }
 }
 
 export type SingleCellSamplesNative = {

--- a/server/shared/types/terms/singleCellCellType.ts
+++ b/server/shared/types/terms/singleCellCellType.ts
@@ -1,0 +1,68 @@
+//import { TermWrapper, BaseQ } from '../termdb'
+import {
+	BaseTerm,
+	BaseValue,
+	TermValues,
+	BaseQ,
+	BaseTW,
+	EmptyGroupSetting,
+	PredefinedGroupSetting,
+	CustomGroupSetting,
+	ValuesGroup
+} from './term.ts'
+import { TermTypes } from '../../terms.js'
+
+/*
+--------EXPORTED--------
+CategoricalQ
+CategoricalTW
+CategoricaTermSettingInstance
+
+*/
+
+/**
+ * A categorical term q object
+ *
+ * test:CategoricalQ:
+ *
+ * @category TW
+ */
+
+export type CategoricalValuesObject = {
+	mode: 'binary' | 'discrete'
+	type?: 'values'
+	values: {
+		[key: string]: BaseValue
+	}
+	groupsetting: EmptyGroupSetting
+}
+
+export type GroupSet = {
+	mode: 'binary' | 'discrete'
+	type?: 'predefined-groupset' | 'custom-groupset'
+	name: string
+	groups: ValuesGroup[]
+	groupsetting: PredefinedGroupSetting | CustomGroupSetting | EmptyGroupSetting
+}
+
+export type SingleCellCellTypeTerm = BaseTerm & {
+	type: 'singleCellCellType'
+	values: CategoricalValuesObject //the cell types may be also cell attributes like CNV, Fusion, etc
+	sample: string //single cell terms require a sample to read the term values, they are associated with a sample
+	plot: string //the plot defined in the dataset contains a column with the term values for the sample, it needs to be passed to read the sample values
+	//groupsetting: { disabled?: boolean | undefined } //, lst?: GroupSet }
+}
+
+export type CategoricalQ = BaseQ & (CategoricalValuesObject | GroupSet)
+
+export type SingleCellCellTypeTW = BaseTW & {
+	term: SingleCellCellTypeTerm
+	q: CategoricalQ
+}
+
+export type GroupSetInputValues = {
+	[index: string]: {
+		label?: string | number //value's label on client
+		group?: number //value's current group index
+	}
+}

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -467,9 +467,8 @@ CAUTION if a datatype naming in ds.queries{} cannot follow this pattern then it 
 	try {
 		if (tw.term.type == TermTypes.SINGLECELL_GENE_EXPRESSION) {
 			if (!ds.queries?.singleCell?.geneExpression) throw 'term type not supported by this dataset'
-			binsCache = ds.queries.singleCell.geneExpression.singleCellGeneExpression2bins[tw.term.sample]
-			if (!binsCache)
-				binsCache = ds.queries.singleCell.geneExpression.singleCellGeneExpression2bins[tw.term.sample] = {}
+			binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample]
+			if (!binsCache) binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample] = {}
 			else if (binsCache[tw.term.gene]) return res.send(binsCache[tw.term.gene])
 			const args = {
 				sample: tw.term.sample,

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -221,6 +221,16 @@ async function getSampleData(q) {
 				}
 				samples[sampleId][tw.$id] = { value, key }
 			}
+		} else if (tw.term.type == TermTypes.CELLTYPE) {
+			const data = await q.ds.queries?.singleCell?.data.get({ sample: tw.term.sample, plots: [tw.term.plot] })
+			for (const cell of data.plots[0].cells) {
+				const sampleId = cell.cellId
+				if (!(sampleId in samples)) {
+					samples[sampleId] = { sample: sampleId }
+				}
+				const value = cell.category
+				samples[sampleId][tw.$id] = { value, key: value }
+			}
 		} else {
 			throw 'unknown type of non-dictionary term'
 		}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -221,14 +221,20 @@ async function getSampleData(q) {
 				}
 				samples[sampleId][tw.$id] = { value, key }
 			}
-		} else if (tw.term.type == TermTypes.CELLTYPE) {
+		} else if (tw.term.type == TermTypes.SINGLECELL_CELLTYPE) {
 			const data = await q.ds.queries?.singleCell?.data.get({ sample: tw.term.sample, plots: [tw.term.plot] })
+			const groups = tw.q?.groupsetting?.customset?.groups
 			for (const cell of data.plots[0].cells) {
 				const sampleId = cell.cellId
 				if (!(sampleId in samples)) {
 					samples[sampleId] = { sample: sampleId }
 				}
-				const value = cell.category
+				let value = cell.category
+				if (groups) {
+					//custom groups where created
+					const group = groups.find(g => Object.values(g.values).find(v => v.key == value))
+					if (group) value = group.name
+				}
 				samples[sampleId][tw.$id] = { value, key: value }
 			}
 		} else {


### PR DESCRIPTION
## Description

Displayed violins divided by cell type, for each plot. Fixed bug selecting samples in GDC. Renamed cache to sample2gene2expressionBins. Added type definition, solved groupsetting, etc.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
