### PR TITLE
ppHic citation

### DIFF
--- a/front/public/cards/arc.json
+++ b/front/public/cards/arc.json
@@ -30,5 +30,6 @@
             "name": "Documentation",
             "link": "https://github.com/stjude/proteinpaint/wiki/Interaction-Tracks:-Hi%E2%80%90C-and-Arc"
         }
-    ]
+    ],
+    "citation_id": 1007
 }

--- a/front/public/cards/citations.json
+++ b/front/public/cards/citations.json
@@ -57,6 +57,16 @@
             "pmid": "35982322",
             "pmidURL": "https://pubmed.ncbi.nlm.nih.gov/35982322/",
             "doi": "https://doi.org/10.1007/s00401-022-02484-7"
+        },
+        {
+            "id": 1007,
+            "title": "ppHiC: Interactive exploration of Hi-C results on the ProteinPaint web portal",
+            "appHeaderTitle":"ppHiC: Zhou X <em>et al</em>",
+            "year": "2024",
+            "journal": "Computational and Structural Biotechnology Journal",
+            "pmid": "39430404",
+            "pmidURL": "https://pubmed.ncbi.nlm.nih.gov/39430404/",
+            "doi": "https://doi.org/10.1016/j.csbj.2024.09.020"
         }
     ]
 }

--- a/front/public/cards/hic.json
+++ b/front/public/cards/hic.json
@@ -148,5 +148,6 @@
             "name": "Documentation",
             "link": "https://github.com/stjude/proteinpaint/wiki/Interaction-Tracks:-Hi%E2%80%90C-and-Arc"
         }
-    ]
+    ],
+    "citation_id": 1007
 }


### PR DESCRIPTION
## Description
Addresses comment from https://github.com/stjude/proteinpaint/pull/2331. ppHiC citation appears in hic card, in omnisearch, and publications button in the app header. 

Test: 
1. http://localhost:3000/?appcard=hic
2. Omnisearch and publication button

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
