### PR TITLE
fix: Proper pass case filter to GenesTable gdc query so ssm case coun…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Proper pass case filter to GenesTable gdc query so ssm case count can correspond to filter

--- a/server/routes/gdc.topMutatedGenes.ts
+++ b/server/routes/gdc.topMutatedGenes.ts
@@ -227,6 +227,8 @@ const queryV2: any = {
 		}
 
 		if (q.filter0) {
+			// Phil 8/9/2024: must set case filter to both "ssmCase" and "caseFilters" to get correct ssm affected counts
+			variables.ssmCase.content.push(JSON.parse(JSON.stringify(q.filter0)))
 			variables.caseFilters.content.push(JSON.parse(JSON.stringify(q.filter0)))
 			variables.geneCaseFilter.content.push(JSON.parse(JSON.stringify(q.filter0)))
 			variables.cnvLossFilters.content.push(JSON.parse(JSON.stringify(q.filter0)))


### PR DESCRIPTION
…t can correspond to filter

## Description

closes #1996
test with all gdc or cohort by dict term works http://localhost:3000/example.gdc.matrix.html?&cohort=Myeloid_leukemias
but cohort for cases mutated in a gene doesn't http://localhost:3000/example.gdc.matrix.html?&cohort=IDH1

gene filter is a separate issue in filter construction and unrelated to this change

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
