### PR TITLE
snp term type

### DIFF
--- a/client/dom/genesearch.ts
+++ b/client/dom/genesearch.ts
@@ -65,7 +65,7 @@ by calling addGeneSearchbox(), it redirectly returns a RESULT object detailed be
 */
 
 /** "start/stop" are included when entered a coordinate or the coord is mapped from a gene/snp */
-type GeneOrSNPResult = { start: number; stop: number }
+type GeneOrSNPResult = { start: number; stop: number; ref?: string; alt?: [] }
 /** "pos/ref/alt" are included when entered a variant */
 type VariantResult = { pos: number; ref: string; alt: string; isVariant: boolean }
 type ResultArg = (GeneOrSNPResult | VariantResult) & {
@@ -122,6 +122,8 @@ insertion
     chr5:g.171410539_171410540insTCTG
     parse to chr5.171410539.-.TCTG
 */
+
+// TODO: create a new flag or mode for querying a single snp
 
 export function addGeneSearchbox(arg: GeneSearchBoxArg) {
 	const tip = arg.tip,
@@ -393,8 +395,9 @@ export function addGeneSearchbox(arg: GeneSearchBoxArg) {
 		})
 		if (data.error) throw data.error
 		if (!data.results || data.results.length == 0) throw 'Not a gene or SNP'
+		// TODO: if #snps > 1, then display snp hits in a menu
 		const r = data.results[0]
-		getResult({ chr: r.chrom, start: r.chromStart, stop: r.chromEnd }, s)
+		getResult({ chr: r.chrom, start: r.chromStart, stop: r.chromEnd, ref: r.ref, alt: r.alt }, s)
 	}
 
 	const result: Result = {}
@@ -436,6 +439,8 @@ export function addGeneSearchbox(arg: GeneSearchBoxArg) {
 				result.chr = r.chr
 				result.start = r.start
 				result.stop = r.stop
+				if (r.ref) result.ref = r.ref
+				if (r.alt) result.alt = r.alt
 			} else if (r.geneSymbol) {
 				// is only a gene symbol
 				searchbox.property('value', r.geneSymbol)

--- a/client/dom/genesearch.ts
+++ b/client/dom/genesearch.ts
@@ -65,7 +65,7 @@ by calling addGeneSearchbox(), it redirectly returns a RESULT object detailed be
 */
 
 /** "start/stop" are included when entered a coordinate or the coord is mapped from a gene/snp */
-type GeneOrSNPResult = { start: number; stop: number; ref?: string; alt?: [] }
+type GeneOrSNPResult = { start: number; stop: number; ref?: string; alt?: string[] | string }
 /** "pos/ref/alt" are included when entered a variant */
 type VariantResult = { pos: number; ref: string; alt: string; isVariant: boolean }
 type ResultArg = (GeneOrSNPResult | VariantResult) & {

--- a/client/filter/tvs.js
+++ b/client/filter/tvs.js
@@ -2,7 +2,7 @@ import * as rx from '../rx'
 import { select } from 'd3-selection'
 import { Menu } from '../dom/menu'
 import { renderTable } from '../dom/table'
-import { isNumericTerm } from '#shared/terms'
+import { isNumericTerm, isCategoricalTerm } from '#shared/terms'
 
 /*
 ********************** EXPORTED
@@ -60,7 +60,7 @@ class TVS {
 	async setHandler() {
 		if (!this.tvs || !this.tvs.term) return
 		const term = this.tvs.term
-		const type = isNumericTerm(term) ? 'numeric' : term.type // 'categorical', 'condition', 'survival', etc
+		const type = isNumericTerm(term) ? 'numeric' : isCategoricalTerm(term) ? 'categorical' : term.type
 		if (!this.handlerByType[type]) {
 			try {
 				const _ = await import(`./tvs.${type}.js`)

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -568,6 +568,8 @@ function validatePlotTerm(t, vocabApi) {
 			if (!t.q.value_by_max_grade && !t.q.value_by_most_recent && !t.q.value_by_computable_grade)
 				throw 'neither q.value_by_max_grade or q.value_by_most_recent or q.value_by_computable_grade is true'
 			break
+		case TermTypes.SNP:
+			break
 		case 'snplst':
 		case 'snplocus':
 		case 'geneVariant':

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -132,6 +132,8 @@ function setRenderers(self) {
 				break
 			case 'samplelst':
 				break
+			case TermTypes.SNP:
+				break
 			case TermTypes.GENE_EXPRESSION:
 				break
 			case TermTypes.METABOLITE_INTENSITY:

--- a/client/termdb/handlers/snp.ts
+++ b/client/termdb/handlers/snp.ts
@@ -1,0 +1,24 @@
+import { Menu } from '#dom/menu'
+import { addGeneSearchbox } from '../../dom/genesearch.ts'
+
+export class SearchHandler {
+	callback: any
+
+	init(opts) {
+		this.callback = opts.callback
+		const geneSearch = addGeneSearchbox({
+			tip: new Menu({ padding: '0px' }),
+			genome: opts.genomeObj,
+			row: opts.holder,
+			callback: () => this.selectSnp(geneSearch),
+			hideHelp: true,
+			focusOff: true
+		})
+	}
+
+	async selectSnp(geneSearch) {
+		const { chr, start, stop, ref, alt, fromWhat } = geneSearch
+		if (!chr || !start || !stop || !ref || !alt || !fromWhat) throw 'missing snp metadata'
+		this.callback({ id: fromWhat, chr, start, stop, name: fromWhat, ref, alt, type: 'snp' })
+	}
+}

--- a/client/termsetting/handlers/snp.ts
+++ b/client/termsetting/handlers/snp.ts
@@ -1,0 +1,32 @@
+import { VocabApi } from '../../shared/types/index'
+import { SnpTW, SnpQ } from '../../shared/types/terms/snp'
+import { copyMerge } from '../../rx'
+
+/*
+******** EXPORTED ********
+getHandler()
+fillTW()
+*/
+
+export async function getHandler(self) {
+	return {
+		getPillName() {
+			return self.term.name
+		}
+		//getPillStatus()
+	}
+}
+
+export async function fillTW(tw: SnpTW, vocabApi: VocabApi, defaultQ: SnpQ | null = null) {
+	if (typeof tw.term !== 'object') throw 'tw.term is not an object'
+	if (!tw.term.id || !tw.term.name) throw 'missing snp id/name'
+	if (!tw.term.chr || !tw.term.start || !tw.term.stop) throw 'incomplete position information'
+	if (!tw.term.ref || !tw.term.alt) 'missing allele information'
+
+	if (defaultQ) {
+		// merge defaultQ into tw.q
+		copyMerge(tw.q, defaultQ)
+	}
+
+	return tw
+}

--- a/client/termsetting/handlers/snp.ts
+++ b/client/termsetting/handlers/snp.ts
@@ -12,8 +12,10 @@ export async function getHandler(self) {
 	return {
 		getPillName() {
 			return self.term.name
+		},
+		getPillStatus() {
+			return { text: '' }
 		}
-		//getPillStatus()
 	}
 }
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- implemented the "snp" term type for summarizing and analyzing sample genotypes for a given SNP

--- a/server/routes/snp.ts
+++ b/server/routes/snp.ts
@@ -122,6 +122,8 @@ function snp2hit(snp) {
 		chromEnd: Number(fields[2]),
 		name: fields[3],
 		observed: observed,
+		ref: ref,
+		alt: alts,
 		alleles: [ref, ...alts]
 	}
 	return hit

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -13,7 +13,8 @@ export const graphableTypes = new Set([
 	'geneExpression',
 	TermTypes.METABOLITE_INTENSITY,
 	TermTypes.SINGLECELL_GENE_EXPRESSION,
-	TermTypes.SINGLECELL_CELLTYPE
+	TermTypes.SINGLECELL_CELLTYPE,
+	TermTypes.SNP
 ])
 /*
 	isUsableTerm() will

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -72,6 +72,7 @@ const nonDictTypes = new Set([
 	TermTypes.SINGLECELL_GENE_EXPRESSION,
 	TermTypes.SINGLECELL_CELLTYPE
 ])
+
 export const numericTypes = new Set([
 	TermTypes.INTEGER,
 	TermTypes.FLOAT,
@@ -79,6 +80,8 @@ export const numericTypes = new Set([
 	TermTypes.METABOLITE_INTENSITY,
 	TermTypes.SINGLECELL_GENE_EXPRESSION
 ])
+
+const categoricalTypes = new Set([TermTypes.CATEGORICAL, TermTypes.SNP])
 
 const singleSampleTerms = new Set([TermTypes.SINGLECELL_GENE_EXPRESSION])
 
@@ -89,6 +92,10 @@ export function isSingleSampleTerm(term) {
 export function isNumericTerm(term) {
 	if (!term) return false
 	return numericTypes.has(term.type)
+}
+export function isCategoricalTerm(term) {
+	if (!term) return false
+	return categoricalTypes.has(term.type)
 }
 
 export function isDictionaryType(type) {

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -12,6 +12,7 @@ export const TermTypes = {
 	CATEGORICAL: 'categorical',
 	INTEGER: 'integer',
 	FLOAT: 'float',
+	SNP: 'snp',
 	SNP_LIST: 'snplst',
 	SNP_LOCUS: 'snplocus',
 	CONDITION: 'condition',
@@ -39,6 +40,7 @@ export const TermTypeGroups = {
 	METABOLITE_INTENSITY: 'Metabolite Intensity',
 	GSEA: 'GSEA',
 	MUTATION_SIGNATURE: 'Mutation Signature',
+	SNP: 'SNP Genotype',
 	SNP_LIST: 'SNP List',
 	SNP_LOCUS: 'SNP Locus'
 }
@@ -53,6 +55,7 @@ export const typeGroup = {
 	[TermTypes.SAMPLELST]: TermTypeGroups.DICTIONARY_VARIABLES,
 	[TermTypes.SURVIVAL]: TermTypeGroups.DICTIONARY_VARIABLES,
 	[TermTypes.GENE_VARIANT]: TermTypeGroups.MUTATION_CNV_FUSION,
+	[TermTypes.SNP]: TermTypeGroups.SNP,
 	[TermTypes.SNP_LIST]: TermTypeGroups.SNP_LIST,
 	[TermTypes.SNP_LOCUS]: TermTypeGroups.SNP_LOCUS,
 	[TermTypes.GENE_EXPRESSION]: TermTypeGroups.GENE_EXPRESSION,

--- a/server/shared/terms.js
+++ b/server/shared/terms.js
@@ -63,6 +63,7 @@ export const typeGroup = {
 }
 
 const nonDictTypes = new Set([
+	TermTypes.SNP,
 	TermTypes.SNP_LIST,
 	TermTypes.SNP_LOCUS,
 	TermTypes.GENE_EXPRESSION,

--- a/server/shared/types/terms/snp.ts
+++ b/server/shared/types/terms/snp.ts
@@ -1,6 +1,6 @@
-import { TermWrapper } from './tw'
-import { BaseQ, BaseTerm } from './term'
-import { TermSettingInstance } from '../termsetting'
+import { TermWrapper } from './tw.js'
+import { BaseQ, BaseTerm } from './term.js'
+import { TermSettingInstance } from '../termsetting.js'
 
 /*
 For term type 'snp'

--- a/server/shared/types/terms/snp.ts
+++ b/server/shared/types/terms/snp.ts
@@ -1,0 +1,27 @@
+import { TermWrapper } from './tw'
+import { BaseQ, BaseTerm } from './term'
+import { TermSettingInstance } from '../termsetting'
+
+/*
+For term type 'snp'
+*/
+
+export type SnpQ = BaseQ
+
+export type SnpTW = TermWrapper & {
+	q: SnpQ
+	term: SnpTerm
+}
+
+export type SnpTerm = BaseTerm & {
+	chr: string
+	start: number
+	stop: number
+	ref: string
+	alt: string[]
+}
+
+export type SnpTermSettingInstance = TermSettingInstance & {
+	q: SnpQ
+	term: SnpTerm
+}

--- a/server/shared/types/terms/snp.ts
+++ b/server/shared/types/terms/snp.ts
@@ -1,6 +1,6 @@
-import { TermWrapper } from './tw.js'
-import { BaseQ, BaseTerm } from './term.js'
-import { TermSettingInstance } from '../termsetting.js'
+import { TermWrapper } from './tw.ts'
+import { BaseQ, BaseTerm } from './term.ts'
+import { TermSettingInstance } from '../termsetting.ts'
 
 /*
 For term type 'snp'

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -311,9 +311,12 @@ async function queryServerFileBySsmid(q, twLst, ds) {
 			const pos = Number(tmp)
 			if (Number.isNaN(pos)) throw 'no integer position for snvindel from ssm id'
 
-			// new param with rglst as the variant position, also inherit q.tid2value if provided
+			// new param with rglst as the variant position
+			// pos is 0-based start coordinate, to convert to 0-based
+			// region need to set stop coordinate to be pos + 1
+			// also inherit q.tid2value if provided
 			const param = Object.assign({}, q, {
-				rglst: [{ chr, start: pos, stop: pos }]
+				rglst: [{ chr, start: pos, stop: pos + 1 }]
 			})
 
 			const mlst = await ds.queries.snvindel.byrange.get(param)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -119,15 +119,54 @@ async function getSampleData(q) {
 			const data = await q.ds.mayGetGeneVariantData(tw, q)
 
 			for (const [sampleId, value] of data.entries()) {
-				if (!(tw.$id in value)) continue
-				if (!dictTerms.length) {
-					// only create a sample entry/row when it is not already filtered out by not having any dictionary term values
-					// FIXME invalid assumption for data downloading
-					if (!(sampleId in samples)) samples[sampleId] = { sample: sampleId }
+				if (!(sampleId in samples)) samples[sampleId] = { sample: sampleId }
+				samples[sampleId][tw.$id] = value[tw.$id]
+			}
+		} else if (tw.term.type == 'snp') {
+			const arg = {
+				addFormatValues: true,
+				filter0: q.filter0, // hidden filter
+				filterObj: q.filter, // pp filter, must change key name to "filterObj" to be consistent with mds3 client
+				sessionid: q.sessionid
+			}
+			if (!(tw.term.chr && Number.isInteger(tw.term.start) && Number.isInteger(tw.term.stop)))
+				throw 'snp term does not have valid coordinate'
+			arg.rglst = [tw.term]
+			// retrieve variant data
+			// will include all alleles of any snv or indel
+			// that overlaps the given coordinate
+			const _mlst = await q.ds.queries.snvindel.byrange.get(arg)
+			// filter for alleles of queried variant
+			const mlst = _mlst.filter(m => m.pos == tw.term.start && m.ref == tw.term.ref && tw.term.alt.includes(m.alt))
+			// parse sample genotypes
+			// can use mlst[0].samples because .samples[] will
+			// be identical for each element of mlst[]
+			for (const s of mlst[0].samples) {
+				if (!('GT' in s.formatK2v)) throw 'sample must have GT format'
+				const gt = s.formatK2v.GT
+				const alleles = []
+				for (const a of gt.split('/')) {
+					if (!a || a === '.') {
+						// gt is missing
+						// TODO: handle missing gt
+						continue
+					} else {
+						// gt is present
+						// allele is represented as index
+						const i = Number(a)
+						if (i === 0) {
+							// ref allele
+							alleles.push(tw.term.ref)
+						} else {
+							// alt allele
+							const m = mlst.find(m => i === m.altAlleleIdx)
+							if (!m) throw 'alt allele idx cannot be found'
+							alleles.push(m.alt)
+						}
+					}
 				}
-				if (samples[sampleId]) {
-					samples[sampleId][tw.$id] = value[tw.$id]
-				}
+				if (!(s.sample_id in samples)) samples[s.sample_id] = { sample: s.sample_id }
+				samples[s.sample_id][tw.$id] = { key: alleles.join('/'), value: alleles.join('/') }
 			}
 		} else if (tw.term.type == 'snplst' || tw.term.type == 'snplocus') {
 			const sampleFilterSet = await mayGetSampleFilterSet4snplst(q, nonDictTerms) // conditionally returns a set of sample ids, FIXME *only* for snplst and snplocus data download in supported ds, not for anything else. TODO remove this bad quick fix


### PR DESCRIPTION
## Description

This PR creates a new term type called `snp`, which summarizes the genotypes of samples for a given SNP. Now, a single SNP can be searched by rsID and sample genotypes can be plotted, analyzed, and filtered. Both bi-allelic and multi-allelic SNPs are supported.

The `snp` term type is supported in the sjlife dataset (see corresponding [sjpp PR](https://github.com/stjude/sjpp/pull/417)). Can test by going to http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22}, open data dictionary, and select the `SNP genotype` tab.

SNPs for testing:
- Bi-allelic SNP: rs1641548
- Multi-allelic SNP: rs370886766  (use the SJLIFE+CCSS cohort to see the presence of the second alternative allele)

Can test with multiple different chart types and with the FILTER and GROUPS tabs.

Will address the following in next PR:
- Support querying SNPs by position
- If a SNP query yields multiple SNP hits, render hits in a menu to allow user to select one
- Implement edit menu (groupsetting)
- Also summarize missing genotypes (will hide by default on client-side)
- Support SNP genotype in cumulative incidence analysis, which currently does not use `getData()`


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
