### PR TITLE
SC misc fixes

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -233,8 +233,8 @@ class singleCellPlot {
 					let plots = structuredClone(this.state.config.plots)
 					plots.find(p => p.name == plot.name).selected = e.target.checked
 					const selectedPlots = plots.filter(p => p.selected)
-					const width = 900
-					const height = 900
+					const width = 1000
+					const height = 1000
 					let settings = {}
 					settings.svgh = width / selectedPlots.length
 					settings.svgw = height / selectedPlots.length
@@ -702,8 +702,6 @@ class singleCellPlot {
 		plot.headerDiv = plot.plotDiv.append('div')
 		plot.headerDiv.append('label').text(plot.name).style('font-size', '1.2em').style('margin-right', '10px')
 
-		this.renderLegend(plot)
-
 		plot.svg = plot.plotDiv
 			.append('div')
 			.style('display', 'inline-block')
@@ -750,6 +748,7 @@ class singleCellPlot {
 			.attr('r', this.settings.sampleSize)
 			.attr('fill', d => this.getColor(d, plot))
 			.style('fill-opacity', d => this.getOpacity(d))
+		this.renderLegend(plot)
 	}
 
 	getOpacity(d) {
@@ -826,7 +825,7 @@ class singleCellPlot {
 			}
 			legendSVG = plot.plotDiv
 				.append('svg')
-				.attr('width', 280)
+				.attr('width', 250)
 				.attr('height', this.settings.svgh)
 				.style('vertical-align', 'top')
 			plot.legendSVG = legendSVG
@@ -855,7 +854,7 @@ class singleCellPlot {
 		}
 		this.legendRendered = true
 
-		const legendG = legendSVG.append('g').attr('transform', `translate(10, 50)`).style('font-size', '0.8em')
+		const legendG = legendSVG.append('g').attr('transform', `translate(20, 0)`).style('font-size', '0.9em')
 		if (
 			this.state.config.activeTab == GENE_EXPRESSION_TAB ||
 			this.state.config.activeTab == DIFFERENTIAL_EXPRESSION_TAB
@@ -879,7 +878,7 @@ class singleCellPlot {
 			const n = clusterCells.length
 			const color = colorMap[cluster]
 			const itemG = legendG.append('g').attr('transform', c => `translate(${x}, ${y})`)
-			itemG.append('circle').attr('r', 3).attr('fill', color)
+			itemG.append('circle').attr('r', 5).attr('fill', color)
 			itemG
 				.append('g')
 				.attr('transform', `translate(${x + 10}, ${5})`)

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -159,7 +159,9 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 				const colorColumn = plot.colorColumns.find(c => c.name == q.colorBy?.[plot.name]) || plot.colorColumns[0]
 				const lines = file2Lines[tsvfile]
 				// 1st line is header
-				const cells = [] as Cell[]
+				const expCells = [] as Cell[]
+				const noExpCells = [] as Cell[]
+
 				for (let i = 1; i < lines.length; i++) {
 					// each line is a cell
 					const l = lines[i].split('\t')
@@ -174,13 +176,16 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 					if (geneExpMap) {
 						if (geneExpMap[cellId] !== undefined) {
 							cell.geneExp = geneExpMap[cellId]
+							expCells.push(cell)
+						} else {
+							noExpCells.push(cell)
 						}
-					}
-					cells.push(cell)
+					} else noExpCells.push(cell)
 				}
 				plots.push({
 					name: plot.name,
-					cells,
+					expCells,
+					noExpCells,
 					colorColumns: plot.colorColumns.map(c => c.name),
 					colorBy: colorColumn?.name,
 					colorMap: colorColumn?.colorMap

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2277,7 +2277,7 @@ export function gdc_validate_query_singleCell_data(ds, genome) {
 		!! important !! file column index must match with x/y values of each plot in dataset/gdc.hg38.ts 
 		*/
 		const seuratClusterTerm = { id: 'cluster', name: 'Seurat cluster', type: 'categorical', values: {} }
-		const plots = q.plots.map(p => ({ cells: [], name: p }))
+		const plots = q.plots.map(p => ({ expCells: [], noExpCells: [], name: p }))
 
 		let geneExpMap
 		if (ds.queries.singleCell.geneExpression && q.gene) {
@@ -2309,9 +2309,9 @@ export function gdc_validate_query_singleCell_data(ds, genome) {
 				if (geneExpMap) {
 					if (geneExpMap[cellId] !== undefined) {
 						cell.geneExp = geneExpMap[cellId]
-					}
-				}
-				plot.cells.push(cell)
+						plot.expCells.push(cell)
+					} else plot.noExpCells.push(cell)
+				} else plot.noExpCells.push(cell)
 			}
 		}
 		return { plots }

--- a/shared/types/src/routes/termdb.singlecellData.ts
+++ b/shared/types/src/routes/termdb.singlecellData.ts
@@ -18,8 +18,10 @@ export type Cell = {
 export type Plot = {
 	/** name of the plot */
 	name: string
-	/** List of cells */
-	cells: Cell[]
+	/** List of cells with gene expression */
+	expCells?: Cell[]
+	/** List of cells with no gene expression, if no gene provided all cells will be here */
+	noExpCells?: Cell[]
 	/** Column name to color by, e.g Cell type, CNV, Fusion */
 	colorBy: string
 	colorColumns: string[]


### PR DESCRIPTION
## Description

Improvements rendering legend and cells. Used lighter gray if no gene exp to improve contrast with cells with expression. Renamed _Color by_ tab to _Clusters_. Now the server sends a list of expCells and noExpCells instead of cells, as this allows to speed up rendering by avoiding creating these on the client. Color scale starts on white now. See corresponding [PR](https://github.com/stjude/sjpp/pull/539) in sjpp reducing size of the fetalCerebellum plot so the legend is not clipped. Also some cleanup done.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
