### PR TITLE
fix: barchart scale min should be zero even when unit='log'

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- barchart scale min should be zero even when unit='log', since a linear bar scale is still used


### PR DESCRIPTION
 since a linear bar scale is still used

## Description

In case the `log` scale option gets enabled in barchart, this fix would address the issue of bars not lining up to the matching log-scale tick value. In TermdbTest, avg dose to heart in log scale should show `1500 to <2000` line up to 100 and `3000 to <3500` bar length should be about 3/4 of `1500 to <2000` bar.

![Screenshot 2024-11-07 at 4 12 09 PM](https://github.com/user-attachments/assets/8a14a5e4-91b5-4bff-9164-7df88f8db48a)

Tested with http://localhost:3000/testrun.html?dir=mass&name=barchart.integration and unit tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
