### PR TITLE
Misc fixes

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -293,7 +293,7 @@ function setRenderers(self) {
 			aboutTab.top = 'COHORT'
 			aboutTab.mid = ''
 			aboutTab.btm = ''
-		}
+		} else aboutTab.top = massNav?.tabs?.about?.top || appState.vocab.dslabel
 		const tabIdx = appState.termdbConfig?.selectCohort ? 0 : massNav?.tabs?.about?.order || 0
 		self.tabs.splice(tabIdx, 0, aboutTab)
 

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -100,7 +100,7 @@ export function setRenderers(self) {
 			.transition()
 			.duration(s.duration)
 			.attr('width', width)
-			.attr('height', Math.max(s.svgh + 100, self.legendHeight)) //leaving some space for top/bottom padding and y axis
+			.attr('height', Math.max(s.svgh + 200, self.legendHeight)) //leaving some space for axis/ref/ scale legend/padding
 
 		/* eslint-disable */
 		fillSvgSubElems(chart)
@@ -665,6 +665,7 @@ export function setRenderers(self) {
 		legendG.selectAll('*').remove()
 		let offsetX = 0
 		let offsetY = 25
+		let legendHeight = 0
 		if (!self.config.colorTW && !self.config.shapeTW && !self.config.colorColumn) {
 			if (self.config.scaleDotTW) {
 				chart.scaleG = legendG.append('g').attr('transform', `translate(${offsetX + 45},${self.legendHeight - 150})`)
@@ -772,11 +773,9 @@ export function setRenderers(self) {
 
 				refText.on('click', e => self.onLegendClick(chart, legendG, 'colorTW', 'Ref', e, colorRefCategory))
 			}
+			legendHeight = offsetY
 		}
-		if (self.config.scaleDotTW) {
-			chart.scaleG = legendG.append('g').attr('transform', `translate(${offsetX},${self.legendHeight - 30})`)
-			self.drawScaleDotLegend(chart)
-		}
+
 		if (self.config.shapeTW) {
 			offsetX = !self.config.colorTW ? 0 : 300
 			offsetY = 60
@@ -817,6 +816,12 @@ export function setRenderers(self) {
 					itemG.on('click', event => self.onLegendClick(chart, legendG, 'shapeTW', key, event, shape))
 				}
 			}
+			if (offsetY > legendHeight) legendHeight = offsetY
+		}
+
+		if (self.config.scaleDotTW) {
+			chart.scaleG = legendG.append('g').attr('transform', `translate(${0},${legendHeight + 50})`)
+			self.drawScaleDotLegend(chart)
 		}
 
 		function getTitle(name, complete = false) {

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -123,12 +123,11 @@ class singleCellPlot {
 			tabsPosition: 'horizontal',
 			tabs: this.tabs
 		}).main()
-		const topDiv = contentDiv.append('div')
 
-		const headerDiv = topDiv.append('div').style('display', 'inline-block')
-		const showDiv = topDiv.append('div').style('padding-bottom', '10px')
+		const headerDiv = contentDiv.append('div').style('display', 'inline-block')
+		const showDiv = headerDiv.append('div').style('padding-bottom', '10px')
 
-		const tableDiv = contentDiv.append('div').style('margin-bottom', '20px')
+		const tableDiv = headerDiv.append('div').style('margin-bottom', '20px')
 		await this.renderSamplesTable(tableDiv, state)
 
 		if (state.config.plots.length > 1) this.renderShowPlots(showDiv, state)
@@ -156,6 +155,7 @@ class singleCellPlot {
 
 		this.dom = {
 			header: this.opts.header,
+			headerDiv,
 			showDiv,
 			mainDiv,
 			loadingDiv,
@@ -332,6 +332,7 @@ class singleCellPlot {
 		const tab = this.state.config.activeTab || this.tabs[0].id
 		switch (tab) {
 			case SAMPLES_TAB:
+				this.dom.headerDiv.style('display', 'block')
 				this.dom.tableDiv.style('display', 'block')
 				this.dom.showDiv.style('display', 'none')
 				this.dom.deDiv.style('display', 'none')
@@ -339,18 +340,21 @@ class singleCellPlot {
 
 				break
 			case PLOTS_TAB:
+				this.dom.headerDiv.style('display', 'block')
 				this.dom.tableDiv.style('display', 'none')
 				this.dom.showDiv.style('display', 'block')
 				this.dom.deDiv.style('display', 'none')
 				this.dom.geDiv.style('display', 'none')
 				break
 			case COLORBY_TAB:
+				this.dom.headerDiv.style('display', 'none')
 				this.dom.geDiv.style('display', 'none')
 				this.dom.deDiv.style('display', 'none')
 				this.dom.tableDiv.style('display', 'none')
 				this.dom.showDiv.style('display', 'none')
 				break
 			case GENE_EXPRESSION_TAB:
+				this.dom.headerDiv.style('display', 'block')
 				this.dom.deDiv.style('display', 'none')
 				this.dom.geDiv.style('display', 'inline-block')
 				this.dom.tableDiv.style('display', 'none')
@@ -360,6 +364,7 @@ class singleCellPlot {
 				this.fillColorBy()
 				break
 			case DIFFERENTIAL_EXPRESSION_TAB:
+				this.dom.headerDiv.style('display', 'block')
 				this.dom.deDiv.style('display', 'inline-block')
 				this.dom.geDiv.style('display', 'none')
 				this.dom.tableDiv.style('display', 'none')

--- a/server/routes/brainImaging.ts
+++ b/server/routes/brainImaging.ts
@@ -75,14 +75,16 @@ async function getBrainImage(query: GetBrainImagingRequest, genomes: any) {
 
 		return new Promise((resolve, reject) => {
 			const filePaths = query.selectedSampleFileNames!.map(file => path.join(dirPath, file))
-			const ps = spawn('python3', [
+			const cmd = [
 				`${serverconfig.binpath}/../python/src/plotBrainImaging.py`,
 				refFile,
 				query.l!,
 				query.f!,
 				query.t!,
 				...filePaths
-			])
+			]
+			//console.log(cmd)
+			const ps = spawn(serverconfig.python, cmd)
 			const imgData: Buffer[] = []
 			ps.stdout.on('data', data => {
 				imgData.push(data)

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -485,7 +485,7 @@ export function server_init_db_queries(ds) {
 			if (!r.type) continue // skip ungraphable parent terms
 
 			if (!(r.cohort in supportedChartTypes)) {
-				supportedChartTypes[r.cohort] = new Set(['regression', 'summary'])
+				supportedChartTypes[r.cohort] = new Set(['regression', 'summary', 'facet'])
 				if (ds.cohort.scatterplots) supportedChartTypes[r.cohort].add('sampleScatter')
 
 				numericTypeCount[r.cohort] = 0


### PR DESCRIPTION
## Description

When adding a scale [here](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:{%22term%22:%20{%22gene%22:%20%22KBTBD4%22,%20%22type%22:%20%22geneVariant%22}},%22shapeTW%22:{%22id%22:%20%22Molecular%20Subgroup%20(MNPv12.8)%22}}]}) the scale legend was being clipped. Showed dslabel on about tab if no top provided. Fixed tabs space on SC. Restored facet as a default plot unless is not allowed. It was not showing before, now it shows except for the profile, that is the only one hiding all our plots.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
