### PR TITLE
fix: pass filter0 at sampleScatter to enable gdc gene exp plot, remov…

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -129,6 +129,7 @@ class Scatter {
 			filter: this.getFilter(),
 			coordTWs
 		}
+		if (this.state.termfilter.filter0) opts.filter0 = this.state.termfilter.filter0
 		if (c.colorColumn) opts.colorColumn = c.colorColumn
 		if (c.shapeTW) opts.shapeTW = c.shapeTW
 		if (c.scaleDotTW) {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -958,6 +958,7 @@ export class TermdbVocab extends Vocab {
 			plotName: opts.name,
 			coordTWs: opts.coordTWs.map(tw => this.getTwMinCopy(tw)),
 			filter: getNormalRoot(opts.filter),
+			filter0: opts.filter0,
 			embedder: window.location.hostname
 		}
 		if (opts.colorColumn) body.colorColumn = opts.colorColumn

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- pass filter0 at sampleScatter to enable gdc gene exp plot, remove duplicating backend call for gene exp data

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -216,7 +216,8 @@ async function getSamples(req, ds, plot) {
 	}
 }
 
-/* on coordTwData and otherData:
+/*
+on coordTwData and otherData:
 for prebuilt map:
 	coordTwData is undefined
 	otherData is set
@@ -225,6 +226,8 @@ for coord-by-tw:
 	otherData may be set or missing, if no color/shape term etc is requested
 
 to look up color/shape info, always use otherData.refs{}
+
+using such two objects is confusing, but is necessary in the case of gdc two-gene exp plot to avoid duplicating exp data queries which breaks the app
 */
 async function colorAndShapeSamples(refSamples, cohortSamples, coordTwData, otherData, q) {
 	const results = {}


### PR DESCRIPTION
…e duplicating backend call for gene exp data

## Description

[gdc gene exp scatter works](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:%22Gliomas%22}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22,%22name%22:%22TP53%22},%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22AKT1%22,%22name%22:%22AKT1%22},%22q%22:{%22mode%22:%22continuous%22}}}]}), on master this takes long time with duplicated calls to entire cohort, and for some reason the plot won't show

known issue with such gdc plot: adding colorTW breaks

samplescatter CI passed


please examine and test

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
