### PR TITLE
fix: Assign alive/dead labels to GDC survival exit codes

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Assign alive/dead labels to GDC survival exit codes

--- a/server/src/termdb.gdc.js
+++ b/server/src/termdb.gdc.js
@@ -169,7 +169,9 @@ export async function initGDCdictionary(ds) {
 			name: id,
 			type: 'survival',
 			isleaf: true,
-			unit: 'year', // api returns time-to-event in number of days, and mds3.gdc.js converts it to decimal years
+			// see querySamplesSurvival(): api returns time-to-event in number of days, and we convert it to decimal years; also about exit code assignment
+			unit: 'year',
+			values: { 0: { label: 'Alive' }, 1: { label: 'Dead' } },
 			included_types_set: new Set(), // apply to leaf terms, should have its own term.type
 			child_types_set: new Set() // empty for leaf terms
 		}


### PR DESCRIPTION
## Description

closes #2014 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
