### PR TITLE
Fix for omnisearch gene menu

### DIFF
--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -716,6 +716,7 @@ async function openDatasetButtonSandbox(pageArgs, res, sandboxDiv) {
 		genome: par.genome,
 		tip: new Menu({ padding: '' }),
 		row: searchBarDiv,
+		searchOnly: par.searchBar == 'gene' ? 'gene' : '',
 		focusOff: true,
 		callback: async div => {
 			//Creates search results as tracks, last to first
@@ -746,8 +747,6 @@ async function openDatasetButtonSandbox(pageArgs, res, sandboxDiv) {
 			par.runargs.block == true
 				? (runppArg.position = `${coords.chr}:${coords.start}-${coords.stop}`) && (runppArg.nativetracks = 'Refgene')
 				: (runppArg.gene = coords.geneSymbol)
-
-			if (par.searchBar == 'gene') par.searchOnly = 'gene'
 
 			const callpp = JSON.parse(JSON.stringify(par.runargs))
 

--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -716,7 +716,6 @@ async function openDatasetButtonSandbox(pageArgs, res, sandboxDiv) {
 		genome: par.genome,
 		tip: new Menu({ padding: '' }),
 		row: searchBarDiv,
-		geneOnly: par.searchBar == 'gene' ? true : false,
 		focusOff: true,
 		callback: async div => {
 			//Creates search results as tracks, last to first
@@ -747,6 +746,8 @@ async function openDatasetButtonSandbox(pageArgs, res, sandboxDiv) {
 			par.runargs.block == true
 				? (runppArg.position = `${coords.chr}:${coords.start}-${coords.stop}`) && (runppArg.nativetracks = 'Refgene')
 				: (runppArg.gene = coords.geneSymbol)
+
+			if (par.searchBar == 'gene') par.searchOnly = 'gene'
 
 			const callpp = JSON.parse(JSON.stringify(par.runargs))
 

--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -149,7 +149,7 @@ export class GeneSetEditUI {
 			tip: this.tip2,
 			genome: this.genome,
 			row,
-			geneOnly: true,
+			searchOnly: 'gene',
 			callback: addGene,
 			hideHelp: true,
 			focusOff: true

--- a/client/dom/search.ts
+++ b/client/dom/search.ts
@@ -39,7 +39,7 @@ type InputSearchOpts = {
 export class InputSearch {
 	holder: Elem
 	input: Input
-	tip: any
+	readonly tip: any
 	searchItems: () => Promise<SearchGroupEntry[]> | SearchGroupEntry[]
 	style: any
 	size: number
@@ -96,7 +96,7 @@ export class InputSearch {
 				.style('border-left', '0.5px solid lightgrey')
 				.each(this.showResultsList)
 		} catch (e: any) {
-			if (e.stack) console.log(e.stack)
+			if (e.stack) console.error(e.stack)
 			else throwMsgWithFilePathAndFnName(e)
 		}
 	}
@@ -133,6 +133,10 @@ export class InputSearch {
 			.on('click', (event: MouseEvent, item: any) => {
 				event.stopPropagation()
 				result.callback(item)
+				/** Use tip.hide() in callback,
+				 * This will allow the tip to remain open for other
+				 * use cases.
+				 * */
 			})
 	}
 

--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -58,7 +58,7 @@ export async function init(arg, holder, genomes) {
 		genome,
 		tip,
 		row: geneInputDiv,
-		geneOnly: true,
+		searchOnly: 'gene',
 		callback: launchView,
 		geneSymbol: arg.geneSymbol
 	}

--- a/client/plots/genomeBrowser.js
+++ b/client/plots/genomeBrowser.js
@@ -395,7 +395,6 @@ export function makeChartBtnMenu(holder, chartsInstance) {
 		tip: geneTip,
 		genome: genomeObj,
 		row: holder.append('div').style('margin', '10px'),
-		geneOnly: chartsInstance.state.termdbConfig.queries.defaultBlock2GeneMode,
 		callback: async () => {
 			// found a gene {chr,start,stop,geneSymbol}
 			// dispatch to create new plot
@@ -420,6 +419,8 @@ export function makeChartBtnMenu(holder, chartsInstance) {
 	if (!chartsInstance.state.termdbConfig.queries.defaultBlock2GeneMode) {
 		// block is not shown in gene mode, add default coord to arg
 		arg.defaultCoord = chartsInstance.state.termdbConfig.queries.defaultCoord
+	} else {
+		arg.searchOnly = 'gene'
 	}
 	const result = addGeneSearchbox(arg)
 }

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -95,7 +95,7 @@ class singleCellPlot {
 				tip: new Menu({ padding: '0px' }),
 				genome: this.app.opts.genome,
 				row: searchGeneDiv,
-				geneOnly: true,
+				searchOnly: 'gene',
 				placeholder: state.config.gene || 'Gene',
 				callback: () => {
 					violinBt?.style('display', 'inline-block')

--- a/client/src/header/AppHeader.ts
+++ b/client/src/header/AppHeader.ts
@@ -174,11 +174,9 @@ export class AppHeader {
 			.style('font-weight', 'bold')
 
 		// 2, search box
-		const tip = new Menu({ border: '', padding: '0px' })
-
 		const omniSearch = new InputSearch({
 			holder: headbox,
-			tip,
+			tip: this.headtip,
 			style: {
 				padding: padw_sm,
 				border: `'solid 1px ${defaultcolor}`

--- a/client/termdb/handlers/geneExpression.ts
+++ b/client/termdb/handlers/geneExpression.ts
@@ -12,7 +12,7 @@ export class SearchHandler {
 			tip: new Menu({ padding: '0px' }),
 			genome: opts.genomeObj,
 			row: opts.holder,
-			geneOnly: true,
+			searchOnly: 'gene',
 			callback: () => this.selectGene(geneSearch.geneSymbol)
 		})
 	}

--- a/client/termdb/handlers/snp.ts
+++ b/client/termdb/handlers/snp.ts
@@ -10,7 +10,7 @@ export class SearchHandler {
 			tip: new Menu({ padding: '0px' }),
 			genome: opts.genomeObj,
 			row: opts.holder,
-			snpOnly: true,
+			searchOnly: 'snp',
 			allowVariant: true,
 			callback: () => this.selectSnp(geneSearch)
 		})

--- a/front/public/cards/index.json
+++ b/front/public/cards/index.json
@@ -248,7 +248,7 @@
             "description": "Mutation heatmap",
             "image": "https://proteinpaint.stjude.org/ppdemo/images/heatmap-square.png",
             "sandboxJson": "study",
-            "searchterms": ["heat map", "oncoprint"]
+            "searchterms": ["heatmap", "oncoprint"]
         },
         {
             "type": "card",


### PR DESCRIPTION
## Description
Changes:
1. Consolidate `.geneOnly` and `.snpOnly` flags into one `.searchOnly` parameter in `genesearch.ts`
2. Fix for the menu not hiding when clicking on a gene search result

Test:
1. Open http://localhost:3000/ -> Type `TP53` in search box -> Click on first result -> menu should disappear
2. Type `atm` in search box -> Both `Single cell` and `Load mutations from text files` should appear for search term `heatmap`. 
3. Test flag changes: 
   -   http://localhost:3000/?appcard=civicBtn -> only `Gene` appears in the placeholder. 
   - [SJLife](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22}) -> open Data Dictionary -> SNP Genotype -> Should read `Position, dsSNP, variant`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
