### PR TITLE
Add a footnote to the bottom of survival plot p-value table to explai…

### DIFF
--- a/client/dom/renderPvalueTable.js
+++ b/client/dom/renderPvalueTable.js
@@ -188,5 +188,14 @@ export function renderPvalues({ title, holder, plot, tests, s, bins, tip, setAct
 					tip.show(event.clientX, event.clientY)
 				})
 		}
+
+		//footnote: pvalue is still computed with all survival data when Survival Time Cut-Off is set
+		if (s.maxTimeToEvent && visibleTests.length) {
+			holder
+				.append('div')
+				.style('margin-top', '10px')
+				.style('font-size', fontSize - 2 + 'px')
+				.text((visibleTests.length > 1 ? 'p-values are' : 'p-value is') + ' computed with all survival data')
+		}
 	}
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Add a footnote to the bottom of survival plot p-value table to explaine that pvalues are still computed with all survival data when Survival Time Cut-Off is set


### PR DESCRIPTION
…ne that pvalues are still computed with all survival data when Survival Time Cut-Off is set

## Description

To test, from : http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis%22}

open survival plot, overlay with a term, p-value table should show footnote

NOTE: footnote only shown when Survival Time Cut-Off is set, Survival Time Cut-Off is only set for mbmeta by default

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
