### PR TITLE
Toggle for triggering univariate+multivariable UI

### DIFF
--- a/client/plots/regression.inputs.js
+++ b/client/plots/regression.inputs.js
@@ -1,6 +1,6 @@
-import { deepEqual } from '../rx'
 import { select } from 'd3-selection'
 import { InputTerm } from './regression.inputs.term'
+import { make_one_checkbox } from '#dom'
 
 /*
 outcome and independent are two sections sharing same structure
@@ -208,6 +208,25 @@ function setRenderers(self) {
 			.text('Run analysis')
 			.on('click', self.submit)
 
+		self.dom.univariateCheckbox = self.dom.foot.append('div').style('display', 'none')
+
+		make_one_checkbox({
+			labeltext: 'Include univariate results',
+			checked: false,
+			holder: self.dom.univariateCheckbox,
+			callback: checked => {
+				self.app.dispatch({
+					type: 'plot_edit',
+					id: self.parent.id,
+					chartType: 'regression',
+					config: {
+						hasUnsubmittedEdits: true,
+						includeUnivariate: checked
+					}
+				})
+			}
+		})
+
 		self.dom.submitMsg = self.dom.foot
 			.append('div')
 			.style('display', 'none')
@@ -331,6 +350,18 @@ function setRenderers(self) {
 			.text('Run analysis')
 			.style('display', self.config.outcome && self.config.independent.length ? 'block' : 'none')
 			.property('disabled', self.hasError)
+	}
+
+	self.mayShowUnivariateCheckbox = () => {
+		// show the univariate checkbox if analysis is multivariate and
+		// is using a neuro-oncology dataset
+		self.dom.univariateCheckbox.style(
+			'display',
+			self.app.vocabApi.termdbConfig.neuroOncRegression && self.config.outcome && self.config.independent.length > 1
+				? 'block'
+				: 'none'
+		)
+		self.dom.univariateCheckbox.select('input[type=checkbox]').property('checked', self.config.includeUnivariate)
 	}
 }
 

--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -78,6 +78,7 @@ class Regression {
 			await this.inputs.main()
 			await this.results.main()
 			this.inputs.resetSubmitButton()
+			this.inputs.mayShowUnivariateCheckbox()
 		} catch (e) {
 			if (this.inputs.hasError) {
 				// will hide the results ui

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -134,7 +134,8 @@ export class RegressionResults {
 		const opts = {
 			regressionType: c.regressionType,
 			outcome: c.outcome,
-			independent: c.independent
+			independent: c.independent,
+			includeUnivariate: c.includeUnivariate
 		}
 		opts.filter = this.parent.filter
 		return opts

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -703,7 +703,7 @@ function setRenderers(self) {
 
 			// fill headers for data columns
 			fillDataHeaders(header_uni, tr, tr_label, 'Univariate')
-			fillDataHeaders(header_multi, tr, tr_label, 'Multivariate')
+			fillDataHeaders(header_multi, tr, tr_label, 'Multivariable-adjusted')
 		}
 
 		/* term rows:

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -310,6 +310,7 @@ export class TermdbVocab extends Vocab {
 
 		const filterData = getNormalRoot(opts.filter)
 		if (filterData.lst.length) body.filter = filterData
+		if (opts.includeUnivariate) body.includeUnivariate = opts.includeUnivariate
 		const data = await dofetch3('termdb', { body }, this.opts.fetchOpts)
 		if (data.error) throw data.error
 		return data

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -397,7 +397,8 @@ function makeRinput(q, sampledata) {
 		independent
 	}
 
-	if (q.ds.cohort.termdb.neuroOncRegression) Rinput.neuroOnc = true
+	if (q.ds.cohort.termdb.neuroOncRegression) Rinput.neuroOnc = q.ds.cohort.termdb.neuroOncRegression
+	if (q.includeUnivariate) Rinput.includeUnivariate = q.includeUnivariate
 
 	return Rinput
 }

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -208,6 +208,13 @@ function parse_q(q, ds) {
 				throw 'interacting term id missing from independent[]: ' + x
 		}
 	}
+
+	// univariate/multivariate
+	if (q.includeUnivariate) {
+		// both univariate and multivariate analyses will be performed
+		if (q.independent.length < 2) throw 'multiple covariates expected'
+		if (q.independent.find(i => i.interactions.length)) throw 'interactions not allowed in univariate analysis'
+	}
 }
 
 function checkTwAncestryRestriction(tw, q, ds) {

--- a/server/utils/regression.R
+++ b/server/utils/regression.R
@@ -109,7 +109,7 @@ benchmark[["prepareDataTable"]] <- unbox(paste(round(as.numeric(dtime), 4), attr
 ##################
 
 stime <- Sys.time()
-formulas <- buildFormulas(input$outcome, input$independent, input$neuroOnc)
+formulas <- buildFormulas(input$outcome, input$independent, input$includeUnivariate)
 etime <- Sys.time()
 dtime <- etime - stime
 benchmark[["buildFormulas"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dtime, "units")))
@@ -137,9 +137,9 @@ benchmark[["runRegression"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dt
 # PARSE RESULTS #
 ##################
 
-if (isTRUE(input$neuroOnc) && nrow(input$independent) > 1) {
-  # neuro-oncology dataset using multiple covariates
-  # parse the results from univariate and multivariate analyses
+if (isTRUE(input$includeUnivariate)) {
+  # univariate analysis included along with multivariate analysis
+  # parse the results
   # TODO: this function will not work with snplocus regression because it
   # will combine results from multiple analyses into a single set of results
   reg_results <- parseUniMultiResults(reg_results, input$regressionType)

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -54,7 +54,7 @@ cubic_spline <- function(values, knots) {
 }
 
 # build formulas
-buildFormulas <- function(outcome, independent, neuroOnc) {
+buildFormulas <- function(outcome, independent, includeUnivariate) {
   # first, format variables for building formulas
   
   # declare new objects
@@ -117,8 +117,6 @@ buildFormulas <- function(outcome, independent, neuroOnc) {
     }
   }
   
-  if (isTRUE(neuroOnc) && length(formula_interaction) > 0) stop ("interactions not supported in neuro-onc datasets")
-  
   # combine variables into formula(s)
   # if snplocus snps are present, then prepare a
   # separate formula for each snplocus snp
@@ -152,9 +150,10 @@ buildFormulas <- function(outcome, independent, neuroOnc) {
     }
   } else {
     # no snplocus snps
-    if (isTRUE(neuroOnc) && length(formula_independent) > 1) {
-      # neuro-onc dataset using multiple covariates
-      # build multivariate and univariate formulas
+    if (isTRUE(includeUnivariate)) {
+      # include univariate formulas along with the multivariate formula
+      if (length(formula_independent) < 2) stop("must have multiple covariates to build multivariate and univariate formulas")
+      if (length(formula_interaction) > 0) stop("interactions not supported in univariate models")
       formula <- as.formula(paste(formula_outcome, paste(formula_independent, collapse = "+"), sep = "~"))
       formulas[[1]] <- list("id" = "", "type" = "multivariate", "formula" = formula)
       for (var in formula_independent) {


### PR DESCRIPTION
## Description

For Neuro-Onc datasets, when multiple covariates are used in a regression analysis, a checkbox appears to allow user to include results from univariate analyses as well.

In the next branch, will standardize this new regression UI for all datasets.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
