### PR TITLE
Update deps image version in ppserver and ppfull

### DIFF
--- a/.github/workflows/CD-publish-deps-image.yml
+++ b/.github/workflows/CD-publish-deps-image.yml
@@ -74,7 +74,10 @@ jobs:
             docker push ghcr.io/stjude/ppfull:$TAG
             docker push ghcr.io/stjude/ppserver:latest
             docker push ghcr.io/stjude/ppfull:latest
-          
+            
+            ./update_deps_version.sh $TAG ./full/Dockerfile
+            ./update_deps_version.sh $TAG ./server/Dockerfile
+            
             if [[ "$BRANCH" != "master" ]]; then
               echo "merging to master"
               git fetch --depth=10 origin master:master
@@ -89,5 +92,4 @@ jobs:
             git stash -a
             git pull --rebase
             git push origin master
-          
           fi

--- a/container/update_deps_version.sh
+++ b/container/update_deps_version.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# call from the container dir
+# ./update_deps_version.sh <new_version> <Dockerfile>
+# - new_version: the new deps image version to set in the Dockerfile
+
+# Check if both the version and path are passed as arguments
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <new_version> <path_to_dockerfile>"
+  exit 1
+fi
+
+NEW_VERSION=$1
+DOCKERFILE=$2
+
+# Check if the Dockerfile exists
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "Dockerfile not found at $DOCKERFILE"
+  exit 1
+fi
+
+# Use sed to find and replace the VERSION in the Dockerfile
+sed -i.bak "s/^ARG VERSION=.*/ARG VERSION=$NEW_VERSION/" "$DOCKERFILE"
+
+# Provide feedback to the user
+if [ $? -eq 0 ]; then
+  echo "Dockerfile updated successfully. VERSION is now set to $NEW_VERSION."
+else
+  echo "Failed to update Dockerfile."
+fi


### PR DESCRIPTION
## Description

@siosonel @xzhou82 I've tested the building of the deps docker image yesterday and I've automated the workflow, so it updates the deps image version in ppserver and ppfull docker file.

We don't have to test this on the branch, I've testing it yesterday. We can merge this PR and I'll run it on master.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
