### PR TITLE
Hier cluster z score check box

### DIFF
--- a/client/plots/matrix/hierCluster.config.js
+++ b/client/plots/matrix/hierCluster.config.js
@@ -25,12 +25,25 @@ export async function getPlotConfig(opts = {}, app) {
 		clusterMethod: 'average', // complete
 		distanceMethod: 'euclidean',
 		zScoreCap: 5,
+		zScoreTransformation: true,
 		xDendrogramHeight: 100,
 		yDendrogramHeight: 200,
 		colorScale: 'blueWhiteRed'
 	}
 	const overrides = app.vocabApi.termdbConfig.hierCluster || {}
-	copyMerge(config.settings.hierCluster, overrides.settings, opts.settings?.hierCluster || {})
+
+	// hierClusterSubTypeOverrides has settings from specific hierCluster type, such as geneExpression, metaboliteIntensity, numericDictTermCluster.
+	// should override config so that each hierCluster type could have its own customized settings that are different from the other hierCluster
+	// types in the same dataset. e.g. redomics could do z-score transformation for gene expression cluster and do not do z-score tranformation for
+	// metabolite intensity cluster
+	const hierClusterSubTypeOverrides = app.vocabApi.termdbConfig[`${config.dataType}Cluster`] || {}
+
+	copyMerge(
+		config.settings.hierCluster,
+		overrides.settings,
+		opts.settings?.hierCluster || {},
+		hierClusterSubTypeOverrides.settings
+	)
 
 	// okay to validate state here?
 	{

--- a/client/plots/matrix/hierCluster.interactivity.js
+++ b/client/plots/matrix/hierCluster.interactivity.js
@@ -1,5 +1,6 @@
 import { renderTable } from '#dom'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
+import { select } from 'd3-selection'
 
 // Given a clusterId, return all its children clusterIds
 export function getAllChildrenClusterIds(clickedClusterId, left) {
@@ -334,6 +335,28 @@ export function setClusteringBtn(holder, callback) {
 					}
 				},
 				{
+					label: 'ZScore Transformation',
+					title: `Option to do zScore transformation`,
+					type: 'checkbox',
+					chartType: 'hierCluster',
+					settingsKey: 'zScoreTransformation',
+					boxLabel: `Perform zScore Transformation`,
+					callback: checked => {
+						if (!checked) {
+							this.config.settings.hierCluster.zScoreTransformation = false
+							this.config.settings.hierCluster.colorScale = 'whiteRed'
+						} else {
+							this.config.settings.hierCluster.zScoreTransformation = true
+							this.config.settings.hierCluster.colorScale = 'blueWhiteRed'
+						}
+						this.app.dispatch({
+							type: 'plot_edit',
+							id: this.id,
+							config: this.config
+						})
+					}
+				},
+				{
 					label: `Clustering Method`,
 					title: `Sets which clustering method to use`,
 					type: 'radio',
@@ -407,9 +430,35 @@ export function setClusteringBtn(holder, callback) {
 						}
 					]
 				}
-			]
+			],
+			customInputs: updateClusteringControls
 		})
 		.html(d => d.label)
 		.style('margin', '2px 0')
 		.on('click', callback)
+}
+
+function updateClusteringControls(self, app, parent, table) {
+	if (parent.chartType == 'hierCluster' && !parent.config.settings.hierCluster.zScoreTransformation) {
+		const zScoreCapControl = select(
+			table
+				.selectAll('td')
+				.filter(function () {
+					return select(this).text() == 'z-score Cap'
+				})
+				.node()
+				.closest('tr')
+		)
+		zScoreCapControl.style('display', 'none')
+		const colorSchemeControl = select(
+			table
+				.selectAll('td')
+				.filter(function () {
+					return select(this).text() == 'Color Scheme'
+				})
+				.node()
+				.closest('tr')
+		)
+		colorSchemeControl.style('display', 'none')
+	}
 }

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -1428,7 +1428,15 @@ export class MatrixControls {
 	updateSamplesControls(self, app, parent, table) {
 		if (parent.chartType == 'hierCluster' && parent.config.settings.hierCluster.clusterSamples) {
 			const l = parent.config.settings.matrix.controlLabels
-			const sortingControl = table.select(`tr[title='Set how to sort ${l.samples}']`)
+			const sortingControl = select(
+				table
+					.selectAll('td')
+					.filter(function () {
+						return select(this).text() == `Sort ${l.Sample} Priority`
+					})
+					.node()
+					.closest('tr')
+			)
 			sortingControl.style('display', 'none')
 		}
 	}

--- a/client/plots/matrix/matrix.js
+++ b/client/plots/matrix/matrix.js
@@ -139,6 +139,7 @@ export class Matrix {
 			clusterMethod: config.settings.hierCluster?.clusterMethod,
 			distanceMethod: config.settings.hierCluster?.distanceMethod,
 			clusterSamples: config.settings.hierCluster?.clusterSamples,
+			zScoreTransformation: config.settings.hierCluster?.zScoreTransformation,
 			nav: appState.nav
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- hiercluster: make zscore transformation a checkbox option in Clustering menu

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -158,7 +158,7 @@ async function doClustering(data: any, q: TermdbClusterRequest, numCases = 1000)
 		for (const s of inputData.col_names) {
 			row.push(o[s] || 0)
 		}
-		inputData.matrix.push(getZscore(row))
+		inputData.matrix.push(q.zScoreTransformation ? getZscore(row) : row)
 	}
 
 	if (inputData.matrix.length == 0) throw 'Clustering matrix is empty'

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -918,6 +918,8 @@ type MatrixSettings = {
 type NumericDictTermClusterSettings = {
 	/** default hiercluster group name */
 	termGroupName?: string
+	zScoreTransformation?: boolean
+	colorScale?: string
 }
 
 type Matrix = {
@@ -932,6 +934,7 @@ type Matrix = {
 	legendValueFilter?: any
 }
 
+// specific hierCluster type settings, should be named as "dataTYpe + Cluster"
 type NumericDictTermCluster = {
 	/** alternative name, e.g. the plot is called "drug sensitivity" in ALL-pharmacotyping; by default it's called "Numeric Dictionary Term cluster" */
 	appName?: string

--- a/shared/types/src/routes/termdb.cluster.ts
+++ b/shared/types/src/routes/termdb.cluster.ts
@@ -34,6 +34,7 @@ export type TermdbClusterRequestGeneExpression = TermdbClusterRequestBase & {
 	dataType: 'geneExpression'
 	/** List of terms */
 	terms: GeneExpressionTerm[]
+	zScoreTransformation?: string
 }
 
 export type TermdbClusterRequestMetabolite = TermdbClusterRequestBase & {
@@ -41,6 +42,7 @@ export type TermdbClusterRequestMetabolite = TermdbClusterRequestBase & {
 	dataType: 'metaboliteIntensity'
 	/** List of terms */
 	terms: MetaboliteIntensityTerm[]
+	zScoreTransformation?: string
 }
 
 export type TermdbClusterRequestNumericDictTerm = TermdbClusterRequestBase & {
@@ -48,6 +50,7 @@ export type TermdbClusterRequestNumericDictTerm = TermdbClusterRequestBase & {
 	dataType: 'numericDictTerm'
 	/** List of terms */
 	terms: NumericDictTerm[]
+	zScoreTransformation?: string
 }
 
 export type TermdbClusterRequest =

--- a/shared/types/src/routes/termdb.cluster.ts
+++ b/shared/types/src/routes/termdb.cluster.ts
@@ -34,6 +34,7 @@ export type TermdbClusterRequestGeneExpression = TermdbClusterRequestBase & {
 	dataType: 'geneExpression'
 	/** List of terms */
 	terms: GeneExpressionTerm[]
+	/** perform z-score transformation on values */
 	zScoreTransformation?: string
 }
 
@@ -42,6 +43,7 @@ export type TermdbClusterRequestMetabolite = TermdbClusterRequestBase & {
 	dataType: 'metaboliteIntensity'
 	/** List of terms */
 	terms: MetaboliteIntensityTerm[]
+	/** perform z-score transformation on values */
 	zScoreTransformation?: string
 }
 
@@ -50,6 +52,7 @@ export type TermdbClusterRequestNumericDictTerm = TermdbClusterRequestBase & {
 	dataType: 'numericDictTerm'
 	/** List of terms */
 	terms: NumericDictTerm[]
+	/** perform z-score transformation on values */
 	zScoreTransformation?: string
 }
 

--- a/shared/utils/src/common.js
+++ b/shared/utils/src/common.js
@@ -1293,5 +1293,7 @@ export const colorScaleMap = {
 	blueBlackYellow: {
 		domain: [0, 0.17, 0.33, 0.5, 0.67, 0.83, 1],
 		range: ['#0000FF', '#0000CC', '#000099', '#202020', '#999900', '#CCCC00', '#FFFF00']
-	}
+	},
+	// when hierCluster z-score transformation is not performed, should use two-color scale
+	whiteRed: { domain: [0, 1], range: ['white', 'red'] }
 }


### PR DESCRIPTION
## Description
please test with sjpp branch: allPharm_disable_zscoreTransformation  and [url](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22hierCluster%22,%22dataType%22:%22numericDictTerm%22,%22termgroups%22:[{%22name%22:%22Drug%20Sensitivity%20Cluster%22,%22lst%22:[{%22id%22:%22Asparaginase_normalizedLC50%22},{%22id%22:%22Bortezomib_normalizedLC50%22},{%22id%22:%22CHZ868_normalizedLC50%22},{%22id%22:%22Cytarabine_normalizedLC50%22},{%22id%22:%22Dasatinib_normalizedLC50%22},{%22id%22:%22Daunorubicin_normalizedLC50%22},{%22id%22:%22Ibrutinib_normalizedLC50%22},{%22id%22:%22Nelarabine_normalizedLC50%22},{%22id%22:%22Panobinostat_normalizedLC50%22},{%22id%22:%22Prednisolone_normalizedLC50%22},{%22id%22:%22Ruxolitinib_normalizedLC50%22},{%22id%22:%22Trametinib_normalizedLC50%22},{%22id%22:%22Venetoclax_normalizedLC50%22},{%22id%22:%22Vincristine_normalizedLC50%22},{%22id%22:%22Vorinostat_normalizedLC50%22}],%22type%22:%22hierCluster%22}]}]})

datasets (ALL-pharmacotyping for example) could by default disable z-score transformation. 

When its disabled, z-score cap and color scheme in clustering control will not be shown. 

Checking the ZScore Transformation checkbox in clustering control will perform z-score transformation on values again and bring back z-score cap and color scheme controls. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
