### PR TITLE
default to group.mode = 'mutation' for matrix term group selector

### DIFF
--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -11,7 +11,7 @@ import { make_one_checkbox } from '#dom/checkbox'
 import { showGenesetEdit } from '../dom/genesetEdit.ts' // cannot use '#dom/', breaks
 import { select } from 'd3-selection'
 import { mclass, dt2label, dtsnvindel, dtcnv, dtfusionrna, dtgeneexpression, dtsv } from '#shared/common'
-import { TermTypes, isNumericTerm } from '../shared/terms'
+import { TermTypes, TermTypeGroups, isNumericTerm } from '../shared/terms'
 
 const tip = new Menu({ padding: '' })
 
@@ -1290,14 +1290,12 @@ export class MatrixControls {
 				name: g.name,
 				type: g.type,
 				lst: g.lst.filter(tw => tw.term.type.startsWith('gene')).map(tw => ({ name: tw.term.name })),
-				dataType: s.dataType,
 				mode:
 					this.parent.chartType == 'hierCluster' && (g.type == 'hierCluster' || g.name == s?.termGroupName)
-						? 'expression'
-						: // !!subject to change!!
-						// when group is not clustering, and ds has mutation, defaults to mutation
+						? s.dataType // is clustering group, pass dataType
+						: // !!subject to change!! when group is not clustering, and ds has mutation, defaults to MUTATION_CNV_FUSION
 						this.parent.state.termdbConfig.queries?.snvindel
-						? 'mutation'
+						? TermTypeGroups.MUTATION_CNV_FUSION
 						: '',
 				selected:
 					(this.parent.chartType == 'hierCluster' &&

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1293,7 +1293,7 @@ export class MatrixControls {
 					this.parent.chartType == 'hierCluster' &&
 					(g.type == 'hierCluster' || g.name == this.parent.config.settings.hierCluster?.termGroupName)
 						? 'expression'
-						: '',
+						: 'mutation',
 				selected:
 					(this.parent.chartType == 'hierCluster' &&
 						(g.type == 'hierCluster' ||

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1283,6 +1283,7 @@ export class MatrixControls {
 		//const label = grpDiv.append('label')
 		//label.append('span').html('')
 		const firstGrpWithGeneTw = tg.find(g => g.lst.find(tw => tw.term.type.startsWith('gene')))
+
 		const groups = tg.map((g, index) => {
 			return {
 				index,
@@ -1293,7 +1294,11 @@ export class MatrixControls {
 					this.parent.chartType == 'hierCluster' &&
 					(g.type == 'hierCluster' || g.name == this.parent.config.settings.hierCluster?.termGroupName)
 						? 'expression'
-						: 'mutation',
+						: // !!subject to change!!
+						// when group is not clustering, and ds has mutation, defaults to mutation
+						this.parent.state.termdbConfig.queries?.snvindel
+						? 'mutation'
+						: '',
 				selected:
 					(this.parent.chartType == 'hierCluster' &&
 						(g.type == 'hierCluster' ||

--- a/client/plots/matrix.controls.js
+++ b/client/plots/matrix.controls.js
@@ -1283,16 +1283,16 @@ export class MatrixControls {
 		//const label = grpDiv.append('label')
 		//label.append('span').html('')
 		const firstGrpWithGeneTw = tg.find(g => g.lst.find(tw => tw.term.type.startsWith('gene')))
-
+		const s = this.parent.config.settings.hierCluster
 		const groups = tg.map((g, index) => {
 			return {
 				index,
 				name: g.name,
 				type: g.type,
 				lst: g.lst.filter(tw => tw.term.type.startsWith('gene')).map(tw => ({ name: tw.term.name })),
+				dataType: s.dataType,
 				mode:
-					this.parent.chartType == 'hierCluster' &&
-					(g.type == 'hierCluster' || g.name == this.parent.config.settings.hierCluster?.termGroupName)
+					this.parent.chartType == 'hierCluster' && (g.type == 'hierCluster' || g.name == s?.termGroupName)
 						? 'expression'
 						: // !!subject to change!!
 						// when group is not clustering, and ds has mutation, defaults to mutation
@@ -1301,8 +1301,7 @@ export class MatrixControls {
 						: '',
 				selected:
 					(this.parent.chartType == 'hierCluster' &&
-						(g.type == 'hierCluster' ||
-							(g.name && g.name == this.parent.config.settings.hierCluster?.termGroupName))) ||
+						(g.type == 'hierCluster' || (g.name && g.name == s?.termGroupName))) ||
 					g === firstGrpWithGeneTw
 			}
 		})


### PR DESCRIPTION
## Description

Fixes https://github.com/stjude/proteinpaint/issues/1852

Tested with http://localhost:3000/testrun.html?name=*.unit and `cd client; npm run test:integration`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
