### PR TITLE
fix: wait for the genelookup request to return before detecting when …

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- wait for the genelookup request to return before detecting when to display genesearch errors


### PR DESCRIPTION
…to display genesearch errors

## Description

Follow up fix for https://gdc-ctds.atlassian.net/issues/SV-2419?filter=12796. A slight delay in the genelookup in non-dev environments makes the debounceDelay insufficient as coded in a previous fix. 

Tested with:
- http://localhost:3000/testrun.html?name=*.unit
- `cd client && npm run test:integration`
- open genome browser, enter KRAS quickly and enter, there should not be any errors. Previously, there were errors similar to those described in the JIRA task.  

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
