### PR TITLE
fix: genome browser plot now saves mds3 subtracks in state and recove…

### DIFF
--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -266,7 +266,11 @@ function loadTk_finish_closure(tk, block) {
 			else*/ updateLegend(data, tk, block)
 		}
 
-		tk.leftLabelMaxwidth = Math.max(tk.leftlabels.maxwidth + tk.leftlabels.xoff, tk.skewer ? tk.skewer.maxwidth : 0)
+		tk.leftLabelMaxwidth = Math.max(
+			tk.leftlabels.maxwidth + tk.leftlabels.xoff,
+			// tk.skewer.maxwidth is undefined if makeTk had exception. must yield valid value for leftLabelMaxwidth for block to show properly with err msg in tk body
+			Number.isFinite(tk.skewer?.maxwidth) ? tk.skewer.maxwidth : 0
+		)
 
 		block.tkcloakoff(tk, { error: data ? data.error : null })
 		block.block_setheight()

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- genome browser plot now saves mds3 subtracks in state and recover from session


### PR DESCRIPTION
…r from session

## Description

test [link](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22}). at genome browser app, launch kbtbd4, at mds3 tk, click Samples and create a subtk. save/share a session and restore it, the subtk will be present. this is good enough to generate mbmeta figure links

all mds3 tk tests pass

- order of tracks are not saved
- skewer config (up/down pointing, shape, numeric mode) are not saved and can be worked on next

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
