### PR TITLE
Fix for radio buttons alignment in single cell plot

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -139,7 +139,7 @@ class singleCellPlot {
 				styles: { display: 'inline' },
 				callback: async value => this.onColorByChange(value)
 			})
-			searchboxDiv = headerDiv.append('div')
+			searchboxDiv = headerDiv.append('div').style('vertical-align', 'top').style('margin', '-3px 0px 10px')
 			geneSearch = addGeneSearchbox({
 				tip: new Menu({ padding: '0px' }),
 				genome: this.app.opts.genome,


### PR DESCRIPTION
## Description
Since the logic for the radio buttons changed, the buttons are out of alignment with the gene search box in the single cell plot. This is what it looks like in master: 
<img width="486" alt="Screenshot 2024-10-08 at 2 36 39 PM" src="https://github.com/user-attachments/assets/013fdc8e-fd66-49ff-96a3-80c2c6689bd8">

This is a simple fix to keep the buttons in alignment with the prompt and gene search box. 

Test with http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22BALL-scrna%22,%22nav%22:{%22header_mode%22:%22only_buttons%22},%22plots%22:[{%22chartType%22:%22singleCellPlot%22,%22sample%22:%22SJBALL030036_D1%22}]} -> Click back and forth between the radio buttons. -> buttons, prompt, and gene search box should remain in place. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
