### PR TITLE
address critical section 508 issues in the PP filter menu and lollipop legend

### DIFF
--- a/client/src/block.tk.usegm.js
+++ b/client/src/block.tk.usegm.js
@@ -1147,12 +1147,18 @@ async function domainlegend(tk, block) {
 	}
 }
 
+let idIncrement = 0
+function getId() {
+	return `sjpp-customdomainui-${idIncrement++}`
+}
+
 function customdomainmakeui(block, tk, proteinDomainUI) {
 	const wrapper = proteinDomainUI.style('padding', '20px')
-
+	const textAreaId = getId()
 	//header
 	wrapper
-		.append('div')
+		.append('label')
+		.attr('for', textAreaId)
 		.html(`Add domains for ${block.usegm.name} <span style="font-size:.8em">${block.usegm.isoform}</span>`)
 	const lst = client.getdomaintypes(block.usegm)
 
@@ -1191,8 +1197,8 @@ function customdomainmakeui(block, tk, proteinDomainUI) {
 	wrapper
 		.append('p')
 		.style('font-size', '.9em')
-		.html('<span style="font-size:.8em;color:#aaa">EXAMPLE</span>&nbsp;&nbsp;domain_name ; 100 200 ; red')
-	const ta = wrapper.append('textarea').attr('rows', 5).attr('cols', 30)
+		.html('<span style="font-size:.8em;color:#000">EXAMPLE</span>&nbsp;&nbsp;domain_name ; 100 200 ; red')
+	const ta = wrapper.append('textarea').attr('id', textAreaId).attr('rows', 5).attr('cols', 30)
 	const row1 = wrapper.append('div').style('margin-top', '5px')
 	const select = row1.append('select')
 	select.append('option').text('Codon position')
@@ -1264,7 +1270,7 @@ function customdomainmakeui(block, tk, proteinDomainUI) {
 	}
 	wrapper
 		.append('div')
-		.style('color', '#858585')
+		.style('color', '#000')
 		.style('margin-top', '20px')
 		.html(
 			`One protein domain per line.<br>

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -155,6 +155,7 @@ by normalize.css are covered here
 .sja_menu_div textarea,
 .sja_pane textarea {
     padding: 2px;
+    border: 1px solid #ccc;
 }
 
 .sja_root_holder input[type="search"].tree_search {

--- a/client/termdb/test/tree.integration.spec.js
+++ b/client/termdb/test/tree.integration.spec.js
@@ -234,9 +234,7 @@ tape('click_term', test => {
 	}
 	function testExpand_child1(tree) {
 		//Find disabled term button specified in tree.disable_terms
-		const disabledlabels = [...childdiv_child1.querySelectorAll('.termlabel')].filter(function (elem) {
-			return elem.style.opacity == '0.4'
-		})
+		const disabledlabels = childdiv_child1.querySelectorAll('.sja_tree_click_term_disabled')
 		test.ok(disabledlabels.length > 0, 'should have one or more disabled terms')
 		//Verify other term buttons enabled
 		const buttons = childdiv_child1.getElementsByClassName('sja_filter_tag_btn sja_tree_click_term termlabel')

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -393,7 +393,7 @@ function setRenderers(self) {
 					.attr('class', 'sja_tree_click_term_disabled ' + cls_termlabel)
 					.style('padding', '5px 8px')
 					.style('margin', '1px 0px')
-					.style('opacity', 0.4)
+					.style('opacity', 0.7)
 			} else if (uses.has('plot')) {
 				labeldiv
 					// need better css class

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -87,7 +87,7 @@ export const mclass = {
 	E: { label: 'EXON', color: '#bcbd22', dt: dtsnvindel, desc: 'A variant in the exon of a non-coding RNA.', key: 'E' },
 	F: {
 		label: 'FRAMESHIFT',
-		color: '#db3d3d',
+		color: 'rgb(200, 61, 61)',
 		dt: dtsnvindel,
 		desc: 'A sequence variant which causes a disruption of the translational reading frame, because the number of nucleotides inserted or deleted is not a multiple of three',
 		key: 'F'

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -108,7 +108,7 @@ export const mclass = {
 	},
 	D: {
 		label: 'PROTEINDEL',
-		color: '#7f7f7f',
+		color: 'rgb(100, 100, 100)',
 		dt: dtsnvindel,
 		desc: 'An inframe non synonymous variant that deletes bases from the coding sequence',
 		key: 'D'


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/issues/SV-2504?filter=12796

To teset, temporarily copy `commonOverrides` from `sjpp/gdc/active/serverconfig.json` to `sjpp/serverconfig.json`.

Darker legend for PROTEINDEL, for better contrast
![Screenshot 2024-09-11 at 3 02 34 PM](https://github.com/user-attachments/assets/b86c9ee8-59e5-45c6-8235-1f05455433c3)

Label and visible border around textarea
![Screenshot 2024-09-11 at 3 09 29 PM](https://github.com/user-attachments/assets/a071f4cc-cb89-48e2-9e8e-b0fdb0d611d3)

Darker disabled term in the tree menu, for better contrast
![Screenshot 2024-09-11 at 3 13 35 PM](https://github.com/user-attachments/assets/0aff556a-e43f-4620-a48c-58025ead22fb)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
