### PR TITLE
Update the z-index below the menu z-index

### DIFF
--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -520,7 +520,7 @@ function getHolder(elem, opts) {
 		if (elem.node().tagName != 'BUTTON') elem.attr('role', 'button').attr('tabindex', 0).style('cursor', 'pointer')
 	}
 	if (opts.title) {
-		elem.attr('aria-label', opts.title).style('z-index', 1000) // to have aria-label based tooltip appear above other elements
+		elem.attr('aria-label', opts.title).style('z-index', 1) // to have aria-label based tooltip appear above other elements
 	}
 
 	return elem


### PR DESCRIPTION
## Description
Closes issue 2150. 

Test with: 
1. [Scatter example from issue](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22sampleScatter%22,%22name%22:%22TermdbTest%20TSNE%22,%22colorTW%22:%7B%22id%22:%22diaggrp%22%7D%7D%5D%7D) -> Should show icons underneath expanded menu. 
2. [Matrix example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22header_mode%22:%22hidden%22%7D,%22plots%22:%5B%7B%22chartType%22:%22matrix%22,%22termgroups%22:%5B%7B%22lst%22:%5B%7B%22term%22:%7B%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22AKT1%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22id%22:%22efs%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%7B%22id%22:%22agedx%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%7B%22id%22:%22diaggrp%22%7D,%7B%22term%22:%7B%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22%7D%7D%5D%7D%5D,%22divideBy%22:%7B%22id%22:%22sex%22%7D%7D%5D%7D) -> Click on any row label -> Should still show tooltip above the input field. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
