### PR TITLE
Profile fixes

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -1,7 +1,7 @@
 import { getCompInit, multiInit } from '#rx'
 import { recoverInit } from '../rx/src/recover'
 import { searchInit } from './search'
-import { chartsInit } from './charts'
+import { chartsInit, getActiveCohortStr } from './charts'
 import { groupsInit } from './groups'
 import { sessionBtnInit } from './sessionBtn'
 import { aboutInit } from './about.ts'
@@ -197,7 +197,7 @@ function setRenderers(self) {
 			.style('float', 'right')
 			.style('font-size', '1.1em')
 			.style('margin-top', '50px')
-			.text(appState.termdbConfig?.title?.text || '')
+		//.text(appState.termdbConfig?.title?.text || cohort) //this line will be executed in update UI to reflect cohort changes
 
 		const tabDiv = header.append('div').style('display', 'none').style('vertical-align', 'bottom')
 		const controlsDiv = header
@@ -391,6 +391,9 @@ function setRenderers(self) {
 	}
 
 	self.updateUI = async (toggleSubheaderdiv = false) => {
+		const state = self.state
+		const cohort = getActiveCohortStr(state)
+		self.dom.titleDiv.text(state.termdbConfig?.title?.text || cohort)
 		if (!self.dom.subheaderDiv) return
 		if (self.activeTab && self.state.termdbConfig.selectCohort && self.activeCohort == -1) {
 			// showing charts or filter tab; cohort selection is enabled but no cohort is selected

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -28,6 +28,8 @@ copyDataFilesFromRepo2Tp()
 export default {
 	isMds3: true,
 	cohort: {
+		title: { text: '' }, //it will show cohorts instead
+
 		db: {
 			file: 'files/hg38/TermdbTest/db'
 		},

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -93,6 +93,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 		title: 'title' in ds.cohort ? ds.cohort.title : { text: ds.label },
 		hideGroupsTab: ds.cohort.hideGroupsTab,
 		tracks: tdb.tracks,
+		sampleTypes: ds.cohort.termdb.sampleTypes,
 		hasSampleAncestry: ds.cohort.termdb.hasSampleAncestry
 	}
 	// optional attributes

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -230,7 +230,7 @@ export async function validate_termdb(ds) {
 	k: sample type key
 	v: {name, plural_name, parent_id}
 	*/
-	tdb.sampleTypes = new Map()
+	tdb.sampleTypes = {}
 
 	if (tdb?.dictionary?.gdcapi) {
 		await initGDCdictionary(ds)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -273,7 +273,7 @@ async function getSampleData(q, ds, onlyChildren = false) {
 	let sampleType
 	if (sids.length > 0) {
 		const stid = q.ds.sampleId2Type.get(Number(sids[0]))
-		sampleType = q.ds.cohort.termdb.sampleTypes.get(stid)
+		sampleType = q.ds.cohort.termdb.sampleTypes[stid]
 	}
 	return { samples, refs: { byTermId, bySampleId }, sampleType }
 }

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -74,13 +74,13 @@ export function server_init_db_queries(ds) {
 		const rows = cn.prepare('SELECT * FROM sample_types').all()
 
 		for (const row of rows) {
-			ds.cohort.termdb.sampleTypes.set(row.id, {
+			ds.cohort.termdb.sampleTypes[row.id] = {
 				name: row.name,
 				plural_name: row.plural_name,
 				parent_id: row.parent_id
-			})
+			}
 		}
-		ds.cohort.termdb.hasSampleAncestry = ds.cohort.termdb.sampleTypes.size > 1
+		ds.cohort.termdb.hasSampleAncestry = Object.keys(ds.cohort.termdb.sampleTypes).length > 1
 	}
 
 	for (const table of schema_tables) if (!tables.has(table)) console.log(`${table} table missing!!!!!!!!!!!!!!!!!!!!`)
@@ -143,7 +143,7 @@ export function server_init_db_queries(ds) {
 				let counts = rows
 					.filter(row => row.cohort == cohortKey || cohortKey == undefined) //one may have multiple types and a default cohort
 					.map(row => {
-						const sample_type = ds.cohort.termdb.sampleTypes.get(row.sample_type)
+						const sample_type = ds.cohort.termdb.sampleTypes[row.sample_type]
 						return `${row.sample_count} ${row.sample_count > 1 ? sample_type.plural_name : sample_type.name}`
 					})
 				let total = counts.join(' and ')

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -109,7 +109,7 @@ return a sample count of sample names passing through the filter
 		SELECT count (distinct sample) as count, sample_type
 		FROM ${filter.CTEname} join sampleidmap on sample = sampleidmap.id group by sample_type`
 		row = ds.cohort.db.connection.prepare(statement).get(filter.values)
-		sample_type = ds.cohort.termdb.sampleTypes.get(row.sample_type)
+		sample_type = ds.cohort.termdb.sampleTypes[row.sample_type]
 		sample_type = row.count > 1 ? sample_type.plural_name : sample_type.name
 	} else {
 		statement = `WITH ${filter.filters}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1006,11 +1006,18 @@ type Termdb = {
 		html: string
 	}
 	hasSampleAncestry?: boolean
+	sampleTypes?: SampleType[]
 
 	tracks?: {
 		/** allow color or shape changes in the lollipop */
 		allowSkewerChanges: boolean
 	}
+}
+
+type SampleType = {
+	name: string
+	plural_name: string
+	parent_id: string
 }
 
 type ChartConfigByType = {

--- a/shared/utils/src/terms.js
+++ b/shared/utils/src/terms.js
@@ -163,11 +163,11 @@ export function getSampleType(term, ds) {
 }
 
 export function getParentType(types, ds) {
-	if (ds.cohort.termdb.sampleTypes.size == 0) return null //dataset only has one type of sample
+	if (Object.keys(ds.cohort.termdb.sampleTypes).length == 0) return null //dataset only has one type of sample
 	const ids = Array.from(types)
 	if (!ids || ids.length == 0) return null
 	for (const id of ids) {
-		const typeObj = ds.cohort.termdb.sampleTypes.get(id)
+		const typeObj = ds.cohort.termdb.sampleTypes[id]
 		if (typeObj.parent_id == null) return id //this is the root type
 		//if my parent is in the list, then I am not the parent
 		if (ids.includes(typeObj.parent_id)) continue


### PR DESCRIPTION
## Description

Updated db that can be copied from hpc, that replaces type sample with site and updates cohort keys. Converted sampleTypes to dictionary to send it to client(maps require parsing) and displayed selected cohort if no title provided. Now datasets with cohorts show selected cohort. See corresponding [PR](https://github.com/stjude/sjpp/pull/511) in sjpp

<img width="1505" alt="Screenshot 2024-10-02 at 8 44 49 PM" src="https://github.com/user-attachments/assets/87632517-21d5-4a68-8149-4bff3f1fe60f">
 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
