### PR TITLE
Open app card on a specific example

### DIFF
--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -23,7 +23,6 @@ openDatasetButtonSandbox()
 
 TODOs: 
 - ***Removed the nested card back button for now
-- add icon link to copy appcard= link for each sandbox and views (i.e. examples, UIs, etc.) in sandbox headers
 - fix nestcard background not in margins when sandbox called from ?appcard=
 
 */
@@ -92,9 +91,9 @@ async function openNestedCardSandbox(nestedCard, sandboxDiv, pageArgs) {
 
 				if (child.type == 'card') {
 					sandboxDiv.header.trail.main()
+					openCardSandbox(child, res, sandboxDiv, pageArgs)
 					const crumbIndex = filteredChildren.findIndex(c => c == child)
 					sandboxDiv.header.trail.update(crumbIndex)
-					openCardSandbox(child, res, sandboxDiv, pageArgs)
 				}
 				if (child.type == 'dsButton') return openDatasetButtonSandbox(pageArgs.app.opts, res, sandboxDiv) //only for .sandboxJson
 			})
@@ -273,6 +272,7 @@ async function makeLeftsideTabMenu(card, contentHolder, examplesOnly, sandboxDiv
 		return {
 			active,
 			inTrail: active,
+			link: `${sessionStorage.getItem('hostURL')}/?appcard=${card.name}&example=${ppcalls.label}`,
 			label: ppcalls.label,
 			callback: async (event, tab) => {
 				const wait = tab_wait(tab.contentHolder)

--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -238,7 +238,7 @@ function makeTopTabs(ppcalls, card, sandboxDiv, pageArgs) {
 	if ((ppcalls.length > 1 && uiPresent == false) || (ppcalls.length > 2 && uiPresent == true)) {
 		tabs.push({
 			label: 'Examples',
-			active: false,
+			active: pageArgs?.example ? true : false,
 			callback: async (event, tab) => {
 				try {
 					const examplesOnly = ppcalls.filter(p => p.isUi != true) //Fix to rm UIs from Examples tab
@@ -269,8 +269,10 @@ async function makeLeftsideTabMenu(card, contentHolder, examplesOnly, sandboxDiv
 	})
 
 	function getTabData(ppcalls, i, section) {
+		const active = pageArgs?.example ? pageArgs.example.toUpperCase() == ppcalls.label.toUpperCase() : i === 0
 		return {
-			active: i === 0,
+			active,
+			inTrail: active,
 			label: ppcalls.label,
 			callback: async (event, tab) => {
 				const wait = tab_wait(tab.contentHolder)

--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -30,7 +30,9 @@ TODOs:
 export async function openSandbox(element, pageArgs) {
 	const sandboxDiv = newSandboxDiv(pageArgs.sandboxDiv)
 	sandboxDiv.header_row
-	sandboxDiv.header.append('span').text(element.name)
+	sandboxDiv.header
+		.append('span')
+		.html(`<a href="${sessionStorage.getItem('hostURL')}/?appcard=${element.name}">${element.name}</a>`)
 	sandboxDiv.body.style('overflow', 'hidden').style('background-color', 'white')
 
 	if (element.type == 'nestedCard') return openNestedCardSandbox(element, sandboxDiv, pageArgs)

--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -32,7 +32,11 @@ export async function openSandbox(element, pageArgs) {
 	sandboxDiv.header_row
 	sandboxDiv.header
 		.append('span')
-		.html(`<a href="${sessionStorage.getItem('hostURL')}/?appcard=${element.name}">${element.name}</a>`)
+		.html(
+			element.type != 'nestedCard'
+				? `<a href="${sessionStorage.getItem('hostURL')}/?appcard=${element.name}">${element.name}</a>`
+				: element.name
+		)
 	sandboxDiv.body.style('overflow', 'hidden').style('background-color', 'white')
 
 	if (element.type == 'nestedCard') return openNestedCardSandbox(element, sandboxDiv, pageArgs)

--- a/client/dom/breadcrumbs.js
+++ b/client/dom/breadcrumbs.js
@@ -44,6 +44,7 @@ function setRenderers(self) {
 		self.crumbs = self.opts.crumbs
 		for (const crumb of self.crumbs) {
 			crumb.label = crumb.label || crumb.name
+			if (!crumb.inTrail) crumb.inTrail = false
 		}
 
 		const has_active_crumb = self.crumbs.find(crumb => crumb.inTrail)
@@ -62,12 +63,10 @@ function setRenderers(self) {
 			.html(crumb => (crumb.link ? `&nbsp> <a href="${crumb.link}">${crumb.label}</a>` : `&nbsp> ${crumb.label}`))
 			.style('display', crumb => (crumb.inTrail ? 'inline-block' : 'none'))
 			.each(async function (crumb) {
-				if (!crumb.inTrail) crumb.inTrail = false
 				crumb.div = select(this)
-				console.log(crumb)
 			})
 
-		const activeCrumbIndex = self.crumbs.findIndex(c => c.active)
+		const activeCrumbIndex = self.crumbs.findIndex(c => c.inTrail)
 		self.update(activeCrumbIndex)
 	}
 

--- a/client/dom/breadcrumbs.js
+++ b/client/dom/breadcrumbs.js
@@ -59,15 +59,16 @@ function setRenderers(self) {
 			.enter()
 			.append('span')
 			.classed('sjpp-breadcrumb', true)
-			// .html(crumb => (crumb.link? ` > <a href="${crumb.link} target="_blank">${crumb.label}</a>` : ` > ${crumb.label}`))
-			.html(crumb => `&nbsp> ${crumb.label}`)
+			.html(crumb => (crumb.link ? `&nbsp> <a href="${crumb.link}">${crumb.label}</a>` : `&nbsp> ${crumb.label}`))
 			.style('display', crumb => (crumb.inTrail ? 'inline-block' : 'none'))
-			.each(async function(crumb) {
+			.each(async function (crumb) {
 				if (!crumb.inTrail) crumb.inTrail = false
-				crumb.crumb = select(this)
+				crumb.div = select(this)
+				console.log(crumb)
 			})
 
-		self.update()
+		const activeCrumbIndex = self.crumbs.findIndex(c => c.active)
+		self.update(activeCrumbIndex)
 	}
 
 	self.update = (crumbIndex = 0) => {
@@ -80,7 +81,7 @@ function setRenderers(self) {
 			.selectAll('span')
 			.data(self.crumbs)
 			.each(async crumb => {
-				crumb.crumb.style('display', crumb.inTrail ? 'inline-block' : 'none')
+				crumb.div.style('display', crumb.inTrail ? 'inline-block' : 'none')
 			})
 	}
 }

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -31,6 +31,7 @@ upon error, throw err message as a string
 	if (urlp.has('appcard')) {
 		const ad = await import('../appdrawer/adSandbox')
 		const cardJsonFile = urlp.get('appcard')
+		const example = urlp.get('example')
 		const re = await client.dofetch2('/cards/index.json')
 		arg.app.drawer.opts.genomes = arg.genomes
 		arg.app.drawer.opts.fromApp = true
@@ -42,7 +43,7 @@ upon error, throw err message as a string
 			t =>
 				t.sandboxJson == cardJsonFile ||
 				t.sandboxHtml == cardJsonFile ||
-				t.name.toUpperCase() == cardJsonFile.toUpperCase()
+				t.name.toUpperCase().includes(cardJsonFile.toUpperCase())
 		)
 
 		//Check if track/app can be shown on this server
@@ -55,12 +56,20 @@ upon error, throw err message as a string
 			}
 		}
 
+		if (example) {
+			arg.app.drawer.opts.example = example
+		}
+
 		if (element <= 0) {
 			const nestedCards = [...re.elements.filter(e => e.type == 'nestedCard')]
 			let element, c
 			nestedCards.findIndex(t => {
 				for (const [i, child] of t.children.entries()) {
-					if (child.sandboxJson == cardJsonFile || child.sandboxHtml == cardJsonFile) {
+					if (
+						child.sandboxJson == cardJsonFile ||
+						child.sandboxHtml == cardJsonFile ||
+						child.name.toUpperCase().includes(cardJsonFile.toUpperCase())
+					) {
 						element = t
 						c = i
 					}

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -38,7 +38,12 @@ upon error, throw err message as a string
 		arg.app.drawer.opts.app = {
 			cardsPath: 'cards'
 		}
-		const element = re.elements.findIndex(t => t.sandboxJson == cardJsonFile || t.sandboxHtml == cardJsonFile)
+		const element = re.elements.findIndex(
+			t =>
+				t.sandboxJson == cardJsonFile ||
+				t.sandboxHtml == cardJsonFile ||
+				t.name.toUpperCase() == cardJsonFile.toUpperCase()
+		)
 
 		//Check if track/app can be shown on this server
 		//If not show error message

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Feature
+- Able to open an app card on an example with new `example` URL parameter.


### PR DESCRIPTION
## Description
Purpose: To cut down on the amount of communication with users and simplify marketing text (e.g. newsletter). 

Changes: 
1. `appcard` now accepts part or the complete app card name along with the json file name (e.g. "wsi", "whole", and "whole slide imaging" opens the Whole Slide Imaging app card
2. adding `&example=` with the complete example name, opens the example directly. 

Test: 
1. http://localhost:3000/?appcard=bedj, http://localhost:3000/?appcard=Json, and http://localhost:3000/?appcard=json%20bed all open the JSON BED app card. 
2. http://localhost:3000/?appcard=xx will throw an error but http://localhost:3000/?appcard=x will open the Expression Rank card
3. http://localhost:3000/?appcard=JSON%20BED&example=Numeric%20Filter opens the Numeric filter example in the JSON BED card directly
4. Except for nested cards, clicking on the breadcrumb in the sandbox header reveals the link. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
