### PR TITLE
Removed allowedChartTypes handling on the client

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -45,7 +45,6 @@ class MassCharts {
 		) {
 			// force to show a dictionary chart button
 			// TODO: may want the server to decide this, and as defined for a dataset
-			if (state.vocab.dslabel == 'profile') state.supportedChartTypes.push(...appState.termdbConfig.allowedChartTypes)
 			state.supportedChartTypes.push('dictionary')
 		}
 		return state

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -76,7 +76,6 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	const c: any = {
 		selectCohort: tdb.selectCohort, // optional
 		supportedChartTypes: tdb.q?.getSupportedChartTypes(q.embedder),
-		allowedChartTypes: ds.cohort.allowedChartTypes,
 		hiddenChartTypes: ds.cohort.hiddenChartTypes,
 		renamedChartTypes: ds.cohort.renamedChartTypes,
 		allowedTermTypes: getAllowedTermTypes(ds),

--- a/server/src/termdb.server.init.js
+++ b/server/src/termdb.server.init.js
@@ -483,9 +483,18 @@ export function server_init_db_queries(ds) {
 		// value: array of chart types allowed by term types
 		for (const r of ds.cohort.termdb.termtypeByCohort) {
 			if (!r.type) continue // skip ungraphable parent terms
+			//add profile chart types to profile subcohorts
 
 			if (!(r.cohort in supportedChartTypes)) {
 				supportedChartTypes[r.cohort] = new Set(['regression', 'summary', 'facet'])
+				if (ds.label == 'profile')
+					supportedChartTypes[r.cohort] = new Set([
+						'profileRadar',
+						'profileRadarFacility',
+						'profilePolar',
+						'profileBarchart'
+					])
+				console.log('supportedChartTypes', supportedChartTypes)
 				if (ds.cohort.scatterplots) supportedChartTypes[r.cohort].add('sampleScatter')
 
 				numericTypeCount[r.cohort] = 0


### PR DESCRIPTION
## Description

Removed allowedChartTypes handling on the client and added profile charts in getSupportedChartTypes


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
