### PR TITLE
Disable download btn when sample name is invalid

### DIFF
--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -115,6 +115,7 @@ class SampleView {
 					const samples = getSamplesRelated(this.samplesData, sampleName)
 
 					this.app.dispatch({ type: 'plot_edit', id: this.id, config: { samples } })
+					this.dom.downloadbt.property('disabled', false)
 				} else {
 					this.dom.tableDiv.style('display', 'none')
 					for (const div of this.discoPlots) div.cellDiv.style('display', 'none')
@@ -124,6 +125,7 @@ class SampleView {
 					for (const div of this.brainPlots) div.cellDiv.style('display', 'none')
 
 					if (sampleName != '') {
+						this.dom.downloadbt.property('disabled', true)
 						const errorDiv = sampleDiv.append('div')
 						sayerror(errorDiv, `Invalid sample ID: ${sampleName}. Please check the sample ID.`)
 						setTimeout(() => {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- Disable sample view download data button when an invalid sample id is entered.


### PR DESCRIPTION
## Description
Closes issue #1376. 

Change:
1. Download button to the right of the input field is disabled when an invalid sample id is entered. 

Test:
1. [TermdbTest sample view](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22sampleView%22,%22samples%22:[{%22sampleId%22:1,%22sampleName%22:%22SJMB030539%22}]}]}) -> type something random into input and enter -> type 2646 and enter. Should disable and then reenable download button. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
