### PR TITLE
Add publicBinOnly param to init.js

### DIFF
--- a/container/full/app-full.mjs
+++ b/container/full/app-full.mjs
@@ -53,9 +53,13 @@ if (serverconfig.releaseTag) {
 	spawnSync('npm', ['install', `"@sjcrh/proteinpaint-front@${serverconfig.releaseTag.front}"`], { encoding: 'utf-8' })
 }
 
-if (!serverconfig.URL) serverconfig.URL = serverconfig.url || '.'
+if (!serverconfig.URL) serverconfig.URL = process.env.URL || serverconfig.url || '.'
+
 console.log(`generating public/bin for ${serverconfig.URL}`)
-spawnSync('npx', ['proteinpaint-front', serverconfig.URL], { encoding: 'utf-8' })
+const publicBinOnly = process.argv.includes('--publicBinOnly')
+spawnSync('npx', ['proteinpaint-front', serverconfig.URL, publicBinOnly ? '--publicBinOnly' : 'allPublic'], {
+	encoding: 'utf-8'
+})
 // since the npx command generated non-root owned js files inside the public/bin folder , we need to change the owner of the folder and files to root
 spawnSync('chown', ['-R', 'root:root', './public/bin'], { encoding: 'utf8' })
 

--- a/front/init.js
+++ b/front/init.js
@@ -8,6 +8,8 @@ const { execSync } = require('child_process')
 
 let URLPATH = process.argv[2] || '.'
 if (URLPATH.endsWith('/')) URLPATH = URLPATH.slice(0, -1)
+let publicBinOnly = process.argv[3] === true
+
 const CWD = process.cwd()
 
 console.log('CWD', CWD)
@@ -16,20 +18,22 @@ try {
 		console.log(`making a public directory at ${CWD}`)
 		fs.mkdirSync(`${CWD}/public`)
 	}
-	if (!fs.existsSync(`${CWD}/public/index.html`)) {
-		console.log(`creating a public/index.html file`)
-		fs.copyFileSync(path.join(__dirname, './public/index.html'), `${CWD}/public/index.html`)
-	}
 	if (fs.existsSync(`${CWD}/public/bin`)) {
 		console.log(`removing the old public/bin at ${CWD}`)
 		// should update as part of v16 upgrade
 		fs.rmdirSync(`${CWD}/public/bin`, { recursive: true, force: true }, () => {})
 	}
-	if (!fs.existsSync(`${CWD}/public/cards`)) {
-		console.log(`Copying cards into public/cards folder`)
-		execSync(`cp -r ${CWD}/node_modules/@sjcrh/proteinpaint-front/public/cards ${CWD}/public/cards`, {
-			stdio: 'inherit'
-		})
+	if (!publicBinOnly) {
+		if (!fs.existsSync(`${CWD}/public/index.html`)) {
+			console.log(`creating a public/index.html file`)
+			fs.copyFileSync(path.join(__dirname, './public/index.html'), `${CWD}/public/index.html`)
+		}
+		if (!fs.existsSync(`${CWD}/public/cards`)) {
+			console.log(`Copying cards into public/cards folder`)
+			execSync(`cp -r ${CWD}/node_modules/@sjcrh/proteinpaint-front/public/cards ${CWD}/public/cards`, {
+				stdio: 'inherit'
+			})
+		}
 	}
 	const tar = ps.spawnSync('tar', [`-xzf`, `${__dirname}/bundles.tgz`, `-C`, `${CWD}`], { encoding: 'utf8' })
 	if (tar.stderr) throw tar.stderr

--- a/front/init.js
+++ b/front/init.js
@@ -8,7 +8,7 @@ const { execSync } = require('child_process')
 
 let URLPATH = process.argv[2] || '.'
 if (URLPATH.endsWith('/')) URLPATH = URLPATH.slice(0, -1)
-let publicBinOnly = process.argv[3] === true
+const publicBinOnly = process.argv.includes('--publicBinOnly')
 
 const CWD = process.cwd()
 

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -67,6 +67,15 @@ if (!('allow_env_overrides' in serverconfig) && serverconfig.debugmode) {
 	serverconfig.allow_env_overrides = true
 }
 
+//if jwt is enabled, check for JWT_SECRET environment variable
+if (serverconfig.jwt) {
+	const jwtSecret = process.env.JWT_SECRET
+	if (!jwtSecret) {
+		throw `JWT_SECRET is not set as an environment variable.`
+	}
+	serverconfig.jwt.secret = jwtSecret
+}
+
 if (!serverconfig.binpath) {
 	const pkfile = process.argv.find(n => n.includes('/build'))
 	if (pkfile) {


### PR DESCRIPTION
## Description

I added the option not to include the index.html file in the public folder.

To test:


Delete public/cards symlink
Delete public/index.html
Execute:
` node front/init.js "http://localhost:3000" `

cards and index.html should reappear. 

Stash changes.

Execute:
` node front/init.js "http://localhost:3000" --publicBinOnly`
The output should be:
removing the old public/bin at /Users/aacic/dev/sjpp/proteinpaint
And public/bin should reappear.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
