### PR TITLE
fix: pp and gdc filter are passed to getDefaultBin request for gene e…

### DIFF
--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -966,16 +966,17 @@ export class TermdbVocab extends Vocab {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
 		const headers = this.mayGetAuthHeaders('termdb')
-
-		// dofetch* mayAdjustRequest() will automatically
-		// convert to GET query params or POST body, as needed
 		const body = {
 			for: 'getDefaultBins',
 			genome: this.state.vocab.genome,
 			dslabel: this.state.vocab.dslabel,
 			tw: opts.tw,
-
 			embedder: window.location.hostname
+		}
+		const tf = this.opts?.state?.termfilter
+		if (tf) {
+			if (tf.filter) body.filter = getNormalRoot(tf.filter)
+			if (tf.filter0) body.filter0 = tf.filter0
 		}
 		return await dofetch3('termdb', { headers, body })
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- pp and gdc filter are passed to getDefaultBin request for gene exp terms etc. bins are always computed against cohort to be precise


### PR DESCRIPTION
…xp terms etc. bins are always computed against cohort to be precise

## Description

closes #1916 
test with same gene for [gdc gliomas](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22GAPDH%22},%22q%22:{%22mode%22:%22discrete%22}}}]}), and [breast](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.primary_site%22,%22value%22:[%22breast%22]}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22GAPDH%22},%22q%22:{%22mode%22:%22discrete%22}}}]}). see the barchart distribution are different

barchart also loads faster by cohort filtering in gene exp query

backend no longer caches bulk gene exp bins. reason is given. scrna exp bin is still cached

metabolite barchart has a known issue unrelated to this PR https://github.com/stjude/proteinpaint/issues/1938

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
