### PR TITLE
fix: when a term has no computable values, do not calculate descripti…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- when a term has no computable values, do not calculate descriptive stats that breaks

--- a/server/routes/termdb.getdescrstats.ts
+++ b/server/routes/termdb.getdescrstats.ts
@@ -87,7 +87,12 @@ function init({ genomes }) {
 				values.push(Number(value))
 			}
 
-			result = Summarystats(values) as getdescrstatsResponse
+			if (values.length) {
+				result = Summarystats(values) as getdescrstatsResponse
+			} else {
+				// no computable values. do not get stats as it breaks code. set result to blank obj to avoid "missing response.header['content-type']" err on client
+				result = {}
+			}
 		} catch (e: any) {
 			if (e instanceof Error && e.stack) console.log(e)
 			result = { error: e?.message || e } as getdescrstatsResponse


### PR DESCRIPTION
…ve stats that breaks

## Description

closes #2020 
test [link](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22dxcode%22%7D%7D%5D,%22nav%22:%7B%22activeTab%22:1%7D%7D). data has no issue. disease code is only available for ccss but not sjlife

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
