### PR TITLE
fix: pass unfrozen filter to launch mds3 tk from Disco

### DIFF
--- a/client/plots/disco/interactions/DiscoInteractions.ts
+++ b/client/plots/disco/interactions/DiscoInteractions.ts
@@ -43,7 +43,7 @@ export class DiscoInteractions {
 						dslabel: this.discoApp.app.opts.state.dslabel,
 						hlaachange: mnames.join(','),
 						filter0,
-						filterObj: filter
+						filterObj: structuredClone(filter) // must not pass filter as frozen. duplicate to pass unfrozen copy so mds3 code will work
 					}
 				]
 			}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- pass unfrozen filter to launch mds3 tk from Disco


### PR DESCRIPTION
## Description

closes #2198 
test at http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-85-7710-01A and http://localhost:3000/?genome=hg19&dslabel=PNET&disco=1&sample=SJBT032239_D1

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
