### PR TITLE
fix: GDC gene exp clustering gene selection step sets min_median_log2…

### DIFF
--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -221,7 +221,8 @@ async function geneExpression_getGenes(genes, cases4clustering, genome, ds, q) {
 				json: {
 					case_ids: cases4clustering,
 					gene_ids: ensgLst,
-					selection_size: ensgLst.length
+					selection_size: ensgLst.length,
+					min_median_log2_uqfpkm: 0.01
 				}
 			})
 			.json()


### PR DESCRIPTION
…_uqfpkm cutoff close to 0 rather than 1, so it will not drop many genes

## Description
closes #1899 

with [this link](http://localhost:3000/example.gdc.exp.html?&cohort=custom1&genes=GRIN2B,GRIN2A,GRIN2D,GRIN3B,GRIN1,GRINA,GRIN2C,GRIN3A), all 6 genes are shown
please test if it impacts other gdc exp examples


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
