### PR TITLE
Hide regression tables

### DIFF
--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -61,8 +61,7 @@ class Regression {
 			termfilter: appState.termfilter,
 			config,
 			allowedTermTypes: appState.termdbConfig.allowedTermTypes,
-			minTimeSinceDx: appState.termdbConfig.minTimeSinceDx,
-			hideRegressionTables: appState.termdbConfig.hideRegressionTables
+			minTimeSinceDx: appState.termdbConfig.minTimeSinceDx
 		}
 	}
 

--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -61,7 +61,8 @@ class Regression {
 			termfilter: appState.termfilter,
 			config,
 			allowedTermTypes: appState.termdbConfig.allowedTermTypes,
-			minTimeSinceDx: appState.termdbConfig.minTimeSinceDx
+			minTimeSinceDx: appState.termdbConfig.minTimeSinceDx,
+			hideRegressionTables: appState.termdbConfig.hideRegressionTables
 		}
 	}
 

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -641,7 +641,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_type3 = result => {
-		if (!result.type3 || self.state.hideRegressionTables?.includes('type3')) return
+		if (!result.type3 || self.parent.app.vocabApi.termdbConfig.hideRegressionTables?.includes('type3')) return
 		const div = self.newDiv(result.type3.label)
 		const table = div.append('table').style('border-spacing', '0px')
 
@@ -694,7 +694,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_tests = result => {
-		if (!result.tests || self.state.hideRegressionTables?.includes('tests')) return
+		if (!result.tests || self.parent.app.vocabApi.termdbConfig.hideRegressionTables?.includes('tests')) return
 		const div = self.newDiv(result.tests.label)
 		const table = div.append('table').style('border-spacing', '0px')
 		const header = table.append('tr').style('opacity', 0.4)

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -641,7 +641,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_type3 = result => {
-		if (!result.type3 || self.state.hideRegressionTables.includes('type3')) return
+		if (!result.type3 || self.state.hideRegressionTables?.includes('type3')) return
 		const div = self.newDiv(result.type3.label)
 		const table = div.append('table').style('border-spacing', '0px')
 
@@ -694,7 +694,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_tests = result => {
-		if (!result.tests || self.state.hideRegressionTables.includes('tests')) return
+		if (!result.tests || self.state.hideRegressionTables?.includes('tests')) return
 		const div = self.newDiv(result.tests.label)
 		const table = div.append('table').style('border-spacing', '0px')
 		const header = table.append('tr').style('opacity', 0.4)

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -641,7 +641,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_type3 = result => {
-		if (!result.type3) return
+		if (!result.type3 || self.state.hideRegressionTables.includes('type3')) return
 		const div = self.newDiv(result.type3.label)
 		const table = div.append('table').style('border-spacing', '0px')
 
@@ -694,7 +694,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_tests = result => {
-		if (!result.tests) return
+		if (!result.tests || self.state.hideRegressionTables.includes('tests')) return
 		const div = self.newDiv(result.tests.label)
 		const table = div.append('table').style('border-spacing', '0px')
 		const header = table.append('tr').style('opacity', 0.4)

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -95,6 +95,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	// when missing, the attribute will not be present as "key:undefined"
 	if (tdb.chartConfigByType) c.chartConfigByType = tdb.chartConfigByType
 	if (tdb.multipleTestingCorrection) c.multipleTestingCorrection = tdb.multipleTestingCorrection
+	if (tdb.hideRegressionTables) c.hideRegressionTables = tdb.hideRegressionTables
 	if (tdb.helpPages) c.helpPages = tdb.helpPages
 	if (tdb.minTimeSinceDx) c.minTimeSinceDx = tdb.minTimeSinceDx
 	if (tdb.timeUnit) c.timeUnit = tdb.timeUnit

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -874,6 +874,7 @@ type Termdb = {
 	dataDownloadCatch?: DataDownloadCatch
 	helpPages?: URLEntry[]
 	multipleTestingCorrection?: MultipleTestingCorrection
+	hideRegressionTables?: string[]
 	urlTemplates?: {
 		/** gene link definition */
 		gene?: UrlTemplateBase


### PR DESCRIPTION
## Description

Conditionally hide regression tables based on settings in dataset. Companion sjpp PR is found here: https://github.com/stjude/sjpp/pull/446

Can test by running regression analysis in SJLIFE and in MBMETA. Type III statistics will show in former, but not latter.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
