### PR TITLE
Allowed to customize tabs top

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -311,7 +311,7 @@ function getProfileButtons(self, state) {
 		},
 		{
 			label: 'Radar 1',
-			tooltip: 'Radar 1-Score-based(Site)',
+			tooltip: () => 'Comparison of Institutional and Aggregated Score-based Results by Module',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',
@@ -326,7 +326,7 @@ function getProfileButtons(self, state) {
 		},
 		{
 			label: 'Radar 2',
-			tooltip:
+			tooltip: state =>
 				state.activeCohort == 0
 					? 'Comparison of Site Coordinator and POC Staff Impressions by Module'
 					: 'Score based results by PrOFILE module',
@@ -381,7 +381,7 @@ function setRenderers(self) {
 				chart.clickTo(chart)
 			})
 			.on('mouseover', (e, d) => {
-				if (d.tooltip) self.dom.tooltip.clear().showunder(e.target).d.text(d.tooltip)
+				if (d.tooltip) self.dom.tooltip.clear().showunder(e.target).d.text(d.tooltip(self.state))
 			})
 	}
 

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -326,7 +326,7 @@ function getProfileButtons(self, state) {
 		},
 		{
 			label: 'Radar 2',
-			tooltip: 'Radar 2-Impressions',
+			tooltip: 'Comparison of Site Coordinator and POC Staff Impressions by Module',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',
@@ -343,7 +343,7 @@ function getProfileButtons(self, state) {
 	if (state.activeCohort == 0) {
 		profileButtons.push({
 			label: 'Radar 3',
-			tooltip: 'Radar 3-Score-based(SC & POC)s',
+			tooltip: 'Comparison of SC and POC Score-based Results by Module',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -326,7 +326,10 @@ function getProfileButtons(self, state) {
 		},
 		{
 			label: 'Radar 2',
-			tooltip: 'Comparison of Site Coordinator and POC Staff Impressions by Module',
+			tooltip:
+				state.activeCohort == 0
+					? 'Comparison of Site Coordinator and POC Staff Impressions by Module'
+					: 'Score based results by PrOFILE module',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -283,7 +283,7 @@ function getChartTypeList(self, state) {
 function getProfileButtons(self, state) {
 	const profileButtons = [
 		{
-			label: 'Profile Polar',
+			label: 'Polar',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',
@@ -296,7 +296,7 @@ function getProfileButtons(self, state) {
 			chartType: 'profilePolar'
 		},
 		{
-			label: 'Profile Barchart',
+			label: 'Barchart',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -13,7 +13,8 @@ class MassCharts {
 	async init(appState) {
 		this.dom = {
 			holder: this.opts.holder,
-			tip: new Menu({ padding: '0px' })
+			tip: new Menu({ padding: '0px' }),
+			tooltip: new Menu({ padding: '4px' })
 		}
 		this.makeButtons(appState)
 	}
@@ -58,7 +59,7 @@ class MassCharts {
 
 	displayProfileButtons() {
 		this.dom.btns.style('display', d =>
-			d.label === 'Radar 3-Score-based(SC & POC)s'
+			d.label === 'Radar 3'
 				? this.state.activeCohort == 0
 					? ''
 					: 'none'
@@ -309,7 +310,8 @@ function getProfileButtons(self, state) {
 			chartType: 'profileBarchart'
 		},
 		{
-			label: 'Radar 1-Score-based(Site)',
+			label: 'Radar 1',
+			tooltip: 'Radar 1-Score-based(Site)',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',
@@ -323,7 +325,8 @@ function getProfileButtons(self, state) {
 			chartType: 'profileRadarFacility'
 		},
 		{
-			label: 'Radar 2-Impressions',
+			label: 'Radar 2',
+			tooltip: 'Radar 2-Impressions',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',
@@ -339,7 +342,8 @@ function getProfileButtons(self, state) {
 	]
 	if (state.activeCohort == 0) {
 		profileButtons.push({
-			label: 'Radar 3-Score-based(SC & POC)s',
+			label: 'Radar 3',
+			tooltip: 'Radar 3-Score-based(SC & POC)s',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',
@@ -372,6 +376,9 @@ function setRenderers(self) {
 			.on('click', function (event, chart) {
 				self.dom.tip.clear().showunder(this)
 				chart.clickTo(chart)
+			})
+			.on('mouseover', (e, d) => {
+				if (d.tooltip) self.dom.tooltip.clear().showunder(e.target).d.text(d.tooltip)
 			})
 	}
 

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -346,7 +346,7 @@ function getProfileButtons(self, state) {
 	if (state.activeCohort == 0) {
 		profileButtons.push({
 			label: 'Radar 3',
-			tooltip: 'Comparison of SC and POC Score-based Results by Module',
+			tooltip: () => 'Comparison of SC and POC Score-based Results by Module',
 			clickTo: () =>
 				self.app.dispatch({
 					type: 'plot_create',

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -197,7 +197,7 @@ function setRenderers(self) {
 			.style('float', 'right')
 			.style('font-size', '1.1em')
 			.style('margin-top', '50px')
-		//.text(appState.termdbConfig?.title?.text || cohort) //this line will be executed in update UI to reflect cohort changes
+			.text(appState.termdbConfig?.title?.text) //this line will be executed in update UI to reflect cohort changes
 
 		const tabDiv = header.append('div').style('display', 'none').style('vertical-align', 'bottom')
 		const controlsDiv = header
@@ -275,15 +275,19 @@ function setRenderers(self) {
 			// For either the COHORT or ABOUT tab
 			about: self.dom.subheaderDiv.append('div').style('display', 'none').attr('data-testid', 'sjpp-mass-about')
 		})
-
+		if (appState.termdbConfig?.tabs) {
+			chartTab.top = appState.termdbConfig.tabs.charts
+			filterTab.top = appState.termdbConfig.tabs.filter
+		}
 		self.tabs = [chartTab, groupsTab, filterTab /*, cartTab*/]
 		if (appState.termdbConfig.hideGroupsTab) self.tabs.splice(1, 1)
 		/** Adds either the COHORT or ABOUT tab
 		 * COHORT is added over ABOUT if both are defined
 		 */
+		const cohortTabTop = appState.termdbConfig?.tabs?.cohort || 'COHORT'
 		if (appState.termdbConfig?.selectCohort || appState.termdbConfig?.about) {
 			const aboutTab = appState.termdbConfig?.about?.tab || {}
-			const topLabel = appState.termdbConfig.selectCohort ? 'COHORT' : aboutTab.topLabel || ''
+			const topLabel = appState.termdbConfig.selectCohort ? cohortTabTop : aboutTab.topLabel || ''
 			const midLabel = aboutTab.midLabel || (aboutTab ? 'ABOUT' : '')
 			const btmLabel = aboutTab.btmLabel || ''
 
@@ -391,9 +395,6 @@ function setRenderers(self) {
 	}
 
 	self.updateUI = async (toggleSubheaderdiv = false) => {
-		const state = self.state
-		const cohort = getActiveCohortStr(state)
-		self.dom.titleDiv.text(state.termdbConfig?.title?.text || cohort)
 		if (!self.dom.subheaderDiv) return
 		if (self.activeTab && self.state.termdbConfig.selectCohort && self.activeCohort == -1) {
 			// showing charts or filter tab; cohort selection is enabled but no cohort is selected

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -92,6 +92,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 		urlTemplates: tdb.urlTemplates,
 		title: 'title' in ds.cohort ? ds.cohort.title : { text: ds.label },
 		hideGroupsTab: ds.cohort.hideGroupsTab,
+		tabs: ds.cohort.tabs,
 		tracks: tdb.tracks,
 		sampleTypes: ds.cohort.termdb.sampleTypes,
 		hasSampleAncestry: ds.cohort.termdb.hasSampleAncestry,

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1087,6 +1087,7 @@ type AssayAvailability = {
 //Shared with genome.ts
 export type Cohort = {
 	hideGroupsTab?: boolean
+	tabs?: { [index: string]: string } //Customizes tab top label
 	/** customize the default chart to open on mass ui when there's no charts. if missing it opens dictionary ui */
 	defaultChartType?: string
 	allowedChartTypes?: string[]


### PR DESCRIPTION
## Description

Allowed to customize tabs top. Removed cohort title to the right. Removed profile preffix from chart buttons as all the plots are profile plots and it saves some space for new plots. See also corresponding PR with dataset changes in [sjpp](https://github.com/stjude/sjpp/pull/519)

Note: To see also the db changes pull the latest db from hpc, that adds child_order.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
