### PR TITLE
Add sandbox header and change sample id for wsiviewer

### DIFF
--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -78,8 +78,8 @@ export default class WSIViewer {
 		}
 
 		if (this.opts.header) {
-			//If sandbox is present, add sample id to the header
-			this.opts.header.text(state.sample_id)
+			//If sandbox is present, add sample id and data type to the header
+			this.opts.header.text(`${state.sample_id} whole slide image${plotConfig.wsimages.length > 1 ? 's' : ''}`)
 		}
 	}
 

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -79,7 +79,7 @@ export default class WSIViewer {
 
 		if (this.opts.header) {
 			//If sandbox is present, add sample id and data type to the header
-			this.opts.header.text(`${state.sample_id} whole slide image${plotConfig.wsimages.length > 1 ? 's' : ''}`)
+			this.opts.header.text(`${state.sample_id} ${state.termdbConfig.queries.WSImages.type}`)
 		}
 	}
 

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -79,7 +79,9 @@ export default class WSIViewer {
 
 		if (this.opts.header) {
 			//If sandbox is present, add sample id and data type to the header
-			this.opts.header.text(`${state.sample_id} ${state.termdbConfig.queries.WSImages.type}`)
+			this.opts.header.html(
+				`${state.sample_id} <span style="font-size:.8em">${state.termdbConfig.queries.WSImages.type} images</span>`
+			)
 		}
 	}
 

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -76,6 +76,11 @@ export default class WSIViewer {
 		if (activeImageExtent) {
 			map.getView().fit(activeImageExtent)
 		}
+
+		if (this.opts.header) {
+			//If sandbox is present, add sample id to the header
+			this.opts.header.text(state.sample_id)
+		}
 	}
 
 	private generateThumbnails(layers: Array<TileLayer<Zoomify>>, setting: Settings) {

--- a/front/public/cards/wsi.json
+++ b/front/public/cards/wsi.json
@@ -11,7 +11,7 @@
                         "nav": {
                             "header_mode": "hidden"
                         },
-                        "sample_id": "B-T87L964D",
+                        "sample_id": "TCGA-22-1017",
                         "plots": [
                             {
                                 "chartType": "WSIViewer",

--- a/front/public/cards/wsi.json
+++ b/front/public/cards/wsi.json
@@ -3,6 +3,7 @@
     "ppcalls": [
         {
             "runargs": {
+                "host": "https://proteinpaint.stjude.org/",
                 "noheader": true,
                 "mass": {
                     "state": {


### PR DESCRIPTION
## Description
Please note: The app card will *not* work until `hg38-test`, `TermdbTest`, and the tileserver is enabled on `prp2`. The host is set to `proteinpaint.stjude.org` to avoid maintaining the image on multiple servers and locally. To see changes, remove the `host` from the `runpp()` in `wsi.json`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
