### PR TITLE
If a small number of radios, show in a single line by default

### DIFF
--- a/client/dom/radiobutton.ts
+++ b/client/dom/radiobutton.ts
@@ -64,8 +64,18 @@ export function make_radios(opts: RadioButtonOpts): RadioApi {
 
 	/** Fix to allow the display to be customizable but show buttons
 	 * in a single line if 3 or less options. Otherwise display vertically. */
-	const displayMode =
-		opts.styles && 'display' in opts.styles ? opts.styles.display : opts.options.length <= 3 ? 'inline-block' : 'block'
+	// const displayMode =
+	// 	opts.styles && 'display' in opts.styles ? opts.styles.display : opts.options.length <= 3 ? 'inline-block' : 'block'
+
+	const displayMode = () => {
+		if (opts.styles && 'display' in opts.styles) return opts.styles.display
+		else {
+			let len = 0
+			opts.options.forEach((d: any) => (len = len + d.label.length))
+			if (len <= 25) return 'inline-block'
+			else return 'block'
+		}
+	}
 
 	const labels = divs
 		.enter()

--- a/client/dom/radiobutton.ts
+++ b/client/dom/radiobutton.ts
@@ -62,19 +62,13 @@ export function make_radios(opts: RadioButtonOpts): RadioApi {
 		.style('display', 'block')
 		.data(opts.options, (d: any) => d?.value)
 
-	/** Fix to allow the display to be customizable but show buttons
-	 * in a single line if 3 or less options. Otherwise display vertically. */
-	// const displayMode =
-	// 	opts.styles && 'display' in opts.styles ? opts.styles.display : opts.options.length <= 3 ? 'inline-block' : 'block'
-
 	const displayMode = () => {
-		if (opts.styles && 'display' in opts.styles) return opts.styles.display
-		else {
-			let len = 0
-			opts.options.forEach((d: any) => (len = len + d.label.length + 4))
-			if (len <= 30) return 'inline-block'
-			else return 'block'
-		}
+		if (opts.styles?.display) return opts.styles.display // use defined style
+		// no style specified. compute automatic style. if total length of all options is small, show all options in one row; otherwise one row per option. this allows to limit width in 2-col edit menu setting
+		let len = 0 // count by total number of characters. radio button counts as 4 characters
+		opts.options.forEach((d: any) => (len = len + d.label.length + 4))
+		if (len <= 30) return 'inline-block'
+		return 'block'
 	}
 
 	const labels = divs

--- a/client/dom/radiobutton.ts
+++ b/client/dom/radiobutton.ts
@@ -71,8 +71,8 @@ export function make_radios(opts: RadioButtonOpts): RadioApi {
 		if (opts.styles && 'display' in opts.styles) return opts.styles.display
 		else {
 			let len = 0
-			opts.options.forEach((d: any) => (len = len + d.label.length))
-			if (len <= 25) return 'inline-block'
+			opts.options.forEach((d: any) => (len = len + d.label.length + 4))
+			if (len <= 30) return 'inline-block'
 			else return 'block'
 		}
 	}

--- a/client/dom/radiobutton.ts
+++ b/client/dom/radiobutton.ts
@@ -62,11 +62,16 @@ export function make_radios(opts: RadioButtonOpts): RadioApi {
 		.style('display', 'block')
 		.data(opts.options, (d: any) => d?.value)
 
+	/** Fix to allow the display to be customizable but show buttons
+	 * in a single line if 3 or less options. Otherwise display vertically. */
+	const displayMode =
+		opts.styles && 'display' in opts.styles ? opts.styles.display : opts.options.length <= 3 ? 'inline-block' : 'block'
+
 	const labels = divs
 		.enter()
 		.append('div')
 		.attr('aria-label', (d: OptionEntry) => d.title)
-		.style('display', opts.styles && 'display' in opts.styles ? opts.styles.display : 'block')
+		.style('display', displayMode)
 		.style('padding', opts.styles && 'padding' in opts.styles ? opts.styles.padding : '3px')
 		.append('label')
 

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -344,6 +344,9 @@ function mayAddSkewerModeOption(tk, block) {
 			.append('div')
 			.attr('class', 'sja_pp_vlb_viewmoderadiodiv') // for testing
 			.style('margin', '10px'),
+		styles: {
+			display: 'block'
+		},
 		options,
 		callback: async idx => {
 			for (const i of tk.skewer.viewModes) i.inuse = false

--- a/client/src/block.tk.aicheck.js
+++ b/client/src/block.tk.aicheck.js
@@ -285,7 +285,6 @@ function configPanel(tk, block) {
 				loadTk(tk, block)
 			},
 			styles: {
-				display: 'inline-block',
 				'margin-right': '5px'
 			}
 		})

--- a/client/src/block.tk.bam.js
+++ b/client/src/block.tk.bam.js
@@ -1590,7 +1590,7 @@ function configPanel(tk, block) {
 				{ label: 'Single', value: false, checked: !tk.asPaired },
 				{ label: 'Paired', value: true, checked: tk.asPaired }
 			],
-			styles: { display: 'inline-block', margin: '10px 5px' },
+			styles: { margin: '10px 5px' },
 			callback: v => {
 				tk.asPaired = v
 				loadTk(tk, block)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- if a small number of radios, show in a single line by default


### PR DESCRIPTION
## Description

~~NOTE: Converted to draft until final release to qa-yellow is done this week. This may affect our tools in GFF, just playing it safe to not have to test many things.~~  (Update: pp-client 2.81.2 should be good in GFF prod release) 

Closes issue #2251. 

Test:
1. [DE example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22sjmb12%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22DEanalysis%22,%22samplelst%22:{%22groups%22:[{%22name%22:%22group%201%22,%22in%22:true,%22values%22:[{%22sampleId%22:81},{%22sampleId%22:83},{%22sampleId%22:225},{%22sampleId%22:223},{%22sampleId%22:208},{%22sampleId%22:220},{%22sampleId%22:96},{%22sampleId%22:100}]},{%22name%22:%22group%202%22,%22in%22:true,%22values%22:[{%22sampleId%22:48},{%22sampleId%22:80},{%22sampleId%22:222},{%22sampleId%22:198},{%22sampleId%22:218},{%22sampleId%22:219},{%22sampleId%22:93}]}],%22groupsetting%22:{%22disabled%22:false},%22isAtomic%22:true,%22type%22:%22custom-samplelst%22}}]}) -> Open the hamburger menu. Should see the radios inline. 
2. [Violin example from issue](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22hrtavg%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D,%22nav%22:%7B%22activeTab%22:1%7D%7D) -> Same as above. 
3. [SJLife example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22hrtavg%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D,%22nav%22:%7B%22activeTab%22:1%7D%7D) -> Same as 1, above. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
