### PR TITLE
Do not show error message on sampleView, for subplots

### DIFF
--- a/client/plots/plot.disco.js
+++ b/client/plots/plot.disco.js
@@ -25,7 +25,7 @@ genomeObj={}
 _overrides={}
 	optional override parameters to pass to disco
 */
-export default async function (termdbConfig, dslabel, sample, holder, genomeObj, _overrides = {}) {
+export default async function (termdbConfig, dslabel, sample, holder, genomeObj, _overrides = {}, showError = true) {
 	const overrides = computeOverrides(_overrides, termdbConfig, genomeObj, sample)
 
 	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
@@ -100,8 +100,11 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj,
 		const plot = await import('#plots/plot.app.js')
 		const plotAppApi = await plot.appInit(opts)
 		loadingDiv.remove()
+		return true
 	} catch (e) {
-		loadingDiv.text('Error: ' + (e.message || e))
+		if (showError) loadingDiv.text('Error: ' + (e.message || e))
+		else loadingDiv.remove()
+		return false
 	}
 }
 

--- a/client/plots/plot.ssgq.js
+++ b/client/plots/plot.ssgq.js
@@ -39,7 +39,8 @@ export async function plotSingleSampleGenomeQuantification(
 	sample,
 	holder,
 	genomeObj,
-	geneName
+	geneName,
+	showError = true
 ) {
 	const loadingDiv = holder.append('div').text('Loading...')
 	try {
@@ -132,8 +133,11 @@ export async function plotSingleSampleGenomeQuantification(
 			// block is not present yet. load block
 			bb = await plotSingleSampleGbtk(dslabel, sample, holder, genomeObj, q, q2, chr, start, stop)
 		})
+		return true
 	} catch (e) {
-		loadingDiv.text('Error: ' + (e.message || e))
+		if (showError) loadingDiv.text('Error: ' + (e.message || e))
+		else loadingDiv.remove()
+		return false
 	}
 }
 

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -576,24 +576,30 @@ class SampleView {
 		if (state.termdbConfig?.queries?.singleSampleMutation) {
 			let div = plotsDiv.append('div')
 			if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
-
+			let someFound = false
 			for (const sample of samples) {
 				const cellDiv = div.append('div').style('display', 'inline-block')
 				this.discoPlots.push({ sample, cellDiv })
 				if (state.samples.length > 1)
 					cellDiv.insert('div').style('font-weight', 'bold').style('padding-left', '20px').text(sample.sampleName)
 				const discoPlotImport = await import('./plot.disco.js')
-				discoPlotImport.default(
+				const found = await discoPlotImport.default(
 					state.termdbConfig,
 					state.vocab.dslabel,
 					{ sample_id: sample.sampleName },
 					cellDiv,
-					this.app.opts.genome
+					this.app.opts.genome,
+					{}, //overrides
+					false //showError
 				)
+				if (found) someFound = true
 			}
+			this.dom.showPlotsDiv.select('input[id=showDisco').style('display', someFound ? 'inline-block' : 'none')
+			this.dom.showPlotsDiv.select('label[for=showDisco').style('display', someFound ? 'inline-block' : 'none')
 		}
 		if (state.termdbConfig.queries?.singleSampleGenomeQuantification) {
 			for (const k in state.termdbConfig.queries.singleSampleGenomeQuantification) {
+				let someFound = false
 				this.singleSamplePlots[k] = []
 				let div = plotsDiv.append('div')
 				if (state.samples.length == 1) div.style('display', 'inline-block').style('width', '50vw')
@@ -604,15 +610,20 @@ class SampleView {
 					if (state.samples.length > 1)
 						plotDiv.insert('div').style('font-weight', 'bold').text(`${sample.sampleName} ${label}`)
 					const ssgqImport = await import('./plot.ssgq.js')
-					await ssgqImport.plotSingleSampleGenomeQuantification(
+					const found = await ssgqImport.plotSingleSampleGenomeQuantification(
 						state.termdbConfig,
 						state.vocab.dslabel,
 						k,
 						{ sample_id: sample.sampleName },
 						plotDiv.insert('div'),
-						this.app.opts.genome
+						this.app.opts.genome,
+						null, //geneName
+						false //showError
 					)
+					if (found) someFound = true
 				}
+				this.dom.showPlotsDiv.select(`input[id=${k}`).style('display', someFound ? 'inline-block' : 'none')
+				this.dom.showPlotsDiv.select(`label[for=${k}`).style('display', someFound ? 'inline-block' : 'none')
 			}
 		}
 		if (state.termdbConfig.queries?.NIdata) {

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -147,7 +147,6 @@ export function server_init_db_queries(ds) {
 			}
 		} else if (tables.has('cohorts')) {
 			rows = cn.prepare('SELECT cohort, sample_count from cohorts').all()
-			console.log(rows)
 			q.getCohortSampleCount = cohortKey => {
 				let counts = rows
 					.filter(row => row.cohort == cohortKey)


### PR DESCRIPTION
## Description

If no data found for a plot in the sampleView, do not display error message, just do not render, and handle show/hide of showPlot checkbox.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
