### PR TITLE
load singlecell gene exp data from R rds files

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- singlecell native gene exp data is loaded from rds file; no longer grep

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -1,6 +1,5 @@
 import fs from 'fs'
 import path from 'path'
-import { spawn } from 'child_process'
 import { read_file } from '#src/utils.js'
 import run_R from '#src/run_R.js'
 import serverconfig from '#src/serverconfig.js'

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -1,7 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 import { spawn } from 'child_process'
-import { read_file, get_header_txt } from '#src/utils.js'
+import { read_file } from '#src/utils.js'
+import run_R from '#src/run_R.js'
 import serverconfig from '#src/serverconfig.js'
 import {
 	SingleCellQuery,
@@ -190,54 +191,27 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 	G.sample2gene2expressionBins = {} // cache for binning gene expression values
 
-	// per-sample matrix files are not validated up front, but are verified on the fly. subject to change
+	// per-sample rds files are not validated up front, and simply used as-is on the fly
 	G.get = async (q: any) => {
 		// q {sample:str, gene:str}
-		const tsvfile = path.join(serverconfig.tpmasterdir, G.folder, q.sample)
-		const cell2value = {} // data returned by getter. key: cell barcode in header, value: exp value
-
+		const rdsfile = path.join(serverconfig.tpmasterdir, G.folder, q.sample + '.rds')
 		try {
-			await fs.promises.stat(tsvfile)
+			await fs.promises.stat(rdsfile)
 		} catch (e: any) {
-			return cell2value
-			//throw 'geneExp matrix file not found or readable for this sample'
-			// do not throw when matrix file is unreabable, but returns blank data. this simplifies client logic
+			return {}
+			// do not throw when file is missing/unreabable, but returns blank data. this simplifies client logic
 		}
-		const header = (await get_header_txt(tsvfile)).split('\t')
-		if (header.length == 0) throw 'blank header line'
-		await grepMatrix4geneExpression(tsvfile, q.gene, header, cell2value)
-		return cell2value
+
+		let out // object of barcodes as keys, and values as value
+		try {
+			out = JSON.parse(
+				await run_R(path.join(serverconfig.binpath, 'utils', 'getGeneFromMatrix.R'), null, [rdsfile, q.gene])
+			)
+		} catch (e) {
+			// if gene is not found will emit such msg
+			return {}
+		}
+
+		return out
 	}
-}
-
-function grepMatrix4geneExpression(tsvfile: string, gene: string, header: string[], cell2value: any) {
-	return new Promise((resolve, reject) => {
-		const cp = spawn('grep', ['-m', '1', gene + '\t', tsvfile])
-		const out: string[] = [],
-			err: string[] = []
-		cp.stdout.on('data', d => out.push(d))
-		cp.stderr.on('data', d => err.push(d))
-		cp.on('close', () => {
-			const e = err.join('')
-			if (e) reject(e)
-			// got data
-
-			const line = out.join('').trim() // should find one line of text
-			if (!line) {
-				// blank line. gene is not found and missed out in this experiment
-				resolve(null) // add null to avoid tsc err
-			}
-
-			const l = line.split('\t')
-			if (l.length != header.length)
-				reject(`number of fields differ between data line and header: ${l.length} ${header.length}`)
-
-			for (let i = 1; i < l.length; i++) {
-				const v = Number(l[i])
-				if (Number.isNaN(v)) continue // invalid value
-				cell2value[header[i]] = v
-			}
-			resolve(null)
-		})
-	})
 }

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -355,19 +355,11 @@ export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNa
 
 export type SingleCellGeneExpressionNative = {
 	src: 'native'
-	/** path to gene-by-cell matrices per sample
-	each matrix file:
-		- is named by sample name
-		- is a tab-delimited text file
-		- has a header line: `gene \t cell1 \t cell2 ...`
-		- each gene has a line with gene symbol at first column, and sctransform values in rest columns
-
-	note that such matrices should be available for all samples present from queries.singleCell.samples{}
-	if a sample is missing its matrix in this folder, it may cause unexpected behavior
-	*/
+	/** path to R rds files, each is a gene-by-cell matrix for a sample, with ".rdx" suffix. missing files are detected and handled */
 	folder: string
 	/** dynamically added getter */
 	get?: (q: any) => any
+	/** cached gene exp bins */
 	sample2gene2expressionBins?: { [sample: string]: { [gene: string]: any } }
 }
 


### PR DESCRIPTION
## Description

please pull sjpp master
scp one rds file from hpc:

`~/data/tp/files/hg38/BALL-scrna % scp hpc:~/tp/qgao/sctransform/SJBALL030036_D1.rds geneExp`

then test with a [new sample](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22BALL-scrna%22,%22nav%22:{%22header_mode%22:%22only_buttons%22},%22plots%22:[{%22chartType%22:%22singleCellPlot%22,%22sample%22:%22SJBALL030036_D1%22}]})

(the old one in url.html has an invalid rds file and thus gene search won't work for that)

try gene ACTB, it works. MYC has data for subset of cells. HOXA1 is not present


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
