### PR TITLE
process q.hidden_values in categorical router

### DIFF
--- a/client/tw/CategoricalCustomGS.ts
+++ b/client/tw/CategoricalCustomGS.ts
@@ -1,6 +1,7 @@
 import { CatTWCustomGS, CustomGroupSettingQ, RawCustomGroupsetQ, CategoricalTerm, RawCatTW } from '#types'
 import { CategoricalRouter } from './CategoricalRouter.ts'
 import { Handler, HandlerOpts } from './Handler'
+import { set_hiddenvalues } from '#termsetting'
 
 export class CategoricalCustomGS extends Handler {
 	tw: CatTWCustomGS
@@ -35,7 +36,7 @@ export class CategoricalCustomGS extends Handler {
 			// 	}
 			// }
 		}
-
+		set_hiddenvalues(q, term)
 		return true
 	}
 }

--- a/client/tw/CategoricalPredefinedGS.ts
+++ b/client/tw/CategoricalPredefinedGS.ts
@@ -8,6 +8,7 @@ import {
 } from '#types'
 import { CategoricalRouter } from './CategoricalRouter.ts'
 import { Handler, HandlerOpts } from './Handler'
+import { set_hiddenvalues } from '#termsetting'
 
 export class CategoricalPredefinedGS extends Handler {
 	tw: CatTWPredefinedGS
@@ -50,6 +51,7 @@ export class CategoricalPredefinedGS extends Handler {
 			// 	}
 			// }
 		}
+		set_hiddenvalues(q, term)
 		return true
 	}
 }

--- a/client/tw/CategoricalValues.ts
+++ b/client/tw/CategoricalValues.ts
@@ -1,6 +1,7 @@
 import { CatTWValues, ValuesQ, RawCatTW, CategoricalTerm } from '#types'
 import { CategoricalRouter } from './CategoricalRouter.ts'
 import { Handler, HandlerOpts } from './Handler'
+import { set_hiddenvalues } from '#termsetting'
 
 export class CategoricalValues extends Handler {
 	tw: CatTWValues
@@ -41,6 +42,7 @@ export class CategoricalValues extends Handler {
 			// 	}
 			// }
 		}
+		set_hiddenvalues(q, term)
 		return true
 	}
 }

--- a/client/tw/test/CategoricalRouter.unit.spec.ts
+++ b/client/tw/test/CategoricalRouter.unit.spec.ts
@@ -105,7 +105,8 @@ tape(`fill() default q.type='values'`, async test => {
 				term: tw.term,
 				q: {
 					type: 'values',
-					isAtomic: true
+					isAtomic: true,
+					hiddenValues: {}
 				},
 				isAtomic: true
 			},
@@ -136,7 +137,8 @@ tape('fill() predefined-groupset', async test => {
 				q: {
 					type: 'predefined-groupset',
 					predefined_groupset_idx: 0,
-					isAtomic: true
+					isAtomic: true,
+					hiddenValues: {}
 				},
 				isAtomic: true
 			},
@@ -162,7 +164,7 @@ tape('fill() custom-groupset', async test => {
 	}
 
 	const twCopy = structuredClone(tw)
-
+	twCopy.q.hiddenValues = {}
 	try {
 		const fullTw = await CategoricalRouter.fill(tw, { vocabApi })
 		const testedKeys = new Set()
@@ -201,7 +203,7 @@ tape('init() categorical', async test => {
 			//id: term.id,
 			term,
 			isAtomic: true as const,
-			q: { type: 'predefined-groupset', isAtomic: true as const }
+			q: { type: 'predefined-groupset', isAtomic: true as const, hiddenValues: {} }
 		}
 
 		const handler = await CategoricalRouter.initRaw(tw, { vocabApi })

--- a/client/tw/test/TwRouter.integration.spec.ts
+++ b/client/tw/test/TwRouter.integration.spec.ts
@@ -94,7 +94,7 @@ tape('fill({id}) no tw.term, no tw.q', async test => {
 					sample_type: '1',
 					hashtmldetail: true
 				},
-				q: { type: 'values', isAtomic: true }
+				q: { type: 'values', isAtomic: true, hiddenValues: {} }
 			},
 			'should fill-in a minimal dictionary tw with only {id}'
 		)

--- a/client/tw/test/TwRouter.unit.spec.ts
+++ b/client/tw/test/TwRouter.unit.spec.ts
@@ -88,7 +88,8 @@ tape('fill({id, q}) nested q.groupsetting (legacy support)', async test => {
 			{
 				type: 'predefined-groupset',
 				predefined_groupset_idx: 0,
-				isAtomic: true
+				isAtomic: true,
+				hiddenValues: {}
 			},
 			`should reshape a legacy nested q.groupsetting`
 		)


### PR DESCRIPTION
## Description

This bug was not released to any environment, so not adding a `release.txt` entry. And the bug may only affect edge cases, it's not visible when opening a few examples URL that would  have required `categoricalRouter.fill()`. So, this is mostly a proactive fix.

Tested with  http://localhost:3000/testrun.html?name=*.unit and `cd client; npm run test:integration`.
 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
