### PR TITLE
fix: improve isNumeric() helper to not allow truncated alphanumeric p…

### DIFF
--- a/client/mass/test/summary.integration.spec.js
+++ b/client/mass/test/summary.integration.spec.js
@@ -31,6 +31,10 @@ const runpp = helpers.getRunPp('mass', {
 	debug: 1
 })
 
+const features = JSON.parse(sessionStorage.getItem('optionalFeatures')) || {}
+const tabLabels2Find = ['Barchart', 'Violin'] //hardcoded data in summary.js.
+if (features?.draftChartTypes?.includes('boxplot')) tabLabels2Find.push('Boxplot')
+
 /**************
  test sections
 ***************/
@@ -89,7 +93,6 @@ tape('Render summary plot, term: "agedx"', test => {
 			.filter(d => d.__data__.isVisible() == true)
 
 		//test correct tabs exist
-		const tabLabels2Find = ['Barchart', 'Violin', 'Boxplot'] //hardcoded data in summary.js.
 		let foundLabels = 0
 		const notFoundLabels = []
 		for (const toggle of toggles) {
@@ -282,7 +285,6 @@ tape('Barchart & violin toggles, term: "agedx", term2: "diaggrp"', test => {
 	}
 
 	function testToggleButtonRendering(toggles) {
-		const tabLabels2Find = ['Barchart', 'Violin', 'Boxplot']
 		let foundLabels = 0
 		for (const toggle of toggles) {
 			if (tabLabels2Find.some(d => d == toggle.__data__.label)) ++foundLabels
@@ -362,15 +364,16 @@ tape('Barchart, violin, and scatter toggles, term: "agedx", term2: "hrtavg"', te
 	}
 
 	function testToggleButtonRendering(toggles) {
-		const tabLabels2Find = ['Barchart', 'Violin', 'Boxplot', 'Scatter']
+		const tabLabels2Find2 = [...tabLabels2Find]
+		tabLabels2Find2.push('Scatter')
 		let foundLabels = 0
 		for (const toggle of toggles) {
-			if (tabLabels2Find.some(d => d == toggle.__data__.label)) ++foundLabels
+			if (tabLabels2Find2.some(d => d == toggle.__data__.label)) ++foundLabels
 		}
 		test.equal(
-			tabLabels2Find.length,
+			tabLabels2Find2.length,
 			toggles.length,
-			`Should render ${tabLabels2Find.length} tabs: ${tabLabels2Find} for 2 numeric terms`
+			`Should render ${tabLabels2Find2.length} tabs: ${tabLabels2Find2} for 2 numeric terms`
 		)
 	}
 

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -238,7 +238,7 @@ function setRenderers(self) {
 						//Remove after development
 						const features = JSON.parse(sessionStorage.getItem('optionalFeatures')) || {}
 						if (
-							features?.draftChartTypes?.indexOf('boxplot') != -1 &&
+							features?.draftChartTypes?.includes('boxplot') &&
 							(isNumericTerm(self.config?.term?.term) || isNumericTerm(self.config?.term2?.term))
 						)
 							return true

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- improve isNumeric() helper to not allow truncated alphanumeric parseFloat(), and create strictNumeric() helper
+- improve isNumeric() helper to not allow truncated alphanumeric parseFloat(), and create strictNumeric() helper;

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -9,6 +9,7 @@ import serverconfig from './serverconfig.js'
 import { authApi } from './auth.js'
 import * as validator from './validator.js'
 import { decode as urlJsonDecode } from '#shared/urljson.js'
+
 import jsonwebtoken from 'jsonwebtoken'
 
 const basepath = serverconfig.basepath || ''
@@ -160,8 +161,4 @@ function setHeaders(req, res, next) {
 	res.header('Access-Control-Allow-Credentials', true)
 
 	next()
-}
-
-function isNumeric(d) {
-	return !isNaN(parseFloat(d)) && isFinite(d) && d !== ''
 }

--- a/shared/utils/src/helpers.js
+++ b/shared/utils/src/helpers.js
@@ -1,13 +1,20 @@
 /*
 this is a helper file with a collection of functions to be used in backend and client side code. Here is a list.
 
-1. isNumeric(n) - checks whether given argument n is Numeric
+1. isNumeric(n) - checks whether given argument n is Numeric, with option to cast from string
+2. strictNumeric(n) - like isNumeric but does not cast from string
 2. convertUnits - converts a value from a unit to another unit
 3. TODO - move computepercentile, roundValue, etc here?
 */
 
 export function isNumeric(n) {
-	return Number.isFinite(n) || !isNaN(parseFloat(n))
+	const v = typeof n != 'string' || n === '' ? n : Number(n)
+	const f = parseFloat(n)
+	return !isNaN(f) && Number.isFinite(v) && v === f
+}
+
+export function strictNumeric(n) {
+	return !isNaN(parseFloat(n)) && Number.isFinite(n)
 }
 
 export function convertUnits(v, fromUnit, toUnit, scaleFactor, compact) {

--- a/shared/utils/src/helpers.js
+++ b/shared/utils/src/helpers.js
@@ -1,22 +1,25 @@
 /*
 this is a helper file with a collection of functions to be used in backend and client side code. Here is a list.
 
-1. isNumeric(n) - checks whether given argument n is Numeric, with option to cast from string
-2. strictNumeric(n) - like isNumeric but does not cast from string
-2. convertUnits - converts a value from a unit to another unit
+1. isNumeric(n)
+2. strictNumeric(n) 
+2. convertUnits
 3. TODO - move computepercentile, roundValue, etc here?
 */
 
+// checks whether given argument n is Numeric, with option to cast from string
 export function isNumeric(n) {
 	const v = typeof n != 'string' || n === '' ? n : Number(n)
 	const f = parseFloat(n)
 	return !isNaN(f) && Number.isFinite(v) && v === f
 }
 
-export function strictNumeric(n) {
-	return !isNaN(parseFloat(n)) && Number.isFinite(n)
+// like isNumeric but does not cast from string
+export function isStrictNumeric(n) {
+	return typeof n === 'number' && Number.isFinite(n)
 }
 
+// converts a value from a unit to another unit
 export function convertUnits(v, fromUnit, toUnit, scaleFactor, compact) {
 	// do floor() on toUnit
 	// do ceil() on fromUnit, in case v is decimal (from violin range selection) and to keep showing integer fromUnit

--- a/shared/utils/src/termdb.bins.js
+++ b/shared/utils/src/termdb.bins.js
@@ -1,6 +1,6 @@
 import { format } from 'd3-format'
 import { getColors } from './common.js'
-import { strictNumeric, convertUnits } from './helpers.js'
+import { isStrictNumeric, convertUnits } from './helpers.js'
 
 export default function validate_bins(binconfig) {
 	// Number.isFinite('1') returns false, which is desired
@@ -35,14 +35,14 @@ export default function validate_bins(binconfig) {
 				if (!('stop' in bin)) {
 					throw `a custom first bin must define a bin.stop value`
 				}
-				if (!strictNumeric(bin.stop)) {
+				if (!isStrictNumeric(bin.stop)) {
 					throw `a custom first bin.stop value should be numeric`
 				}
 			} else if (bin == last_bin) {
 				if (!('start' in bin)) {
 					throw `a custom last bin must define a bin.start value`
 				}
-				if (!strictNumeric(bin.start)) {
+				if (!isStrictNumeric(bin.start)) {
 					throw `a custom last bin.start must be numeric`
 				}
 				if ('stopunbounded' in bin && !bin.stopunbounded) {
@@ -53,8 +53,8 @@ export default function validate_bins(binconfig) {
 					throw 'a custom last bin must not set a bin.stop value'
 				}
 			} else {
-				if (!strictNumeric(bin.start)) throw 'bin.start must be numeric for a non-first bin'
-				if (!strictNumeric(bin.stop)) throw 'bin.stop must be numeric for a non-last bin'
+				if (!isStrictNumeric(bin.start)) throw 'bin.start must be numeric for a non-first bin'
+				if (!isStrictNumeric(bin.stop)) throw 'bin.stop must be numeric for a non-last bin'
 			}
 		}
 	} else if (bc.type == 'regular-bin') {
@@ -156,19 +156,19 @@ summaryfxn (percentiles)=> return {min, max, pX, pY, ...}
 			? maxCeil // in order to include the max value in the last bin
 			: bc.last_bin.stop_percentile
 			? summary['p' + bc.last_bin.stop_percentile]
-			: strictNumeric(bc.last_bin.stop) && bc.last_bin.stop <= summary.max
+			: isNumeric(bc.last_bin.stop) && bc.last_bin.stop <= summary.max // '0.0088' < 0.0088
 			? bc.last_bin.stop
 			: maxCeil // in order to include the max value in the last bin
-		last_start = strictNumeric(bc.last_bin.start_percentile)
+		last_start = isStrictNumeric(bc.last_bin.start_percentile)
 			? summary['p' + bc.last_bin.start_percentile]
-			: strictNumeric(bc.last_bin.start)
+			: isStrictNumeric(bc.last_bin.start)
 			? bc.last_bin.start
 			: undefined
 		last_stop = bc.last_bin.stopunbounded
 			? null
 			: bc.last_bin.stop_percentile
 			? summary['p' + bc.last_bin.stop_percentile]
-			: strictNumeric(bc.last_bin.stop)
+			: isStrictNumeric(bc.last_bin.stop)
 			? bc.last_bin.stop
 			: null
 	} else if (bc.lst) {
@@ -181,9 +181,9 @@ summaryfxn (percentiles)=> return {min, max, pX, pY, ...}
 		last_stop = maxCeil
 	}
 
-	const numericMax = strictNumeric(max)
-	const numericLastStart = strictNumeric(last_start)
-	const numericLastStop = strictNumeric(last_stop)
+	const numericMax = isStrictNumeric(max)
+	const numericLastStart = isStrictNumeric(last_start)
+	const numericLastStop = isStrictNumeric(last_stop)
 
 	if (!numericMax && !numericLastStart) return [] //throw 'unable to compute the last bin start or stop'
 
@@ -191,16 +191,16 @@ summaryfxn (percentiles)=> return {min, max, pX, pY, ...}
 	let currBin = {
 		startunbounded: bc.first_bin.startunbounded,
 		start: bc.first_bin.startunbounded ? undefined : min,
-		stop: strictNumeric(bc.first_bin.stop_percentile)
+		stop: isStrictNumeric(bc.first_bin.stop_percentile)
 			? +summary['p' + bc.first_bin.stop_percentile]
-			: strictNumeric(bc.first_bin.stop)
+			: isStrictNumeric(bc.first_bin.stop)
 			? +bc.first_bin.stop
 			: min + bc.bin_size,
 		startinclusive: bc.startinclusive,
 		stopinclusive: bc.stopinclusive
 	}
 
-	if (!strictNumeric(currBin.stop)) throw 'the computed first_bin.stop is non-numeric' + currBin.stop
+	if (!isStrictNumeric(currBin.stop)) throw 'the computed first_bin.stop is non-numeric' + currBin.stop
 	const maxNumBins = 100 // harcoded limit for now to not stress sqlite
 
 	while ((numericMax && currBin.stop <= max) || (currBin.startunbounded && !bins.length) || currBin.stopunbounded) {
@@ -372,10 +372,10 @@ export function get_bin_range_equation(bin, binconfig) {
 export function target_percentiles(binconfig) {
 	const percentiles = []
 	const f = binconfig.first_bin
-	if (f && strictNumeric(f.start_percentile)) percentiles.push(f.start_percentile)
-	if (f && strictNumeric(f.stop_percentile)) percentiles.push(f.stop_percentile)
+	if (f && isStrictNumeric(f.start_percentile)) percentiles.push(f.start_percentile)
+	if (f && isStrictNumeric(f.stop_percentile)) percentiles.push(f.stop_percentile)
 	const l = binconfig.last_bin
-	if (l && strictNumeric(l.start_percentile)) percentiles.push(l.start_percentile)
-	if (l && strictNumeric(l.stop_percentile)) percentiles.push(l.stop_percentile)
+	if (l && isStrictNumeric(l.start_percentile)) percentiles.push(l.start_percentile)
+	if (l && isStrictNumeric(l.stop_percentile)) percentiles.push(l.stop_percentile)
 	return percentiles
 }

--- a/shared/utils/src/termdb.bins.js
+++ b/shared/utils/src/termdb.bins.js
@@ -1,6 +1,6 @@
 import { format } from 'd3-format'
 import { getColors } from './common.js'
-import { isNumeric, convertUnits } from './helpers.js'
+import { strictNumeric, convertUnits } from './helpers.js'
 
 export default function validate_bins(binconfig) {
 	// Number.isFinite('1') returns false, which is desired
@@ -35,14 +35,14 @@ export default function validate_bins(binconfig) {
 				if (!('stop' in bin)) {
 					throw `a custom first bin must define a bin.stop value`
 				}
-				if (!isNumeric(bin.stop)) {
+				if (!strictNumeric(bin.stop)) {
 					throw `a custom first bin.stop value should be numeric`
 				}
 			} else if (bin == last_bin) {
 				if (!('start' in bin)) {
 					throw `a custom last bin must define a bin.start value`
 				}
-				if (!isNumeric(bin.start)) {
+				if (!strictNumeric(bin.start)) {
 					throw `a custom last bin.start must be numeric`
 				}
 				if ('stopunbounded' in bin && !bin.stopunbounded) {
@@ -53,8 +53,8 @@ export default function validate_bins(binconfig) {
 					throw 'a custom last bin must not set a bin.stop value'
 				}
 			} else {
-				if (!isNumeric(bin.start)) throw 'bin.start must be numeric for a non-first bin'
-				if (!isNumeric(bin.stop)) throw 'bin.stop must be numeric for a non-last bin'
+				if (!strictNumeric(bin.start)) throw 'bin.start must be numeric for a non-first bin'
+				if (!strictNumeric(bin.stop)) throw 'bin.stop must be numeric for a non-last bin'
 			}
 		}
 	} else if (bc.type == 'regular-bin') {
@@ -156,19 +156,19 @@ summaryfxn (percentiles)=> return {min, max, pX, pY, ...}
 			? maxCeil // in order to include the max value in the last bin
 			: bc.last_bin.stop_percentile
 			? summary['p' + bc.last_bin.stop_percentile]
-			: isNumeric(bc.last_bin.stop) && bc.last_bin.stop <= summary.max
+			: strictNumeric(bc.last_bin.stop) && bc.last_bin.stop <= summary.max
 			? bc.last_bin.stop
 			: maxCeil // in order to include the max value in the last bin
-		last_start = isNumeric(bc.last_bin.start_percentile)
+		last_start = strictNumeric(bc.last_bin.start_percentile)
 			? summary['p' + bc.last_bin.start_percentile]
-			: isNumeric(bc.last_bin.start)
+			: strictNumeric(bc.last_bin.start)
 			? bc.last_bin.start
 			: undefined
 		last_stop = bc.last_bin.stopunbounded
 			? null
 			: bc.last_bin.stop_percentile
 			? summary['p' + bc.last_bin.stop_percentile]
-			: isNumeric(bc.last_bin.stop)
+			: strictNumeric(bc.last_bin.stop)
 			? bc.last_bin.stop
 			: null
 	} else if (bc.lst) {
@@ -181,9 +181,9 @@ summaryfxn (percentiles)=> return {min, max, pX, pY, ...}
 		last_stop = maxCeil
 	}
 
-	const numericMax = isNumeric(max)
-	const numericLastStart = isNumeric(last_start)
-	const numericLastStop = isNumeric(last_stop)
+	const numericMax = strictNumeric(max)
+	const numericLastStart = strictNumeric(last_start)
+	const numericLastStop = strictNumeric(last_stop)
 
 	if (!numericMax && !numericLastStart) return [] //throw 'unable to compute the last bin start or stop'
 
@@ -191,16 +191,16 @@ summaryfxn (percentiles)=> return {min, max, pX, pY, ...}
 	let currBin = {
 		startunbounded: bc.first_bin.startunbounded,
 		start: bc.first_bin.startunbounded ? undefined : min,
-		stop: isNumeric(bc.first_bin.stop_percentile)
+		stop: strictNumeric(bc.first_bin.stop_percentile)
 			? +summary['p' + bc.first_bin.stop_percentile]
-			: isNumeric(bc.first_bin.stop)
+			: strictNumeric(bc.first_bin.stop)
 			? +bc.first_bin.stop
 			: min + bc.bin_size,
 		startinclusive: bc.startinclusive,
 		stopinclusive: bc.stopinclusive
 	}
 
-	if (!isNumeric(currBin.stop)) throw 'the computed first_bin.stop is non-numeric' + currBin.stop
+	if (!strictNumeric(currBin.stop)) throw 'the computed first_bin.stop is non-numeric' + currBin.stop
 	const maxNumBins = 100 // harcoded limit for now to not stress sqlite
 
 	while ((numericMax && currBin.stop <= max) || (currBin.startunbounded && !bins.length) || currBin.stopunbounded) {
@@ -372,10 +372,10 @@ export function get_bin_range_equation(bin, binconfig) {
 export function target_percentiles(binconfig) {
 	const percentiles = []
 	const f = binconfig.first_bin
-	if (f && isNumeric(f.start_percentile)) percentiles.push(f.start_percentile)
-	if (f && isNumeric(f.stop_percentile)) percentiles.push(f.stop_percentile)
+	if (f && strictNumeric(f.start_percentile)) percentiles.push(f.start_percentile)
+	if (f && strictNumeric(f.stop_percentile)) percentiles.push(f.stop_percentile)
 	const l = binconfig.last_bin
-	if (l && isNumeric(l.start_percentile)) percentiles.push(l.start_percentile)
-	if (l && isNumeric(l.stop_percentile)) percentiles.push(l.stop_percentile)
+	if (l && strictNumeric(l.start_percentile)) percentiles.push(l.start_percentile)
+	if (l && strictNumeric(l.stop_percentile)) percentiles.push(l.stop_percentile)
 	return percentiles
 }

--- a/shared/utils/src/urljson.js
+++ b/shared/utils/src/urljson.js
@@ -1,3 +1,5 @@
+import { isNumeric } from './helpers'
+
 const reserved = ['false', 'true', 'null', 'undefined']
 const delimiters = ['"', '{', '[']
 function encode(rawObject) {
@@ -28,7 +30,5 @@ function decode(query) {
 	}
 	return query
 }
-function isNumeric(d) {
-	return !isNaN(parseFloat(d)) && isFinite(d) && d !== ''
-}
+
 export { decode, encode }

--- a/shared/utils/src/urljson.ts
+++ b/shared/utils/src/urljson.ts
@@ -1,3 +1,5 @@
+import { isNumeric } from './helpers.js'
+
 /*
 	A custom encoder-decoder for URL query parameter values
 
@@ -78,8 +80,4 @@ export function decode(query: UrlJsonEncoded) {
 		// else the value is already a string
 	}
 	return query
-}
-
-function isNumeric(d) {
-	return !isNaN(parseFloat(d)) && isFinite(d) && d !== ''
 }


### PR DESCRIPTION
…arseFloat(), and create strictNumeric() helper. This also fixes intermittent session id errors dues to parseFloat() issue. It also adds a `strictNumeric()` helper for `termdb.bins.js` code that does not allow casting from string. 

To test, click `Session` button and `Share`, it should not fail intermittently. The issue was inside `isNumeric()` helper, `parseFloat(n)` was evaluating to `true` when a string starts with a number even if it's followed by non-numeric characters. This caused the subsequent `Number()` to be `NaN` and then converted as a `null` session id. 

Also tested with all unit and integration tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
