### PR TITLE
initialize optional matrix tw props in TwBase constructor

### DIFF
--- a/client/tw/TwBase.ts
+++ b/client/tw/TwBase.ts
@@ -27,10 +27,19 @@ export class TwBase {
 	// TwBase will be type checked
 	setCellProps!: SetCellPropsSignature
 
+	// TODO: may need to track these matrix specific tw props elsewhere
+	sortSamples?: any
+	minNumSamples?: number
+	valueFilter?: any
+
 	constructor(tw: TermWrapper, opts: TwOpts) {
 		this.type = tw.type
 		this.isAtomic = true
 		if (tw.$id) this.$id = tw.$id
+		if (tw.sortSamples) this.sortSamples = tw.sortSamples
+		if (tw.minNumSamples) this.minNumSamples = tw.minNumSamples
+		if (tw.valueFilter) this.valueFilter = tw.valueFilter
+
 		// By using Object.defineProperties(), addon methods are not enumerable
 		// and makes the xtw instance compatible with structuredClone(),
 		// in contrast to using Object.assign()

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- initialize optional matrix tw props in TwBase constructor

--- a/server/shared/types/terms/term.ts
+++ b/server/shared/types/terms/term.ts
@@ -155,6 +155,9 @@ export type BaseTW = {
 	settings?: {
 		[key: string]: any
 	}
+	sortSamples?: any
+	minNumSamples?: number
+	valueFilter?: any
 }
 
 /*** types supporting Term types ***/


### PR DESCRIPTION
## Description

Fixes issue with not being able to sort matrix plot, using the left blue arrow in the menu after clicking a row label.

Also tested with http://localhost:3000/testrun.html?name=*.unit and `cd client && npm run integration`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
