### PR TITLE
Hover effects for the shape picker in mds3 legend

### DIFF
--- a/client/dom/shapes.js
+++ b/client/dom/shapes.js
@@ -1,3 +1,5 @@
+import { select as d3select } from 'd3-selection'
+
 //Icons from bootstrap: https://icons.getbootstrap.com/
 export const shapes = {
 	//circle filled
@@ -227,7 +229,6 @@ export function shapeSelector(div, callback, arr = shapesArray, opts = {}) {
 		.append('svg')
 		.attr('width', size * cols)
 		.attr('height', height)
-		.style('background-color', 'rgba(239, 239, 239, 0.3)')
 	let count = 0
 	let y = 0
 	for (const shape of arr) {
@@ -240,6 +241,12 @@ export function shapeSelector(div, callback, arr = shapesArray, opts = {}) {
 			.attr('transform', `translate(${size * count}, ${y * size})`)
 			.on('click', () => {
 				callback(index)
+			})
+			.on('mouseover', function () {
+				d3select(this).style('fill', 'black')
+			})
+			.on('mouseout', function () {
+				d3select(this).style('fill', 'gray')
 			})
 		count++
 		if (count % cols == 0) {

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -903,6 +903,7 @@ function createLegendTipMenu(opts, tk, elem) {
 					.style('border-radius', '5px')
 					.on('click', () => {
 						div.classed('sja_menuoption', false)
+						div.style('background-color', 'white')
 						if (called == false) {
 							called = true
 							renderShapePicker({

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -888,10 +888,21 @@ function createLegendTipMenu(opts, tk, elem) {
 				let called = false
 				const div = tk.legend.tip.d
 					.append('div')
-					.text('Change Shape')
+					.text('Change shape')
 					.style('vertical-align', 'middle')
-					.attr('class', 'sja_menuoption')
+					/** Adding the class here for the hover effect
+					 * Styles are repeated to maintain the appearance
+					 * of the menu item after the class (aka hover
+					 * effect) is removed.
+					 */
+					.classed('sja_menuoption', true)
+					.style('padding', '5px 10px')
+					.style('cursor', 'default')
+					.style('background-color', '#f2f2f2')
+					.style('margin', '1px')
+					.style('border-radius', '5px')
 					.on('click', () => {
+						div.classed('sja_menuoption', false)
 						if (called == false) {
 							called = true
 							renderShapePicker({


### PR DESCRIPTION
## Description
In the mds3 lollipop legend, the hover effect for 'Change shape' is removed onclick. The shapes change to black on hover. 

Test: 
1. [Lollipop example](http://localhost:3000/?appcard=Lollipop&example=Custom%20Variants)
2. [Scatter example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:{%22id%22:%22TSNE%20Category%22},%20%22shapeTW%22:%20{%22term%22:%20{%22gene%22:%20%22KRAS%22,%20%22type%22:%20%22geneVariant%22}}}]})


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
