### PR TITLE
Enable univariate-multivariate regression for all datasets

### DIFF
--- a/client/mass/test/regression.integration.spec.js
+++ b/client/mass/test/regression.integration.spec.js
@@ -163,8 +163,8 @@ tape('Linear: continuous outcome = "agedx", cat. independents = "sex" + "genetic
 		coefHeader.splice(3, 2, '95% CI')
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const linearHeaders = coefHeader.filter(d => d === 'Beta' || d === 't value')
-		test.equal(linearHeaders.length, 2, `Should render headers specific to linear regression`)
+		const linearHeaders = coefHeader.filter(d => d === 'Beta')
+		test.equal(linearHeaders.length, 1, `Should render headers specific to linear regression`)
 		const coefIntercept = [data.coefficients.intercept[0], data.coefficients.intercept[1]]
 		coefIntercept.push(...getCoefData(data.coefficients.intercept.slice(2)))
 		results = checkTableRow(table, 1, coefIntercept)
@@ -269,7 +269,7 @@ tape('Linear: continuous outcome = "agedx", continuous independent = "aaclassic_
 		)
 
 		const values2check = Array.from(table[2].childNodes).slice(3)
-		results = checkOnlyRowValues(values2check, data.coefficients.terms.aaclassic_5.fields)
+		results = checkOnlyRowValues(values2check, getCoefData(data.coefficients.terms.aaclassic_5.fields))
 		test.equal(results, true, `Should render all continous 'aaclassic_5' data in ${tableLabel}`)
 
 		//Type III Stats
@@ -398,13 +398,13 @@ tape('Linear: continuous outcome = "agedx", cubic spline independent = "aaclassi
 				//Skip the beginning cell spanning the remain rows
 				results = checkOnlyRowValues(
 					Array.from(tr.childNodes).slice(1),
-					data.coefficients.terms.aaclassic_5.categories[tr.childNodes[1].innerText]
+					getCoefData(data.coefficients.terms.aaclassic_5.categories[tr.childNodes[1].innerText])
 				)
 				test.equal(results, true, `Should render all ${tr.childNodes[1].innerText} data in ${tableLabel}`)
 			} else {
 				results = checkOnlyRowValues(
 					Array.from(tr.childNodes),
-					data.coefficients.terms.aaclassic_5.categories[tr.childNodes[0].innerText]
+					getCoefData(data.coefficients.terms.aaclassic_5.categories[tr.childNodes[0].innerText])
 				)
 				test.equal(results, true, `Should render all ${tr.childNodes[0].innerText} data in ${tableLabel}`)
 			}
@@ -471,8 +471,8 @@ tape('Logistic: binary outcome = "hrtavg", continuous independent = "agedx"', te
 		coefHeader.splice(3, 2, '95% CI')
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const logHeaders = coefHeader.filter(d => d === 'Odds ratio' || d === 'Log odds' || d === 'z value')
-		test.equal(logHeaders.length, 3, `Should render headers specific to logistic regression`)
+		const logHeaders = coefHeader.filter(d => d === 'Odds ratio')
+		test.equal(logHeaders.length, 1, `Should render headers specific to logistic regression`)
 
 		const coefIntercept = [data.coefficients.intercept[0], data.coefficients.intercept[1]]
 		coefIntercept.push(...getCoefData(data.coefficients.intercept.slice(2)))
@@ -573,14 +573,16 @@ tape('Cox: graded outcome = "Arrhythmias", continuous independent = "agedx"', te
 		tableLabel = 'coefficients table'
 		table = regDom.results.selectAll('div[name^="Coefficients"] table tr').nodes()
 		const coefHeader = structuredClone(data.coefficients.header)
+		coefHeader.splice(2, 2)
 		coefHeader.splice(3, 2, '95% CI')
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const coxHeaders = coefHeader.filter(d => d === 'HR' || d === 'z')
-		test.equal(coxHeaders.length, 2, `Should render headers specific to cox regression in ${tableLabel}`)
+		const coxHeaders = coefHeader.filter(d => d === 'HR')
+		test.equal(coxHeaders.length, 1, `Should render headers specific to cox regression in ${tableLabel}`)
 
 		testTerm = 'Age (years) at Cancer Diagnosis'
 		const checkValues1 = [testTerm, '(continuous)']
+		data.coefficients.terms.agedx.fields.splice(0, 2)
 		checkValues1.push(...getCoefData(data.coefficients.terms.agedx.fields))
 		results = checkTableRow(table, 1, checkValues1)
 		test.equal(results, true, `Should render all ${testTerm} data in ${tableLabel}`)
@@ -680,14 +682,16 @@ tape('Cox: survival outcome, continuous independent = "agedx"', test => {
 		tableLabel = 'coefficients table'
 		table = regDom.results.selectAll('div[name^="Coefficients"] table tr').nodes()
 		const coefHeader = structuredClone(data.coefficients.header)
+		coefHeader.splice(2, 2)
 		coefHeader.splice(3, 2, '95% CI')
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const coxHeaders = coefHeader.filter(d => d === 'HR' || d === 'z')
-		test.equal(coxHeaders.length, 2, `Should render headers specific to cox regression in ${tableLabel}`)
+		const coxHeaders = coefHeader.filter(d => d === 'HR')
+		test.equal(coxHeaders.length, 1, `Should render headers specific to cox regression in ${tableLabel}`)
 
 		testTerm = 'Age (years) at Cancer Diagnosis'
 		const checkValues1 = [testTerm, '(continuous)']
+		data.coefficients.terms.agedx.fields.splice(0, 2)
 		checkValues1.push(...getCoefData(data.coefficients.terms.agedx.fields))
 		results = checkTableRow(table, 1, checkValues1)
 		test.equal(results, true, `Should render all ${testTerm} data in ${tableLabel}`)

--- a/client/plots/regression.inputs.js
+++ b/client/plots/regression.inputs.js
@@ -208,8 +208,9 @@ function setRenderers(self) {
 			.text('Run analysis')
 			.on('click', self.submit)
 
+		// checkbox for whether or not to include univariate results
+		// along with multivariate results
 		self.dom.univariateCheckbox = self.dom.foot.append('div').style('display', 'none')
-
 		make_one_checkbox({
 			labeltext: 'Include univariate results',
 			checked: false,
@@ -357,9 +358,7 @@ function setRenderers(self) {
 		// is using a neuro-oncology dataset
 		self.dom.univariateCheckbox.style(
 			'display',
-			self.app.vocabApi.termdbConfig.neuroOncRegression && self.config.outcome && self.config.independent.length > 1
-				? 'block'
-				: 'none'
+			self.config.outcome && self.config.independent.length > 1 ? 'block' : 'none'
 		)
 		self.dom.univariateCheckbox.select('input[type=checkbox]').property('checked', self.config.includeUnivariate)
 	}

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -433,6 +433,11 @@ export class InputTerm {
 	renderInteractionOptions() {
 		const self = this
 		self.dom.tip.clear().showunder(self.dom.interactionDiv.node())
+		if (self.parent.config.includeUnivariate) {
+			const label = self.parent.dom.univariateCheckbox.select('label').text().trim()
+			self.dom.tip.d.append('div').text(`Cannot add interactions. Please uncheck the "${label}" checkbox.`)
+			return
+		}
 		self.dom.tip.d
 			.append('div')
 			.style('padding', '5px')

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -434,7 +434,7 @@ export class InputTerm {
 		const self = this
 		self.dom.tip.clear().showunder(self.dom.interactionDiv.node())
 		if (self.parent.config.includeUnivariate) {
-			const label = self.parent.dom.univariateCheckbox.select('label').text().trim()
+			const label = self.parent.dom.univariateCheckboxDiv.select('label').text().trim()
 			self.dom.tip.d.append('div').text(`Cannot add interactions. Please uncheck the "${label}" checkbox.`)
 			return
 		}

--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -79,6 +79,7 @@ class Regression {
 			await this.results.main()
 			this.inputs.resetSubmitButton()
 			this.inputs.mayShowUnivariateCheckbox()
+			this.inputs.mayShowSubmitMsgs()
 		} catch (e) {
 			if (this.inputs.hasError) {
 				// will hide the results ui
@@ -121,11 +122,9 @@ class Regression {
 			const tw = tws_restrictAncestry[0]
 			filters.push({ type: 'tvs', tvs: tw.q.restrictAncestry.tvs })
 			// notify user that samples will be restricted by ancestry
-			this.inputs.dom.submitMsg
-				.style('display', 'block')
-				.text(`restricting analysis to samples of ${tw.q.restrictAncestry.name}`)
+			this.inputs.submitMsgs.restrictAncestry = `Restricting analysis to samples of ${tw.q.restrictAncestry.name}`
 		} else {
-			this.inputs.dom.submitMsg.style('display', 'none')
+			delete this.inputs.submitMsgs.restrictAncestry
 		}
 
 		// store filters

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -637,10 +637,22 @@ function setRenderers(self) {
 				fillColumn2coefficientsTable(td.append('div'), term1, row.category1)
 				fillColumn2coefficientsTable(td.append('div'), term2, row.category2)
 			}
-			// col 3
-			forestPlotter(tr.append('td'), row.lst)
+
+			const cols = row.lst
+
+			if (self.config.regressionType == 'cox') {
+				// sample size and event count columns are present
+				// skip for now for interactions
+				// TODO: how to handle sample size/event counts for interactions?
+				cols.shift()
+				cols.shift()
+			}
+
+			// display forest plot
+			forestPlotter(tr.append('td'), cols)
+
 			// display data columns
-			fillDataColumns(tr, row.lst)
+			fillDataColumns(tr, cols)
 		}
 
 		// last row to show forest plot axis (call function without data)

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -478,8 +478,6 @@ function setRenderers(self) {
 
 		// padding is set on every <td>. need a better solution
 
-		const neuroOncCox = self.app.vocabApi.termdbConfig.neuroOncRegression && self.config.regressionType == 'cox'
-
 		// header row
 		let header
 		{
@@ -490,7 +488,7 @@ function setRenderers(self) {
 			// header for category column
 			tr.append('td').text(header.shift()).style('padding', '8px')
 			// skip headers for sample and event count columns
-			if (neuroOncCox) {
+			if (self.config.regressionType == 'cox') {
 				header.shift()
 				header.shift()
 			}
@@ -550,8 +548,7 @@ function setRenderers(self) {
 					fillColumn2coefficientsTable(td, tw)
 				}
 
-				if (neuroOncCox) {
-					// neuro-onc dataset using cox regression
+				if (self.config.regressionType == 'cox') {
 					// sample size and event count columns are present
 					// but do not need to report for continuous variable
 					cols.shift()
@@ -595,9 +592,8 @@ function setRenderers(self) {
 					const td = tr.append('td').style('padding', '8px')
 					fillColumn2coefficientsTable(td, tw, k)
 
-					if (neuroOncCox) {
-						// neuro-oncology dataset using cox regression
-						// sample size and event count columns are present
+					if (self.config.regressionType == 'cox') {
+						// sample size and event count columns present
 						// report sample sizes and event counts of coefficients
 						// for both ref and non-ref categories
 						const [samplesize_ref, samplesize_c] = cols.shift().split('/')
@@ -1129,8 +1125,7 @@ function setRenderers(self) {
 		}
 		///////// helpers
 		function numbers2array(_lst) {
-			const lst =
-				self.app.vocabApi.termdbConfig.neuroOncRegression && self.config.regressionType == 'cox' ? _lst.slice(2) : _lst // exclude sample and event count columns
+			const lst = self.config.regressionType == 'cox' ? _lst.slice(2) : _lst // exclude sample and event count columns
 			const m = Number(lst[midIdx])
 			if (!Number.isNaN(m)) values.push(m)
 			const l = Number(lst[CIlow]),

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -548,12 +548,19 @@ function setInteractivity(self) {
 		}
 		self.dom.tip.clear().showunder(self.dom.nopilldiv.node())
 		// create small menu, one option for each ele in noTermPromptOptions[]
+		const optionTip = new Menu()
 		for (const option of self.noTermPromptOptions) {
 			// {isDictionary, termtype, text, html, q{}}
 			const item = self.dom.tip.d
 				.append('div')
 				.attr('class', 'sja_menuoption sja_sharp_border')
-				.on('click', async () => {
+				.on('click', async event => {
+					optionTip.clear().hide()
+					if (option.invalid) {
+						// invalid option, display message
+						optionTip.show(event.clientX, event.clientY).d.append('div').text(option.invalidMsg)
+						return
+					}
 					self.dom.tip.clear()
 					if (option.isDictionary) {
 						await self.showTree(self.dom.tip.d.node())

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Features:
+- inclusion of univariate results in a multivariable regression analysis is now a user-controllable option that is enabled in all datasets

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -214,6 +214,8 @@ function parse_q(q, ds) {
 		// both univariate and multivariate analyses will be performed
 		if (q.independent.length < 2) throw 'multiple covariates expected'
 		if (q.independent.find(i => i.interactions.length)) throw 'interactions not allowed in univariate analysis'
+		if (q.independent.find(i => i.term.type == 'snplocus'))
+			throw 'snplocus term not supported in univariate/multivariable analysis'
 	}
 }
 

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -671,16 +671,16 @@ async function parseRoutput(Rinput, Routput, id2originalId, q, result) {
 			for (const row of in_coef.rows) {
 				if (row[0].indexOf(':') != -1) {
 					// is an interaction
-					const interaction = {}
 					const [id1, id2] = row.shift().split(':')
 					const [cat1, cat2] = row.shift().split(':')
+					const termid1 = id2originalId[id1]
+					const termid2 = id2originalId[id2]
 					// row is now only data fields
-					interaction.term1 = id2originalId[id1]
-					interaction.category1 = cat1
-					interaction.term2 = id2originalId[id2]
-					interaction.category2 = cat2
-					interaction.lst = row
-					out_coef.interactions.push(interaction)
+					const interactions = out_coef.interactions
+					if (!interactions.some(x => x.term1 == termid1 && x.term2 == termid2))
+						interactions.push({ term1: termid1, term2: termid2, categories: [] })
+					const interaction = interactions.find(x => x.term1 == termid1 && x.term2 == termid2)
+					interaction.categories.push({ category1: cat1, category2: cat2, lst: row })
 				} else {
 					// not interaction, individual variable
 					const id = row.shift()

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -401,11 +401,9 @@ function makeRinput(q, sampledata) {
 		binpath: serverconfig.binpath, // for importing regression utilities
 		data,
 		outcome,
-		independent
+		independent,
+		includeUnivariate: q.includeUnivariate
 	}
-
-	if (q.ds.cohort.termdb.neuroOncRegression) Rinput.neuroOnc = q.ds.cohort.termdb.neuroOncRegression
-	if (q.includeUnivariate) Rinput.includeUnivariate = q.includeUnivariate
 
 	return Rinput
 }

--- a/server/utils/regression.R
+++ b/server/utils/regression.R
@@ -127,7 +127,7 @@ benchmark[["buildFormulas"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dt
 stime <- Sys.time()
 cores <- detectCores()
 if (is.na(cores)) stop("unable to detect number of cores")
-reg_results <- mclapply(X = formulas, FUN = runRegression, regtype = input$regressionType, dat = dat, outcome = input$outcome, neuroOnc = input$neuroOnc, mc.cores = cores)
+reg_results <- mclapply(X = formulas, FUN = runRegression, regtype = input$regressionType, dat = dat, outcome = input$outcome, mc.cores = cores)
 etime <- Sys.time()
 dtime <- etime - stime
 benchmark[["runRegression"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dtime, "units")))

--- a/server/utils/regression.R
+++ b/server/utils/regression.R
@@ -127,7 +127,7 @@ benchmark[["buildFormulas"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dt
 stime <- Sys.time()
 cores <- detectCores()
 if (is.na(cores)) stop("unable to detect number of cores")
-reg_results <- mclapply(X = formulas, FUN = runRegression, regtype = input$regressionType, dat = dat, outcome = input$outcome, mc.cores = cores)
+reg_results <- mclapply(X = formulas, FUN = runRegression, regtype = input$regressionType, dat = dat, outcome = input$outcome, cachedir = input$cachedir, mc.cores = cores)
 etime <- Sys.time()
 dtime <- etime - stime
 benchmark[["runRegression"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dtime, "units")))

--- a/server/utils/regression.R
+++ b/server/utils/regression.R
@@ -138,10 +138,8 @@ benchmark[["runRegression"]] <- unbox(paste(round(as.numeric(dtime), 4), attr(dt
 ##################
 
 if (isTRUE(input$includeUnivariate)) {
-  # univariate analysis included along with multivariate analysis
-  # parse the results
-  # TODO: this function will not work with snplocus regression because it
-  # will combine results from multiple analyses into a single set of results
+  # univariate analysis included along with multivariable analysis
+  # parse the univariate/multivariable results
   reg_results <- parseUniMultiResults(reg_results, input$regressionType)
 }
 

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -651,11 +651,8 @@ build_coef_table <- function(res_summ) {
 
 # reformat the coefficients table
 formatCoefficients <- function(coefficients_table, res, regtype, dat) {
-  # round columns to 2 decimal places
-  # round p-value column to 3 significant digits
-  coefficients_table[,-ncol(coefficients_table)] <- round(coefficients_table[,-ncol(coefficients_table)], 2)
-  coefficients_table[,ncol(coefficients_table)] <- signif(coefficients_table[,ncol(coefficients_table)], 3)
-  
+  # round all columns to 4 significant digits
+  coefficients_table <- signif(coefficients_table, 4)
   # add variable and category columns
   if (regtype == "cox") {
     vCol <- vector(mode = "character")
@@ -737,7 +734,7 @@ formatCoefficients <- function(coefficients_table, res, regtype, dat) {
         eventcnt_c <- m["1",c]
         eCol <- c(eCol, paste(eventcnt_ref, eventcnt_c, sep = "/"))
       } else {
-        # continuous variable
+        # continuous or spline variable
         # set sample size and event count to NA
         sCol <- c(sCol, NA)
         eCol <- c(eCol, NA)

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -517,7 +517,7 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   # plot data
   plotfile <- paste0(cachedir, "splinePlot_", ifelse(is.null(formulatype), "", paste0(formulatype, "_")), createRandString(), ".png")
   png(filename = plotfile, width = 950, height = 550, res = 200)
-  par(mar = c(3, 2.5, 2, 5), mgp = c(1, 0.5, 0), xpd = T)
+  par(mar = c(3, 2.5, 1, 5) + 0.1, mgp = c(0.5, 0.5, 0), xpd = T)
   if (regtype == "linear" | regtype == "logistic") {
     if (regtype == "linear") {
       # for linear, plot predicted values
@@ -576,7 +576,7 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   else if (formulatype == "univariate") title <- "Univariate"
   else if (formulatype == "multivariate") title <- "Multivariable-adjusted"
   else stop("unexpected formula type")
-  title(main = title, cex.main = 0.75)
+  title(main = title, cex.main = 0.6)
   title(xlab = splineVariable$name,
         ylab = ylab,
         line = 1.5,

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -939,9 +939,8 @@ type Termdb = {
 	dataDownloadCatch?: DataDownloadCatch
 	helpPages?: URLEntry[]
 	multipleTestingCorrection?: MultipleTestingCorrection
-	/** regression settings for neuro-oncology portals:
+	/** regression settings for neuro-oncology datasets:
 	- no interaction terms
-	- report event counts of cox coefficients
 	- hide type III stats and miscellaneous statistical tests */
 	neuroOncRegression?: boolean
 	urlTemplates?: {

--- a/shared/types/src/termsetting.ts
+++ b/shared/types/src/termsetting.ts
@@ -43,6 +43,10 @@ export type NoTermPromptOptsEntry = {
 	text?: string
 	html?: string
 	q?: Q
+	/** whether or not opt is invalid */
+	invalid?: boolean
+	/** message displayed when opt is invalid */
+	invalidMsg?: string
 }
 
 type NumericContEditOptsEntry = {


### PR DESCRIPTION
## Description

The univariate/multivariate regression UI is now enabled for all datasets.
- Interactions and snplocus variables are not allowed in the univariate/multivariate view.
- Cubic spline is supported in the univariate/multivariate view

Miscellaneuous stylistic improvements have also been made to the regression UI.

Please test thoroughly using the sjlife dataset (linear/logistic/cox, regular view vs. univariate/multivariate view, continuous/discrete/categorical/spline variables, interactions, etc.)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
