### PR TITLE
Fix for ColorScale rendering requirement in regression results

### DIFF
--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -1560,9 +1560,13 @@ export function showLDlegend(div, colorScale) {
 	const xpad = 10
 	const axiswidth = 150
 
-	const colorScaleElem = new ColorScale({
+	/** ColorScale component requires the color and data array to be the same
+	 * length. This data array is purely to fulfill that requirement.*/
+	const data = colorlst.map((d, i) => i / (colorlst.length - 1))
+
+	new ColorScale({
 		holder: colorbardiv,
-		data: [0, 1],
+		data,
 		topTicks: true,
 		width: xpad * 2 + axiswidth,
 		height: axisheight + barheight,


### PR DESCRIPTION
## Description
Closes issue #2368. Please use [this example](http://localhost:3000/?noheader=1&mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:%7B%22id%22:%22LV_Ejection_Fraction_3D%22%7D,%22independent%22:%5B%7B%22id%22:%22sex%22,%22refGrp%22:%222%22%7D,%7B%22term%22:%7B%22type%22:%22snplocus%22%7D,%22q%22:%7B%22chr%22:%22chr17%22,%22start%22:7664218,%22stop%22:7671018,%22AFcutoff%22:5,%22alleleType%22:0,%22geneticModel%22:0,%22restrictAncestry%22:%7B%22name%22:%22European%20ancestry%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22genetic_race%22,%22type%22:%22categorical%22,%22name%22:%22Genetically%20defined%20race%22%7D,%22values%22:%5B%7B%22key%22:%22European%20Ancestry%22,%22label%22:%22European%20Ancestry%22%7D%5D%7D%7D,%22variant_filter%22:%7B%22type%22:%22tvslst%22,%22join%22:%22and%22,%22in%22:true,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22isnot%22:true,%22values%22:%5B%7B%22label%22:%22Bad%22,%22key%22:%22Bad%22%7D%5D,%22term%22:%7B%22id%22:%22QC%22,%22name%22:%22Classification%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22,%22values%22:%7B%22Good%22:%7B%22label%22:%22Good%22,%22key%22:%22Good%22%7D,%22Bad%22:%7B%22label%22:%22Bad%22,%22key%22:%22Bad%22%7D%7D%7D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22ranges%22:%5B%7B%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true%7D%5D,%22term%22:%7B%22id%22:%22SJcontrol_CR%22,%22name%22:%22SJLIFE%20control%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22%7D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22ranges%22:%5B%7B%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true%7D%5D,%22term%22:%7B%22id%22:%22CR%22,%22name%22:%22Call%20rate,%20SJLIFE+CCSS%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22%7D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22ranges%22:%5B%7B%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true%7D%5D,%22term%22:%7B%22id%22:%22CR_sjlife%22,%22name%22:%22SJLIFE%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22%7D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22ranges%22:%5B%7B%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true%7D%5D,%22term%22:%7B%22id%22:%22CR_ccss%22,%22name%22:%22CCSS%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22%7D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22isnot%22:true,%22values%22:%5B%7B%22label%22:%22yes%22,%22key%22:%221%22%7D%5D,%22term%22:%7B%22id%22:%22Polymer_region%22,%22name%22:%22Polymer%20region%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22%7D%7D%7D%5D%7D%7D%7D%5D%7D%5D%7D) to test. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
