### PR TITLE
gdc bam: increase number of queried cases in order to max out number …

### DIFF
--- a/client/gdc/test/bam.spec.js
+++ b/client/gdc/test/bam.spec.js
@@ -90,7 +90,7 @@ tape('Hide token input', test => {
 		const handle = await detectOne({ elem: holder, selector: '.sja-gdcbam-listCaseFileHandle' })
 		test.equal(
 			handle.innerHTML,
-			'Or, Browse 594 Available BAM Files',
+			'Or, Browse 1000 Available BAM Files',
 			'List case file handle is shown with correct text'
 		)
 

--- a/server/src/bam.gdc.js
+++ b/server/src/bam.gdc.js
@@ -84,7 +84,7 @@ const entityTypes = [
 
 const skip_workflow_type = 'STAR 2-Pass Transcriptome'
 
-const maxCaseNumber = 150 // max number of cases to request based on cohort
+const maxCaseNumber = 300 // max number of cases to request based on cohort. use big number of 300 but not 150 allows number of available bams to easily max out listCaseFileSize which is desirable on client
 const listCaseFileSize = 1000 // max number of bam files to request based on case ids
 
 let queryApi


### PR DESCRIPTION
…of available bams on client

## Description

please pull sjpp master and test with http://localhost:3000/example.gdc.bam.html

it is by design to only show up to 1000 available bam files when that number is very big

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
