### PR TITLE
Prototype About tab in mass app

### DIFF
--- a/client/dom/sandbox.ts
+++ b/client/dom/sandbox.ts
@@ -1,6 +1,7 @@
 import { icons } from './control.icons'
 import { Selection } from 'd3-selection'
 import { Genome } from '#shared/types/index'
+import { Elem } from '../types/d3'
 
 /*
 Creates sandbox divs, containers running proteinpaint calls, forms, etc. 
@@ -17,7 +18,7 @@ renderSandboxFormDiv
 newSandboxDiv
 */
 
-export function renderSandboxFormDiv(holder: Selection<HTMLElement, any, any, any>, genomes: Genome[]) {
+export function renderSandboxFormDiv(holder: Elem, genomes: Genome[]) {
 	//Classes for unit testing
 	holder.classed('sjpp-sandbox-form', true)
 	const inputdiv = holder
@@ -59,7 +60,7 @@ type PlotOps = {
 	close: () => void
 }
 
-export function newSandboxDiv(sandbox_holder: Selection<HTMLDivElement, any, any, any>, opts: Partial<PlotOps> = {}) {
+export function newSandboxDiv(sandbox_holder: Elem, opts: Partial<PlotOps> = {}) {
 	// NOTE: plotId=0 (Number) will not be tracked, assumes a non-empty plotId is used
 	const insertSelector = opts.beforePlotId ? '#' + plotIdToSandboxId[opts.beforePlotId] : ':first-child'
 	const app_div = sandbox_holder.insert('div', insertSelector).attr('class', 'sjpp-sandbox')

--- a/client/dom/sandbox.ts
+++ b/client/dom/sandbox.ts
@@ -1,7 +1,7 @@
 import { icons } from './control.icons'
-import { Selection } from 'd3-selection'
-import { Genome } from '#shared/types/index'
+import { ClientCopyGenome } from '../types/global'
 import { Elem } from '../types/d3'
+import { RenderSandboxForm, NewSandboxOpts, NewSandbox } from './types/sandbox'
 
 /*
 Creates sandbox divs, containers running proteinpaint calls, forms, etc. 
@@ -18,7 +18,7 @@ renderSandboxFormDiv
 newSandboxDiv
 */
 
-export function renderSandboxFormDiv(holder: Elem, genomes: Genome[]) {
+export function renderSandboxFormDiv(holder: Elem, genomes: ClientCopyGenome[]): RenderSandboxForm {
 	//Classes for unit testing
 	holder.classed('sjpp-sandbox-form', true)
 	const inputdiv = holder
@@ -48,19 +48,7 @@ let sandboxIdSuffix = 0
 	sandbox_holder: a d3-selection
 */
 
-type PlotOps = {
-	/**.beforePlotId: optional insertion position, a key in the plotIdToSandboxId tracker */
-	beforePlotId: string
-	/**.plotId: optional plot.id, for which a sandbox div ID will be assigned, should not be an 'empty' value (null , undefined, 0) */
-	plotId: string
-	style: {
-		width: string
-	}
-	/**.close: optional callback to trigger when the sandbox is closed */
-	close: () => void
-}
-
-export function newSandboxDiv(sandbox_holder: Elem, opts: Partial<PlotOps> = {}) {
+export function newSandboxDiv(sandbox_holder: Elem, opts: Partial<NewSandboxOpts> = {}): NewSandbox {
 	// NOTE: plotId=0 (Number) will not be tracked, assumes a non-empty plotId is used
 	const insertSelector = opts.beforePlotId ? '#' + plotIdToSandboxId[opts.beforePlotId] : ':first-child'
 	const app_div = sandbox_holder.insert('div', insertSelector).attr('class', 'sjpp-sandbox')

--- a/client/dom/types/sandbox.ts
+++ b/client/dom/types/sandbox.ts
@@ -1,0 +1,40 @@
+import { Div } from '../../types/d3'
+
+/** Renders forms in a specific format */
+export type RenderSandboxForm = [
+	/** inputdiv */
+	Div,
+	/** gselect.node(): genome dropdown */
+	HTMLSelectElement | null,
+	/** fileDiv: for file select, pathway input, etc */
+	Div,
+	/** sayDiv: for error messages */
+	Div,
+	/** visualDiv: for displaying output */
+	Div
+]
+
+export type NewSandboxOpts = {
+	/**.beforePlotId: optional insertion position, a key in the plotIdToSandboxId tracker */
+	beforePlotId: string
+	/**.plotId: optional plot.id, for which a sandbox div ID will be assigned, should not be an 'empty' value (null , undefined, 0) */
+	plotId: string
+	style: {
+		width: string
+	}
+	/**.close: optional callback to trigger when the sandbox is closed */
+	close: () => void
+}
+
+export type NewSandbox = {
+	/** Creates a div to insert the new sandbox before all other sandboxes*/
+	app_div: Div
+	/** Header text only */
+	header: Div
+	/** Entire header div for adding buttons, additional text, etc. */
+	header_row: Div
+	/** Content of the sandbox, below the header */
+	body: Div
+	/** dom element id created for identifying the sandbox */
+	id: string
+}

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -1,8 +1,8 @@
 import { getCompInit } from '../rx'
 import { Elem } from '../types/d3'
 import { MassAppApi } from './types/mass'
-import { newSandboxDiv } from '#dom/sandbox'
-import { NewSandbox } from '#dom/types/sandbox'
+import { newSandboxDiv } from '../dom/sandbox' //Do not use #dom. Will look for .js file
+import { NewSandbox } from '../dom/types/sandbox' //Do not use #dom. Will look for .js file
 
 /** --In development--
  * Only .html property enabled from ds.cohort.termdb.about

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -1,13 +1,7 @@
 import { getCompInit } from '../rx'
 import { Elem } from '../types/d3'
 import { MassAppApi } from './types/mass'
-import { newSandboxDiv } from '../dom/sandbox' //Do not use #dom. Will look for .js file
-import { NewSandbox } from '../dom/types/sandbox' //Do not use #dom. Will look for .js file
 
-/** --In development--
- * Only .html property enabled from ds.cohort.termdb.about
- * Later may add other properties
- */
 type AboutObj = {
 	html: string
 }
@@ -23,31 +17,22 @@ class MassAbout {
 	app: MassAppApi
 	holder: Elem
 	features: AboutObj
-	sandbox: NewSandbox
-	readonly id = `${Math.random() * (1 - 0) + 1}`
 
 	constructor(opts: MassAboutOpts) {
 		this.type = 'about'
 		this.app = opts.app
 		this.holder = opts.holder
 		this.features = opts.features
-		this.sandbox = newSandboxDiv(this.holder, { plotId: this.id })
 	}
 
 	init() {
-		this.sandbox.app_div.style('display', 'none')
-		this.sandbox.header.append('div').text('About').style('color', 'rgb(85, 85, 85)')
-		this.sandbox.body.append('div').style('padding', '10px').html(this.features.html)
-	}
-
-	getState(appState) {
-		return {
-			nav: appState.nav
-		}
+		this.holder.append('div').style('padding', '10px').html(this.features.html)
 	}
 
 	main() {
-		this.sandbox.app_div.style('display', this.app.Inner.state.nav.activeTab == 0 ? '' : 'none')
+		const aboutIdx = this.app.Inner.components.nav.Inner.tabs.findIndex(tab => tab.subheader == 'about')
+		const isActive = this.app.Inner.state.nav.activeTab == aboutIdx
+		this.holder.style('display', isActive ? '' : 'none')
 	}
 }
 

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -1,7 +1,8 @@
 import { getCompInit } from '../rx'
-import { Div, Elem } from '../types/d3'
+import { Elem } from '../types/d3'
 import { MassApp } from './types/mass'
 import { newSandboxDiv } from '#dom/sandbox'
+import { NewSandbox } from '#dom/types/sandbox'
 
 type MassAboutOpts = {
 	app: MassApp
@@ -14,19 +15,31 @@ class MassAbout {
 	app: MassApp
 	holder: Elem
 	obj: any
+	sandbox: NewSandbox
+	readonly id = `${Math.random() * (1 - 0) + 1}`
 
 	constructor(opts: MassAboutOpts) {
 		this.type = 'about'
 		this.app = opts.app
 		this.holder = opts.holder
 		this.obj = opts.obj
+		this.sandbox = newSandboxDiv(this.holder, { plotId: this.id })
 	}
 
 	init() {
-		const sandbox = newSandboxDiv(this.holder, {})
-		//nice name here as well?
-		sandbox.header_row.append('div').text('About')
-		sandbox.body.html(this.obj.html)
+		this.sandbox.app_div.style('display', 'none')
+		this.sandbox.header.append('div').text('About').style('color', 'rgb(85, 85, 85)')
+		this.sandbox.body.append('div').style('padding', '10px').html(this.obj.html)
+	}
+
+	getState(appState) {
+		return {
+			nav: appState.nav
+		}
+	}
+
+	main() {
+		this.sandbox.app_div.style('display', this.app.Inner.state.nav.activeTab == 0 ? '' : 'none')
 	}
 }
 

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -1,20 +1,28 @@
 import { getCompInit } from '../rx'
 import { Elem } from '../types/d3'
-import { MassApp } from './types/mass'
+import { MassAppApi } from './types/mass'
 import { newSandboxDiv } from '#dom/sandbox'
 import { NewSandbox } from '#dom/types/sandbox'
 
+/** --In development--
+ * Only .html property enabled from ds.cohort.termdb.about
+ * Later may add other properties
+ */
+type AboutObj = {
+	html: string
+}
+
 type MassAboutOpts = {
-	app: MassApp
+	app: MassAppApi
 	holder: Elem
-	obj: any
+	features: AboutObj
 }
 
 class MassAbout {
 	type: string
-	app: MassApp
+	app: MassAppApi
 	holder: Elem
-	obj: any
+	features: AboutObj
 	sandbox: NewSandbox
 	readonly id = `${Math.random() * (1 - 0) + 1}`
 
@@ -22,14 +30,14 @@ class MassAbout {
 		this.type = 'about'
 		this.app = opts.app
 		this.holder = opts.holder
-		this.obj = opts.obj
+		this.features = opts.features
 		this.sandbox = newSandboxDiv(this.holder, { plotId: this.id })
 	}
 
 	init() {
 		this.sandbox.app_div.style('display', 'none')
 		this.sandbox.header.append('div').text('About').style('color', 'rgb(85, 85, 85)')
-		this.sandbox.body.append('div').style('padding', '10px').html(this.obj.html)
+		this.sandbox.body.append('div').style('padding', '10px').html(this.features.html)
 	}
 
 	getState(appState) {

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -1,6 +1,7 @@
 import { getCompInit } from '../rx'
-import { Elem } from '../types/d3'
+import { Div, Elem } from '../types/d3'
 import { MassApp } from './types/mass'
+import { newSandboxDiv } from '#dom/sandbox'
 
 type MassAboutOpts = {
 	app: MassApp
@@ -21,9 +22,11 @@ class MassAbout {
 		this.obj = opts.obj
 	}
 
-	main() {
-		const messageDiv = this.holder
-		messageDiv.html(this.obj.html)
+	init() {
+		const sandbox = newSandboxDiv(this.holder, {})
+		//nice name here as well?
+		sandbox.header_row.append('div').text('About')
+		sandbox.body.html(this.obj.html)
 	}
 }
 

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -5,17 +5,25 @@ import { MassApp } from './types/mass'
 type MassAboutOpts = {
 	app: MassApp
 	holder: Elem
+	obj: any
 }
 
 class MassAbout {
 	type: string
 	app: MassApp
 	holder: Elem
+	obj: any
 
 	constructor(opts: MassAboutOpts) {
 		this.type = 'about'
 		this.app = opts.app
 		this.holder = opts.holder
+		this.obj = opts.obj
+	}
+
+	main() {
+		const messageDiv = this.holder
+		messageDiv.html(this.obj.html)
 	}
 }
 

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -1,0 +1,22 @@
+import { getCompInit } from '../rx'
+import { Elem } from '../types/d3'
+import { MassApp } from './types/mass'
+
+type MassAboutOpts = {
+	app: MassApp
+	holder: Elem
+}
+
+class MassAbout {
+	type: string
+	app: MassApp
+	holder: Elem
+
+	constructor(opts: MassAboutOpts) {
+		this.type = 'about'
+		this.app = opts.app
+		this.holder = opts.holder
+	}
+}
+
+export const aboutInit = getCompInit(MassAbout)

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -112,7 +112,7 @@ class TdbNav {
 					? aboutInit({
 							app: this.app,
 							holder: this.dom.subheader.about,
-							obj: appState.termdbConfig.about
+							features: appState.termdbConfig.about
 					  })
 					: []
 			})

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -32,7 +32,7 @@ headtip.d.style('z-index', 5555)
 // headtip must get a crazy high z-index so it can stay on top of all, no matter if server config has base_zindex or not
 
 // data elements for navigation header tabs
-const aboutTab = { top: 'ABOUT', mid: '', btm: '', subheader: 'about' }
+const aboutTab = { top: '', mid: 'ABOUT', btm: '', subheader: 'about' }
 const cohortTab = { top: 'COHORT', mid: 'NONE', btm: '', subheader: 'cohort' }
 const chartTab = { top: 'CHARTS', mid: 'NONE', btm: '', subheader: 'charts' }
 const groupsTab = { top: 'GROUPS', mid: 'NONE', btm: '', subheader: 'groups' }

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -4,6 +4,7 @@ import { searchInit } from './search'
 import { chartsInit } from './charts'
 import { groupsInit } from './groups'
 import { sessionBtnInit } from './sessionBtn'
+import { aboutInit } from './about.ts'
 import { select } from 'd3-selection'
 import { dofetch3 } from '#common/dofetch'
 import { Menu } from '#dom/menu'
@@ -32,6 +33,7 @@ headtip.d.style('z-index', 5555)
 
 // data elements for navigation header tabs
 const cohortTab = { top: 'COHORT', mid: 'NONE', btm: '', subheader: 'cohort' }
+const aboutTab = { top: 'ABOUT', mid: 'NONE', btm: '', subheader: 'about' }
 const chartTab = { top: 'CHARTS', mid: 'NONE', btm: '', subheader: 'charts' }
 const groupsTab = { top: 'GROUPS', mid: 'NONE', btm: '', subheader: 'groups' }
 const filterTab = { top: 'FILTER', mid: 'NONE', btm: '', subheader: 'filter' }
@@ -105,6 +107,10 @@ class TdbNav {
 					button: this.dom.saveBtn,
 					massSessionDuration: this.opts.massSessionDuration,
 					sessionDaysLeft: this.app.opts.sessionDaysLeft || null
+				}),
+				about: aboutInit({
+					app: this.app,
+					holder: this.dom.subheader.about
 				})
 			})
 			this.mayShowMessage_sessionDaysLeft()
@@ -258,10 +264,12 @@ function setRenderers(self) {
 			cart: self.dom.subheaderDiv
 				.append('div')
 				.style('display', 'none')
-				.html('<br/>Cart feature under construction - work in progress<br/>&nbsp;<br/>')
+				.html('<br/>Cart feature under construction - work in progress<br/>&nbsp;<br/>'),
+			about: self.dom.subheaderDiv.append('div').style('display', 'none')
 		})
 
 		self.tabs = [chartTab, groupsTab, filterTab /*, cartTab*/]
+		if (appState.termdbConfig.about) self.tabs.unshift(aboutTab) // show the About tab at the beginning if defined in dataset config
 		if (appState.termdbConfig.selectCohort) self.tabs.unshift(cohortTab) // dataset has "sub-cohorts", show the Cohort tab at the beginning
 
 		const table = self.dom.tabDiv.append('table').style('border-collapse', 'collapse')

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -32,7 +32,7 @@ headtip.d.style('z-index', 5555)
 // headtip must get a crazy high z-index so it can stay on top of all, no matter if server config has base_zindex or not
 
 // data elements for navigation header tabs
-const aboutTab = { top: 'ABOUT', mid: 'DATASET', btm: '', subheader: 'about' }
+const aboutTab = { top: 'ABOUT', mid: '', btm: '', subheader: 'about' }
 const cohortTab = { top: 'COHORT', mid: 'NONE', btm: '', subheader: 'cohort' }
 const chartTab = { top: 'CHARTS', mid: 'NONE', btm: '', subheader: 'charts' }
 const groupsTab = { top: 'GROUPS', mid: 'NONE', btm: '', subheader: 'groups' }

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -145,6 +145,10 @@ class TdbNav {
 	}
 
 	async main() {
+		if (this.state.termdbConfig.selectCohort && this.state.termdbConfig.about) {
+			console.error('Cohort(s) and an About tab are defined. Only one can be used.')
+			return
+		}
 		this.dom.tabDiv.style('display', this.state.nav.header_mode === 'with_tabs' ? 'inline-block' : 'none')
 		this.dom.tip.hide()
 		this.activeTab = this.state.nav.activeTab

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -288,8 +288,8 @@ function setRenderers(self) {
 				btm: btmLabel,
 				subheader: 'about'
 			}
-
-			self.tabs.unshift(tab)
+			const tabIdx = appState.termdbConfig?.selectCohort ? 0 : aboutTab.order || 0
+			self.tabs.splice(tabIdx, 0, tab)
 		}
 
 		const table = self.dom.tabDiv.append('table').style('border-collapse', 'collapse')

--- a/client/mass/test/nav.integration.spec.js
+++ b/client/mass/test/nav.integration.spec.js
@@ -101,7 +101,7 @@ tape('filter subheader and tab', function (test) {
 
 	function triggerTabSwitch(nav) {
 		tds
-			.filter((d, i) => i === 3)
+			.filter((d, i) => i === 4)
 			.node()
 			.click()
 	}
@@ -126,11 +126,10 @@ tape('filter subheader and tab', function (test) {
 			1,
 			'should add blue pill'
 		)
-
-		const itemCountTd = tds._groups[0][7]
+		const itemCountTd = tds._groups[0][9]
 		test.equal(itemCountTd.innerText, '1', 'should indicate a filter item count of 1')
 
-		const sampleCountTd = tds._groups[0][11]
+		const sampleCountTd = tds._groups[0][14]
 		const n = 35
 		test.equal(sampleCountTd.innerText, `${n} patients`, 'should display the correct filtered sample count')
 	}

--- a/client/mass/test/nav.integration.spec.js
+++ b/client/mass/test/nav.integration.spec.js
@@ -101,7 +101,7 @@ tape('filter subheader and tab', function (test) {
 
 	function triggerTabSwitch(nav) {
 		tds
-			.filter((d, i) => i === 4)
+			.filter((d, i) => i === 3)
 			.node()
 			.click()
 	}
@@ -126,10 +126,10 @@ tape('filter subheader and tab', function (test) {
 			1,
 			'should add blue pill'
 		)
-		const itemCountTd = tds._groups[0][9]
+		const itemCountTd = tds._groups[0][7]
 		test.equal(itemCountTd.innerText, '1', 'should indicate a filter item count of 1')
 
-		const sampleCountTd = tds._groups[0][14]
+		const sampleCountTd = tds._groups[0][11]
 		const n = 35
 		test.equal(sampleCountTd.innerText, `${n} patients`, 'should display the correct filtered sample count')
 	}

--- a/client/mass/test/sampleScatter.integration.spec.js
+++ b/client/mass/test/sampleScatter.integration.spec.js
@@ -218,7 +218,7 @@ tape('Render TermdbTest scatter plot and open survival and summary', function (t
 
 		async function testOpenSurvivalPlot() {
 			const plots = scatter.Inner.app.getState().plots
-			const elem = scatter.Inner.app.Inner.dom.holder.node()
+			const elem = scatter.Inner.app.Inner.dom.plotDiv.node()
 			const preSandboxes = [...elem.querySelectorAll('.sjpp-sandbox')]
 			const sandboxes = await detectLst({
 				elem,
@@ -235,7 +235,7 @@ tape('Render TermdbTest scatter plot and open survival and summary', function (t
 
 		async function testOpenSummaryPlot() {
 			const plots = scatter.Inner.app.getState().plots
-			const elem = scatter.Inner.app.Inner.dom.holder.node()
+			const elem = scatter.Inner.app.Inner.dom.plotDiv.node()
 			const preSandboxes = [...elem.querySelectorAll('.sjpp-sandbox')]
 			const survivalTerm = await scatter.Inner.app.vocabApi.getterm('efs')
 			const sandboxes = await detectLst({

--- a/client/mass/types/mass.d.ts
+++ b/client/mass/types/mass.d.ts
@@ -1,32 +1,59 @@
-import { RxApp } from '../../types/rx'
+import { RxAppApi } from '../../types/rx'
 import { Menu } from '../../dom/menu'
 import { Elem } from '../../types/d3'
 
-export type MassApp = RxApp & {
-	Inner: {
-		eventTypes: ['preDispatch', 'postInit', 'postRender', 'firstRender', 'error']
-		dom: {
-			holder: Elem
-			topbar: Elem
-			errdiv: Elem
-			plotDiv: Elem
-		}
-		opts: any
-		plotIdToSandboxId: any
-		state: any
-		store: any
-		type: 'app'
-	}
+export type MassAppApi = RxAppApi & {
+	Inner: MassApp
 	printError: (e: string) => void
 	tip: Menu
-	type: 'app'
 	/** Should be a type for TermdbVocab or Frontend Vocab later */
 	vocabApi: any
+}
+type MassApp = {
+	api: MassAppApi
+	/** TODO */
+	bus: any
+	components: {
+		nav: any
+		plots: any
+	}
+	eventTypes: ['preDispatch', 'postInit', 'postRender', 'firstRender', 'error']
+	dom: {
+		holder: Elem
+		topbar: Elem
+		/** printError() message appear above the plots */
+		errdiv: Elem
+		/** plots appear below the tabs and button controls */
+		plotDiv: Elem
+	}
+	/** TODO */
+	opts: any
+	plotIdToSandboxId: any
+	/** TODO */
+	state: any
+	/** TODO */
+	store: any
+	/** required app type */
+	type: 'app'
 }
 
 /** TODO: Start of all possible options for the mass state */
 type MassState = {
-	nav: {
-		activeTab: number
-	}
+	nav: MassNav
+}
+
+type MassNav = {
+	/** Default is 0. Shows the tabs in this order depending on
+	 * dataset -> about > cohort > charts tab */
+	activeTab: number
+	/** -1: unselected, 0,1,2...: selected */
+	activeCohort: number
+	header_mode:
+		| 'only_buttons'
+		| 'with_tabs'
+		| 'search_only'
+		| 'hidden'
+		| 'hide_search'
+		| 'with_cohortHtmlSelect'
+		| 'with_cohort_select'
 }

--- a/client/mass/types/mass.d.ts
+++ b/client/mass/types/mass.d.ts
@@ -20,5 +20,13 @@ export type MassApp = RxApp & {
 	printError: (e: string) => void
 	tip: Menu
 	type: 'app'
+	/** Should be a type for TermdbVocab or Frontend Vocab later */
 	vocabApi: any
+}
+
+/** TODO: Start of all possible options for the mass state */
+type MassState = {
+	nav: {
+		activeTab: number
+	}
 }

--- a/client/mass/types/mass.d.ts
+++ b/client/mass/types/mass.d.ts
@@ -1,0 +1,24 @@
+import { RxApp } from '../../types/rx'
+import { Menu } from '../../dom/menu'
+import { Elem } from '../../types/d3'
+
+export type MassApp = RxApp & {
+	Inner: {
+		eventTypes: ['preDispatch', 'postInit', 'postRender', 'firstRender', 'error']
+		dom: {
+			holder: Elem
+			topbar: Elem
+			errdiv: Elem
+			plotDiv: Elem
+		}
+		opts: any
+		plotIdToSandboxId: any
+		state: any
+		store: any
+		type: 'app'
+	}
+	printError: (e: string) => void
+	tip: Menu
+	type: 'app'
+	vocabApi: any
+}

--- a/client/types/rx.d.ts
+++ b/client/types/rx.d.ts
@@ -1,0 +1,13 @@
+export type RxApp = {
+	type: 'app'
+	deregister: (api2: any) => void
+	destroy: () => void
+	dispatch: (action: any) => Promise<void>
+	getComponents: (dotSepNames?: string) => any
+	getState: () => any
+	hasWebGL: () => boolean
+	middle: (fxn: any) => void
+	on: (eventType: string, callback: (event: any) => void) => void
+	register: (api2: any) => void
+	save: (action: any) => Promise<void>
+}

--- a/client/types/rx.d.ts
+++ b/client/types/rx.d.ts
@@ -1,13 +1,17 @@
-export type RxApp = {
+export type RxAppApi = {
 	type: 'app'
 	deregister: (api2: any) => void
+	/** delete references to other objects to make it easier
+	 * for automatic garbage collection to find unreferenced objects */
 	destroy: () => void
 	dispatch: (action: any) => Promise<void>
 	getComponents: (dotSepNames?: string) => any
+	/** return entire or selected state properties */
 	getState: () => any
 	hasWebGL: () => boolean
 	middle: (fxn: any) => void
 	on: (eventType: string, callback: (event: any) => void) => void
 	register: (api2: any) => void
+	/** save changes to store, do not notify components */
 	save: (action: any) => Promise<void>
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- Prototype for about tab in mass ui. Intended to build out per dataset. 

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -109,16 +109,16 @@ export default {
 					ignoreCnvValues: true
 				}
 			},
-			termid2totalsize2: {},
-			about: {
-				tab: {
-					order: 4,
-					topLabel: 'test',
-					midLabel: 'test about',
-					btmLabel: 'test'
-				},
-				html: 'Test'
-			}
+			termid2totalsize2: {}
+			// about: {
+			// 	tab: {
+			// 		order: 4,
+			// 		topLabel: 'test',
+			// 		midLabel: 'test about',
+			// 		btmLabel: 'test'
+			// 	},
+			// 	html: 'Test'
+			// }
 		},
 		scatterplots: {
 			plots: [

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -111,6 +111,12 @@ export default {
 			},
 			termid2totalsize2: {},
 			about: {
+				tab: {
+					order: 1,
+					topLabel: 'test',
+					midLabel: 'test about',
+					btmLabel: 'test'
+				},
 				html: 'Test'
 			}
 		},

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -112,7 +112,7 @@ export default {
 			termid2totalsize2: {},
 			about: {
 				tab: {
-					order: 1,
+					order: 4,
 					topLabel: 'test',
 					midLabel: 'test about',
 					btmLabel: 'test'

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -109,7 +109,10 @@ export default {
 					ignoreCnvValues: true
 				}
 			},
-			termid2totalsize2: {}
+			termid2totalsize2: {},
+			about: {
+				html: 'Test'
+			}
 		},
 		scatterplots: {
 			plots: [

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -105,6 +105,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	if (tdb.logscaleBase2) c.logscaleBase2 = tdb.logscaleBase2
 	if (tdb.useCasesExcluded) c.useCasesExcluded = tdb.useCasesExcluded
 	if (tdb.excludedTermtypeByTarget) c.excludedTermtypeByTarget = tdb.excludedTermtypeByTarget
+	if (tdb.about) c.about = tdb.about
 
 	if (ds.assayAvailability) c.assayAvailability = ds.assayAvailability
 	if (ds.customTwQByType) c.customTwQByType = ds.customTwQByType

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -926,7 +926,21 @@ type Termdb = {
 	/** in development!
 	 * Supports the About tab in mass UI
 	 */
-	about?: any
+	about?: {
+		/** Customization for the tab */
+		tab?: {
+			/** show in a specific order of tabs */
+			order?: number
+			/** label appearing in the top row in upper case */
+			topLabel?: string
+			/** biggest label appearing in the middle row in upper case */
+			midLabel?: string
+			/** label appearing in the bottom row*/
+			btmLabel?: string
+		}
+		/** html code */
+		html: string
+	}
 }
 
 type ChartConfigByType = {

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -923,6 +923,10 @@ type Termdb = {
 		/** key is usecase target (todo restrict). value is array of term type (todo restrict) */
 		[useCaseTarget: string]: string[]
 	}
+	/** in development!
+	 * Supports the About tab in mass UI
+	 */
+	about?: any
 }
 
 type ChartConfigByType = {


### PR DESCRIPTION
## Description
Closes issue #2090. 

Changes: 
1. An About tab appears in the mass ui if `ds.cohort.termdb.about` is present and `ds.cohort.termdb.selectCohort` is not present.
2. Types for mass app and rx app api for typescript files. 

Test: 
1. Comment out `cohort.termdb.selectCohort` and uncomment `cohort.termdb.about` in `server/dataset/termdb.test.ts` -> open [TermdbTest example](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38-test%22,%22dslabel%22:%22TermdbTest%22}) -> should see the About tab in the last position. 
2. Does not appear in [other datasets, such as sjmb12](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22sjmb12%22}). To see in other datasets, add the following to `cohort.termdb`: 
```
about: {
    tab: {
	    order: 1,
	    topLabel: 'test',
	    midLabel: 'test about',
	    btmLabel: 'test'
    },
    html: 'Test'
}
```
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
