### PR TITLE
fix: allow to customize cnv colorscale in mds3 tk

### DIFF
--- a/client/mds3/cnv.js
+++ b/client/mds3/cnv.js
@@ -4,6 +4,12 @@ import { table_cnv } from './itemtable'
 import { table2col } from '#dom'
 
 /*
+
+tk.cnv = {
+	presetMax: number // if set, use this to set colorscale domain
+	absoluteMax: number // if presetMax is not set, use this for colorscale domain
+}
+
 to find out if server can return a cnv segment with >1 samples
 
 click cnv legend to:
@@ -29,9 +35,10 @@ export function may_render_cnv(data, tk, block) {
 	// FIXME if this tk is subtk keep value from parent tk and do not overwrite
 	tk.cnv.absoluteMax = absoluteMax
 
-	tk.cnv.colorScale = scaleLinear([-absoluteMax, 0, absoluteMax], [tk.cnv.lossColor, 'white', tk.cnv.gainColor]).clamp(
-		true
-	)
+	tk.cnv.colorScale = scaleLinear(
+		tk.cnv.presetMax ? [-tk.cnv.presetMax, 0, tk.cnv.presetMax] : [-absoluteMax, 0, absoluteMax],
+		[tk.cnv.lossColor, 'white', tk.cnv.gainColor]
+	).clamp( true)
 
 	const [rowheight, rowspace] = getRowHeight(cnvBySample || cnvLst)
 

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -238,6 +238,8 @@ function showSummary4oneTerm(termid, div, numbycategory, tk, block) {
 			filterObj: getNewFilter(tk, newTvs),
 			allow2selectSamples: tk.allow2selectSamples
 		}
+		if(tk.cnv?.presetMax) tkarg.cnv={presetMax: tk.cnv.presetMax} // preset value is present, pass to subtk
+		// TODO mclass
 		const tk2 = block.block_addtk_template(tkarg)
 		block.tk_load(tk2)
 	}

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -827,10 +827,7 @@ function may_create_cnv(tk, block) {
 		barwidth: axiswidth,
 		barheight,
 		colors: [tk.cnv.lossColor, 'white', tk.cnv.gainColor],
-		//[-tk.cnv.absoluteMax, tk.cnv.absoluteMax]
-		// Neither value available on init
-		// Added during update
-		data: [-1, 1],
+		data: [-1,0, 1], // actual domain added during update
 		fontSize: 12,
 		holder: R.holder,
 		height: axisheight + barheight,
@@ -838,14 +835,18 @@ function may_create_cnv(tk, block) {
 		position: `${xpad},${axisheight}`,
 		ticks: 4,
 		tickSize: 6,
-		topTicks: true
+		topTicks: true,
+		setMinMax: number=>{
+			tk.cnv.presetMax=Math.abs(number)
+			tk.load()
+		}
 	})
 }
 
 function may_update_cnv(tk) {
 	if (!tk.cnv) return
 	tk.legend.cnv.colorScale.colors = [tk.cnv.lossColor, 'white', tk.cnv.gainColor]
-	tk.legend.cnv.colorScale.data = [-tk.cnv.absoluteMax, tk.cnv.absoluteMax]
+	tk.legend.cnv.colorScale.data = tk.cnv.presetMax ? [-tk.cnv.presetMax,0,tk.cnv.presetMax] : [-tk.cnv.absoluteMax, 0,tk.cnv.absoluteMax]
 	tk.legend.cnv.colorScale.updateScale()
 }
 

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -339,15 +339,14 @@ function mayInitCnv(tk) {
 		}
 	}
 	if (!cfg) return // lack this. no cnv from this tk
-	tk.cnv = {
-		g: tk.glider.append('g'),
-		cnvMaxLength: cfg.cnvMaxLength, // if missing do not filter
-		cnvGainCutoff: cfg.cnvGainCutoff, // if missing do not filter
-		cnvLossCutoff: cfg.cnvLossCutoff,
-		absoluteValueRenderMax: cfg.absoluteValueRenderMax || 5,
-		gainColor: cfg.gainColor || '#D6683C',
-		lossColor: cfg.lossColor || '#67a9cf'
-	}
+	if(!tk.cnv) tk.cnv={} // preserve
+	tk.cnv.g= tk.glider.append('g')
+	tk.cnv.cnvMaxLength= cfg.cnvMaxLength // if missing do not filter
+	tk.cnv.cnvGainCutoff= cfg.cnvGainCutoff // if missing do not filter
+	tk.cnv.cnvLossCutoff= cfg.cnvLossCutoff
+	tk.cnv.absoluteValueRenderMax= cfg.absoluteValueRenderMax || 5
+	tk.cnv.gainColor= cfg.gainColor || '#D6683C'
+	tk.cnv.lossColor= cfg.lossColor || '#67a9cf'
 }
 
 function setSkewerMode(tk) {


### PR DESCRIPTION
## Description

closes #2294 
test at http://localhost:3000/?genome=hg38&block=1&position=chr8:127711430-129748930&mds3=ASH. set either min/max to 1.5 to take effect


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
