### PR TITLE
geneVariant edit UI improvements and regression support

### DIFF
--- a/client/plots/controls.divide.js
+++ b/client/plots/controls.divide.js
@@ -45,6 +45,9 @@ class Divide {
 			debug: this.opts.debug,
 			menuOptions: 'all', // to show edit/replace/remove menu upon clicking pill
 			defaultQ4fillTW: this.opts.defaultQ4fillTW,
+			// edit menu of geneVariant term should only display
+			// groupsetting options
+			geneVariantEditMenuOnlyGrp: true,
 			getBodyParams: this.opts.getBodyParams,
 			callback: term0 => {
 				// term0 is {term,q} and can be null

--- a/client/plots/controls.overlay.js
+++ b/client/plots/controls.overlay.js
@@ -47,6 +47,10 @@ class Overlay {
 			// overlay term can be continous for bar/violin; but not for cuminc plot, thus the option
 			numericEditMenuVersion: this.opts.numericEditMenuVersion || ['continuous', 'discrete'],
 
+			// edit menu of geneVariant term should only display
+			// groupsetting options
+			geneVariantEditMenuOnlyGrp: true,
+
 			callback: term2 => {
 				// term2 is {term,q} and can be null
 				this.app.dispatch({

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -111,6 +111,9 @@ export class InputTerm {
 			// this temr is independent
 			// do not allow condition term
 			arg.numericEditMenuVersion = ['continuous', 'discrete', 'spline']
+			// for geneVariant term, only allow groupsetting
+			arg.defaultQ4fillTW['geneVariant'] = { groupsetting: { inuse: true } }
+			arg.geneVariantEditMenuOnlyGrp = true
 			return
 		}
 		throw 'unknown section.configKey: ' + this.section.configKey
@@ -271,7 +274,7 @@ export class InputTerm {
 							.join(', ')}`
 					)
 				}
-			} else if (tw.term.type == 'categorical') {
+			} else if (tw.term.type == 'categorical' || tw.term.type == 'geneVariant') {
 				this.termStatus.allowToSelectRefGrp = true
 			} else if (tw.term.type == 'condition') {
 				if (this.section.configKey == 'outcome' && this.parent.opts.regressionType == 'logistic') {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -584,6 +584,9 @@ export class TermdbVocab extends Vocab {
 		}
 
 		// use same query method for all dictionary terms
+
+		// prepare termwrapper using fillTermWrapper(), which
+		// will also compute a $id for the termwrapper
 		const tw = await fillTermWrapper({ term, q: _body.term1_q || {} }, this)
 		delete _body.term1_q // no longer needed, tw now contains updated q
 		const body = {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -5,6 +5,7 @@ import { getNormalRoot } from '#filter'
 import { isUsableTerm, graphableTypes } from '#shared/termdb.usecase'
 import { throwMsgWithFilePathAndFnName } from '../dom/sayerror'
 import { isDictionaryType } from '#shared/terms'
+import { fillTermWrapper } from '#termsetting'
 
 export class TermdbVocab extends Vocab {
 	// migrated from termdb/store
@@ -574,11 +575,13 @@ export class TermdbVocab extends Vocab {
 		}
 
 		// use same query method for all dictionary terms
+		const tw = await fillTermWrapper({ term, q: _body.term1_q || {} }, this)
+		delete _body.term1_q // no longer needed, tw now contains updated q
 		const body = {
 			getcategories: 1,
 			genome: this.state.vocab.genome,
 			dslabel: this.state.vocab.dslabel,
-			term,
+			tw: this.getTwMinCopy(tw),
 			..._body
 		}
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -139,7 +139,7 @@ export class TermdbVocab extends Vocab {
 
 		for (const _key of ['term0', 'term', 'term2']) {
 			// "term" on client is "term1" at backend
-			const tw = opts[_key]
+			const tw = this.getTwMinCopy(opts[_key])
 			if (!tw) continue
 			const key = _key == 'term' ? 'term1' : _key
 			params.push(key + '_$id=' + encodeURIComponent(tw.$id))
@@ -431,6 +431,8 @@ export class TermdbVocab extends Vocab {
 		// the violin plot may still render when not in session,
 		// but not have an option to list samples
 		const headers = this.mayGetAuthHeaders('termdb')
+		arg.term = this.getTwMinCopy(arg.term)
+		if (arg.divideTw) arg.divideTw = this.getTwMinCopy(arg.divideTw)
 		const body = Object.assign(
 			{
 				getViolinPlotData: 1,
@@ -940,15 +942,15 @@ export class TermdbVocab extends Vocab {
 			genome: this.state.vocab.genome,
 			dslabel: this.state.vocab.dslabel,
 			plotName: opts.name,
-			coordTWs: opts.coordTWs,
+			coordTWs: opts.coordTWs.map(tw => this.getTwMinCopy(tw)),
 			filter: getNormalRoot(opts.filter),
 			embedder: window.location.hostname
 		}
 		if (opts.colorColumn) body.colorColumn = opts.colorColumn
-		if (opts.colorTW) body.colorTW = opts.colorTW
-		if (opts.shapeTW) body.shapeTW = opts.shapeTW
-		if (opts.divideByTW) body.divideByTW = opts.divideByTW
-		if (opts.scaleDotTW) body.scaleDotTW = opts.scaleDotTW
+		if (opts.colorTW) body.colorTW = this.getTwMinCopy(opts.colorTW)
+		if (opts.shapeTW) body.shapeTW = this.getTwMinCopy(opts.shapeTW)
+		if (opts.divideByTW) body.divideByTW = this.getTwMinCopy(opts.divideByTW)
+		if (opts.scaleDotTW) body.scaleDotTW = this.getTwMinCopy(opts.scaleDotTW)
 
 		return await dofetch3('termdb', { headers, body })
 	}

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -143,18 +143,26 @@ export class Vocab {
 	// get a minimum copy of tw
 	// for better GET caching by the browser
 	getTwMinCopy(tw) {
+		if (!tw) return
 		const copy = { $id: tw.$id, term: {}, q: tw.q }
-		if (isDictionaryType(tw.term?.type)) {
-			copy.term.id = tw.term?.id
-			copy.term.name = tw.term?.name
-			copy.term.type = tw.term?.type
-			copy.term.values = tw.term?.values
-		} else {
-			// passing whole tw.term for non-dictionary term because
-			// different term types need different term properties passed
-			// to backend (e.g., geneVariant term needs term.groupsetting,
-			// geneExpression term needs term.chr, term.start, and term.stop)
-			copy.term = tw.term
+		if (tw.term) {
+			if (tw.term.id) copy.term.id = tw.term.id
+			if (tw.term.name) copy.term.name = tw.term.name
+			if (tw.term.type) {
+				copy.term.type = tw.term.type
+				if (isDictionaryType(tw.term.type)) {
+					if (tw.term.values) copy.term.values = tw.term.values
+				} else {
+					if (tw.term.gene) {
+						copy.term.gene = tw.term.gene
+					} else if (tw.term.type.startsWith('gene')) {
+						//quick fix that should be fixed later
+						copy.term.chr = tw.term.chr
+						copy.term.start = tw.term.start
+						copy.term.stop = tw.term.stop
+					}
+				}
+			}
 		}
 		return copy
 	}

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -146,22 +146,21 @@ export class Vocab {
 		if (!tw) return
 		const copy = { $id: tw.$id, term: {}, q: tw.q }
 		if (tw.term) {
-			if (tw.term.id) copy.term.id = tw.term.id
-			if (tw.term.name) copy.term.name = tw.term.name
-			if (tw.term.type) {
-				copy.term.type = tw.term.type
-				if (isDictionaryType(tw.term.type)) {
-					if (tw.term.values) copy.term.values = tw.term.values
-				} else {
-					if (tw.term.gene) {
-						copy.term.gene = tw.term.gene
-					} else if (tw.term.type.startsWith('gene')) {
-						//quick fix that should be fixed later
-						copy.term.chr = tw.term.chr
-						copy.term.start = tw.term.start
-						copy.term.stop = tw.term.stop
-					}
-				}
+			if (isDictionaryType(tw.term.type)) {
+				// dictionary term
+				if (tw.term.id) copy.term.id = tw.term.id
+				if (tw.term.name) copy.term.name = tw.term.name
+				if (tw.term.type) copy.term.type = tw.term.type
+				if (tw.term.values) copy.term.values = tw.term.values
+			} else {
+				// non-dictionary term
+				// pass entire tw.term because different term types need
+				// different term properties passed to backend (e.g.,
+				// geneExpression and metaboliteIntensity terms need
+				// term.bins, but geneVariant term does not)
+				copy.term = structuredClone(tw.term)
+				// remove unnecesssary properties
+				delete copy.term.groupsetting // will get rehydrated on server-side
 			}
 		}
 		return copy

--- a/client/termsetting/handlers/categorical.ts
+++ b/client/termsetting/handlers/categorical.ts
@@ -158,7 +158,7 @@ export function setCategoryMethods(self) {
 		// if (!activeGroup) await new GroupSettingMethods(Object.assign(self, {newMenu: true})).main()
 		// else {
 		//const valGrp = self.grpSet2valGrp(activeGroup)
-		await new GroupSettingMethods(Object.assign(self, { newMenu: true })).main()
+		await new GroupSettingMethods(self).main()
 		// }
 	}
 

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -162,7 +162,7 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 
 	// radio buttons for whether or not to group variants
 	optsDiv.append('div').style('font-weight', 'bold').text('Group variants')
-	const radios = make_radios({
+	make_radios({
 		holder: optsDiv,
 		options: [
 			{ label: 'No variant grouping', value: false, checked: !self.q.groupsetting.inuse },
@@ -182,6 +182,13 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 			}
 		}
 	})
+
+	if (self.opts.geneVariantEditMenuOnlyGrp) {
+		// only show groupsetting options
+		// so that user does not turn off groupsetting
+		optsDiv.style('display', 'none')
+		groupsDiv.style('margin', '10px 0px 0px 00px')
+	}
 
 	if (self.q.groupsetting.inuse) await makeRadiosForGrouping()
 

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -53,11 +53,7 @@ export function getHandler(self: GeneVariantTermSettingInstance) {
 		async postMain() {
 			// for rendering groupsetting menu
 			const body = self.opts.getBodyParams?.() || {}
-			// remove groupsetting from term prior to server request
-			// TODO: implement getTwMinCopy() in getCategories()
-			const term = structuredClone(self.term)
-			delete term.groupsetting
-			const data = await self.vocabApi.getCategories(term, self.filter!, body)
+			const data = await self.vocabApi.getCategories(self.term, self.filter!, body)
 			self.category2samplecount = data.lst
 		}
 	}

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -51,9 +51,13 @@ export function getHandler(self: GeneVariantTermSettingInstance) {
 		},
 
 		async postMain() {
-			//for rendering groupsetting menu
+			// for rendering groupsetting menu
 			const body = self.opts.getBodyParams?.() || {}
-			const data = await self.vocabApi.getCategories(self.term, self.filter!, body)
+			// remove groupsetting from term prior to server request
+			// TODO: implement getTwMinCopy() in getCategories()
+			const term = structuredClone(self.term)
+			delete term.groupsetting
+			const data = await self.vocabApi.getCategories(term, self.filter!, body)
 			self.category2samplecount = data.lst
 		}
 	}

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -25,8 +25,8 @@ Future plans:
 */
 
 type Opts = {
-	holder: HTMLElement // div holder for drag-and-drop
-	hideApply: boolean // whether to hide apply button
+	holder?: HTMLElement // div holder for drag-and-drop
+	hideApply?: boolean // whether to hide apply button
 }
 
 type ItemEntry = {
@@ -69,7 +69,7 @@ export class GroupSettingMethods {
 	data: { groups: GrpEntry[]; values: ItemEntry[] }
 	initGrpSetUI: any //func init for groupsetting UI
 
-	constructor(tsInstance, opts = {}) {
+	constructor(tsInstance, opts: Opts = {}) {
 		this.tsInstance = tsInstance
 		this.opts = opts
 		this.dom = {
@@ -91,6 +91,7 @@ export class GroupSettingMethods {
 			//returns found groups to data.groups and values for groups and excluded groups
 			this.formatCustomset(grpIdxes, input)
 		} else if (this.tsInstance.term.type == 'geneVariant') {
+			// @ts-expect-error, need to harmonize input data structure between dictionary term (no customset), geneVariant term (no custom set), and customset
 			const dt = input.find(i => i.dt == this.tsInstance.q.dt)
 			const classes = dt.classes.byOrigin ? dt.classes.byOrigin[this.tsInstance.q.origin] : dt.classes
 			const groupset = this.tsInstance.term.groupsetting.lst[this.tsInstance.q.groupsetting.predefined_groupset_idx]
@@ -109,6 +110,7 @@ export class GroupSettingMethods {
 							key,
 							label: mclass[key].label,
 							group: grpIdx,
+							// @ts-expect-error, will resolve when input data structure is harmonized (see above)
 							samplecount
 						})
 					}
@@ -208,6 +210,7 @@ export class GroupSettingMethods {
 							key,
 							label: mclass[key].label,
 							group: 0,
+							// @ts-expect-error, will resolve when input data structure is harmonized (see above)
 							samplecount
 						})
 					}

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -375,6 +375,9 @@ function setRenderers(self: any) {
 	}
 
 	self.processDraggables = () => {
+		// if no item was dragged
+		// then do not create custom groups
+		if (!draggedItem) return
 		const customset: any = { groups: [] }
 		for (const group of self.data.groups) {
 			if (group.currentIdx === 0) continue

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -610,7 +610,7 @@ function setInteractivity(self) {
 		type opt = { label: string; callback: (f?: any) => void }
 		const options: opt[] = []
 
-		if (self.q.groupsetting?.inuse && self.q.mode != 'binary') {
+		if (self.q.groupsetting?.inuse && self.q.mode != 'binary' && self.term.type != 'geneVariant') {
 			// this instance is using a categorical term doing groupsetting; add option to cancel it
 			// as categorical edit menu cannot do the canceling
 			options.push({ label: 'Cancel grouping', callback: self.cancelGroupsetting } as opt)

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -921,11 +921,12 @@ export async function fillTermWrapper(
 	// tw.id is no longer needed
 	delete tw.id
 	if (!tw.q) tw.q = {}
-	if (!tw.$id) tw.$id = await get$id(vocabApi.getTwMinCopy(tw))
 	tw.q.isAtomic = true
 	// call term-type specific logic to fill tw
 	await call_fillTW(tw, vocabApi, defaultQByTsHandler)
 	mayValidateQmode(tw)
+	// compute $id after tw is filled
+	if (!tw.$id) tw.$id = await get$id(vocabApi.getTwMinCopy(tw))
 	return tw
 }
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Features
+- support drag-and-drop groupsetting for geneVariant term
+- support geneVariant term in regression analysis

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -91,11 +91,10 @@ async function trigger_getcategories(
 	ds: { assayAvailability: { byDt: { [s: string]: any } | ArrayLike<any> } },
 	genome: any
 ) {
-	const $id = Math.random().toString()
-	const tw: TermWrapper = { $id, term: q.term, q: q.term1_q || getDefaultQ(q.term, q) }
+	const $id = q.tw.$id
 	const arg = {
 		filter: q.filter,
-		terms: [tw],
+		terms: [q.tw],
 		currentGeneNames: q.currentGeneNames, // optional, from mds3 mayAddGetCategoryArgs()
 		rglst: q.rglst // optional, from mds3 mayAddGetCategoryArgs()
 	}
@@ -103,8 +102,8 @@ async function trigger_getcategories(
 	const data = await getData(arg, ds, genome)
 	if (data.error) throw data.error
 
-	const lst = [] as any[]
-	if (q.term.type == 'geneVariant') {
+	const lst: any[] = []
+	if (q.tw.term.type == 'geneVariant') {
 		const samples = data.samples as { [sampleId: string]: any }
 		const dtClassMap = new Map()
 		if (ds.assayAvailability?.byDt) {
@@ -175,17 +174,17 @@ async function trigger_getcategories(
 				key,
 				label:
 					data.refs?.byTermId?.[$id]?.events?.find((e: { event: any }) => e.event === key).label ||
-					q.term?.values?.[key]?.label ||
+					q.tw.term?.values?.[key]?.label ||
 					key
 			})
 		}
 	}
 
 	const orderedLabels = getOrderedLabels(
-		q.term,
+		q.tw.term,
 		data.refs?.byTermId?.[$id]?.bins || [],
 		data.refs?.byTermId?.[$id]?.events,
-		q.term1_q
+		q.tw.q
 	)
 	if (orderedLabels.length) {
 		lst.sort((a, b) => orderedLabels.indexOf(a.label) - orderedLabels.indexOf(b.label))

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -103,7 +103,9 @@ async function trigger_getcategories(
 	if (data.error) throw data.error
 
 	const lst: any[] = []
-	if (q.tw.term.type == 'geneVariant') {
+	if (q.tw.term.type == 'geneVariant' && !q.tw.q.groupsetting.inuse) {
+		// specialized data processing for geneVariant term when
+		// groupsetting is not in use
 		const samples = data.samples as { [sampleId: string]: any }
 		const dtClassMap = new Map()
 		if (ds.assayAvailability?.byDt) {

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -1106,6 +1106,139 @@ export const CNVClasses = Object.values(mclass)
 	.filter(m => m.dt == dtcnv)
 	.map(m => m.key)
 
+/*
+Term groupsetting used for geneVariant term
+NOTE: for each groupsetting, groups[] is ordered by priority
+for example: in the 'Protein-changing vs. rest' groupsetting, the
+'Protein-changing' group is listed first in groups[] so that samples
+that have both missense and silent mutations are classified in the
+'Protein-changing' group
+*/
+export const geneVariantTermGroupsetting = {
+	disabled: false,
+	lst: [
+		{
+			// SNV/indel groupsetting
+			name: 'Mutated vs. wildtype',
+			groups: [
+				{
+					name: 'Mutated',
+					values: mutationClasses
+						.filter(key => key != 'WT' && key != 'Blank')
+						.map(key => {
+							return { key, dt: mclass[key].dt, label: mclass[key].label }
+						})
+				},
+				{
+					name: 'Wildtype',
+					values: [{ key: 'WT', label: 'Wildtype' }]
+				},
+				{
+					name: 'Not tested',
+					values: [{ key: 'Blank', label: 'Not tested' }],
+					uncomputable: true
+				}
+			]
+		},
+		// SNV/indel groupsetting
+		{
+			name: 'Protein-changing vs. rest',
+			groups: [
+				{
+					name: 'Protein-changing',
+					values: proteinChangingMutations.map(key => {
+						return { key, dt: mclass[key].dt, label: mclass[key].label }
+					})
+				},
+				{
+					name: 'Rest',
+					values: Object.keys(mclass)
+						.filter(key => !proteinChangingMutations.includes(key) && key != 'Blank')
+						.map(key => {
+							return { key, dt: mclass[key].dt, label: mclass[key].label }
+						})
+				},
+				{
+					name: 'Not tested',
+					values: [{ key: 'Blank', label: 'Not tested' }],
+					uncomputable: true
+				}
+			]
+		},
+		// SNV/indel groupsetting
+		{
+			name: 'Truncating vs. rest',
+			groups: [
+				{
+					name: 'Truncating',
+					values: truncatingMutations.map(key => {
+						return { key, dt: mclass[key].dt, label: mclass[key].label }
+					})
+				},
+				{
+					name: 'Rest',
+					values: Object.keys(mclass)
+						.filter(key => !truncatingMutations.includes(key) && key != 'Blank')
+						.map(key => {
+							return { key, dt: mclass[key].dt, label: mclass[key].label }
+						})
+				},
+				{
+					name: 'Not tested',
+					values: [{ key: 'Blank', label: 'Not tested' }],
+					uncomputable: true
+				}
+			]
+		},
+		// CNV groupsetting
+		{
+			name: 'Gain vs. Loss vs. LOH vs. Wildtype',
+			groups: [
+				{
+					name: 'Copy number gain',
+					values: [{ key: 'CNV_amp', dt: mclass['CNV_amp'].dt, label: mclass['CNV_amp'].label }]
+				},
+				{
+					name: 'Copy number loss',
+					values: [{ key: 'CNV_loss', dt: mclass['CNV_loss'].dt, label: mclass['CNV_loss'].label }]
+				},
+				{
+					name: 'LOH',
+					values: [{ key: 'CNV_loh', dt: mclass['CNV_loh'].dt, label: mclass['CNV_loh'].label }]
+				},
+				{
+					name: 'Wildtype',
+					values: [{ key: 'WT', label: 'Wildtype' }]
+				},
+				{
+					name: 'Not tested',
+					values: [{ key: 'Blank', label: 'Not tested' }],
+					uncomputable: true
+				}
+			]
+		},
+		// SV fusion groupsetting
+		{
+			name: 'Fusion vs. Wildtype',
+			groups: [
+				{
+					name: 'Fusion transcript',
+					values: [{ key: 'Fuserna', dt: mclass['Fuserna'].dt, label: mclass['Fuserna'].label }]
+				},
+				{
+					name: 'Wildtype',
+					values: [{ key: 'WT', label: 'Wildtype' }]
+				},
+				{
+					name: 'Not tested',
+					values: [{ key: 'Blank', label: 'Not tested' }],
+					uncomputable: true
+				}
+			]
+		}
+	]
+}
+
 export const colorScaleMap = {
 	blueWhiteRed: { domain: [0, 0.5, 1], range: ['blue', 'white', 'red'] },
 	greenWhiteRed: { domain: [0, 0.5, 1], range: ['green', 'white', 'red'] },

--- a/server/shared/types/termsetting.ts
+++ b/server/shared/types/termsetting.ts
@@ -106,6 +106,7 @@ export type TermSettingOpts = BaseTermSettingOpts & {
 	menuOptions: string //all, edit, replace, remove
 	menuLayout?: string //horizonal, all
 	numericEditMenuVersion?: string[]
+	geneVariantEditMenuOnlyGrp?: boolean
 	numericContinuousEditOptions?: NumericContEditOptsEntry[]
 	placeholder?: string
 	placeholderIcon?: string //default '+'

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2466,7 +2466,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				const group = groupset.groups.find(group => {
 					return group.values.some(v => mclasses.includes(v.key))
 				})
-				if (!group) continue
+				if (!group || group.uncomputable) continue
 				// store sample data
 				// key will be the name of the assigned group
 				data.set(sample, {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2309,8 +2309,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 			throw 'no gene or position specified'
 		if (tw.q?.groupsetting?.inuse) {
 			if (!Number.isInteger(tw.q.dt)) throw 'dt is not an integer value'
-			if (!Number.isInteger(tw.q.groupsetting.predefined_groupset_idx))
-				throw 'predefined_groupset_idx is not an integer value'
+			if (!Number.isInteger(tw.q.groupsetting.predefined_groupset_idx) && !tw.q.groupsetting.customset)
+				throw 'invalid predefined_groupset_idx and customset'
 		}
 
 		if (tw.term.subtype == 'snp') {
@@ -2466,8 +2466,9 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				const group = groupset.groups.find(group => {
 					return group.values.some(v => mclasses.includes(v.key))
 				})
-				if (!group) throw 'unable to assign sample to group'
-				// .key will be the name of the assigned group
+				if (!group) continue
+				// store sample data
+				// key will be the name of the assigned group
 				data.set(sample, {
 					sample,
 					[tw.$id]: { key: group.name, label: group.name, value: group.name, values: mlst }

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -21,7 +21,8 @@ import {
 	mclassfusionrna,
 	mclasssv,
 	mclasscnvgain,
-	mclasscnvloss
+	mclasscnvloss,
+	geneVariantTermGroupsetting
 } from '#shared/common.js'
 import { get_samples, get_active_groupset } from './termdb.sql.js'
 import { server_init_db_queries } from './termdb.server.init.js'
@@ -2312,6 +2313,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 			if (!Number.isInteger(tw.q.groupsetting.predefined_groupset_idx) && !tw.q.groupsetting.customset)
 				throw 'invalid predefined_groupset_idx and customset'
 		}
+		// rehydrate term.groupsetting
+		if (!tw.term.groupsetting) tw.term.groupsetting = geneVariantTermGroupsetting
 
 		if (tw.term.subtype == 'snp') {
 			throw 'subtype snp not supported'


### PR DESCRIPTION
## Description

- Implemented drag-and-drop groupsetting for geneVariant edit UI
- Discriminated between predefined and custom groupsetting options in edit UI
- Create `term.groupsetting` for geneVariant term in `shared/common.js` and import on server-side to avoid sending it as part of request.
- Restrict geneVariant term to groupsetting when used as overlay or divideBy term
- Supported geneVariant term in regression analysis

All unit tests and integration tests pass. Please test further.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
