### PR TITLE
allow q.mode=continuous for q.type=custom-bin

### DIFF
--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -932,8 +932,6 @@ export async function mayHydrateDictTwLst(twlst: TwLst, vocabApi: VocabApi) {
 	}
 }
 
-// TODO: emit to verify xtw is being used
-console.warn('--- Using xtw ---')
 // add migrated tw fillers here, by term.type
 const routedTermTypes = new Set(['categorical', 'integer', 'float'])
 

--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -175,8 +175,8 @@ export class NumCustomBins extends NumericBase {
 		else if (tw.type != 'NumTWCustomBin') throw `expecting tw.type='NumTWCustomBin', got '${tw.type}'`
 
 		if (!tw.q.mode) tw.q.mode = 'discrete'
-		else if (tw.q.mode != 'discrete' && tw.q.mode != 'binary')
-			throw `expecting tw.q.mode='discrete'|binary', got '${tw.q.mode}'`
+		else if (tw.q.mode != 'discrete' && tw.q.mode != 'binary' && tw.q.mode != 'continuous')
+			throw `expecting tw.q.mode='discrete'|binary|continuous', got '${tw.q.mode}'`
 
 		if (tw.q.mode == 'binary' && !tw.q.preferredBins) tw.q.preferredBins = 'median'
 


### PR DESCRIPTION
## Description

Fixes the issue when switching from a custom-bin barchart to a violin plot. q.mode='continuous' was already allowed for `q.type=regular-bin`, just need to do the same for `q.type=custom-bin`. Longer term, it doesn't seem right to allow bin q.type and continuous mode, not sure if this is only required in violin plot code or elsewhere.

Tested with http://localhost:3000/testrun.html?name=*.unit and `cd client; npm run test:integration`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
