### PR TITLE
cutting off the survival plot after maxTimeToEvent

### DIFF
--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -166,7 +166,6 @@ export class TermdbVocab extends Vocab {
 		}
 		if (opts.filter0) body.filter0 = opts.filter0
 
-		if (opts.maxTimeToEvent) body.maxTimeToEvent = opts.maxTimeToEvent
 		if ('grade' in opts) body.grade = opts.grade
 		if ('minSampleSize' in opts) body.minSampleSize = opts.minSampleSize
 

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -96,11 +96,7 @@ export async function get_survival(q, ds) {
 
 		// perform survival analysis for each chart
 		for (const chartId in byChartSeries) {
-			let data = byChartSeries[chartId]
-			if (q.maxTimeToEvent) {
-				// Filter out the survival data with Time to event longer than survial time cut-off (defined in dataset)
-				data = data.filter(d => d.time <= q.maxTimeToEvent)
-			}
+			const data = byChartSeries[chartId]
 			const survival_data = JSON.parse(
 				await run_R(path.join(serverconfig.binpath, 'utils', 'survival.R'), JSON.stringify(data))
 			)

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -867,7 +867,7 @@ type SortPriorityEntry = {
 }
 
 type SurvivalSettings = {
-	/** filters out all the survival data with Time-to-Event longer than this maxTimeToEvent */
+	/** The max time-to-event to be displayed in plot, hide all the samples with Time-to-Event longer than this maxTimeToEvent */
 	maxTimeToEvent?: number
 }
 


### PR DESCRIPTION
## Description
cutting off the survival plot after maxTimeToEvent, while keeping all the data. most clinicians care more about 0,5 and 10 years survival time.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
