### PR TITLE
bug fix to allow to add survival term to GDC gene exp map

### DIFF
--- a/client/plots/test/expclust.gdc.spec.js
+++ b/client/plots/test/expclust.gdc.spec.js
@@ -7,7 +7,7 @@ import { select } from 'd3-selection'
 /**************
  test sections
 
-TME genes and dictionary variables
+TME genes and dictionary variables, survival
 gdc laucher with top variably expressed genes, for gliomas
 
 ***************/
@@ -16,7 +16,7 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('TME genes and dictionary variables', function (test) {
+tape('TME genes and dictionary variables, survival', function (test) {
 	test.timeoutAfter(60000)
 	runpp({
 		state: {
@@ -285,4 +285,9 @@ const TMEgenes = [
 	{ gene: 'KIF2C' },
 	{ gene: 'CDCA8' }
 ]
-const dictTerms = [{ id: 'case.disease_type' }, { id: 'case.primary_site' }, { id: 'case.demographic.gender' }]
+const dictTerms = [
+	{ id: 'case.disease_type' },
+	{ id: 'case.primary_site' },
+	{ id: 'case.demographic.gender' },
+	{ id: 'Overall Survival' }
+]

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Allow to add survival term to GDC gene expression clustering map


### PR DESCRIPTION
## Description

closes #1909. thanks for spotting the issue
tested both oncomatrix and gene exp to work. survival term is now included in [non-ci test](http://localhost:3000/testrun.html?dir=plots&name=expclust.gdc)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
