### PR TITLE
Add survival time cut off

### DIFF
--- a/client/plots/survival.js
+++ b/client/plots/survival.js
@@ -149,6 +149,13 @@ class TdbSurvival {
 							]
 						},
 						{
+							label: 'Survival Time Cut-Off',
+							type: 'number',
+							chartType: 'survival',
+							settingsKey: 'maxSurTime',
+							title: 'The max survival time to be displayed in this plot'
+						},
+						{
 							label: 'Time Factor',
 							type: 'math',
 							chartType: 'survival',
@@ -249,7 +256,8 @@ class TdbSurvival {
 		const opts = {
 			chartType: 'survival',
 			term: c.term,
-			filter: this.state.termfilter.filter
+			filter: this.state.termfilter.filter,
+			maxSurTime: this.state.config.settings.maxSurTime
 		}
 		if (c.term2) opts.term2 = c.term2
 		if (c.term0) opts.term0 = c.term0
@@ -1223,6 +1231,10 @@ export async function getPlotConfig(opts, app) {
 			}
 		}
 	}
+
+	// default survival settings will be overwritten by the survival settings defined in dataset
+	const overrides = app.vocabApi.termdbConfig.survival || {}
+	copyMerge(config.settings.survival, overrides.settings)
 
 	// may apply term-specific changes to the default object
 	return copyMerge(config, opts)

--- a/client/plots/survival.js
+++ b/client/plots/survival.js
@@ -152,8 +152,9 @@ class TdbSurvival {
 							label: 'Survival Time Cut-Off',
 							type: 'number',
 							chartType: 'survival',
-							settingsKey: 'maxSurTime',
-							title: 'The max survival time to be displayed in this plot'
+							settingsKey: 'maxTimeToEvent',
+							title:
+								'The max time-to-event to be displayed in plot,  if left empty or 0, would default to not having a max time-to-event cutoff'
 						},
 						{
 							label: 'Time Factor',
@@ -257,7 +258,7 @@ class TdbSurvival {
 			chartType: 'survival',
 			term: c.term,
 			filter: this.state.termfilter.filter,
-			maxSurTime: this.state.config.settings.maxSurTime
+			maxTimeToEvent: this.state.config.settings.maxTimeToEvent
 		}
 		if (c.term2) opts.term2 = c.term2
 		if (c.term0) opts.term0 = c.term0

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -166,6 +166,7 @@ export class TermdbVocab extends Vocab {
 		}
 		if (opts.filter0) body.filter0 = opts.filter0
 
+		if (opts.maxSurTime) body.maxSurTime = opts.maxSurTime
 		if ('grade' in opts) body.grade = opts.grade
 		if ('minSampleSize' in opts) body.minSampleSize = opts.minSampleSize
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -166,7 +166,7 @@ export class TermdbVocab extends Vocab {
 		}
 		if (opts.filter0) body.filter0 = opts.filter0
 
-		if (opts.maxSurTime) body.maxSurTime = opts.maxSurTime
+		if (opts.maxTimeToEvent) body.maxTimeToEvent = opts.maxTimeToEvent
 		if ('grade' in opts) body.grade = opts.grade
 		if ('minSampleSize' in opts) body.minSampleSize = opts.minSampleSize
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Survival plot: add a control "Survival Time Cut-Off" to filter out all the survival data with Time-to-Event longer than Survival Time Cut-Off

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -108,7 +108,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	if (tdb.useCasesExcluded) c.useCasesExcluded = tdb.useCasesExcluded
 	if (tdb.excludedTermtypeByTarget) c.excludedTermtypeByTarget = tdb.excludedTermtypeByTarget
 	if (tdb.about) c.about = tdb.about
-
+	if (tdb.survival) c.survival = tdb.survival
 	if (ds.assayAvailability) c.assayAvailability = ds.assayAvailability
 	if (ds.customTwQByType) c.customTwQByType = ds.customTwQByType
 	c.requiredAuth = authApi.getRequiredCredForDsEmbedder(q.dslabel, q.embedder)

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -52,9 +52,9 @@ type InfoFieldEntry = {
 
 /*
 type GenomicPositionEntry = {
-        chr: string
-        start: number
-        stop: number
+		chr: string
+		start: number
+		stop: number
 }
 */
 
@@ -230,8 +230,8 @@ type SnvIndelQuery = {
 	variant_filter?: VariantFilter
 	populations?: Population[]
 	/** NOTE **
-    this definition can appear either in queries.snvindel{} or termdb{}
-    so that it can work for a termdb-less ds, e.g. clinvar, where termdbConfig cannot be made */
+	this definition can appear either in queries.snvindel{} or termdb{}
+	so that it can work for a termdb-less ds, e.g. clinvar, where termdbConfig cannot be made */
 	ssmUrl?: UrlTemplateSsm
 	m2csq?: {
 		gdcapi?: boolean
@@ -345,21 +345,21 @@ type TrackLstEntry = {
 type CnvSegment = {
 	byrange: CnvSegmentByRange
 	/****** rendering parameters ****
-    not used as query parameter to filter segments
-    value range for color scaling. default to 5. cnv segment value>this will use solid color
-    */
+	not used as query parameter to filter segments
+	value range for color scaling. default to 5. cnv segment value>this will use solid color
+	*/
 	absoluteValueRenderMax?: number
 	gainColor?: string
 	lossColor?: string
 
 	/*** filtering parameters ***
-    default max length setting to restrict to focal events; if missing show all */
+	default max length setting to restrict to focal events; if missing show all */
 	cnvMaxLength?: number
 
 	/** TODO define value type, if logratio, or copy number */
 
 	/** following two cutoffs only apply to log ratio, cnv gain value is positive, cnv loss value is negative
-    if cnv is gain, skip if value<this cutoff */
+	if cnv is gain, skip if value<this cutoff */
 	cnvGainCutoff?: number
 	/** if cnv is loss, skip if value>this cutoff */
 	cnvLossCutoff?: number
@@ -377,7 +377,7 @@ for a given region, the median signal from probes in the region is used to make 
 this is alternative to CnvSegment
 
 type Probe2Cnv = {
-        file: string
+		file: string
 }
 */
 
@@ -437,10 +437,10 @@ export type SingleCellSamplesNative = {
 	src: 'native'
 
 	/** logic to decide sample table columns (the one shown on singlecell app ui, displaying a table of samples with sc data)
-    a sample table will always have a sample column, to show sample.sample value
-    firstColumnName allow to change name of 1st column from "Sample" to different, e.g. "Case" for gdc
-    the other two properties allow to declare additional columns to be shown in table, that are for display only
-    when sample.experiments[] are used, a last column of experiment id will be auto added
+	a sample table will always have a sample column, to show sample.sample value
+	firstColumnName allow to change name of 1st column from "Sample" to different, e.g. "Case" for gdc
+	the other two properties allow to declare additional columns to be shown in table, that are for display only
+	when sample.experiments[] are used, a last column of experiment id will be auto added
 	*/
 	firstColumnName?: string
 
@@ -475,8 +475,8 @@ export type SingleCellDataGdc = {
 export type SingleCellDEgeneGdc = {
 	src: 'gdcapi'
 	/** Column name.
-    this must be the colorColumn from one of the plots. so that at the client app, as soon as the plot data have been loaded and maps rendered, client will find out the cell groups based on this columnName value, and show a drop down of these groups on UI. user selects a group, and pass it as request body to backend to get DE genes for this group
-    */
+	this must be the colorColumn from one of the plots. so that at the client app, as soon as the plot data have been loaded and maps rendered, client will find out the cell groups based on this columnName value, and show a drop down of these groups on UI. user selects a group, and pass it as request body to backend to get DE genes for this group
+	*/
 	columnName: string
 }
 
@@ -536,7 +536,7 @@ export type SingleCellDataNative = {
 export type SingleCellQuery = {
 	/** methods to identify samples with singlecell data,
 	this data allows client-side to display a table with these samples for user to choose from
-    also, sampleView uses this to determine if to invoke the sc plot for a sample
+	also, sampleView uses this to determine if to invoke the sc plot for a sample
 	*/
 	samples: SingleCellSamplesGdc | SingleCellSamplesNative
 	/** defines tsne/umap type of clustering maps for each sample
@@ -714,9 +714,9 @@ type ScatterPlotsEntry = {
 	colorTW?: { id: string }
 	colorColumn?: ColorColumn
 	/** provide a sampletype term to filter for specific type of samples for subjects with multiple samples and show in the plot.
-    e.g. to only show D samples from all patients
-    this is limited to only one term and doesn't allow switching between multiple terms
-    */
+	e.g. to only show D samples from all patients
+	this is limited to only one term and doesn't allow switching between multiple terms
+	*/
 	sampleCategory?: {
 		/** categorical term like "sampleType" which describes types of multiple samples from the same subject */
 		tw: { id: string }
@@ -778,6 +778,7 @@ type SortPriorityEntry = {
 }
 
 type SurvivalSettings = {
+	/** filters out all the survival data with Time-to-Event longer than this maxTimeToEvent */
 	maxTimeToEvent?: number
 }
 
@@ -892,10 +893,10 @@ type UrlTemplateBase = {
 }
 export type UrlTemplateSsm = UrlTemplateBase & {
 	/** to create separate link, but not directly on chr.pos.ref.alt string.
-    name of link is determined by either namekey or linkText. former allows to retrieve a name per m that's different from chr.pos.xx */
+	name of link is determined by either namekey or linkText. former allows to retrieve a name per m that's different from chr.pos.xx */
 	shownSeparately?: boolean
 	/** optional name of link, if set, same name will be used for all links. e.g. "ClinVar".
-    if missing, name is value of m[url.namekey], as used in url itself (e.g. snp rsid) */
+	if missing, name is value of m[url.namekey], as used in url itself (e.g. snp rsid) */
 	linkText?: string
 }
 
@@ -919,11 +920,11 @@ type Termdb = {
 	selectCohort?: SelectCohortEntry
 
 	/** quick fix to convert category values from a term to lower cases for comparison (case insensitive comparison)
-    for gdc, graphql and rest apis return case-mismatching strings for the same category e.g. "Breast/breast"
-    keep this setting here for reason of:
-    - in mds3.gdc.js, when received all-lowercase values from graphql, it's hard to convert them to Title case for comparison
-    - mds3.variant2samples consider this setting, allows to handle other datasets of same issue
-      */
+	for gdc, graphql and rest apis return case-mismatching strings for the same category e.g. "Breast/breast"
+	keep this setting here for reason of:
+	- in mds3.gdc.js, when received all-lowercase values from graphql, it's hard to convert them to Title case for comparison
+	- mds3.variant2samples consider this setting, allows to handle other datasets of same issue
+	  */
 	useLower?: boolean
 
 	scatterplots?: Scatterplots
@@ -1184,9 +1185,9 @@ type Svcnv = BaseTrack & {
 
 type KeyLabelFull = {
 	/* Used in: 
-            queries.genefpkm.boxplotbysamplegroup.attributes
-            cohort.hierarchies.lst[i].levels
-    */
+			queries.genefpkm.boxplotbysamplegroup.attributes
+			cohort.hierarchies.lst[i].levels
+	*/
 	k: string
 	label: string
 	full?: string

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -777,6 +777,10 @@ type SortPriorityEntry = {
 	tiebreakers: TieBreakersEntry[]
 }
 
+type SurvivalSettings = {
+	maxSurTime?: number
+}
+
 type MatrixSettings = {
 	maxSample?: number
 	svgCanvasSwitch?: number
@@ -818,6 +822,11 @@ type Matrix = {
 	// TODO: improve definitions below
 	legendGrpFilter?: any
 	legendValueFilter?: any
+}
+
+type Survival = {
+	/** default settings for survival plot */
+	settings?: SurvivalSettings
 }
 
 type MatrixPlotsEntry = {
@@ -919,6 +928,7 @@ type Termdb = {
 
 	scatterplots?: Scatterplots
 	matrix?: Matrix
+	survival?: Survival
 	logscaleBase2?: boolean
 	chartConfigByType?: ChartConfigByType
 	/** Functionality */

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -778,7 +778,7 @@ type SortPriorityEntry = {
 }
 
 type SurvivalSettings = {
-	maxSurTime?: number
+	maxTimeToEvent?: number
 }
 
 type MatrixSettings = {

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -97,9 +97,9 @@ export async function get_survival(q, ds) {
 		// perform survival analysis for each chart
 		for (const chartId in byChartSeries) {
 			let data = byChartSeries[chartId]
-			if (q.maxSurTime) {
+			if (q.maxTimeToEvent) {
 				// Filter out the survival data with Time to event longer than survial time cut-off (defined in dataset)
-				data = data.filter(d => d.time <= q.maxSurTime)
+				data = data.filter(d => d.time <= q.maxTimeToEvent)
 			}
 			const survival_data = JSON.parse(
 				await run_R(path.join(serverconfig.binpath, 'utils', 'survival.R'), JSON.stringify(data))

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -96,7 +96,11 @@ export async function get_survival(q, ds) {
 
 		// perform survival analysis for each chart
 		for (const chartId in byChartSeries) {
-			const data = byChartSeries[chartId]
+			let data = byChartSeries[chartId]
+			if (q.maxSurTime) {
+				// Filter out the survival data with Time to event longer than survial time cut-off (defined in dataset)
+				data = data.filter(d => d.time <= q.maxSurTime)
+			}
 			const survival_data = JSON.parse(
 				await run_R(path.join(serverconfig.binpath, 'utils', 'survival.R'), JSON.stringify(data))
 			)


### PR DESCRIPTION
## Description

Test with sjpp: mbmeta_add_survival_cutoff

Only mbmeta has a default survival cutoff of 10 years

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
