### PR TITLE
Custom track UI update

### DIFF
--- a/client/mds3/customdata.inputui.js
+++ b/client/mds3/customdata.inputui.js
@@ -8,7 +8,6 @@ ui only works for gm mode
 
 TODO
 - allow it to for genomic mode too, so can input custom data for 
-- unit test
 - reuse ui on appdrawer card
 */
 
@@ -114,7 +113,7 @@ export default function (block) {
 export function parseMutation(l, mlst, selecti, block) {
 	// mutation: aachange, pos, class, sample
 	const _class = l[2].trim()
-	if (!common.mclass[_class]) throw 'invalid mutation class'
+	if (!common.mclass[_class]) throw `Invalid mutation class=${_class}`
 	const m = {
 		class: _class,
 		dt: common.dtsnvindel,
@@ -172,7 +171,7 @@ export async function parseFusion(l, mlst, selecti, block) {
 }
 
 export function parseCnv(l, mlst, selecti, block) {
-	const value = parsePosition(l)
+	const value = Number(l[2].trim())
 	if (!Number.isFinite(value)) throw 'CNV value is not number'
 	const m = {
 		chr: block.usegm.chr,
@@ -206,7 +205,7 @@ returns:
 throws on any err
 */
 export function parsePositionFromGm(selecti, str, gm) {
-	const value = parsePosition(str)
+	const value = parseInputPosition(str, gm.chr)
 	if (!Number.isInteger(value)) throw 'position is not integer'
 	if (selecti == 0) {
 		const p = coord.aa2gmcoord(value, gm)
@@ -224,13 +223,14 @@ export function parsePositionFromGm(selecti, str, gm) {
 	throw 'unknown selection'
 }
 
-export function parsePosition(str) {
+export function parseInputPosition(str, chr) {
 	let value
 	if (str.includes(':')) {
 		/** Allows users to submit the customary `chr##:`
 		 * position to avoid confusion.
 		 */
 		const tmp = str.split(':')
+		if (tmp[0] != chr) throw `Included chromsome=${tmp[0]} does not match current chromosome position=${chr}`
 		value = Number(tmp[1])
 	} else {
 		value = Number(str)

--- a/client/mds3/customdata.inputui.js
+++ b/client/mds3/customdata.inputui.js
@@ -111,7 +111,7 @@ export default function (block) {
 	printHelp(div)
 }
 
-function parseMutation(l, mlst, selecti, block) {
+export function parseMutation(l, mlst, selecti, block) {
 	// mutation: aachange, pos, class, sample
 	const _class = l[2].trim()
 	if (!common.mclass[_class]) throw 'invalid mutation class'
@@ -129,7 +129,7 @@ function parseMutation(l, mlst, selecti, block) {
 	mlst.push(m)
 }
 
-async function parseFusion(l, mlst, selecti, block) {
+export async function parseFusion(l, mlst, selecti, block) {
 	const m = {
 		class: common.mclassfusionrna,
 		dt: common.dtfusionrna
@@ -171,7 +171,7 @@ async function parseFusion(l, mlst, selecti, block) {
 	mlst.push(m)
 }
 
-function parseCnv(l, mlst, selecti, block) {
+export function parseCnv(l, mlst, selecti, block) {
 	const value = parsePosition(l)
 	if (!Number.isFinite(value)) throw 'CNV value is not number'
 	const m = {
@@ -205,7 +205,7 @@ returns:
 	[chr, pos]
 throws on any err
 */
-function parsePositionFromGm(selecti, str, gm) {
+export function parsePositionFromGm(selecti, str, gm) {
 	const value = parsePosition(str)
 	if (!Number.isInteger(value)) throw 'position is not integer'
 	if (selecti == 0) {
@@ -214,7 +214,7 @@ function parsePositionFromGm(selecti, str, gm) {
 		return [gm.chr, p]
 	}
 	if (selecti == 1) {
-		const p = coord.rna2gmcoord(value, block.usegm)
+		const p = coord.rna2gmcoord(value, gm)
 		if (p == null) throw 'cannot convert RNA position to genomic position'
 		return [gm.chr, p]
 	}
@@ -224,7 +224,7 @@ function parsePositionFromGm(selecti, str, gm) {
 	throw 'unknown selection'
 }
 
-function parsePosition(str) {
+export function parsePosition(str) {
 	let value
 	if (str.includes(':')) {
 		/** Allows users to submit the customary `chr##:`

--- a/client/mds3/customdata.inputui.js
+++ b/client/mds3/customdata.inputui.js
@@ -230,7 +230,7 @@ export function parseInputPosition(str, chr) {
 		 * position to avoid confusion.
 		 */
 		const tmp = str.split(':')
-		if (tmp[0] != chr) throw `Included chromsome=${tmp[0]} does not match current chromosome position=${chr}`
+		if (tmp[0] != chr) throw `Included chromosome=${tmp[0]} does not match current chromosome position=${chr}`
 		value = Number(tmp[1])
 	} else {
 		value = Number(str)

--- a/client/mds3/test/customDataUI.unit.spec.ts
+++ b/client/mds3/test/customDataUI.unit.spec.ts
@@ -1,0 +1,254 @@
+import tape from 'tape'
+import { parseMutation, parseCnv, parsePositionFromGm, parseInputPosition } from '../customdata.inputui.js'
+
+/* Tests
+ - parseMutation()
+ - parseCnv()
+ - parsePositionFromGm()
+ - parsePosition()
+*/
+
+const block = {
+	usegm: {
+		name: 'TP53',
+		isoform: 'NM_000546',
+		chr: 'chr17',
+		coding: [
+			[7676520, 7676594],
+			[7676381, 7676403],
+			[7675993, 7676272],
+			[7675052, 7675236],
+			[7674858, 7674971],
+			[7674180, 7674290],
+			[7673700, 7673837],
+			[7673534, 7673608],
+			[7670608, 7670715],
+			[7669608, 7669690]
+		],
+		codingstart: 7669608,
+		codingstop: 7676594,
+		exon: [
+			[7687376, 7687490],
+			[7676520, 7676622],
+			[7676381, 7676403],
+			[7675993, 7676272],
+			[7675052, 7675236],
+			[7674858, 7674971],
+			[7674180, 7674290],
+			[7673700, 7673837],
+			[7673534, 7673608],
+			[7670608, 7670715],
+			[7668420, 7669690]
+		],
+		start: 7668420,
+		stop: 7687490,
+		strand: '-'
+	}
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.pass('-***- mds3/customdata.inputui -***-')
+	test.end()
+})
+
+tape('parseMutation()', function (test) {
+	test.timeoutAfter(100)
+
+	let input: string[], expected: any, message: string
+	const mlst = []
+	const selecti = 2
+
+	//Invalid mutation class
+	input = ['MyMutation', '7674903', 'abc', 'sample1']
+	message = `Should throw for invalid mutation class`
+	try {
+		parseMutation(input, mlst, selecti, block)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	//Missing name
+	input = ['', '7674903', 'M', 'sample1']
+	message = `Should throw for missing mutation name`
+	try {
+		parseMutation(input, mlst, selecti, block)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	//With sample name
+	input = ['c.215C>G', 'chr17:7579472', 'M', 'sample1']
+	parseMutation(input, mlst, selecti, block)
+	expected = {
+		class: 'M',
+		dt: 1,
+		isoform: 'NM_000546',
+		mname: 'c.215C>G',
+		chr: 'chr17',
+		pos: 7579471,
+		sample: 'sample1'
+	}
+	test.deepEqual(mlst[mlst.length - 1], expected, 'Should return correct mutation object with supplied sample name')
+
+	//No sample name
+	input = ['c.215C>G', 'chr17:7579472', 'I']
+	parseMutation(input, mlst, selecti, block)
+	expected = {
+		class: 'I',
+		dt: 1,
+		isoform: 'NM_000546',
+		mname: 'c.215C>G',
+		chr: 'chr17',
+		pos: 7579471
+	}
+	test.deepEqual(mlst[mlst.length - 1], expected, 'Should return correct mutation object without a sample property')
+
+	test.end()
+})
+
+tape('parseCnv()', function (test) {
+	test.timeoutAfter(100)
+
+	let input: string[], expected: any
+	const mlst = []
+	const selecti = 2
+
+	//Invalid value
+	input = ['7674902', '7674903', 'abc', 'sample1']
+	const message = `Should throw for CNV value not being a number`
+	try {
+		parseCnv(input, mlst, selecti, block)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	//With sample name
+	input = ['7578785', '7608909', '-1', 'sample1']
+	parseCnv(input, mlst, selecti, block)
+	expected = {
+		chr: 'chr17',
+		dt: 4,
+		value: -1,
+		class: 'CNV_loss',
+		sample: 'sample1',
+		start: 7578784,
+		stop: 7608908
+	}
+	test.deepEqual(mlst[mlst.length - 1], expected, 'Should return correct CNV loss object with supplied sample name')
+
+	//No sample name
+	input = ['7578785', '7608909', '-1']
+	parseCnv(input, mlst, selecti, block)
+	expected = {
+		chr: 'chr17',
+		dt: 4,
+		value: -1,
+		class: 'CNV_loss',
+		start: 7578784,
+		stop: 7608908
+	}
+	test.deepEqual(mlst[mlst.length - 1], expected, 'Should return correct CNV loss object withot a sample property')
+
+	test.end()
+})
+
+tape('parsePositionFromGm()', function (test) {
+	test.timeoutAfter(100)
+
+	let selecti: number, str: string, result: (number | string)[], message: string
+
+	//Codon tests
+	selecti = 0
+	message = `Should throw for the position not being a number`
+	try {
+		str = 'abc'
+		result = parsePositionFromGm(selecti, str, block.usegm)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	str = 'chr17:7675519'
+	result = parsePositionFromGm(selecti, str, block.usegm)
+	test.true(
+		result[0] == block.usegm.chr && result[1] == 7669608,
+		`Should return the chromosome from the gene and correct position for a codon`
+	)
+
+	message = `Should throw because cannot convert codon to genomic position`
+	try {
+		str = '55211628.7'
+		result = parsePositionFromGm(selecti, str, block.usegm)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	//RNA position tests
+	selecti = 1
+	str = '7675519'
+	result = parsePositionFromGm(selecti, str, block.usegm)
+	test.true(
+		result[0] == block.usegm.chr && result[1] == 7668420,
+		`Should return the chromosome from the gene and correct position for a genomic position`
+	)
+
+	message = `Should throw because cannot convert RNA position to genomic position`
+	try {
+		str = '55211628.1'
+		result = parsePositionFromGm(selecti, str, block.usegm)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	//Genomic position tests
+	selecti = 2
+	str = 'chr17:7675519'
+	result = parsePositionFromGm(selecti, str, block.usegm)
+	test.true(
+		result[0] == block.usegm.chr && result[1] == 7675518,
+		`Should return the chromosome from the gene and correct position for a genomic position`
+	)
+
+	test.end()
+})
+
+tape('parsePosition()', function (test) {
+	test.timeoutAfter(100)
+
+	let str: string, chr: string, result: number
+
+	//Position only
+	str = '7668421'
+	chr = 'chr17'
+	result = parseInputPosition(str, chr)
+	test.true(result == 7668421 && typeof result == 'number', 'Should return the position as a number')
+
+	//Chromosome and position
+	str = 'chr17:7668421'
+	result = parseInputPosition(str, chr)
+	test.true(
+		result == 7668421 && typeof result == 'number',
+		'Should remove "chr17:" and only return the position as a number'
+	)
+
+	//Mismatched chromosome
+	const message = 'Should throw for user input chromosome mismatching the gene chromosome'
+	try {
+		chr = 'chr14'
+		result = parseInputPosition(str, chr)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
+
+	test.end()
+})


### PR DESCRIPTION
## Description
Addresses [user concern.](https://groups.google.com/g/proteinpaint/c/mgERFylR2uY).

Changes: 
1. UI accepts positions with or without a chromosome (e.g. chr1:123 or 123).
2. Fix for broken RNA position parsing.
3. Unit tests for parsing logic. 

Test with: 
1. [http://localhost:3000/?genome=hg38&gene=DNMT1](url). Both `Y1080, chr19:10142098, M` and `Y1080, 10142098, M` will work in the custom UI. 
2. [New unit tests](http://localhost:3000/testrun.html?dir=mds3&name=customDataUI.unit)

@xzhou82, I guessed on the data to use for the unit tests. The RNA position needs to be tested from the UI as well but I'm not aware of a good example. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
