### PR TITLE
Survival scatter predefined order

### DIFF
--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -281,6 +281,16 @@ export function setRenderers(self) {
 	}
 
 	self.processData = async function () {
+		const term0Values = self.config.term0?.term.values
+		if (term0Values) {
+			// sort the divideBy subCharts based on pre-defined term0 order in db
+			const orderedLabels = Object.values(term0Values).sort((a, b) =>
+				'order' in a && 'order' in b ? a.order - b.order : 0
+			)
+			self.charts.sort(
+				(a, b) => orderedLabels.findIndex(v => v.label == a.id) - orderedLabels.findIndex(v => v.label == b.id)
+			)
+		}
 		for (const chart of self.charts) {
 			self.initAxes(chart)
 			const regressionType = self.config.settings.sampleScatter.regression

--- a/client/plots/survival.js
+++ b/client/plots/survival.js
@@ -1363,7 +1363,11 @@ function getPj(self) {
 			sortCharts(result) {
 				if (!self.refs.orderedKeys) return
 				const c = self.refs.orderedKeys.chart
-				result.charts.sort((a, b) => c.indexOf(a.chartId) - c.indexOf(b.chartId))
+				result.charts.sort(
+					(a, b) =>
+						(c.indexOf(a.chartId) == -1 ? c.indexOf(a.rawChartId) : c.indexOf(a.chartId)) -
+						(c.indexOf(b.chartId) == -1 ? c.indexOf(b.rawChartId) : c.indexOf(b.chartId))
+				)
 			}
 		}
 	})

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- survival plot: use pre-defined order in db for overlay and divideby
+- scatter plot: use pre-defined order in db for divideby

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -139,8 +139,11 @@ export async function get_survival(q, ds) {
 		// sort by d.x
 		final_data.case.sort((a, b) => a[2] - b[2])
 		const orderedLabels = getOrderedLabels(q.term2, bins ? bins.map(bin => (bin.name ? bin.name : bin.label)) : [])
+		const orderedLabelsTerm0 = getOrderedLabels(q.term0)
 		final_data.refs.orderedKeys = {
-			chart: [...keys.chart].sort(),
+			chart: [...keys.chart].sort(
+				!orderedLabelsTerm0 ? undefined : (a, b) => orderedLabelsTerm0.indexOf(a) - orderedLabelsTerm0.indexOf(b)
+			),
 			series: [...keys.series].sort(
 				!orderedLabels ? undefined : (a, b) => orderedLabels.indexOf(a) - orderedLabels.indexOf(b)
 			)
@@ -205,11 +208,9 @@ function getOrderedLabels(term, bins = []) {
 				.map(i => term.values[i].label)
 		}
 		if (term.values) {
-			return Object.keys(term.values)
-				.sort((a, b) =>
-					'order' in term.values[a] && 'order' in term.values[b] ? term.values[a].order - term.values[b].order : 0
-				)
-				.map(i => term.values[i].label)
+			return Object.keys(term.values).sort((a, b) =>
+				'order' in term.values[a] && 'order' in term.values[b] ? term.values[a].order - term.values[b].order : 0
+			)
 		}
 	}
 	return bins.map(bin => (bin.name ? bin.name : bin.label))


### PR DESCRIPTION
## Description
Please use [mbmeta](http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22}) to test:

survival plot: overlay or devideby with _Molecular Group_ will have predefined order: wnt, shh, g3, g4
scatter plot: devideby with _Molecular Group_ will have predefined order: wnt, shh, g3, g4



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
