### PR TITLE
fix: bug fix on mds3 INFO legend, always show hidden categories, and allow to filter by Unannotated category

### DIFF
--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -457,7 +457,6 @@ function may_update_infoFields(data, tk) {
 					.style('display', 'inline-block')
 					.attr('class', 'sja_clb')
 					.style('text-decoration', 'line-through')
-					.style('opacity', 0)
 					.text(c)
 					.on('click', async () => {
 						if (loading) return

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -446,7 +446,8 @@ function may_update_infoFields(data, tk) {
 					.append('div')
 					.style('display', 'inline-block')
 					.style('color', tk.mds.bcf.info[infoKey].categories?.[category]?.color || unknown_infoCategory_textcolor)
-					.html('&nbsp;' + tk.mds.bcf.info[infoKey].categories?.[category]?.label || category)
+					.style('padding-left', '5px')
+					.text(tk.mds.bcf.info[infoKey].categories?.[category]?.label || category)
 			}
 
 			// hidden ones

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- revert opacity=0 on hidden legend items so they are always shown

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -96,7 +96,10 @@ arguments:
 		bootstrap object for this ds
 */
 
-const unannotatedKey = 'Unannotated' // this duplicates the same string in mds3/legend.js
+/* used in mds3 tk ui, when a info or format key is not found in a variant, to be able to count the variant by this key in the info/format legend
+ this duplicates the same string in mds3/legend.js
+*/
+const unannotatedKey = 'Unannotated'
 
 export async function init(ds, genome, _servconfig) {
 	// optional features/settings supplied by ds, when missing from serverconfig.features{}, are centralized here.
@@ -1200,9 +1203,11 @@ function mayDropMbyInfoFilter(m0, param) {
 	if (!param.infoFilter) return false
 	for (const infoKey in param.infoFilter) {
 		// each key corresponds to a value to skip
+
 		const variantValue = m0.info[infoKey]
 		if (!variantValue) {
-			// no value, don't skip
+			// no value. client displays such values with the hardcoded value. compare if it is to be skipped
+			if (param.infoFilter[infoKey].includes(unannotatedKey)) return true // skip unannotated value
 			continue
 		}
 		if (Array.isArray(variantValue)) {


### PR DESCRIPTION
## Description

closes #2065 
test at http://localhost:3000/?genome=hg38&gene=kras&mds3=clinvar by hiding one ClinSig item from legend
at http://localhost:3000/?genome=hg38&gene=brca1&mds3=clinvar, click Unannotated works as other clinsig categories

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
