### PR TITLE
Support overall survival data from gdc

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Support overall survival data from gdc

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1353,8 +1353,7 @@ async function querySamplesSurvival(q, survivalTwLst, ds, samples, geneTwLst) {
 	// the survival term itself is not used in api query, since there's just one type of survival data from gdc and no need to distinguish
 	const { host, headers } = ds.getHostHeaders(q)
 	const re = await ky
-		// hardcoded url in production environment. TODO check if works at all for qa environments
-		.post('https://portal.gdc.cancer.gov/auth/api/v0/analysis/survival', {
+		.post(path.join(host.rest, 'analysis/survival'), {
 			timeout: false,
 			headers,
 			json: { filters: [filter] }

--- a/server/src/termdb.gdc.js
+++ b/server/src/termdb.gdc.js
@@ -152,6 +152,21 @@ export async function initGDCdictionary(ds) {
 	// k: term id, string with full path
 	// v: term obj
 
+	{
+		// declare hardcoded survival term! there is one api https://portal.gdc.cancer.gov/auth/api/v0/analysis/survival that serves one type of surv data, thus one hardcoded term. wip parent_id is not set, later can nest under a branch
+		const id = 'Overall Survival'
+		const term = {
+			id,
+			name: id,
+			type: 'survival',
+			isleaf: true,
+			included_types_set: new Set(), // apply to leaf terms, should have its own term.type
+			child_types_set: new Set() // empty for leaf terms
+		}
+		term.included_types_set.add('survival')
+		id2term.set(id, term)
+	}
+
 	// TODO switch to https://api.gdc.cancer.gov/cases/_mapping
 	const { host, headers } = ds.getHostHeaders()
 	const dictUrl = path.join(host.rest, 'ssm_occurrences/_mapping')
@@ -176,6 +191,7 @@ export async function initGDCdictionary(ds) {
 		categoricalCount = 0,
 		integerCount = 0,
 		floatCount = 0,
+		survivalCount = 0,
 		parentCount = 0
 
 	for (const fieldLine of re.fields) {
@@ -314,6 +330,7 @@ export async function initGDCdictionary(ds) {
 	if (categoricalCount) ds.cohort.termdb.termtypeByCohort.push({ cohort: '', type: 'categorical' })
 	if (integerCount) ds.cohort.termdb.termtypeByCohort.push({ cohort: '', type: 'integer' })
 	if (floatCount) ds.cohort.termdb.termtypeByCohort.push({ cohort: '', type: 'float' })
+	if (survivalCount) ds.cohort.termdb.termtypeByCohort.push({ cohort: '', type: 'survival' })
 
 	/**********************************
 	       additional prepping

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -510,9 +510,15 @@ async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 					value: v[0]
 				}
 			} else if (v != undefined && v != null) {
-				s2[$id] = {
-					key: v,
-					value: v
+				if (typeof v == 'object') {
+					// v is {key,value}, should be for survival term
+					s2[$id] = v
+				} else {
+					// v is number/string, should be for non-survival term
+					s2[$id] = {
+						key: v,
+						value: v
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

at gdc dictionary, Overall Survival is added as the first root term. some improvements to querySamples_gdcapi()

<img width="387" alt="image" src="https://github.com/stjude/proteinpaint/assets/1619109/6cf1c027-99ba-4c57-9064-bb0b96701c26">

adding it to oncomatrix and gene exp clustering seems to work

it doesn't work for [mds3 subtk](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.demographic.gender%22},%22values%22:[{%22key%22:%22female%22}],%22isnot%22:true}}]}) filtering, same reason as unable to use gene exp for sample filtering for gdc (api issue)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
