### PR TITLE
Restore access to public radars without site filter

### DIFF
--- a/client/src/profileHome.js
+++ b/client/src/profileHome.js
@@ -107,12 +107,11 @@ function addButtons(headerHolder, app, dslabel, logged, site) {
 			.on('click', e =>
 				launchRadarPlot(app, 'profileRadarFacility', 'Radar 1-Score-based(Site)', 'plot1', logged, site)
 			)
-	if (logged)
-		div
-			.append('button')
-			.text('Radar 2-Impressions')
-			.on('click', e => launchRadarPlot(app, 'profileRadar', 'Radar 2-Impressions', 'plot1', logged, site))
-	if (isFull && logged)
+	div
+		.append('button')
+		.text('Radar 2-Impressions')
+		.on('click', e => launchRadarPlot(app, 'profileRadar', 'Radar 2-Impressions', 'plot1', logged, site))
+	if (isFull)
 		div
 			.append('button')
 			.text('Radar 3-Score-based(SC & POC)')


### PR DESCRIPTION
## Description

As Heather mentioned, public users can access Radar Graph 2 for the Abbreviated and Radar Graphs 2 and 3 for the Full , as these graphs can still be created using aggregated data, just we do not show the site filter. So now I show the buttons for the public link

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
