### PR TITLE
fix: allow GDC gene exp scatter plot to show case name

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- allow GDC gene exp scatter plot to show case name

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -791,6 +791,7 @@ export type UrlTemplateSsm = UrlTemplateBase & {
 type Termdb = {
 	/** Terms */
 	termIds?: TermIds
+	/** if true, backend is allowed to send sample names to client in charts */
 	displaySampleIds?: boolean
 	converSampleIds?: boolean
 	allowedTermTypes?: string[]

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -323,7 +323,7 @@ async function get_matrix(q, req, res, ds, genome) {
 	if (authApi.canDisplaySampleIds(req, ds)) {
 		if (data.samples)
 			for (const sample of Object.values(data.samples)) {
-				sample.sampleName = ds.sampleId2Name.get(sample.sample)
+				sample.sampleName = data.refs.bySampleId?.[sample.sample]?.label || sample.sample
 			}
 	}
 	res.send(data)

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -459,7 +459,9 @@ async function getSampleCoordinatesByTerms(req, q, ds, data) {
 		}
 
 		const sample = { sampleId, x: Number(x), y: Number(y), z: Number(z) } // TODO do not pass z when no divideByTW
-		if (canDisplay) sample.sample = ds.sampleId2Name.get(Number(sampleId))
+		if (canDisplay) {
+			sample.sample = data.refs.bySampleId[sampleId]?.label || sampleId
+		}
 		samples.push(sample)
 	}
 	return [samples, data]


### PR DESCRIPTION
## Description

closes #1887
please pull sjpp master
[test link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:%22Gliomas%22}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22idh1%22},%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22egfr%22},%22q%22:{%22mode%22:%22continuous%22}}}]}). replaced a `ds.sampleId2Name` usage following getData() call

all CI and gdc tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
