### PR TITLE
use TwRouter.fill() as needed in call_fillTW(), in case the latter is…

### DIFF
--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -1004,6 +1004,21 @@ function checkLegacyTw(tw) {
 }
 
 async function call_fillTW(tw: TermWrapper, vocabApi: VocabApi, defaultQByTsHandler?: DefaultQByTsHandler) {
+	// repeating this logic from fillTermWrapper(), since call_fillTW() may be called directly
+	// TODO: may deprecate call_fillTW() once all term types have been migrated to xtw
+	if (routedTermTypes.has(tw.term?.type)) {
+		// NOTE: while the tw refactor is not done for all term types and q.types/modes,
+		// there will be some code duplication between TwRouter and the legacy code;
+		// the latter will be deleted once the refactor/migration is done
+		const fullTw = await TwRouter.fill(tw, { vocabApi, defaultQByTsHandler })
+		Object.assign(tw, fullTw)
+		mayValidateQmode(tw)
+		// this should be moved to the term-type specific handler??
+		if (!tw.$id) tw.$id = await get$id(vocabApi.getTwMinCopy(tw))
+		if (tw.q) tw.q.isAtomic = true
+		return tw
+	}
+
 	if (!tw.$id) tw.$id = await get$id(vocabApi.getTwMinCopy(tw))
 	const t = tw.term.type
 	const type = t == 'float' || t == 'integer' ? 'numeric' : (t as string)


### PR DESCRIPTION
… called directly

## Description

This moves uses migrated tw.fill() code instead of unmigrated ts handlers/[termtype] `.fillTW()` code, for term types that have been migrated.

Tested with 
- http://localhost:3000/testrun.html?name=*.unit
- `cd client && npm run test:integration`
- opening plots like matrix and bar chart from a dictionary tree menu
- adding filter items from a dictionary tree menu

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
