### PR TITLE
feat: Support inputing custom CNV segments in mds3 tk, improve cnv re…

### DIFF
--- a/client/mds3/itemtable.js
+++ b/client/mds3/itemtable.js
@@ -538,7 +538,7 @@ export function table_cnv(arg, table) {
 		c1.text('Position')
 		c2.text(m.chr + ':' + m.start + '-' + m.stop)
 	}
-	{
+	if (m.samples) {
 		const [c1, c2] = table.addRow()
 		c1.text('Sample')
 		for (const s of m.samples) {

--- a/client/mds3/itemtable.js
+++ b/client/mds3/itemtable.js
@@ -168,9 +168,12 @@ async function itemtable_multiItems(arg) {
 		if (infoFields.length == 0) infoFields = null
 	}
 	// numeric value view mode object (that is not occurrence)
-	const numViewMode = arg.tk.skewer.viewModes.find(i => i.inuse && i.type == 'numeric' && i.byAttribute != 'occurrence')
-	if (numViewMode) {
-		columns.push({ label: numViewMode.label })
+	let numViewMode
+	if (arg.tk.skewer) {
+		numViewMode = arg.tk.skewer.viewModes.find(i => i.inuse && i.type == 'numeric' && i.byAttribute != 'occurrence')
+		if (numViewMode) {
+			columns.push({ label: numViewMode.label })
+		}
 	}
 
 	////////////////// generate table rows

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -920,7 +920,7 @@ tape('Custom cnv and ssm, no sample', test => {
 	}
 })
 
-tape.only('Custom cnv and ssm, WITH sample', test => {
+tape('Custom cnv and ssm, WITH sample', test => {
 	test.timeoutAfter(3000)
 	const holder = getHolder()
 

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -15,6 +15,7 @@ Incorrect dslabel
 Custom cnv only, no sample
 Custom ssm only, no sample
 Custom cnv and ssm, no sample
+Custom cnv and ssm, WITH sample
 Custom variants, missing or invalid mclass
 Custom variants WITH samples (allows some to be without)
 Custom data with samples and sample selection
@@ -912,6 +913,70 @@ tape('Custom cnv and ssm, no sample', test => {
 		}
 
 		if (test._ok) {
+			tk.menutip.d.remove()
+			holder.remove()
+		}
+		test.end()
+	}
+})
+
+tape.only('Custom cnv and ssm, WITH sample', test => {
+	test.timeoutAfter(3000)
+	const holder = getHolder()
+
+	const custom_variants = [
+		{ chr: 'chr17', start: 7670699, stop: 7674000, dt: 4, class: 'CNV_amp', value: 1, sample: 's1' },
+		{ chr: 'chr17', start: 7670699, stop: 7674000, dt: 4, class: 'CNV_loss', value: -1, sample: 's2' },
+		{ chr: 'chr17', start: 7670699, stop: 7676000, dt: 4, class: 'CNV_loss', value: -0.5, sample: 's3' },
+		{ chr: 'chr17', pos: 7675993, mname: 'point 1', class: 'M', dt: 1, sample: 's3' },
+		{ chr: 'chr17', pos: 7676520, mname: 'point 2', class: 'M', dt: 1, sample: 's4' },
+		{ chr: 'chr17', pos: 7676381, mname: 'point 3', class: 'M', dt: 1, sample: 's1' }
+	]
+	runproteinpaint({
+		holder,
+		parseurl: true,
+		nobox: true,
+		noheader: true,
+		genome: 'hg38-test',
+		gene: 'NM_000546',
+		tracks: [
+			{
+				type: 'mds3',
+				name: 'Custom data',
+				custom_variants: JSON.parse(JSON.stringify(custom_variants))
+			}
+		],
+		onloadalltk_always: checkTrack
+	})
+	async function checkTrack(bb) {
+		const tk = bb.tklst.find(i => i.type == 'mds3')
+		test.equal(
+			tk.cnv.g.selectAll('rect')._groups[0].length,
+			custom_variants.filter(i => i.dt == 4).length,
+			`All cnv segments should be rendered`
+		)
+
+		{
+			//Test variant label left of track
+			const lab = tk.leftlabels.doms.variants
+			test.ok(lab, '"Variants" leftlabel should be displayed')
+			test.equal(
+				lab.node().innerHTML,
+				`${custom_variants.length} variants`,
+				`Variant leftlabel should print "${custom_variants.length} variants"`
+			)
+		}
+
+		{
+			// Test sample leftlabel
+			const lab = tk.leftlabels.doms.samples
+			test.ok(lab, '"Samples" leftlabel should be displayed')
+
+			const set = new Set(custom_variants.map(i => i.sample))
+			test.equal(lab.node().innerHTML, `${set.size} samples`, `Samples leftlabel should print "${set.size} samples"`)
+		}
+
+		if (0 && test._ok) {
 			tk.menutip.d.remove()
 			holder.remove()
 		}

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -12,7 +12,9 @@ Official - mclass filtering
 Official - sample summaries table, create subtrack (tk.filterObj)
 Official - allow2selectSamples
 Incorrect dslabel
-TP53 custom data, no sample
+Custom cnv only, no sample
+Custom ssm only, no sample
+Custom cnv and ssm, no sample
 Custom variants, missing or invalid mclass
 Custom variants WITH samples (allows some to be without)
 Custom data with samples and sample selection
@@ -492,7 +494,7 @@ tape('Incorrect dslabel', test => {
 	}
 })
 
-tape('TP53 custom data, no sample', test => {
+tape('Custom ssm only, no sample', test => {
 	test.timeoutAfter(2000)
 	const holder = getHolder()
 
@@ -799,6 +801,113 @@ tape('Custom data with samples and sample selection', test => {
 			test.ok(
 				tableBtn[0] && tableBtn[0].innerText == buttonText,
 				`Sample table should contain a <button> with custom text`
+			)
+		}
+
+		if (test._ok) {
+			tk.menutip.d.remove()
+			holder.remove()
+		}
+		test.end()
+	}
+})
+
+tape('Custom cnv only, no sample', test => {
+	test.timeoutAfter(3000)
+	const holder = getHolder()
+
+	const custom_variants = [
+		{ chr: 'chr17', start: 7670699, stop: 7674000, dt: 4, class: 'CNV_amp', value: 1 },
+		{ chr: 'chr17', start: 7670699, stop: 7674000, dt: 4, class: 'CNV_loss', value: -1 },
+		{ chr: 'chr17', start: 7670699, stop: 7676000, dt: 4, class: 'CNV_loss', value: -0.5 }
+	]
+	runproteinpaint({
+		holder,
+		parseurl: true,
+		nobox: true,
+		noheader: true,
+		genome: 'hg38-test',
+		gene: 'NM_000546',
+		tracks: [
+			{
+				type: 'mds3',
+				name: 'Custom data',
+				custom_variants
+			}
+		],
+		onloadalltk_always: checkTrack
+	})
+	async function checkTrack(bb) {
+		const tk = bb.tklst.find(i => i.type == 'mds3')
+		test.equal(
+			tk.cnv.g.selectAll('rect')._groups[0].length,
+			custom_variants.length,
+			`All ${custom_variants.length} segments should be rendered`
+		)
+
+		{
+			//Test variant label left of track
+			const lab = tk.leftlabels.doms.variants
+			test.ok(lab, '"Variants" leftlabel should be displayed')
+			test.equal(
+				lab.node().innerHTML,
+				`${custom_variants.length} variants`,
+				`Variant leftlabel should print "${custom_variants.length} variants"`
+			)
+		}
+
+		if (test._ok) {
+			tk.menutip.d.remove()
+			holder.remove()
+		}
+		test.end()
+	}
+})
+
+tape('Custom cnv and ssm, no sample', test => {
+	test.timeoutAfter(3000)
+	const holder = getHolder()
+
+	const custom_variants = [
+		{ chr: 'chr17', start: 7670699, stop: 7674000, dt: 4, class: 'CNV_amp', value: 1 },
+		{ chr: 'chr17', start: 7670699, stop: 7674000, dt: 4, class: 'CNV_loss', value: -1 },
+		{ chr: 'chr17', start: 7670699, stop: 7676000, dt: 4, class: 'CNV_loss', value: -0.5 },
+		{ chr: 'chr17', pos: 7675993, mname: 'point 1', class: 'M', dt: 1 },
+		{ chr: 'chr17', pos: 7676520, mname: 'point 2', class: 'M', dt: 1 },
+		{ chr: 'chr17', pos: 7676381, mname: 'point 3', class: 'M', dt: 1 }
+	]
+	runproteinpaint({
+		holder,
+		parseurl: true,
+		nobox: true,
+		noheader: true,
+		genome: 'hg38-test',
+		gene: 'NM_000546',
+		tracks: [
+			{
+				type: 'mds3',
+				name: 'Custom data',
+				custom_variants
+			}
+		],
+		onloadalltk_always: checkTrack
+	})
+	async function checkTrack(bb) {
+		const tk = bb.tklst.find(i => i.type == 'mds3')
+		test.equal(
+			tk.cnv.g.selectAll('rect')._groups[0].length,
+			custom_variants.filter(i => i.dt == 4).length,
+			`All cnv segments should be rendered`
+		)
+
+		{
+			//Test variant label left of track
+			const lab = tk.leftlabels.doms.variants
+			test.ok(lab, '"Variants" leftlabel should be displayed')
+			test.equal(
+				lab.node().innerHTML,
+				`${custom_variants.length} variants`,
+				`Variant leftlabel should print "${custom_variants.length} variants"`
 			)
 		}
 

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -358,16 +358,24 @@ async function dataFromCustomVariants(tk, block) {
 
 	if (data.cnv.length == 0) delete data.cnv // important to delete to avoid triggering cnv logic
 
-	if (data.skewer.some(i => i.samples)) {
+	// count unique number of samples, if has such
+	const set = new Set()
+	if (data.skewer?.some(i => i.samples)) {
 		// has .samples[], get sample count
-		const set = new Set()
 		for (const m of data.skewer) {
 			if (m.samples) {
 				for (const s of m.samples) set.add(s.sample_id)
 			}
 		}
-		data.sampleTotalNumber = set.size
 	}
+	if (data.cnv?.some(i => i.samples)) {
+		for (const m of data.cnv) {
+			if (m.samples) {
+				for (const s of m.samples) set.add(s.sample_id)
+			}
+		}
+	}
+	if (set.size) data.sampleTotalNumber = set.size
 
 	data.mclass2variantcount = [...m2c]
 

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -30,7 +30,6 @@ export async function loadTk(tk, block) {
 		}
 
 		const data = await getData(tk, block)
-		console.log('tk data', data)
 		if (tk.uninitialized) {
 			tk.clear()
 			delete tk.uninitialized

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Support inputing custom CNV segments in mds3 tk, improve cnv rendering


### PR DESCRIPTION
…ndering

## Description

refactoring to fix logic of assuming mds3 tk only works with "skewer" data. now it can support cnv-only data. also has a convenient format to drop in custom cnv segments

to test, at http://localhost:3000/?genome=hg38-test&gene=p53&mds3=TermdbTest, click `+` button and paste below to render custom cnv segments:

only cnv, no sample:
> 100 200 1
> 50 250 -1

cnv+ssm, no sample:

> abc 100 M
> 100 200 1
> 50 250 -1

cnv+ssm, has sample:

> abc 100 M sample1
> 100 200 1 sample2
> 50 250 -1 sample3

all mds3 tests pass. a few new tests added to cover cnv rendering. all gdc lollipop features are not impacted

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
