### PR TITLE
fix: Speed up top variably expressed genes query from gdc api, direct…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Speed up top variably expressed genes query from gdc api, directly submit case filter and do not first retrieve list of cases

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -169,7 +169,8 @@ function gdcValidateQuery(ds: any, genome: any) {
 	}
 
 	function getGeneSelectionArg(q: any) {
-		const arg = {
+		const arg: any = {
+			// add any to avoid tsc err
 			case_filters: makeFilter(q),
 			selection_size: Number(q.maxGenes)
 		}


### PR DESCRIPTION
…ly submit case filter and do not first retrieve list of cases

## Description

querying top variably expressed genes from gdc sees a speed gain. there had been a step to first query list of cases passing filter (takes 10 seconds, especially bad when there's no cohort), then pass these cases to /gene_selection/ api to get top genes. now the case querying step is eliminated. the cohort is directly passed to api (didn't know that before)

for exp clustering, will still retrieve list of cases from cohort as before, since the app must restrict to 1K cases otherwise it breaks. no speed gain there

all tested to work: adhoc and integrated views, non-ci test, adding gene exp row to matrix

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
