### PR TITLE
feat:display WSI metadata.

### DIFF
--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -84,6 +84,8 @@ export default class WSIViewer {
 				`${state.sample_id} <span style="font-size:.8em">${state.termdbConfig.queries.WSImages.type} images</span>`
 			)
 		}
+
+		this.renderMetadata(holder, layers, settings)
 	}
 
 	private generateThumbnails(layers: Array<TileLayer<Zoomify>>, setting: Settings) {
@@ -109,6 +111,7 @@ export default class WSIViewer {
 					.style('height', setting.thumbnailHeight)
 					.style('margin-right', '10px')
 					.style('display', 'flex')
+					.style('height', 'auto')
 					.style('align-items', 'center')
 					.style('justify-content', 'center')
 					.style('border', isActive ? setting.activeThumbnailBorderStyle : setting.nonActiveThumbnailBorderStyle)
@@ -116,14 +119,12 @@ export default class WSIViewer {
 						this.wsiViewerInteractions.thumbnailClickListener(i)
 					})
 
-				// TODO plot metadata
-
 				thumbnail
 					.append('img')
 					.attr('src', layers[i].get('preview'))
 					.attr('alt', `Thumbnail ${i}`)
 					.style('max-width', '100%')
-					.style('height', 'auto')
+					.style('height', '60px')
 					.style('object-fit', 'cover')
 			}
 		} else {
@@ -195,6 +196,7 @@ export default class WSIViewer {
 			const options = {
 				// title: "Set Title",
 				preview: `/tileserver/layer/slide/${data.sessionId}/zoomify/TileGroup0/0-0-0@1x.jpg`,
+				metadata: wsimages[i].metadata,
 				source: source,
 				baseLayer: true
 			}
@@ -204,6 +206,27 @@ export default class WSIViewer {
 			layers.push(layer)
 		}
 		return layers
+	}
+
+	private renderMetadata(holder: any, layers: Array<TileLayer<Zoomify>>, settings: Settings) {
+		holder.select('table[id="metadata"]').remove()
+
+		const metadata = layers[settings.displayedImageIndex].get('metadata')
+
+		if (metadata) {
+			const table = holder.append('table').attr('id', 'metadata')
+
+			// Create table rows for each key-value pair
+			Object.entries(JSON.parse(metadata)).forEach(([key, value]) => {
+				const row = table.append('tr')
+
+				// Append a cell for the key
+				row.append('td').text(key).style('padding', '8px').style('border', '1px solid black')
+
+				// Append a cell for the value
+				row.append('td').text(value).style('padding', '8px').style('border', '1px solid black')
+			})
+		}
 	}
 }
 

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -15,6 +15,7 @@ import wsiViewerDefaults from '#plots/wsiviewer/defaults.ts'
 import { GetWSImagesRequest, GetWSImagesResponse } from '../../shared/types/routes/wsimages.ts'
 import wsiViewerImageFiles from './wsimagesloaded.ts'
 import { WSImage } from '../../../server/shared/types/routes/samplewsimages.ts'
+import { table2col } from '#dom/table2col'
 
 export default class WSIViewer {
 	// following attributes are required by rx
@@ -209,22 +210,18 @@ export default class WSIViewer {
 	}
 
 	private renderMetadata(holder: any, layers: Array<TileLayer<Zoomify>>, settings: Settings) {
-		holder.select('table[id="metadata"]').remove()
+		holder.select('div[id="metadata"]').remove()
+		const holderDiv = holder.append('div').attr('id', 'metadata')
 
+		const table = table2col({ holder: holderDiv })
 		const metadata = layers[settings.displayedImageIndex].get('metadata')
 
 		if (metadata) {
-			const table = holder.append('table').attr('id', 'metadata')
-
 			// Create table rows for each key-value pair
 			Object.entries(JSON.parse(metadata)).forEach(([key, value]) => {
-				const row = table.append('tr')
-
-				// Append a cell for the key
-				row.append('td').text(key).style('padding', '8px').style('border', '1px solid black')
-
-				// Append a cell for the value
-				row.append('td').text(value).style('padding', '8px').style('border', '1px solid black')
+				const [c1, c2] = table.addRow()
+				c1.html(key)
+				c2.html(value)
 			})
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- display WSI metadata


### PR DESCRIPTION
## Description

To test:

 update nintento-public dataset. 
 
Download from hpc /path/to/nintendo-public/wsimages/B-T87L964D/ to local tp.

Load:

http://localhost:3000/?noheader=1&mass={%22genome%22:%22mm10%22,%22dslabel%22:%22nintendoPublic%22}


<img width="398" alt="Screenshot 2024-09-10 at 4 46 58 PM" src="https://github.com/user-attachments/assets/6b654b41-b5e4-4533-867e-db9e50d3d15a">

Metadata should appear bellow the image. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
