### PR TITLE
fix file-based session recovery of regression plot

### DIFF
--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -141,17 +141,23 @@ let _ID_ = 1
 
 export async function getPlotConfig(opts, app) {
 	// TODO need to supply term filter of app to fillTermWrapper
-	if (!opts.outcome) {
-		opts.outcome = {}
-	}
+	if (!opts.outcome) opts.outcome = {}
 
 	{
 		/* for condition term as outcome, it will have q.mode='binary', rather than default "discrete"
 		as required by logistic/cox regression
 		*/
-		const plot = app.opts.state.plots.find(i => i.chartType == 'regression')
-		if (!plot) throw 'regression plot missing in state'
-		await fillTermWrapper(opts.outcome, app.vocabApi, get_defaultQ4fillTW(plot.regressionType, 'outcome'))
+		// const plot = app.opts.state.plots.find(i => i.chartType == 'regression')
+		// if (!plot) throw 'regression plot missing in state'
+		// await fillTermWrapper(opts.outcome, app.vocabApi, get_defaultQ4fillTW(plot.regressionType, 'outcome'))
+
+		// !!!
+		// the code above assumes that a regression plot exists, and that the first one
+		// relates to this particular opts.outcome, which may not be true when recovering a saved session
+		// with multiple regression plots
+		// !!!
+		// should check that the conditions are actually matched before using fillTermWrapper
+		await fillTermWrapper(opts.outcome, app.vocabApi, get_defaultQ4fillTW(opts.regressionType, 'outcome'))
 	}
 
 	const id = 'id' in opts ? opts.id : `_REGRESSION_${_ID_++}`
@@ -166,7 +172,7 @@ export async function getPlotConfig(opts, app) {
 			await fillTermWrapper(t, app.vocabApi, defaultQ)
 		}
 		config.independent = opts.independent
-		delete opts.independent
+		//delete opts.independent // not sure why this has to be deleted? it causes an issue with file-based session recovery
 	} else {
 		config.independent = []
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- fix file-based session recovery of regression plot


### PR DESCRIPTION
## Description

Tested by opening a downloaded session file with regression plot.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
