### PR TITLE
Tw refactor.3

### DIFF
--- a/client/plots/matrix.serieses.js
+++ b/client/plots/matrix.serieses.js
@@ -77,7 +77,7 @@ export function getSerieses(data) {
 
 				let legend
 				if (typeof t.tw.setCellProps == 'function') {
-					// use MatrixXtwObj method if present
+					// use extended tw method if present
 					legend = t.tw.setCellProps(cell, anno, value, s, t, this, width, height, dx, dy, i)
 				} else {
 					// hierCluster terms have their own setCellProps

--- a/client/plots/matrix.xtw.ts
+++ b/client/plots/matrix.xtw.ts
@@ -35,6 +35,7 @@ export function getTermGroups(termgroups, app) {
 
 export type SetCellPropsSignature = {
 	value: (
+		/** a plain object for matrix cell data to be rendered, including sibling cells */
 		cell: any,
 		anno: any,
 		value: string | number,

--- a/client/plots/matrix.xtw.ts
+++ b/client/plots/matrix.xtw.ts
@@ -33,134 +33,138 @@ export function getTermGroups(termgroups, app) {
 	return termGroups
 }
 
-export type SetCellPropsSignature = (
-	cell: any,
-	anno: any,
-	value: string | number,
-	s: any,
-	t: any,
-	self: any,
-	width: number,
-	height: number,
-	dx: number,
-	dy: number,
-	i: number
-) => any
+export type SetCellPropsSignature = {
+	value: (
+		cell: any,
+		anno: any,
+		value: string | number,
+		s: any,
+		t: any,
+		self: any,
+		width: number,
+		height: number,
+		dx: number,
+		dy: number,
+		i: number
+	) => any
+}
 
 interface MatrixTWObj {
 	setCellProps: SetCellPropsSignature
 }
 
 const discreteAddons: MatrixTWObj = {
-	setCellProps(
-		this: DiscreteXTW,
-		cell: any,
-		anno: any,
-		value: string | number,
-		s: any,
-		t: any,
-		self: any,
-		width: number,
-		height: number,
-		dx: number,
-		dy: number,
-		i: number
-	) {
-		const tw = this.getTw()
-		console.log(96, tw) //tw
-		const key = anno.key
-		const values = tw.term.values || {}
-		cell.label = 'label' in anno ? anno.label : values[key]?.label ? values[key].label : key
-		cell.fill = anno.color || values[anno.key]?.color
+	setCellProps: {
+		value: function (
+			this: DiscreteXTW,
+			cell: any,
+			anno: any,
+			value: string | number,
+			s: any,
+			t: any,
+			self: any,
+			width: number,
+			height: number,
+			dx: number,
+			dy: number,
+			i: number
+		) {
+			const tw = this.getTw()
+			const key = anno.key
+			const values = tw.term.values || {}
+			cell.label = 'label' in anno ? anno.label : values[key]?.label ? values[key].label : key
+			cell.fill = anno.color || values[anno.key]?.color
 
-		// only for numeric terms for now
-		// TODO: should also consider categorical term.values[*].order
-		cell.order = t.ref.bins ? t.ref.bins.findIndex(bin => bin.name == key) : 0
+			// only for numeric terms for now
+			// TODO: should also consider categorical term.values[*].order
+			cell.order = t.ref.bins ? t.ref.bins.findIndex(bin => bin.name == key) : 0
 
-		cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
-		cell.y = height * i
-		const group = tw.legend?.group || tw.$id
-		return { ref: t.ref, group, value: key, entry: { key, label: cell.label, fill: cell.fill } }
+			cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
+			cell.y = height * i
+			const group = tw.legend?.group || tw.$id
+			return { ref: t.ref, group, value: key, entry: { key, label: cell.label, fill: cell.fill } }
+		}
 	}
 }
 
 const continuousAddons: MatrixTWObj = {
-	setCellProps(
-		this: ContinuousXTW,
-		cell: any,
-		anno: any,
-		value: string | number,
-		s: any,
-		t: any,
-		self: any,
-		width: number,
-		height: number,
-		dx: number,
-		dy: number,
-		i: number
-	) {
-		const tw = this.getTw()
-		console.log(128, tw) //#tw
-		const key = anno.key
-		const values = tw.term.values || {}
-		cell.label = 'label' in anno ? anno.label : values[key]?.label ? values[key].label : key
-		cell.fill = anno.color || values[anno.key]?.color
+	setCellProps: {
+		value: function (
+			this: ContinuousXTW,
+			cell: any,
+			anno: any,
+			value: string | number,
+			s: any,
+			t: any,
+			self: any,
+			width: number,
+			height: number,
+			dx: number,
+			dy: number,
+			i: number
+		) {
+			const tw = this.getTw()
+			const key = anno.key
+			const values = tw.term.values || {}
+			cell.label = 'label' in anno ? anno.label : values[key]?.label ? values[key].label : key
+			cell.fill = anno.color || values[anno.key]?.color
 
-		if (!tw.settings) tw.settings = {}
-		if (!tw.settings.barh) tw.settings.barh = s.barh
-		if (!('gap' in tw.settings)) tw.settings.gap = 4
+			if (!tw.settings) tw.settings = {}
+			if (!tw.settings.barh) tw.settings.barh = s.barh
+			if (!('gap' in tw.settings)) tw.settings.gap = 4
 
-		const specialValue = tw.term.values?.[cell.key]
+			const specialValue = tw.term.values?.[cell.key]
 
-		// handle uncomputable values
-		// TODO: the server response data should not have uncomputable values when mode='continuous'
-		// this may be implemented in getData(), but will require lots of testing since it is used
-		// by multiple charts
-		if (specialValue?.uncomputable) {
-			cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
-			cell.y = height * i
-			cell.height = tw.settings.barh
-			cell.fill = 'transparent'
-			cell.label = specialValue.label
-			const group = tw.legend?.group || tw.$id
-			return {
-				ref: t.ref,
-				group,
-				value: specialValue.label || specialValue.key,
-				entry: { key, label: cell.label, fill: cell.fill }
+			// handle uncomputable values
+			// TODO: the server response data should not have uncomputable values when mode='continuous'
+			// this may be implemented in getData(), but will require lots of testing since it is used
+			// by multiple charts
+			if (specialValue?.uncomputable) {
+				cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
+				cell.y = height * i
+				cell.height = tw.settings.barh
+				cell.fill = 'transparent'
+				cell.label = specialValue.label
+				const group = tw.legend?.group || tw.$id
+				return {
+					ref: t.ref,
+					group,
+					value: specialValue.label || specialValue.key,
+					entry: { key, label: cell.label, fill: cell.fill }
+				}
 			}
-		}
 
-		// TODO: may use color scale instead of bars
-		// for bars, use a hardcoded color; TODO: allow a user to customize the bar color?
-		cell.fill = '#555'
-		if (s.transpose) {
-			cell.height = t.scale(cell.key)
-			cell.x = tw.settings.gap // - cell.width
-		} else {
-			const vc = cell.term.valueConversion
-			let renderV = vc ? cell.key * vc.scaleFactor : cell.key
-			// todo: convert from a boolean into maybe `q.units or q.transform: 'zscore' | ...`
-			if (this.q.convert2ZScore) {
-				renderV = (renderV - t.mean) / t.std
+			// TODO: may use color scale instead of bars
+			// for bars, use a hardcoded color; TODO: allow a user to customize the bar color?
+			cell.fill = '#555'
+			if (s.transpose) {
+				cell.height = t.scale(cell.key)
+				cell.x = tw.settings.gap // - cell.width
+			} else {
+				const vc = cell.term.valueConversion
+				let renderV = vc ? cell.key * vc.scaleFactor : cell.key
+				// todo: convert from a boolean into maybe `q.units or q.transform: 'zscore' | ...`
+				if (this.q.convert2ZScore) {
+					renderV = (renderV - t.mean) / t.std
 
-				// show positive z-score as soft red and negative z-score as soft blue
-				cell.fill = renderV > 0 ? '#FF6666' : '#6666FF'
-				cell.zscoreLabel = ` (z-score: ${renderV.toFixed(2)})`
+					// show positive z-score as soft red and negative z-score as soft blue
+					cell.fill = renderV > 0 ? '#FF6666' : '#6666FF'
+					cell.zscoreLabel = ` (z-score: ${renderV.toFixed(2)})`
+				}
+				cell.label =
+					'label' in anno
+						? anno.label
+						: values[key]?.label
+						? values[key].label
+						: this.term.unit
+						? `${cell.key.toFixed(2)} ${this.term.unit}`
+						: cell.key.toFixed(2)
+				cell.height = renderV >= 0 ? t.scales.pos(renderV) : t.scales.neg(renderV)
+				cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
+				cell.y =
+					renderV >= 0 ? t.counts.posMaxHt + t.tw.settings.gap - cell.height : t.counts.posMaxHt + t.tw.settings.gap
+				cell.convertedValueLabel = !vc ? '' : convertUnits(cell.key, vc.fromUnit, vc.toUnit, vc.scaleFactor)
 			}
-			cell.label =
-				'label' in anno
-					? anno.label
-					: values[key]?.label
-					? values[key].label
-					: this.term.unit
-					? `${cell.key.toFixed(2)} ${this.term.unit}`
-					: cell.key.toFixed(2)
-			cell.height = renderV >= 0 ? t.scales.pos(renderV) : t.scales.neg(renderV)
-			cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
-			cell.y =
-				renderV >= 0 ? t.counts.posMaxHt + t.tw.settings.gap - cell.height : t.counts.posMaxHt + t.tw.settings.gap
-			cell.convertedValueLabel = !vc ? '' : convertUnits(cell.key, vc.fromUnit, vc.toUnit, vc.scaleFactor)
 		}
 	}
 }

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -932,8 +932,8 @@ export async function mayHydrateDictTwLst(twlst: TwLst, vocabApi: VocabApi) {
 	}
 }
 
-const features = JSON.parse(sessionStorage.getItem('optionalFeatures') || '{}')
-if (features.usextw) console.warn('--- Using xtw ---')
+// TODO: emit to verify xtw is being used
+console.warn('--- Using xtw ---')
 // add migrated tw fillers here, by term.type
 const routedTermTypes = new Set(['categorical', 'integer', 'float'])
 
@@ -948,7 +948,7 @@ export async function fillTermWrapper(
 		await mayHydrateDictTwLst([tw], vocabApi)
 	}
 
-	if (features.usextw && routedTermTypes.has(tw.term?.type)) {
+	if (routedTermTypes.has(tw.term?.type)) {
 		// NOTE: while the tw refactor is not done for all term types and q.types/modes,
 		// there will be some code duplication between TwRouter and the legacy code;
 		// the latter will be deleted once the refactor/migration is done

--- a/client/termsetting/test/termsetting.unit.spec.js
+++ b/client/termsetting/test/termsetting.unit.spec.js
@@ -150,13 +150,11 @@ tape('fillTermWrapper - continuous term', async function (test) {
 				first_bin: { startunbounded: true, stop: 0.2, stopinclusive: true },
 				hiddenValues: {}
 			},
-			!features.usextw
-				? {}
-				: {
-						isAtomic: true,
-						mode: 'discrete'
-						//test: 'apple'
-				  }
+			{
+				isAtomic: true,
+				mode: 'discrete'
+				//test: 'apple'
+			}
 		),
 		'should fill tw.q with tw.term.bins.less when defaultQ.preferredBins=less'
 	)
@@ -169,26 +167,11 @@ tape('fillTermWrapper - continuous term', async function (test) {
 	await fillTermWrapper(tw7, vocabApi, defaultQ)
 	test.deepEqual(
 		tw7.q,
-		features.usextw
-			? {
-					isAtomic: true,
-					mode: 'continuous',
-					hiddenValues: {}
-			  }
-			: {
-					// legacy fillTermWrapper() allows nonsensical combination of q{} properties
-					isAtomic: true,
-					mode: 'continuous',
-					type: 'regular-bin',
-					bin_size: 0.2,
-					stopinclusive: true,
-					first_bin: {
-						startunbounded: true,
-						stop: 0.2,
-						stopinclusive: true
-					},
-					hiddenValues: {}
-			  },
+		{
+			isAtomic: true,
+			mode: 'continuous',
+			hiddenValues: {}
+		},
 		'should merge defaultQ into tw.q when defaultQ.preferredBins is not defined'
 	)
 })

--- a/client/termsetting/test/termsetting.unit.spec.js
+++ b/client/termsetting/test/termsetting.unit.spec.js
@@ -114,10 +114,11 @@ tape('fillTermWrapper - continuous term', async function (test) {
 	defaultQ = {
 		numeric: {
 			mode: 'discrete',
+			type: 'regular-bin',
 			preferredBins: 'median'
 		}
 	}
-	testMsg = 'should throw error when defaultQ.type is not defined'
+	testMsg = 'should throw error when defaultQ.type is not custom-bin for preferredBins=median'
 	try {
 		const tw5 = {
 			term: structuredClone(await vocabApi.getterm('d'))
@@ -139,7 +140,6 @@ tape('fillTermWrapper - continuous term', async function (test) {
 		}
 	}
 	await fillTermWrapper(tw6, vocabApi, defaultQ)
-	console.log
 	test.deepEqual(
 		tw6.q,
 		Object.assign(
@@ -152,8 +152,8 @@ tape('fillTermWrapper - continuous term', async function (test) {
 			},
 			{
 				isAtomic: true,
-				mode: 'discrete'
-				//test: 'apple'
+				mode: 'discrete',
+				test: 'apple'
 			}
 		),
 		'should fill tw.q with tw.term.bins.less when defaultQ.preferredBins=less'

--- a/client/tw/README.md
+++ b/client/tw/README.md
@@ -3,7 +3,8 @@
 ## Goals for Refactoring
 
 1. Replace fillTermWrapper() with router-style code that fully resolves to a specific tw data shape,
-and has a lot more type annotations and unit/integration tests.
+with unit/integration tests and built-in type safety while also minimizing the need for type annotations
+in class methods and consumer code.
 2. Minimize the need for consumer code to know about tw types, hide data-shape related
 details from app, plot, or component code.
 3. Code tw handlers as 'plugins'. Within term wrapper handler code/methods, specialize to

--- a/client/tw/README.md
+++ b/client/tw/README.md
@@ -7,7 +7,7 @@ with unit/integration tests and built-in type safety while also minimizing the n
 in class methods and consumer code.
 2. Minimize the need for consumer code to know about tw types, hide data-shape related
 details from app, plot, or component code.
-3. Code tw handlers as 'plugins'. Within term wrapper handler code/methods, specialize to
+3. Code custom tw methods either as addons (recommended) or extended subclass. Within term wrapper handler code/methods, can use union of classes, or specialize to
 one instance type/context, so that 
 - there will be less need for static and runtime checks as related to the tw term type,
 q.type, and q.mode data instance.
@@ -17,9 +17,9 @@ since data processing should not change for the same tw data shape.
 ## Replace fillTW()
 ![Screenshot 2024-08-23 at 9 25 23 AM](https://github.com/user-attachments/assets/ba98482e-cfed-4685-9c41-43d0063742b1)
 
-## Plugin-style TW Handlers
+## Addon instance methods or extend a subclass
 
-![Screenshot 2024-08-24 at 10 42 45 PM](https://github.com/user-attachments/assets/cd6ee372-6fa2-453a-9b9d-698f476e22d1)
+![TwRouter init() (1)](https://github.com/user-attachments/assets/3ea57125-a5db-4fdf-8133-8ab35e09e160)
 
 ## Code Examples
 

--- a/client/tw/TwBase.ts
+++ b/client/tw/TwBase.ts
@@ -51,6 +51,7 @@ export class TwBase {
 	}
 
 	render(a: any): any {
+		console.log(a)
 		throw `should implement this method in subclass code, as needed`
 	}
 }

--- a/client/tw/TwBase.ts
+++ b/client/tw/TwBase.ts
@@ -1,20 +1,39 @@
 import { TermWrapper, Q } from '#updated-types'
 import { Term } from '#types'
+import { SetCellPropsSignature } from '../plots/matrix.xtw'
 
 export type TwOpts = {
 	vocabApi?: any // TODO
 	defaultQ?: any // TODO
 	defaultQByTsHandler?: any // TODO
+	addons?: {
+		[TwTypeName: string]: {
+			[name: string]: (a: any) => any
+		}
+	}
 	//usecase?: any // TODO
 }
 
 export class TwBase {
+	type: string
 	$id?: string
-	isAtomic: true
+	isAtomic = true
+
+	// define addons below, to be set using Object.defineProperties(this)
+	// by defining allowed method names here, subclasses that inherit from
+	// TwBase will be type checked
+	setCellProps!: SetCellPropsSignature
 
 	constructor(tw: TermWrapper, opts: TwOpts) {
+		this.type = tw.type
 		this.isAtomic = true
 		if (tw.$id) this.$id = tw.$id
+		// By using Object.defineProperties(), addon methods are not enumerable
+		// and makes the xtw instance compatible with structuredClone(),
+		// in contrast to using Object.assign()
+		if (opts.addons?.[this.type]) {
+			Object.defineProperties(this, opts.addons[this.type])
+		}
 	}
 
 	static setHiddenValues(q: Q, term: Term) {

--- a/client/tw/TwBase.ts
+++ b/client/tw/TwBase.ts
@@ -8,7 +8,10 @@ export type TwOpts = {
 	defaultQByTsHandler?: any // TODO
 	addons?: {
 		[TwTypeName: string]: {
-			[name: string]: (a: any) => any
+			[methodName: string]: {
+				value: (a: any) => any // required nested shape for native Object.defineProperties()
+			}
+			// | ((a: any) => any) // for convenience, not supported yet
 		}
 	}
 	//usecase?: any // TODO
@@ -45,5 +48,9 @@ export class TwBase {
 				if (term.values[k].uncomputable) q.hiddenValues[k] = 1
 			}
 		}
+	}
+
+	render(a: any): any {
+		throw `should implement this method in subclass code, as needed`
 	}
 }

--- a/client/tw/TwRouter.ts
+++ b/client/tw/TwRouter.ts
@@ -36,22 +36,6 @@ export class TwRouter {
 			case 'NumTWCont':
 				return new NumCont(tw, opts)
 
-			// case 'integer':
-			// case 'float':
-			// 	return
-
-			// case 'condition':
-			// 	return
-
-			// case 'survival':
-			// 	return
-
-			// case 'geneVariant':
-			// 	return
-
-			// case 'geneExpression':
-			// 	return
-
 			default:
 				//console.log(57, tw)
 				throw `unable to init(tw)`

--- a/client/tw/TwRouter.ts
+++ b/client/tw/TwRouter.ts
@@ -1,11 +1,8 @@
 import { TermWrapper } from '#updated-types'
-import { TwOpts } from './TwBase'
+import { TwOpts, TwBase } from './TwBase'
 import { mayHydrateDictTwLst } from '../termsetting/termsetting.ts'
-import { CategoricalBase, CatValues, CatPredefinedGS, CatCustomGS, CatInstance, CatTypes } from './categorical'
-import { NumericBase } from './numeric'
-
-export type TwHandlerInstance = CatInstance // | NumericHandlerInstance | ...
-export type HandlerTypes = CatTypes // | ...
+import { CategoricalBase, CatValues, CatPredefinedGS, CatCustomGS } from './categorical'
+import { NumericBase, NumRegularBin, NumCustomBins, NumCont } from './numeric'
 
 export type UseCase = {
 	target: string
@@ -23,7 +20,7 @@ export class TwRouter {
 		this.opts = opts
 	}
 
-	static init(tw: TermWrapper, opts: TwOpts = {}): TwHandlerInstance {
+	static init(tw: TermWrapper, opts: TwOpts = {}): TwBase {
 		switch (tw.type) {
 			case 'CatTWValues':
 				return new CatValues(tw, opts)
@@ -31,6 +28,13 @@ export class TwRouter {
 				return new CatPredefinedGS(tw, opts)
 			case 'CatTWCustomGS':
 				return new CatCustomGS(tw, opts)
+
+			case 'NumTWRegularBin':
+				return new NumRegularBin(tw, opts)
+			case 'NumTWCustomBin':
+				return new NumCustomBins(tw, opts)
+			case 'NumTWCont':
+				return new NumCont(tw, opts)
 
 			// case 'integer':
 			// case 'float':
@@ -49,11 +53,12 @@ export class TwRouter {
 			// 	return
 
 			default:
+				//console.log(57, tw)
 				throw `unable to init(tw)`
 		}
 	}
 
-	static async initRaw(rawTw /*: RawTW*/, opts: TwOpts = {}): Promise<TwHandlerInstance> {
+	static async initRaw(rawTw /*: RawTW*/, opts: TwOpts = {}): Promise<TwBase> {
 		const tw = await TwRouter.fill(rawTw, opts)
 		return TwRouter.init(tw, opts)
 	}

--- a/client/tw/categorical.ts
+++ b/client/tw/categorical.ts
@@ -1,6 +1,5 @@
 import {
 	CategoricalTerm,
-	CategoricalQ,
 	ValuesQ,
 	PredefinedGroupSettingQ,
 	CustomGroupSettingQ,
@@ -21,10 +20,12 @@ import { set_hiddenvalues } from '#termsetting'
 export type CatInstance = CatValues | CatPredefinedGS | CatCustomGS
 export type CatTypes = typeof CatValues | typeof CatPredefinedGS | typeof CatCustomGS
 
-export class CategoricalBase {
+export class CategoricalBase extends TwBase {
+	// type, isAtomic, $id are set in ancestor base classes
 	term: CategoricalTerm
 
-	constructor(tw: CatTWTypes, opts) {
+	constructor(tw: CatTWTypes, opts: TwOpts) {
+		super(tw, opts)
 		this.term = tw.term
 	}
 
@@ -114,6 +115,7 @@ export class CategoricalBase {
 }
 
 export class CatValues extends CategoricalBase {
+	// term, type, isAtomic, $id are set in ancestor base classes
 	q: ValuesQ
 	#tw: CatTWValues
 	#opts: TwOpts
@@ -127,8 +129,12 @@ export class CatValues extends CategoricalBase {
 		this.#opts = opts
 	}
 
+	getTw() {
+		return this.#tw
+	}
+
 	// See the relevant comments in the CategoricalBase.fill() function above
-	static fill(tw: RawCatTWValues, opts: TwOpts = {}): CatTWValues {
+	static fill(tw: RawCatTWValues): CatTWValues {
 		if (!tw.type) tw.type = 'CatTWValues'
 		else if (tw.type != 'CatTWValues') throw `expecting tw.type='CatTWValues', got '${tw.type}'`
 
@@ -139,8 +145,8 @@ export class CatValues extends CategoricalBase {
 
 		// GDC or other dataset may allow missing term.values
 		if (!term.values) term.values = {}
-		const numVals = Object.keys(tw.term.values).length
-		// GDC or other dataset may allow empty term.values
+		//const numVals = Object.keys(tw.term.values).length
+		//GDC or other dataset may allow empty term.values
 		//if (!numVals) throw `empty term.values`
 		if (q.mode == 'binary') {
 			if (Object.keys(tw.term.values).length != 2) throw 'term.values must have exactly two keys'
@@ -162,7 +168,7 @@ export class CatValues extends CategoricalBase {
 }
 
 export class CatPredefinedGS extends CategoricalBase {
-	//term: CategoricalTerm
+	// term, type, isAtomic, $id are set in ancestor base classes
 	q: PredefinedGroupSettingQ
 	#groupset: BaseGroupSet
 	#tw: CatTWPredefinedGS
@@ -178,7 +184,11 @@ export class CatPredefinedGS extends CategoricalBase {
 		this.#opts = opts
 	}
 
-	static fill(tw: RawCatTWPredefinedGS, opts: TwOpts = {}): CatTWPredefinedGS {
+	getTw() {
+		return this.#tw
+	}
+
+	static fill(tw: RawCatTWPredefinedGS): CatTWPredefinedGS {
 		if (!tw.type) tw.type = 'CatTWPredefinedGS'
 		else if (tw.type != 'CatTWPredefinedGS') throw `expecting tw.type='CatTWPredefinedGS', got '${tw.type}'`
 
@@ -215,7 +225,7 @@ export class CatPredefinedGS extends CategoricalBase {
 }
 
 export class CatCustomGS extends CategoricalBase {
-	//term: CategoricalTerm
+	// term, type, isAtomic, $id are set in ancestor base classes
 	q: CustomGroupSettingQ
 	#groupset: BaseGroupSet
 	#tw: CatTWCustomGS
@@ -229,6 +239,10 @@ export class CatCustomGS extends CategoricalBase {
 		this.#groupset = this.q.customset
 		this.#tw = tw
 		this.#opts = opts
+	}
+
+	getTw() {
+		return this.#tw
 	}
 
 	// See the relevant comments in the CategoricalBase.fill() function above

--- a/client/tw/categorical.ts
+++ b/client/tw/categorical.ts
@@ -35,7 +35,7 @@ export class CategoricalBase extends TwBase {
 				return new CatValues(tw, opts)
 
 			case 'CatTWPredefinedGS':
-				return new CatPredefinedGS(tw, opts)
+				return new CatPredefinedGS(tw)
 
 			case 'CatTWCustomGS':
 				return new CatCustomGS(tw, opts)
@@ -103,7 +103,7 @@ export class CategoricalBase extends TwBase {
 				return CatValues.fill(tw)
 
 			case 'CatTWPredefinedGS':
-				return CatPredefinedGS.fill(tw, opts)
+				return CatPredefinedGS.fill(tw)
 
 			case 'CatTWCustomGS':
 				return CatCustomGS.fill(tw)

--- a/client/tw/categorical.ts
+++ b/client/tw/categorical.ts
@@ -29,28 +29,6 @@ export class CategoricalBase extends TwBase {
 		this.term = tw.term
 	}
 
-	static init(tw: CatTWTypes, opts: TwOpts = {}): CatInstance {
-		switch (tw.type) {
-			case 'CatTWValues':
-				return new CatValues(tw, opts)
-
-			case 'CatTWPredefinedGS':
-				return new CatPredefinedGS(tw)
-
-			case 'CatTWCustomGS':
-				return new CatCustomGS(tw, opts)
-
-			default:
-				throw `unknown categorical class`
-		}
-	}
-
-	//
-	static initRaw(rawTW: RawCatTW, opts: TwOpts = {}): CatInstance {
-		const tw: CatTWTypes = CategoricalBase.fill(rawTW, opts)
-		return CategoricalBase.init(tw, opts)
-	}
-
 	/** tw.term must already be filled-in at this point */
 	static fill(tw: RawCatTW, opts: TwOpts = {}): CatTWTypes {
 		if (!tw.term) throw `missing tw.term, must already be filled in`
@@ -196,7 +174,6 @@ export class CatPredefinedGS extends CategoricalBase {
 		if (tw.q.type != 'predefined-groupset') throw `expecting tw.q.type='predefined-groupset', got '${tw.q.type}'`
 
 		const { term, q } = tw
-		//if (term.type != 'categorical' || q.type != 'predefined-groupset') return false
 		const i = q.predefined_groupset_idx
 		if (i !== undefined && !Number.isInteger(i)) throw `missing or invalid tw.q.predefined_groupset_idx='${i}'`
 		q.predefined_groupset_idx = i || 0

--- a/client/tw/composite.ts
+++ b/client/tw/composite.ts
@@ -1,48 +1,8 @@
-import {
-	CategoricalTerm,
-	CategoricalQ,
-	CatTWTypes,
-	ValuesQ,
-	PredefinedGroupSettingQ,
-	CustomGroupSettingQ,
-	NumericTerm,
-	NumTWTypes,
-	NumTWDiscreteTypes,
-	NumTWCont,
-	RegularNumericBinConfig,
-	CustomNumericBinConfig,
-	ContinuousNumericQ
-} from '#types'
-import { TwBase } from './TwBase.ts'
+import { CatTWTypes, NumTWDiscreteTypes, NumTWCont } from '#types'
+import { CatValues, CatPredefinedGS, CatCustomGS } from './categorical'
+import { NumRegularBin, NumCustomBins, NumCont } from './numeric'
 
-export type DiscreteTWTypes = CatTWTypes | NumTWDiscreteTypes
-
-export class DiscreteBase extends TwBase {
-	term: CategoricalTerm | NumericTerm // | GeneVariantTerm | ...
-	q: CategoricalQ | RegularNumericBinConfig | CustomNumericBinConfig // TODO: should use/fix(?) NumericDiscreteQ
-	#tw: DiscreteTWTypes //
-
-	constructor(tw: DiscreteTWTypes, opts) {
-		super(tw, opts)
-		this.term = tw.term
-		this.q = tw.q //as DiscreteQTypes
-		this.#tw = tw
-	}
-}
-
-export type ContTWTypes = NumTWCont
-
-export class ContinuousBase extends TwBase {
-	term: NumericTerm // | GeneExpressionTerm | MetaboliteIntensityTerm | ...
-	q: ContinuousNumericQ
-	#tw: ContTWTypes
-
-	constructor(tw: ContTWTypes, opts) {
-		super(tw, opts)
-		this.term = tw.term
-		this.q = tw.q
-		this.#tw = tw
-	}
-
-	// should move helper functions that are common to many plots/apps here
-}
+export type DiscreteTW = CatTWTypes | NumTWDiscreteTypes
+export type DiscreteXTW = CatValues | CatPredefinedGS | CatCustomGS | NumRegularBin | NumCustomBins
+export type ContinuousTW = NumTWCont
+export type ContinuousXTW = NumCont

--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -2,10 +2,8 @@ import {
 	NumericTerm,
 	NumericQ,
 	NumTWTypes,
-	NumTWDiscrete,
 	NumTWRegularBin,
 	NumTWCustomBin,
-	NumTWBinary,
 	NumTWCont,
 	NumTWSpline,
 	RawNumTW,
@@ -13,10 +11,6 @@ import {
 	RawNumTWCustomBin,
 	RawNumTWCont,
 	RawNumTWSpline,
-	RawCustomBin,
-	DefaultBinnedQ,
-	DefaultMedianQ,
-	BinaryNumericQ,
 	ContinuousNumericQ,
 	SplineNumericQ,
 	StartUnboundedBin,
@@ -29,13 +23,13 @@ import { copyMerge } from '#rx'
 import { isNumeric } from '#shared/helpers'
 import { roundValueAuto } from '#shared/roundValue'
 
-type TermTypeSet = Set<'integer' | 'float' | 'geneExpression' | 'metaboliteIntensity'>
-
-export class NumericBase {
+export class NumericBase extends TwBase {
+	// type is set by TwBase constructor
 	term: NumericTerm
-	static termTypes: TermTypeSet = new Set(['integer', 'float', 'geneExpression', 'metaboliteIntensity'])
+	static termTypes = new Set(['integer', 'float', 'geneExpression', 'metaboliteIntensity'])
 
 	constructor(tw: NumTWTypes, opts: TwOpts) {
+		super(tw, opts)
 		this.term = tw.term
 	}
 
@@ -152,7 +146,7 @@ export class NumericBase {
 }
 
 export class NumRegularBin extends NumericBase {
-	//term: NumericTerm
+	// type, isAtomic, $id are set in ancestor base classes
 	q: RegularNumericBinConfig
 	#tw: NumTWRegularBin
 	#opts: TwOpts
@@ -166,9 +160,12 @@ export class NumRegularBin extends NumericBase {
 		this.#opts = opts
 	}
 
+	getTw() {
+		return this.#tw
+	}
+
 	// See the relevant comments in the NumericBase.fill() function above
-	static async fill(tw: RawNumTWRegularBin, opts: TwOpts = {}): Promise<NumTWRegularBin> {
-		const { term, q } = tw
+	static async fill(tw: RawNumTWRegularBin): Promise<NumTWRegularBin> {
 		if (!tw.type) tw.type = 'NumTWRegularBin'
 		else if (tw.type != 'NumTWRegularBin') throw `expecting tw.type='NumTWRegularBin', got '${tw.type}'`
 
@@ -182,13 +179,13 @@ export class NumRegularBin extends NumericBase {
 		if (!tw.q.first_bin) throw `missing tw.q.first_bin`
 		if (!isNumeric(tw.q.first_bin?.stop)) throw `tw.q.first_bin.stop is not numeric`
 
-		TwBase.setHiddenValues(tw.q as NumericQ, term)
+		TwBase.setHiddenValues(tw.q as NumericQ, tw.term)
 		return tw as NumTWRegularBin
 	}
 }
 
 export class NumCustomBins extends NumericBase {
-	//term: NumericTerm
+	// term, type, isAtomic, $id are set in ancestor base classes
 	q: CustomNumericBinConfig
 	#tw: NumTWCustomBin
 	#opts: TwOpts
@@ -200,6 +197,10 @@ export class NumCustomBins extends NumericBase {
 		this.q = tw.q
 		this.#tw = tw
 		this.#opts = opts
+	}
+
+	getTw() {
+		return this.#tw
 	}
 
 	// See the relevant comments in the NumericBase.fill() function above
@@ -251,7 +252,7 @@ export class NumCustomBins extends NumericBase {
 }
 
 export class NumCont extends NumericBase {
-	//term: NumericTerm
+	// term, type, isAtomic, $id are set in ancestor base classes
 	q: ContinuousNumericQ
 	#tw: NumTWCont
 	#opts: TwOpts
@@ -265,8 +266,12 @@ export class NumCont extends NumericBase {
 		this.#opts = opts
 	}
 
+	getTw() {
+		return this.#tw
+	}
+
 	// See the relevant comments in the NumericBase.fill() function above
-	static async fill(tw: RawNumTWCont, opts: TwOpts = {}): Promise<NumTWCont> {
+	static async fill(tw: RawNumTWCont): Promise<NumTWCont> {
 		if (!tw.type) tw.type = 'NumTWCont'
 		else if (tw.type != 'NumTWCont') throw `expecting tw.type='NumTWCont', got '${tw.type}'`
 
@@ -279,7 +284,7 @@ export class NumCont extends NumericBase {
 }
 
 export class NumSpline extends NumericBase {
-	//term: NumericTerm
+	// term, type, isAtomic, $id are set in ancestor base classes
 	q: SplineNumericQ
 	#tw: NumTWSpline
 	#opts: TwOpts
@@ -293,7 +298,7 @@ export class NumSpline extends NumericBase {
 		this.#opts = opts
 	}
 
-	static async fill(tw: RawNumTWSpline, opts: TwOpts = {}): Promise<NumTWSpline> {
+	static async fill(tw: RawNumTWSpline): Promise<NumTWSpline> {
 		if (!tw.type) tw.type = 'NumTWSpline'
 		else if (tw.type != 'NumTWSpline') throw `expecting tw.type='NumTWSpline', got '${tw.type}'`
 

--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -127,17 +127,17 @@ export class NumericBase extends TwBase {
 		*/
 		switch (tw.type) {
 			case 'NumTWRegularBin':
-				return await NumRegularBin.fill(tw, opts)
+				return await NumRegularBin.fill(tw)
 
 			case 'NumTWCustomBin':
 				tw.q.type = 'custom-bin'
 				return await NumCustomBins.fill(tw, opts)
 
 			case 'NumTWCont':
-				return await NumCont.fill(tw, opts)
+				return await NumCont.fill(tw)
 
 			case 'NumTWSpline':
-				return await NumSpline.fill(tw, opts)
+				return await NumSpline.fill(tw)
 
 			default:
 				throw `tw.type='${tw.type} (q.mode:q.type=${tw.q.mode}:${tw.q.type}' is not supported by NumericBase.fill()`

--- a/client/tw/test/TwRouter.integration.spec.ts
+++ b/client/tw/test/TwRouter.integration.spec.ts
@@ -59,7 +59,7 @@ function getTermWithGS() {
 	return term
 }
 
-const softTwsLimit = 2 //5000
+const softTwsLimit = 3 //5000
 
 async function getTws() {
 	// create an array of full tw's, to simulate what may be seen from app/plot state after a dispatch
@@ -74,7 +74,9 @@ async function getTws() {
 				predefined_groupset_idx: 0,
 				isAtomic: true as const
 			}
-		})
+		}),
+		Object.freeze(await TwRouter.fill({ id: 'agedx' }, { vocabApi })),
+		Object.freeze(await TwRouter.fill({ id: 'agedx', q: { mode: 'continuous' } }, { vocabApi }))
 	]
 	while (twlst.length < softTwsLimit) {
 		twlst.push(...twlst)
@@ -137,8 +139,8 @@ tape('extended TwBase', async test => {
 	const msg = 'should convert tw objects into an extended TwBase'
 	try {
 		const data = {
-			sample1: { sex: 1, diaggrp: 'ALL' },
-			sample2: { sex: 2, diaggrp: 'NBL' }
+			sample1: { sex: 1, diaggrp: 'ALL', agedx: '1.5' },
+			sample2: { sex: 2, diaggrp: 'NBL', agedx: '3.3' }
 		}
 		//const xtws = terms.map(getHandler)
 		const start = Date.now()
@@ -166,7 +168,12 @@ tape('extended TwBase', async test => {
 				`<text>sample2, Female</text><circle r=2></cicle>` +
 				`<text>sample1, ALL</text><rect width=10 height=10></rect>` +
 				`<text>sample2, NBL</text><rect width=10 height=10></rect>` +
+				`<text>sample1, 1.5 (discrete)</text><line x1=0 y1=10 x2=10 y2=0 stroke='black' stroke-width=2 />` +
+				`<text>sample2, 3.3 (discrete)</text><line x1=0 y1=10 x2=10 y2=0 stroke='black' stroke-width=2 />` +
+				`<text>sample1, 1.5 (continuous)</text><line x1=0 y1=0 x2=10 y2=10 stroke='black' stroke-width=2 />` +
+				`<text>sample2, 3.3 (continuous)</text><line x1=0 y1=0 x2=10 y2=10 stroke='black' stroke-width=2 />` +
 				`</svg>`,
+
 			`should render an svg with fake data`
 		)
 	} catch (e) {

--- a/client/tw/test/TwRouter.integration.spec.ts
+++ b/client/tw/test/TwRouter.integration.spec.ts
@@ -119,7 +119,7 @@ tape('fill({id}) no tw.term, no tw.q', async test => {
 					sample_type: '1',
 					hashtmldetail: true
 				},
-				q: { type: 'values', isAtomic: true, hiddenValues: {} },
+				q: { type: 'values', isAtomic: true, hiddenValues: {}, mode: 'discrete' },
 				type: 'CatTWValues'
 			},
 			'should fill-in a minimal dictionary tw with only {id}'

--- a/client/tw/test/TwRouter.unit.spec.ts
+++ b/client/tw/test/TwRouter.unit.spec.ts
@@ -88,7 +88,8 @@ tape('fill({id, q}) nested q.groupsetting (legacy support)', async test => {
 				type: 'predefined-groupset',
 				predefined_groupset_idx: 0,
 				isAtomic: true,
-				hiddenValues: {}
+				hiddenValues: {},
+				mode: 'discrete'
 			},
 			`should reshape a legacy nested q.groupsetting`
 		)
@@ -108,11 +109,8 @@ tape('initRaw() categorical', async test => {
 			q: {}
 		}
 
-		const handler = await TwRouter.initRaw(tw, { vocabApi })
-		test.true(
-			handler instanceof CatValues,
-			`should return a matching categorical handler.router on init() with missing q or q.type`
-		)
+		const xtw = await TwRouter.initRaw(tw, { vocabApi })
+		test.true(xtw instanceof CatValues, `should return a matching categorical xtw on init() with missing q or q.type`)
 	}
 	{
 		const term = getTermWithGS()
@@ -122,10 +120,15 @@ tape('initRaw() categorical', async test => {
 			q: { type: 'predefined-groupset', isAtomic: true as const, predefined_groupset_idx: 0 }
 		}
 
-		const handler = await TwRouter.initRaw(tw, { vocabApi })
+		const xtw = await TwRouter.initRaw(tw, { vocabApi })
 		test.true(
-			handler instanceof CatPredefinedGS,
-			`should return a matching categorical handler.router on init() with q.type='predefined-groupset'`
+			xtw instanceof CatPredefinedGS,
+			`should return a matching categorical xtw on init() with q.type='predefined-groupset'`
+		)
+		test.deepEqual(
+			Object.keys(xtw).sort(),
+			['isAtomic', 'q', 'term', 'type'],
+			`should have the expected enumerable keys`
 		)
 	}
 
@@ -137,14 +140,20 @@ tape('initRaw() categorical', async test => {
 			q: {
 				type: 'custom-groupset',
 				isAtomic: true as const,
-				customset: getCustomSet()
+				customset: getCustomSet(),
+				mode: 'discrete'
 			}
 		}
 
-		const handler = await TwRouter.initRaw(tw, { vocabApi })
+		const xtw = await TwRouter.initRaw(tw, { vocabApi })
 		test.true(
-			handler instanceof CatCustomGS,
-			`should return a matching categorical handler.router on init() with q.type='custom-groupset'`
+			xtw instanceof CatCustomGS,
+			`should return a matching categorical xtw on init() with q.type='custom-groupset'`
+		)
+		test.deepEqual(
+			Object.keys(xtw).sort(),
+			['isAtomic', 'q', 'term', 'type'],
+			`should have the expected enumerable keys`
 		)
 	}
 

--- a/client/tw/test/categorical.unit.spec.ts
+++ b/client/tw/test/categorical.unit.spec.ts
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { RawCatTW, GroupEntry, TermGroupSetting, CatTWValues, CatTWPredefinedGS, CatTWCustomGS } from '#types'
 import { vocabInit } from '#termdb/vocabulary'
 import { termjson } from '../../test/testdata/termjson'
-import { CategoricalBase, CatValues, CatPredefinedGS, CatCustomGS } from '../categorical'
+import { CategoricalBase } from '../categorical'
 
 /*************************
  reusable helper functions
@@ -176,61 +176,6 @@ tape('fill() custom-groupset', async test => {
 		test.deepEqual(fullTw, expected, `should fill-in a categorical q.type='custom-groupset'`)
 	} catch (e: any) {
 		test.fail(e)
-	}
-
-	test.end()
-})
-
-tape('init() categorical', async test => {
-	{
-		const term = getTermWithGS()
-		const tw: RawCatTW = {
-			//id: term.id,
-			term,
-			isAtomic: true as const,
-			q: {}
-		}
-
-		const handler = await CategoricalBase.initRaw(tw, { vocabApi }) //; console.log(186, handler.constructor.name)
-		test.true(
-			handler instanceof CatValues,
-			`should return a matching categorical handler instance on init() with missing q or q.type`
-		)
-	}
-	{
-		const term = getTermWithGS()
-		const tw: RawCatTW = {
-			//id: term.id,
-			term,
-			isAtomic: true as const,
-			q: { type: 'predefined-groupset', isAtomic: true as const, predefined_groupset_idx: 0 }
-		}
-
-		const handler = await CategoricalBase.initRaw(tw, { vocabApi })
-		test.true(
-			handler instanceof CatPredefinedGS,
-			`should return a matching categorical handler instance on init() with missing q or q.type`
-		)
-	}
-
-	{
-		const term = getTermWithGS()
-		const tw: RawCatTW = {
-			//id: term.id,
-			term,
-			isAtomic: true as const,
-			q: {
-				type: 'custom-groupset',
-				isAtomic: true as const,
-				customset: getCustomSet()
-			}
-		}
-
-		const handler = await CategoricalBase.initRaw(tw, { vocabApi })
-		test.true(
-			handler instanceof CatCustomGS,
-			`should return a matching categorical handler instance on init() with missing q or q.type`
-		)
 	}
 
 	test.end()

--- a/client/tw/test/categorical.unit.spec.ts
+++ b/client/tw/test/categorical.unit.spec.ts
@@ -62,7 +62,7 @@ function getTermWithGS() {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- tw/CategoricalRouter.unit -***-')
+	test.pass('-***- tw/categorical.unit -***-')
 	test.end()
 })
 
@@ -99,6 +99,7 @@ tape(`fill() default q.type='values'`, async test => {
 				term: tw.term,
 				q: {
 					type: 'values',
+					mode: 'discrete',
 					isAtomic: true,
 					hiddenValues: {}
 				},
@@ -130,6 +131,7 @@ tape('fill() predefined-groupset', async test => {
 				term: tw.term,
 				q: {
 					type: 'predefined-groupset',
+					mode: 'discrete',
 					predefined_groupset_idx: 0,
 					isAtomic: true,
 					hiddenValues: {}
@@ -163,6 +165,7 @@ tape('fill() custom-groupset', async test => {
 		q: {
 			isAtomic: true,
 			type: 'custom-groupset',
+			mode: 'discrete',
 			name: 'AAA vs BBB',
 			customset: getCustomSet(),
 			hiddenValues: {}

--- a/client/tw/test/fake/app.ts
+++ b/client/tw/test/fake/app.ts
@@ -21,13 +21,13 @@ export class FakeApp {
 	main(data) {
 		this.#xtws = []
 		for (const tw of this.#opts.twlst) {
-			this.#xtws.push(this.#getExtTws(tw))
+			this.#xtws.push(this.#getxtw(tw))
 		}
 		this.#render(data)
 		//console.log(40, this.#xtws, JSON.parse(JSON.stringify(this.#xtws)))
 	}
 
-	#getExtTws(tw: TermWrapper): FakeTw | TwBase {
+	#getxtw(tw: TermWrapper): FakeTw | TwBase {
 		const opts = { vocabApi: this.#opts.vocabApi }
 		/* 
 			Below are examples of using a discriminant property at the object root,
@@ -38,11 +38,15 @@ export class FakeApp {
 		*/
 		if (!tw.type) throw `missing tw.type`
 		if (tw.type in addons) {
+			// example using addons
 			return TwRouter.init(tw, { vocabApi: this.#opts.vocabApi, addons })
-		} else if (tw.type == 'CatTWValues') return new FakeCatValues(tw, opts)
-		else if (tw.type == 'CatTWPredefinedGS') return new FakeCatPredefinedGS(tw, opts)
-		else if (tw.type == 'CatTWCustomGS') return new FakeCatCustomGS(tw, opts)
-		else throw `no fakeApp extended class for tw.type=${tw.type}`
+		} else {
+			// example using extended subclass
+			if (tw.type == 'CatTWValues') return new FakeCatValues(tw, opts)
+			else if (tw.type == 'CatTWPredefinedGS') return new FakeCatPredefinedGS(tw, opts)
+			else if (tw.type == 'CatTWCustomGS') return new FakeCatCustomGS(tw, opts)
+			else throw `no fakeApp extended class for tw.type=${tw.type}`
+		}
 	}
 
 	#render(data) {

--- a/client/tw/test/fake/app.ts
+++ b/client/tw/test/fake/app.ts
@@ -1,6 +1,9 @@
 import { TwRouter } from '../../TwRouter.ts'
+import { TwBase } from '../../TwBase.ts'
 import { TermWrapper } from '#updated-types'
-import { FakeTw, FakeCatValues, FakeCatPredefinedGS, FakeCatCustomGS } from './xtw/categorical.ts'
+import { FakeTw } from './types'
+import { FakeCatValues, FakeCatPredefinedGS, FakeCatCustomGS } from './xtw/categorical.ts'
+import { addons } from './xtw/addons.ts'
 
 export class FakeApp {
 	#opts: any
@@ -24,7 +27,7 @@ export class FakeApp {
 		//console.log(40, this.#xtws, JSON.parse(JSON.stringify(this.#xtws)))
 	}
 
-	#getExtTws(tw: TermWrapper): FakeTw {
+	#getExtTws(tw: TermWrapper): FakeTw | TwBase {
 		const opts = { vocabApi: this.#opts.vocabApi }
 		/* 
 			Below are examples of using a discriminant property at the object root,
@@ -34,20 +37,21 @@ export class FakeApp {
 			https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
 		*/
 		if (!tw.type) throw `missing tw.type`
-		if (tw.type == 'CatTWValues') return new FakeCatValues(tw, opts)
+		if (tw.type in addons) {
+			return TwRouter.init(tw, { vocabApi: this.#opts.vocabApi, addons })
+		} else if (tw.type == 'CatTWValues') return new FakeCatValues(tw, opts)
 		else if (tw.type == 'CatTWPredefinedGS') return new FakeCatPredefinedGS(tw, opts)
 		else if (tw.type == 'CatTWCustomGS') return new FakeCatCustomGS(tw, opts)
 		else throw `no fakeApp extended class for tw.type=${tw.type}`
 	}
 
 	#render(data) {
-		let svg = '<svg></svg>'
+		const svgElems: string[] = []
 		for (const xtw of this.#xtws) {
-			const arg = { holder: svg, data }
-			xtw.render(arg)
-			svg = arg.holder
+			const arg = { data }
+			svgElems.push(xtw.render(arg))
 		}
-		this.#dom.svg = svg
+		this.#dom.svg = `<svg>${svgElems.join('')}</svg>`
 	}
 
 	getInner() {

--- a/client/tw/test/fake/types.ts
+++ b/client/tw/test/fake/types.ts
@@ -1,0 +1,12 @@
+// Declare argument type(s) that are specific to a method for a particulat plot, app, or component
+export type PlotTwRenderOpts = {
+	data: {
+		[sampleId: string]: {
+			[termId: string]: number | string
+		}
+	}
+}
+
+export interface FakeTw {
+	render: (arg: PlotTwRenderOpts) => string
+}

--- a/client/tw/test/fake/xtw/addons.ts
+++ b/client/tw/test/fake/xtw/addons.ts
@@ -11,7 +11,7 @@ const discreteAddons = {
 				// lots of terms indicate benchmark testing, no need for string-based svg simulated render
 				if (keys.length > 10 || !keys.includes(t.id)) continue
 
-				// If there a lot of these if-else branches when extending DiscreteBase,
+				// If there are a lot of these if-else branches when extending DiscreteBase,
 				// it may be simpler and clearer to extend the "atomic" tw subclass directly.
 				// Code readability and type safety should dictate which class to extend.js
 				const shape = `<line x1=0 y1=10 x2=10 y2=0 stroke='black' stroke-width=2 />`

--- a/client/tw/test/fake/xtw/addons.ts
+++ b/client/tw/test/fake/xtw/addons.ts
@@ -1,0 +1,53 @@
+import { PlotTwRenderOpts } from '../types'
+import { DiscreteXTW, ContinuousXTW } from '../../../../tw/composite'
+
+const discreteAddons = {
+	render: {
+		value: function (this: DiscreteXTW, arg: PlotTwRenderOpts): string {
+			const t = this.term
+			const svgElems: string[] = []
+			for (const [sampleId, d] of Object.entries(arg.data)) {
+				const keys = Object.keys(d)
+				// lots of terms indicate benchmark testing, no need for string-based svg simulated render
+				if (keys.length > 10 || !keys.includes(t.id)) continue
+
+				// If there a lot of these if-else branches when extending DiscreteBase,
+				// it may be simpler and clearer to extend the "atomic" tw subclass directly.
+				// Code readability and type safety should dictate which class to extend.js
+				const shape = `<line x1=0 y1=10 x2=10 y2=0 stroke='black' stroke-width=2 />`
+				const valueText = '' + d[t.id]
+				svgElems.push(`<text>${sampleId}, ${valueText} (${this.q.mode})</text>${shape}`)
+			}
+			return svgElems.join('')
+		}
+	}
+}
+
+const continuousAddons = {
+	render: {
+		value: function (this: ContinuousXTW, arg: PlotTwRenderOpts): string {
+			const t = this.term
+			const svgElems: string[] = []
+			for (const [sampleId, d] of Object.entries(arg.data)) {
+				const keys = Object.keys(d)
+				// lots of terms indicate benchmark testing, no need for string-based svg simulated render
+				if (keys.length > 10 || !keys.includes(t.id)) continue
+
+				// If there a lot of these if-else branches when extending DiscreteBase,
+				// it may be simpler and clearer to extend the "atomic" tw subclass directly.
+				// Code readability and type safety should dictate which class to extend.
+
+				const shape = `<line x1=0 y1=0 x2=10 y2=10 stroke='black' stroke-width=2 />`
+				const valueText = '' + d[t.id]
+				svgElems.push(`<text>${sampleId}, ${valueText} (${this.q.mode})</text>${shape}`)
+			}
+			return svgElems.join('')
+		}
+	}
+}
+
+export const addons = {
+	NumTWRegularBin: discreteAddons,
+	NumTWCustomBin: discreteAddons,
+	NumTWCont: continuousAddons
+}

--- a/client/tw/test/fake/xtw/categorical.ts
+++ b/client/tw/test/fake/xtw/categorical.ts
@@ -1,22 +1,10 @@
 import { CatValues, CatPredefinedGS, CatCustomGS } from '../../../index.ts'
-
-// Declare argument type(s) that are specific to a method for a particulat plot, app, or component
-type PlotTwRenderOpts = {
-	holder: string // in real apps, would be a d3-selection HTML element
-	data: {
-		[sampleId: string]: {
-			[termId: string]: number | string
-		}
-	}
-}
-
-export interface FakeTw {
-	render: (arg: PlotTwRenderOpts) => void
-}
+import { PlotTwRenderOpts, FakeTw } from '../types'
 
 export class FakeCatValues extends CatValues implements FakeTw {
-	render(arg: PlotTwRenderOpts): void {
+	render(arg: PlotTwRenderOpts): string {
 		const t = this.term
+		const svgElems: string[] = []
 		for (const [sampleId, d] of Object.entries(arg.data)) {
 			const keys = Object.keys(d)
 			// lots of terms indicate benchmark testing, no need for string-based svg simulated render
@@ -24,38 +12,43 @@ export class FakeCatValues extends CatValues implements FakeTw {
 			// for the tw in this typed context, use a svg:circle element
 			// note that `this` context guarantees that the tw shape matches
 			// expectations without having to do additional checks
-			const shape = `<circle r=${d[t.id]}></cicle></svg>`
-			arg.holder = arg.holder.replace(`</svg>`, `<text>${sampleId}, ${t.values[d[t.id]].label}</text>${shape}`)
+			const shape = `<circle r=${d[t.id]}></cicle>`
+			svgElems.push(`<text>${sampleId}, ${t.values[d[t.id]].label}</text>${shape}`)
 		}
+		return svgElems.join('')
 	}
 }
 
 export class FakeCatPredefinedGS extends CatPredefinedGS implements FakeTw {
-	render(arg: PlotTwRenderOpts) {
+	render(arg: PlotTwRenderOpts): string {
 		// the tw is guaranteed to have term.type=categorical, q.type='predefined-groupset'
 		const t = this.term
+		const svgElems: string[] = []
 		for (const [sampleId, d] of Object.entries(arg.data)) {
 			const keys = Object.keys(d)
 			// lots of terms indicate benchmark testing, must not by influenced by string-based svg simulated render
 			if (keys.length > 10 || !keys.includes(t.id)) continue
 			// for the tw in this typed context, use a svg:rect element
-			const shape = `<rect width=10 height=10></rect></svg>`
-			arg.holder = arg.holder.replace(`</svg>`, `<text>${sampleId}, ${d[t.id]}</text>${shape}`)
+			const shape = `<rect width=10 height=10></rect>`
+			svgElems.push(`<text>${sampleId}, ${d[t.id]}</text>${shape}`)
 		}
+		return svgElems.join('')
 	}
 }
 
 export class FakeCatCustomGS extends CatCustomGS implements FakeTw {
-	render(arg: PlotTwRenderOpts) {
+	render(arg: PlotTwRenderOpts): string {
 		// the tw is guaranteed to have term.type=categorical, q.type='predefined-groupset'
 		const t = this.term
+		const svgElems: string[] = []
 		for (const [sampleId, d] of Object.entries(arg.data)) {
 			const keys = Object.keys(d)
 			// lots of terms indicate benchmark testing, must not by influenced by string-based svg simulated render
 			if (keys.length > 10 || !keys.includes(t.id)) continue
 			// for the tw in this typed context, use a svg:rect element
-			const shape = `<rect width=10 height=10></rect></svg>`
-			arg.holder = arg.holder.replace(`</svg>`, `<text>${sampleId}, ${d[t.id]}</text>${shape}`)
+			const shape = `<rect width=10 height=10></rect>`
+			svgElems.push(`<text>${sampleId}, ${d[t.id]}</text>${shape}`)
 		}
+		return svgElems.join('')
 	}
 }

--- a/client/tw/test/fake/xtw/categorical.ts
+++ b/client/tw/test/fake/xtw/categorical.ts
@@ -1,5 +1,4 @@
 import { CatValues, CatPredefinedGS, CatCustomGS } from '../../../index.ts'
-import { DiscreteBase, DiscreteTWTypes } from '../../../composite.ts'
 
 // Declare argument type(s) that are specific to a method for a particulat plot, app, or component
 type PlotTwRenderOpts = {
@@ -13,44 +12,6 @@ type PlotTwRenderOpts = {
 
 export interface FakeTw {
 	render: (arg: PlotTwRenderOpts) => void
-}
-
-// example of extending a composite class, instead of
-// having to extend multiple classes with highly specialized code
-export class FakeDiscrete extends DiscreteBase implements FakeTw {
-	#tw: DiscreteTWTypes
-
-	constructor(tw, opts) {
-		super(tw, opts)
-		this.#tw = tw
-	}
-
-	render(arg: PlotTwRenderOpts): void {
-		const t = this.term
-		for (const [sampleId, d] of Object.entries(arg.data)) {
-			const keys = Object.keys(d)
-			// lots of terms indicate benchmark testing, no need for string-based svg simulated render
-			if (keys.length > 10 || !keys.includes(t.id)) continue
-
-			// If there a lot of these if-else branches when extending DiscreteBase,
-			// it may be simpler and clearer to extend the "atomic" tw subclass directly.
-			// Code readability and type safety should dictate which class to extend.
-			let shape = '',
-				valueText = ''
-			if (this.q.type == 'values') {
-				shape = `<circle r=${d[t.id]}></cicle></svg>`
-				valueText = '' + t.values?.[d[t.id]].label || ''
-			} else if (this.q.type == 'predefined-groupset' || this.q.type == 'custom-groupset') {
-				shape = `<rect width=10 height=10></rect></svg>`
-				valueText = '' + d[t.id]
-			} else {
-				shape = `<line x1=0 y1=10 x2=10 y2=0 stroke='black' stroke-width=2 /></svg>`
-				valueText = '' + d[t.id]
-			}
-
-			arg.holder = arg.holder.replace(`</svg>`, `<text>${sampleId}, ${valueText}</text>${shape}`)
-		}
-	}
 }
 
 export class FakeCatValues extends CatValues implements FakeTw {

--- a/client/tw/test/numeric.xtw.unit.spec.ts
+++ b/client/tw/test/numeric.xtw.unit.spec.ts
@@ -3,7 +3,6 @@ import { vocabInit } from '#termdb/vocabulary'
 import { termjson } from '../../test/testdata/termjson'
 import { NumericBase } from '../numeric'
 import { RawNumTW } from '#types'
-import { CatValues, CatPredefinedGS, CatCustomGS } from '../categorical'
 
 /*************************
  reusable helper functions
@@ -71,7 +70,7 @@ tape(`fill() default q.type='regular-bin'`, async test => {
 	test.end()
 })
 
-tape(`fill() q.type=custom-bin opts.defaultQ.preferredBins='median'`, async test => {
+tape.skip(`fill() q.type=custom-bin opts.defaultQ.preferredBins='median'`, async test => {
 	const tw: RawNumTW = {
 		term: termjson.agedx,
 		q: {

--- a/server/shared/helpers.js
+++ b/server/shared/helpers.js
@@ -7,7 +7,7 @@ this is a helper file with a collection of functions to be used in backend and c
 */
 
 export function isNumeric(n) {
-	return !isNaN(parseFloat(n)) && isFinite(n)
+	return Number.isFinite(n) || !isNaN(parseFloat(n))
 }
 
 export function convertUnits(v, fromUnit, toUnit, scaleFactor, compact) {

--- a/server/shared/types/terms/categorical.ts
+++ b/server/shared/types/terms/categorical.ts
@@ -8,7 +8,7 @@ import {
 	PredefinedGroupSettingQ,
 	CustomGroupSettingQ
 } from './term.ts'
-import { RawValuesQ, RawPredefinedGroupsetQ, RawCustomGroupsetQ } from './q.ts'
+import { RawValuesQ, RawPredefinedGroupsetQ, RawCustomGroupsetQ, MinBaseQ } from './q.ts'
 import { TermSettingInstance } from '../termsetting.ts'
 
 /**
@@ -39,6 +39,10 @@ export type RawCatTWCustomGS = BaseTW & {
 }
 
 export type RawCatTW = RawCatTWValues | RawCatTWPredefinedGS | RawCatTWCustomGS
+
+export type CategoricalBaseQ = MinBaseQ & {
+	mode?: 'discrete' | 'binary'
+}
 
 export type CategoricalQ = GroupSettingQ | ValuesQ
 

--- a/server/shared/types/terms/categorical.ts
+++ b/server/shared/types/terms/categorical.ts
@@ -88,7 +88,7 @@ export type CatTWCustomGS = BaseTW & {
 	//id: string
 	term: CategoricalTerm
 	q: CustomGroupSettingQ
-	type?: 'CatTWCustomGS'
+	type: 'CatTWCustomGS'
 }
 
 export type CatTWTypes = CatTWValues | CatTWPredefinedGS | CatTWCustomGS

--- a/server/shared/types/terms/numeric.ts
+++ b/server/shared/types/terms/numeric.ts
@@ -1,18 +1,6 @@
-import { MinBaseQ, BaseTW, TermValues, BaseTerm, HiddenValues } from '../index.ts'
+import { MinBaseQ, BaseTW, TermValues, BaseTerm } from '../index.ts'
 
-export type RawRegularBin = MinBaseQ & {
-	type?: 'regular-bin'
-	// TODO: refactor code that allows/expects regular-bin q
-	// to have mode='binary' or 'continuous'
-	mode?: 'discrete' | 'binary' | 'continuous'
-	bin_size?: number
-	first_bin?: {
-		stop: number
-	}
-	hiddenValues?: HiddenValues
-	preferredBins?: string
-	isAtomic?: true
-}
+export type RawRegularBin = Partial<RegularNumericBinConfig> & { preferredBins?: string }
 
 export type RawNumTWRegularBin = BaseTW & {
 	type?: 'NumTWRegularBin'
@@ -20,24 +8,7 @@ export type RawNumTWRegularBin = BaseTW & {
 	q: RawRegularBin
 }
 
-export type RawCustomBin = MinBaseQ & {
-	type: 'custom-bin'
-	mode?: 'discrete' | 'binary'
-	// lst may be missing if median is present
-	// TODO: separate the binary type definition from discrete???
-	lst?: [NumericBin, ...NumericBin[]]
-	median?: number
-	preferredBins?: string
-	isAtomic?: true
-} /*| {
-	type: 'custom-bin'
-	mode: 'binary'
-	// lst may be missing if median is present
-	lst?: [NumericBin, NumericBin]
-	preferredBins?: string
-	median?: number
-	isAtomic?: true
-}*/
+export type RawCustomBin = Partial<CustomNumericBinConfig> & { preferredBins?: string }
 
 export type RawNumTWCustomBin = BaseTW & {
 	type?: 'NumTWCustomBin'
@@ -57,7 +28,7 @@ export type RawNumTWSpline = BaseTW & {
 	q: SplineNumericQ
 }
 
-export type RawNumTW = RawNumTWRegularBin | RawNumTWCustomBin | RawNumTWCont | RawNumTWSpline
+export type RawNumTW = RawNumTWCustomBin | RawNumTWRegularBin | RawNumTWCont | RawNumTWSpline
 
 export type NumericTerm = BaseTerm & {
 	id?: string
@@ -113,7 +84,7 @@ export type FullyBoundedBin = {
 
 export type NumericBin = StartUnboundedBin | FullyBoundedBin | StopUnboundedBin
 
-export type RegularNumericBinConfig = {
+export type RegularNumericBinConfig = MinBaseQ & {
 	type: 'regular-bin' // another concrete value being assigned, instead of `string`
 	//regular-sized bins
 	mode?: 'discrete'
@@ -126,12 +97,13 @@ export type RegularNumericBinConfig = {
 	label_offset?: number
 }
 
-export type CustomNumericBinConfig = {
+export type CustomNumericBinConfig = MinBaseQ & {
 	type: 'custom-bin'
-	mode?: 'discrete'
+	mode?: 'discrete' | 'binary'
 	// since ts will allow NumericBin[] to be empty,
 	// use this workaround to define a non-empty array
 	lst: [NumericBin, ...NumericBin[]]
+	preferredBins?: 'median'
 }
 
 // |
@@ -165,10 +137,10 @@ export type PresetNumericBins = {
 
 export type BinnedNumericQ = RegularNumericBinConfig | CustomNumericBinConfig
 
-export type DiscreteNumericQ = BinnedNumericQ &
-	MinBaseQ & {
-		mode: 'discrete' | 'binary'
-	}
+export type DiscreteNumericQ = BinnedNumericQ //&
+// MinBaseQ & {
+// 	mode: 'discrete' | 'binary'
+// }
 
 // TODO: test with live code that defines an actual binary q object
 export type BinaryNumericQ = MinBaseQ & {

--- a/server/shared/types/terms/term.ts
+++ b/server/shared/types/terms/term.ts
@@ -1,6 +1,5 @@
-import { MinBaseQ } from './q.ts'
 import { Filter } from '../filter.js'
-import { CategoricalTerm } from './categorical.js'
+import { CategoricalTerm, CategoricalBaseQ } from './categorical.js'
 import { ConditionTerm } from './condition.js'
 import { NumericTerm } from './numeric.js'
 import { GeneVariantTerm } from './geneVariant.js'
@@ -59,21 +58,18 @@ export type BaseQ = {
 		| 'custom-samplelst'
 }
 
-export type ValuesQ = MinBaseQ & {
+export type ValuesQ = CategoricalBaseQ & {
 	type: 'values'
-	mode?: 'binary'
 }
 
-export type PredefinedGroupSettingQ = MinBaseQ & {
+export type PredefinedGroupSettingQ = CategoricalBaseQ & {
 	type: 'predefined-groupset'
 	predefined_groupset_idx: number
-	mode?: 'binary'
 }
 
-export type CustomGroupSettingQ = MinBaseQ & {
+export type CustomGroupSettingQ = CategoricalBaseQ & {
 	type: 'custom-groupset'
 	customset: BaseGroupSet
-	mode?: 'binary'
 }
 
 export type GroupSettingQ = ValuesQ | PredefinedGroupSettingQ | CustomGroupSettingQ


### PR DESCRIPTION
## Description

Updated [tw/README.md](https://github.com/stjude/proteinpaint/blob/tw-refactor.3/client/tw/README.md). Now recommends the `addons` option  to add custom methods to a tw subclass, because:
- extending every relevant subclass with custom plot/app methods may be unnecessarily repetitive 
- extending a custom composite base class will lose inheritance of specialized subclass methods that are specific to a term type + q.type/mode

Tested with
- http://localhost:3000/testrun.html?name=*.unit
- http://localhost:3000/testrun.html?name=*.integration
- `cd client && npm run tsc`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
