### PR TITLE
Show user error message for an invalid sample id and remove previously displayed plots

### DIFF
--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -4,6 +4,7 @@ import { controlsInit } from './controls'
 import { getNormalRoot } from '#filter/filter'
 import { dofetch3 } from '#common/dofetch'
 import { isNumericTerm, ROOT_SAMPLE_TYPE } from '../shared/terms.js'
+import { sayerror } from '#dom/sayerror'
 
 const root_ID = 'root'
 const samplesLimit = 15
@@ -116,9 +117,19 @@ class SampleView {
 					this.app.dispatch({ type: 'plot_edit', id: this.id, config: { samples } })
 				} else {
 					this.dom.tableDiv.style('display', 'none')
-					for (const div of this.discoPlots) div.style('display', 'none')
-					for (const div of this.singleSamplePlots) div.style('display', 'none')
-					for (const div of this.brainPlots) div.style('display', 'none')
+					for (const div of this.discoPlots) div.cellDiv.style('display', 'none')
+					for (const div of Object.values(this.singleSamplePlots)) {
+						div.forEach(p => p.cellDiv.style('display', 'none'))
+					}
+					for (const div of this.brainPlots) div.cellDiv.style('display', 'none')
+
+					if (sampleName != '') {
+						const errorDiv = sampleDiv.append('div')
+						sayerror(errorDiv, `Invalid sample ID: ${sampleName}. Please check the sample ID.`)
+						setTimeout(() => {
+							errorDiv.remove()
+						}, 6000)
+					}
 				}
 			}
 			const sampleName = searchSampleInput(this.dom.sampleDiv, this.samplesData, callback)

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -4,7 +4,7 @@ import { controlsInit } from './controls'
 import { getNormalRoot } from '#filter/filter'
 import { dofetch3 } from '#common/dofetch'
 import { isNumericTerm, ROOT_SAMPLE_TYPE } from '../shared/terms.js'
-import { sayerror } from '#dom/sayerror'
+import { sayerror } from '../dom/sayerror.ts'
 
 const root_ID = 'root'
 const samplesLimit = 15


### PR DESCRIPTION
## Description
Closes issue #2048 

Changes: 
When an invalid id is entered:
  1. An error message is shown for six seconds 
  2. All plots are hidden 

Test: 
http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22} -> enter SJMB123456 or any other invalid id. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
