### PR TITLE
Render breakpoints consistently for all shapes and color reset button

### DIFF
--- a/client/dom/shapes.js
+++ b/client/dom/shapes.js
@@ -216,11 +216,11 @@ export const shapes = {
 
 export const shapesArray = Object.values(shapes).map(shape => shape.path)
 
-export function shapeSelector(div, callback, shapesArray = shapesArray) {
+export function shapeSelector(div, callback, arr = shapesArray, opts = {}) {
 	const size = 20
 	const cols = 8
-	const height = Math.ceil(shapesArray.length / cols) * size
-	div.style('background-color', '#f2f2f2')
+	const height = Math.ceil(arr.length / cols) * size
+	div.style('background-color', 'backgroundColor' in opts ? opts.backgroundColor : '#f2f2f2')
 	const svg = div
 		.append('div')
 		.style('padding', '5px')
@@ -230,7 +230,7 @@ export function shapeSelector(div, callback, shapesArray = shapesArray) {
 		.style('background-color', 'rgba(239, 239, 239, 0.3)')
 	let count = 0
 	let y = 0
-	for (const shape of shapesArray) {
+	for (const shape of arr) {
 		const index = count + y * cols
 		svg
 			.append('path')

--- a/client/dom/shapes.js
+++ b/client/dom/shapes.js
@@ -216,7 +216,7 @@ export const shapes = {
 
 export const shapesArray = Object.values(shapes).map(shape => shape.path)
 
-export function shapeSelector(div, callback) {
+export function shapeSelector(div, callback, shapesArray = shapesArray) {
 	const size = 20
 	const cols = 8
 	const height = Math.ceil(shapesArray.length / cols) * size

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -318,7 +318,9 @@ export function renderShapePicker(arg) {
 		callback(shape, tk)
 	}
 
-	shapeSelector(holder, selectorCallback, shapePaths)
+	const opts = { backgroundColor: '' }
+
+	shapeSelector(holder, selectorCallback, shapePaths, opts)
 }
 
 function mayAddSkewerModeOption(tk, block) {

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -2,7 +2,7 @@ import { fold_glyph, settle_glyph } from './skewer.render'
 import { may_render_skewer } from './skewer'
 import { itemtable } from './itemtable'
 import { makelabel, positionLeftlabelg } from './leftlabel'
-import { to_textfile, Tabs, make_radios, shapes } from '#dom'
+import { to_textfile, Tabs, make_radios, shapes, shapeSelector } from '#dom'
 import { rangequery_rglst } from './tk'
 import { samples2columnsRows, block2source } from './sampletable'
 import { dt2label, mclass, dtsnvindel, dtsv, dtcnv, dtfusionrna } from '#shared/common.js'
@@ -176,10 +176,16 @@ function menu_variants(tk, block) {
 					.on('click', () => {
 						if (called == false) {
 							called = true
-							displayVectorGraphics({
+							renderShapePicker({
 								holder: div.append('div').style('margin-top', '10px'),
-								callback: onShapeClick,
-								tk: tk
+								callback: shape => {
+									Object.keys(tk.shapes).forEach(key => {
+										tk.shapes[key] = shape
+									})
+									tk.load()
+									tk.menutip.hide()
+								},
+								tk
 							})
 						}
 					})
@@ -292,8 +298,8 @@ async function listVariantData(tk, block) {
 	}
 }
 
-export function displayVectorGraphics(arg) {
-	const desiredShapes = {
+export function renderShapePicker(arg) {
+	const lollipopShapes = {
 		filledCircle: shapes.filledCircle,
 		emptyCircle: shapes.emptyCircle,
 		filledVerticalRectangle: shapes.filledVerticalRectangle,
@@ -303,54 +309,16 @@ export function displayVectorGraphics(arg) {
 		filledSquare: shapes.filledSquare,
 		emptySquare: shapes.emptySquare
 	}
+
 	const { holder, callback, tk } = arg
+	const shapePaths = Object.values(lollipopShapes).map(shape => shape.path)
 
-	const vectorGraphicsDiv = holder.append('div')
-	vectorGraphicsDiv
-		.append('div')
-		.style('display', 'flex')
-		.style('flex-direction', 'row')
-		.style('align-items', 'center')
-		.style('justify-content', 'center')
-		.style('border', 'none')
-		.style('width', '100%')
-		.style('font-size', '20px')
-		.style('margin-top', '5px')
-
-	const shapesContainer = vectorGraphicsDiv
-		.append('div')
-		.style('display', 'flex')
-		.style('flex-wrap', 'wrap')
-		.style('width', 'max-content')
-
-	for (const val of Object.entries(desiredShapes)) {
-		const width = 18
-		const height = 18
-		const shapeSvg = shapesContainer
-			.append('svg')
-			.attr('width', width)
-			.attr('height', height)
-			.attr('viewBox', `-1 -1 ${width} ${height}`)
-			.style('padding', '0px 2px')
-			.style('cursor', 'pointer')
-			.on('click', () => {
-				callback(val, tk)
-			})
-		shapeSvg
-			.append('path')
-			.attr('d', val[1].path)
-			.attr('fill', val[1].isFilled ? 'black' : 'none')
-			.attr('stroke', 'black')
+	const selectorCallback = val => {
+		const shape = Object.keys(lollipopShapes)[val]
+		callback(shape, tk)
 	}
-}
 
-function onShapeClick(val, tk) {
-	// Logic to change the pre-existing shape to the chosen shape
-	Object.keys(tk.shapes).forEach(key => {
-		tk.shapes[key] = val[0]
-	})
-	tk.load()
-	tk.menutip.hide()
+	shapeSelector(holder, selectorCallback, shapePaths)
 }
 
 function mayAddSkewerModeOption(tk, block) {

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -1,5 +1,5 @@
 import { legend_newrow } from '#src/block.legend'
-import { Menu, axisstyle } from '#dom'
+import { Menu, axisstyle, icons } from '#dom'
 import { mclass, dt2label, dtcnv, dtloh, dtitd, dtsv, dtfusionrna, mclassitd } from '#shared/common.js'
 import { interpolateRgb } from 'd3-interpolate'
 import { showLDlegend } from '../plots/regression.results'
@@ -62,7 +62,7 @@ run only once, called by makeTk
 	tk.legend.table = table
 
 	create_mclass(tk, block)
-	// may_create_variantShapeName(tk)
+	may_create_variantShapeName(tk)
 	may_create_infoFields(tk)
 	may_create_formatFilter(tk)
 	may_create_skewerRim(tk)
@@ -93,41 +93,41 @@ function create_mclass(tk, block) {
 	tk.legend.mclass.holder = tk.legend.mclass.row.append('td')
 }
 
-// function may_create_variantShapeName(tk) {
-// 	if (!tk.variantShapeName) return
-// 	const holder = tk.legend.table.append('tr').append('td').attr('colspan', 2)
-// 	const vl = (tk.legend.variantShapeName = {})
-// 	{
-// 		const d = holder.append('div')
-// 		d.append('span').html(
-// 			`<svg style="display:inline-block" width=12 height=12>
-// 			<circle cx=6 cy=6 r=6 fill=gray></circle></svg> n=`
-// 		)
-// 		vl.dotCount = d.append('span')
-// 		if (tk.variantShapeName.dot) d.append('span').text(', ' + tk.variantShapeName.dot)
-// 		vl.dotDiv = d
-// 	}
-// 	{
-// 		const d = holder.append('div')
-// 		d.append('span').html(
-// 			`<svg style="display:inline-block" width=12 height=12>
-// 			<path d="M 6 0 L 0 12 h 12 Z" fill=gray></path></svg> n=`
-// 		)
-// 		vl.triangleCount = d.append('span')
-// 		if (tk.variantShapeName.triangle) d.append('span').text(', ' + tk.variantShapeName.triangle)
-// 		vl.triangleDiv = d
-// 	}
-// 	{
-// 		const d = holder.append('div')
-// 		d.append('span').html(
-// 			`<svg style="display:inline-block" width=13 height=13>
-// 			<circle cx=6.5 cy=6.5 r=6 stroke=gray fill=none></circle></svg> n=`
-// 		)
-// 		vl.circleCount = d.append('span')
-// 		if (tk.variantShapeName.circle) d.append('span').text(', ' + tk.variantShapeName.circle)
-// 		vl.circleDiv = d
-// 	}
-// }
+function may_create_variantShapeName(tk) {
+	if (!tk.variantShapeName) return
+	const holder = tk.legend.table.append('tr').append('td').attr('colspan', 2)
+	const vl = (tk.legend.variantShapeName = {})
+	{
+		const d = holder.append('div')
+		d.append('span').html(
+			`<svg style="display:inline-block" width=12 height=12>
+			<circle cx=6 cy=6 r=6 fill=gray></circle></svg> n=`
+		)
+		vl.dotCount = d.append('span')
+		if (tk.variantShapeName.dot) d.append('span').text(', ' + tk.variantShapeName.dot)
+		vl.dotDiv = d
+	}
+	{
+		const d = holder.append('div')
+		d.append('span').html(
+			`<svg style="display:inline-block" width=12 height=12>
+			<path d="M 6 0 L 0 12 h 12 Z" fill=gray></path></svg> n=`
+		)
+		vl.triangleCount = d.append('span')
+		if (tk.variantShapeName.triangle) d.append('span').text(', ' + tk.variantShapeName.triangle)
+		vl.triangleDiv = d
+	}
+	{
+		const d = holder.append('div')
+		d.append('span').html(
+			`<svg style="display:inline-block" width=13 height=13>
+			<circle cx=6.5 cy=6.5 r=6 stroke=gray fill=none></circle></svg> n=`
+		)
+		vl.circleCount = d.append('span')
+		if (tk.variantShapeName.circle) d.append('span').text(', ' + tk.variantShapeName.circle)
+		vl.circleDiv = d
+	}
+}
 
 function may_create_infoFields(tk) {
 	if (!tk.mds.bcf?.info) return // not using bcf with info fields
@@ -317,7 +317,7 @@ export function updateLegend(data, tk, block) {
 	tk.legend.mclass.currentData = data.mclass2variantcount
 	update_mclass(tk)
 
-	// may_update_variantShapeName(data, tk)
+	may_update_variantShapeName(data, tk)
 	may_update_infoFields(data, tk)
 	may_update_formatFilter(data, tk)
 	may_update_skewerRim(data, tk)
@@ -325,24 +325,24 @@ export function updateLegend(data, tk, block) {
 	may_update_cnv(tk)
 }
 
-// function may_update_variantShapeName(data, tk) {
-// 	if (!tk.variantShapeName) return
-// 	let dot = 0,
-// 		triangle = 0,
-// 		circle = 0
-// 	for (const m of data.skewer) {
-// 		if (m.shapeTriangle) triangle++
-// 		else if (m.shapeCircle) circle++
-// 		else dot++
-// 	}
-// 	const vl = tk.legend.variantShapeName
-// 	vl.dotDiv.style('display', dot ? 'block' : 'none')
-// 	vl.triangleDiv.style('display', triangle ? 'block' : 'none')
-// 	vl.circleDiv.style('display', circle ? 'block' : 'none')
-// 	vl.dotCount.text(dot)
-// 	vl.triangleCount.text(triangle)
-// 	vl.circleCount.text(circle)
-// }
+function may_update_variantShapeName(data, tk) {
+	if (!tk.variantShapeName) return
+	let dot = 0,
+		triangle = 0,
+		circle = 0
+	for (const m of data.skewer) {
+		if (m.shapeTriangle) triangle++
+		else if (m.shapeCircle) circle++
+		else dot++
+	}
+	const vl = tk.legend.variantShapeName
+	vl.dotDiv.style('display', dot ? 'block' : 'none')
+	vl.triangleDiv.style('display', triangle ? 'block' : 'none')
+	vl.circleDiv.style('display', circle ? 'block' : 'none')
+	vl.dotCount.text(dot)
+	vl.triangleCount.text(triangle)
+	vl.circleCount.text(circle)
+}
 
 /*
 update legend for all info fields of this track
@@ -562,7 +562,11 @@ function update_mclass(tk) {
 						value: color,
 						isVisible: () => true,
 						callback: colorValue => {
+							if (!mclass[c.k].origColor) mclass[c.k].origColor = mclass[c.k].color
 							mclass[c.k].color = colorValue
+						},
+						reset: () => {
+							mclass[c.k].color = mclass[c.k].origColor
 						}
 					}
 				]
@@ -813,6 +817,7 @@ function createLegendTipMenu(opts, tk, elem) {
 				tk.legend.tip.d
 					.append('div')
 					.style('padding', '5px 10px')
+					.style('display', 'inline-block')
 					.text('Color:')
 					.append('input')
 					.attr('type', 'color')
@@ -822,6 +827,14 @@ function createLegendTipMenu(opts, tk, elem) {
 						opt.callback(color)
 						reload(tk)
 					})
+				if (opt.reset) {
+					const resetDiv = tk.legend.tip.d.append('div').style('display', 'inline-block')
+					const handler = () => {
+						opt.reset()
+						reload(tk)
+					}
+					icons['restart'](resetDiv, { handler, title: 'Reset to original color' })
+				}
 			} else if (opt.isChangeShape) {
 				let called = false
 				const div = tk.legend.tip.d

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -572,12 +572,15 @@ function update_mclass(tk) {
 				]
 				createLegendTipMenu(opts, tk, event.target)
 
-				tk.legend.tip.d
+				const descDiv = tk.legend.tip.d
 					.append('div')
 					.style('padding', '10px')
 					.style('font-size', '.8em')
 					.style('width', '150px')
-					.html(desc)
+
+				descDiv.append('span').style('color', color).text(label.toUpperCase())
+
+				descDiv.append('div').style('color', 'black').html(desc)
 			})
 
 		cell

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -6,7 +6,7 @@ import { showLDlegend } from '../plots/regression.results'
 import { axisTop } from 'd3-axis'
 import { scaleLinear } from 'd3-scale'
 import { rgb } from 'd3-color'
-import { displayVectorGraphics } from './leftlabel.variant'
+import { renderShapePicker } from './leftlabel.variant'
 
 /*	
 ********************** EXPORTED
@@ -552,7 +552,7 @@ function update_mclass(tk) {
 								: false
 						},
 						callback: (val, tk) => {
-							tk.shapes[c.k] = val[0]
+							tk.shapes[c.k] = val
 							tk.load()
 							tk.legend.tip.hide()
 						}
@@ -832,7 +832,7 @@ function createLegendTipMenu(opts, tk, elem) {
 					.on('click', () => {
 						if (called == false) {
 							called = true
-							displayVectorGraphics({
+							renderShapePicker({
 								holder: div.append('div').style('margin-top', '10px'),
 								callback: val => opt.callback(val, tk),
 								tk: tk

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -566,7 +566,9 @@ function update_mclass(tk) {
 							mclass[c.k].color = colorValue
 						},
 						reset: () => {
+							if (!mclass[c.k].origColor) return
 							mclass[c.k].color = mclass[c.k].origColor
+							reload(tk)
 						}
 					}
 				]
@@ -834,7 +836,6 @@ function createLegendTipMenu(opts, tk, elem) {
 					const resetDiv = tk.legend.tip.d.append('div').style('display', 'inline-block')
 					const handler = () => {
 						opt.reset()
-						reload(tk)
 					}
 					icons['restart'](resetDiv, { handler, title: 'Reset to original color' })
 				}

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -565,10 +565,9 @@ function update_mclass(tk) {
 							if (!mclass[c.k].origColor) mclass[c.k].origColor = mclass[c.k].color
 							mclass[c.k].color = colorValue
 						},
-						reset: () => {
-							if (!mclass[c.k].origColor) return
-							mclass[c.k].color = mclass[c.k].origColor
-							reload(tk)
+						reset: {
+							isVisible: () => mclass[c.k].origColor,
+							callback: () => (mclass[c.k].color = mclass[c.k].origColor)
 						}
 					}
 				]
@@ -832,10 +831,11 @@ function createLegendTipMenu(opts, tk, elem) {
 						opt.callback(color)
 						reload(tk)
 					})
-				if (opt.reset) {
+				if (opt.reset && opt.reset?.isVisible()) {
 					const resetDiv = tk.legend.tip.d.append('div').style('display', 'inline-block')
 					const handler = () => {
-						opt.reset()
+						opt.reset.callback()
+						reload(tk)
 					}
 					icons['restart'](resetDiv, { handler, title: 'Reset to original color' })
 				}

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -74,6 +74,14 @@ when requesting skewer data at gmmode (not genomic) for the first time,
 data is queried by isoform, and returned data is kept at tk.skewer.rawmlst
 at subsequent panning/zooming, it won't re-request skewer data, as it's still using the same isoform
 and will use cached data at rawmlst instead
+
+********************************
+* On skewer shapes             *
+********************************
+In both the numeric and skewer modes, one of eight shapes is defined for each data point. In 
+skewer mode, shapes are mapped to the mutation and assigned to each skewer on render init. 
+In numeric mode, the shape is defined individually via the custom_variants.shape[Triangle/Circle] arg. 
+The default is the `filledCircle` for both modes. 
 */
 
 export async function makeTk(tk, block) {

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -248,10 +248,10 @@ function numeric_make(nm, tk, block) {
 				//May allow other shapes
 				if (m.shapeCircle) {
 					m.shape = 'emptyCircle'
-					delete m.shapeCircle
+					// delete m.shapeCircle
 				} else if (m.shapeTriangle) {
 					m.shape = 'filledTriangle'
-					delete m.shapeTriangle
+					// delete m.shapeTriangle
 				} else m.shape = 'filledCircle'
 			}
 		}

--- a/client/mds3/skewer.render.js
+++ b/client/mds3/skewer.render.js
@@ -165,8 +165,12 @@ export function skewer_make(tk, block) {
 						d3arc()({
 							innerRadius: 0,
 							outerRadius: d.radius - 2,
-							startAngle: d.useNterm ? 0 : Math.PI,
-							endAngle: d.useNterm ? Math.PI : Math.PI * 2
+							/**** Always show the colored area on the correct side ****
+							 * Preserves showing the colored:white areas regardless if
+							 * the shape is filled or not
+							 */
+							startAngle: d.useNterm == shapes[d.shape].isFilled ? 0 : Math.PI,
+							endAngle: d.useNterm == shapes[d.shape].isFilled ? Math.PI : Math.PI * 2
 						})
 					)
 			}

--- a/client/mds3/skewer.render.js
+++ b/client/mds3/skewer.render.js
@@ -152,14 +152,14 @@ export function skewer_make(tk, block) {
 				// full filled
 				discdot
 					.filter(d => d.dt == dtsnvindel || d.dt == dtsv || d.dt == dtfusionrna)
-					.attr('fill', d => (tk.shapes && !shapes[d.shape].isFilled ? 'white' : tk.color4disc(d.mlst[0])))
-					.attr('stroke', d => (tk.shapes && !shapes[d.shape].isFilled ? tk.color4disc(d.mlst[0]) : 'white'))
+					.attr('fill', d => (!shapes[d.shape].isFilled ? 'white' : tk.color4disc(d.mlst[0])))
+					.attr('stroke', d => (!shapes[d.shape].isFilled ? tk.color4disc(d.mlst[0]) : 'white'))
 					.attr('r', d => d.radius - 0.5)
 				// masking half
 				d3select(this)
 					.filter(d => d.dt == dtfusionrna || d.dt == dtsv)
 					.append('path')
-					.attr('fill', d => (tk.shapes && !shapes[d.shape].isFilled ? 'black' : 'white'))
+					.attr('fill', d => (!shapes[d.shape].isFilled ? tk.color4disc(d.mlst[0]) : 'white'))
 					.attr('stroke', 'none')
 					.attr('d', d =>
 						d3arc()({
@@ -197,7 +197,7 @@ export function skewer_make(tk, block) {
 		.attr('stroke', d => tk.color4disc(d.mlst[0]))
 		.attr('stroke-width', 0.8)
 		.attr('font-weight', 'bold')
-		.attr('fill', d => (tk.shapes && !shapes[d.shape].isFilled ? 'black' : 'white'))
+		.attr('fill', 'white')
 	// right-side label
 	const textlab = discg
 		.append('text')

--- a/client/mds3/skewer.render.shapes.ts
+++ b/client/mds3/skewer.render.shapes.ts
@@ -1,6 +1,7 @@
 import { Elem } from '../types/d3'
 import { shapes } from '#dom'
 import { dtsnvindel, dtsv, dtfusionrna } from '#shared/common.js'
+import { select as d3select } from 'd3-selection'
 
 export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 	shapeG
@@ -9,8 +10,42 @@ export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 		.attr('d', d => shapes[d.shape].calculatePath(getPathDimensions(d.shape, d.radius, skewer.pointup)))
 		.attr('fill', d => (!shapes[d.shape].isFilled ? 'none' : d.mlst?.[0] ? tk.color4disc(d.mlst[0]) : tk.color4disc(d)))
 		.attr('stroke', d =>
-			shapes[d.shape].isFilled ? 'white' : d.mlst?.[0] ? tk.color4disc(d.mlst[0]) : tk.color4disc(d)
+			(d.dt == dtfusionrna || d.dt == dtsv) && d?.mlst[0]
+				? tk.color4disc(d.mlst[0])
+				: shapes[d.shape].isFilled
+				? 'white'
+				: d.mlst?.[0]
+				? tk.color4disc(d.mlst[0])
+				: tk.color4disc(d)
 		)
+
+	const defs = shapeG
+		.append('defs')
+		.selectAll('clipPath')
+		.data(shapeG.data())
+		.enter()
+		.append('clipPath')
+		.attr('id', d => `clip-path-${d?.mlst ? `${d.mlst[0].mname}-${d.mlst[0].__x}` : `${d.mname}-${d.__x}`}`)
+
+	defs.each(function (d) {
+		const { width, height } = getPathDimensions(d.shape, d.radius, skewer.pointup)
+		if (!width || !height) return
+		d3select(this)
+			.append('rect')
+			.attr('x', d.useNterm != shapes[d.shape].isFilled ? -(width / 2) : 0)
+			.attr('y', -(height / 2))
+			.attr('width', d.useNterm != shapes[d.shape].isFilled ? width / 2 : width)
+			.attr('height', height)
+	})
+
+	shapeG
+		.filter(d => d.dt == dtfusionrna || d.dt == dtsv)
+		.append('g')
+		.attr('clip-path', d => `url(#clip-path-${d?.mlst ? `${d.mlst[0].mname}-${d.mlst[0].__x}` : `${d.mname}-${d.__x}`}`)
+		.append('path')
+		.attr('d', d => shapes[d.shape].calculatePath(getPathDimensions(d.shape, d.radius, skewer.pointup)))
+		.attr('fill', d => (shapes[d.shape].isFilled ? 'white' : tk.color4disc(d.mlst[0])))
+		.attr('stroke', 'none')
 }
 
 export function renderShapeKick(skewer: any, elem: any) {

--- a/client/mds3/skewer.render.shapes.ts
+++ b/client/mds3/skewer.render.shapes.ts
@@ -25,7 +25,11 @@ export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 		.data(shapeG.data())
 		.enter()
 		.append('clipPath')
-		.attr('id', d => `clip-path-${d?.mlst ? `${d.mlst[0].mname}-${d.mlst[0].__x}` : `${d.mname}-${d.__x}`}`)
+		//Keep the long id. It must be unique to the data point for rendering
+		.attr(
+			'id',
+			d => `clip-path-${d?.mlst ? `${d.mlst[0].mname}-${d.mlst[0].__x}-${d.yoffset}` : `${d.mname}-${d.__x}-${d._y}`}`
+		)
 
 	defs.each(function (d) {
 		const { width, height } = getPathDimensions(d.shape, d.radius, skewer.pointup)
@@ -45,7 +49,11 @@ export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 	shapeG
 		.filter(d => d.dt == dtfusionrna || d.dt == dtsv)
 		.append('g')
-		.attr('clip-path', d => `url(#clip-path-${d?.mlst ? `${d.mlst[0].mname}-${d.mlst[0].__x}` : `${d.mname}-${d.__x}`}`)
+		.attr(
+			'clip-path',
+			d =>
+				`url(#clip-path-${d?.mlst ? `${d.mlst[0].mname}-${d.mlst[0].__x}-${d.yoffset}` : `${d.mname}-${d.__x}-${d._y}`}`
+		)
 		.append('path')
 		.attr('d', d => shapes[d.shape].calculatePath(getPathDimensions(d.shape, d.radius, skewer.pointup)))
 		.attr('fill', d => (shapes[d.shape].isFilled ? 'white' : tk.color4disc(d.mlst[0])))

--- a/client/mds3/skewer.render.shapes.ts
+++ b/client/mds3/skewer.render.shapes.ts
@@ -32,6 +32,10 @@ export function renderSkewerShapes(tk: any, skewer: any, shapeG: Elem) {
 		if (!width || !height) return
 		d3select(this)
 			.append('rect')
+			/**** Always show the colored area on the correct side ****
+			 * Preserves showing the colored:white areas regardless if
+			 * the shape is filled or not
+			 */
 			.attr('x', d.useNterm != shapes[d.shape].isFilled ? -(width / 2) : 0)
 			.attr('y', -(height / 2))
 			.attr('width', d.useNterm != shapes[d.shape].isFilled ? width / 2 : width)

--- a/server/shared/common.js
+++ b/server/shared/common.js
@@ -276,7 +276,9 @@ mclass[mclasssv] = {
 	label: 'Structural variation',
 	color: '#858585',
 	dt: dtsv,
-	desc: 'Structural variation detected in genomic DNA.',
+	desc:
+		'<span style="font-size:150%">&#9680;</span> - 3\' end of the break point is fused to the 5\' end of another break point in a different gene.<br>' +
+		'<span style="font-size:150%">&#9681;</span> - 5\' end of the break point is fused to the 3\' end of another break point in a different gene.',
 	key: mclasssv
 }
 


### PR DESCRIPTION
## Description

Changes: 
1. All shapes for fusions render half colored, consistently on the same side
2. Reused the shape selector in the variant label and legend menu
3. Added an icon to reset the mutation color back to the original color
4. Minor changes: updated the description for structural variations and add the mutation title above the description to mimic the legacy lollipop

Test with: 
1. [pantall example](http://localhost:3000/?genome=hg38&mds3=pantallMds3&block=1&position=chr9:21967751-21995324) -> Click on Structural variation in the legend -> Change shape, reset color, etc. 
2. [Scatter example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22MB_meta_analysis%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:{%22term%22:%20{%22gene%22:%20%22CTNNB1%22,%20%22type%22:%20%22geneVariant%22}},%22shapeTW%22:{%22id%22:%20%22Molecular%20Subgroup%22}}]}) -> should see no change in shape selection

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
