### PR TITLE
Enable overlaying violin with survival terms

### DIFF
--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -696,7 +696,7 @@ tape('term1=categorical, term2=numeric', function (test) {
 	}
 })
 
-tape.skip('term1=numeric, term2=survival', function (test) {
+tape('term1=numeric, term2=survival', function (test) {
 	test.timeoutAfter(3000)
 	runpp({
 		state: {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- Reenabled overlaying the violin plot with survival terms. 

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -19,7 +19,11 @@ export async function trigger_getViolinPlotData(q, res, ds, genome) {
 	if (!isNumericTerm(term) && term.type !== TermTypes.SURVIVAL) throw 'term type is not numeric or survival'
 
 	const terms = [q.tw]
-	if (q.divideTw) terms.push(q.divideTw)
+	let isSurvival = false
+	if (q.divideTw) {
+		terms.push(q.divideTw)
+		isSurvival = q.divideTw.term.type == TermTypes.SURVIVAL
+	}
 
 	const data = await getData(
 		{ terms, filter: q.filter, filter0: q.filter0, currentGeneNames: q.currentGeneNames },
@@ -41,7 +45,7 @@ export async function trigger_getViolinPlotData(q, res, ds, genome) {
 
 	const valuesObject = divideValues(q, data, q.tw)
 	const result = resultObj(valuesObject, data, q, ds)
-	const isSurvival = q.divideTw.term.type == TermTypes.SURVIVAL
+
 	// wilcoxon test data to return to client
 	await wilcoxon(q.divideTw, result, isSurvival)
 
@@ -67,13 +71,11 @@ export async function wilcoxon(divideTw, result, isSurvival) {
 
 	for (let i = 0; i < numPlots; i++) {
 		const group1_id =
-			isSurvival && Number.isFinite(result.plots[i].label) ? result.plots[i].label.toString() : result.plots[i].seriesId
+			isSurvival && Number.isFinite(result.plots[i].label) ? result.plots[i].label.toString() : result.plots[i].label
 		const group1_values = result.plots[i].values
 		for (let j = i + 1; j < numPlots; j++) {
 			const group2_id =
-				isSurvival && Number.isFinite(result.plots[j].label)
-					? result.plots[j].label.toString()
-					: result.plots[j].seriesId
+				isSurvival && Number.isFinite(result.plots[j].label) ? result.plots[j].label.toString() : result.plots[j].label
 			const group2_values = result.plots[j].values
 			wilcoxInput.push({ group1_id, group1_values, group2_id, group2_values })
 		}


### PR DESCRIPTION
## Description
Closes issue #1991. 

Changes: 
1. If `term.values` is missing, will return the numeric value labeled as the `Exit code [n]` for survival terms. 
2. Enabled broken integration test

Test: 
1. [Age at dx overlayed with efs](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22agedx%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%22term2%22:%7B%22id%22:%22efs%22%7D%7D%5D%7D)
2. [Example with term.values](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22IHG%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22Age%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%22term2%22:%7B%22id%22:%22Event-free%20survival%22%7D%7D%5D%7D)
3. [Violin integration tests](http://localhost:3000/testrun.html?dir=mass&name=violin.integration)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
