### PR TITLE
fix geneSearchBox bugs

### DIFF
--- a/client/dom/genesearch.ts
+++ b/client/dom/genesearch.ts
@@ -129,6 +129,7 @@ insertion
 */
 
 export function addGeneSearchbox(arg: GeneSearchBoxArg) {
+	const debounceDelay = 500
 	const tip = arg.tip,
 		row = arg.row
 	const result: Result = {}
@@ -201,6 +202,9 @@ export function addGeneSearchbox(arg: GeneSearchBoxArg) {
 				input.blur()
 				tip.hide()
 
+				// delay for debounceDelay time, so that debounce fucntion could be executed after keyupEnter and before getResult.
+				await new Promise(resolve => setTimeout(resolve, debounceDelay))
+
 				// try to parse as gene
 				// get first gene match from menu
 				if (arg?.searchOnly != 'snp') {
@@ -209,6 +213,9 @@ export function addGeneSearchbox(arg: GeneSearchBoxArg) {
 						// gene match
 						const geneSymbol = hitgene.datum()
 						arg?.searchOnly == 'gene' ? getResult({ geneSymbol }, geneSymbol) : await geneCoordSearch(geneSymbol)
+
+						// clear gene hits
+						tip.showunder(searchbox.node()).clear()
 						return
 					}
 				}
@@ -383,7 +390,7 @@ export function addGeneSearchbox(arg: GeneSearchBoxArg) {
 			return
 		}
 	}
-	const debouncer = debounce(checkInput, 500)
+	const debouncer = debounce(checkInput, debounceDelay)
 
 	function displayVariantHits(tip, data) {
 		tip.d

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- fix geneSearchBox errors: 1. type a valid gene name and enter, see "Gene not found". 2. type a valid gene name and enter, see previous gene typed. 3. type a valid gene name and enter, gene hits still showing.


### PR DESCRIPTION
## Description
the geneSearchBox bugs: (exist in _portal.gdc.cancer.gov_, _proteinpaint.stjude.org_, localhost)

1. type a valid gene name and enter, if input entered quickly, see "Gene not found". 
2. type a valid gene name and enter slowly, and then type another gene and enter quickly, see the gene previously typed. 
3. type a valid gene name and enter, gene hits still showing.


related JIRA ticket: https://gdc-ctds.atlassian.net/browse/SV-2419

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
