### PR TITLE
fix: prototype to allow GDC dictionary terms to work for barchart and…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- prototype to allow GDC dictionary terms to work for barchart and query data without any genomic filter

--- a/server/src/termdb.gdc.js
+++ b/server/src/termdb.gdc.js
@@ -341,7 +341,13 @@ export async function initGDCdictionary(ds) {
 	if (floatCount) ds.cohort.termdb.termtypeByCohort.push({ cohort: '', type: 'float' })
 	if (survivalCount) ds.cohort.termdb.termtypeByCohort.push({ cohort: '', type: 'survival' })
 
-	runRemainingWithoutAwait(ds)
+	if (serverconfig.features.await4completeGdcCaseCache) {
+		// only use on dev environment. here as soon as server is launched, it will signal client to refresh (sse). if still caching asyncly, a gdc view may break due to incomplete cache, thus await a bit for cache to complete. also should use extApiCache
+		await runRemainingWithoutAwait(ds)
+	} else {
+		// use on prod, not to hold up container launch by caching
+		runRemainingWithoutAwait(ds)
+	}
 }
 
 function mayAddTermAttribute(t) {


### PR DESCRIPTION
… query data without any genomic filter

## Description

closes #1961 
below works:
[barchart without filter](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22case.disease_type%22}}]}), takes 30 sec
[barchart with filter](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.demographic.gender%22,%22value%22:%22male%22}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22case.disease_type%22}}]}), 20 sec
[oncomatrix](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22and%22,%22content%22:[{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:%22ductal%20and%20lobular%20neoplasms%22}}]}},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22id%22:%22case.primary_site%22},{%22id%22:%22case.demographic.gender%22},{%22id%22:%22case.project.name%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}]}]}) with only dictionary terms and tiny filter

time taken is mostly determined by /cases/ endpoint. the more cases involved, the slower for it to return

previously all above breaks
a "bypass" is added to query /cases endpoint to retrieve term data when there's no ssm filters. if present will use existing methods

only gdc-specific code is modified. lollipop/oncomatrix/hiercluster tests all pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
