### PR TITLE
detect invalid use of Inner in pre-commit hook

### DIFF
--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -21,4 +21,12 @@ pre-commit run --files "$FILES"
 echo "Linting ..."
 echo "$FILES" | grep "\.ts" | xargs npx eslint
 
+# check for invalid use of .Inner reference
+PRODINNER=$(echo "$FILES" | xargs grep -lr --exclude=\*.spec\* --exclude=\*dist/\* --exclude=\*test/\* --exclude=\*.md "\.Inner\.")
+if [[ "$PRODINNER" != "" ]]; then
+	echo "\n--- !!! invalid use of .Inner found in: !!! ---"
+	echo "$PRODINNER\n"
+	exit 1
+fi 
+
 exit 0


### PR DESCRIPTION
## Description

Testable only when making a commit. Can simulate invalid usage by adding `.Inner` string in any non-spec `.js` or `.ts` file, and create a disposable commit.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
