### PR TITLE
fix: prototype cnv filter prompt to change cnvMaxLength

### DIFF
--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -827,7 +827,7 @@ function may_create_cnv(tk, block) {
 		.style('font-size', '.8em')
 		.attr('class', 'sja_clbtext')
 		.on('click', () => {
-			menu.clear().showunder(R.cnvFilterPrompt.node()) // TODO show above prompt
+			menu.clear().showunder(R.cnvFilterPrompt.node()) // TODO as this prompt is usually at bottom of page, best to show menu above prompt
 			menu.d.append('div').text('Max segment length. Set 0 for not restricting by max length.')
 			menu.d
 				.append('input')
@@ -836,6 +836,7 @@ function may_create_cnv(tk, block) {
 				.on('change', event => {
 					const v = Number(event.target.value)
 					tk.cnv.cnvMaxLength = v <= 0 ? null : v
+					menu.hide()
 					tk.load()
 				})
 		})

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -1,6 +1,6 @@
 import { legend_newrow } from '#src/block.legend'
 import { Menu, ColorScale, icons, shapes } from '#dom'
-import { mclass, dt2label, dtcnv, dtloh, dtitd, dtsv, dtfusionrna, mclassitd } from '#shared/common.js'
+import { mclass, dt2label, dtcnv, dtloh, dtitd, dtsv, dtfusionrna, mclassitd, bplen } from '#shared/common.js'
 import { interpolateRgb } from 'd3-interpolate'
 import { showLDlegend } from '../plots/regression.results'
 import { rgb } from 'd3-color'
@@ -816,8 +816,31 @@ function may_create_cnv(tk, block) {
 	// contents are filled in dynamically
 	R.headerTd = R.row.append('td').style('text-align', 'right').style('opacity', 0.7).text('CNV')
 	R.holder = R.row.append('td')
-	R.showHolder = R.holder.append('div').style('display', 'none')
+	R.colorscaleHolder = R.holder.append('div') // visibility determined by if any segments are shown in view range
+	R.noCnv = R.holder.append('div').text('No data').style('opacity', 0.6).style('margin-left', '10px') // indicator there's no cnv data
+	// prompt to show cnv filter stats. click prompt to show menu to adjust filter parameters
+	const menu = new Menu()
+	R.cnvFilterPrompt = R.holder
+		.append('div')
+		.style('display', 'inline-block')
+		.style('margin-left', '10px')
+		.style('font-size', '.8em')
+		.attr('class', 'sja_clbtext')
+		.on('click', () => {
+			menu.clear().showunder(R.cnvFilterPrompt.node()) // TODO show above prompt
+			menu.d.append('div').text('Max segment length. Set 0 for not restricting by max length.')
+			menu.d
+				.append('input')
+				.attr('type', 'number')
+				.attr('value', Number.isFinite(tk.cnv.cnvMaxLength) ? tk.cnv.cnvMaxLength : 0)
+				.on('change', event => {
+					const v = Number(event.target.value)
+					tk.cnv.cnvMaxLength = v <= 0 ? null : v
+					tk.load()
+				})
+		})
 
+	// initiate colorscale component
 	const axisheight = 20
 	const barheight = 15
 	const xpad = 10
@@ -827,17 +850,17 @@ function may_create_cnv(tk, block) {
 		barwidth: axiswidth,
 		barheight,
 		colors: [tk.cnv.lossColor, 'white', tk.cnv.gainColor],
-		data: [-1,0, 1], // actual domain added during update
+		data: [-1, 0, 1], // actual domain added during update
 		fontSize: 12,
-		holder: R.holder,
+		holder: R.colorscaleHolder,
 		height: axisheight + barheight,
 		width: xpad * 2 + axiswidth,
 		position: `${xpad},${axisheight}`,
 		ticks: 4,
 		tickSize: 6,
 		topTicks: true,
-		setMinMax: number=>{
-			tk.cnv.presetMax=Math.abs(number)
+		setMinMax: number => {
+			tk.cnv.presetMax = Math.abs(number)
 			tk.load()
 		}
 	})
@@ -845,9 +868,28 @@ function may_create_cnv(tk, block) {
 
 function may_update_cnv(tk) {
 	if (!tk.cnv) return
-	tk.legend.cnv.colorScale.colors = [tk.cnv.lossColor, 'white', tk.cnv.gainColor]
-	tk.legend.cnv.colorScale.data = tk.cnv.presetMax ? [-tk.cnv.presetMax,0,tk.cnv.presetMax] : [-tk.cnv.absoluteMax, 0,tk.cnv.absoluteMax]
-	tk.legend.cnv.colorScale.updateScale()
+	// tk is equipped with cnv. determine if cnv data is actually shown
+	if (tk.cnv.cnvLst.length == 0) {
+		// no cnv shown in this region. hide colorscale
+		tk.legend.cnv.colorscaleHolder.style('display', 'none')
+		tk.legend.cnv.noCnv.style('display', 'inline-block')
+	} else {
+		// has cnv shown
+		tk.legend.cnv.colorscaleHolder.style('display', 'inline-block')
+		tk.legend.cnv.noCnv.style('display', 'none')
+		// update colorscale
+		tk.legend.cnv.colorScale.colors = [tk.cnv.lossColor, 'white', tk.cnv.gainColor]
+		tk.legend.cnv.colorScale.data = tk.cnv.presetMax
+			? [-tk.cnv.presetMax, 0, tk.cnv.presetMax]
+			: [-tk.cnv.absoluteMax, 0, tk.cnv.absoluteMax]
+		tk.legend.cnv.colorScale.updateScale()
+	}
+	// update filter prompt. each applicable filter criteria generates a phrase. concatenated phrases are shown in prompt
+	// must do this even if no cnv is shown, which could be caused by filter param and allow to change here
+	const lst = [
+		Number.isFinite(tk.cnv.cnvMaxLength) ? `segment length <= ${bplen(tk.cnv.cnvMaxLength)}` : 'no length limit'
+	]
+	tk.legend.cnv.cnvFilterPrompt.text(`Filter: ${lst.join(', ')}`)
 }
 
 function createLegendTipMenu(opts, tk, elem) {

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -813,18 +813,21 @@ function may_create_cnv(tk, block) {
 	if (!tk.cnv) return
 	const R = (tk.legend.cnv = {})
 	R.row = tk.legend.table.append('tr')
-	// contents are filled in dynamically
 	R.headerTd = R.row.append('td').style('text-align', 'right').style('opacity', 0.7).text('CNV')
-	R.holder = R.row.append('td')
+	R.holder = R.row.append('td').style('padding-left', '10px')
+	// make all pieces that are arranged left to right inside <td>
 	R.colorscaleHolder = R.holder.append('div') // visibility determined by if any segments are shown in view range
-	R.noCnv = R.holder.append('div').text('No data').style('opacity', 0.6).style('margin-left', '10px') // indicator there's no cnv data
+	R.colorscaleHolder.append('span').text('Loss').style('font-size', '.8em').style('opacity', 0.6) // "Loss" label on left of colorscale
+	const csHolder = R.colorscaleHolder.append('span') // actual holder of colorscale
+	R.colorscaleHolder.append('span').text('Gain').style('font-size', '.8em').style('opacity', 0.6) // "Loss" label on left of colorscale
+	R.noCnv = R.holder.append('div').text('No data').style('opacity', 0.6) // indicator there's no cnv in the region
+	const menu = new Menu() // launched by prompt
 	// prompt to show cnv filter stats. click prompt to show menu to adjust filter parameters
-	const menu = new Menu()
 	R.cnvFilterPrompt = R.holder
 		.append('div')
 		.style('display', 'inline-block')
 		.style('margin-left', '10px')
-		.style('font-size', '.8em')
+		.style('font-size', '.9em')
 		.attr('class', 'sja_clbtext')
 		.on('click', () => {
 			menu.clear().showunder(R.cnvFilterPrompt.node()) // TODO as this prompt is usually at bottom of page, best to show menu above prompt
@@ -853,7 +856,7 @@ function may_create_cnv(tk, block) {
 		colors: [tk.cnv.lossColor, 'white', tk.cnv.gainColor],
 		data: [-1, 0, 1], // actual domain added during update
 		fontSize: 12,
-		holder: R.colorscaleHolder,
+		holder: csHolder,
 		height: axisheight + barheight,
 		width: xpad * 2 + axiswidth,
 		position: `${xpad},${axisheight}`,

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- prototype cnv filter prompt to change cnvMaxLength


### PR DESCRIPTION
## Description

closes #2302 
[test link](http://localhost:3000/?genome=hg38&block=1&position=chr8:127711430-129748930&mds3=ASH). click the prompt on the right of colorscale. change value to 0 to get 4k segments

also in [centromere region with no cnv](http://localhost:3000/?genome=hg38&block=1&position=chr1:126525824-127180585&mds3=ASH), the colorscale is now hidden

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
