### PR TITLE
Fix for cnv legend rects overlapping

### DIFF
--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -98,9 +98,9 @@ export default function svgLegend(opts) {
 		if (settings.linesep) {
 			currlinex = settings.padleft
 			currliney += settings.lineh
-		} else if (d.hasScale) {
-			currlinex = leftdist - 2 * settings.padx + 2
-		} else if (settings.hangleft) {
+			// } else if (d.hasScale) {
+			// 	currlinex = leftdist - 2 * settings.padx + 2
+		} else if (d.hasScale || settings.hangleft) {
 			currlinex = leftdist + 2 * settings.padx
 		} else {
 			currlinex += settings.padleft + grplabel.node().getBBox().width + 2 * settings.padx


### PR DESCRIPTION
## Description
Closes issue #2362. Please test with [this example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22matrix%22,%22termgroups%22:%5B%7B%22lst%22:%5B%7B%22id%22:%22Sex%22%7D,%7B%22term%22:%7B%22gene%22:%22TAL1%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22KRAS%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22MYB%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22PAX5%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22NOTCH1%22,%22type%22:%22geneVariant%22%7D%7D%5D%7D%5D%7D%5D%7D). The overlapping scale ticks are fixed in PR #2344. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
