### PR TITLE
introduce temporary flag while migrating bcf to using string sample n…

### DIFF
--- a/server/shared/types/dataset.ts
+++ b/server/shared/types/dataset.ts
@@ -69,8 +69,10 @@ type bcfMafFile = {
 type SnvindelByRange = {
 	/** if true, served from gdc. no other parameters TODO change to src='gdc/native' */
 	gdcapi?: boolean
-	/**local file can have following different setup
-	 * one single bcf file */
+
+	//local ds can have following different setup
+
+	/** one single bcf file */
 	bcffile?: string
 	/** one bcf file per chr */
 	chr2bcffile?: Chr2bcffile
@@ -78,6 +80,8 @@ type SnvindelByRange = {
 	bcfMafFile?: bcfMafFile
 	/** allow to apply special configurations to certain INFO fields of the bcf file */
 	infoFields?: InfoFieldEntry[]
+	/** if true, bcf or chr2bcf uses string sample name in header. to be used during this migrating so the code can deal with old files with integer sample ids and new ones; TODO once all datasets are migrated, delete the flag */
+	tempflag_sampleNameInVcfHeader?: boolean
 }
 
 type SvfusionByRange = {


### PR DESCRIPTION
…ame in header

## Description

i'm asking Karishma to change mbmeta2 bcf and test with this branch.
please insert `ds.queries.snvindel.byrange.tempflag_sampleNameInVcfHeader=true` flag on mbmeta2 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
