### PR TITLE
Re-enable server-side tsc checks and resolve tsc errors

### DIFF
--- a/server/routes/hicstat.ts
+++ b/server/routes/hicstat.ts
@@ -46,9 +46,7 @@ function init() {
 			const out = await do_hicstat(file, isurl)
 			res.send({ out })
 		} catch (e: any) {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			res.send({ error: e?.message || e })
+			res.send({ error: e instanceof Error ? e.message : e })
 			if (e instanceof Error && e.stack) console.log(e)
 		}
 	}

--- a/server/routes/hicstat.ts
+++ b/server/routes/hicstat.ts
@@ -45,7 +45,7 @@ function init() {
 			}
 			const out = await do_hicstat(file, isurl)
 			res.send({ out })
-		} catch (e: any) {
+		} catch (e) {
 			res.send({ error: e instanceof Error ? e.message : e })
 			if (e instanceof Error && e.stack) console.log(e)
 		}

--- a/server/routes/termdb.getnumericcategories.ts
+++ b/server/routes/termdb.getnumericcategories.ts
@@ -73,9 +73,7 @@ function init({ genomes }) {
 
 			await trigger_getnumericcategories(q, res, tdb, ds) // as getnumericcategoriesResponse
 		} catch (e) {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			res.send({ error: e?.message || e })
+			res.send({ error: e instanceof Error ? e.message : e })
 			if (e instanceof Error && e.stack) console.log(e)
 		}
 	}

--- a/server/routes/termdb.getpercentile.ts
+++ b/server/routes/termdb.getpercentile.ts
@@ -70,9 +70,7 @@ function init({ genomes }) {
 			if (!ds) throw 'invalid dataset name'
 			await trigger_getpercentile(q, res, ds) // as getpercentileResponse
 		} catch (e) {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			res.send({ error: e?.message || e })
+			res.send({ error: e instanceof Error ? e.message : e })
 			if (e instanceof Error && e.stack) console.log(e)
 		}
 	}

--- a/server/routes/termdb.getrootterm.ts
+++ b/server/routes/termdb.getrootterm.ts
@@ -1,7 +1,6 @@
 import { getroottermRequest, getroottermResponse } from '#shared/types/routes/termdb.getrootterm.ts'
 import { get_ds_tdb } from '#src/termdb.js'
 
-
 export const api: any = {
 	endpoint: 'termdb/rootterm',
 	methods: {
@@ -54,9 +53,7 @@ function init({ genomes }) {
 
 			await trigger_rootterm(q, res, tdb) // as getroottermResponse
 		} catch (e) {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			res.send({ error: e?.message || e })
+			res.send({ error: e instanceof Error ? e.message : e })
 			if (e instanceof Error && e.stack) console.log(e)
 		}
 	}

--- a/server/routes/termdb.gettermchildren.ts
+++ b/server/routes/termdb.gettermchildren.ts
@@ -43,16 +43,13 @@ function init({ genomes }) {
 		try {
 			const g = genomes[req.query.genome]
 			if (!g) throw 'invalid genome name'
-			const [ds, tdb] =await get_ds_tdb(g, q)
+			const [ds, tdb] = await get_ds_tdb(g, q)
 			if (!ds) throw 'invalid dataset name'
 			if (!tdb) throw 'invalid termdb object'
 
-
 			await trigger_children(q, res, tdb)
 		} catch (e) {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			res.send({ error: e?.message || e })
+			res.send({ error: e instanceof Error ? e.message : e })
 			if (e instanceof Error && e.stack) console.log(e)
 		}
 	}

--- a/server/routes/termdb.termsbyids.ts
+++ b/server/routes/termdb.termsbyids.ts
@@ -39,9 +39,7 @@ function init({ genomes }) {
 
 			await trigger_gettermsbyid(q, res, tdb)
 		} catch (e) {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			res.send({ error: e?.message || e })
+			res.send({ error: e instanceof Error ? e.message : e })
 			if (e instanceof Error && e.stack) console.log(e)
 		}
 	}

--- a/server/src/test/routes.type.spec.ts
+++ b/server/src/test/routes.type.spec.ts
@@ -13,7 +13,9 @@ import serverconfig from '../serverconfig.js'
 const genomes = {
 	// test genome js location can be hardcoded for testing
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
+	// @ts-ignore, not meant for tsc which already excludes spec files
+	// in server/tsconfig.json, but for typia and typedoc to ignore type
+	// check warning/errors when generating tester functions and documentation
 	'hg38-test': __non_webpack_require__(path.join(import.meta.dirname, '../../server/genome/hg38.test.js'))
 }
 const g = genomes['hg38-test']
@@ -154,7 +156,9 @@ async function setDataset(g, d) {
 	*/
 	const jsfile = path.join(process.cwd(), d.jsfile)
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
+	// @ts-ignore, not meant for tsc which already excludes spec files
+	// in server/tsconfig.json, but for typia and typedoc to ignore type
+	// check warning/errors when generating tester functions and documentation
 	const _ds = __non_webpack_require__(jsfile)
 	const ds = _ds.default || _ds
 


### PR DESCRIPTION
## Description

To test, test for typescript errors on server-side by runing the following from `~/dev/sjpp/proteinpaint/server`:
```
npx tsc
```


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
