### PR TITLE
Downloading geneExpression and metaboliteIntensity data is allowed in the download use case

### DIFF
--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -30,9 +30,7 @@ const useCasesExcluded = {
 	dataDownload: [
 		//TermTypeGroups.SNP_LOCUS, //this tabs require that the handler for this term type to be implemented
 		//TermTypeGroups.SNP_LIST, //this tabs require that the handler for this term type to be implemented
-		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
+		TermTypeGroups.MUTATION_CNV_FUSION
 	], //Later on can support other term types like snplocus, snplst, geneVariant, non dictionary terms
 	survival: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed


### PR DESCRIPTION
## Description

As @congyu-lu commented out that downloading geneExpression and metaboliteIntensity data was supported by the matrix, I tried restoring these tabs in the dataDownload use case and it works. geneVariant it is still pending.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
