### PR TITLE
Show more options for selected samples in the facet table

### DIFF
--- a/client/mass/test/facet.integration.spec.ts
+++ b/client/mass/test/facet.integration.spec.ts
@@ -1,5 +1,6 @@
 import tape from 'tape'
 import * as helpers from '../../test/front.helpers.js'
+import { detectGte } from '../../test/test.helpers.js'
 
 /* 
 Tests:
@@ -52,7 +53,7 @@ tape('Render facet table', test => {
 		}
 	})
 
-	function runTests(facet) {
+	async function runTests(facet) {
 		const table = facet.Inner.dom.mainDiv
 
 		const headerNum = table.selectAll('th[data-testid="sjpp-facet-col-header"]').size()
@@ -60,11 +61,23 @@ tape('Render facet table', test => {
 		const rowNum = table.selectAll('td[data-testid="sjpp-facet-row-label"]').size()
 		test.equal(rowNum, 10, 'Should render 10 rows')
 
-		const findSampleBtn = table.select('button').node()
+		const prompt = table.select('div[data-testid="sjpp-facet-start-prompt"]')
 		test.true(
-			findSampleBtn && findSampleBtn.textContent == 'Show samples' && findSampleBtn.disabled,
-			'Should render "Show samples" button that is disabled'
+			prompt && prompt.text() == 'Select samples to see data',
+			'Should render prompt to select cells on render.'
 		)
+
+		const blankCells = await detectGte({
+			elem: table.node(),
+			selector: 'td.highlightable-cell'
+		})
+		test.equal(blankCells.length, 24, 'Should render over 20 blank, highlightable cells.')
+
+		const clickableCells = await detectGte({
+			elem: table.node(),
+			selector: 'td.sja_menuoption'
+		})
+		test.equal(clickableCells.length, 26, 'Should render over 20 clickable cells.')
 
 		if (test['_ok']) facet.Inner.app.destroy()
 		test.end()

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -152,6 +152,7 @@ class Facet {
 		}
 		const startPrompt = this.dom.mainDiv
 			.append('div')
+			.attr('data-testid', 'sjpp-facet-start-prompt')
 			.style('margin-top', '20px')
 			.style('color', 'red')
 			.text('Select samples to see data')

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -141,13 +141,13 @@ class Facet {
 								for (const category of categories) {
 									if (cells[category2][category].selected) {
 										buttonDiv.style('display', '')
-										prompt.text('Select how to see sample data:')
+										prompt.text('Choose how to use samples:')
 										return
 									}
 								}
 							}
 							buttonDiv.style('display', 'none')
-							prompt.text('Select samples to see data')
+							prompt.text('Click on cells to select samples')
 						})
 				}
 			}
@@ -155,13 +155,13 @@ class Facet {
 		const prompt = this.dom.mainDiv
 			.append('div')
 			.attr('data-testid', 'sjpp-facet-start-prompt')
-			.style('margin-top', '20px')
-			.style('opacity', '0.75')
-			.text('Select samples to see data')
-		const buttonDiv = this.dom.mainDiv.append('div').style('margin-top', '20px').style('display', 'none')
+			.style('margin', '20px 0px 0px 15px')
+			.style('opacity', '0.7')
+			.text('Click on cells to select samples')
+		const buttonDiv = this.dom.mainDiv.append('div').style('margin', '20px 0px 0px 25px').style('display', 'none')
 		const btns = [
 			{
-				text: 'Show samples',
+				text: 'Show samples view',
 				// disabled: () => {}, add this if needed later
 				callback: () => {
 					const samples = this.getSelectedSamples(categories, categories2, cells)
@@ -202,7 +202,7 @@ class Facet {
 				}
 			},
 			{
-				text: 'Add group',
+				text: 'Create group',
 				callback: () => {
 					this.addGroup(categories, categories2, cells)
 				}

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -141,18 +141,18 @@ class Facet {
 								for (const category of categories) {
 									if (cells[category2][category].selected) {
 										buttonDiv.style('display', '')
-										startPrompt.style('display', 'none')
+										prompt.text('Select how to see sample data:')
 										return
 									}
 								}
 							}
 							buttonDiv.style('display', 'none')
-							startPrompt.style('display', '')
+							prompt.text('Select samples to see data')
 						})
 				}
 			}
 		}
-		const startPrompt = this.dom.mainDiv
+		const prompt = this.dom.mainDiv
 			.append('div')
 			.attr('data-testid', 'sjpp-facet-start-prompt')
 			.style('margin-top', '20px')

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -4,7 +4,8 @@ import { controlsInit } from './controls'
 import { select2Terms } from '#dom/select2Terms'
 import { isNumericTerm } from '../shared/terms'
 import { addNewGroup, getFilter, getSamplelstTW } from '../mass/groups'
-import { filterJoin, getFilterItemByTag } from '#filter'
+// import { filterJoin, getFilterItemByTag } from '#filter'
+import { Menu } from '#dom/menu'
 
 /*
 state {
@@ -27,7 +28,8 @@ class Facet {
 			holder: opts.holder.style('padding', '20px'),
 			header: opts.header,
 			controlsHolder,
-			mainDiv
+			mainDiv,
+			tip: opts.tip || new Menu()
 		}
 	}
 
@@ -58,6 +60,7 @@ class Facet {
 	async renderTable() {
 		const config = this.config
 		this.dom.mainDiv.selectAll('*').remove()
+		this.dom.tip.clear().hide()
 		const table = this.dom.mainDiv.append('table')
 		const tbody = table.append('tbody')
 		const headerRow = tbody.append('tr').style('text-align', 'center')
@@ -172,24 +175,48 @@ class Facet {
 				}
 			},
 			{
+				text: 'List samples',
+				callback: () => {
+					const samples = this.getSelectedSamples(categories, categories2, cells)
+					const sampleRows = samples.map(d => [
+						result.refs.bySampleId[d.sample].label,
+						d[config.columnTw.$id].key,
+						d[config.rowTw.$id].key
+					])
+					this.dom.tip.clear().showunder(buttonDiv.node())
+					// this.dom.tip.d.append('div').style('padding', '0px 5px 5px 5px').text('Selected samples:')
+					const tbody = this.dom.tip.d.append('table').append('tbody')
+					const headerRow = tbody.append('tr').style('text-align', 'center')
+					headerRow.append('th').text('Sample')
+					headerRow.append('th').text(config.columnTw.term.name)
+					headerRow.append('th').text(config.rowTw.term.name)
+					for (const row of sampleRows) {
+						const tr = tbody.append('tr')
+						tr.append('td').text(row[0])
+						tr.append('td').text(row[1])
+						tr.append('td').text(row[2])
+					}
+				}
+			},
+			{
 				text: 'Add group',
 				callback: () => {
 					this.addGroup(categories, categories2, cells)
 				}
-			},
-			{
-				text: 'Add group and filter',
-				callback: () => {
-					const groupFilter = this.addGroup(categories, categories2, cells)
-					const filterUiRoot = getFilterItemByTag(this.state.termfilter.filter, 'filterUiRoot')
-					const filter = filterJoin([filterUiRoot, groupFilter])
-					filter.tag = 'filterUiRoot'
-					this.app.dispatch({
-						type: 'filter_replace',
-						filter
-					})
-				}
 			}
+			// {
+			// 	text: 'Add group and filter',
+			// 	callback: () => {
+			// 		const groupFilter = this.addGroup(categories, categories2, cells)
+			// 		const filterUiRoot = getFilterItemByTag(this.state.termfilter.filter, 'filterUiRoot')
+			// 		const filter = filterJoin([filterUiRoot, groupFilter])
+			// 		filter.tag = 'filterUiRoot'
+			// 		this.app.dispatch({
+			// 			type: 'filter_replace',
+			// 			filter
+			// 		})
+			// 	}
+			// }
 		]
 
 		for (const btn of btns) {

--- a/client/plots/facet.js
+++ b/client/plots/facet.js
@@ -146,6 +146,8 @@ class Facet {
 									}
 								}
 							}
+							buttonDiv.style('display', 'none')
+							startPrompt.style('display', '')
 						})
 				}
 			}
@@ -154,7 +156,7 @@ class Facet {
 			.append('div')
 			.attr('data-testid', 'sjpp-facet-start-prompt')
 			.style('margin-top', '20px')
-			.style('color', 'red')
+			.style('opacity', '0.75')
 			.text('Select samples to see data')
 		const buttonDiv = this.dom.mainDiv.append('div').style('margin-top', '20px').style('display', 'none')
 		const btns = [

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- In addition to launching the sample view, the user may also see a simplified list and/or create a group from selected samples from the facet table.


### PR DESCRIPTION
## Description
Addresses requests in issue #1986. If no other requests are made, I will close this issue. 

Changes: 
1. Prompt shows to select samples. When a cell is clicked, the buttons appear.
2. In addition to `Show samples`, buttons to list samples and add a group appear below the table. 
3. Updated facet table test

Test: 
Use [this termdb example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22facet%22,%20%22columnTw%22:{%22id%22:%20%22aaclassic_5%22},%20%22rowTw%22:%20{%22id%22:%22diaggrp%22}}]}) and click through the different options. 

## Checklist
[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
