### PR TITLE
Default about tab for datasets

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -33,7 +33,7 @@ export type Button = {
 // ariaLabelledBy is an optional attribute on the array object,
 // if present, will be used as aria-labelledby attribute on the
 // radio or checkbox input element, to address Section 508 requirement
-type TableRow = Cell[] & { ariaLabelledBy?: string }
+export type TableRow = Cell[] & { ariaLabelledBy?: string }
 
 export type TableArgs = {
 	columns: Column[] //List of table columns
@@ -52,7 +52,7 @@ export type TableArgs = {
 	maxHeight?: string //The max height of the table, 40vh by default
 
 	selectedRows?: number[] //Preselect rows specified
-	selectAll: boolean //Preselect all rows
+	selectAll?: boolean //Preselect all rows
 	resize?: boolean //Allow to resize the table height dragging the border
 	selectedRowStyle?: any //An object of arbitrary css key-values on how to style selected rows,
 	//for example `{text-decoration: 'line-through'}`. If a row is not

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -167,6 +167,7 @@ class MassAbout {
 	}
 
 	showReleaseVersion = () => {
+		if (!this.app.opts.pkgver) return
 		this.subheader
 			.append('div')
 			.style('margin-left', '10px')

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -22,7 +22,6 @@ class MassAbout {
 	aboutOverrides: AboutObj | null
 	activeCohort: number
 	app: MassAppApi
-	cohortNames: string[]
 	dom: any
 	instanceNum: number
 	selectCohort: any
@@ -37,14 +36,13 @@ class MassAbout {
 		this.activeCohort = opts.activeCohort
 		this.aboutOverrides = opts.aboutOverrides
 		this.selectCohort = opts.selectCohort
-		this.cohortNames = opts.selectCohort.values.map((d: any) => d.keys.slice().sort().join(','))
 		this.dom = {}
 
-		if (opts.selectCohort.title) {
+		if (opts.selectCohort?.title) {
 			this.dom.cohortTitle = opts.subheader.append('h2').style('margin-left', '10px').text(opts.selectCohort.title)
 		}
 
-		if (opts.selectCohort.description || opts.selectCohort.descriptionByUser) {
+		if (opts.selectCohort?.description || opts.selectCohort?.descriptionByUser) {
 			//temporary logic to get the description until the login is implemented
 			const loginInfo = getProfileLogin()
 			if (loginInfo[2]) {
@@ -53,7 +51,7 @@ class MassAbout {
 			}
 		}
 
-		if (opts.selectCohort.prompt) {
+		if (opts.selectCohort?.prompt) {
 			this.dom.cohortPrompt = this.subheader
 				.append('div')
 				.style('margin-left', '10px')
@@ -73,7 +71,6 @@ class MassAbout {
 			this.subheader.append('div').style('padding', '10px').html(this.aboutOverrides.html)
 		}
 		this.initCohort()
-
 		//Always show the release version at the bottom
 		this.showReleaseVersion()
 	}
@@ -84,12 +81,12 @@ class MassAbout {
 
 	initCohort = () => {
 		if (this.selectCohort == null) return
-		//Move back to nav.js
-		// self.dom.tds.filter(d => d.colNum === 0).style('display', '')
+
 		const instanceNum = this.instanceNum
 		const activeCohort = this.activeCohort
 		const app = this.app
 		const state = () => this.app.getState()
+
 		this.dom.cohortOpts
 			.append('table')
 			.selectAll('tr')

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -1,36 +1,230 @@
 import { getCompInit } from '../rx'
 import { Elem } from '../types/d3'
 import { MassAppApi } from './types/mass'
+import { renderTable, TableRow } from '#dom'
+import { select } from 'd3-selection'
+import { getProfileLogin } from '../plots/profilePlot.js'
 
 type AboutObj = {
 	html: string
 }
 
 type MassAboutOpts = {
+	aboutOverrides: AboutObj | null
+	activeCohort: number
 	app: MassAppApi
-	holder: Elem
-	features: AboutObj
+	instanceNum: number
+	selectCohort: any
+	subheader: Elem
 }
 
 class MassAbout {
-	type: string
+	aboutOverrides: AboutObj | null
+	activeCohort: number
 	app: MassAppApi
-	holder: Elem
-	features: AboutObj
+	cohortNames: string[]
+	dom: any
+	instanceNum: number
+	selectCohort: any
+	subheader: Elem
+	type: string
 
 	constructor(opts: MassAboutOpts) {
 		this.type = 'about'
 		this.app = opts.app
-		this.holder = opts.holder
-		this.features = opts.features
+		this.subheader = opts.subheader
+		this.instanceNum = opts.instanceNum
+		this.activeCohort = opts.activeCohort
+		this.aboutOverrides = opts.aboutOverrides
+		this.selectCohort = opts.selectCohort
+		this.cohortNames = opts.selectCohort.values.map((d: any) => d.keys.slice().sort().join(','))
+		this.dom = {}
+
+		if (opts.selectCohort.title) {
+			this.dom.cohortTitle = opts.subheader.append('h2').style('margin-left', '10px').text(opts.selectCohort.title)
+		}
+
+		if (opts.selectCohort.description || opts.selectCohort.descriptionByUser) {
+			//temporary logic to get the description until the login is implemented
+			const loginInfo = getProfileLogin()
+			if (loginInfo[2]) {
+				const description = opts.selectCohort.descriptionByUser?.[loginInfo[2]]
+				this.dom.cohortDescription = this.subheader.append('div').style('margin-left', '10px').html(description)
+			}
+		}
+
+		if (opts.selectCohort.prompt) {
+			this.dom.cohortPrompt = this.subheader
+				.append('div')
+				.style('margin-left', '10px')
+				.style('padding-top', '30px')
+				.style('padding-bottom', '10px')
+				.style('font-weight', 'bold')
+				.text(opts.selectCohort.prompt)
+		}
+
+		if (opts.selectCohort) {
+			this.dom.cohortOpts = this.subheader.append('div').style('margin-bottom', '30px').style('margin-left', '10px')
+		}
 	}
 
 	init() {
-		this.holder.append('div').style('padding', '10px').html(this.features.html)
+		if (this.aboutOverrides) {
+			this.subheader.append('div').style('padding', '10px').html(this.aboutOverrides.html)
+		}
+		this.initCohort()
+
+		//Always show the release version at the bottom
+		this.showReleaseVersion()
 	}
 
-	main() {
-		//TODO: May add code for interactive elements here at a later time.
+	async main() {
+		await this.renderCohortsTable()
+	}
+
+	initCohort = () => {
+		if (this.selectCohort == null) return
+		//Move back to nav.js
+		// self.dom.tds.filter(d => d.colNum === 0).style('display', '')
+		const instanceNum = this.instanceNum
+		const activeCohort = this.activeCohort
+		const app = this.app
+		const state = () => this.app.getState()
+		this.dom.cohortOpts
+			.append('table')
+			.selectAll('tr')
+			.data(this.selectCohort.values)
+			.enter()
+			.append('tr')
+			.each(function (d, i, nodes) {
+				const tr = select(nodes[i])
+				const td0 = tr.append('td')
+				const radioName = 'sja-termdb-cohort-' + instanceNum
+				const radioId = radioName + '-' + i
+				td0
+					.append('input')
+					.attr('type', 'radio')
+					.attr('name', radioName)
+					.attr('id', radioId)
+					.attr('value', i)
+					.property('checked', i === activeCohort)
+					.style('margin-right', '5px')
+					.style('margin-left', '0px')
+					.on('click', async () => {
+						const s = state()
+						const clearOnChange = s.termdbConfig.selectCohort.clearOnChange
+						if (clearOnChange) {
+							const subactions: { [index: string]: string | number | any }[] = [{ type: 'cohort_set', activeCohort: i }]
+							if (clearOnChange.filter)
+								subactions.push({
+									type: 'filter_replace',
+									filter: {
+										type: 'tvslst',
+										in: true,
+										join: '',
+										tag: 'filterUiRoot',
+										lst: []
+									}
+								})
+							if (clearOnChange.plots)
+								for (const plot of s.plots) {
+									subactions.push({
+										type: 'plot_delete',
+										id: plot.id
+									})
+								}
+
+							app.dispatch({
+								type: 'app_refresh',
+								subactions
+							})
+						} else app.dispatch({ type: 'cohort_set', activeCohort: i })
+					})
+
+				td0
+					.append('label')
+					.attr('for', radioId)
+					.attr('colspan', 2)
+					.style('cursor', 'pointer')
+					.html((d: any) => d.label)
+
+				tr.selectAll('td')
+					.style('max-width', '600px')
+					.style('padding-bottom', '10px')
+					.style('padding-right', '20px')
+					.style('vertical-align', 'top')
+			})
+
+		this.dom.cohortInputs = this.dom.cohortOpts.selectAll('input')
+		this.dom.cohortTable = this.subheader.append('div').style('margin-left', '12px')
+
+		if (this.selectCohort.asterisk) {
+			this.dom.cohortAsterisk = this.subheader
+				.append('div')
+				.style('margin-left', '10px')
+				.style('padding-top', '20px')
+				.style('padding-bottom', '20px')
+				.style('font-size', 'small')
+				.text(this.selectCohort.asterisk)
+		}
+	}
+
+	showReleaseVersion = () => {
+		this.subheader
+			.append('div')
+			.style('margin-left', '10px')
+			.style('padding-bottom', '5px')
+			.style('font-size', '.8em')
+			.text('Release version: ')
+			.append('a')
+			.property('href', 'https://github.com/stjude/proteinpaint/pkgs/container/ppfull')
+			.property('target', `${this.app.opts.pkgver}`)
+			.text(`${this.app.opts.pkgver}`)
+	}
+
+	renderCohortsTable = async () => {
+		if (!this.dom.cohortTable) return
+		this.dom.cohortTable.selectAll('*').remove()
+		const columns = [{ label: 'Feature' }]
+		const rows: TableRow[] = []
+		const result = await this.app.vocabApi.getCohortsData()
+		if ('error' in result) throw result.error
+		if (!result.cfeatures.length) return
+		for (const feature of result.features) rows.push([{ value: feature.name }])
+		for (const cohort of result.cohorts) {
+			columns.push({ label: cohort.name })
+			for (const [i, feature] of result.features.entries()) {
+				const cf = result.cfeatures.find(cf => cf.idfeature === feature.idfeature && cf.cohort === cohort.cohort)
+				if (cf) rows[i].push({ value: cf.value })
+			}
+		}
+
+		renderTable({
+			rows,
+			columns,
+			div: this.dom.cohortTable,
+			showLines: false,
+			maxHeight: '60vh'
+		})
+
+		this.dom.cohortTable.select('table').style('border-collapse', 'collapse')
+		this.dom.cohortTable.selectAll(`tbody > tr > td`).style('background-color', 'transparent').style('padding', '6px')
+		const state = this.app.getState()
+		const selectCohort = state.termdbConfig.selectCohort
+		const keys = selectCohort.values[this.activeCohort].keys
+		let selector = `tbody > tr > td:nth-child(${this.activeCohort + 2})`
+		const combined = keys.length > 1
+		if (combined) {
+			selector = ''
+			for (const key of keys) {
+				const i = result.cohorts.map(c => c.cohort).indexOf(key)
+				if (selector !== '') selector += ','
+				selector += `tbody > tr > td:nth-child(${i + 2})`
+			}
+		}
+		const activeColumns = this.dom.cohortTable.selectAll(selector)
+		activeColumns.style('background-color', 'yellow')
+		this.dom.cohortInputs.property('checked', (d, i) => i === this.activeCohort)
 	}
 }
 

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -289,13 +289,12 @@ function setRenderers(self) {
 		Object.assign(filterTab, massNav?.tabs?.filter)
 
 		if (massNav?.tabs?.groups?.hide) self.tabs.splice(1, 1)
-		/** Updates tab for cohorts */
-		if (appState.termdbConfig?.selectCohort) {
+		/** Updates about tab for cohorts */
+		if (appState.termdbConfig?.selectCohort && !massNav?.tabs?.about) {
 			aboutTab.top = 'COHORT'
 			aboutTab.mid = ''
 			aboutTab.btm = ''
 		}
-
 		const tabIdx = appState.termdbConfig?.selectCohort ? 0 : massNav?.tabs?.about?.order || 0
 		self.tabs.splice(tabIdx, 0, aboutTab)
 

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -479,8 +479,8 @@ function setRenderers(self) {
 			self.dom.subheader[key].style('display', self.tabs[self.activeTab].subheader === key ? 'block' : 'none')
 		}
 
-		if (self.opts.header_mode === 'with_cohort_select') {
-			self.dom.cohortSelect.selectAll('option').property('value', appState.activeCohort)
+		if (self.opts.header_mode === 'with_cohortHtmlSelect') {
+			self.dom.cohortSelect.selectAll('option').property('value', self.activeCohort)
 		}
 	}
 }

--- a/client/mass/types/mass.d.ts
+++ b/client/mass/types/mass.d.ts
@@ -64,12 +64,5 @@ type MassNav = {
 	activeTab: number
 	/** -1: unselected, 0,1,2...: selected */
 	activeCohort: number
-	header_mode:
-		| 'only_buttons'
-		| 'with_tabs'
-		| 'search_only'
-		| 'hidden'
-		| 'hide_search'
-		| 'with_cohortHtmlSelect'
-		| 'with_cohort_select'
+	header_mode: 'only_buttons' | 'with_tabs' | 'search_only' | 'hidden' | 'hide_search' | 'with_cohortHtmlSelect'
 }

--- a/client/mass/types/mass.d.ts
+++ b/client/mass/types/mass.d.ts
@@ -1,11 +1,27 @@
 import { RxAppApi } from '../../types/rx'
-import { Menu } from '../../dom/menu'
+import { Menu } from '#dom'
 import { Elem } from '../../types/d3'
+import { ClientCopyGenome } from 'types/global'
 
 export type MassAppApi = RxAppApi & {
 	Inner: MassApp
 	printError: (e: string) => void
 	tip: Menu
+	opts: {
+		/** TODO!! -> {} */
+		callbacks: any
+		genome: ClientCopyGenome
+		holder: Elem
+		/** Current release version. See https://github.com/stjude/proteinpaint/releases */
+		pkgver: string
+		/** TODO!! These are probably defined somehwere else */
+		state: {
+			vocab: {
+				dslabel: string
+				genome: string
+			}
+		}
+	}
 	/** Should be a type for TermdbVocab or Frontend Vocab later */
 	vocabApi: any
 }

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -157,7 +157,8 @@ upon error, throw err message as a string
 		const opts = {
 			debug: arg.app.debugmode,
 			holder: arg.holder,
-			state
+			state,
+			pkgver: arg.app.pkgver
 		}
 		if (state.genome) {
 			opts.genome = arg.genomes[state.genome]
@@ -182,7 +183,8 @@ upon error, throw err message as a string
 				debug: arg.app.debugmode,
 				holder: arg.holder,
 				state,
-				genome: arg.genomes[state.vocab.genome]
+				genome: arg.genomes[state.vocab.genome],
+				pkgver: arg.app.pkgver
 			}
 		}
 		if (urlp.has('mass-session-url')) {
@@ -196,7 +198,8 @@ upon error, throw err message as a string
 				debug: arg.app.debugmode,
 				holder: arg.holder,
 				state,
-				genome: arg.genomes[state.vocab.genome]
+				genome: arg.genomes[state.vocab.genome],
+				pkgver: arg.app.pkgver
 			}
 		}
 		const _ = await import('../mass/app')
@@ -240,7 +243,8 @@ upon error, throw err message as a string
 			state: res.state,
 			genome: arg.genomes[res.state.vocab.genome],
 			sessionDaysLeft: res.sessionDaysLeft,
-			sessionId: id
+			sessionId: id,
+			pkgver: arg.app.pkgver
 		}
 		const _ = await import('../mass/app')
 		_.appInit(opts)


### PR DESCRIPTION
## Description
Closes issue #2253.

Changes: 
1. All about/cohort tab content moved to `client/mass/about.ts`. This encapsulates the tab logic and the content logic.  
2. The about tab is added by default and shown as the active tab unless otherwise specified. 
3. Fixed code for an invalid `header_mode`. 

Test: 
1. [Termdb example](http://localhost:3000/?noheader=1&massnative=hg38-test,TermdbTest) -> Note there is no change to the cohort lables in the tab. Also note the release version message at the bottom has been updated. To test various scenarios, comment out `...selectCohort` and uncomment `..massNav.tabs.about` in `server/dataset/termdb.test.ts`. 
2. [Profile example](http://localhost:3000/profile/index.html) -> Note all the tab customizations from `.massNav` still display. 
3. [MB meta example](http://localhost:3000/?noheader=1&massnative=hg38,MB_meta_analysis) -> See the about tab show by default with only the release version in the subheader. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
