### PR TITLE
New unit column in phenotree parsing. 

### DIFF
--- a/client/src/databrowser/dictionary.parse.js
+++ b/client/src/databrowser/dictionary.parse.js
@@ -124,10 +124,9 @@ export function parseDictionary(input) {
 		/* 
 		Parses phenotree:
 			- Parses tab delim data arranged in cols: levels(n), variable (i.e. term_id), type, and categories 
-			(i.e. previous configuration).
-			- Only the vairable and type cols are required
-			- Blank and '-' values for levels converted to null -- how to distinguish between no id vs no 
-			hierarchy??
+			(i.e. previous configuration) as well as unit.
+			- Only the variable and type cols are required
+			- Blank and '-' values for levels converted to null.
 			- Assumptions:
 				1. Headers required. `Variable', 'Type', 'Categories', and 'Unit' may appear anywhere. 
 				'Level_[XX]' for optional hierarchy/level columns. 'Unit' is optional for numeric terms.

--- a/client/src/databrowser/dictionary.parse.js
+++ b/client/src/databrowser/dictionary.parse.js
@@ -123,11 +123,14 @@ export function parseDictionary(input) {
 	function parsePhenotree(lines, header) {
 		/* 
 		Parses phenotree:
-			- Parses tab delim data arranged in cols: levels(n), variable (i.e. term_id), type, and categories (i.e. previous configuration).
+			- Parses tab delim data arranged in cols: levels(n), variable (i.e. term_id), type, and categories 
+			(i.e. previous configuration).
 			- Only the vairable and type cols are required
-			- Blank and '-' values for levels converted to null -- how to distinguish between no id vs no hierarchy??
+			- Blank and '-' values for levels converted to null -- how to distinguish between no id vs no 
+			hierarchy??
 			- Assumptions:
-				1. Headers required. `Variable', 'Type', and 'Categories' may appear anywhere. 'Level_[XX]' for optional hierarchy/level columns. 
+				1. Headers required. `Variable', 'Type', 'Categories', and 'Unit' may appear anywhere. 
+				'Level_[XX]' for optional hierarchy/level columns. 'Unit' is optional for numeric terms.
 				2. Levels are defined left to right, highest to lowest, and in order, no gaps.
 				3. No blanks or '-' between levels as well as no duplicate values in the same line.
 				4. No identical term ids
@@ -147,6 +150,8 @@ export function parseDictionary(input) {
 		const levelColIndexes = header.map((c, i) => (c.toLowerCase().includes('level_') ? i : -1)).filter(i => i != -1)
 		//If no level cols provided, use key/Variable col as single level. Will print the id as name
 		if (!levelColIndexes.length) levelColIndexes.push(variableIndex)
+
+		const unitIndex = header.findIndex(l => l.toLowerCase().includes('unit'))
 
 		/** Old implementation
 		 * .attributes is passed to the term obj (see below) but not used.
@@ -193,7 +198,6 @@ export function parseDictionary(input) {
 				if (firstDashIndex != -1 && firstDashIndex < cols.indexOf(name)) {
 					throw `Blank or '-' value detected between levels in line ${lineNum}`
 				}
-
 				const term = parseCategories(cols[typeIndex], cols[categoriesIndex], cols[additionalAttrIndexes], lineNum, name)
 
 				const id = cols[variableIndex] || name
@@ -216,6 +220,7 @@ export function parseDictionary(input) {
 					lineNum, // to be deleted later
 					additionalAttributes: term.attributes
 				}
+				if (cols[unitIndex] != null) terms[id].unit = cols[unitIndex]
 				termNameToId[name] = id
 				parentTermNames.add(terms[id].parent_name)
 			} catch (e) {

--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -658,6 +658,72 @@ tape('uncomputable category is empty string but not number', function (test) {
 	test.end()
 })
 
+tape.only('add unit to term', function (test) {
+	test.timeoutAfter(100)
+	const tsv = [
+		`Level_1\tLevel_2\tLevel_3\tLevel_4\tLevel_5\tVariable\ttype\tCategories\tUnit`,
+		`Root\tL2\tL3\t-\t-\tdiaggrp\tcategorical\t`,
+		`Root\tAge at Sample\t-\t-\t-\tsnp6_sample_age\tinteger\t{\"999\":{\"label\":\"N/A:CCSS\"}}\tyears`
+	].join('\n')
+	const message = `Should add unit to term`
+	try {
+		const holder = getHolder()
+		const results = parseDictionary(tsv)
+		const expected = [
+			{
+				id: 'diaggrp',
+				name: 'L3',
+				type: 'categorical',
+				values: {},
+				groupsetting: {
+					disabled: true
+				},
+				additionalAttributes: {},
+				child_order: 1,
+				isleaf: true,
+				parent_id: 'L2'
+			},
+			{
+				id: 'snp6_sample_age',
+				name: 'Age at Sample',
+				type: 'integer',
+				groupsetting: undefined,
+				values: {
+					999: {
+						label: 'N/A:CCSS',
+						uncomputable: true
+					}
+				},
+				additionalAttributes: {},
+				child_order: 2,
+				isleaf: true,
+				unit: 'years',
+				parent_id: 'Root'
+			},
+			{
+				id: 'Root',
+				name: 'Root',
+				isleaf: false,
+				child_order: 1,
+				parent_id: null
+			},
+			{
+				id: 'L2',
+				name: 'L2',
+				isleaf: false,
+				child_order: 1,
+				parent_id: 'Root'
+			}
+		]
+		test.deepEqual(results.terms, expected, message)
+		test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
+	} catch (e) {
+		test.fail(message + ': ' + e)
+	}
+
+	test.end()
+})
+
 /***********************************
  reusable helper vars and functions
 ************************************/

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Feature: 
+- Phenotree parser accepts a new 'unit' column for numeric terms. 


### PR DESCRIPTION
## Description
Closes issue #2277. See new unit test. 

Test: 
http://localhost:3000/?appcard=Data%20Browser
Copy and paste into UI
```
Level_1	Level_2	Level_3	Level_4	Level_5	Variable	type	Categories	Unit
Genomic Profiling Status	Whole Genome Sequencing	-	-	-	wgs_sequenced	categorical	{"1":{"label":"Yes"}}
Genomic Profiling Status	Affymetrix Genome-Wide Human SNP Array 6.0	-	-	-	snp6_genotyped	categorical	{"1":{"label":"Yes"}, "0":{"label":"No"}, "-994":{"label":"N/A:CCSS"} }
Genomic Profiling Status	Whole Genome Sequencing Curated Variant Calls	-	-	-	wgs_curated	categorical	{"1":{"label":"Yes"}, "-9999":{"label":"Pending review"} }
Genomic Profiling Status	Age (years) at genomic sample collection	-	-	-	wgs_sample_age	integer	{"-9999":{"label":"Unknown"}}	years
Genomic Profiling Status	Age (years) at SNP Array 6.0 sample collection	-	-	-	snp6_sample_age	integer	{"-994":{"label":"N/A:CCSS"}}	years
Cancer-related Variables	Diagnosis	Diagnosis Group	-	-	diaggrp	categorical	
Cancer-related Variables	Diagnosis	Diagnosis Code	-	-	dxcode	integer	{"-9999":{"label":"Pending"}}
Cancer-related Variables	Diagnosis	Diagnosis Code Description	-	-	dxcode_text	categorical	{"-9999":{"label":"Pending"}}
Cancer-related Variables	Diagnosis	Diagnosis Year	-	-	yeardx	integer		years
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Alkylating Agents, mg/m2	Cyclophosphamide	cyclophosphamide_5	float	{"0":{"label":"not exposed;"}, "-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Alkylating Agents, mg/m2	Cumulative Alkylating Agents (Cyclophosphamide Equivalent Dose)	aaclassic_5	float	{"0":{"label":"not exposed;"}, "-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Anthracyclines, mg/m2	Doxorubicin (IV)	doxorubicin_5	float	{"-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Anthracyclines, mg/m2	Daunorubicin (IV)	daunorubicin_5	float	{"-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Anthracyclines, mg/m2	Epirubicin (IV)	epirubicin_5	float	{"-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Anthracyclines, mg/m2	Idarubicin (IV)	idarubicin_5	float	{"-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Anthracyclines, mg/m2	Mitoxantrone (IV)	mitoxantrone_5	float	{"-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Anthracyclines, mg/m2	Cumulative Anthracyclines (Doxorubicin Equivalent Dose, COG method)	anthracyclines_cog_5	float	{"-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
Cancer-related Variables	Treatment	Chemotherapy, First 5 Years of Therapy	Anthracyclines, mg/m2	Cumulative Anthracyclines (Doxorubicin Equivalent Dose, Feijen et al. Journal of Clinical Oncology, 2015)	anthracyclines_jco_5	float	{"-8888":{"label":"exposed, dose unknown"}, "-9999":{"label":"unknown exposure"} }	mg/m2
```
Should see the data accepted. 

Will update the wiki once this is merged. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
