### PR TITLE
Wsi plot.2

### DIFF
--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -2,7 +2,6 @@ import { getCompInit, copyMerge } from '#rx'
 import { select } from 'd3-selection'
 import { controlsInit } from './controls'
 import { getNormalRoot } from '#filter/filter'
-import dziviewer from './dziviewer/plot.dzi'
 import { dofetch3 } from '#common/dofetch'
 
 const root_ID = 'root'
@@ -544,7 +543,8 @@ class SampleView {
 				if (data.sampleDZImages?.length > 0) {
 					const cellDiv = div.append('div').style('display', 'inline-block')
 					this.dziPlots.push({ sample, cellDiv })
-					dziviewer(state.vocab.dslabel, cellDiv, this.app.opts.genome, sample.sampleName, data.sampleDZImages)
+					const dziviewer = await import('./dziviewer/plot.dzi.js')
+					dziviewer.default(state.vocab.dslabel, cellDiv, this.app.opts.genome, sample.sampleName, data.sampleDZImages)
 				}
 			}
 		}

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -4,7 +4,6 @@ import { controlsInit } from './controls'
 import { getNormalRoot } from '#filter/filter'
 import dziviewer from './dziviewer/plot.dzi'
 import { dofetch3 } from '#common/dofetch'
-import wsiViewer from './wsiviewer/plot.wsi'
 
 const root_ID = 'root'
 const samplesLimit = 15
@@ -555,7 +554,8 @@ class SampleView {
 			if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
 			for (const sample of samples) {
 				const cellDiv = div.append('div').style('display', 'inline-block')
-				wsiViewer(state.vocab.dslabel, cellDiv, this.app.opts.genome, sample.sampleName)
+				const wsiViewer = await import('./wsiviewer/plot.wsi.js')
+				wsiViewer.default(state.vocab.dslabel, cellDiv, this.app.opts.genome, sample.sampleName)
 			}
 		}
 

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -85,6 +85,7 @@ export default class WSIViewer {
 			this.thumbnailsContainer = holder
 				.append('div')
 				.attr('id', 'thumbnails')
+				.attr('data-testid', 'sjpp-thumbnails')
 				.style('width', '600px')
 				.style('height', '80px')
 				.style('display', 'flex')

--- a/client/src/header/AppHeader.ts
+++ b/client/src/header/AppHeader.ts
@@ -7,6 +7,7 @@ import { rgb as d3rgb } from 'd3-color'
 import { defaultcolor } from '../../shared/common.js'
 import { Menu } from '../../dom/menu.js'
 import { dofetch3 } from '#common/dofetch'
+import { ClientCopyGenome } from 'types/global.ts'
 
 type Citation = {
 	id: number
@@ -215,12 +216,9 @@ export class AppHeader {
 				omniSearch.updatePlaceholder(get_placeholder())
 			})
 
-		for (const n in this.app.genomes) {
-			this.app.selectgenome
-				.append('option')
-				.attr('n', n)
-				.text(this.app.genomes[n].species + ' ' + n)
-				.property('value', n)
+		const filterGenomes = Object.values(this.app.genomes).filter((g: any) => !g.hideOnClient) as ClientCopyGenome[]
+		for (const n of filterGenomes) {
+			this.app.selectgenome.append('option').attr('n', n.name).text(`${n.species} ${n.name}`).property('value', n.name)
 		}
 		this.app.genome_browser_btn = this.make_genome_browser_btn(this.app, headbox, this.jwt)
 

--- a/client/types/global.ts
+++ b/client/types/global.ts
@@ -30,7 +30,7 @@ type ClientCopyDataset = {
 	isoffical?: boolean
 	legacyDsIsUninitiated?: boolean | number
 	mdsIsUninitiated?: boolean | number
-	/** Ignored by the client */
+	/** if true, will not show dataset button in lollipop plot */
 	noHandleOnClient?: boolean | number
 }
 // WIP
@@ -49,6 +49,8 @@ export type ClientCopyGenome = {
 	hasSNP: boolean
 	hicdomain?: { groups: any }
 	hicenzymefragment: { enzyme: string; file: string }[]
+	/** if true, do not show genome in the header dropdown */
+	hideOnClient?: boolean
 	geneset?: GeneSet
 	isdefault?: boolean
 	/** k: upper isoform

--- a/front/public/cards/index.json
+++ b/front/public/cards/index.json
@@ -362,6 +362,16 @@
             "ribbon": { "text":"new", "expireDate": "2024-09-01" },
             "sandboxJson": "geneExp",
             "searchterms": ["clustering","expression","hierarchical"]
+        },
+        {
+            "type": "card",
+            "name": "Whole Slide Imaging",
+            "section": "apps",
+            "description": "H&E images zooming and panning",
+            "image": "https://proteinpaint.stjude.org/ppdemo/images/wsi-square.png",
+            "ribbon": { "text": "new", "expireDate": "2024-10-01" },
+            "sandboxJson": "wsi",
+            "searchterms": ["H&E", "HE", "histology", "slice", "slide", "pathology"]  
         }
     ]
 }

--- a/front/public/cards/wsi.json
+++ b/front/public/cards/wsi.json
@@ -1,0 +1,27 @@
+{
+    "ribbonMessage": "We're excited to announce our new whole slide imaging viewer!",
+    "ppcalls": [
+        {
+            "runargs": {
+                "noheader": true,
+                "mass": {
+                    "state": {
+                        "dslabel": "TermdbTest",
+                        "genome": "hg38-test",
+                        "nav": {
+                            "header_mode": "hidden"
+                        },
+                        "sample_id": "B-T87L964D",
+                        "plots": [
+                            {
+                                "chartType": "WSIViewer",
+                                "subfolder": "wsiviewer",
+                                "extension": "ts"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Features
+- WSIViewer launchable from runproteinpaint() as a mass plot.
+- Example for the WSIViewer available from the app drawer. 

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -219,7 +219,13 @@ export default {
 			src: 'native',
 			file: 'files/hg38/TermdbTest/TermdbTest.fpkm.matrix.gz'
 		},
-		topVariablyExpressedGenes: { src: 'native' }
+		topVariablyExpressedGenes: {
+			src: 'native'
+		},
+		WSImages: {
+			type: 'H&E',
+			imageBySampleFolder: 'hg38-test/TermdbTest/wsimages'
+		}
 	},
 	assayAvailability: {
 		// term used below must be annotated on samples rather than patients(root). otherwise matrix will pull wrong samples for geneVariant term

--- a/server/routes/genomes.ts
+++ b/server/routes/genomes.ts
@@ -93,7 +93,8 @@ function clientcopy_genome(genomename, genomes) {
 		minorchr: g.minorchr,
 		tracks: g.tracks,
 		hicenzymefragment: g.hicenzymefragment,
-		datasets: {}
+		datasets: {},
+		hideOnClient: g.hideOnClient
 	}
 
 	if (g.termdbs) {

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -181,6 +181,9 @@ export async function initGenomesDs(serverconfig) {
 				}
 			}
 		}
+		if (g?.hideOnClient) {
+			g2.hideOnClient = g.hideOnClient
+		}
 	}
 
 	if (serverconfig.defaultgenome) {
@@ -389,7 +392,6 @@ export async function initGenomesDs(serverconfig) {
 			// allow to have no ds
 			continue
 		}
-
 		/*
 	done everything except dataset
 	*/


### PR DESCRIPTION
## Description
Addresses second and third tasks listed in issue #2021. 

Changes: 
1. Dynamically import wsi and dzi viewers in sample view
2. WSIViewer in app drawer
3. New `hideOnClient` flag for genomes. When true, will not show genome in app header genome dropdown

Test: 
1. Copy `wsimages` dir to the new -> `~data/tp/hg38-test/TermdbTest/wsimages`
2. [ws image app card]( http://localhost:3000/?appcard=wsi)
3. [Ninetindo public example](http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22mm10%22,%22dslabel%22:%22nintendoPublic%22%7D) -> should show same functionality 
4. Include `"hideOnClient": true,` for `hg38-test` in local server config. Should not show `hg38-test` in the header dropdown but still able to use the dataset. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
