### PR TITLE
Centralize client-side filter rehydration

### DIFF
--- a/client/filter/rehydrateFilter.js
+++ b/client/filter/rehydrateFilter.js
@@ -1,0 +1,32 @@
+/*
+hydrate filter by filling tvs term obj.
+only works for dictionary terms e.g. term:{id:'xx'} with id but lacks type etc.
+provides convenience for hand coding dictionary filter
+
+TODO allow to work for non-dict terms
+
+args:
+- filter: modifiable filter obj
+- vocabApi
+- proms[] optional array to hold promises to be resolved at once. if not provided, new array is created and returned
+*/
+export function rehydrateFilter(filter, vocabApi, proms = []) {
+	if (Object.isFrozen(filter)) throw 'filter obj is frozen, unable to rehydrate and modify'
+
+	if (filter.type == 'tvslst') {
+		for (const f of filter.lst) rehydrateFilter(f, vocabApi, proms)
+	} else if (filter.type == 'tvs') {
+		if (typeof filter.tvs?.term != 'object') throw 'a tvs lacks structure of .tvs.term{}'
+		if (filter.tvs.term.id && !filter.tvs.term.name)
+			// has term.id. allows term obj to be like {id:'xx'} and assumes it must be dict term
+			console.log(filter.tvs.term.id)
+		proms.push(
+			vocabApi.getterm(filter.tvs.term.id).then(term => {
+				filter.tvs.term = term
+			})
+		)
+	} else {
+		throw `cannot rehydrate filter.type='${filter.type}'`
+	}
+	return proms
+}

--- a/client/filter/rehydrateFilter.js
+++ b/client/filter/rehydrateFilter.js
@@ -4,6 +4,7 @@ only works for dictionary terms e.g. term:{id:'xx'} with id but lacks type etc.
 provides convenience for hand coding dictionary filter
 
 TODO allow to work for non-dict terms
+TODO unit test
 
 args:
 - filter: modifiable filter obj
@@ -17,14 +18,14 @@ export function rehydrateFilter(filter, vocabApi, proms = []) {
 		for (const f of filter.lst) rehydrateFilter(f, vocabApi, proms)
 	} else if (filter.type == 'tvs') {
 		if (typeof filter.tvs?.term != 'object') throw 'a tvs lacks structure of .tvs.term{}'
-		if (filter.tvs.term.id && !filter.tvs.term.name)
+		if (filter.tvs.term.id && !filter.tvs.term.name) {
 			// has term.id. allows term obj to be like {id:'xx'} and assumes it must be dict term
-			console.log(filter.tvs.term.id)
-		proms.push(
-			vocabApi.getterm(filter.tvs.term.id).then(term => {
-				filter.tvs.term = term
-			})
-		)
+			proms.push(
+				vocabApi.getterm(filter.tvs.term.id).then(term => {
+					filter.tvs.term = term
+				})
+			)
+		}
 	} else {
 		throw `cannot rehydrate filter.type='${filter.type}'`
 	}

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -3,6 +3,7 @@ import { dofetch3 } from '#common/dofetch'
 import { getFilterItemByTag, findParent } from '#filter/filter'
 import { getSamplelstTW, getFilter } from '../mass/groups.js'
 import { TermTypes } from '../shared/terms.js'
+import { rehydrateFilter } from '../filter/rehydrateFilter.js'
 
 // to distinguish from IDs assigned by other code or users
 const idPrefix = '_MASS_AUTOID_' + Math.random().toString().slice(-6)
@@ -180,22 +181,6 @@ class TdbStore {
 		}
 		await Promise.all(lst)
 	}
-}
-
-function rehydrateFilter(filter, vocabApi, proms = []) {
-	if (filter.type == 'tvslst') {
-		for (const f of filter.lst) rehydrateFilter(f, vocabApi, proms)
-	} else if (filter.type == 'tvs') {
-		if (!filter.tvs.term.name)
-			proms.push(
-				vocabApi.getterm(filter.tvs.term.id).then(term => {
-					filter.tvs.term = term
-				})
-			)
-	} else {
-		throw `cannot rehydrate filter.type='${filter.type}'`
-	}
-	return proms
 }
 
 /*

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -7,6 +7,7 @@ import { mclass, dtsnvindel, dtsv, dtfusionrna, dtcnv } from '#shared/common'
 import { vcfparsemeta } from '#shared/vcf'
 import { getFilterName } from './filterName'
 import { fillTermWrapper } from '#termsetting'
+import { rehydrateFilter } from '../filter/rehydrateFilter.js'
 
 /*
 this script exports one function "makeTk()" that will be called just once
@@ -126,7 +127,7 @@ export async function makeTk(tk, block) {
 
 	mayInitCnv(tk)
 
-	await mayHydrateFilter(tk)
+	if (tk.filterObj) await Promise.all(rehydrateFilter(tk.filterObj, tk.mds.termdb.vocabApi))
 
 	tk.tklabel.text(tk.mds.label || tk.name)
 
@@ -1014,34 +1015,4 @@ function validateSelectSamples(tk) {
 	}
 	if (typeof a.callback != 'function') throw 'allow2selectSamples.callback() is not function'
 	a._cart = [] // array to hold samples selected so far (e.g. separately from multiple mutations), for submitting to a.callback()
-}
-
-/* hydrate filter by filling tvs term obj.
-only works for dictionary terms e.g. term:{id:'xx'} with id but lacks type etc.
-provides convenience for hand coding dictionary filter
-do not work for non-dict terms! may fix later
-*/
-async function mayHydrateFilter(tk) {
-	if (!tk.filterObj) return
-
-	if (typeof tk.filterObj != 'object') throw 'tk.filterObj{} is set but is not object'
-
-	await hydrate(tk.filterObj)
-
-	async function hydrate(f) {
-		if (f.type == 'tvs') {
-			if (!f.tvs?.term) throw 'tvs.tvs.term missing'
-			if (f.tvs.term.id) {
-				// has term.id. allows term obj to be like {id:'xx'} and assumes it must be dict term
-				f.tvs.term = await tk.mds.termdb.vocabApi.getterm(f.tvs.term.id)
-			}
-			return
-		}
-		if (f.type == 'tvslst') {
-			if (!Array.isArray(f.lst)) throw 'tvslst.lst[] not array'
-			for (const t of f.lst) await hydrate(t)
-			return
-		}
-		throw 'type not tvs or tvslst'
-	}
 }

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -1016,9 +1016,14 @@ function validateSelectSamples(tk) {
 	a._cart = [] // array to hold samples selected so far (e.g. separately from multiple mutations), for submitting to a.callback()
 }
 
+/* hydrate filter by filling tvs term obj.
+only works for dictionary terms e.g. term:{id:'xx'} with id but lacks type etc.
+provides convenience for hand coding dictionary filter
+do not work for non-dict terms! may fix later
+*/
 async function mayHydrateFilter(tk) {
 	if (!tk.filterObj) return
-	// hydrate filter by filling tvs term obj
+
 	if (typeof tk.filterObj != 'object') throw 'tk.filterObj{} is set but is not object'
 
 	await hydrate(tk.filterObj)
@@ -1026,8 +1031,10 @@ async function mayHydrateFilter(tk) {
 	async function hydrate(f) {
 		if (f.type == 'tvs') {
 			if (!f.tvs?.term) throw 'tvs.tvs.term missing'
-			if (!f.tvs.term.id) throw 'tvs.tvs.term.id missing'
-			f.tvs.term = await tk.mds.termdb.vocabApi.getterm(f.tvs.term.id)
+			if (f.tvs.term.id) {
+				// has term.id. allows term obj to be like {id:'xx'} and assumes it must be dict term
+				f.tvs.term = await tk.mds.termdb.vocabApi.getterm(f.tvs.term.id)
+			}
 			return
 		}
 		if (f.type == 'tvslst') {

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -976,7 +976,7 @@ tape('Custom cnv and ssm, WITH sample', test => {
 			test.equal(lab.node().innerHTML, `${set.size} samples`, `Samples leftlabel should print "${set.size} samples"`)
 		}
 
-		if (0 && test._ok) {
+		if (test._ok) {
 			tk.menutip.d.remove()
 			holder.remove()
 		}

--- a/client/plots/genomeBrowser.js
+++ b/client/plots/genomeBrowser.js
@@ -141,7 +141,7 @@ class genomeBrowser {
 				}
 				if (this.state.filter?.lst?.length > 0) {
 					// state has a non-empty filter, register at tk obj to pass to mds3 data queries
-					tk.filterObj = this.state.filter
+					tk.filterObj = structuredClone(this.state.filter)
 					// TODO this will cause mds3 tk to show a leftlabel to indicate the filtering, which should be hidden
 				}
 				await this.launchBlockWithTracks([tk])

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -720,6 +720,7 @@ function setTermActions(self) {
 		const sandbox = newSandboxDiv(self.opts.plotDiv || select(self.opts.holder.node().parentNode))
 		sandbox.header.text(t.tw.term.name)
 		const arg = {
+			debugmode: self.app.opts.state.debug,
 			holder: sandbox.body.append('div').style('margin', '20px'),
 			genome: self.app.opts.genome,
 			nobox: true,
@@ -729,7 +730,8 @@ function setTermActions(self) {
 					type: 'mds3',
 					dslabel: self.app.opts.state.vocab.dslabel,
 					filter0: self.state.filter0,
-					filterObj: self.state.filter
+					// state.filter is frozen. make a copy and pass the writable obj to tk. currently in mds3 it always hydrates filter and modify it
+					filterObj: structuredClone(self.state.filter)
 				}
 			]
 		}

--- a/client/plots/matrix.interactivity.js
+++ b/client/plots/matrix.interactivity.js
@@ -720,7 +720,7 @@ function setTermActions(self) {
 		const sandbox = newSandboxDiv(self.opts.plotDiv || select(self.opts.holder.node().parentNode))
 		sandbox.header.text(t.tw.term.name)
 		const arg = {
-			debugmode: self.app.opts.state.debug,
+			debugmode: self.app.opts.debug,
 			holder: sandbox.body.append('div').style('margin', '20px'),
 			genome: self.app.opts.genome,
 			nobox: true,

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -369,7 +369,7 @@ export function setInteractivity(self) {
 					type: 'mds3',
 					dslabel: self.app.opts.state.vocab.dslabel,
 					filter0: self.state.termfilter.filter0,
-					filterObj: self.state.termfilter.filter
+					filterObj: structuredClone(self.state.termfilter.filter)
 				}
 			]
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,215 @@
         "ppfull": "app-full.js"
       }
     },
+    "container/node_modules/@sindresorhus/is": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-6.3.1.tgz",
+      "integrity": "sha512-FX4MfcifwJyFOI2lPoX7PQxCqx8BG1HCho7WdiXwpEQx1Ycij0JxkfYtGK7yqNScrZGSlt6RE6sw8QYoH7eKnQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "container/node_modules/@sjcrh/proteinpaint-server": {
+      "version": "2.66.0",
+      "resolved": "https://registry.npmjs.org/@sjcrh/proteinpaint-server/-/proteinpaint-server-2.66.0.tgz",
+      "integrity": "sha512-mPpG18g42+Ljakvip2lDU45btnRq+bFiA3Do4ceSSEyGKwLpnm3mT0fTWb7hUm1CEtveUSagKcKWzX6dsZkhJQ==",
+      "dependencies": {
+        "@sjcrh/augen": "2.46.0",
+        "@sjcrh/proteinpaint-rust": "2.61.1",
+        "better-sqlite3": "^9.4.1",
+        "body-parser": "^1.15.2",
+        "canvas": "~2.11.2",
+        "compression": "^1.6.2",
+        "cookie-parser": "^1.4.5",
+        "d3": "^7.6.1",
+        "deep-object-diff": "^1.1.0",
+        "express": "^4.17.1",
+        "express-basic-auth": "^1.1.5",
+        "got": "^14.2.0",
+        "image-size": "^0.5.5",
+        "jsonwebtoken": "^9.0.0",
+        "jstat": "^1.9.3",
+        "ky": "^1.2.1",
+        "lazy": "^1.0.11",
+        "micromatch": "^4.0.5",
+        "minimatch": "^3.1.2",
+        "node-fetch": "^2.6.1",
+        "partjson": "^0.58.2",
+        "tiny-async-pool": "^1.2.0",
+        "typedoc-plugin-missing-exports": "^2.0.1"
+      },
+      "bin": {
+        "proteinpaint-server": "start.js"
+      }
+    },
+    "container/node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "container/node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "container/node_modules/cacheable-request": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-12.0.1.tgz",
+      "integrity": "sha512-Yo9wGIQUaAfIbk+qY0X4cDQgCosecfBe3V9NSyeY4qPC2SAkbCS4Xj79VP8WOzitpJUZKc/wsRCYF5ariDIwkg==",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.4",
+        "get-stream": "^9.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.4",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.1",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "container/node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "container/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "container/node_modules/got": {
+      "version": "14.4.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.4.1.tgz",
+      "integrity": "sha512-IvDJbJBUeexX74xNQuMIVgCRRuNOm5wuK+OC3Dc2pnSoh1AOmgc7JVj7WC+cJ4u0aPcO9KZ2frTXcqK4W/5qTQ==",
+      "dependencies": {
+        "@sindresorhus/is": "^6.3.1",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^12.0.1",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^4.0.2",
+        "get-stream": "^8.0.1",
+        "http2-wrapper": "^2.2.1",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^4.0.1",
+        "responselike": "^3.0.0",
+        "type-fest": "^4.19.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "container/node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "container/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "container/node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "container/node_modules/normalize-url": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "container/node_modules/p-cancelable": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+      "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "container/node_modules/responselike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "container/node_modules/type-fest": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.21.0.tgz",
+      "integrity": "sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "container/server": {
       "name": "@sjcrh/ppserver",
       "version": "2.66.0",
@@ -2941,6 +3150,11 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -9402,6 +9616,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -15059,7 +15284,7 @@
     },
     "server": {
       "name": "@sjcrh/proteinpaint-server",
-      "version": "2.66.0",
+      "version": "2.65.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "@sjcrh/augen": "2.46.0",
@@ -17120,6 +17345,11 @@
           "dev": true
         }
       }
+    },
+    "@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",
@@ -22350,6 +22580,11 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
+    },
+    "is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
     },
     "is-string": {
       "version": "1.0.7",

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Centralize filter rehydration

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -228,17 +228,7 @@ async function get_geneVariant(tvs, CTEname, ds) {
 }
 
 async function get_geneExpression(tvs, CTEname, ds) {
-	const args = {
-		genome: ds.genome,
-		dslabel: ds.label,
-		clusterMethod: 'hierarchical',
-		/** distance method */
-		distanceMethod: 'euclidean',
-		/** Data type */
-		dataType: TermTypes.GENE_EXPRESSION,
-		terms: [{ gene: tvs.term.gene, type: TermTypes.GENE_EXPRESSION }]
-	}
-	const data = await ds.queries.geneExpression.get(args)
+	const data = await ds.queries.geneExpression.get({ terms: [{ gene: tvs.term.gene }] })
 	const samples = []
 	for (const sampleId in data.term2sample2value.get(tvs.term.gene)) {
 		const values = data.term2sample2value.get(tvs.term.gene)

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -43,6 +43,8 @@ export async function getFilterCTEs(filter, ds, CTEname = 'f') {
 		const CTEname_i = CTEname + '_' + i
 		let f
 		if (item.type == 'tvslst') {
+			if (item.lst.length == 0) continue // do not process blank list
+
 			f = await getFilterCTEs(item, ds, CTEname_i)
 			// .filters: str, the CTE cascade, not used here!
 			// .CTEs: [] list of individual CTE string
@@ -78,6 +80,7 @@ export async function getFilterCTEs(filter, ds, CTEname = 'f') {
 		} else {
 			throw 'unknown term type'
 		}
+
 		thislevelCTEnames.push(f.CTEname)
 		CTEs.push(...f.CTEs)
 		values.push(...f.values)


### PR DESCRIPTION
## Description

previously, creating lollipop from [termdbtest matrix](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22debug%22:true,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22AKT1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22sex%22},{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22diaggrp%22},{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22}}]}],%22divideBy%22:{%22id%22:%22sex%22}}]}) breaks, due to trying to modify a frozen filter obj. fixed it with minor change on client and backend

TODO rehydration to support non-dict terms as well 

all mds3 and filter tests work

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
