### PR TITLE
Gene overrepresentation analysis update

### DIFF
--- a/client/plots/geneORA.js
+++ b/client/plots/geneORA.js
@@ -166,7 +166,9 @@ add:
 		self.gene_ora_table_cols = [
 			{ label: 'Gene set group' },
 			{ label: 'Original p-value (linear scale)' },
-			{ label: 'Adjusted p-value (linear scale)' }
+			{ label: 'Adjusted p-value (linear scale)' },
+			{ label: 'Gene set hits' },
+			{ label: 'Gene set size' }
 		]
 		self.gene_ora_table_rows = []
 		for (const pathway of output.pathways) {
@@ -174,7 +176,9 @@ add:
 				self.gene_ora_table_rows.push([
 					{ value: pathway.pathway_name },
 					{ value: pathway.p_value_original.toPrecision(4) },
-					{ value: pathway.p_value_adjusted.toPrecision(4) }
+					{ value: pathway.p_value_adjusted.toPrecision(4) },
+					{ value: pathway.gene_set_hits },
+					{ value: pathway.gene_set_size }
 				])
 			} else if (
 				self.settings.adjusted_original_pvalue == 'original' &&
@@ -183,7 +187,9 @@ add:
 				self.gene_ora_table_rows.push([
 					{ value: pathway.pathway_name },
 					{ value: pathway.p_value_original.toPrecision(4) },
-					{ value: pathway.p_value_adjusted.toPrecision(4) }
+					{ value: pathway.p_value_adjusted.toPrecision(4) },
+					{ value: pathway.gene_set_hits },
+					{ value: pathway.gene_set_size }
 				])
 			}
 		}

--- a/client/plots/geneORA.js
+++ b/client/plots/geneORA.js
@@ -62,6 +62,15 @@ class geneORA {
 					{ label: 'adjusted', value: 'adjusted' },
 					{ label: 'original', value: 'original' }
 				]
+			},
+			{
+				label: 'Gene set size filter cutoff',
+				type: 'number',
+				chartType: 'geneORA',
+				settingsKey: 'gene_set_size_cutoff',
+				title: 'Gene set size cutoff',
+				min: 0,
+				max: 20000
 			}
 		]
 
@@ -172,7 +181,11 @@ add:
 		]
 		self.gene_ora_table_rows = []
 		for (const pathway of output.pathways) {
-			if (self.settings.adjusted_original_pvalue == 'adjusted' && self.settings.pvalue >= pathway.p_value_adjusted) {
+			if (
+				self.settings.adjusted_original_pvalue == 'adjusted' &&
+				self.settings.pvalue >= pathway.p_value_adjusted &&
+				self.settings.gene_set_size_cutoff > pathway.gene_set_size
+			) {
 				self.gene_ora_table_rows.push([
 					{ value: pathway.pathway_name },
 					{ value: pathway.p_value_original.toPrecision(4) },
@@ -182,7 +195,8 @@ add:
 				])
 			} else if (
 				self.settings.adjusted_original_pvalue == 'original' &&
-				self.settings.pvalue >= pathway.p_value_original
+				self.settings.pvalue >= pathway.p_value_original &&
+				self.settings.gene_set_size_cutoff > pathway.gene_set_size
 			) {
 				self.gene_ora_table_rows.push([
 					{ value: pathway.pathway_name },
@@ -216,7 +230,8 @@ export async function getPlotConfig(opts, app) {
 				geneORA: {
 					pvalue: 1.0,
 					adjusted_original_pvalue: 'adjusted',
-					pathway: undefined
+					pathway: undefined,
+					gene_set_size_cutoff: 2000
 				},
 				controls: { isOpen: true }
 			}

--- a/client/plots/geneORA.js
+++ b/client/plots/geneORA.js
@@ -143,7 +143,18 @@ add:
 	if (self.settings.pathway != '-') {
 		self.dom.detailsDiv.selectAll('*').remove()
 		self.config.geneORAparams.geneSetGroup = self.settings.pathway
-		const output = await rungeneORA(self.config.geneORAparams)
+		const wait = self.dom.detailsDiv.append('div').text('Loading...')
+		let output
+		try {
+			output = await rungeneORA(self.config.geneORAparams)
+			wait.remove()
+			if (output.error) {
+				throw output.error
+			}
+		} catch (e) {
+			alert('Error: ' + e)
+			return
+		}
 		const table_stats = table2col({ holder: self.dom.detailsDiv })
 		const [t1, t2] = table_stats.addRow()
 		t2.style('text-align', 'center').style('font-size', '0.8em').style('opacity', '0.8').text('COUNT')

--- a/rust/src/genesetORA.rs
+++ b/rust/src/genesetORA.rs
@@ -40,17 +40,29 @@ fn calculate_hypergeometric_p_value(
     sample_genes: &Vec<&str>,
     num_background_genes: usize,
     genes_in_pathway: Vec<pathway_genes>,
-) -> f64 {
-    let matching_sample_genes_counts: f64 = sample_genes
-        .iter()
-        .zip(&genes_in_pathway)
-        .filter(|&(a, b)| *a.to_string() == b.symbol)
-        .count() as f64;
+) -> (f64, f64) {
+    //let matching_sample_genes_counts: f64 = sample_genes
+    //    .iter()
+    //    .zip(&genes_in_pathway)
+    //    .filter(|&(a, b)| *a.to_string() == b.symbol)
+    //    .count() as f64;
+
+    let mut matching_sample_genes_counts = 0.0;
+    for gene in sample_genes {
+        for pathway in &genes_in_pathway {
+            if pathway.symbol == gene.to_string() {
+                matching_sample_genes_counts += 1.0;
+            }
+        }
+    }
+
+    //println!("sample_genes:{:?}", sample_genes);
+    //println!("genes_in_pathway:{:?}", genes_in_pathway);
     //println!("k-1:{}", matching_sample_genes_counts - 1.0);
     //println!("M:{}", genes_in_pathway.len() as f64);
     //println!(
     //    "N-M:{}",
-    //    background_genes.len() as f64 - genes_in_pathway.len() as f64
+    //    num_background_genes as f64 - genes_in_pathway.len() as f64
     //);
     //println!("n:{}", sample_genes.len() as f64);
     let p_value = r_mathlib::hypergeometric_cdf(
@@ -62,7 +74,7 @@ fn calculate_hypergeometric_p_value(
         false,
     );
     //println!("p_value:{}", p_value);
-    p_value
+    (p_value, matching_sample_genes_counts)
 }
 
 fn main() -> Result<()> {
@@ -184,12 +196,12 @@ fn main() -> Result<()> {
                                                 }
                                             }
                                         }
-                                        let p_value = calculate_hypergeometric_p_value(
+                                        let (p_value, matches) = calculate_hypergeometric_p_value(
                                             &sample_genes,
                                             num_background_genes,
                                             names,
                                         );
-                                        if p_value.is_nan() == false {
+                                        if matches >= 1.0 && p_value.is_nan() == false {
                                             pathway_p_values.push(pathway_p_value {
                                                 pathway_name: n.GO_id,
                                                 p_value_original: p_value,

--- a/rust/src/genesetORA.rs
+++ b/rust/src/genesetORA.rs
@@ -43,12 +43,6 @@ fn calculate_hypergeometric_p_value(
     num_background_genes: usize,
     genes_in_pathway: Vec<pathway_genes>,
 ) -> (f64, f64, String) {
-    //let matching_sample_genes_counts: f64 = sample_genes
-    //    .iter()
-    //    .zip(&genes_in_pathway)
-    //    .filter(|&(a, b)| *a.to_string() == b.symbol)
-    //    .count() as f64;
-
     let mut matching_sample_genes_counts = 0.0;
     let mut gene_set_hits: String = "".to_string();
     for gene in sample_genes {

--- a/rust/src/genesetORA.rs
+++ b/rust/src/genesetORA.rs
@@ -148,7 +148,6 @@ fn main() -> Result<()> {
                             + &genesetgroup
                             + "'"),
                     );
-                    let mut iter = 0;
                     match stmt_result {
                         Ok(mut stmt) => {
                             #[allow(non_snake_case)]
@@ -156,7 +155,6 @@ fn main() -> Result<()> {
                                 stmt.query_map([], |row| Ok(GO_pathway { GO_id: row.get(0)? }))?;
                             #[allow(non_snake_case)]
                             for GO_term in GO_iter {
-                                iter += 1;
                                 match GO_term {
                                     Ok(n) => {
                                         //println!("GO term {:?}", n);
@@ -218,7 +216,7 @@ fn main() -> Result<()> {
                         Err(_) => panic!("sqlite database file not found"),
                     }
                     let output_string = "{\"num_pathways\":".to_string()
-                        + &iter.to_string()
+                        + &pathway_p_values.len().to_string()
                         + &",\"pathways\":"
                         + &adjust_p_values(pathway_p_values, num_items_output)
                         + &"}";

--- a/rust/src/genesetORA.rs
+++ b/rust/src/genesetORA.rs
@@ -289,8 +289,7 @@ fn adjust_p_values(
 
     let mut output_string = "[".to_string();
     for i in 0..num_items_output {
-        let j = adjusted_p_values.len() - i - 1;
-        output_string += &serde_json::to_string(&adjusted_p_values[j]).unwrap();
+        output_string += &serde_json::to_string(&adjusted_p_values[i]).unwrap();
         if i < num_items_output - 1 {
             output_string += &",".to_string();
         }


### PR DESCRIPTION
## Description

 1) Fixed error in calculating matches between input genes and pathways.
 2) Now gene sets with matches are only used for calculating adjusted p-values.
 3) Display gene hits and gene set sizes for each gene set.
 4) Added gene set size cutoff to optionally remove gene sets with very large number of genes.

NOTE: GeneORA is a bit slow (for sample gene size ~ 800) when invoked through the DE app. It takes ~30s. This will be addressed in a subsequent branch. Maybe this is not required at all as gene ORA has an upper limit of 500 in hierarchial clustering (and gsea is more applicable for DE).


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
