### PR TITLE
Misc fixes in sampleView

### DIFF
--- a/client/plots/dziviewer/DziViewer.ts
+++ b/client/plots/dziviewer/DziViewer.ts
@@ -29,6 +29,7 @@ export default class DziViewer {
 			prefixUrl: 'https://openseadragon.github.io/openseadragon/images/',
 			showNavigator: true,
 			sequenceMode: tileSources.length > 1,
+			defaultZoomLevel: 1,
 			gestureSettingsMouse: {
 				clickToZoom: true,
 				scrollToZoom: false,

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -30,7 +30,7 @@ class SampleView {
 		const plotsDiv = div //div.append('div').style('display', 'inline-block').style('margin-top', '10px') //div with plots
 		const sampleDiv = leftDiv.insert('div').style('display', 'inline-block').style('padding', '20px')
 
-		const tableDiv = leftDiv.insert('div').style('padding', '10px').style('width', '45vw')
+		const tableDiv = leftDiv.insert('div').style('padding', '10px')
 
 		const table = tableDiv.append('table').style('border-collapse', 'collapse')
 		const thead = table.append('thead')
@@ -481,7 +481,7 @@ class SampleView {
 
 		if (state.termdbConfig.queries?.DZImages) {
 			let div = plotsDiv.append('div')
-			if (state.samples.length == 1) div.style('display', 'inline-block')
+			if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
 			for (const sample of samples) {
 				const data = await dofetch3('sampledzimages', {
 					body: {
@@ -500,7 +500,7 @@ class SampleView {
 
 		if (state.termdbConfig?.queries?.singleSampleMutation) {
 			let div = plotsDiv.append('div')
-			if (state.samples.length == 1) div.style('display', 'inline-block')
+			if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
 
 			for (const sample of samples) {
 				const cellDiv = div.append('div').style('display', 'inline-block')
@@ -520,7 +520,7 @@ class SampleView {
 		if (state.termdbConfig.queries?.singleSampleGenomeQuantification) {
 			for (const k in state.termdbConfig.queries.singleSampleGenomeQuantification) {
 				let div = plotsDiv.append('div')
-				if (state.samples.length == 1) div.style('display', 'inline-block')
+				if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '40vw')
 				for (const sample of samples) {
 					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
 					const plotDiv = div.insert('div').style('display', 'table-cell').style('padding', '20px')
@@ -545,7 +545,7 @@ class SampleView {
 
 			for (const k in state.termdbConfig.queries?.NIdata) {
 				let div = plotsDiv.append('div')
-				if (state.samples.length == 1) div.style('display', 'inline-block')
+				if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
 				for (const sample of samples) {
 					const plotDiv = div.insert('div').style('display', 'inline-block')
 					this.brainPlots.push({ sample, cellDiv: plotDiv })
@@ -566,7 +566,7 @@ class SampleView {
 		}
 		if (state.termdbConfig?.queries?.images) {
 			let div = plotsDiv.append('div')
-			if (state.samples.length == 1) div.style('display', 'inline-block')
+			if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
 			for (const sample of samples) {
 				const cellDiv = div.append('div').style('display', 'inline-block')
 				this.imagePlots.push({ sample: cellDiv })
@@ -609,6 +609,7 @@ export const componentInit = sampleViewInit
 
 function setRenderers(self) {
 	self.renderSampleDictionary = function () {
+		if (self.state.samples.length == 1) self.dom.tableDiv.style('width', '48vw')
 		// use an array to support multiple visible samples,
 		// but prototyping with just one sample for now
 		const visibleSamples = []

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -520,7 +520,7 @@ class SampleView {
 		if (state.termdbConfig.queries?.singleSampleGenomeQuantification) {
 			for (const k in state.termdbConfig.queries.singleSampleGenomeQuantification) {
 				let div = plotsDiv.append('div')
-				if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '40vw')
+				if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
 				for (const sample of samples) {
 					const label = k.match(/[A-Z][a-z]+|[0-9]+/g).join(' ')
 					const plotDiv = div.insert('div').style('display', 'table-cell').style('padding', '20px')

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -1776,7 +1776,7 @@ function plotSampleGenomeQuantification(file, genome, control, devicePixelRatio 
 		ypad = 20,
 		xpad = 20,
 		plotWidth = 800,
-		axisWidth = 50
+		axisWidth = 10
 
 	let bpTotal = 0
 	for (const chr in genome.majorchr) {


### PR DESCRIPTION
## Description

Reduced left padding in sample genome quantification plot.  Distributed evenly width if on two columns view, when a single sample is selected. Increased default zoom in dzi to improve visualization. Looks like this now:

<img width="950" alt="Screenshot 2024-07-01 at 3 11 13 PM" src="https://github.com/stjude/proteinpaint/assets/12271391/a8bb4ed9-b69f-4c55-ad2c-574fb8c4d0f3">


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
