### PR TITLE
Show the release version in the app header with github link

### DIFF
--- a/client/src/header/AppHeader.ts
+++ b/client/src/header/AppHeader.ts
@@ -128,16 +128,16 @@ export class AppHeader {
 		{
 			// a row for server stats
 			const row = headinfo.append('div').style('padding-left', '15px')
+			// link to the published ppfull container version, instead of github release tarball which we do not advertise;
+			// github's pkgs/container link has a timestamp before the tag, which cannot be computed here (but may be able to query later?)
+			const link = `https://github.com/stjude/proteinpaint/pkgs/container/ppfull` // url to list of published container versions
+			const version = this.data.pkgver
+				? `Version: <a href="${link}" target="${this.data.pkgver}">${this.data.pkgver}</a>`
+				: `Code date: ${this.data.codedate}` // default to using code date as before if pkgver is not available
 			row
 				.attr('id', 'sjpp-serverstat')
 				.append('span')
-				.html(
-					`${
-						this.data.pkgver
-							? `Release version: <a href="https://github.com/stjude/proteinpaint/releases/tag/v${this.data.pkgver}" target="${this.data.pkgver}">${this.data.pkgver}</a>`
-							: 'No version information available'
-					}, server launched: ${this.data.launchdate || '??'}.`
-				)
+				.html(`${version}, server launched: ${this.data.launchdate || '??'}.`)
 			if (this.data.hasblat) {
 				row
 					.append('a')

--- a/client/src/header/AppHeader.ts
+++ b/client/src/header/AppHeader.ts
@@ -131,8 +131,12 @@ export class AppHeader {
 			row
 				.attr('id', 'sjpp-serverstat')
 				.append('span')
-				.text(
-					'Code updated: ' + (this.data.codedate || '??') + ', server launched: ' + (this.data.launchdate || '??') + '.'
+				.html(
+					`${
+						this.data.pkgver
+							? `Release version: <a href="https://github.com/stjude/proteinpaint/releases/tag/v${this.data.pkgver}" target="${this.data.pkgver}">${this.data.pkgver}</a>`
+							: 'No version information available'
+					}, server launched: ${this.data.launchdate || '??'}.`
 				)
 			if (this.data.hasblat) {
 				row

--- a/client/src/header/test/AppHeader.integration.spec.ts
+++ b/client/src/header/test/AppHeader.integration.spec.ts
@@ -30,6 +30,7 @@ function getHeader(opts) {
 		data: {
 			// cardsPath: 'cards',
 			pkgver: '1.0.0',
+			codedate: 'Wed Oct 09 2024',
 			genomes
 		},
 		jwt: {}
@@ -101,7 +102,7 @@ tape('Validate app header rendering, makeheader()', async test => {
 
 	const codeMessage = holder.select('#sjpp-serverstat > span').node()
 	test.ok(
-		codeMessage && codeMessage['textContent'].includes(header.data.pkgver),
+		codeMessage?.['textContent']?.includes(header.data.pkgver),
 		'Should render server status message with the package version'
 	)
 

--- a/client/src/header/test/AppHeader.integration.spec.ts
+++ b/client/src/header/test/AppHeader.integration.spec.ts
@@ -29,7 +29,7 @@ function getHeader(opts) {
 		},
 		data: {
 			// cardsPath: 'cards',
-			codedate: 'Fri Jul 12 2024',
+			pkgver: '1.0.0',
 			genomes
 		},
 		jwt: {}
@@ -101,8 +101,8 @@ tape('Validate app header rendering, makeheader()', async test => {
 
 	const codeMessage = holder.select('#sjpp-serverstat > span').node()
 	test.ok(
-		codeMessage && codeMessage['textContent'].includes(header.data.codedate),
-		'Should render server status message with the codedate'
+		codeMessage && codeMessage['textContent'].includes(header.data.pkgver),
+		'Should render server status message with the package version'
 	)
 
 	if (test['_ok']) holder.remove()

--- a/front/init.js
+++ b/front/init.js
@@ -22,12 +22,11 @@ try {
 	}
 	if (fs.existsSync(`${CWD}/public/bin`)) {
 		console.log(`removing the old public/bin at ${CWD}`)
-		// TODO: node 12 in pp-prt does not support rmSync,
 		// should update as part of v16 upgrade
 		fs.rmdirSync(`${CWD}/public/bin`, { recursive: true, force: true }, () => {})
 	}
 	if (!fs.existsSync(`${CWD}/public/cards`)) {
-		console.log(`Coping cards into public/cards folder`)
+		console.log(`Copying cards into public/cards folder`)
 		execSync(`cp -r ${CWD}/node_modules/@sjcrh/proteinpaint-front/public/cards ${CWD}/public/cards`, {
 			stdio: 'inherit'
 		})
@@ -36,9 +35,17 @@ try {
 	if (tar.stderr) throw tar.stderr
 	console.log(`Setting the dynamic bundle path to ${URLPATH}`)
 	const codeFile = `${CWD}/public/bin/proteinpaint.js`
+	// remember the modified time before setting the bundle public path
+	const mtime = fs.statSync(codeFile).mtime
 	const code = fs.readFileSync(codeFile, { encoding: 'utf8' })
 	const newcode = code.replace(`__PP_URL__`, `${URLPATH}/bin/`)
 	fs.writeFileSync(codeFile, newcode, { encoding: 'utf8' }, () => {})
+	try {
+		// reset the atime and mtime to the original mtime before setting the bundle publit path
+		fs.utimesSync(codepath, mtime, mtime)
+	} catch (e) {
+		console.log('--- !!! unable to reset the mtime for the extracted proteinpaint bundle: ', e)
+	}
 } catch (e) {
 	console.error(e)
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- Instead of the `code updated` date, the header displays the release version a link to the appropriate github release page.

--- a/server/routes/genomes.ts
+++ b/server/routes/genomes.ts
@@ -65,7 +65,7 @@ function init({ genomes }) {
 			headermessage: serverconfig.headermessage,
 			base_zindex: serverconfig.base_zindex,
 			pkgver: versionInfo.pkgver,
-			codedate: versionInfo.codedate,
+			codedate: versionInfo.codedate, // still useful to know the package build/publish date in the response payload, even if it's not displayed
 			launchdate: versionInfo.launchdate,
 			hasblat,
 			features: serverconfig.features,

--- a/server/routes/genomes.ts
+++ b/server/routes/genomes.ts
@@ -64,6 +64,7 @@ function init({ genomes }) {
 			debugmode: serverconfig.debugmode,
 			headermessage: serverconfig.headermessage,
 			base_zindex: serverconfig.base_zindex,
+			pkgver: versionInfo.pkgver,
 			codedate: versionInfo.codedate,
 			launchdate: versionInfo.launchdate,
 			hasblat,

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -1,5 +1,6 @@
 import serverconfig from './serverconfig.js'
 import fs from 'fs'
+import path from 'path'
 import pkg from '../package.json'
 import type { VersionInfo, GenomeBuildInfo, HealthCheckResponse } from '#types'
 import { authApi } from './auth.js'
@@ -51,9 +52,13 @@ function setGenomeDbInfo(genomes, health) {
 	}
 }
 
+const codedate = get_codedate()
+const revFile = path.join(process.cwd(), 'public/rev.txt')
+const hash = fs.existsSync(revFile) && fs.readFileSync(revFile, { encoding: 'utf8' }).split(' ')[1]
+
 export const versionInfo: VersionInfo = {
-	pkgver: pkg.version,
-	codedate: get_codedate(),
+	pkgver: pkg.version + '-' + (hash || codedate),
+	codedate, // still useful to know the package build/publish date in the response payload, even if it's not displayed
 	launchdate: new Date(Date.now()).toString().split(' ').slice(0, 5).join(' '),
 	deps: {}
 }
@@ -109,5 +114,10 @@ function get_codedate() {
 	const date2 =
 		(fs.existsSync('public/bin/proteinpaint.js') && fs.statSync('public/bin/proteinpaint.js').mtime) || new Date(0)
 	const date = date1 > date2 ? date1 : date2
-	return date.toDateString()
+	const year = date.getUTCFullYear()
+	const month = (date.getUTCMonth() + 1).toString().padStart(2, '0') // months from 1-12
+	const day = date.getUTCDate().toString().padStart(2, '0')
+	const hours = date.getHours().toString().padStart(2, '0')
+	const minutes = date.getMinutes().toString().padStart(2, '0')
+	return `${year}${month}${day}.${hours}:${minutes}`
 }


### PR DESCRIPTION
## Description
Closes issue #2226 

If this is the desired replacement text and functionality, then I can add something similar to the mass UI. 
Test: Open any local page with the header -> http://localhost:3000. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
