### PR TITLE
Facet updates

### DIFF
--- a/client/mass/test/facet.integration.spec.ts
+++ b/client/mass/test/facet.integration.spec.ts
@@ -36,10 +36,10 @@ tape('Render facet table', test => {
 			plots: [
 				{
 					chartType: 'facet',
-					term: {
+					columnTw: {
 						id: 'agedx'
 					},
-					term2: {
+					rowTw: {
 						id: 'diaggrp'
 					}
 				}

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -67,6 +67,14 @@ class Facet {
 			 * and on submit launches the sample view plot
 			 */
 			const { result, categories, categories2 } = await this.getSampleTableData(config)
+			if (!categories.length || !categories2.length) {
+				this.dom.mainDiv
+					.append('div')
+					.style('padding', '0px 50px')
+					.style('font-size', '1.15em')
+					.text('No overlapping samples')
+				return
+			}
 			for (const category of categories) {
 				const label = config.columnTw.term.values?.[category]?.label || category
 				this.addHeader(headerRow, label)
@@ -304,7 +312,7 @@ class Facet {
 		const inputs = [
 			{
 				type: 'term',
-				configKey: 'term',
+				configKey: 'columnTw',
 				chartType: this.type,
 				usecase: { target: this.type },
 				title: 'Facet column categories',
@@ -314,7 +322,7 @@ class Facet {
 			},
 			{
 				type: 'term',
-				configKey: 'term2',
+				configKey: 'rowTw',
 				chartType: this.type,
 				usecase: { target: this.type },
 				title: 'Facet row categories',

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -71,6 +71,7 @@ class Facet {
 			 */
 			const { result, categories, categories2 } = await this.getSampleTableData(config)
 			if (!categories.length || !categories2.length) {
+				//Show message if no overlapping samples
 				this.dom.mainDiv
 					.append('div')
 					.style('padding', '0px 50px')
@@ -88,6 +89,14 @@ class Facet {
 			/** If sample data is not available or not authorized for this user,
 			 * render a static table with counts. No interactivity. */
 			const { rows, filteredCols } = await this.getStaticTableData(config)
+			if (!rows.size || !filteredCols.length) {
+				this.dom.mainDiv
+					.append('div')
+					.style('padding', '0px 50px')
+					.style('font-size', '1.15em')
+					.text('No overlapping samples')
+				return
+			}
 			for (const col of filteredCols) {
 				const label = config.columnTw.term.values?.[col.seriesId]?.label || col.seriesId
 				this.addHeader(headerRow, label)
@@ -292,7 +301,6 @@ class Facet {
 		await this.getDescrStats(opts.term2)
 
 		const result = await this.app.vocabApi.getNestedChartSeriesData(opts)
-		console.log('static', result)
 		const rows = new Map()
 
 		//These columns and rows are in the correct ascending order

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -330,7 +330,7 @@ class Facet {
 		headerRow
 			.append('th')
 			.attr('data-testid', 'sjpp-facet-col-header')
-			// .style('background-color', '#FAFAFA')
+			.style('border', '2.5px solid white')
 			.style('padding', '0px 25px')
 			.text(text)
 	}
@@ -338,7 +338,7 @@ class Facet {
 	addRowLabel(tr, label) {
 		tr.append('td')
 			.attr('data-testid', 'sjpp-facet-row-label')
-			// .style('background-color', '#FAFAFA')
+			.style('border', '2.5px solid white')
 			.style('font-weight', 'bold')
 			.text(label)
 	}

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -121,9 +121,7 @@ class Facet {
 				if (!samples.length) td.classed('highlightable-cell', true)
 				if (samples.length > 0) {
 					const colIdx = categories.indexOf(category) + 2
-					td
-						// .classed('sja_menuoption', true)
-						.style('background-color', '#F2F2F2')
+					td.classed('sja_menuoption', true)
 						.style('text-align', 'center')
 						.style('border', '2.5px solid white')
 						.text(samples.length)


### PR DESCRIPTION
## Description
Changes: 
1. Config accepts `.columnTw{}` instead of `.term{}` and `.rowTw{}` instead of `.term2{}`
2. The entire row and column highlights when hovering over clickable cells
3. A message displays when no overlapping samples are found to create the facet table. 

To test: 
1. Checkout [sjpp facetUpdate branch](https://github.com/stjude/sjpp/tree/facetUpdate). See https://github.com/stjude/sjpp/pull/431
2. [Highlight example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22facet%22,%20%22columnTw%22:{%22id%22:%20%22aaclassic_5%22},%20%22rowTw%22:%20{%22id%22:%22diaggrp%22}}]})
3. [No overlapping samples example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22facet%22,%20%22columnTw%22:{%22id%22:%20%22efs%22},%20%22rowTw%22:%20{%22id%22:%22ctcae_graded%22}}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
