### PR TITLE
Only show tabs in summary plot when more than one is visible

### DIFF
--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -75,6 +75,11 @@ class SummaryPlot {
 
 		const activeTabIndex = this.tabsData.findIndex(tab => tab.childType == this.config.childType)
 		this.chartToggles.update(activeTabIndex, this.config)
+
+		//Only show tabs when more than one are present
+		const numVisTabs = this.tabsData.filter(d => d.isVisible()).length
+		if (numVisTabs > 1) this.dom.chartToggles.style('display', 'inline-block')
+		else this.dom.chartToggles.style('display', 'none')
 	}
 
 	async setComponent(config) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- At mass summary plot header, when there's only one subtype tab, do not show the toggle


### PR DESCRIPTION
## Description

Test:
1. [Barchart example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22diaggrp%22}}],%22nav%22:{%22activeTab%22:1}}). Show not show a tab on load and show tabs when overlaid with a continuous term.
2. [Violin example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22efs%22}}]}). Should show relevant plot tabs on load. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
