### PR TITLE
Hide app cards base on server config options

### DIFF
--- a/client/appdrawer/layout.js
+++ b/client/appdrawer/layout.js
@@ -76,12 +76,8 @@ class AppDrawerLayoutComp {
 	}
 
 	validateElements() {
-		const features = JSON.parse(sessionStorage.getItem('optionalFeatures'))
-		this.elements = this.index.elements
-			.filter(e => !e.hidden)
-			.filter(e => {
-				return e.configFeature ? features[e.configFeature] === 1 || features[e.configFeature] === true : true
-			})
+		const features = JSON.parse(sessionStorage.getItem('optionalFeatures')) || {}
+		this.elements = this.index.elements.filter(e => !e.hidden && (!e.configFeature || features[e.configFeature]))
 	}
 
 	async init() {

--- a/client/appdrawer/layout.js
+++ b/client/appdrawer/layout.js
@@ -75,11 +75,20 @@ class AppDrawerLayoutComp {
 		return re
 	}
 
+	validateElements() {
+		const features = JSON.parse(sessionStorage.getItem('optionalFeatures'))
+		this.elements = this.index.elements
+			.filter(e => !e.hidden)
+			.filter(e => {
+				return e.configFeature ? features[e.configFeature] === 1 || features[e.configFeature] === true : true
+			})
+	}
+
 	async init() {
 		this.index = await this.validateIndexJson()
 		this.elementsRendered = false
 		setRenderers(this)
-		this.elements = this.index.elements.filter(e => !e.hidden)
+		this.validateElements()
 		this.layout = this.index.columnsLayout ? this.index.columnsLayout : null
 		this.components = {
 			elements: []
@@ -87,7 +96,7 @@ class AppDrawerLayoutComp {
 	}
 
 	async main() {
-		//prevent elements from reloading each time
+		// prevent elements from reloading each time
 		if (this.elementsRendered == true) return
 		this.elementsRendered = true
 		for (const element of this.elements) {
@@ -155,10 +164,7 @@ function columnsLayout(self) {
 	for (const column of self.index.columnsLayout) gridareas.push(column.gridarea)
 	parentGrid.style('grid-template-areas', `"${gridareas.toString().replace(',', ' ')}"`)
 	for (const col of self.index.columnsLayout) {
-		const newCol = parentGrid
-			.append('div')
-			.style('grid-area', col.gridarea)
-			.classed('.sjpp-track-cols', true)
+		const newCol = parentGrid.append('div').style('grid-area', col.gridarea).classed('.sjpp-track-cols', true)
 		for (const section of col.sections) addSection(section, newCol)
 	}
 
@@ -170,10 +176,7 @@ function columnsLayout(self) {
 				.classed('sjpp-appdrawer-cols', true)
 				.style('color', rgb(defaultcolor).darker())
 				.text(section.name)
-		newSection
-			.append('div')
-			.classed('sjpp-element-list', true)
-			.style('padding', '10px')
+		newSection.append('div').classed('sjpp-element-list', true).style('padding', '10px')
 
 		return newSection
 	}

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -39,6 +39,17 @@ upon error, throw err message as a string
 			cardsPath: 'cards'
 		}
 		const element = re.elements.findIndex(t => t.sandboxJson == cardJsonFile || t.sandboxHtml == cardJsonFile)
+
+		//Check if track/app can be shown on this server
+		//If not show error message
+		if (re.elements[element].configFeature) {
+			const features = JSON.parse(sessionStorage.getItem('optionalFeatures'))
+			if (!features[re.elements[element].configFeature]) {
+				sayerror(arg.holder, `This track or app is not enabled on this site.`)
+				return
+			}
+		}
+
 		if (element <= 0) {
 			const nestedCards = [...re.elements.filter(e => e.type == 'nestedCard')]
 			let element, c

--- a/front/public/cards/index.json
+++ b/front/public/cards/index.json
@@ -366,6 +366,7 @@
         {
             "type": "card",
             "name": "Whole Slide Imaging",
+            "configFeature": "showWSImages",
             "section": "apps",
             "description": "H&E images zooming and panning",
             "image": "https://proteinpaint.stjude.org/ppdemo/images/wsi-square.png",

--- a/front/public/cards/wsi.json
+++ b/front/public/cards/wsi.json
@@ -3,7 +3,6 @@
     "ppcalls": [
         {
             "runargs": {
-                "host": "https://proteinpaint.stjude.org/",
                 "noheader": true,
                 "mass": {
                     "state": {

--- a/front/public/cards/wsi.json
+++ b/front/public/cards/wsi.json
@@ -3,6 +3,7 @@
     "ppcalls": [
         {
             "runargs": {
+                "host": "https://proteinpaint.stjude.org/",
                 "noheader": true,
                 "mass": {
                     "state": {


### PR DESCRIPTION
## Description
Fix for showing elements on the app drawer based on features enabled on the server. 

Changes: 
1. Allow filtering elements based on the serverconfig
2. Show error message when trying to access a card that is not enabled on a site

Test: 
1. Remove `features.showWSImages` from serverconfig. 
2. Open http://localhost:3000/ -> Should not show wsi card. 
3. Open http://localhost:3000/?appcard=wsi -> Should show user error message
4. Adding `features.showWSImages` back to the serverconfig shows the card and the card from `appcard`. **Please note, the example is still the `prp2` host which will not work until `hg38-test`, `TermdbTest`, and the tileserver are enabled.**


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
