### PR TITLE
Fix for finding the user inputted gene for gene fusion

### DIFF
--- a/client/mds3/itemtable.js
+++ b/client/mds3/itemtable.js
@@ -577,8 +577,8 @@ async function makeSvgraph(m, div, block) {
 			}
 		}
 
-		await getGm(svpair.a, block)
-		await getGm(svpair.b, block)
+		await getGm(svpair.a, block, m.pairlst[0].a.name)
+		await getGm(svpair.b, block, m.pairlst[0].b.name)
 
 		wait.remove()
 
@@ -592,11 +592,12 @@ async function makeSvgraph(m, div, block) {
 		wait.text(e.message || e)
 	}
 }
-async function getGm(p, block) {
+async function getGm(p, block, name) {
 	// p={chr, position}
 	const d = await dofetch3('isoformbycoord', { body: { genome: block.genome.name, chr: p.chr, pos: p.position } })
 	if (d.error) throw d.error
-	const u = d.lst.find(i => i.isdefault) || d.lst[0]
+	//Find name if more than one gene returned
+	const u = d.lst.find(i => i.isdefault && name == i.name) || d.lst[0]
 	if (u) {
 		p.name = u.name
 		p.gm = { isoform: u.isoform }

--- a/client/mds3/itemtable.js
+++ b/client/mds3/itemtable.js
@@ -553,9 +553,9 @@ export function printSvPair(pair, div) {
 	div
 		.append('span')
 		.text(
-			`${pair.a.chr}:${pair.a.pos} ${pair.a.strand == '+' ? 'forward' : 'reverse'} > ${pair.b.chr}:${pair.b.pos} ${
-				pair.b.strand == '+' ? 'forward' : 'reverse'
-			}`
+			`${pair.a.chr}:${pair.a.pos + 1} ${pair.a.strand == '+' ? 'forward' : 'reverse'} > ${pair.b.chr}:${
+				pair.b.pos + 1
+			} ${pair.b.strand == '+' ? 'forward' : 'reverse'}`
 		)
 	if (pair.b.name) div.append('span').text(pair.b.name).style('font-weight', 'bold').style('margin-left', '5px')
 }

--- a/client/src/genefusion/genefusion.ui.js
+++ b/client/src/genefusion/genefusion.ui.js
@@ -125,7 +125,7 @@ function makeInfoSection(div) {
 		Each line has eight fields. four fields for each gene. For each gene join the following fields separated by a comma:
 		<ol><li>Gene symbol</li>
 		<li>Chromosome</li>
-		<li>Position</li>
+		<li>Position, 1-based coordinate</li>
 		<li>Strand</li>
 		</ol>
 		Separate the two genes by a double colon (::). <br><br>
@@ -221,11 +221,11 @@ function makeFusionTabs(div, runpp_arg, gene1, gene2) {
 								{
 									gene1: gene1[0],
 									chr1: gene1[1],
-									pos1: parseInt(gene1[2]),
+									pos1: parseInt(gene1[2]) - 1,
 									strand1: gene1[3],
 									gene2: gene2[0],
 									chr2: gene2[1],
-									pos2: parseInt(gene2[2]),
+									pos2: parseInt(gene2[2]) - 1,
 									strand2: gene2[3],
 									dt: 2,
 									class: 'Fuserna'
@@ -253,11 +253,11 @@ function makeFusionTabs(div, runpp_arg, gene1, gene2) {
 								{
 									gene1: gene1[0],
 									chr1: gene1[1],
-									pos1: parseInt(gene1[2]),
+									pos1: parseInt(gene1[2]) - 1,
 									strand1: gene1[3],
 									gene2: gene2[0],
 									chr2: gene2[1],
-									pos2: parseInt(gene2[2]),
+									pos2: parseInt(gene2[2]) - 1,
 									strand2: gene2[3],
 									dt: 2,
 									class: 'Fuserna'


### PR DESCRIPTION
## Description
Addresses issue found by user for [inputting gene fusions](https://groups.google.com/g/proteinpaint/c/D8Ah0hLYCyg). In master when using TIMP3, either through the lollipop custom data UI or the gene fusion UI, the svgraph displays SYN3. Both genes are returned from `isoformbycoord` but only the first default isoform is used; potentially not matching the user's input. This fix matches the gene name and the default to return the user's desired gene. 

Test: 
1. [Lollipop UI](http://localhost:3000/?gene=TIMP3&genome=hg19) => Click on '+' => input TIMP3,NM_000362,chr22:33198108,PAX5,NM_016734,chr9:37024824 -> Should see TIMP3 displayed in fusion graph
2. [Gene fusion UI](http://localhost:3000/?appcard=genefusion) -> input TIMP3,chr22,33198108,+::PAX5,chr9,37024824,- => Should see TIMP3, not SYN3. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
