### PR TITLE
fix: detect and set the gdc version first before caching

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- detect and set the gdc version first before caching

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1535,6 +1535,11 @@ export type PreInit = {
 	retryDelay?: number
 	retryMax?: number
 	errorCallback?: (response: PreInitStatus) => void
+	test?: {
+		numCalls: number
+		minor: number
+		mayEditResponse: (response: any) => any
+	}
 }
 
 export type Mds3 = BaseMds & {

--- a/shared/utils/src/helpers.js
+++ b/shared/utils/src/helpers.js
@@ -29,3 +29,22 @@ export function convertUnits(v, fromUnit, toUnit, scaleFactor, compact) {
 	if (compact) return `${toUnitV}${toUnit.charAt(0)}${fromUnitV}${fromUnit.charAt(0)}`
 	return `${toUnitV} ${toUnitV > 1 ? toUnit + 's' : toUnit} ${fromUnitV} ${fromUnitV > 1 ? fromUnit + 's' : fromUnit}`
 }
+
+export function deepEqual(x, y) {
+	if (x === y) {
+		return true
+	} else if (typeof x == 'object' && x != null && typeof y == 'object' && y != null) {
+		if (Object.keys(x).length != Object.keys(y).length) {
+			return false
+		}
+
+		for (var prop in x) {
+			if (y.hasOwnProperty(prop)) {
+				if (!deepEqual(x[prop], y[prop])) return false
+			} else {
+				return false
+			}
+		}
+		return true
+	} else return false
+}


### PR DESCRIPTION
## Description

Pull latest `ppgdc` develop branch.

Set `serverconfig.features."gdcCacheCheckWait": 5000` to replicate the reported getStatus() error, it should not show up with the fix in this PR. May also need to remove `stopGdcCacheAliquot` option or set it to `false`.

To simulate gdc caching with more detailed logs, uncomment line 132 `// if (preInit.test) await preInit.test.mayEditResponse(response)` in `sjpp/gdc/active/gdc.hg38.ts`.  These various cache handling results should be observed: 
- test #s 2, 5, 8 should recache because the minor version has been updated in each run
- test #s 3, 4, 6, 9 should skip recache because the minor version number stays the same
- test # 7 should try to recache, but should be canceled since its become stale once test # 8 started 

```
--- call #2 to preInit.test.mayEditResponse() ---
GDC open-access projects: 52
GDC: Start to cache sample IDs of 44736 cases...
GDC: Done caching sample IDs. Time: 1 s
  ...

--- call #3 to preInit.test.mayEditResponse() ---
GDC: skip recache of  0 undefined 0
checking for cached bam files to delete ...
deleted 0 of 0 cached bam files (0 bytes deleted, 0 remaining)
GDC: checking if cache is stale

--- call #4 to preInit.test.mayEditResponse() ---
GDC: skip recache of  0 undefined 0
GDC: checking if cache is stale

--- call #5 to preInit.test.mayEditResponse() ---
GDC: cache is stale. Re-caching... 1
GDC open-access projects: 52
GDC: Start to cache sample IDs of 44736 cases...
GDC: Done caching sample IDs. Time: 1 s
  ...

--- call #6 to preInit.test.mayEditResponse() ---
GDC: skip recache of  1 undefined 1
GDC: checking if cache is stale

--- call #7 to preInit.test.mayEditResponse() ---
GDC: checking if cache is stale

--- call #8 to preInit.test.mayEditResponse() ---
GDC: cache is stale. Re-caching... 3
GDC open-access projects: 52
GDC: Start to cache sample IDs of 44736 cases...
GDC: Done caching sample IDs. Time: 1 s
	...
... after call #7 delay ..., version.minor= 2
GDC: !!! cancel stale pending cache for  { major: 41, minor: 2, release_date: '2024-08-28' }
GDC: checking if cache is stale

--- call #9 to preInit.test.mayEditResponse() ---
GDC: skip recache of  3 undefined 3
```

Also tested with http://localhost:3000/testrun.html?name=*.unit and `cd client && npm run test:integration && cd ../server && npm run test:unit`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
