### PR TITLE
Enable changing shape and color from lollipop legend

### DIFF
--- a/client/dom/shapes.js
+++ b/client/dom/shapes.js
@@ -3,6 +3,13 @@ export const shapes = {
 	//circle filled
 	filledCircle: {
 		path: 'M 8,8 m 8,0 a 8,8 0 1,0 -16,0 a 8,8 0 1,0 16,0',
+		calculatePath: opts => {
+			const _opts = { radius: 16 }
+			Object.assign(_opts, opts)
+			const { radius } = _opts
+
+			return `M${radius},0 A${radius},${radius} 0 1,1 ${-radius},0 A${radius},${radius} 0 1,1 ${radius},0 Z`
+		},
 		isFilled: true
 	},
 

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -94,7 +94,7 @@ function menu_variants(tk, block) {
 		.append('div')
 		.text('List')
 		.attr('class', 'sja_menuoption')
-		.attr('data-testid', 'sja_list_menuoption') // FIXME mds3tk_variantleftlabel_list
+		.attr('data-testid', 'sjpp_mds3tk_variantleftlabel_list')
 		.style('border-radius', '0px')
 		.on('click', () => {
 			listVariantData(tk, block)

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -200,12 +200,6 @@ function menu_variants(tk, block) {
 				}
 				const { holder, callbacks, tk } = arg
 
-				if (!tk.shapes) {
-					//TODO init this somewhere else
-					tk.shapes = { mclass: {} }
-					Object.keys(mclass).forEach(v => (tk.shapes.mclass[v] = 'filledCircle'))
-				}
-
 				const vectorGraphicsDiv = holder.append('div')
 				vectorGraphicsDiv
 					.append('div')

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -324,14 +324,14 @@ export function displayVectorGraphics(arg) {
 		.style('width', 'max-content')
 
 	for (const val of Object.entries(desiredShapes)) {
-		const shapeWrapper = shapesContainer.append('div').style('padding', '0px 2px')
 		const width = 18
 		const height = 18
-		const shapeSvg = shapeWrapper
+		const shapeSvg = shapesContainer
 			.append('svg')
 			.attr('width', width)
 			.attr('height', height)
-			.attr('viewBox', `0 0 ${width} ${height}`)
+			.attr('viewBox', `-1 -1 ${width} ${height}`)
+			.style('padding', '0px 2px')
 			.style('cursor', 'pointer')
 			.on('click', () => {
 				callback(val, tk)

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -178,76 +178,11 @@ function menu_variants(tk, block) {
 							called = true
 							displayVectorGraphics({
 								holder: div.append('div').style('margin-top', '10px'),
-								callbacks: {
-									onShapeClick: onShapeClick
-								},
+								callback: onShapeClick,
 								tk: tk
 							})
 						}
 					})
-			}
-
-			function displayVectorGraphics(arg) {
-				const desiredShapes = {
-					filledCircle: shapes.filledCircle,
-					emptyCircle: shapes.emptyCircle,
-					filledVerticalRectangle: shapes.filledVerticalRectangle,
-					emptyVerticalRectangle: shapes.emptyVerticalRectangle,
-					filledTriangle: shapes.filledTriangle,
-					emptyTriangle: shapes.emptyTriangle,
-					filledSquare: shapes.filledSquare,
-					emptySquare: shapes.emptySquare
-				}
-				const { holder, callbacks, tk } = arg
-
-				const vectorGraphicsDiv = holder.append('div')
-				vectorGraphicsDiv
-					.append('div')
-					.style('display', 'flex')
-					.style('flex-direction', 'row')
-					.style('align-items', 'center')
-					.style('justify-content', 'center')
-					.style('border', 'none')
-					.style('width', '100%')
-					.style('font-size', '20px')
-					.style('margin-top', '5px')
-
-				const shapesContainer = vectorGraphicsDiv
-					.append('div')
-					.style('display', 'flex')
-					.style('flex-wrap', 'wrap')
-					.style('width', 'max-content')
-
-				for (const val of Object.entries(desiredShapes)) {
-					const shapeWrapper = shapesContainer.append('div').style('padding', '0px 2px')
-					const width = 18
-					const height = 18
-					const shapeSvg = shapeWrapper
-						.append('svg')
-						.attr('width', width)
-						.attr('height', height)
-						.attr('viewBox', `0 0 ${width} ${height}`)
-						.style('cursor', 'pointer')
-						.on('click', () => {
-							if (callbacks && typeof callbacks.onShapeClick === 'function') {
-								callbacks.onShapeClick(val, tk)
-							}
-						})
-					shapeSvg
-						.append('path')
-						.attr('d', val[1].path)
-						.attr('fill', val[1].isFilled ? 'black' : 'none')
-						.attr('stroke', 'black')
-				}
-			}
-
-			function onShapeClick(val, tk) {
-				// Logic to change the pre-existing shape to the chosen shape
-				Object.keys(tk.shapes.mclass).forEach(key => {
-					tk.shapes.mclass[key] = val[0]
-				})
-				tk.load()
-				tk.menutip.hide()
 			}
 		} else if (vm.type == 'numeric') {
 			// only show this opt in numeric mode; delete when label hiding works for skewer mode
@@ -355,6 +290,67 @@ async function listVariantData(tk, block) {
 			doNotListSample4multim: true
 		})
 	}
+}
+
+export function displayVectorGraphics(arg) {
+	const desiredShapes = {
+		filledCircle: shapes.filledCircle,
+		emptyCircle: shapes.emptyCircle,
+		filledVerticalRectangle: shapes.filledVerticalRectangle,
+		emptyVerticalRectangle: shapes.emptyVerticalRectangle,
+		filledTriangle: shapes.filledTriangle,
+		emptyTriangle: shapes.emptyTriangle,
+		filledSquare: shapes.filledSquare,
+		emptySquare: shapes.emptySquare
+	}
+	const { holder, callback, tk } = arg
+
+	const vectorGraphicsDiv = holder.append('div')
+	vectorGraphicsDiv
+		.append('div')
+		.style('display', 'flex')
+		.style('flex-direction', 'row')
+		.style('align-items', 'center')
+		.style('justify-content', 'center')
+		.style('border', 'none')
+		.style('width', '100%')
+		.style('font-size', '20px')
+		.style('margin-top', '5px')
+
+	const shapesContainer = vectorGraphicsDiv
+		.append('div')
+		.style('display', 'flex')
+		.style('flex-wrap', 'wrap')
+		.style('width', 'max-content')
+
+	for (const val of Object.entries(desiredShapes)) {
+		const shapeWrapper = shapesContainer.append('div').style('padding', '0px 2px')
+		const width = 18
+		const height = 18
+		const shapeSvg = shapeWrapper
+			.append('svg')
+			.attr('width', width)
+			.attr('height', height)
+			.attr('viewBox', `0 0 ${width} ${height}`)
+			.style('cursor', 'pointer')
+			.on('click', () => {
+				callback(val, tk)
+			})
+		shapeSvg
+			.append('path')
+			.attr('d', val[1].path)
+			.attr('fill', val[1].isFilled ? 'black' : 'none')
+			.attr('stroke', 'black')
+	}
+}
+
+function onShapeClick(val, tk) {
+	// Logic to change the pre-existing shape to the chosen shape
+	Object.keys(tk.shapes.mclass).forEach(key => {
+		tk.shapes.mclass[key] = val[0]
+	})
+	tk.load()
+	tk.menutip.hide()
 }
 
 function mayAddSkewerModeOption(tk, block) {

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -200,11 +200,11 @@ function menu_variants(tk, block) {
 				}
 				const { holder, callbacks, tk } = arg
 
-				// Set default shape for load and create a toggle
-				// to switch back to default lollipop when another
-				// shape is selected
-				if (!tk.skewer.shape) tk.skewer.shape = Object.entries(desiredShapes)[0]
-				delete desiredShapes[tk.skewer?.shape?.[0]]
+				if (!tk.shapes) {
+					//TODO init this somewhere else
+					tk.shapes = { mclass: {} }
+					Object.keys(mclass).forEach(v => (tk.shapes.mclass[v] = 'filledCircle'))
+				}
 
 				const vectorGraphicsDiv = holder.append('div')
 				vectorGraphicsDiv
@@ -249,7 +249,9 @@ function menu_variants(tk, block) {
 
 			function onShapeClick(val, tk) {
 				// Logic to change the pre-existing shape to the chosen shape
-				tk.skewer.shape = val
+				Object.keys(tk.shapes.mclass).forEach(key => {
+					tk.shapes.mclass[key] = val[0]
+				})
 				tk.load()
 				tk.menutip.hide()
 			}

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -346,8 +346,8 @@ export function displayVectorGraphics(arg) {
 
 function onShapeClick(val, tk) {
 	// Logic to change the pre-existing shape to the chosen shape
-	Object.keys(tk.shapes.mclass).forEach(key => {
-		tk.shapes.mclass[key] = val[0]
+	Object.keys(tk.shapes).forEach(key => {
+		tk.shapes[key] = val[0]
 	})
 	tk.load()
 	tk.menutip.hide()

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -254,10 +254,7 @@ function may_update_formatFilter(data, tk) {
 						},
 						{
 							label: 'Show all',
-							isVisible: () => {
-								if (tk.legend.formatFilter[formatKey].hiddenvalues.size) return true
-								else false
-							},
+							isVisible: () => tk.legend.formatFilter[formatKey].hiddenvalues.size,
 							callback: () => {
 								tk.legend.formatFilter[formatKey].hiddenvalues.clear()
 							}
@@ -408,10 +405,7 @@ function may_update_infoFields(data, tk) {
 							},
 							{
 								label: 'Show all',
-								isVisible: () => {
-									if (tk.legend.bcfInfo[infoKey].hiddenvalues.size) return true
-									else false
-								},
+								isVisible: () => tk.legend.bcfInfo[infoKey].hiddenvalues.size,
 								callback: () => {
 									tk.legend.bcfInfo[infoKey].hiddenvalues.clear()
 								}
@@ -545,17 +539,18 @@ function update_mclass(tk) {
 					},
 					{
 						label: 'Show all',
-						isVisible: () => {
-							if (hiddenlst.length) return true
-							else return false
-						},
+						isVisible: () => hiddenlst.length,
 						callback: () => {
 							tk.legend.mclass.hiddenvalues.clear()
 						}
 					},
 					{
 						isChangeShape: true,
-						isVisible: () => true,
+						isVisible: () => {
+							return !tk.skewer.viewModes.find(v => v.type === 'numeric').inuse
+								? tk.mds?.termdbConfig?.tracks?.allowSkewerChanges ?? true
+								: false
+						},
 						callback: (val, tk) => {
 							tk.shapes.mclass[c.k] = val[0]
 							tk.load()
@@ -563,7 +558,7 @@ function update_mclass(tk) {
 						}
 					},
 					{
-						isColor: true,
+						isChangeColor: true,
 						value: color,
 						isVisible: () => true,
 						callback: colorValue => {
@@ -814,7 +809,7 @@ function createLegendTipMenu(opts, tk, elem) {
 
 	for (const opt of opts) {
 		if (opt.isVisible()) {
-			if (opt.isColor) {
+			if (opt.isChangeColor) {
 				tk.legend.tip.d
 					.append('div')
 					.style('padding', '5px 10px')
@@ -831,7 +826,7 @@ function createLegendTipMenu(opts, tk, elem) {
 				let called = false
 				const div = tk.legend.tip.d
 					.append('div')
-					.text('Change variant shape')
+					.text('Change Shape')
 					.style('vertical-align', 'middle')
 					.attr('class', 'sja_menuoption')
 					.on('click', () => {

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -3,10 +3,12 @@ import { Menu, axisstyle } from '#dom'
 import { mclass, dt2label, dtcnv, dtloh, dtitd, dtsv, dtfusionrna, mclassitd } from '#shared/common'
 import { interpolateRgb } from 'd3-interpolate'
 import { showLDlegend } from '../plots/regression.results'
-import { axisBottom, axisTop } from 'd3-axis'
+import { axisTop } from 'd3-axis'
 import { scaleLinear } from 'd3-scale'
+import { rgb } from 'd3-color'
+import { displayVectorGraphics } from './leftlabel.variant'
 
-/*
+/*	
 ********************** EXPORTED
 initLegend
 updateLegend
@@ -518,7 +520,6 @@ function update_mclass(tk) {
 			color = mclass[c.k].color
 			desc = mclass[c.k].desc
 		}
-
 		const cell = tk.legend.mclass.holder
 			.append('div')
 			.attr('class', 'sja_clb')
@@ -553,11 +554,20 @@ function update_mclass(tk) {
 						}
 					},
 					{
-						isColor: true,
-						value: mclass[c.k].color,
+						isChangeShape: true,
 						isVisible: () => true,
-						callback: color => {
-							mclass[c.k].color = color
+						callback: (val, tk) => {
+							tk.shapes.mclass[c.k] = val[0]
+							tk.load()
+							tk.legend.tip.hide()
+						}
+					},
+					{
+						isColor: true,
+						value: color,
+						isVisible: () => true,
+						callback: colorValue => {
+							mclass[c.k].color = colorValue
 						}
 					}
 				]
@@ -811,11 +821,28 @@ function createLegendTipMenu(opts, tk, elem) {
 					.text('Color:')
 					.append('input')
 					.attr('type', 'color')
-					.property('value', opt.value)
+					.property('value', rgb(opt.value).formatHex())
 					.on('change', event => {
 						const color = event.target.value
 						opt.callback(color)
 						reload(tk)
+					})
+			} else if (opt.isChangeShape) {
+				let called = false
+				const div = tk.legend.tip.d
+					.append('div')
+					.text('Change variant shape')
+					.style('vertical-align', 'middle')
+					.attr('class', 'sja_menuoption')
+					.on('click', () => {
+						if (called == false) {
+							called = true
+							displayVectorGraphics({
+								holder: div.append('div').style('margin-top', '10px'),
+								callback: val => opt.callback(val, tk),
+								tk: tk
+							})
+						}
 					})
 			} else {
 				tk.legend.tip.d

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -552,7 +552,7 @@ function update_mclass(tk) {
 								: false
 						},
 						callback: (val, tk) => {
-							tk.shapes.mclass[c.k] = val[0]
+							tk.shapes[c.k] = val[0]
 							tk.load()
 							tk.legend.tip.hide()
 						}

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -60,7 +60,7 @@ run only once, called by makeTk
 	tk.legend.table = table
 
 	create_mclass(tk, block)
-	may_create_variantShapeName(tk)
+	// may_create_variantShapeName(tk)
 	may_create_infoFields(tk)
 	may_create_formatFilter(tk)
 	may_create_skewerRim(tk)
@@ -91,41 +91,41 @@ function create_mclass(tk, block) {
 	tk.legend.mclass.holder = tk.legend.mclass.row.append('td')
 }
 
-function may_create_variantShapeName(tk) {
-	if (!tk.variantShapeName) return
-	const holder = tk.legend.table.append('tr').append('td').attr('colspan', 2)
-	const vl = (tk.legend.variantShapeName = {})
-	{
-		const d = holder.append('div')
-		d.append('span').html(
-			`<svg style="display:inline-block" width=12 height=12>
-			<circle cx=6 cy=6 r=6 fill=gray></circle></svg> n=`
-		)
-		vl.dotCount = d.append('span')
-		if (tk.variantShapeName.dot) d.append('span').text(', ' + tk.variantShapeName.dot)
-		vl.dotDiv = d
-	}
-	{
-		const d = holder.append('div')
-		d.append('span').html(
-			`<svg style="display:inline-block" width=12 height=12>
-			<path d="M 6 0 L 0 12 h 12 Z" fill=gray></path></svg> n=`
-		)
-		vl.triangleCount = d.append('span')
-		if (tk.variantShapeName.triangle) d.append('span').text(', ' + tk.variantShapeName.triangle)
-		vl.triangleDiv = d
-	}
-	{
-		const d = holder.append('div')
-		d.append('span').html(
-			`<svg style="display:inline-block" width=13 height=13>
-			<circle cx=6.5 cy=6.5 r=6 stroke=gray fill=none></circle></svg> n=`
-		)
-		vl.circleCount = d.append('span')
-		if (tk.variantShapeName.circle) d.append('span').text(', ' + tk.variantShapeName.circle)
-		vl.circleDiv = d
-	}
-}
+// function may_create_variantShapeName(tk) {
+// 	if (!tk.variantShapeName) return
+// 	const holder = tk.legend.table.append('tr').append('td').attr('colspan', 2)
+// 	const vl = (tk.legend.variantShapeName = {})
+// 	{
+// 		const d = holder.append('div')
+// 		d.append('span').html(
+// 			`<svg style="display:inline-block" width=12 height=12>
+// 			<circle cx=6 cy=6 r=6 fill=gray></circle></svg> n=`
+// 		)
+// 		vl.dotCount = d.append('span')
+// 		if (tk.variantShapeName.dot) d.append('span').text(', ' + tk.variantShapeName.dot)
+// 		vl.dotDiv = d
+// 	}
+// 	{
+// 		const d = holder.append('div')
+// 		d.append('span').html(
+// 			`<svg style="display:inline-block" width=12 height=12>
+// 			<path d="M 6 0 L 0 12 h 12 Z" fill=gray></path></svg> n=`
+// 		)
+// 		vl.triangleCount = d.append('span')
+// 		if (tk.variantShapeName.triangle) d.append('span').text(', ' + tk.variantShapeName.triangle)
+// 		vl.triangleDiv = d
+// 	}
+// 	{
+// 		const d = holder.append('div')
+// 		d.append('span').html(
+// 			`<svg style="display:inline-block" width=13 height=13>
+// 			<circle cx=6.5 cy=6.5 r=6 stroke=gray fill=none></circle></svg> n=`
+// 		)
+// 		vl.circleCount = d.append('span')
+// 		if (tk.variantShapeName.circle) d.append('span').text(', ' + tk.variantShapeName.circle)
+// 		vl.circleDiv = d
+// 	}
+// }
 
 function may_create_infoFields(tk) {
 	if (!tk.mds.bcf?.info) return // not using bcf with info fields
@@ -232,39 +232,36 @@ function may_update_formatFilter(data, tk) {
 				.attr('class', 'sja_clb')
 				.style('display', 'inline-block')
 				.on('click', () => {
-					tk.legend.tip
-						.clear()
-						.showunder(cell.node())
-						.d.append('div')
-						.attr('class', 'sja_menuoption')
-						.text('Hide')
-						.on('click', () => {
-							tk.legend.formatFilter[formatKey].hiddenvalues.add(category)
-							reload(tk)
-						})
-
-					tk.legend.tip.d
-						.append('div')
-						.attr('class', 'sja_menuoption')
-						.text('Show only')
-						.on('click', () => {
-							for (const c2 of show_lst) {
-								tk.legend.formatFilter[formatKey].hiddenvalues.add(c2[0])
+					const opts = [
+						{
+							label: 'Hide',
+							isVisible: () => true,
+							callback: () => {
+								tk.legend.formatFilter[formatKey].hiddenvalues.add(category)
 							}
-							tk.legend.formatFilter[formatKey].hiddenvalues.delete(category)
-							reload(tk)
-						})
-
-					if (tk.legend.formatFilter[formatKey].hiddenvalues.size) {
-						tk.legend.tip.d
-							.append('div')
-							.attr('class', 'sja_menuoption')
-							.text('Show all')
-							.on('click', () => {
+						},
+						{
+							label: 'Show only',
+							isVisible: () => true,
+							callback: () => {
+								for (const c2 of show_lst) {
+									tk.legend.formatFilter[formatKey].hiddenvalues.add(c2[0])
+								}
+								tk.legend.formatFilter[formatKey].hiddenvalues.delete(category)
+							}
+						},
+						{
+							label: 'Show all',
+							isVisible: () => {
+								if (tk.legend.formatFilter[formatKey].hiddenvalues.size) return true
+								else false
+							},
+							callback: () => {
 								tk.legend.formatFilter[formatKey].hiddenvalues.clear()
-								reload(tk)
-							})
-					}
+							}
+						}
+					]
+					createLegendTipMenu(opts, tk, cell.node())
 				})
 			cell
 				.append('div')
@@ -321,7 +318,7 @@ export function updateLegend(data, tk, block) {
 	tk.legend.mclass.currentData = data.mclass2variantcount
 	update_mclass(tk)
 
-	may_update_variantShapeName(data, tk)
+	// may_update_variantShapeName(data, tk)
 	may_update_infoFields(data, tk)
 	may_update_formatFilter(data, tk)
 	may_update_skewerRim(data, tk)
@@ -329,24 +326,24 @@ export function updateLegend(data, tk, block) {
 	may_update_cnv(tk)
 }
 
-function may_update_variantShapeName(data, tk) {
-	if (!tk.variantShapeName) return
-	let dot = 0,
-		triangle = 0,
-		circle = 0
-	for (const m of data.skewer) {
-		if (m.shapeTriangle) triangle++
-		else if (m.shapeCircle) circle++
-		else dot++
-	}
-	const vl = tk.legend.variantShapeName
-	vl.dotDiv.style('display', dot ? 'block' : 'none')
-	vl.triangleDiv.style('display', triangle ? 'block' : 'none')
-	vl.circleDiv.style('display', circle ? 'block' : 'none')
-	vl.dotCount.text(dot)
-	vl.triangleCount.text(triangle)
-	vl.circleCount.text(circle)
-}
+// function may_update_variantShapeName(data, tk) {
+// 	if (!tk.variantShapeName) return
+// 	let dot = 0,
+// 		triangle = 0,
+// 		circle = 0
+// 	for (const m of data.skewer) {
+// 		if (m.shapeTriangle) triangle++
+// 		else if (m.shapeCircle) circle++
+// 		else dot++
+// 	}
+// 	const vl = tk.legend.variantShapeName
+// 	vl.dotDiv.style('display', dot ? 'block' : 'none')
+// 	vl.triangleDiv.style('display', triangle ? 'block' : 'none')
+// 	vl.circleDiv.style('display', circle ? 'block' : 'none')
+// 	vl.dotCount.text(dot)
+// 	vl.triangleCount.text(triangle)
+// 	vl.circleCount.text(circle)
+// }
 
 /*
 update legend for all info fields of this track
@@ -389,39 +386,37 @@ function may_update_infoFields(data, tk) {
 					.attr('class', 'sja_clb')
 					.style('display', 'inline-block')
 					.on('click', () => {
-						tk.legend.tip
-							.clear()
-							.showunder(cell.node())
-							.d.append('div')
-							.attr('class', 'sja_menuoption')
-							.text('Hide')
-							.on('click', () => {
-								tk.legend.bcfInfo[infoKey].hiddenvalues.add(category)
-								reload(tk)
-							})
-
-						tk.legend.tip.d
-							.append('div')
-							.attr('class', 'sja_menuoption')
-							.text('Show only')
-							.on('click', () => {
-								for (const c2 of show_lst) {
-									tk.legend.bcfInfo[infoKey].hiddenvalues.add(c2[0])
+						const opts = [
+							{
+								label: 'Hide',
+								isVisible: () => true,
+								callback: () => {
+									tk.legend.bcfInfo[infoKey].hiddenvalues.add(category)
 								}
-								tk.legend.bcfInfo[infoKey].hiddenvalues.delete(category)
-								reload(tk)
-							})
-
-						if (tk.legend.bcfInfo[infoKey].hiddenvalues.size) {
-							tk.legend.tip.d
-								.append('div')
-								.attr('class', 'sja_menuoption')
-								.text('Show all')
-								.on('click', () => {
+							},
+							{
+								label: 'Show only',
+								isVisible: () => true,
+								callback: () => {
+									for (const c2 of show_lst) {
+										tk.legend.bcfInfo[infoKey].hiddenvalues.add(c2[0])
+									}
+									tk.legend.bcfInfo[infoKey].hiddenvalues.delete(category)
+								}
+							},
+							{
+								label: 'Show all',
+								isVisible: () => {
+									if (tk.legend.bcfInfo[infoKey].hiddenvalues.size) return true
+									else false
+								},
+								callback: () => {
 									tk.legend.bcfInfo[infoKey].hiddenvalues.clear()
-									reload(tk)
-								})
-						}
+								}
+							}
+						]
+
+						createLegendTipMenu(opts, tk, cell.node())
 
 						// optional description of this category
 						const desc = tk.mds.bcf.info[infoKey].categories?.[category]?.desc
@@ -529,39 +524,44 @@ function update_mclass(tk) {
 			.attr('class', 'sja_clb')
 			.style('display', 'inline-block')
 			.on('click', event => {
-				tk.legend.tip
-					.clear()
-					.showunder(event.target)
-					.d.append('div')
-					.attr('class', 'sja_menuoption')
-					.text('Hide')
-					.on('click', () => {
-						tk.legend.mclass.hiddenvalues.add(c.k)
-						reload(tk)
-					})
-
-				tk.legend.tip.d
-					.append('div')
-					.attr('class', 'sja_menuoption')
-					.text('Show only')
-					.on('click', () => {
-						for (const c2 of showlst) {
-							tk.legend.mclass.hiddenvalues.add(c2.k)
+				const opts = [
+					{
+						label: 'Hide',
+						isVisible: () => true,
+						callback: () => {
+							tk.legend.mclass.hiddenvalues.add(c.k)
 						}
-						tk.legend.mclass.hiddenvalues.delete(c.k)
-						reload(tk)
-					})
-
-				if (hiddenlst.length) {
-					tk.legend.tip.d
-						.append('div')
-						.attr('class', 'sja_menuoption')
-						.text('Show all')
-						.on('click', () => {
+					},
+					{
+						label: 'Show only',
+						isVisible: () => true,
+						callback: () => {
+							for (const c2 of showlst) {
+								tk.legend.mclass.hiddenvalues.add(c2.k)
+							}
+							tk.legend.mclass.hiddenvalues.delete(c.k)
+						}
+					},
+					{
+						label: 'Show all',
+						isVisible: () => {
+							if (hiddenlst.length) return true
+							else return false
+						},
+						callback: () => {
 							tk.legend.mclass.hiddenvalues.clear()
-							reload(tk)
-						})
-				}
+						}
+					},
+					{
+						isColor: true,
+						value: mclass[c.k].color,
+						isVisible: () => true,
+						callback: color => {
+							mclass[c.k].color = color
+						}
+					}
+				]
+				createLegendTipMenu(opts, tk, event.target)
 
 				tk.legend.tip.d
 					.append('div')
@@ -797,4 +797,36 @@ function may_update_cnv(tk) {
 		.attr('fill', `url(#${id})`)
 
 	svg.attr('width', xpad * 2 + axiswidth).attr('height', axisheight + barheight)
+}
+
+function createLegendTipMenu(opts, tk, elem) {
+	tk.legend.tip.clear().showunder(elem)
+
+	for (const opt of opts) {
+		if (opt.isVisible()) {
+			if (opt.isColor) {
+				tk.legend.tip.d
+					.append('div')
+					.style('padding', '5px 10px')
+					.text('Color:')
+					.append('input')
+					.attr('type', 'color')
+					.property('value', opt.value)
+					.on('change', event => {
+						const color = event.target.value
+						opt.callback(color)
+						reload(tk)
+					})
+			} else {
+				tk.legend.tip.d
+					.append('div')
+					.attr('class', 'sja_menuoption')
+					.text(opt.label)
+					.on('click', () => {
+						opt.callback()
+						reload(tk)
+					})
+			}
+		}
+	}
 }

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -246,9 +246,13 @@ function numeric_make(nm, tk, block) {
 				}
 				//Backwards compatibility with .variantShapeName{} arg
 				//May allow other shapes
-				if (m.shapeCircle) m.shape = 'emptyCircle'
-				else if (m.shapeTriangle) m.shape = 'filledTriangle'
-				else m.shape = 'filledCircle'
+				if (m.shapeCircle) {
+					m.shape = 'emptyCircle'
+					delete m.shapeCircle
+				} else if (m.shapeTriangle) {
+					m.shape = 'filledTriangle'
+					delete m.shapeTriangle
+				} else m.shape = 'filledCircle'
 			}
 		}
 	}

--- a/client/mds3/skewer.render.js
+++ b/client/mds3/skewer.render.js
@@ -108,8 +108,10 @@ export function skewer_make(tk, block) {
 		/** TODO: This assumes every skewer track has mutations
 		 * In future change to accept other annotations
 		 */
-		tk.shapes = { mclass: {} }
-		Object.keys(mclass).forEach(v => (tk.shapes.mclass[v] = 'filledCircle'))
+		if (!tk.shapeBy) {
+			tk.shapes = {}
+			Object.keys(mclass).forEach(v => (tk.shapes[v] = 'filledCircle'))
+		}
 	}
 
 	ss.selection = ss.g
@@ -135,11 +137,10 @@ export function skewer_make(tk, block) {
 		.attr('class', 'sja_aa_discg')
 		.each(function (d) {
 			d.g = this
-
 			if (!d.shape) {
 				//TODO: Add logic to determine when to apply shape or color
-				// and which annotation to use if multiple
-				d.shape = tk.shapes.mclass[d.aa.mlst[0].class]
+				// and which annotation to use if multiple (i.e. tk.shapeBy)
+				d.shape = tk.shapes[d.mlst[0].class]
 			}
 			if (!d.shape.includes('Circle')) {
 				//Use existing rendering code for circle shapes

--- a/client/mds3/skewer.render.js
+++ b/client/mds3/skewer.render.js
@@ -903,13 +903,7 @@ export function fold_glyph(lst, tk) {
 		.selectAll('.sja_aa_skkick')
 		.transition()
 		.duration(dur) // to prevent showing pica over busy skewer
-		.attr(
-			'transform',
-			d =>
-				`${
-					d.shape && !d.shape.includes('Circle') ? `translate(0, ${(tk.skewer.pointup ? -1 : 1) * d.maxradius})` : ''
-				} scale(1)`
-		)
+		.attr('transform', d => `${d.shape ? `translate(0, ${(tk.skewer.pointup ? -1 : 1) * d.maxradius})` : ''} scale(1)`)
 		.on('end', () => {
 			//For e2e testing
 			set.selectAll('.sja_aa_skkick').classed('sjpp-active', true)

--- a/client/mds3/skewer.render.shapes.ts
+++ b/client/mds3/skewer.render.shapes.ts
@@ -1,8 +1,10 @@
 import { Elem } from '../types/d3'
 import { shapes } from '#dom'
+import { dtsnvindel, dtsv, dtfusionrna } from '#shared/common'
 
 export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 	shapeG
+		.filter(d => d.dt == dtsnvindel || d.dt == dtsv || d.dt == dtfusionrna)
 		.append('path')
 		.attr('d', d => shapes[d.shape].calculatePath(getPathDimensions(d.shape, d.radius, skewer.pointup)))
 		.attr('fill', d => (!shapes[d.shape].isFilled ? 'none' : d.mlst?.[0] ? tk.color4disc(d.mlst[0]) : tk.color4disc(d)))

--- a/client/mds3/skewer.render.shapes.ts
+++ b/client/mds3/skewer.render.shapes.ts
@@ -1,19 +1,21 @@
 import { Elem } from '../types/d3'
+import { shapes } from '../dom/shapes.js'
 
 export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 	shapeG
 		.append('path')
-		.attr('d', d => skewer.shape[1].calculatePath(getPathDimensions(skewer.shape[0], d.radius, skewer)))
-		.attr('fill', skewer.shape[1].isFilled ? d => tk.color4disc(d.mlst[0]) : 'white')
-		.attr('stroke', skewer.shape[1].isFilled ? 'white' : d => tk.color4disc(d.mlst[0]))
+		.attr('d', d => shapes[d.shape].calculatePath(getPathDimensions(d.shape, d.radius, skewer)))
+		.attr('fill', d => (shapes[d.shape].isFilled ? tk.color4disc(d.mlst[0]) : 'white'))
+		.attr('stroke', d => (shapes[d.shape].isFilled ? 'white' : tk.color4disc(d.mlst[0])))
 }
 
 export function renderShapeKick(skewer: any, elem: any) {
 	const kick = elem
 		.append('path')
 		.attr('d', d => {
+			if (!d.shape) d.shape = d.groups[0].shape
 			const radius = d.radius * 1.01 || d.maxradius + 2
-			return skewer.shape[1].calculatePath(getPathDimensions(skewer.shape[0], radius, skewer))
+			return shapes[d.shape].calculatePath(getPathDimensions(d.shape, radius, skewer))
 		})
 		.attr('stroke-width', 1.75)
 
@@ -23,6 +25,8 @@ export function renderShapeKick(skewer: any, elem: any) {
 function getPathDimensions(key: string, radius: number, skewer: any) {
 	//Add more shapes here using the key from #dom/shapes.js
 	switch (key) {
+		case 'filledCircle':
+			return { radius }
 		case 'emptyCircle':
 			return { radius }
 		case 'filledVerticalRectangle':

--- a/client/mds3/skewer.render.shapes.ts
+++ b/client/mds3/skewer.render.shapes.ts
@@ -1,12 +1,14 @@
 import { Elem } from '../types/d3'
-import { shapes } from '../dom/shapes.js'
+import { shapes } from '#dom'
 
 export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 	shapeG
 		.append('path')
-		.attr('d', d => shapes[d.shape].calculatePath(getPathDimensions(d.shape, d.radius, skewer)))
-		.attr('fill', d => (shapes[d.shape].isFilled ? tk.color4disc(d.mlst[0]) : 'white'))
-		.attr('stroke', d => (shapes[d.shape].isFilled ? 'white' : tk.color4disc(d.mlst[0])))
+		.attr('d', d => shapes[d.shape].calculatePath(getPathDimensions(d.shape, d.radius, skewer.pointup)))
+		.attr('fill', d => (!shapes[d.shape].isFilled ? 'none' : d.mlst?.[0] ? tk.color4disc(d.mlst[0]) : tk.color4disc(d)))
+		.attr('stroke', d =>
+			shapes[d.shape].isFilled ? 'white' : d.mlst?.[0] ? tk.color4disc(d.mlst[0]) : tk.color4disc(d)
+		)
 }
 
 export function renderShapeKick(skewer: any, elem: any) {
@@ -15,14 +17,14 @@ export function renderShapeKick(skewer: any, elem: any) {
 		.attr('d', d => {
 			if (!d.shape) d.shape = d.groups[0].shape
 			const radius = d.radius * 1.01 || d.maxradius + 2
-			return shapes[d.shape].calculatePath(getPathDimensions(d.shape, radius, skewer))
+			return shapes[d.shape].calculatePath(getPathDimensions(d.shape, radius, skewer.pointup))
 		})
 		.attr('stroke-width', 1.75)
 
 	return kick
 }
 
-function getPathDimensions(key: string, radius: number, skewer: any) {
+function getPathDimensions(key: string, radius: number, pointup = true) {
 	//Add more shapes here using the key from #dom/shapes.js
 	switch (key) {
 		case 'filledCircle':
@@ -34,9 +36,9 @@ function getPathDimensions(key: string, radius: number, skewer: any) {
 		case 'emptyVerticalRectangle':
 			return { width: radius * 1.4, height: radius * 2 }
 		case 'filledTriangle':
-			return { width: radius * 2.1, height: radius * 2.1, isUp: skewer.pointup }
+			return { width: radius * 2.1, height: radius * 2.1, isUp: pointup }
 		case 'emptyTriangle':
-			return { width: radius * 2, height: radius * 2, isUp: skewer.pointup }
+			return { width: radius * 2, height: radius * 2, isUp: pointup }
 		case 'filledSquare':
 			return { width: radius * 1.7, height: radius * 1.7 }
 		case 'emptySquare':

--- a/client/mds3/skewer.render.shapes.ts
+++ b/client/mds3/skewer.render.shapes.ts
@@ -26,7 +26,7 @@ function getPathDimensions(key: string, radius: number, skewer: any) {
 	//Add more shapes here using the key from #dom/shapes.js
 	switch (key) {
 		case 'filledCircle':
-			return { radius }
+			return { radius: radius * 0.95 }
 		case 'emptyCircle':
 			return { radius }
 		case 'filledVerticalRectangle':

--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -339,7 +339,7 @@ tape('GDC - sunburst', test => {
 	async function callbackOnRender(tk, bb) {
 		// Click on track variant link to open menu
 		const discFound = tk.skewer.g
-			.selectAll('circle.sja_aa_disckick')
+			.selectAll('.sja_aa_disckick')
 			.nodes()
 			.find(e => e.__data__.occurrence >= 10)
 		test.ok(discFound, 'Found a mutation with occurrence >= 10, click on it to show sunburst')

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -91,7 +91,8 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 		lollipop: tdb.lollipop,
 		urlTemplates: tdb.urlTemplates,
 		title: 'title' in ds.cohort ? ds.cohort.title : { text: ds.label },
-		hideGroupsTab: ds.cohort.hideGroupsTab
+		hideGroupsTab: ds.cohort.hideGroupsTab,
+		tracks: tdb.tracks
 	}
 	// optional attributes
 	// when missing, the attribute will not be present as "key:undefined"

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -637,10 +637,6 @@ type Mds3Queries = {
 	DZImages?: DZImages
 	WSImages?: WSImages
 	images?: Images
-	tracks?: {
-		/** allow color or shape changes in the lollipop */
-		allowSkewerChanges: boolean
-	}
 }
 
 /** non-zoom small images

--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -637,6 +637,10 @@ type Mds3Queries = {
 	DZImages?: DZImages
 	WSImages?: WSImages
 	images?: Images
+	tracks?: {
+		/** allow color or shape changes in the lollipop */
+		allowSkewerChanges: boolean
+	}
 }
 
 /** non-zoom small images
@@ -1001,6 +1005,10 @@ type Termdb = {
 		}
 		/** html code */
 		html: string
+	}
+	tracks?: {
+		/** allow color or shape changes in the lollipop */
+		allowSkewerChanges: boolean
 	}
 }
 


### PR DESCRIPTION
## Description
Shapes are now defined for each data point rather than the track level for both the skewer and numeric mode. From the legend, the user can click on the mutation to change the color and the shape. The shape change is disabled for the GDC. 

Test: 
Pull https://github.com/stjude/sjpp/pull/499
1. [pantall example](http://localhost:3000/?genome=hg38&mds3=pantallMds3&block=1&position=chr9:21967751-21995324) -> change the shape or color for any mutation from the legend
2. [GDC example](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.demographic.gender%22},%22values%22:[{%22key%22:%22female%22}],%22isnot%22:true}}]}) -> change the only the color from the legend


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
