### PR TITLE
cachedFetch() should not cache error response

### DIFF
--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -216,7 +216,6 @@ function gdcValidateQuery(ds: any, genome: any) {
 					body: getGeneSelectionArg(q)
 				},
 				{
-					noCache: true,
 					// use an already decoded response.body as argument
 					getErrMessage: ({ body }) => {
 						// no error message if there is a gene_selection array in the response payload

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -216,8 +216,9 @@ function gdcValidateQuery(ds: any, genome: any) {
 					body: getGeneSelectionArg(q)
 				},
 				{
-					getErrMessage: r => {
-						const body = r.body || r
+					noCache: true,
+					// use an already decoded response.body as argument
+					getErrMessage: body => {
 						// no error message if there is a gene_selection array in the response payload
 						return Array.isArray(body.gene_selection) ? '' : body.message || body.error || JSON.stringify(body)
 					}

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -218,7 +218,7 @@ function gdcValidateQuery(ds: any, genome: any) {
 				{
 					noCache: true,
 					// use an already decoded response.body as argument
-					getErrMessage: body => {
+					getErrMessage: ({ body }) => {
 						// no error message if there is a gene_selection array in the response payload
 						return Array.isArray(body.gene_selection) ? '' : body.message || body.error || JSON.stringify(body)
 					}

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -887,7 +887,7 @@ export async function cachedFetch(url, opts = {}, use = {}) {
 				// - In the meantime, replacing ky with node-fetch may be a good enough fix for edge cases of very large, long-running requests.
 				jsonBody = await nodeFetch(url, opts)
 					.then(async r => {
-						const contentType = r.headers.get('content-type') //.map(k => r.headers[k].toLowerCase()); console.log(888, contentType)
+						const contentType = r.headers.get('content-type')
 						const payload = contentType == 'application/json' ? await r.json() : await r.text()
 						if (!r.ok || (typeof r.status == 'number' && r.status > 299))
 							throw `error from ${url}: ` + (payload.message || payload.error || JSON.stringify(payload))


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/2275 and https://github.com/stjude/proteinpaint/issues/2274.

This fix only affects mostly dev, since the `serverconfig.features.extApiCache` is not used in any qa or prod environments.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
