### PR TITLE
Profile region fix

### DIFF
--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -195,10 +195,7 @@ export class profilePlot {
 			termsPerRequest: 10
 		})
 
-		this.regions = Object.keys(this.config.regionTW.term.values).map(value => {
-			return { label: value, value }
-		})
-		this.regions.unshift({ label: '', value: '' })
+		this.regions = this.getList(this.config.regionTW)
 		this.countries = this.getList(this.config.countryTW)
 		this.incomes = this.getList(this.config.incomeTW)
 		this.teachingStates = this.getList(this.config.teachingStatusTW)


### PR DESCRIPTION

## Description

In the plot filters, the region may have a global filter limiting its values, so it needs to be filled depending on that

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
