### PR TITLE
fix: violin data request at gene exp termsetting ui observes filter0

### DIFF
--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -59,6 +59,7 @@ export function getHandler(self) {
 				{
 					tw: { term: self.term, q: self.q },
 					filter: self.filter,
+					filter0: self.vocabApi.opts?.state?.termfilter?.filter0,
 					svgw: self.num_obj.plot_size.width / window.devicePixelRatio
 				},
 				self.opts.getBodyParams?.()

--- a/client/termsetting/handlers/numeric.continuous.ts
+++ b/client/termsetting/handlers/numeric.continuous.ts
@@ -46,6 +46,7 @@ export function getHandler(self) {
 				{
 					tw: { term: self.term, q: self.q },
 					filter: self.filter,
+					filter0: self.vocabApi.opts?.state?.termfilter?.filter0,
 					svgw: plot_size.width / window.devicePixelRatio
 				},
 				self.opts.getBodyParams?.()

--- a/client/termsetting/handlers/numeric.discrete.ts
+++ b/client/termsetting/handlers/numeric.discrete.ts
@@ -77,6 +77,7 @@ async function showBinsMenu(self, div: any) {
 			{
 				tw: { term: self.term, q: { mode: 'continuous' } },
 				filter: self.filter,
+				filter0: self.vocabApi.opts?.state?.termfilter?.filter0,
 				svgw: self.num_obj.plot_size.width / window.devicePixelRatio,
 				strokeWidth: 0.2
 			},

--- a/client/termsetting/handlers/numeric.spline.ts
+++ b/client/termsetting/handlers/numeric.spline.ts
@@ -58,6 +58,7 @@ export function getHandler(self) {
 					{
 						tw: { term: self.term, q: self.q },
 						filter: self.filter,
+						filter0: self.vocabApi.opts?.state?.termfilter?.filter0,
 						svgw: self.num_obj.plot_size.width / window.devicePixelRatio
 					},
 					self.opts.getBodyParams?.()

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- violin data request at gene exp termsetting ui observes filter0


### PR DESCRIPTION
## Description

closes #1944 
[test link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22}}}]}). Edit on term1. the density plot in edit menu is consistent with violin and loads much faster (prev slow to cover all gdc cases)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
