### PR TITLE
Table input label

### DIFF
--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -512,16 +512,16 @@ export const icons = {
 }
 
 function getHolder(elem, opts) {
-	// for Section 508: a clickable element should have a recognized aria-role,
-	// which a button element has but not a div or span
-	const holder = !opts.handler ? elem : elem.append('button').attr('class', 'sja_icon_btn')
+	if (opts.handler) {
+		elem.on('click', opts.handler)
 
-	holder
-		// presentation elements/tags like div, span, etc do not aria-roles
-		// and should not have aria-label attribute
-		.attr(opts.handler ? 'aria-label' : 'title', opts.title || null)
-		.style('cursor', 'pointer')
+		// for Section 508: a clickable element should have a recognized aria-role,
+		// either implied by element tagName (button, submit, etc) or via "role" attribute
+		if (elem.node().tagName != 'BUTTON') elem.attr('role', 'button').attr('tabindex', 0).style('cursor', 'pointer')
+	}
+	if (opts.title) {
+		elem.attr('aria-label', opts.title).style('z-index', 1000) // to have aria-label based tooltip appear above other elements
+	}
 
-	if (opts.handler) elem.on('click', opts.handler)
-	return holder
+	return elem
 }

--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -17,8 +17,7 @@ const disabled = {
 export const icons = {
 	x: (elem, o) => {
 		return (
-			elem
-				.attr('aria-label', o.title)
+			getHolder(elem, o)
 				.style('padding', '0 3px')
 				.style('color', 'rgb(255,100,100)')
 				.style('opacity', 0.9)
@@ -28,45 +27,33 @@ export const icons = {
 				.style('cursor', 'pointer')
 				//.html('&otimes;')
 				.html('&oplus;')
-				.on('click', o.handler)
 		)
 	},
 	plus: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
-			.style('padding', '0 3px')
-			.style('opacity', 0.9)
-			.style('font-size', '18px')
-			.html('&oplus;')
-			.on('click', o.handler)
+		return getHolder(elem, o).style('padding', '0 3px').style('opacity', 0.9).style('font-size', '18px').html('&oplus;')
 	},
 	combine: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('opacity', 0.9)
 			.style('font-size', '12px')
 			.style('color', 'rgb(100,100,255)')
 			.style('cursor', 'pointer')
 			.html('[]+[]')
-			.on('click', o.handler)
 	},
 	divide: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('opacity', 0.9)
 			.style('font-size', '12px')
 			.style('color', 'rgb(100,100,255)')
 			.style('cursor', 'pointer')
 			.html('[&divide;]')
-			.on('click', o.handler)
 	},
 	expand: (elem, o) => {
 		const color = 'color' in o ? o.color : 'rgb(100,100,255)'
 		return (
-			elem
-				.attr('aria-label', o.title)
+			getHolder(elem, o)
 				.style('height', 'auto')
 				.style('color', color)
 				.style('opacity', 0.9)
@@ -82,14 +69,12 @@ export const icons = {
 					  <path stroke='${color}' stroke-width='1' d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/>
 					</svg>`
 				)
-				.on('click', o.handler)
 		)
 	},
 	collapse: (elem, o) => {
 		const color = 'color' in o ? o.color : 'rgb(100,100,255)'
 		return (
-			elem
-				.attr('aria-label', o.title)
+			getHolder(elem, o)
 				.style('height', 'auto')
 				.style('color', color)
 				.style('opacity', 0.9)
@@ -105,24 +90,20 @@ export const icons = {
 					  <path stroke='${color}' stroke-width='1' fill-rule="evenodd" d="M2 8a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11A.5.5 0 0 1 2 8Z"/>
 					</svg>`
 				)
-				.on('click', o.handler)
 		)
 	},
 	corner: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', o.disabled ? disabled.color : 'rgb(100,100,255)')
 			.style('opacity', 0.9)
 			.style('font-size', '16px')
 			.style('cursor', 'pointer')
 			.html('&#8689;')
-			.on('click', o.handler)
 	},
 	left: (elem, o) => {
 		const fill = o.fill ? o.fill : o.disabled ? disabled.color : 'rgb(100,100,255)'
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', o.disabled ? disabled.color : 'rgb(100,100,255)')
 			.style('opacity', 0.9)
@@ -136,11 +117,9 @@ export const icons = {
 				</g>
 			</svg>`
 			)
-			.on('click', o.handler)
 	},
 	right: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)
@@ -154,13 +133,11 @@ export const icons = {
 				</g>
 			</svg>`
 			)
-			.on('click', o.handler)
 	},
 	up: (elem, o) => {
 		const fill = o.disabled ? disabled.color : 'rgb(100,100,255)'
 		return (
-			elem
-				.attr('aria-label', o.title)
+			getHolder(elem, o)
 				.style('padding', '0 3px')
 				//.style('color', 'rgb(100,100,255)')
 				.style('opacity', 0.9)
@@ -171,14 +148,12 @@ export const icons = {
 				<path d='M6,0L12,12L0,12Z' style='fill:${fill}'></path>
 			</svg>`
 				)
-				.on('click', o.handler)
 		)
 	},
 	down: (elem, o) => {
 		const fill = o.disabled ? disabled.color : 'rgb(100,100,255)'
 		return (
-			elem
-				.attr('aria-label', o.title)
+			getHolder(elem, o)
 				.style('padding', '0 3px')
 				//.style('color', 'rgb(100,100,255)')
 				.style('opacity', 0.9)
@@ -191,11 +166,10 @@ export const icons = {
 				</g>
 			</svg>`
 				)
-				.on('click', o.handler)
 		)
 	},
 	updown: (elem, o) => {
-		return elem
+		return getHolder(elem, o)
 			.attr('aria-label', o.title)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
@@ -205,11 +179,9 @@ export const icons = {
 			.style('text-decoration', 'underline')
 			.style('cursor', 'pointer')
 			.html('&#8693;')
-			.on('click', o.handler)
 	},
 	seHookArrow: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)
@@ -217,11 +189,9 @@ export const icons = {
 			.style('font-weight', 800)
 			.style('cursor', 'pointer')
 			.html('&#10533;')
-			.on('click', o.handler)
 	},
 	swHookArrow: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)
@@ -229,12 +199,10 @@ export const icons = {
 			.style('font-weight', 800)
 			.style('cursor', 'pointer')
 			.html('&#10534;')
-			.on('click', o.handler)
 	},
 	unlock: (elem, o) => {
 		return (
-			elem
-				.attr('aria-label', o.title)
+			getHolder(elem, o)
 				.style('padding', '0 3px')
 				//.style('color', 'rgb(100,100,255)')
 				.style('opacity', 0.9)
@@ -247,12 +215,10 @@ export const icons = {
 			</g>
 		</svg>`
 				)
-				.on('click', o.handler)
 		)
 	},
 	leftBorder: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)
@@ -266,11 +232,9 @@ export const icons = {
 				</g>
 			</svg>`
 			)
-			.on('click', o.handler)
 	},
 	leftCrossedOut: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)
@@ -285,20 +249,17 @@ export const icons = {
 				</g>
 			</svg>`
 			)
-			.on('click', o.handler)
 	},
 	filter: (elem, o) => {
-		elem
-			.attr('aria-label', o.title)
+		const holder = getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)
 			.style('font-size', '16px')
 			.style('padding', '3px')
 			.style('cursor', 'pointer')
-			.on('click', o.handler)
 
-		elem.iconPath = elem
+		elem.iconPath = holder
 			.append('svg')
 			.attr('width', 16)
 			.attr('height', 12)
@@ -308,12 +269,11 @@ export const icons = {
 			.attr('d', 'M8,0L2,6L2,12L-2,12L-2,6L-8,0Z')
 			.style('fill', 'rgb(100,100,255)')
 
-		return elem
+		return holder
 	},
 	colorScale: (elem, o) => {
 		return (
-			elem
-				.attr('aria-label', o.title)
+			getHolder(elem, o)
 				.style('padding', '0 3px')
 				.style('color', 'rgb(100,100,255)')
 				.style('opacity', 0.9)
@@ -336,12 +296,10 @@ export const icons = {
 				</g>
 			</svg>`
 				)
-				.on('click', o.handler)
 		)
 	},
 	bar: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)
@@ -357,11 +315,9 @@ export const icons = {
 				</g>
 			</svg>`
 			)
-			.on('click', o.handler)
 	},
 	rect: (elem, o) => {
-		return elem
-			.attr('aria-label', o.title)
+		return getHolder(elem, o)
 			.style('padding', '0 3px')
 			.style('stroke', 'rgb(100,100,255)')
 			.style('fill', 'fill' in o ? o.fill : 'none')
@@ -373,7 +329,6 @@ export const icons = {
 				</g>
 			</svg>`
 			)
-			.on('click', o.handler)
 	},
 	text: (elem, o) => {
 		const addWrapper = elem.append('div').style('display', 'none')
@@ -422,7 +377,7 @@ export const icons = {
 		<path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/>
 		<path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>
 	  </svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	zoomIn: (elem, opts) => {
 		const _opts = { color: 'black', width: 18, height: 18 }
@@ -432,7 +387,7 @@ export const icons = {
 	<path d="M10.344 11.742c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1 6.538 6.538 0 0 1-1.398 1.4z"/>
 	<path fill-rule="evenodd" d="M6.5 3a.5.5 0 0 1 .5.5V6h2.5a.5.5 0 0 1 0 1H7v2.5a.5.5 0 0 1-1 0V7H3.5a.5.5 0 0 1 0-1H6V3.5a.5.5 0 0 1 .5-.5z"/>
 	</svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	zoomOut: (elem, opts) => {
 		const _opts = { color: 'black', width: 18, height: 18 }
@@ -442,7 +397,7 @@ export const icons = {
 		<path d="M10.344 11.742c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1 6.538 6.538 0 0 1-1.398 1.4z"/>
 		<path fill-rule="evenodd" d="M3 6.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1h-6a.5.5 0 0 1-.5-.5z"/>
 	  </svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	lasso: (elem, opts) => {
 		const _opts = { color: 'black', width: 18, height: 18 }
@@ -451,7 +406,7 @@ export const icons = {
 		const svg = `<button style="cursor:pointer;border:none;background-color:${color};"><svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-zoom-in" viewBox="0 0 16 16">
 		<path d="M15.825.12a.5.5 0 0 1 .132.584c-1.53 3.43-4.743 8.17-7.095 10.64a6.067 6.067 0 0 1-2.373 1.534c-.018.227-.06.538-.16.868-.201.659-.667 1.479-1.708 1.74a8.118 8.118 0 0 1-3.078.132 3.659 3.659 0 0 1-.562-.135 1.382 1.382 0 0 1-.466-.247.714.714 0 0 1-.204-.288.622.622 0 0 1 .004-.443c.095-.245.316-.38.461-.452.394-.197.625-.453.867-.826.095-.144.184-.297.287-.472l.117-.198c.151-.255.326-.54.546-.848.528-.739 1.201-.925 1.746-.896.126.007.243.025.348.048.062-.172.142-.38.238-.608.261-.619.658-1.419 1.187-2.069 2.176-2.67 6.18-6.206 9.117-8.104a.5.5 0 0 1 .596.04zM4.705 11.912a1.23 1.23 0 0 0-.419-.1c-.246-.013-.573.05-.879.479-.197.275-.355.532-.5.777l-.105.177c-.106.181-.213.362-.32.528a3.39 3.39 0 0 1-.76.861c.69.112 1.736.111 2.657-.12.559-.139.843-.569.993-1.06a3.122 3.122 0 0 0 .126-.75l-.793-.792zm1.44.026c.12-.04.277-.1.458-.183a5.068 5.068 0 0 0 1.535-1.1c1.9-1.996 4.412-5.57 6.052-8.631-2.59 1.927-5.566 4.66-7.302 6.792-.442.543-.795 1.243-1.042 1.826-.121.288-.214.54-.275.72v.001l.575.575zm-4.973 3.04.007-.005a.031.031 0 0 1-.007.004zm3.582-3.043.002.001h-.002z"/>
 		</svg></button>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	download: (elem, opts) => {
 		const _opts = { color: 'black', width: 18, height: 18 }
@@ -460,7 +415,7 @@ export const icons = {
 		<path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
 		<path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
 	  </svg>`
-		elem.html(svg).on('click', opts.handler).style('cursor', 'pointer')
+		return getHolder(elem, opts).html(svg)
 	},
 	help: (elem, opts) => {
 		const _opts = { color: 'black', width: 18, height: 18 }
@@ -469,7 +424,7 @@ export const icons = {
 		<path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
 		<path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>
 	  </svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	search: (elem, opts) => {
 		const _opts = { color: 'black', width: 18, height: 18 }
@@ -477,7 +432,7 @@ export const icons = {
 		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-search" viewBox="0 0 16 16">
 		<path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
 	  </svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	crosshair: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 18, height: 18, d: 2 }
@@ -492,7 +447,7 @@ export const icons = {
 		<path d="M${w / 2},${d}L${w / 2},${h - d}Z" stroke='${_opts.color}'/>
 		<path d="M${d},${h / 2}L${w - d},${h / 2}Z" stroke='${_opts.color}'/>
 		</svg>`
-		elem.html(svg).on('click', opts.handler).style('cursor', 'pointer')
+		return getHolder(elem, opts).html(svg)
 	},
 	grab: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
@@ -501,9 +456,7 @@ export const icons = {
 		<!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
 		<path transform='${_opts.transform}' d="M144 64c0-8.8 7.2-16 16-16s16 7.2 16 16c0 9.1 5.1 17.4 13.3 21.5s17.9 3.2 25.1-2.3c2.7-2 6-3.2 9.6-3.2c8.8 0 16 7.2 16 16c0 9.1 5.1 17.4 13.3 21.5s17.9 3.2 25.1-2.3c2.7-2 6-3.2 9.6-3.2c8.8 0 16 7.2 16 16c0 9.1 5.1 17.4 13.3 21.5s17.9 3.2 25.1-2.3c2.7-2 6-3.2 9.6-3.2c8.8 0 16 7.2 16 16V264c0 31.3-20 58-48 67.9c-9.6 3.4-16 12.5-16 22.6V488c0 13.3 10.7 24 24 24s24-10.7 24-24V370.2c38-20.1 64-60.1 64-106.2V160c0-35.3-28.7-64-64-64c-2.8 0-5.6 .2-8.3 .5C332.8 77.1 311.9 64 288 64c-2.8 0-5.6 .2-8.3 .5C268.8 45.1 247.9 32 224 32c-2.8 0-5.6 .2-8.3 .5C204.8 13.1 183.9 0 160 0C124.7 0 96 28.7 96 64v64.3c-11.7 7.4-22.5 16.4-32 26.9l17.8 16.1L64 155.2l-9.4 10.5C40 181.8 32 202.8 32 224.6v12.8c0 49.6 24.2 96.1 64.8 124.5l13.8-19.7L96.8 361.9l8.9 6.2c6.9 4.8 14.4 8.6 22.3 11.3V488c0 13.3 10.7 24 24 24s24-10.7 24-24V359.9c0-12.6-9.8-23.1-22.4-23.9c-7.3-.5-14.3-2.9-20.3-7.1l-13.1 18.7 13.1-18.7-8.9-6.2C96.6 303.1 80 271.3 80 237.4V224.6c0-9.9 3.7-19.4 10.3-26.8l9.4-10.5c3.8-4.2 7.9-8.1 12.3-11.6V208c0 8.8 7.2 16 16 16s16-7.2 16-16V142.3 128 64z"/>
 		</svg>`
-		elem.html(svg).style('cursor', 'pointer')
-
-		if (opts.handler) elem.on('click', opts.handler)
+		return getHolder(elem, opts).html(svg)
 	},
 	arrowPointer: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
@@ -512,9 +465,7 @@ export const icons = {
 		<!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
 		<path transform='${_opts.transform}' d="M0 55.2V426c0 12.2 9.9 22 22 22c6.3 0 12.4-2.7 16.6-7.5L121.2 346l58.1 116.3c7.9 15.8 27.1 22.2 42.9 14.3s22.2-27.1 14.3-42.9L179.8 320H297.9c12.2 0 22.1-9.9 22.1-22.1c0-6.3-2.7-12.3-7.4-16.5L38.6 37.9C34.3 34.1 28.9 32 23.2 32C10.4 32 0 42.4 0 55.2z"/>
 		</svg>`
-		elem.html(svg).style('cursor', 'pointer')
-
-		if (opts.handler) elem.on('click', opts.handler)
+		return getHolder(elem, opts).html(svg)
 	},
 	compare: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
@@ -523,7 +474,7 @@ export const icons = {
 		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-copy" viewBox="0 0 16 16">
   		<path d="M0 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v2h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2H2a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z"/>
 		</svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	table: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
@@ -531,7 +482,7 @@ export const icons = {
 		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-copy" viewBox="0 0 16 16">
   			<path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm15 2h-4v3h4zm0 4h-4v3h4zm0 4h-4v3h3a1 1 0 0 0 1-1zm-5 3v-3H6v3zm-5 0v-3H1v2a1 1 0 0 0 1 1zm-4-4h4V8H1zm0-4h4V4H1zm5-3v3h4V4zm4 4H6v3h4z"/>
 		</svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	pdf: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
@@ -539,7 +490,7 @@ export const icons = {
 		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-copy" viewBox="0 0 16 16">
   			<path fill-rule="evenodd" d="M14 4.5V14a2 2 0 0 1-2 2h-1v-1h1a1 1 0 0 0 1-1V4.5h-2A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v9H2V2a2 2 0 0 1 2-2h5.5zM1.6 11.85H0v3.999h.791v-1.342h.803q.43 0 .732-.173.305-.175.463-.474a1.4 1.4 0 0 0 .161-.677q0-.375-.158-.677a1.2 1.2 0 0 0-.46-.477q-.3-.18-.732-.179m.545 1.333a.8.8 0 0 1-.085.38.57.57 0 0 1-.238.241.8.8 0 0 1-.375.082H.788V12.48h.66q.327 0 .512.181.185.183.185.522m1.217-1.333v3.999h1.46q.602 0 .998-.237a1.45 1.45 0 0 0 .595-.689q.196-.45.196-1.084 0-.63-.196-1.075a1.43 1.43 0 0 0-.589-.68q-.396-.234-1.005-.234zm.791.645h.563q.371 0 .609.152a.9.9 0 0 1 .354.454q.118.302.118.753a2.3 2.3 0 0 1-.068.592 1.1 1.1 0 0 1-.196.422.8.8 0 0 1-.334.252 1.3 1.3 0 0 1-.483.082h-.563zm3.743 1.763v1.591h-.79V11.85h2.548v.653H7.896v1.117h1.606v.638z"/>
 		</svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	add: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 18, height: 18, transform: '' }
@@ -548,7 +499,7 @@ export const icons = {
 			<path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
 			<path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>
 		</svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	},
 	burguer: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 20, height: 20, transform: '' }
@@ -556,12 +507,21 @@ export const icons = {
 		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-copy" viewBox="0 0 16 16">
   				<path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5"/>
 		</svg>`
-		addSvg(elem, svg, _opts)
+		return getHolder(elem, _opts).html(svg)
 	}
 }
 
-function addSvg(elem, svg, opts) {
-	elem.attr('aria-label', opts.title)
-	elem.html(svg).style('cursor', 'pointer')
+function getHolder(elem, opts) {
+	// for Section 508: a clickable element should have a recognized aria-role,
+	// which a button element has but not a div or span
+	const holder = !opts.handler ? elem : elem.append('button').attr('class', 'sja_icon_btn')
+
+	holder
+		// presentation elements/tags like div, span, etc do not aria-roles
+		// and should not have aria-label attribute
+		.attr(opts.handler ? 'aria-label' : 'title', opts.title || null)
+		.style('cursor', 'pointer')
+
 	if (opts.handler) elem.on('click', opts.handler)
+	return holder
 }

--- a/client/dom/test/sandbox.unit.spec.js
+++ b/client/dom/test/sandbox.unit.spec.js
@@ -61,7 +61,8 @@ tape('newSandboxDiv(), holder arg only and empty', async test => {
 	test.ok(elem, `Should render destroy/delete button`)
 
 	elem = holder.select('.sjpp-output-sandbox-collapse-btn').node()
-	test.equal(elem.style.display, 'inline-block', `Should render collapse button by default`)
+	console.log(63, elem)
+	test.notEqual(elem.style.display, 'none', `Should render collapse button by default`)
 
 	elem = holder.select('.sjpp-output-sandbox-expand-btn').node()
 	test.equal(elem.style.display, 'none', `Should not render expand button by default`)

--- a/client/plots/controls.btns.js
+++ b/client/plots/controls.btns.js
@@ -108,9 +108,8 @@ function helpBtnInit(opts) {
 }
 
 function downloadBtnInit(opts) {
-	const downloadDiv = opts.holder.style('margin-left', '20px').attr('aria-label', 'Download plot image')
-
-	icon_functions['download'](downloadDiv, { handler: opts.callback })
+	const downloadDiv = opts.holder.style('margin-left', '20px')
+	icon_functions['download'](downloadDiv, { handler: opts.callback, title: opts.title || 'Download plot image' })
 
 	const self = {
 		plotTypes: ['summary', 'boxplot', 'scatter'],

--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -727,7 +727,7 @@ function setTermActions(self) {
 		await self.pill.main(Object.assign({ menuOptions: self.getMenuOptions(t) }, t.tw ? t.tw : { term: null, q: null }))
 		termMenuWaitDiv.remove()
 
-		self.dom.shortcutDiv = self.dom.menutop.append('div')
+		self.dom.shortcutDiv = self.dom.menutop.append('div').style('z-index', 10000)
 		self.showShortcuts(t, self.dom.shortcutDiv)
 
 		self.dom.twMenuDiv = self.dom.menutop.append('div')

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -264,8 +264,10 @@ class singleCellPlot {
 		this.axisOffset = { x: offsetX, y: 30 }
 
 		if (q.singleCell?.DEgenes) {
-			this.dom.deDiv.append('label').html('View differentially expresed genes of a cluster vs rest of cells:&nbsp;')
-			this.dom.deselect = this.dom.deDiv.append('select')
+			const label = this.dom.deDiv
+				.append('label')
+				.html('View differentially expresed genes of a cluster vs rest of cells:&nbsp;')
+			this.dom.deselect = label.append('select')
 			if (this.app.opts.genome.termdbs)
 				this.dom.GSEAbt = this.dom.deDiv
 					.append('button')

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -118,6 +118,20 @@ by normalize.css are covered here
     box-shadow: none;
 }
 
+.sja_root_holder .sja_icon_btn,
+.sja_menu_div .sja_icon_btn,
+.sja_pane .sja_icon_btn {
+	background: none;
+	color: inherit;
+	border: none;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+	outline: inherit;
+	z-index: 1000;
+}
+
+
 .sja_root_holder label,
 .sja_menu_div label,
 .sja_pane label {
@@ -1268,6 +1282,7 @@ sandbox header
     top: 1.75em; /* put it on the top */
     /*bottom: 50%;*/
     background-color: white;
+    color: #000;
     font-size: 15px;
     padding: 5px;
     opacity: 0;

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -118,20 +118,6 @@ by normalize.css are covered here
     box-shadow: none;
 }
 
-.sja_root_holder .sja_icon_btn,
-.sja_menu_div .sja_icon_btn,
-.sja_pane .sja_icon_btn {
-	background: none;
-	color: inherit;
-	border: none;
-	padding: 0;
-	font: inherit;
-	cursor: pointer;
-	outline: inherit;
-	z-index: 1000;
-}
-
-
 .sja_root_holder label,
 .sja_menu_div label,
 .sja_pane label {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- section 508 issues in singleCellPlot controls: aria-label should be on element with roles


### PR DESCRIPTION
## Description

Fixes Lighthouse accessibility issues in chrome devtools. Tested on http://localhost:3000/example.gdc.scRNAseq.html and [termdbtest matrix](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22AKT1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22efs%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22diaggrp%22},{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22}}]}],%22divideBy%22:{%22id%22:%22sex%22}}]}), by clicking on a matrix row label and hovering over the shortcut control icons at the top - the info tooltip should not be covered by the input element below it.

Also tested with the full unit and integration tests. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
