### PR TITLE
fix: support new GDC /status api return in stale cache check

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- support new GDC /status api return in stale cache check


### PR DESCRIPTION
## Description

to test, add this in serverconfig features to trigger status api check every 1 sec: `"gdcCacheCheckWait":1000,`

tested not to break with prod gdc api, which lacks the new property

Congyu please test it with qa-int; you should get this on pp server log:

GDC: checking if cache is stale
(new api)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
