### PR TITLE
Cox coefficient sample size and event count

### DIFF
--- a/client/mass/test/regression.integration.spec.js
+++ b/client/mass/test/regression.integration.spec.js
@@ -161,13 +161,13 @@ tape('Linear: continuous outcome = "agedx", cat. independents = "sex" + "genetic
 		test.equal(results, true, `Should render all intercept data in ${tableLabel}`)
 
 		testTerm = 'Sex'
-		const checkValues1 = ['Sex\nREF Female', 'Male']
+		const checkValues1 = ['Sex\nREFFemale', 'Male']
 		data.coefficients.terms.sex.categories[1].forEach(d => checkValues1.push(d))
 		results = checkTableRow(table, 2, checkValues1)
 		test.equal(results, true, `Should render all ${testTerm} data in ${tableLabel}`)
 
 		testTerm = 'African Ancestry'
-		const checkValues2 = ['Genetically defined race\nREF European Ancestry', testTerm]
+		const checkValues2 = ['Genetically defined race\nREFEuropean Ancestry', testTerm]
 		data.coefficients.terms.genetic_race.categories[testTerm].forEach(d => checkValues2.push(d))
 		results = checkTableRow(table, 3, checkValues2)
 		test.equal(results, true, `Should render all ${testTerm} data in ${tableLabel}`)

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -583,10 +583,7 @@ function setRenderers(self) {
 							const refGrpDiv = termNameTd.select('.sjpcb-regression-results-refGrp')
 							refGrpDiv.append('div').html(`n = ${samplesize_ref}<br>events = ${eventcnt_ref}`)
 						}
-						td.append('div')
-							.style('font-size', '.8em')
-							.style('opacity', 0.6)
-							.html(`n = ${samplesize_c}<br>events = ${eventcnt_c}`)
+						td.append('div').style('font-size', '.8em').html(`n = ${samplesize_c}<br>events = ${eventcnt_c}`)
 					}
 
 					// col 3
@@ -976,7 +973,7 @@ function fillCoefficientTermname(tw, td) {
 
 	if (tw.q.mode != 'spline' && 'refGrp' in tw && tw.refGrp != refGrp_NA) {
 		// do not display ref for spline variable
-		const refGrpDiv = td.append('div').style('margin-top', '1px').style('font-size', '.8em').style('opacity', 0.6)
+		const refGrpDiv = td.append('div').style('margin-top', '2px').style('font-size', '.8em')
 
 		refGrpDiv
 			.append('div')

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -477,9 +477,9 @@ function setRenderers(self) {
 		{
 			const tr = table.append('tr').style('opacity', 0.4)
 			result.coefficients.header.forEach((v, i) => {
-				if (neuroOncCox && i == 2) return // skip sample count column
+				if (neuroOncCox && (i == 2 || i == 3)) return // skip sample count and event count columns
 				tr.append('td').text(v).style('padding', '8px')
-				if (i === (neuroOncCox ? 3 : 1)) tr.append('td') // add column for forest plot
+				if (i === 1) tr.append('td') // add column for forest plot
 			})
 		}
 
@@ -531,8 +531,8 @@ function setRenderers(self) {
 					// cox regression for neuro-onc datasets
 					// sample size and event count columns present
 					// both will be NA for continuous variable
-					cols.shift() // no need to show sample size NA
-					tr.append('td').style('padding', '8px').text(cols.shift()) // show event count NA in column
+					cols.shift()
+					cols.shift()
 				}
 
 				// col 3
@@ -576,17 +576,17 @@ function setRenderers(self) {
 					if (neuroOncCox) {
 						// cox regression for neuro-onc datasets
 						// report sample sizes and event counts of coefficients
-						const [sampleSize_ref, sampleSize_c] = cols.shift().split('/')
-						// for sample sizes, append to ref and non-ref category labels
+						// report for both ref and non-ref categories
+						const [samplesize_ref, samplesize_c] = cols.shift().split('/')
+						const [eventcnt_ref, eventcnt_c] = cols.shift().split('/')
 						if (isfirst) {
 							const refGrpDiv = termNameTd.select('.sjpcb-regression-results-refGrp')
-							const label = `${refGrpDiv.html()} (n=${sampleSize_ref})`
-							refGrpDiv.html(label)
+							refGrpDiv.append('div').html(`n = ${samplesize_ref}<br>events = ${eventcnt_ref}`)
 						}
-						const label = `${td.text()} (n=${sampleSize_c})`
-						td.text(label)
-						// for event counts, report as a column
-						tr.append('td').style('padding', '8px').text(cols.shift())
+						td.append('div')
+							.style('font-size', '.8em')
+							.style('opacity', 0.6)
+							.html(`n = ${samplesize_c}<br>events = ${eventcnt_c}`)
 					}
 
 					// col 3
@@ -635,7 +635,6 @@ function setRenderers(self) {
 		const tr = table.append('tr')
 		tr.append('td') // col 1
 		tr.append('td') // col 2
-		if (neuroOncCox) tr.append('td')
 		forestPlotter(tr.append('td')) // forest plot axis
 		for (const v of result.coefficients.header) tr.append('td')
 	}
@@ -977,15 +976,25 @@ function fillCoefficientTermname(tw, td) {
 
 	if (tw.q.mode != 'spline' && 'refGrp' in tw && tw.refGrp != refGrp_NA) {
 		// do not display ref for spline variable
-		td.append('div')
+		const refGrpDiv = td.append('div').style('margin-top', '1px').style('font-size', '.8em').style('opacity', 0.6)
+
+		refGrpDiv
+			.append('div')
+			.style('display', 'inline-block')
+			.style('vertical-align', 'top')
+			.style('padding', '1px 5px')
+			.style('border', '1px solid #aaa')
+			.style('border-radius', '10px')
+			.style('font-size', '.7em')
+			.text('REF')
+
+		refGrpDiv
+			.append('div')
 			.attr('class', 'sjpcb-regression-results-refGrp')
-			.style('font-size', '.8em')
-			.style('opacity', 0.6)
-			.html(
-				'<span style="padding:1px 5px;border:1px solid #aaa;border-radius:10px;font-size:.7em">REF</span> ' +
-					(tw.term.values && tw.term.values[tw.refGrp] ? tw.term.values[tw.refGrp].label : tw.refGrp) +
-					'</span>'
-			)
+			.style('display', 'inline-block')
+			.style('vertical-align', 'top')
+			.style('margin-left', '3px')
+			.text(tw.term.values && tw.term.values[tw.refGrp] ? tw.term.values[tw.refGrp].label : tw.refGrp)
 	}
 
 	if (tw.effectAllele) {


### PR DESCRIPTION
## Description

For cox regression in Neuro-Onc portals, report sample sizes and event counts of coefficients for both reference and non-reference categories.

Can test using [regression analysis in Mbmeta portal](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22,%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22cox%22,%22outcome%22:{%22id%22:%22Progression-free%20Survival%22},%22independent%22:[{%22term%22:{%22gene%22:%22TP53%22,%22name%22:%22TP53%22,%22type%22:%22geneVariant%22},%22q%22:{%22isAtomic%22:true,%22type%22:%22predefined-groupset%22,%22dt%22:1,%22origin%22:%22somatic%22,%22predefined_groupset_idx%22:0,%22cnvGainCutoff%22:0.1,%22cnvLossCutoff%22:-0.1,%22cnvMaxLength%22:0,%22hiddenValues%22:{}},%22refGrp%22:%22Wildtype%22,%22interactions%22:[]},{%22id%22:%22Subgroup%22}]}]}).

Will work on univariate/multivariate UI next.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
