### PR TITLE
fix the error that when creating a custom term with just one groupthe…

### DIFF
--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -104,7 +104,18 @@ class MassGroups {
 		}
 
 		const name = samplelstGroups.length == 1 ? samplelstGroups[0].name : 'Sample groups'
-		const tw = getSamplelstTW(samplelstGroups, name)
+		const tw = getSamplelstTW(samplelstGroups, name, this.app.vocabApi)
+
+		//when there is only one group and need to create a others group
+		if (groups.length == 1) {
+			// find the sample count in current cohort
+			const countSampleCount = await this.app.vocabApi.getCohortSampleCount(this.activeCohortName)
+			const countSampleCountInt = parseInt(countSampleCount, 10)
+
+			// get the sample count in "others" group
+			const othersGroup = Object.values(tw.term.values).find(v => v.key.startsWith('Not in'))
+			othersGroup.othersGroupSampleNum = countSampleCountInt - othersGroup.list.length
+		}
 
 		// TEMP change, to be done elsewhere e.g. in getSamplelstTW()
 		for (const g of tw.q.groups) {
@@ -198,7 +209,7 @@ class MassGroups {
 				: `<span style="display:inline-block; width:11px; height:11px; background-color:${'#fff'}; border: 0.1px solid black" ></span>`
 			const [c1, c2] = table.addRow()
 			c1.html(`${colorSquare} ${grp.label}:`)
-			c2.html(`${grp.list.length} samples`)
+			c2.html(`${grp.othersGroupSampleNum || grp.list.length} samples`)
 		}
 
 		let row = menuDiv.append('div')
@@ -739,8 +750,6 @@ export function addNewGroup(app, filter, groups) {
 }
 
 export function getSamplelstTWFromIds(ids) {
-	const qgroups = []
-	let samples
 	const name = 'group'
 	const values = ids.map(id => {
 		return { sampleId: id }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,4 @@
+Fixes:
+- create a custom term with just one group the custom term has equal number of samples in each group
+
 


### PR DESCRIPTION
… custom term has equal number of samples upon clicking on the custom term

## Description
Test with 
[termdbTest.txt](https://github.com/user-attachments/files/16788990/termdbTest.txt)
clicking custom variable should show 25 samples for "Not in ..." group


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
