### PR TITLE
Fetch genomes supporting specific datasets from a specified host

### DIFF
--- a/front/public/cards/survivorBtn.json
+++ b/front/public/cards/survivorBtn.json
@@ -5,7 +5,7 @@
         "searchBar": "none",
         "availableGenomes": ["hg38"],
         "runargs": {
-            "host": "https://survivorship.proteinpaint.stjude.org/",
+            "host": "https://survivorship.proteinpaint.stjude.org",
             "nobox":true,
             "noheader": true,
             "mass": {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- fetch genomes supporting specific datasets from a specified host


### PR DESCRIPTION
## Description
https://proteinpaint.stjude.org/?appcard=survivorBtn is failing in production. Although the host is set to the correct server, the genomes passed are from the embedder. Thus the dataset (SFLife) isn't specified for that genome (hg38) within that serverconfig. This quick fix grabs the genomes from the specified server with the supported dataset, allowing `runproteinpaint` to continue. 

Test: 
1. Open a new tab, then open the network tab in dev tools
2. Load http://localhost:3000/?appcard=survivorBtn
3. Look at the response for genomes?embedder=localhost -> should only be hg38 with SJLife dataset. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
