### PR TITLE
enable filter0 for getdescrstats route and fix tsc errors

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -270,7 +270,7 @@ class Barchart {
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
 			if (isNumericTerm(t.term)) {
-				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter.filter)
+				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
 			}

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -301,7 +301,11 @@ class ViolinPlot {
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
 			if (isNumericTerm(t.term)) {
-				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter.filter, this.config.settings)
+				const data = await this.app.vocabApi.getDescrStats(
+					t,
+					this.state.termfilter,
+					this.config.settings?.violin?.unit == 'log'
+				)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
 			}

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -482,17 +482,18 @@ export class TermdbVocab extends Vocab {
 		return await dofetch3('termdb/getpercentile', { body })
 	}
 
-	async getDescrStats(tw, filter, settings) {
-		// for a numeric term, get descriptive statistics
-		// mean, median, standard deviation, min, max
+	async getDescrStats(tw, termfilter, logScale) {
+		// for a numeric term, get descriptive statistics e.g mean, median, standard deviation, min, max
+		// logScale is boolean
 		const body = {
 			tw,
 			genome: this.vocab.genome,
-			dslabel: this.vocab.dslabel,
-			settings
+			dslabel: this.vocab.dslabel
 		}
-		if (filter) {
-			body.filter = getNormalRoot(filter)
+		if (logScale) body.logScale = true
+		if (termfilter) {
+			if (termfilter.filter) body.filter = getNormalRoot(termfilter.filter)
+			if (termfilter.filter0) body.filter0 = termfilter.filter0
 		}
 		return await dofetch3('/termdb/descrstats', { body })
 	}

--- a/server/shared/types/routes/termdb.getdescrstats.ts
+++ b/server/shared/types/routes/termdb.getdescrstats.ts
@@ -1,14 +1,21 @@
 import { Filter } from '../filter.ts'
+import { TermWrapper } from '../terms/tw.ts'
+import { ErrorResponse } from './errorResponse.ts'
 
 export type getdescrstatsRequest = {
-	/** a user-defined genome label in the serverconfig.json, hg38, hg19, mm10, etc */
+	/** genome label in the serverconfig.json */
 	genome: string
-	/** a user-defined dataset label in the serverconfig.json, such as ClinVar, SJLife, GDC, etc */
+	/** dataset label for the given genome */
 	dslabel: string
 	embedder: string
-	/** term id string */
-	tid: string
-	filter: Filter
+	/** wrapper of a numeric term, q.mode can be any as getData() will always pull sample-level values for summarizing */
+	tw: TermWrapper
+	/** if true, the (violin) plot is in log scale and must exclude 0-values from the stat */
+	logScale?: boolean
+	/** optional pp filter */
+	filter?: Filter
+	/** optional gdc filter */
+	filter0?: any
 }
 
 interface entries {
@@ -17,6 +24,8 @@ interface entries {
 	value: number
 }
 
-export type getdescrstatsResponse = {
+type ValidResponse = {
 	values: entries[]
 }
+
+export type getdescrstatsResponse = ValidResponse | ErrorResponse


### PR DESCRIPTION
## Description

closes #1907 
test [gdc exp link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22,%22name%22:%22TP53%22}}}]}), which shows data from 912 gliomas and correctly indicated in stats. previous stat shows 22K samples. this also speeds up gdc api response

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
