### PR TITLE
fix: do not allow <3 genes in the termdb/cluster request

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- do not allow <3 genes in the termdb/cluster request
+- do not allow <3 genes in the termdb/cluster request and instruct the user to do a page refresh to clear the error

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -47,6 +47,12 @@ function init({ genomes }) {
 				throw 'The server has not finished caching the case IDs: try again in about 2 minutes.'
 			if (q.dataType == TermTypes.GENE_EXPRESSION || q.dataType == TermTypes.METABOLITE_INTENSITY) {
 				if (!ds.queries?.[q.dataType]) throw `no ${q.dataType} data on this dataset`
+				if (!q.terms) throw `missing gene list`
+				if (!Array.isArray(q.terms)) throw `gene list is not an array`
+				// TODO: there should be a fix on the client-side to handle this error more gracefully,
+				// instead of emitting the client-side instructions from the server response and forcing a reload
+				if (q.terms.length < 3)
+					throw `A minimum of three genes is required for clustering. Please refresh this page to clear this error.`
 				result = (await getResult(q, ds)) as TermdbClusterResponse
 			} else {
 				throw 'unknown q.dataType ' + q.dataType


### PR DESCRIPTION
## Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2526, by showing a more relevant and informative message.

![Screenshot 2024-10-21 at 2 35 53 PM](https://github.com/user-attachments/assets/4c769ec5-fc1c-4c63-9dd4-f1a2dbcb8b0e)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
