### PR TITLE
after matrix divide into groups, should use order defined in term

### DIFF
--- a/client/plots/matrix.sort.js
+++ b/client/plots/matrix.sort.js
@@ -531,6 +531,10 @@ export function getSampleGroupSorter(self) {
 		if ('order' in a && 'order' in b) return a.order - b.order
 		if ('order' in a) return -1
 		if ('order' in b) return 1
+		if (a.tw?.term?.values?.[a.id]?.order && b.tw?.term?.values?.[b.id]?.order) {
+			// when the term has order defined
+			return a.tw.term.values[a.id].order - b.tw.term.values[b.id].order
+		}
 		return defaultSorter(a, b)
 	}
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- matrix groups should be sorted based on order defined in divideby term


### PR DESCRIPTION
## Description
Test with [mbmeta](http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22}), matrix divideby subGroups should have order of WNT, SHH, G3, G4



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
