### PR TITLE
fix: report genome name on samtools-fasta error

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- report genome name on samtools-fasta error

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -200,8 +200,13 @@ export async function initGenomesDs(serverconfig) {
 		if (!g.majorchr) throw genomename + ': majorchr missing'
 		if (!g.defaultcoord) throw genomename + ': defaultcoord missing'
 
-		// test samtools and genomefile
-		await utils.get_fasta(g, g.defaultcoord.chr + ':' + g.defaultcoord.start + '-' + (g.defaultcoord.start + 1))
+		try {
+			// test samtools and genomefile
+			await utils.get_fasta(g, g.defaultcoord.chr + ':' + g.defaultcoord.start + '-' + (g.defaultcoord.start + 1))
+		} catch (e) {
+			// either samtools or fasta file failed
+			throw `${genomename}: cannot get genome sequence: ${e.message || e}`
+		}
 
 		if (!g.tracks) {
 			g.tracks = []


### PR DESCRIPTION
## Description

tested with invalid fasta file, gives below now

!!!
hg19: cannot get genome sequence: [E::fai_load3_core] Failed to open FASTA file /Users/xzhou1/data/tp/genomes/hg19.gz
[faidx] Could not load fai index /Users/xzhou1/data/tp/genomes/hg19.gz.fai

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
