### PR TITLE
Implement sample and static rendering for the facet table

### DIFF
--- a/client/mass/test/facet.integration.spec.ts
+++ b/client/mass/test/facet.integration.spec.ts
@@ -58,7 +58,7 @@ tape('Render facet table', test => {
 		const headerNum = table.selectAll('th[data-testid="sjpp-facet-col-header"]').size()
 		test.equal(headerNum, 5, 'Should render 5 headers')
 		const rowNum = table.selectAll('td[data-testid="sjpp-facet-row-label"]').size()
-		test.equal(rowNum, 7, 'Should render 7 rows')
+		test.equal(rowNum, 10, 'Should render 10 rows')
 
 		const findSampleBtn = table.select('button').node()
 		test.true(

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -185,34 +185,34 @@ class Facet {
 	}
 
 	async getStaticTableData(config) {
-		config.settings = {
-			exclude: {
-				cols: Object.keys(config.term.q?.hiddenValues || {})
-					.filter(id => config.term.q.hiddenValues[id])
-					.map(id => {
-						return config.term.term.type == 'categorical'
-							? id
-							: config.settings.cols?.includes(id)
-							? id
-							: config.term.term.values[id]?.label
-							? config.term.term.values[id].label
-							: id
-					}),
-				rows: !config.term2?.q?.hiddenValues
-					? []
-					: Object.keys(config.term2.q.hiddenValues)
-							.filter(id => config.term2.q.hiddenValues[id])
-							.map(id =>
-								config.term2.term.type == 'categorical'
-									? id
-									: config.settings.rows?.includes(id)
-									? id
-									: config.term2.term.values[id]?.label
-									? config.term2.term.values[id].label
-									: id
-							)
-			}
-		}
+		// config.settings = {
+		// 	exclude: {
+		// 		cols: Object.keys(config.term.q?.hiddenValues || {})
+		// 			.filter(id => config.term.q.hiddenValues[id])
+		// 			.map(id => {
+		// 				return config.term.term.type == 'categorical'
+		// 					? id
+		// 					: config.settings.cols?.includes(id)
+		// 					? id
+		// 					: config.term.term.values[id]?.label
+		// 					? config.term.term.values[id].label
+		// 					: id
+		// 			}),
+		// 		rows: !config.term2?.q?.hiddenValues
+		// 			? []
+		// 			: Object.keys(config.term2.q.hiddenValues)
+		// 					.filter(id => config.term2.q.hiddenValues[id])
+		// 					.map(id =>
+		// 						config.term2.term.type == 'categorical'
+		// 							? id
+		// 							: config.settings.rows?.includes(id)
+		// 							? id
+		// 							: config.term2.term.values[id]?.label
+		// 							? config.term2.term.values[id].label
+		// 							: id
+		// 					)
+		// 	}
+		// }
 
 		const opts = { term: config.term, filter: this.state.termfilter.filter }
 		if (this.state.termfilter.filter0) opts.filter0 = this.state.termfilter.filter0
@@ -227,13 +227,14 @@ class Facet {
 
 		const result = await this.app.vocabApi.getNestedChartSeriesData(opts)
 		const rows = new Map()
-		const filteredCols = result.data.charts[0].serieses.filter(
-			col => !config.settings.exclude.cols.some(i => i == col.seriesId)
-		)
-		//These rows are in the correct ascending order
+
+		//These columns and rows are in the correct ascending order
 		//Set first and no need to sort later
+		const filteredCols = result.data.refs.cols
+			// .filter(col => !config.settings.exclude.cols.some(i => i == col.seriesId))
+			.map(col => result.data.charts[0].serieses.find(s => s.seriesId == col))
 		result.data.refs.rows
-			.filter(row => !config.settings.exclude.rows.some(i => i == row))
+			// .filter(row => !config.settings.exclude.rows.some(i => i == row))
 			.forEach(row => {
 				rows.set(row, new Map())
 				for (const col of filteredCols) {

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -204,7 +204,7 @@ class Facet {
 	renderStaticTable(tbody, config, rows) {
 		for (const row of rows) {
 			const tr = tbody.append('tr')
-			const label = config.term2.term.values?.[row[0]].label || row[0]
+			const label = config.term2.term.values?.[row[0]]?.label || row[0]
 			this.addRowLabel(tr, label)
 			for (const col of row[1]) {
 				const label = col[1].value > 0 ? col[1].value : ''

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -101,27 +101,29 @@ class Facet {
 					s => s[config.columnTw.$id]?.key == category && s[config.rowTw.$id]?.key == category2
 				)
 				cells[category2][category] = { samples, selected: false }
-				const label = samples.length > 0 ? samples.length : ''
-				const td = this.addCellCount(tr, label)
+				const td = tr.append('td')
 				if (samples.length > 0)
-					td.on('click', () => {
-						const selected = (cells[category2][category].selected = !cells[category2][category].selected)
-						if (selected) {
-							td.style('border', '1px solid blue')
-						} else {
-							td.style('border', 'none')
-						}
+					td.style('background-color', '#F2F2F2')
+						.style('text-align', 'center')
+						.text(samples.length)
+						.on('click', () => {
+							const selected = (cells[category2][category].selected = !cells[category2][category].selected)
+							if (selected) {
+								td.style('border', '1px solid blue')
+							} else {
+								td.style('border', 'none')
+							}
 
-						for (const category2 of categories2) {
-							for (const category of categories) {
-								if (cells[category2][category].selected) {
-									showSamplesBt.property('disabled', false)
-									return
+							for (const category2 of categories2) {
+								for (const category of categories) {
+									if (cells[category2][category].selected) {
+										showSamplesBt.property('disabled', false)
+										return
+									}
 								}
 							}
-						}
-						showSamplesBt.property('disabled', true)
-					})
+							showSamplesBt.property('disabled', true)
+						})
 			}
 		}
 		const buttonDiv = this.dom.mainDiv.append('div').style('display', 'inline-block').style('margin-top', '20px')
@@ -293,7 +295,7 @@ class Facet {
 		headerRow
 			.append('th')
 			.attr('data-testid', 'sjpp-facet-col-header')
-			.style('background-color', '#FAFAFA')
+			// .style('background-color', '#FAFAFA')
 			.style('padding', '0px 25px')
 			.text(text)
 	}
@@ -301,7 +303,7 @@ class Facet {
 	addRowLabel(tr, label) {
 		tr.append('td')
 			.attr('data-testid', 'sjpp-facet-row-label')
-			.style('background-color', '#FAFAFA')
+			// .style('background-color', '#FAFAFA')
 			.style('font-weight', 'bold')
 			.text(label)
 	}

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -61,7 +61,7 @@ class Facet {
 
 		this.dom.mainDiv.selectAll('*').remove()
 		const tbody = this.dom.mainDiv.append('table').style('border-spacing', '5px').append('tbody')
-		const headerRow = tbody.append('tr')
+		const headerRow = tbody.append('tr').style('text-align', 'center')
 		//blank space left for row labels
 		headerRow.append('th')
 
@@ -293,9 +293,8 @@ class Facet {
 		headerRow
 			.append('th')
 			.attr('data-testid', 'sjpp-facet-col-header')
-			.style('text-align', 'center')
 			.style('background-color', '#FAFAFA')
-			.style('padding-right', '50px')
+			.style('padding', '0px 25px')
 			.text(text)
 	}
 
@@ -353,8 +352,13 @@ export function makeChartBtnMenu(holder, chartsInstance) {
 			term: { term: xterm },
 			term2: { term: yterm }
 		}
-		if (isNumericTerm(xterm)) config.columnTw.q = { mode: 'discrete' }
-		if (isNumericTerm(yterm)) config.rowTw.q = { mode: 'discrete' }
+
+		//Do not rename, creating the mass state from this function
+		//config.term becomes config.columnTw in renderTable()
+		if (isNumericTerm(xterm)) config.term.term.q = { mode: 'discrete' }
+		//config.term2 becomes config.rowTw in renderTable()
+		if (isNumericTerm(yterm)) config.term2.term.q = { mode: 'discrete' }
+
 		chartsInstance.app.dispatch({
 			type: 'plot_create',
 			config


### PR DESCRIPTION
## Description
The facet table now either shows a sample table with the ability to launch the sample view or a static, readonly table when sample data is not available or unauthorized. 

Changes: 
1. Only one server request for both versions 
2. Range labels appear in order in the sample table
3. Uncomputable values do not show in the sample table but do show in the static table. 
4. Updated integration test

Test with: 
1. [With samples](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22facet%22,%20%22term%22:{%22id%22:%20%22aaclassic_5%22},%20%22term2%22:%20{%22id%22:%22diaggrp%22}}]})
2. [No samples available](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22facet%22,%20%22term%22:{%22id%22:%20%22agedx%22},%20%22term2%22:%20{%22id%22:%22diaggrp%22}}]})

Addresses issue #1975 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
