### PR TITLE
Render facet table for all datasets

### DIFF
--- a/client/mass/test/facet.integration.spec.ts
+++ b/client/mass/test/facet.integration.spec.ts
@@ -1,0 +1,72 @@
+import tape from 'tape'
+import * as helpers from '../../test/front.helpers.js'
+
+/* 
+Tests:
+    - Render facet table
+*/
+
+/*************************
+ reusable helper functions
+**************************/
+
+const runpp = helpers.getRunPp('mass', {
+	state: {
+		nav: { header_mode: 'hidden' },
+		dslabel: 'TermdbTest',
+		genome: 'hg38-test'
+	},
+	debug: 1
+})
+
+/**************
+ test sections
+***************/
+
+tape('\n', test => {
+	test.pass('-***- plots/facet -***-')
+	test.end()
+})
+
+tape('Render facet table', test => {
+	test.timeoutAfter(3000)
+
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'facet',
+					term: {
+						id: 'agedx'
+					},
+					term2: {
+						id: 'diaggrp'
+					}
+				}
+			]
+		},
+		facet: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	function runTests(facet) {
+		const table = facet.Inner.dom.mainDiv
+
+		const headerNum = table.selectAll('th[data-testid="sjpp-facet-col-header"]').size()
+		test.equal(headerNum, 5, 'Should render 5 headers')
+		const rowNum = table.selectAll('td[data-testid="sjpp-facet-row-label"]').size()
+		test.equal(rowNum, 7, 'Should render 7 rows')
+
+		const findSampleBtn = table.select('button').node()
+		test.true(
+			findSampleBtn && findSampleBtn.textContent == 'Show samples' && findSampleBtn.disabled,
+			'Should render "Show samples" button that is disabled'
+		)
+
+		if (test['_ok']) facet.Inner.app.destroy()
+		test.end()
+	}
+})

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -1,9 +1,18 @@
 import { getCompInit, copyMerge } from '#rx'
-// import { appInit } from '#plots/plot.app.js'
 import { fillTermWrapper } from '#termsetting'
 import { controlsInit } from './controls'
 import { select2Terms } from '#dom/select2Terms'
 import { isNumericTerm } from '../shared/terms'
+
+/*
+state {
+	term {} // tw to determine rows
+	term2 {} // tw to determine columns
+}
+
+facet table is always shown for secured or unsecured ds, as it does not reveal sample-level info
+click on table cells allow to select corresponding samples, this is only allowed when hasVerifiedToken() is true
+*/
 
 class Facet {
 	constructor(opts) {
@@ -255,7 +264,9 @@ export const componentInit = facetInit
 
 export async function getPlotConfig(opts, app) {
 	const config = { settings: {} }
+	if (!opts.term) throw '.term{} missing'
 	await fillTermWrapper(opts.term, app.vocabApi)
+	if (!opts.term2) throw '.term2{} missing'
 	await fillTermWrapper(opts.term2, app.vocabApi)
 	const result = copyMerge(config, opts)
 	return result

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -43,8 +43,7 @@ class Facet {
 	async renderTable() {
 		const config = this.config
 		this.dom.mainDiv.selectAll('*').remove()
-		//TODO: Set flag for whether to show samples or not
-		// const reqLogin = this.app.vocabApi.mayGetAuthHeaders()
+		const seeSamplesAuth = this.app.vocabApi.hasVerifiedToken()
 
 		const tbody = this.dom.mainDiv.append('table').style('border-spacing', '5px').append('tbody')
 
@@ -143,7 +142,7 @@ class Facet {
 						}
 						for (const row of rows) {
 							for (const col of row[1]) {
-								if (col[1].selected) {
+								if (col[1].selected && seeSamplesAuth) {
 									showSamplesBt.property('disabled', false)
 									return
 								}
@@ -156,11 +155,10 @@ class Facet {
 		}
 		const buttonDiv = this.dom.mainDiv.append('div').style('display', 'inline-block').style('margin-top', '20px')
 		//.style('float', 'right')
-		const showSamplesBt = buttonDiv
-			.append('button')
-			.property('disabled', true)
-			.text('Show samples')
-			.on('click', async () => {
+		const showSamplesBt = buttonDiv.append('button').property('disabled', true)
+
+		if (seeSamplesAuth) {
+			showSamplesBt.text('Show samples').on('click', async () => {
 				const samples = []
 				const sampleList = await this.app.vocabApi.getAnnotatedSampleData({
 					filter: config.filter,
@@ -186,6 +184,9 @@ class Facet {
 					}
 				})
 			})
+		} else {
+			showSamplesBt.text('Not available')
+		}
 	}
 
 	async setControls() {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- Facet table renders for all datasets.


### PR DESCRIPTION
## Description
Addresses issue #1969. 

Changes: 
1. Facet table renders counts regardless if the sample view is available for the data set. Samples are requested on submit button click. 
2. If the sample view is not available, submit button is always disabled with a text `Not available`. Otherwise expect the current behavior. 
3. New integration test

Test: 
1. [SJ Life example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22facet%22,%20%22term%22:{%22id%22:%20%22diaggrp%22},%20%22term2%22:%20{%22id%22:%22hrtavg%22}}]}) -> samples not available.
2. [Termdb example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22facet%22,%20%22term%22:{%22id%22:%20%22agedx%22},%20%22term2%22:%20{%22id%22:%22diaggrp%22}}]}) -> sample view available.
3. [New integration test](http://localhost:3000/testrun.html?dir=mass&name=facet.integration) for the facet table.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
