### PR TITLE
Fix scatter plot shape selector 

### DIFF
--- a/client/dom/shapes.js
+++ b/client/dom/shapes.js
@@ -222,7 +222,7 @@ export function shapeSelector(div, callback, arr = shapesArray, opts = {}) {
 	const size = 20
 	const cols = 8
 	const height = Math.ceil(arr.length / cols) * size
-	div.style('background-color', 'backgroundColor' in opts ? opts.backgroundColor : '#f2f2f2')
+	div.style('background-color', 'backgroundColor' in opts ? opts.backgroundColor : 'white')
 	const svg = div
 		.append('div')
 		.style('padding', '5px')

--- a/client/plots/sampleScatter.interactivity.js
+++ b/client/plots/sampleScatter.interactivity.js
@@ -519,6 +519,7 @@ export function setInteractivity(self) {
 	self.changeShape = async function (key, shape) {
 		const tw = self.config.shapeTW
 		if (!tw.term.values) tw.term.values = {}
+		if (!tw.term.values[key]) tw.term.values[key] = {}
 		tw.term.values[key].shape = shape
 		await self.app.dispatch({
 			type: 'plot_edit',


### PR DESCRIPTION
## Description
Closes issue #2219 

Fix for the shape selector callback failing. As requested, changed the default background to white. 

Test with [scatter plot example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:%5B%7B%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:%7B%22id%22:%22TSNE%20Category%22%7D,%22shapeTW%22:%7B%22term%22:%7B%22gene%22:%22KRAS%22,%22type%22:%22geneVariant%22%7D%7D%7D%5D%7D)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
