### PR TITLE
fix: At GDC lollipop subtrack, disable survival term when building th…

### DIFF
--- a/client/filter/filter.interactivity.js
+++ b/client/filter/filter.interactivity.js
@@ -228,13 +228,7 @@ export function setInteractivity(self) {
 			state: {
 				activeCohort: self.activeCohort,
 				termfilter: { filter: rootFilterCopy },
-				tree: {
-					usecase: {
-						target: 'filter',
-						// pass ds label to perform ds-specific control. for gdc, need to exclude survival term from filter. using "detail" property for termdb.usecase.js to carry out this logic without introducing any new property
-						detail: self.vocabApi.vocab.dslabel
-					}
-				}
+				tree: { usecase: { target: 'filter' } }
 			},
 			tree: {
 				disable_terms:

--- a/client/filter/filter.interactivity.js
+++ b/client/filter/filter.interactivity.js
@@ -228,7 +228,13 @@ export function setInteractivity(self) {
 			state: {
 				activeCohort: self.activeCohort,
 				termfilter: { filter: rootFilterCopy },
-				tree: { usecase: { target: 'filter' } }
+				tree: {
+					usecase: {
+						target: 'filter',
+						// pass ds label to perform ds-specific control. for gdc, need to exclude survival term from filter. using "detail" property for termdb.usecase.js to carry out this logic without introducing any new property
+						detail: self.vocabApi.vocab.dslabel
+					}
+				}
 			},
 			tree: {
 				disable_terms:

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -236,7 +236,7 @@ class TdbApp {
 		// filter for display terms with usecase
 		const useTerms = []
 		for (const tw of tws) {
-			const uses = isUsableTerm(tw.term, this.state.tree.usecase)
+			const uses = isUsableTerm(tw.term, this.state.tree.usecase, this.state.termdbConfig)
 			if (uses.has('plot')) useTerms.push(tw)
 		}
 		if (useTerms.length == 0) return this.dom.customTermDiv.style('display', 'none')

--- a/client/termdb/search.js
+++ b/client/termdb/search.js
@@ -162,6 +162,7 @@ function setRenderers(self) {
 
 	self.getPrompt = state => {
 		/* term search prompt is decided by two factors:
+		TODO geneVariant is no longer supported here
 		1. if the term type exists in allowedTermTypes from the dataset
 		   e.g. if geneVariant type does not exist in the dataset, do not show prompt (and no need to check usecase)
 		2. termdb client app usecase, defines the context for using terms selected from the termdb app
@@ -222,7 +223,7 @@ function setRenderers(self) {
 	self.showTerm = function (term) {
 		const tr = select(this)
 		const button = tr.append('td').text(term.name)
-		const uses = isUsableTerm(term, self.state.usecase)
+		const uses = isUsableTerm(term, self.state.usecase, self.app.vocabApi.termdbConfig)
 		/*
 		below, both callbacks are made in app.js validateOpts()
 		1. self.opts.click_term() is for selecting to tvs

--- a/client/termdb/store.js
+++ b/client/termdb/store.js
@@ -208,7 +208,7 @@ TdbStore.prototype.actions = {
 				expandedTermIds.push(...term.__ancestors)
 			}
 
-			if (isUsableTerm(term).has('plot')) {
+			if (isUsableTerm(term, {}, this.state.termdbConfig).has('plot')) {
 				Object.assign(this.state.submenu, action.submenu)
 			} else {
 				expandedTermIds.push(term.id)

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -268,7 +268,7 @@ function setRenderers(self) {
 		self.included_terms = []
 		if (self.state.usecase) {
 			for (const t of term.terms) {
-				if (isUsableTerm(t, self.state.usecase).size) {
+				if (isUsableTerm(t, self.state.usecase, self.app.vocabApi.termdbConfig).size) {
 					self.included_terms.push(t)
 				}
 			}
@@ -328,7 +328,7 @@ function setRenderers(self) {
 		}
 
 		const termIsDisabled = self.opts.disable_terms?.includes(term.id)
-		const uses = isUsableTerm(term, self.state.usecase)
+		const uses = isUsableTerm(term, self.state.usecase, self.app.vocabApi.termdbConfig)
 
 		div.style('display', '')
 		const isExpanded = self.state.expandedTermIds.includes(term.id)
@@ -350,7 +350,7 @@ function setRenderers(self) {
 
 	self.addTerm = async function (term) {
 		const termIsDisabled = self.opts.disable_terms?.includes(term.id)
-		const uses = isUsableTerm(term, self.state.usecase)
+		const uses = isUsableTerm(term, self.state.usecase, self.app.vocabApi.termdbConfig)
 
 		const div = select(this)
 			.attr('class', cls_termdiv)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- At GDC lollipop subtrack, disable survival term when building the filter

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -103,6 +103,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	if (tdb.hasAncestry) c.hasAncestry = tdb.hasAncestry
 	if (tdb.logscaleBase2) c.logscaleBase2 = tdb.logscaleBase2
 	if (tdb.useCasesExcluded) c.useCasesExcluded = tdb.useCasesExcluded
+	if (tdb.excludedTermtypeByTarget) c.excludedTermtypeByTarget = tdb.excludedTermtypeByTarget
 
 	if (ds.assayAvailability) c.assayAvailability = ds.assayAvailability
 	if (ds.customTwQByType) c.customTwQByType = ds.customTwQByType

--- a/server/shared/termdb.usecase.js
+++ b/server/shared/termdb.usecase.js
@@ -179,6 +179,18 @@ export function isUsableTerm(term, _usecase, ds) {
 				return uses
 			}
 
+		case 'filter':
+			if (graphableTypes.has(term.type)) {
+				if (usecase.detail == 'GDC') {
+					// is gdc ds. api doesn't support filtering by survival, do not show survival
+					if (term.type != 'survival') uses.add('plot')
+				} else {
+					uses.add('plot')
+				}
+			}
+			if (!term.isleaf) uses.add('branch')
+			return uses
+
 		default:
 			if (graphableTypes.has(term.type)) uses.add('plot')
 			if (!term.isleaf) uses.add('branch')

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -903,9 +903,18 @@ type Termdb = {
 	}
 	hierCluster?: any
 
-	/** ds customization of rules on what term type to exclude for a usecase. used by gdc in that gene exp cannot be used for filtering */
+	/** ds customization of rules in TermTypeSelect on what term type to exclude for a usecase.
+	used by gdc in that gene exp cannot be used for filtering 
+	note this applies to left-side term type tabs, but not terms in dict tree. latter is controlled by excludeTermtypeByTarget
+	*/
 	useCasesExcluded?: {
 		/** key is target name (todo restrict values), value is array of 1 or more term types (todo restrict values) */
+		[useCaseTarget: string]: string[]
+	}
+	/** ds customization to rules in isUsableTerm(). this applies to what's showing in dict tree
+	 */
+	excludedTermtypeByTarget?: {
+		/** key is usecase target (todo restrict). value is array of term type (todo restrict) */
 		[useCaseTarget: string]: string[]
 	}
 }


### PR DESCRIPTION
…e filter

## Description

closes #1948 

please pull sjpp master to test

test at http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC. build a subtk. click on the filter handle on left, and +ADD, at the dict tree, Overall survival is no longer present

for a non-gdc case, the survival term can still be added to subtk filter

all CI passed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
