### PR TITLE
fix and improve git hook scripts 

### DIFF
--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -2,34 +2,39 @@
 
 set -e
 
-FILES=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.ts" "*.mjs" "*.cjs" | sed 's| |\\ |g')
-[ -z "$FILES" ] && exit 0
-
-echo "Prettifying $FILES ..."
-
-# Prettify all selected files
-# configuration are under the `"prettier": {}` object in package.json
-echo "$FILES" | xargs npx prettier --no-semi --use-tabs --write
-
-# Add back the modified/prettified files to staging
-echo "$FILES" | xargs git add
-
+STAGEDFILES=$(git diff --cached --name-only | sed 's| |\\ |g')
 # doing per GDC requirements
-pre-commit run --files "$FILES"
+pre-commit run --files "$STAGEDFILES"
 
-# lint against team preferences
-echo "Linting ..."
-echo "$FILES" | grep "\.ts" | xargs npx eslint
+# select changed/added file extensions where prettier format is preferred,
+# for other file extensions nests, prettier rules might not be preferred,
+# for example it nests html tags too much
+FILES=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.ts" "*.mjs" "*.cjs" | sed 's| |\\ |g')
 
-# check for invalid use of .Inner reference
-echo "checking for forbidden .Inner. usage"
-set +e
-PRODINNER=$(echo "$FILES" | xargs grep -lr --exclude=\*.spec\* --exclude=\*dist\/ --exclude=\*test\/ --exclude=\*.md "\.Inner\.")
-set -e
-if [[ "$PRODINNER" != "" ]]; then
-	echo "\n--- !!! forbidden use of .Inner. found in: !!! ---"
-	echo "$PRODINNER\n"
-	exit 1
-fi 
+if [[ "$FILES" != "" ]]; then
+	echo "Prettifying $FILES ..."
+
+	# Prettify all selected files
+	# configuration are under the `"prettier": {}` object in package.json
+	echo "$FILES" | xargs npx prettier --no-semi --use-tabs --write
+
+	# Add back the modified/prettified files to staging
+	echo "$FILES" | xargs git add
+
+	# lint against team preferences
+	echo "Linting ..."
+	echo "$FILES" | xargs npx eslint
+
+	# check for invalid use of .Inner reference
+	echo "checking for forbidden .Inner. usage"
+	set +e
+	PRODINNER=$(echo "$FILES" | xargs grep -lr --exclude=\*.spec\* --exclude=\*dist\/ --exclude=\*test\/ --exclude=\*.md "\.Inner\.")
+	set -e
+	if [[ "$PRODINNER" != "" ]]; then
+		echo "\n--- !!! forbidden use of .Inner. found in: !!! ---"
+		echo "$PRODINNER\n"
+		exit 1
+	fi
+fi
 
 exit 0

--- a/utils/hooks/pre-push
+++ b/utils/hooks/pre-push
@@ -2,7 +2,7 @@
 
 set -e
 
-FILES=$(git diff-tree --no-commit-id --name-only --diff-filter=M -r origin/master..HEAD)
+FILES=$(git diff-tree --no-commit-id --name-only --diff-filter=ACM -r origin/master..HEAD)
 echo "number of files to be checked=$(echo "$FILES" | wc -w)"
 # doing this per GDC requirements
 pre-commit run --files $FILES


### PR DESCRIPTION
## Description

Include more file extensions to format, lint, detect secrets as part of the pre-commit and pre-push hooks.

Tested with:
- `pre-commit run --all-files`: to make sure there are no undetected secrets in all files in latest commit
- create a test branch to trigger the commit hooks: (1) search for `pragma: allowlist secret` and remove that string from a few .html, .sh and other non-js files. The secret detection should run on all files, previously the pre-commit hook would only run on js/ts files. Note that the pre-push hook was already checking all modified, added, copied files. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
