### PR TITLE
stricter type check for bundled datasets, using the satisfies keyword

### DIFF
--- a/server/dataset/clinvar.hg19.ts
+++ b/server/dataset/clinvar.hg19.ts
@@ -1,7 +1,7 @@
 import { clinsig } from './clinvar.js'
 import { Mds3 } from '#types'
 
-export default <Mds3>{
+export default {
 	isMds3: true,
 	dsinfo: [
 		{ k: 'Source', v: '<a href=http://www.ncbi.nlm.nih.gov/clinvar/ target=_blank>NCBI ClinVar</a>' },
@@ -51,4 +51,4 @@ export default <Mds3>{
 		]
 	},
 */
-}
+} satisfies Mds3

--- a/server/dataset/clinvar.hg38.ts
+++ b/server/dataset/clinvar.hg38.ts
@@ -1,7 +1,7 @@
 import { clinsig } from './clinvar.js'
 import { Mds3 } from '#types'
 
-export default <Mds3>{
+export default {
 	isMds3: true,
 	dsinfo: [
 		{ k: 'Source', v: '<a href=http://www.ncbi.nlm.nih.gov/clinvar/ target=_blank>NCBI ClinVar</a>' },
@@ -76,4 +76,4 @@ export default <Mds3>{
 		]
 	}
 	*/
-}
+} satisfies Mds3

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -25,7 +25,7 @@ reason:
 
 copyDataFilesFromRepo2Tp()
 
-export default <Mds3>{
+export default {
 	isMds3: true,
 	cohort: {
 		db: {
@@ -258,7 +258,7 @@ export default <Mds3>{
 			}
 		}
 	}
-}
+} satisfies Mds3
 
 function copyDataFilesFromRepo2Tp() {
 	// when running tests in a CI environment, the workflow script should copy

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -119,7 +119,10 @@ type SnvIndelFormat = {
 }
 
 type FilterValues = {
-	[index: string | number]: { label: string }
+	[index: string | number]: {
+		key?: string | number
+		label: string
+	}
 }
 
 type RangesEntry = {
@@ -134,10 +137,13 @@ type BaseTvsFilter = {
 }
 
 type TvsFilter = BaseTvsFilter & {
-	values?: (string | number)[]
+	values?: (string | number | { label: string })[]
 }
 
-type FilterTermEntry = BaseTvsFilter & {
+export type FilterTermEntry = BaseTvsFilter & {
+	id: string
+	name: string
+	type: string
 	parent_id: string | null
 	isleaf: boolean
 	values?: FilterValues
@@ -163,10 +169,8 @@ type Filter = {
 	lst?: FilterLstEntry[]
 }
 
-type VariantFilterOpts = { joinWith: string[] }
-
 type VariantFilter = {
-	opts: VariantFilterOpts
+	opts: { joinWith: string[] }
 	filter: Filter
 	terms: FilterTermEntry[]
 }
@@ -234,6 +238,8 @@ type SnvIndelQuery = {
 		by: string
 	}
 	allowSNPs?: boolean
+	vcfid4skewerName?: boolean
+	details?: any
 }
 
 type SvFusion = {
@@ -739,7 +745,10 @@ type Matrix = {
 type MatrixPlotsEntry = {
 	name: string
 	file: string
-	getConfig: (f: any) => void
+	settings?: {
+		[key: string]: any
+	}
+	getConfig?: (f: any) => void
 }
 
 type MatrixPlots = {
@@ -832,7 +841,6 @@ type Termdb = {
 
 	scatterplots?: Scatterplots
 	matrix?: Matrix
-	matrixplots?: MatrixPlots
 	logscaleBase2?: boolean
 	chartConfigByType?: ChartConfigByType
 	/** Functionality */
@@ -906,6 +914,7 @@ type BaseDtEntry = {
 	term_id: string
 	yes: { value: string[] }
 	no: { value: string[] }
+	label?: string
 }
 
 type SNVByOrigin = {
@@ -947,6 +956,7 @@ export type Cohort = {
 	db: FileObj
 	termdb: Termdb
 	scatterplots?: Scatterplots
+	matrixplots?: MatrixPlots
 	/** optional title of this ds, if missing use ds.label. shown on mass nav header. use blank string to not to show a label*/
 	title?: Title
 	cumburden?: {


### PR DESCRIPTION
## Description

Will need to merge this to master before merging  https://github.com/stjude/sjpp/pull/428

Tested with testrun.html unit and integration, and also
```sh
cd server
npx tsc
cd ../client
npm run tsc
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
