### PR TITLE
Improvements in UI for gsea and geneORA

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -206,11 +206,12 @@ function getChartTypeList(self, state) {
 			clickTo: self.loadChartSpecificMenu
 		},
 
-		{
-			label: 'Differential Expression',
-			chartType: 'DEanalysis',
-			clickTo: self.loadChartSpecificMenu
-		},
+		// Commenting out this button since DE does not work without specifying two groups
+		//{
+		//	label: 'Differential Expression',
+		//	chartType: 'DEanalysis',
+		//	clickTo: self.loadChartSpecificMenu
+		//},
 
 		{
 			label: 'Data Download',

--- a/client/plots/geneORA.js
+++ b/client/plots/geneORA.js
@@ -197,8 +197,8 @@ add:
 			{ label: 'Gene set group' },
 			{ label: 'Original p-value (linear scale)' },
 			{ label: 'Adjusted p-value (linear scale)' },
-			{ label: 'Gene set hits' },
-			{ label: 'Gene set size' }
+			{ label: 'Gene set size' },
+			{ label: 'Gene set hits' }
 		]
 		self.gene_ora_table_rows = []
 		for (const pathway of output.pathways) {
@@ -211,8 +211,8 @@ add:
 					{ value: pathway.pathway_name },
 					{ value: roundValueAuto(pathway.p_value_original) },
 					{ value: roundValueAuto(pathway.p_value_adjusted) },
-					{ value: pathway.gene_set_hits },
-					{ value: pathway.gene_set_size }
+					{ value: pathway.gene_set_size },
+					{ value: pathway.gene_set_hits }
 				])
 			} else if (
 				self.settings.adjusted_original_pvalue == 'original' &&
@@ -223,8 +223,8 @@ add:
 					{ value: pathway.pathway_name },
 					{ value: roundValueAuto(pathway.p_value_original) },
 					{ value: roundValueAuto(pathway.p_value_adjusted) },
-					{ value: pathway.gene_set_hits },
-					{ value: pathway.gene_set_size }
+					{ value: pathway.gene_set_size },
+					{ value: pathway.gene_set_hits }
 				])
 			}
 		}

--- a/client/plots/geneORA.js
+++ b/client/plots/geneORA.js
@@ -69,7 +69,7 @@ class geneORA {
 				type: 'number',
 				chartType: 'geneORA',
 				settingsKey: 'gene_set_size_cutoff',
-				title: 'Gene set size cutoff',
+				title: 'Gene set size cutoff. Helps in filtering out large gene sets',
 				min: 0,
 				max: 20000
 			},

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -71,6 +71,15 @@ class gsea {
 					{ label: 'adjusted', value: 'adjusted' },
 					{ label: 'original', value: 'original' }
 				]
+			},
+			{
+				label: 'Gene set size filter cutoff',
+				type: 'number',
+				chartType: 'gsea',
+				settingsKey: 'gene_set_size_cutoff',
+				title: 'Gene set size cutoff. Helps in filtering out large gene sets',
+				min: 0,
+				max: 20000
 			}
 		]
 
@@ -121,11 +130,6 @@ class gsea {
 		this.settings = this.config.settings.gsea
 		await this.setControls()
 		if (this.dom.header)
-			//this.dom.header
-			//	.style('opacity', 0.6)
-			//	.style('padding-left', '10px')
-			//	.style('font-size', '0.75em')
-			//	.text('GENE SET ENRICHMENT ANALYSIS')
 			this.dom.header.html(
 				this.config.gsea_params.genes.length +
 					' genes <span style="font-size:.8em;opacity:.7">GENE SET ENRICHMENT ANALYSIS</span>'
@@ -183,7 +187,11 @@ add:
 		self.gsea_table_rows = []
 		for (const pathway_name of Object.keys(output.data)) {
 			const pathway = output.data[pathway_name]
-			if (self.settings.adjusted_original_pvalue == 'adjusted' && self.settings.pvalue >= pathway.fdr) {
+			if (
+				self.settings.adjusted_original_pvalue == 'adjusted' &&
+				self.settings.pvalue >= pathway.fdr &&
+				self.settings.gene_set_size_cutoff > pathway.geneset_size
+			) {
 				const es = pathway.es ? roundValueAuto(pathway.es) : pathway.es
 				const nes = pathway.nes ? roundValueAuto(pathway.nes) : pathway.nes
 				const pval = pathway.pval ? roundValueAuto(pathway.pval) : pathway.pval
@@ -199,7 +207,11 @@ add:
 					{ value: fdr },
 					{ value: pathway.leading_edge }
 				])
-			} else if (self.settings.adjusted_original_pvalue == 'original' && self.settings.pvalue >= pathway.pval) {
+			} else if (
+				self.settings.adjusted_original_pvalue == 'original' &&
+				self.settings.pvalue >= pathway.pval &&
+				self.settings.gene_set_size_cutoff > pathway.geneset_size
+			) {
 				const es = pathway.es ? roundValueAuto(pathway.es) : pathway.es
 				const nes = pathway.nes ? roundValueAuto(pathway.nes) : pathway.nes
 				const pval = pathway.pval ? roundValueAuto(pathway.pval) : pathway.pval
@@ -326,7 +338,8 @@ export async function getPlotConfig(opts, app) {
 				gsea: {
 					pvalue: 0.05,
 					adjusted_original_pvalue: 'adjusted',
-					pathway: undefined
+					pathway: undefined,
+					gene_set_size_cutoff: 2000
 				},
 				controls: { isOpen: true }
 			}

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -121,11 +121,15 @@ class gsea {
 		this.settings = this.config.settings.gsea
 		await this.setControls()
 		if (this.dom.header)
-			this.dom.header
-				.style('opacity', 0.6)
-				.style('padding-left', '10px')
-				.style('font-size', '0.75em')
-				.text('GENE SET ENRICHMENT ANALYSIS')
+			//this.dom.header
+			//	.style('opacity', 0.6)
+			//	.style('padding-left', '10px')
+			//	.style('font-size', '0.75em')
+			//	.text('GENE SET ENRICHMENT ANALYSIS')
+			this.dom.header.html(
+				this.config.gsea_params.genes.length +
+					' genes <span style="font-size:.8em;opacity:.7">GENE SET ENRICHMENT ANALYSIS</span>'
+			)
 		render_gsea(this)
 	}
 }
@@ -320,7 +324,7 @@ export async function getPlotConfig(opts, app) {
 			//samplelst: { groups: app.opts.state.groups}
 			settings: {
 				gsea: {
-					pvalue: 1.0,
+					pvalue: 0.05,
 					adjusted_original_pvalue: 'adjusted',
 					pathway: undefined
 				},

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -80,6 +80,14 @@ class gsea {
 				title: 'Gene set size cutoff. Helps in filtering out large gene sets',
 				min: 0,
 				max: 20000
+			},
+			{
+				label: 'Filter non-coding genes',
+				type: 'checkbox',
+				chartType: 'gsea',
+				settingsKey: 'filter_non_coding_genes',
+				title: 'Filter non-coding genes',
+				boxLabel: ''
 			}
 		]
 
@@ -154,6 +162,7 @@ add:
 		self.dom.holder.selectAll('*').remove()
 		self.dom.tableDiv.selectAll('*').remove()
 		self.config.gsea_params.geneSetGroup = self.settings.pathway
+		self.config.gsea_params.filter_non_coding_genes = self.settings.filter_non_coding_genes
 		const wait = self.dom.detailsDiv.append('div').text('Loading...')
 		//console.log('self.config.gsea_params:', self.config.gsea_params)
 		let output
@@ -248,7 +257,8 @@ add:
 					genes: self.config.gsea_params.genes,
 					fold_change: self.config.gsea_params.fold_change,
 					geneSetGroup: self.config.gsea_params.geneSetGroup,
-					pickle_file: output.pickle_file
+					pickle_file: output.pickle_file,
+					filter_non_coding_genes: self.settings.filter_non_coding_genes
 				}
 				const holder = self.dom.holder
 				holder.selectAll('*').remove()
@@ -339,7 +349,8 @@ export async function getPlotConfig(opts, app) {
 					pvalue: 0.05,
 					adjusted_original_pvalue: 'adjusted',
 					pathway: undefined,
-					gene_set_size_cutoff: 2000
+					gene_set_size_cutoff: 2000,
+					filter_non_coding_genes: true
 				},
 				controls: { isOpen: true }
 			}

--- a/server/routes/genesetEnrichment.ts
+++ b/server/routes/genesetEnrichment.ts
@@ -67,12 +67,13 @@ async function run_genesetEnrichment_analysis(
 		geneset_group: q.geneSetGroup,
 		cachedir: serverconfig.cachedir,
 		geneset_name: q.geneset_name,
-		pickle_file: q.pickle_file
+		pickle_file: q.pickle_file,
+		genedb: path.join(serverconfig.tpmasterdir, genomes[q.genome].genedb.dbfile),
+		filter_non_coding_genes: q.filter_non_coding_genes
 	}
 
+	//console.log('genesetenrichment_input:', genesetenrichment_input)
 	//console.log('__dirname:',__dirname)
-	//console.log('genesetenrichment_input:', JSON.stringify(genesetenrichment_input))
-	//
 	//fs.writeFile('test.txt', '/' + JSON.stringify(genesetenrichment_input), function (err) {
 	//	// For catching input to rust pipeline, in case of an error
 	//	if (err) return console.log(err)

--- a/server/utils/gsea.py
+++ b/server/utils/gsea.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
             
 def extract_symbols(x):
-   return x['symbol'] 
+   return x['symbol']
 
 def extract_plot_data(signature, geneset, library, result, center=True):
    signature = signature.copy()
@@ -48,6 +48,7 @@ try:
             genes=json_object['genes']
             fold_change=json_object['fold_change']
             table_name=json_object['geneset_group']
+            filter_non_coding_genes=json_object['filter_non_coding_genes']
             df = {'Genes': genes, 'fold_change': fold_change}
             signature=pd.DataFrame(df)
             db=json_object['db']
@@ -59,10 +60,19 @@ try:
             
             # SQL query to select all data from the table
             query = f"select id from terms where parent_id='" + table_name  + "'"
-            
             # Execute the SQL query
             cursor.execute(query)
-            
+            if filter_non_coding_genes == True:
+                 # SQL query to code all the protein coding genes
+                 coding_genes_query = f"select * from codingGenes"
+                 genedb = json_object['genedb']
+                 gene_conn = sqlite3.connect(genedb)
+                 gene_cursor = gene_conn.cursor()
+                 gene_cursor.execute(coding_genes_query)
+                 coding_genes_list=gene_cursor.fetchall()
+                 coding_genes_list=list(map(lambda x: x[0],coding_genes_list))
+                 signature=signature[signature['Genes'].isin(coding_genes_list)]
+                 
             # Fetch all rows from the executed SQL query
             rows = cursor.fetchall()
             

--- a/shared/types/src/routes/genesetEnrichment.ts
+++ b/shared/types/src/routes/genesetEnrichment.ts
@@ -5,6 +5,8 @@ export type GenesetEnrichmentRequest = {
 	genes: string[]
 	/** Background genes against which the sample genes will be queried */
 	fold_change: number[]
+	/** Filter non-coding genes */
+	filter_non_coding_genes: boolean
 	/** Genome build */
 	genome: string
 	/** Type of GO to be queried e.g MF, CC, BP */


### PR DESCRIPTION
## Description

1) Added number of genes analyzed in GSEA header (like how it is for geneORA).
2) Added gene set size filter cutoff to gsea (similar to geneORA). 
3) Change p-value filter cutoff in gsea to 0.05.
4) In geneORA, placed gene set size before the gene set hits because its usually not visible until scrolled to the other end of the table.
5) Commented out the DE button in charts.js since DE does not work without specifying two groups of samples.
6) Added checkbox in gsea burger plot, which filters out non-coding genes by default (like geneORA).
7) Made changes so that geneORA and gsea panels do not pop up without selection by the user.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
