### PR TITLE
Fix for broken `Multicolor bars` checkbox

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -525,7 +525,7 @@ class Barchart {
 
 	sortStacking(series, chart, chartsData) {
 		this.term1toColor[series.seriesId] = this.settings.colorBars
-			? this.getColor(this.config.term.term, series.seriesId, this.bins?.[1])
+			? this.getColor(this.config.term, series.seriesId, this.bins?.[1])
 			: this.settings.defaultColor
 
 		series.visibleData.sort(this.overlaySorter)


### PR DESCRIPTION
## Description
In production, selecting `Multicolor bars` for any bar chart renders all the bars black. Test with any of the bar chart examples.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
