### PR TITLE
Color scale tooltip and minor styling changes

### DIFF
--- a/client/dom/ColorScale.ts
+++ b/client/dom/ColorScale.ts
@@ -136,13 +136,24 @@ export class ColorScale {
 						this.tip.hide()
 					})
 			}
-
-			scaleSvg.on('click', () => {
-				this.tip.clear().showunder(barG.node())
-				//TODO apply to all colors or only start and end?
-				appendColor('Min:', 0)
-				appendColor('Max:', this.colors.length - 1)
-			})
+			let showTooltip = true
+			scaleSvg
+				.on('click', () => {
+					this.tip.clear().showunder(barG.node())
+					//TODO apply to all colors or only start and end?
+					appendColor('Min:', 0)
+					appendColor('Max:', this.colors.length - 1)
+					showTooltip = false
+				})
+				.on('mouseenter', () => {
+					//Prevent showing the tooltip after user interacts with the color picker
+					if (showTooltip == false) return
+					this.tip.clear().showunder(barG.node())
+					this.tip.d.append('div').style('padding', '2px').text('Click to customize colors')
+				})
+				.on('mouseleave', () => {
+					if (showTooltip) this.tip.hide()
+				})
 		}
 		this.render()
 	}

--- a/client/dom/ColorScale.ts
+++ b/client/dom/ColorScale.ts
@@ -138,7 +138,7 @@ export class ColorScale {
 			}
 
 			scaleSvg.on('click', () => {
-				this.tip.clear().showunder(scaleSvg.node())
+				this.tip.clear().showunder(barG.node())
 				//TODO apply to all colors or only start and end?
 				appendColor('Min:', 0)
 				appendColor('Max:', this.colors.length - 1)
@@ -168,7 +168,7 @@ export class ColorScale {
 			.attr('fill', 'url(#' + id + ')')
 
 		const scaleAxis = div.append('g').attr('data-testid', 'sjpp-color-scale-axis')
-		if (this.topTicks === false) scaleAxis.attr('transform', `translate(0, ${this.barheight + 2})`)
+		if (this.topTicks === false) scaleAxis.attr('transform', `translate(0, ${this.barheight})`)
 		const scale = scaleLinear().domain(this.data).range([0, this.barwidth])
 
 		return { scale, scaleAxis }

--- a/client/tracks/hic/dom/InfoBar.ts
+++ b/client/tracks/hic/dom/InfoBar.ts
@@ -78,7 +78,7 @@ export class InfoBar {
 			colors: [this.startColor, this.endColor],
 			position: '20,0',
 			ticks: 3,
-			tickSize: 3,
+			tickSize: 5,
 			//Do not use min value here on initialization. It's 0 and will not update later.
 			markedValue: 1
 		})


### PR DESCRIPTION
## Description

Addresses comments from previous PR (#2188)

Changes: 
1. Tooltip shows until users clicks on the color bar.
2. Removed space between the color bar and ticks

Test:
1. [Tooltip example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:%5B%7B%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:%7B%22id%22:%22Age%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D%7D)
2. [Space removed example](http://localhost:3000/?appcard=hic)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
