### PR TITLE
may pass unfrozen term, q to term1 pill to allow setting additional t…

### DIFF
--- a/client/plots/controls.divide.js
+++ b/client/plots/controls.divide.js
@@ -2,7 +2,7 @@ import { getCompInit } from '../rx'
 import { termsettingInit } from '#termsetting'
 import { Menu } from '../dom/menu'
 import { getNormalRoot } from '#filter'
-import { TermTypes } from '#shared/terms.js'
+import { TermTypes, isDictionaryType } from '#shared/terms.js'
 
 /*
 model after overlay2.js
@@ -90,11 +90,17 @@ class Divide {
 			filter: this.state.filter,
 			disable_terms: [plot.term]
 		}
+
 		if (plot.term0) {
-			a.term = plot.term0.term
-			a.q = plot.term0.q
+			const isDictTerm = isDictionaryType(plot.term0.term.type)
+			// assume that dictionary tw are complete after fillTermWrapper(),
+			// whereas non-dictionary terms may require additional term/q properties
+			// to be added when the pill edit UI is opened, so term/q must not be frozen
+			a.term = isDictTerm ? plot.term0.term : structuredClone(plot.term0.term)
+			a.q = isDictTerm ? plot.term0.q : structuredClone(plot.term0.q || {})
 			a.disable_terms.push(plot.term0)
 		}
+
 		if (plot.term2) a.disable_terms.push(plot.term2)
 		if (!this.pill) this.initPill()
 		this.pill.main(a)

--- a/client/plots/controls.overlay.js
+++ b/client/plots/controls.overlay.js
@@ -2,6 +2,7 @@ import { getCompInit } from '../rx'
 import { termsettingInit } from '#termsetting'
 import { Menu } from '#dom/menu'
 import { getNormalRoot } from '#filter'
+import { isDictionaryType } from '#shared/terms'
 
 /*
 options for term2:
@@ -108,8 +109,12 @@ class Overlay {
 		}
 
 		if (plot.term2) {
-			a.term = plot.term2.term
-			a.q = plot.term2.q
+			const isDictTerm = isDictionaryType(plot.term2.term.type)
+			// assume that dictionary tw are complete after fillTermWrapper(),
+			// whereas non-dictionary terms may require additional term/q properties
+			// to be added when the pill edit UI is opened, so term/q must not be frozen
+			a.term = isDictTerm ? plot.term2.term : structuredClone(plot.term2.term)
+			a.q = isDictTerm ? plot.term2.q : structuredClone(plot.term2.q || {})
 			a.disable_terms.push(plot.term2)
 		}
 		if (plot.term0) a.disable_terms.push(plot.term0)

--- a/client/plots/controls.term1.js
+++ b/client/plots/controls.term1.js
@@ -1,7 +1,7 @@
 import { getCompInit } from '../rx'
 import { termsettingInit } from '#termsetting'
 import { getNormalRoot } from '#filter'
-import { TermTypes } from '#shared/terms'
+import { TermTypes, isDictionaryType } from '#shared/terms'
 
 /*
 for configuring term1; wraps termsetting
@@ -146,9 +146,15 @@ function setRenderers(self) {
 				throw 'unknown term type'
 		}
 		if (!self.pill) self.setPill()
+		const isDictTerm = isDictionaryType(plot.term.term.type)
+		// assume that dictionary tw are complete after fillTermWrapper(),
+		// whereas non-dictionary terms may require additional term/q properties
+		// to be added when the pill edit UI is opened, so term/q must not be frozen
+		const term = isDictTerm ? plot.term.term : structuredClone(plot.term.term)
+		const q = isDictTerm ? plot.term.q : structuredClone(plot.term.q)
 		await self.pill.main({
-			term: plot.term.term,
-			q: plot.term.q,
+			term,
+			q,
 			activeCohort: this.state.activeCohort,
 			filter: this.state.filter
 			// no need for disable_terms as pill won't show tree

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -991,15 +991,13 @@ export class TermdbVocab extends Vocab {
 		//TODO use the PresetNumericBins type for defaultBins
 		const defaultBins = await this.getDefaultBins({ tw })
 		if ('error' in defaultBins) throw defaultBins.error
-
-		const termIsFrozen = Object.isFrozen(tw.term)
-		if (termIsFrozen) tw.term = structuredClone(tw.term)
-
+		// NOTE: if tw.term is frozen, creating an unfrozen copy here will
+		// not propagate changes to tw.term, since term.bins would be set
+		// for the copy and not the original tw.term
 		tw.term.bins = defaultBins
 		const currMode = tw.q.mode // record current mode before q{} is overriden
 		tw.q = tw.term.bins.default
 		tw.q.mode = currMode
-		if (termIsFrozen) Object.freeze(tw.term)
 	}
 
 	async getSingleSampleData(opts) {

--- a/client/termsetting/handlers/numeric.toggle.ts
+++ b/client/termsetting/handlers/numeric.toggle.ts
@@ -46,10 +46,6 @@ export async function getHandler(self) {
 		if (!tab) return
 		if (!self.q) throw `Missing .q{} [numeric.toggle getHandler()]`
 		self.q.mode = tab.mode
-		if (tab.mode == 'discrete' && !self.term.bins) {
-			const tw = { term: self.term, q: self.q }
-			await self.vocabApi.setTermBins(tw)
-		}
 		const typeMode = `numeric.${tab.mode}`
 		if (!self.handlerByType![typeMode]) {
 			const _: HandlerGenerator = await import(`./numeric.${tab.mode}.ts`)
@@ -73,12 +69,6 @@ export async function getHandler(self) {
 	}
 
 	if (self.opts.numericEditMenuVersion!.includes('discrete')) {
-		if (!self.term.bins && self.term.type !== 'survival') {
-			// make the defaultBins request only when 'discrete' tab presents
-			const tw = { term: self.term, q: self.q }
-			await self.vocabApi.setTermBins(tw)
-		}
-
 		tabs.push({
 			mode: 'discrete',
 			label: self.term.type == 'survival' ? 'Exit code' : 'Discrete',

--- a/client/termsetting/handlers/numeric.toggle.ts
+++ b/client/termsetting/handlers/numeric.toggle.ts
@@ -46,6 +46,10 @@ export async function getHandler(self) {
 		if (!tab) return
 		if (!self.q) throw `Missing .q{} [numeric.toggle getHandler()]`
 		self.q.mode = tab.mode
+		if (tab.mode == 'discrete' && !self.term.bins) {
+			const tw = { term: self.term, q: self.q }
+			await self.vocabApi.setTermBins(tw)
+		}
 		const typeMode = `numeric.${tab.mode}`
 		if (!self.handlerByType![typeMode]) {
 			const _: HandlerGenerator = await import(`./numeric.${tab.mode}.ts`)

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -545,8 +545,7 @@ function setInteractivity(self) {
 						if (option.q) self.q = structuredClone(option.q)
 						await self.setHandler!(option.termtype)
 						if (isNumericTerm(self.term) && !self.term.bins && self.term.type != 'survival') {
-							const tw = { term: self.term, q: self.q }
-							await self.vocabApi.setTermBins(tw)
+							await self.vocabApi.setTermBins({ term: self.term, q: self.q })
 						}
 						self.handler!.showEditMenu(self.dom.tip.d)
 					} else {
@@ -626,8 +625,7 @@ function setInteractivity(self) {
 				label: 'Edit',
 				callback: async div => {
 					if (self.term && isNumericTerm(self.term) && !self.term.bins && self.term.type != 'survival') {
-						const tw = { term: self.term, q: self.q }
-						await self.vocabApi.setTermBins(tw)
+						await self.vocabApi.setTermBins({ term: self.term, q: self.q })
 					}
 					self.handler!.showEditMenu(div)
 				}

--- a/server/src/termdb.getDefaultBins.js
+++ b/server/src/termdb.getDefaultBins.js
@@ -1,0 +1,59 @@
+import { TermTypes } from '#shared/terms.js'
+import initBinConfig from '#shared/termdb.initbinconfig'
+
+export async function trigger_getDefaultBins(q, ds, res) {
+	/* only works for non-dict terms declared in ds.queries{}
+NOTE using following pattern:
+	1. tw.term.type identical key is used both for ds.queries{} as well as bin cache named `[type]2bins`
+	2. bin cache is indexed by term.name
+CAUTION if a datatype naming in ds.queries{} cannot follow this pattern then it breaks!
+*/
+	const tw = q.tw
+	const lst = []
+	let min = Infinity
+	let max = -Infinity
+	let binsCache
+	try {
+		if (tw.term.type == TermTypes.SINGLECELL_GENE_EXPRESSION) {
+			if (!ds.queries?.singleCell?.geneExpression) throw 'term type not supported by this dataset'
+			binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample]
+			if (!binsCache) binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample] = {}
+			else if (binsCache[tw.term.gene]) return res.send(binsCache[tw.term.gene])
+			const args = {
+				sample: tw.term.sample,
+				gene: tw.term.gene
+			}
+			const data = await ds.queries.singleCell.geneExpression.get(args)
+			for (const cell in data) {
+				const value = data[cell]
+				if (value < min) min = value
+				if (value > max) max = value
+				lst.push(value)
+			}
+		} else {
+			if (!ds.queries?.[tw.term.type]) throw 'term type not supported by this dataset'
+			binsCache = ds.queries[tw.term.type][`${tw.term.type}2bins`]
+			if (binsCache[tw.term.name]) return res.send(binsCache[tw.term.name])
+
+			const args = {
+				genome: q.genome,
+				dslabel: q.dslabel,
+				terms: [tw.term]
+			}
+			const data = await ds.queries[tw.term.type].get(args)
+			const termData = data.term2sample2value.get(tw.term.name)
+			for (const sample in termData) {
+				const value = termData[sample]
+				if (value < min) min = value
+				if (value > max) max = value
+				lst.push(value)
+			}
+		}
+		const binconfig = initBinConfig(lst)
+		binsCache[tw.term.name] = { default: binconfig, min, max }
+		res.send({ default: binconfig, min, max })
+	} catch (e) {
+		console.log(e)
+		res.send({ error: e.message || e })
+	}
+}

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -14,8 +14,8 @@ import { authApi } from './auth.js'
 import { getResult as geneSearch } from './gene.js'
 import { searchSNP } from '../routes/snp.ts'
 import { get_samples_ancestry, get_samples } from './termdb.sql.js'
-import { TermTypeGroups, TermTypes } from '#shared/terms.js'
-import initBinConfig from '#shared/termdb.initbinconfig'
+import { TermTypeGroups } from '#shared/terms.js'
+import { trigger_getDefaultBins } from './termdb.getDefaultBins.js'
 /*
 ********************** EXPORTED
 handle_request_closure
@@ -450,61 +450,4 @@ async function LDoverlay(q, ds, res) {
 		}
 	})
 	res.send({ lst })
-}
-
-async function trigger_getDefaultBins(q, ds, res) {
-	/* only works for non-dict terms declared in ds.queries{}
-NOTE using following pattern:
-	1. tw.term.type identical key is used both for ds.queries{} as well as bin cache named `[type]2bins`
-	2. bin cache is indexed by term.name
-CAUTION if a datatype naming in ds.queries{} cannot follow this pattern then it breaks!
-*/
-	const tw = q.tw
-	const lst = []
-	let min = Infinity
-	let max = -Infinity
-	let binsCache
-	try {
-		if (tw.term.type == TermTypes.SINGLECELL_GENE_EXPRESSION) {
-			if (!ds.queries?.singleCell?.geneExpression) throw 'term type not supported by this dataset'
-			binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample]
-			if (!binsCache) binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample] = {}
-			else if (binsCache[tw.term.gene]) return res.send(binsCache[tw.term.gene])
-			const args = {
-				sample: tw.term.sample,
-				gene: tw.term.gene
-			}
-			const data = await ds.queries.singleCell.geneExpression.get(args)
-			for (const cell in data) {
-				const value = data[cell]
-				if (value < min) min = value
-				if (value > max) max = value
-				lst.push(value)
-			}
-		} else {
-			if (!ds.queries?.[tw.term.type]) throw 'term type not supported by this dataset'
-			binsCache = ds.queries[tw.term.type][`${tw.term.type}2bins`]
-			if (binsCache[tw.term.name]) return res.send(binsCache[tw.term.name])
-
-			const args = {
-				genome: q.genome,
-				dslabel: q.dslabel,
-				terms: [tw.term]
-			}
-			const data = await ds.queries[tw.term.type].get(args)
-			const termData = data.term2sample2value.get(tw.term.name)
-			for (const sample in termData) {
-				const value = termData[sample]
-				if (value < min) min = value
-				if (value > max) max = value
-				lst.push(value)
-			}
-		}
-		const binconfig = initBinConfig(lst)
-		binsCache[tw.term.name] = { default: binconfig, min, max }
-		res.send({ default: binconfig, min, max })
-	} catch (e) {
-		console.log(e)
-		res.send({ error: e.message || e })
-	}
 }


### PR DESCRIPTION
…erm/q props on non-dictionary terms when edit menu is rendered

Tested with http://localhost:3000/testrun.html?name=*.unit and `cd client; npm run test:integration`. Also with geneExpression term summary plot, opens as violin plot, pill edit menu/toggle to `Discrete` mode should work without error.

NOTE: Won't fix here unrelated geneExpression pill UI issue that may be missing defaultQ, such as sampleScatter shape input.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
