### PR TITLE
fix missing setCellProps() for condition terms in matrix plot

### DIFF
--- a/client/mass/test/matrix.integration.spec.js
+++ b/client/mass/test/matrix.integration.spec.js
@@ -84,6 +84,9 @@ tape('only dictionary terms', function (test) {
 											stopinclusive: true
 										}
 									} // or 'continuous'
+								},
+								{
+									id: 'Arrhythmias'
 								}
 							]
 						}
@@ -102,12 +105,12 @@ tape('only dictionary terms', function (test) {
 		matrix.on('postRender.test', null)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g').size(),
-			3,
+			4,
 			`should render the expected number of serieses`
 		)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g rect').size(),
-			180,
+			240,
 			`should render the expected number of cell rects`
 		)
 		test.equal(

--- a/client/plots/matrix.cells.js
+++ b/client/plots/matrix.cells.js
@@ -357,6 +357,7 @@ export function getEmptyCell(cellTemplate, s, d) {
 */
 export const setCellProps = {
 	categorical: setCategoricalCellProps,
+	condition: setCategoricalCellProps,
 	integer: setNumericCellProps,
 	float: setNumericCellProps,
 	survival: setSurvivalCellProps,
@@ -371,6 +372,7 @@ export const maySetEmptyCell = {
 	integer: setNumericEmptyCell,
 	float: setNumericEmptyCell,
 	categorical: setDefaultEmptyCell,
+	condition: setDefaultEmptyCell,
 	survival: setNumericEmptyCell,
 	[TermTypes.GENE_EXPRESSION]: setNumericEmptyCell,
 	[TermTypes.METABOLITE_INTENSITY]: setNumericEmptyCell


### PR DESCRIPTION
## Description

Added a condition term to dictionary terms test in [matrix.integration.spec.js](http://localhost:3000/testrun.html?dir=mass&name=matrix.integration). Not certain when this bug was introduced, the extended tw logic in `matrix.serieses.js` does not affect the selection of `setCellProps()` for non-migrated term types, it looks like condition-terms were broken even before the tw refactor.

Tested with http://localhost:3000/testrun.html?name=*.unit and `cd client && npm run test:integration`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
