### PR TITLE
enable geneExp for cuminc

### DIFF
--- a/client/plots/controls.overlay.js
+++ b/client/plots/controls.overlay.js
@@ -2,7 +2,7 @@ import { getCompInit } from '../rx'
 import { termsettingInit } from '#termsetting'
 import { Menu } from '#dom/menu'
 import { getNormalRoot } from '#filter'
-import { isDictionaryType } from '#shared/terms'
+import { TermTypes, isDictionaryType } from '#shared/terms'
 
 /*
 options for term2:
@@ -33,7 +33,10 @@ class Overlay {
 	}
 	initPill() {
 		if (!this.opts.defaultQ4fillTW) this.opts.defaultQ4fillTW = {}
-		this.opts.defaultQ4fillTW['geneVariant'] = { groupsetting: { inuse: true } } // geneVariant term should always use groupsetting when used as overlay term
+		this.opts.defaultQ4fillTW[TermTypes.GENE_VARIANT] = { groupsetting: { inuse: true } }
+		this.opts.defaultQ4fillTW[TermTypes.GENE_EXPRESSION] = { mode: 'discrete' }
+		this.opts.defaultQ4fillTW[TermTypes.METABOLITE_INTENSITY] = { mode: 'discrete' }
+
 		this.pill = termsettingInit({
 			vocabApi: this.app.vocabApi,
 			vocab: this.state.vocab,

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -26,7 +26,6 @@ const useCasesExcluded = {
 		TermTypeGroups.SNP_LOCUS,
 		TermTypeGroups.SNP_LIST,
 		TermTypeGroups.MUTATION_CNV_FUSION,
-		TermTypeGroups.GENE_EXPRESSION,
 		TermTypeGroups.METABOLITE_INTENSITY
 	],
 	dataDownload: [

--- a/client/termdb/handlers/geneExpression.ts
+++ b/client/termdb/handlers/geneExpression.ts
@@ -13,9 +13,7 @@ export class SearchHandler {
 			genome: opts.genomeObj,
 			row: opts.holder,
 			geneOnly: true,
-			callback: () => this.selectGene(geneSearch.geneSymbol),
-			hideHelp: true,
-			focusOff: true
+			callback: () => this.selectGene(geneSearch.geneSymbol)
 		})
 	}
 

--- a/client/termdb/handlers/geneVariant.ts
+++ b/client/termdb/handlers/geneVariant.ts
@@ -10,9 +10,7 @@ export class SearchHandler {
 			tip: new Menu({ padding: '0px' }),
 			genome: opts.genomeObj,
 			row: opts.holder,
-			callback: () => this.selectGene(geneSearch),
-			hideHelp: true,
-			focusOff: true
+			callback: () => this.selectGene(geneSearch)
 		})
 	}
 

--- a/client/termdb/handlers/snp.ts
+++ b/client/termdb/handlers/snp.ts
@@ -12,9 +12,7 @@ export class SearchHandler {
 			row: opts.holder,
 			snpOnly: true,
 			allowVariant: true,
-			callback: () => this.selectSnp(geneSearch),
-			hideHelp: true,
-			focusOff: true
+			callback: () => this.selectSnp(geneSearch)
 		})
 	}
 

--- a/server/src/termdb.cuminc.js
+++ b/server/src/termdb.cuminc.js
@@ -33,8 +33,8 @@ export async function get_incidence(q, ds) {
 			if (q[termnum] && !(termnum_$id in q)) {
 				// $id of edited term is undefined and will not get
 				// passed to backend
-				// as a quick fix, use term.id as $id
-				q[termnum_$id] = q[termnum].id
+				// as a quick fix, fill $id with term id or name
+				q[termnum_$id] = q[termnum].id || q[termnum].name
 			}
 
 			if (q[termnum]) twLst.push({ $id: q[termnum_$id], term: q[termnum], q: q[termnum_q] })


### PR DESCRIPTION
## Description

closes #1932 

[cuminc link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Cardiovascular%20System%22,%22q%22:{%22breaks%22:[1]}}}],%22nav%22:{%22activeTab%22:1}}). add gene BCR as overlay works. 

FIXME changing overlay gene to custom bins breaks with a backend err. please help fix

[survival overlay](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38-test%22,%22plots%22:[{%22chartType%22:%22survival%22,%22term2%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22},%22q%22:{%22mode%22:%22discrete%22}},%22term%22:{%22id%22:%22efs%22}}]}) works, for both regular and custom bins of the gene exp term

also made a change at Term type select UI, upon choosing a tab, the gene search box is auto focused

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
