### PR TITLE
fix: improve getData() to handle missing bin config for gene exp term…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- improve getData() to handle missing bin config for gene exp term for better performance

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -12,7 +12,7 @@ const maxCase4geneExpCluster = 1000 // max number of cases allowed for gene exp 
 // convenient helper to only print log on dev environments, and reduce pollution on prod
 // TODO move to utils.js, also fix use of _serverconfig
 function mayLog(...args) {
-	if (serverconfig.debugmode) console.log(args.join(' '))
+	if (serverconfig.debugmode) console.log(...args) // do not use args.join() to allow numbers printed in different color on terminal
 }
 
 /*

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -578,7 +578,6 @@ export async function mayInitiateMatrixplots(ds) {
 async function findListOfBins(q, tw, ds) {
 	// for non-dict terms which may lack tw.term.bins
 	if (tw.q.type == 'custom-bin') {
-		console.log(888, 'has')
 		if (Array.isArray(tw.q.lst)) return tw.q.lst
 		throw 'q.type is custom-bin but q.lst is missing' // when mode is custom bin, q.lst must always be present
 	}
@@ -592,7 +591,6 @@ async function findListOfBins(q, tw, ds) {
 			should be true for both q.type=regular-bin or q.type=custom-bin
 			*/
 			// term lacks bins. compute it on the fly. expensive step and not supposed to happen?
-			console.log(999, 'compute bins')
 			await new Promise(async (resolve, reject) => {
 				const _q = {
 					tw,


### PR DESCRIPTION
… for better performance

## Description

closes #1949 
[test link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22}}}]}). edit term1 to change to regular bin and Apply. the barchart shows up pretty quickly

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
