### PR TITLE
Regression settings for Neuro-Onc datasets

### DIFF
--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -404,6 +404,7 @@ export class InputTerm {
 		if (!this.term) return // missing term
 		if (this.section.configKey != 'independent') return
 		if (this.term.q.mode == 'spline') return // not on a spline term
+		if (this.parent.app.vocabApi.termdbConfig.neuroOncRegression) return
 		{
 			// require minimum of 2 independent terms eligible for interaction
 			let count = 0

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -500,7 +500,11 @@ function setRenderers(self) {
 		a plot is added to 3rd column of each row
 		plotter can be a blank function if there's no valid value for plotting
 		*/
-		const forestPlotter = self.getForestPlotter(result.coefficients.terms, result.coefficients.interactions)
+		const forestPlotter = self.getForestPlotter(
+			result.coefficients.terms,
+			result.coefficients.interactions,
+			neuroOncCox
+		)
 		let rowcount = self.config.regressionType == 'cox' ? 1 : 0
 		for (const tid in result.coefficients.terms) {
 			const termdata = result.coefficients.terms[tid]
@@ -753,7 +757,7 @@ function setRenderers(self) {
 	in that case should use array[i+1] or next to find the smallest real number as axis min
 	an arbitary cap is used to guard against extreme estimate values
 	*/
-	self.getForestPlotter = (terms, interactions) => {
+	self.getForestPlotter = (terms, interactions, neuroOncCox) => {
 		// array indices are the same for both non-interacting and interacting rows
 		let midIdx, // array index of the beta/odds ratio
 			CIlow, // array(column) index of low end of confidence interval of midIdx
@@ -905,7 +909,8 @@ function setRenderers(self) {
 				.attr('stroke', forestcolor)
 		}
 		///////// helpers
-		function numbers2array(lst) {
+		function numbers2array(_lst) {
+			const lst = neuroOncCox ? _lst.slice(1) : _lst // do not consider event count
 			const m = Number(lst[midIdx])
 			if (!Number.isNaN(m)) values.push(m)
 			const l = Number(lst[CIlow]),

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -470,12 +470,15 @@ function setRenderers(self) {
 
 		// padding is set on every <td>. need a better solution
 
+		// different format for cox regression for neuro-oncology datasets
+		const neuroOncCox = self.config.regressionType == 'cox' && self.app.vocabApi.termdbConfig.neuroOncRegression
+
 		// header row
 		{
 			const tr = table.append('tr').style('opacity', 0.4)
 			result.coefficients.header.forEach((v, i) => {
 				tr.append('td').text(v).style('padding', '8px')
-				if (i === 1) tr.append('td') // column 3 will be for forest plot
+				if (i === (neuroOncCox ? 2 : 1)) tr.append('td') // add column for forest plot
 			})
 		}
 
@@ -511,16 +514,24 @@ function setRenderers(self) {
 			if (termdata.fields) {
 				// create only 1 row for this term in coefficients table, as it doesn't have categories
 
+				const cols = termdata.fields
+
 				// col 2: category column
 				{
 					const td = tr.append('td').style('padding', '8px')
 					fillColumn2coefficientsTable(td, tw)
 				}
 
+				if (neuroOncCox) {
+					// add events column for cox regression for
+					// neuro-onc datasets
+					tr.append('td').style('padding', '8px').text(cols.shift())
+				}
+
 				// col 3
-				forestPlotter(tr.append('td'), termdata.fields)
+				forestPlotter(tr.append('td'), cols)
 				// rest of columns
-				for (const v of termdata.fields) {
+				for (const v of cols) {
 					tr.append('td').text(v).style('padding', '8px')
 				}
 			} else if (termdata.categories) {
@@ -551,15 +562,23 @@ function setRenderers(self) {
 						tr = table.append('tr').style('background', rowcount++ % 2 ? '#eee' : 'none')
 					}
 
-					// col 2
+					const cols = termdata.categories[k]
+
+					// col 2: category column
 					const td = tr.append('td').style('padding', '8px')
 					fillColumn2coefficientsTable(td, tw, k)
 
+					if (neuroOncCox) {
+						// add events column for cox regression for
+						// neuro-onc datasets
+						tr.append('td').style('padding', '8px').text(cols.shift())
+					}
+
 					// col 3
-					forestPlotter(tr.append('td'), termdata.categories[k])
+					forestPlotter(tr.append('td'), cols)
 
 					// rest of columns
-					for (const v of termdata.categories[k]) {
+					for (const v of cols) {
 						tr.append('td').text(v).style('padding', '8px')
 					}
 				}
@@ -599,7 +618,8 @@ function setRenderers(self) {
 		const tr = table.append('tr')
 		tr.append('td') // col 1
 		tr.append('td') // col 2
-		forestPlotter(tr.append('td')) // col 3, axis
+		if (neuroOncCox) tr.append('td')
+		forestPlotter(tr.append('td')) // forest plot axis
 		for (const v of result.coefficients.header) tr.append('td')
 	}
 
@@ -641,7 +661,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_type3 = result => {
-		if (!result.type3 || self.parent.app.vocabApi.termdbConfig.hideRegressionTables?.includes('type3')) return
+		if (!result.type3 || self.parent.app.vocabApi.termdbConfig.neuroOncRegression) return
 		const div = self.newDiv(result.type3.label)
 		const table = div.append('table').style('border-spacing', '0px')
 
@@ -694,7 +714,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_tests = result => {
-		if (!result.tests || self.parent.app.vocabApi.termdbConfig.hideRegressionTables?.includes('tests')) return
+		if (!result.tests || self.parent.app.vocabApi.termdbConfig.neuroOncRegression) return
 		const div = self.newDiv(result.tests.label)
 		const table = div.append('table').style('border-spacing', '0px')
 		const header = table.append('tr').style('opacity', 0.4)

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -95,7 +95,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	// when missing, the attribute will not be present as "key:undefined"
 	if (tdb.chartConfigByType) c.chartConfigByType = tdb.chartConfigByType
 	if (tdb.multipleTestingCorrection) c.multipleTestingCorrection = tdb.multipleTestingCorrection
-	if (tdb.hideRegressionTables) c.hideRegressionTables = tdb.hideRegressionTables
+	if (tdb.neuroOncRegression) c.neuroOncRegression = tdb.neuroOncRegression
 	if (tdb.helpPages) c.helpPages = tdb.helpPages
 	if (tdb.minTimeSinceDx) c.minTimeSinceDx = tdb.minTimeSinceDx
 	if (tdb.timeUnit) c.timeUnit = tdb.timeUnit

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -874,7 +874,11 @@ type Termdb = {
 	dataDownloadCatch?: DataDownloadCatch
 	helpPages?: URLEntry[]
 	multipleTestingCorrection?: MultipleTestingCorrection
-	hideRegressionTables?: string[]
+	/** regression settings for neuro-oncology portals:
+	- no interaction terms
+	- report event counts of cox coefficients
+	- hide type III stats and miscellaneous statistical tests */
+	neuroOncRegression?: boolean
 	urlTemplates?: {
 		/** gene link definition */
 		gene?: UrlTemplateBase

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -397,6 +397,8 @@ function makeRinput(q, sampledata) {
 		independent
 	}
 
+	if (q.ds.cohort.termdb.neuroOncRegression) Rinput.neuroOnc = true
+
 	return Rinput
 }
 

--- a/server/utils/regression.R
+++ b/server/utils/regression.R
@@ -127,7 +127,7 @@ benchmark[["buildFormulas"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dt
 stime <- Sys.time()
 cores <- detectCores()
 if (is.na(cores)) stop("unable to detect number of cores")
-reg_results <- mclapply(X = formulas, FUN = runRegression, regtype = input$regressionType, dat = dat, outcome = input$outcome, mc.cores = cores)
+reg_results <- mclapply(X = formulas, FUN = runRegression, regtype = input$regressionType, dat = dat, outcome = input$outcome, neuroOnc = input$neuroOnc, mc.cores = cores)
 etime <- Sys.time()
 dtime <- etime - stime
 benchmark[["runRegression"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dtime, "units")))


### PR DESCRIPTION
## Description

Implemented regression settings specific to Neuro-Onc datasets:

- Disabled interaction terms
- Report event counts of coefficients in Cox regression
- Hide Type III statistics and miscellaneous statistical tests

Corresponding sjpp PR is found here: https://github.com/stjude/sjpp/pull/448

Can test by running regression using a Neuro-Onc dataset (e.g., mbmeta) and a non-Neuro-Onc dataset (e.g., sjlife).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
