### PR TITLE
Improved comparison mode and added summary button

### DIFF
--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -75,7 +75,7 @@ export class profilePlot {
 		this.tip = new Menu({ padding: '4px', offsetX: 10, offsetY: 15 })
 		document.addEventListener('scroll', event => this?.tip?.hide())
 
-		if (this.type != 'profileRadarFacility' && !config.isSecond) {
+		if (this.type != 'profileRadarFacility' && !config.settings[this.type].comparison) {
 			//Facility radar plot does not need to compare
 			const compareIconDiv = iconsDiv.append('div').style('margin-bottom', '20px')
 			const compareBt = compareIconDiv.append('button').style('border', 'none').style('background-color', 'transparent')
@@ -83,6 +83,7 @@ export class profilePlot {
 
 			compareBt.on('click', async event => {
 				const comparison = (this.settings.comparison = !this.settings.comparison)
+				this.settings.showTable = !comparison
 				compareBt.style('background-color', comparison ? 'rgb(207, 226, 243)' : 'transparent')
 				await this.app.dispatch({
 					type: 'plot_edit',
@@ -96,14 +97,14 @@ export class profilePlot {
 		}
 		if (this.type != 'profileBarchart') {
 			const tableIconDiv = iconsDiv.append('div')
-			const tableBt = tableIconDiv
+			this.dom.tableBt = tableIconDiv
 				.append('button')
 				.style('border', 'none')
 				.style('background-color', 'rgb(207, 226, 243)')
-			icon_functions['table'](tableBt, { title: 'Show table with data' })
-			tableBt.on('click', event => {
+			icon_functions['table'](this.dom.tableBt, { title: 'Show table with data' })
+			this.dom.tableBt.on('click', event => {
 				const show = !this.settings.showTable
-				tableBt.style('background-color', show ? 'rgb(207, 226, 243)' : 'transparent')
+				this.dom.tableBt.style('background-color', show ? 'rgb(207, 226, 243)' : 'transparent')
 				this.showTable(show)
 			})
 		}
@@ -144,13 +145,15 @@ export class profilePlot {
 	async main() {
 		this.config = JSON.parse(JSON.stringify(this.state.config))
 		this.settings = this.config.settings[this.type]
+		this.dom.tableBt.style('background-color', this.settings.showTable ? 'rgb(207, 226, 243)' : 'transparent')
 	}
 
 	async addPlot() {
 		this.plotAdded = true
 		const appState = this.state
 		const plotMod = await import('#plots/plot.app.js')
-		const plot = { chartType: this.type, isSecond: true }
+		const plot = { chartType: this.type, settings: { [this.type]: this.settings } }
+
 		if (this.type == 'profileRadar' || this.type == 'profileRadarFacility') plot.plot = this.config.plot
 		const opts = { holder: this.dom.holder2, state: { plots: [plot], vocab: appState.vocab } }
 		const plotAppApi = await plotMod.appInit(opts)
@@ -498,15 +501,15 @@ export class profilePlot {
 		uiG.attr('font-size', '0.8em')
 		let textElem = uiG.append('text').attr('transform', `translate(0, 115)`)
 		textElem.append('tspan').attr('font-weight', 'bold').text('End-user Impression: ')
-		textElem.append('tspan').text('It is provided by the local liaison who completed the assessment in consultation')
+		textElem.append('tspan').text('It is provided by the local liaison who completed the assessment ')
 		uiG
 			.append('text')
 			.attr('transform', `translate(0, 140)`)
-			.text('with the PHO medical director or directly by the PHO medical director.')
+			.text('in consultation with the PHO medical director or directly by the PHO medical director.')
 		uiG
 			.append('text')
 			.attr('transform', `translate(0, 165)`)
-			.text('The end-user was asked to rate the current status of the domains and subdomains included for this module.')
+			.text('The end-user was asked to rate the current status of the domains and subdomains included.')
 	}
 
 	addLegendItem(category, description, index) {

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -319,7 +319,8 @@ export class profilePlot {
 			})
 		}
 		this.components.controls.on(`downloadClick.${chartType}`, () =>
-			downloadSingleSVG(this.svg, this.getDownloadFilename(), this.dom.holder.node())
+			//downloadSingleSVG(this.svg, this.getDownloadFilename(), this.dom.holder.node())
+			window.print()
 		)
 		this.components.controls.on(`helpClick.${chartType}`, () => {
 			let link

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -152,7 +152,7 @@ export class profilePlot {
 		this.plotAdded = true
 		const appState = this.state
 		const plotMod = await import('#plots/plot.app.js')
-		const plot = { chartType: this.type, settings: { [this.type]: this.settings } }
+		const plot = { chartType: this.type, settings: { [this.type]: { comparison: true, showTable: false } } }
 
 		if (this.type == 'profileRadar' || this.type == 'profileRadarFacility') plot.plot = this.config.plot
 		const opts = { holder: this.dom.holder2, state: { plots: [plot], vocab: appState.vocab } }

--- a/client/plots/profilePolar.js
+++ b/client/plots/profilePolar.js
@@ -57,8 +57,8 @@ class profilePolar extends profilePlot {
 	plot() {
 		const config = this.config
 		this.dom.plotDiv.selectAll('*').remove()
-		const width = this.settings.comparison ? 700 : 1000
-		const height = 600
+		const width = this.settings.comparison ? 900 : 1000
+		const height = 700
 		this.svg = this.dom.plotDiv
 			.append('div')
 			.style('display', 'inline-block')
@@ -73,7 +73,7 @@ class profilePolar extends profilePlot {
 
 		this.svg
 			.append('text')
-			.attr('transform', `translate(150, ${height - 20})`)
+			.attr('transform', `translate(130, ${height - 120})`)
 			.attr('font-weight', 'bold')
 			.text(config.title)
 
@@ -82,12 +82,12 @@ class profilePolar extends profilePlot {
 
 		// Create a polar grid.
 		const radius = this.radius
-		const x = 300
+		const x = 280
 		const y = 280
 		const polarG = this.svg.append('g').attr('transform', `translate(${x},${y})`)
 		this.polarG = polarG
 		this.legendG = this.svg.append('g').attr('transform', `translate(${x + 280}, ${y - 200})`)
-		this.filterG = this.svg.append('g').attr('transform', `translate(${x + 280},${y - 80})`)
+		this.filterG = this.svg.append('g').attr('transform', `translate(${x + 260},${y + 180})`)
 
 		for (let i = 0; i <= 10; i++) addCircle(i * 10)
 
@@ -152,9 +152,9 @@ class profilePolar extends profilePlot {
 			this.addLegendItem('A', 'More than 75% of possible scorable items', 1)
 			this.addLegendItem('B', '50-75% of possible scorable items', 2)
 			this.addLegendItem('C', 'Less than 50% of possible scorable items', 3)
-
-			this.addFilterLegend()
 		}
+		this.addFilterLegend()
+
 		function addCircle(percent, text = null) {
 			const circle = polarG
 				.append('circle')

--- a/client/plots/profilePolar.js
+++ b/client/plots/profilePolar.js
@@ -28,10 +28,8 @@ class profilePolar extends profilePlot {
 
 	async main() {
 		await super.main()
-
 		await this.setControls()
 		this.angle = (Math.PI * 2) / this.config.terms.length
-
 		this.plot()
 	}
 
@@ -59,7 +57,7 @@ class profilePolar extends profilePlot {
 	plot() {
 		const config = this.config
 		this.dom.plotDiv.selectAll('*').remove()
-		const width = 1000
+		const width = this.settings.comparison ? 700 : 1000
 		const height = 600
 		this.svg = this.dom.plotDiv
 			.append('div')
@@ -143,18 +141,20 @@ class profilePolar extends profilePlot {
 				.text(`${percent}%`)
 				.attr('pointer-events', 'none')
 		}
-		this.legendG
-			.append('text')
-			.attr('text-anchor', 'left')
-			.style('font-weight', 'bold')
-			.text('Overall Score')
-			.attr('transform', `translate(0, -5)`)
+		if (!this.settings.comparison) {
+			this.legendG
+				.append('text')
+				.attr('text-anchor', 'left')
+				.style('font-weight', 'bold')
+				.text('Overall Score')
+				.attr('transform', `translate(0, -5)`)
 
-		this.addLegendItem('A', 'More than 75% of possible scorable items', 1)
-		this.addLegendItem('B', '50-75% of possible scorable items', 2)
-		this.addLegendItem('C', 'Less than 50% of possible scorable items', 3)
+			this.addLegendItem('A', 'More than 75% of possible scorable items', 1)
+			this.addLegendItem('B', '50-75% of possible scorable items', 2)
+			this.addLegendItem('C', 'Less than 50% of possible scorable items', 3)
 
-		this.addFilterLegend()
+			this.addFilterLegend()
+		}
 		function addCircle(percent, text = null) {
 			const circle = polarG
 				.append('circle')
@@ -181,13 +181,11 @@ class profilePolar extends profilePlot {
 export async function getPlotConfig(opts, app) {
 	try {
 		const defaults = app.vocabApi.termdbConfig?.chartConfigByType?.profilePolar
+		defaults.settings = { profilePolar: getDefaultProfilePlotSettings() }
+
 		if (!defaults) throw 'default config not found in termdbConfig.chartConfigByType.profilePolar'
 		const config = copyMerge(structuredClone(defaults), opts)
-		let settings = getDefaultProfilePlotSettings()
-		config.settings = {
-			profilePolar: settings,
-			controls: { isOpen: false }
-		}
+		config.settings.controls = { isOpen: false }
 		const twlst = []
 		for (const data of config.terms) {
 			const scoreTerm = data.score

--- a/client/plots/profileRadar.js
+++ b/client/plots/profileRadar.js
@@ -39,7 +39,7 @@ class profileRadar extends profilePlot {
 		const config = this.config
 		this.dom.plotDiv.selectAll('*').remove()
 		if (this.data.lst.length == 0) return
-		const width = 1300
+		const width = this.settings.comparison ? 900 : 1400
 		const height = 650
 		this.svg = this.dom.plotDiv
 			.append('div')
@@ -152,19 +152,20 @@ class profileRadar extends profilePlot {
 				.text(`${percent}%`)
 				.attr('pointer-events', 'none')
 		}
+		if (!this.settings.comparison) {
+			this.addFilterLegend()
 
-		this.addFilterLegend()
+			this.legendG.append('text').attr('text-anchor', 'left').style('font-weight', 'bold').text(`Legend`)
+			let abbrev = config[config.plot].term1.abbrev ? `(${config[config.plot].term1.abbrev})` : ''
+			const item1 = `${config[config.plot].term1.name} ${abbrev}`
+			this.addLegendItem(item1, color1, 0, 'none')
+			abbrev = config[config.plot].term2.abbrev ? `(${config[config.plot].term2.abbrev})` : ''
 
-		this.legendG.append('text').attr('text-anchor', 'left').style('font-weight', 'bold').text(`Legend`)
-		let abbrev = config[config.plot].term1.abbrev ? `(${config[config.plot].term1.abbrev})` : ''
-		const item1 = `${config[config.plot].term1.name} ${abbrev}`
-		this.addLegendItem(item1, color1, 0, 'none')
-		abbrev = config[config.plot].term2.abbrev ? `(${config[config.plot].term2.abbrev})` : ''
-
-		const item2 = `${config[config.plot].term2.name} ${abbrev}`
-		this.addLegendItem(item2, color2, 1, '5, 5')
-		if (this.state.dslabel == 'ProfileAbbrev')
-			this.addEndUserImpressionNote(this.legendG.append('g').attr('transform', `translate(0, -15)`))
+			const item2 = `${config[config.plot].term2.name} ${abbrev}`
+			this.addLegendItem(item2, color2, 1, '5, 5')
+			if (this.state.dslabel == 'ProfileAbbrev')
+				this.addEndUserImpressionNote(this.legendG.append('g').attr('transform', `translate(0, -15)`))
+		}
 	}
 
 	addData(field, iangle, i, data) {
@@ -255,14 +256,11 @@ class profileRadar extends profilePlot {
 export async function getPlotConfig(opts, app) {
 	try {
 		const defaults = app.vocabApi.termdbConfig?.chartConfigByType?.profileRadar
-		if (!defaults) throw 'default config not found in termdbConfig.chartConfigByType.profileRadar'
-		let config = copyMerge(structuredClone(defaults), opts)
-		const settings = getDefaultProfilePlotSettings()
+		defaults.settings = { profileRadar: getDefaultProfilePlotSettings() }
 
-		config.settings = {
-			profileRadar: settings,
-			controls: { isOpen: false }
-		}
+		if (!defaults) throw 'default config not found in termdbConfig.chartConfigByType.profileRadar'
+		const config = copyMerge(structuredClone(defaults), opts)
+		config.settings.controls = { isOpen: false }
 		const terms = config[opts.plot].terms
 		const twlst = []
 		for (const row of terms) {

--- a/client/plots/profileRadar.js
+++ b/client/plots/profileRadar.js
@@ -40,7 +40,7 @@ class profileRadar extends profilePlot {
 		this.dom.plotDiv.selectAll('*').remove()
 		if (this.data.lst.length == 0) return
 		const width = this.settings.comparison ? 900 : 1400
-		const height = 650
+		const height = 900
 		this.svg = this.dom.plotDiv
 			.append('div')
 			.style('display', 'inline-block')
@@ -66,14 +66,14 @@ class profileRadar extends profilePlot {
 		const y = 290
 		this.svg
 			.append('text')
-			.attr('transform', `translate(60, ${height - 30})`)
+			.attr('transform', `translate(40, ${y + 340})`)
 			.attr('font-weight', 'bold')
 			.text(config[config.plot].title)
 
 		const polarG = this.svg.append('g').attr('transform', `translate(${x},${y})`)
 		this.polarG = polarG
-		this.legendG = this.svg.append('g').attr('transform', `translate(${x + 390},${y - 200})`)
-		this.filterG = this.svg.append('g').attr('transform', `translate(${x + 390},${y})`)
+		this.legendG = this.svg.append('g').attr('transform', `translate(${x + 380},${y + 180})`)
+		this.filterG = this.svg.append('g').attr('transform', `translate(${40},${y + 370})`)
 
 		for (let i = 0; i <= 10; i++) this.addPoligon(i * 10)
 
@@ -153,8 +153,6 @@ class profileRadar extends profilePlot {
 				.attr('pointer-events', 'none')
 		}
 		if (!this.settings.comparison) {
-			this.addFilterLegend()
-
 			this.legendG.append('text').attr('text-anchor', 'left').style('font-weight', 'bold').text(`Legend`)
 			let abbrev = config[config.plot].term1.abbrev ? `(${config[config.plot].term1.abbrev})` : ''
 			const item1 = `${config[config.plot].term1.name} ${abbrev}`
@@ -166,6 +164,7 @@ class profileRadar extends profilePlot {
 			if (this.state.dslabel == 'ProfileAbbrev')
 				this.addEndUserImpressionNote(this.legendG.append('g').attr('transform', `translate(0, -15)`))
 		}
+		this.addFilterLegend()
 	}
 
 	addData(field, iangle, i, data) {

--- a/client/plots/profileSummary.js
+++ b/client/plots/profileSummary.js
@@ -1,0 +1,80 @@
+import { getCompInit, copyMerge } from '#rx'
+import { fillTwLst } from '#termsetting'
+import * as d3 from 'd3'
+import { profilePlot } from './profilePlot.js'
+import { Menu } from '#dom/menu'
+import { renderTable } from '../dom/table.js'
+import { loadFilterTerms } from './profilePlot.js'
+import { getDefaultProfilePlotSettings } from './profilePlot.js'
+
+class profileSummary extends profilePlot {
+	constructor() {
+		super()
+		this.type = 'profileSummary'
+		this.twLst = []
+	}
+	async init(appState) {
+		await super.init(appState)
+		const config = appState.plots.find(p => p.id === this.id)
+	}
+
+	async main() {
+		await super.main()
+		await this.setControls()
+		this.plot()
+	}
+
+	plot() {
+		const config = this.config
+		this.dom.plotDiv.selectAll('*').remove()
+		const width = 1100
+		const height = 600
+		this.svg = this.dom.plotDiv
+			.append('div')
+			.style('display', 'inline-block')
+			.append('svg')
+			.attr('width', width)
+			.attr('height', height)
+		this.dom.tableDiv = this.dom.plotDiv
+			.append('div')
+			.style('display', 'inline-block')
+			.style('vertical-align', 'top')
+			.style('margin-top', '45px')
+
+		this.svg
+			.append('text')
+			.attr('transform', `translate(150, ${height - 40})`)
+			.attr('font-weight', 'bold')
+			.text(config.title)
+
+		const x = 300
+		const y = 280
+		const mainG = this.svg.append('g').attr('transform', `translate(${x},${y})`)
+		this.mainG = mainG
+		this.legendG = this.svg.append('g').attr('transform', `translate(${x + 280}, ${y - 200})`)
+		this.filterG = this.svg.append('g').attr('transform', `translate(${x + 280},${y - 80})`)
+	}
+}
+
+export async function getPlotConfig(opts, app) {
+	try {
+		const defaults = app.vocabApi.termdbConfig?.chartConfigByType?.profileSummary
+		if (!defaults) throw 'default config not found in termdbConfig.chartConfigByType.profileSummary'
+		const config = copyMerge(structuredClone(defaults), opts)
+		const settings = getDefaultProfilePlotSettings()
+		config.settings = {
+			profileSummary: settings,
+			controls: { isOpen: false }
+		}
+
+		await loadFilterTerms(config, app)
+
+		return config
+	} catch (e) {
+		throw `${e} [profileSummary getPlotConfig()]`
+	}
+}
+
+export const profileSummaryInit = getCompInit(profileSummary)
+// this alias will allow abstracted dynamic imports
+export const componentInit = profileSummaryInit

--- a/client/src/profileHome.js
+++ b/client/src/profileHome.js
@@ -171,7 +171,6 @@ async function launchSummaryPlot(button, app, preserve, isLoggedIn, site) {
 		state: { tree: { usecase: { target: 'profile' } } },
 		tree: {
 			click_term: term => {
-				console.log('click_term', term)
 				app.dispatch({
 					type: 'plot_create',
 					config: {

--- a/client/src/profileHome.js
+++ b/client/src/profileHome.js
@@ -1,4 +1,6 @@
 import { select } from 'd3-selection'
+import { Menu } from '#dom/menu'
+import { appInit } from '#termdb/app'
 
 /*
 holder: html dom
@@ -117,6 +119,11 @@ function addButtons(headerHolder, app, dslabel, isLoggedIn, site) {
 					site
 				)
 			)
+	if (isLoggedIn)
+		div
+			.append('button')
+			.text('Summary')
+			.on('click', e => launchSummaryPlot(e.target, app, preserveCheckbox.node().checked, isLoggedIn, site))
 
 	div.append('label').attr('for', 'preservePlots').text('Preserve Plots')
 	const preserveCheckbox = div.append('input').attr('id', 'preservePlots').attr('type', 'checkbox')
@@ -147,6 +154,36 @@ async function launchRadarPlot(app, chartType, header, plot, preserve, isLoggedI
 			site
 		}
 	})
+}
+
+async function launchSummaryPlot(button, app, preserve, isLoggedIn, site) {
+	/*
+		holder: the holder in the tooltip
+		chartsInstance: MassCharts instance
+			termdbConfig is accessible at chartsInstance.state.termdbConfig{}
+			mass option is accessible at chartsInstance.app.opts{}
+		*/
+	const tip = new Menu()
+	const holder = tip.d
+	appInit({
+		holder,
+		vocabApi: app.vocabApi,
+		state: { tree: { usecase: { target: 'profile' } } },
+		tree: {
+			click_term: term => {
+				console.log('click_term', term)
+				app.dispatch({
+					type: 'plot_create',
+					config: {
+						chartType: 'profileSummary',
+						isLoggedIn,
+						site
+					}
+				})
+			}
+		}
+	})
+	tip.showunder(button)
 }
 
 async function deletePlots(app) {

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -201,8 +201,10 @@ class TdbTree {
 					copy.terms = t0.terms
 				}
 			}
+
 			this.termsById[copy.id] = copy
 		}
+		if (terms) for (const child of terms) child.parent = term
 		return terms
 	}
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -204,6 +204,8 @@ class TdbTree {
 
 			this.termsById[copy.id] = copy
 		}
+		//having a reference to the parent is handy. Used for the profile plot use case where I need to select
+		// from a component -> module -> domain tree, the domain terms
 		if (terms) for (const child of terms) child.parent = term
 		return terms
 	}

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -204,9 +204,6 @@ class TdbTree {
 
 			this.termsById[copy.id] = copy
 		}
-		//having a reference to the parent is handy. Used for the profile plot use case where I need to select
-		// from a component -> module -> domain tree, the domain terms
-		if (terms) for (const child of terms) child.parent = term
 		return terms
 	}
 

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -101,11 +101,10 @@ export function isUsableTerm(term, _usecase, ds) {
 				if (!term.isleaf) uses.add('branch')
 			}
 		case 'profile':
-			//tree to search for component-> module -> domain when opening a summary plot
 			if (!term.isleaf) {
 				uses.add('branch')
-				//the domains are the leafs and are selected to open the summary plot associated
-				if (term.parent?.parent?.parent) {
+				const ancestors = term.id.split('__').length //depends on using the __ naming convension!
+				if (ancestors > 2) {
 					uses.add('plot')
 				}
 			}

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -100,7 +100,11 @@ export function isUsableTerm(term, _usecase, ds) {
 				if (graphableTypes.has(term.type)) uses.add('plot')
 				if (!term.isleaf) uses.add('branch')
 			}
-
+		case 'profile':
+			if (!term.isleaf) {
+				uses.add('plot')
+				uses.add('branch')
+			}
 			return uses
 		case 'boxplot':
 			if (term.type == 'float' || term.type == 'integer') uses.add('plot')

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -102,8 +102,10 @@ export function isUsableTerm(term, _usecase, ds) {
 			}
 		case 'profile':
 			if (!term.isleaf) {
-				uses.add('plot')
 				uses.add('branch')
+				if (term.parent?.parent?.parent) {
+					uses.add('plot')
+				}
 			}
 			return uses
 		case 'boxplot':

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -101,8 +101,10 @@ export function isUsableTerm(term, _usecase, ds) {
 				if (!term.isleaf) uses.add('branch')
 			}
 		case 'profile':
+			//tree to search for component-> module -> domain when opening a summary plot
 			if (!term.isleaf) {
 				uses.add('branch')
+				//the domains are the leafs and are selected to open the summary plot associated
 				if (term.parent?.parent?.parent) {
 					uses.add('plot')
 				}


### PR DESCRIPTION
## Description

During comparison mode hided legends and tables. Kept filters but relocated them to below the plot
Also Profile summary use case is now drafted, we can select a domain and open the plot (empty for now). See corresponding PR in sjpp
<img width="1411" alt="Screenshot 2024-07-25 at 3 07 37 PM" src="https://github.com/user-attachments/assets/544c8cd2-3599-46c7-bc56-6d1b3872cc9c">

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
