### PR TITLE
Regression results tooltips

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -202,11 +202,15 @@ export class Menu {
 		return this
 	}
 
-	showunder(dom) {
+	// opts{}: can supply offsetX and offsetY
+	// necessary because .showunder() uses .show(shift=false), which
+	// ignores offsetY in the constructor option
+	showunder(dom, _opts = {}) {
 		// route to .show()
+		const opts = Object.assign({ offsetX: 0, offsetY: 0 }, _opts)
 		const p = dom.getBoundingClientRect()
-		const x = p.left + window.scrollX
-		const y = p.top + p.height + window.scrollY + 5
+		const x = p.left + window.scrollX + opts.offsetX
+		const y = p.top + p.height + window.scrollY + 5 + opts.offsetY
 		return this.show(x, y, false, true, false)
 
 		/*

--- a/client/mass/test/regression.integration.spec.js
+++ b/client/mass/test/regression.integration.spec.js
@@ -161,9 +161,10 @@ tape('Linear: continuous outcome = "agedx", cat. independents = "sex" + "genetic
 		table = regDom.results.selectAll('div[name^="Coefficients"] table tr').nodes()
 		const coefHeader = structuredClone(data.coefficients.header)
 		coefHeader.splice(3, 2, '95% CI')
+		coefHeader[2] = coefHeader[2] + String.fromCharCode(160) + 'ⓘ'
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const linearHeaders = coefHeader.filter(d => d === 'Beta')
+		const linearHeaders = coefHeader.filter(d => d === 'Beta' + String.fromCharCode(160) + 'ⓘ')
 		test.equal(linearHeaders.length, 1, `Should render headers specific to linear regression`)
 		const coefIntercept = [data.coefficients.intercept[0], data.coefficients.intercept[1]]
 		coefIntercept.push(...getCoefData(data.coefficients.intercept.slice(2)))
@@ -469,9 +470,10 @@ tape('Logistic: binary outcome = "hrtavg", continuous independent = "agedx"', te
 		table = regDom.results.selectAll('div[name^="Coefficients"] table tr').nodes()
 		const coefHeader = structuredClone(data.coefficients.header)
 		coefHeader.splice(3, 2, '95% CI')
+		coefHeader[2] = coefHeader[2] + String.fromCharCode(160) + 'ⓘ'
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const logHeaders = coefHeader.filter(d => d === 'Odds ratio')
+		const logHeaders = coefHeader.filter(d => d === 'Odds ratio' + String.fromCharCode(160) + 'ⓘ')
 		test.equal(logHeaders.length, 1, `Should render headers specific to logistic regression`)
 
 		const coefIntercept = [data.coefficients.intercept[0], data.coefficients.intercept[1]]
@@ -575,9 +577,10 @@ tape('Cox: graded outcome = "Arrhythmias", continuous independent = "agedx"', te
 		const coefHeader = structuredClone(data.coefficients.header)
 		coefHeader.splice(2, 2)
 		coefHeader.splice(3, 2, '95% CI')
+		coefHeader[2] = coefHeader[2] + String.fromCharCode(160) + 'ⓘ'
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const coxHeaders = coefHeader.filter(d => d === 'HR')
+		const coxHeaders = coefHeader.filter(d => d === 'HR' + String.fromCharCode(160) + 'ⓘ')
 		test.equal(coxHeaders.length, 1, `Should render headers specific to cox regression in ${tableLabel}`)
 
 		testTerm = 'Age (years) at Cancer Diagnosis'
@@ -684,9 +687,10 @@ tape('Cox: survival outcome, continuous independent = "agedx"', test => {
 		const coefHeader = structuredClone(data.coefficients.header)
 		coefHeader.splice(2, 2)
 		coefHeader.splice(3, 2, '95% CI')
+		coefHeader[2] = coefHeader[2] + String.fromCharCode(160) + 'ⓘ'
 		results = checkTableRow(table, 0, coefHeader)
 		test.equal(results, true, `Should render all coefficient headers in ${tableLabel}`)
-		const coxHeaders = coefHeader.filter(d => d === 'HR')
+		const coxHeaders = coefHeader.filter(d => d === 'HR' + String.fromCharCode(160) + 'ⓘ')
 		test.equal(coxHeaders.length, 1, `Should render headers specific to cox regression in ${tableLabel}`)
 
 		testTerm = 'Age (years) at Cancer Diagnosis'

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -707,7 +707,7 @@ function getLogisticOutcomeNonref(outcome) {
 		// condition term does not use q.type
 		// from q.groups[], return the str name that's not refgrp
 		for (const i of outcome.q.groups) {
-			if (i.name != outcome.refGrp) return i
+			if (i.name != outcome.refGrp) return i.name
 		}
 		throw 'nonref group not found for logistic outcome'
 	}

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -891,23 +891,17 @@ function setRenderers(self) {
 		for (const v of header_multi) tr.append('td')
 	}
 
+	// fill data columns of row of coefficients table
 	self.fillCoefDataCols = arg => {
 		const { tr, cols } = arg
 		// estimate (Beta/OR/HR) column
 		const est = Number(cols.shift())
 		const estTd = tr.append('td').text(est).style('padding', '8px')
+		// on hover, display explanation of estimate value
 		const tip = new Menu()
-		// get message explaining the meaning of estimate value
 		const estimateMsg = self.getEstimateMsg(Object.assign({ est }, arg))
-		// display message as a tooltip
-		tip.d.append('div').text(estimateMsg)
-		estTd.on('mouseover', event => {
-			/*const p = event.currentTarget.getBoundingClientRect()
-			const x = p.left + window.scrollX + 10
-			const y = p.top + window.scrollY + 20
-			return tip.show(x, y, false, false, false)*/
-			return tip.showunder(event.currentTarget)
-		})
+		tip.d.append('div').style('width', '700px').text(estimateMsg)
+		estTd.on('mouseover', event => tip.showunder(event.currentTarget))
 		estTd.on('mouseout', () => tip.hide())
 		// 95% CI column
 		tr.append('td').html(`${cols.shift()} &ndash; ${cols.shift()}`).style('padding', '8px')
@@ -915,25 +909,18 @@ function setRenderers(self) {
 		for (const v of cols) tr.append('td').text(v).style('padding', '8px')
 	}
 
-	/* get tooltip message for estimate column
+	/*
+	get tooltip message explaining the estimate value
 
-		TODO: currently assuming that if a term does not have a
-		category/refGrp, then it must be a continuous term.
-		This is not a correct assumption because it ignores
-		cubic spline/snplst/snplocus etc. terms. Need to consider these
-		other scenarios in this code.
-
-		TODO: for querying independent variables, see the code in
-		getIndependentInput() because this function can handle both
-		dictionary and non-dictionary variables.
-
-		TODO: for ancestry PC variables can refer to them in
-		the message as "EUR PCs 1-10".
-
-		TODO: make sure to support custom variables
+	TODO: currently assuming that if a term does not have a
+	category/refGrp, then it must be a continuous term.
+	This is not a correct assumption because it ignores
+	cubic spline/snplst/snplocus etc. terms. Need to consider these
+	other scenarios in this code.
 	*/
 	self.getEstimateMsg = arg => {
 		const { est, tw, tw2, categoryKey, categoryKey2, isIntercept } = arg
+		if (tw && (!tw.term.type || tw.q.mode == 'spline')) return '' // TODO: support non-dictionary and cubic spline variables
 		const independentTws = self.independentTws
 		const outcomeTw = self.config.outcome
 		const regtype = self.config.regressionType

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -77,7 +77,8 @@ export class RegressionResults {
 			err_div: holder.append('div'),
 			snplocusBlockDiv: holder.append('div'),
 			// is where newDiv() and displayResult_oneset() writes to
-			oneSetResultDiv: holder.append('div').style('margin', '10px')
+			oneSetResultDiv: holder.append('div').style('margin', '10px'),
+			tip: new Menu()
 		}
 	}
 
@@ -895,14 +896,16 @@ function setRenderers(self) {
 	self.fillCoefDataCols = arg => {
 		const { tr, cols } = arg
 		// estimate (Beta/OR/HR) column
-		const est = Number(cols.shift())
-		const estTd = tr.append('td').text(est).style('padding', '8px')
-		// on hover, display explanation of estimate value
-		const tip = new Menu()
-		const estimateMsg = self.getEstimateMsg(Object.assign({ est }, arg))
-		tip.d.append('div').style('width', '700px').text(estimateMsg)
-		estTd.on('mouseover', event => tip.showunder(event.currentTarget))
-		estTd.on('mouseout', () => tip.hide())
+		const est = cols.shift()
+		const estSpan = tr.append('td').style('padding', '8px').append('span').text(est)
+		// on mouseover, display explanation of estimate value
+		estSpan.on('mouseover', event => {
+			const tip = self.dom.tip.clear()
+			const estimateMsg = self.getEstimateMsg(Object.assign({ est: Number(est) }, arg))
+			tip.d.append('div').style('min-width', '450px').style('max-width', '600px').text(estimateMsg)
+			tip.showunder(event.target, { offsetY: -5 })
+		})
+		estSpan.on('mouseout', () => self.dom.tip.hide())
 		// 95% CI column
 		tr.append('td').html(`${cols.shift()} &ndash; ${cols.shift()}`).style('padding', '8px')
 		// rest of columns

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -267,6 +267,7 @@ export class TermdbVocab extends Vocab {
 		if (!outcome.q.mode && opts.regressionType == 'linear') outcome.q.mode = 'continuous'
 		const contQkeys = ['mode', 'scale']
 		outcome.refGrp = outcome.q.mode == 'continuous' ? 'NA' : opts.outcome.refGrp
+		if (opts.outcome.nonRefGrp) outcome.nonRefGrp = opts.outcome.nonRefGrp
 
 		if (outcome.q.mode == 'continuous') {
 			// remove unneeded parameters from q

--- a/client/tw/categorical.ts
+++ b/client/tw/categorical.ts
@@ -57,15 +57,14 @@ export class CategoricalBase extends TwBase {
 			function directly, outside of TwRouter.fill(). The input tw.type
 			does not have to be discriminated in that case.
 		*/
-		if (!tw.type)
-			tw.type =
-				!tw.q.type || tw.q.type == 'values'
-					? 'CatTWValues'
-					: tw.q.type == 'predefined-groupset'
-					? 'CatTWPredefinedGS'
-					: tw.q.type == 'custom-groupset'
-					? 'CatTWCustomGS'
-					: undefined
+		tw.type =
+			!tw.q.type || tw.q.type == 'values'
+				? 'CatTWValues'
+				: tw.q.type == 'predefined-groupset'
+				? 'CatTWPredefinedGS'
+				: tw.q.type == 'custom-groupset'
+				? 'CatTWCustomGS'
+				: tw.type
 
 		/*
 			For each of fill() functions below:

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -284,7 +284,7 @@ function makeRinput(q, sampledata) {
 		// for logistic regression, if spline terms are present, the spline plot needs to have label for nonref category of outcome
 		outcome.categories = {
 			ref: q.outcome.refGrp,
-			nonref: getLogisticOutcomeNonref(q.outcome)
+			nonref: q.outcome.nonRefGrp
 		}
 	}
 	if (q.regressionType == 'cox') {
@@ -492,53 +492,6 @@ function makeRvariable_snps(tw, independent, q) {
 			})
 		}
 	}
-}
-
-function getLogisticOutcomeNonref(outcome) {
-	// outcome is q.outcome{}, the term-wrapper {q{}, refGrp, term{}}
-	if (outcome.term.type == 'condition') {
-		// condition term does not use q.type
-		// from q.groups[], return the str name that's not refgrp
-		for (const i of outcome.q.groups) {
-			if (i.name != outcome.refGrp) return i
-		}
-		throw 'nonref group not found for logistic outcome'
-	}
-	// not condition term;
-	// depending on q.type, find the non-ref group and return its name, to be used in Y axis of spline plot
-	if (outcome.q.type == 'predefined-groupset') {
-		if (!Number.isInteger(outcome.q.predefined_groupset_idx))
-			throw 'outcome.q.predefined_groupset_idx not integer when q.type is "predefined-groupset"'
-		if (!outcome.term.groupsetting) throw 'outcome.term.groupsetting missing'
-		const grpset = outcome.term.groupsetting.lst[outcome.q.predefined_groupset_idx]
-		if (!grpset) throw 'groupset not found by outcome.q.predefined_groupset_idx'
-		const nonrefgrp = grpset.groups.find(i => i.name != outcome.refGrp)
-		if (!nonrefgrp) throw 'non-ref group not found for predefined-groupset'
-		return nonrefgrp.name
-	}
-	if (outcome.q.type == 'custom-groupset') {
-		if (!outcome.q.customset) throw 'outcome.q.customset missing'
-		const nonrefgrp = outcome.q.customset.groups.find(i => i.name != outcome.refGrp)
-		if (!nonrefgrp) throw 'non-ref group not found for custom-groupset'
-		return nonrefgrp.name
-	}
-	if (outcome.q.type == 'values') {
-		if (!outcome.term.values) throw 'outcome.term.values{} missing'
-		for (const k in outcome.term.values) {
-			const v = outcome.term.values[k]
-			if (v.label != outcome.refGrp) return v.label
-		}
-		throw 'unknown nonref group from outcome.term.values'
-	}
-	if (outcome.q.type == 'custom-bin') {
-		const nonrefbin = outcome.q.lst.find(i => i.label != outcome.refGrp)
-		if (!nonrefbin) throw 'non-ref bin is not found for custom-bin'
-		return nonrefbin.label
-	}
-	if (outcome.q.type == 'regular-bin') {
-		throw 'do not know a way to find computed bin list for type=regular-bin'
-	}
-	throw 'unknown outcome.q.type'
 }
 
 function validateRinput(Rinput) {


### PR DESCRIPTION
## Description

In this PR, tooltips that explain the results of regression analysis have have been enabled (based on [slides](https://docs.google.com/presentation/d/1JH8Kh7bw5fT5xFTJ_V4QAOp_E47ALozcN_AiYeAzuVc/edit#slide=id.p) discussed with Yutaka). Hover mouse over values in the estimate column ("beta" for linear regression, "OR" for logistic regression, and "HR" for cox regression) and tooltip will appear that explains the results. Tooltips are supported for dictionary and custom variables (and their interactions) for linear, logistic, and cox. Tooltips for genetic and cubic spline variables will be supported later.

Please test using linear, logistic, and cox regression with various types of variables (e.g., categorical, discrete, and continuous, etc.) and various numbers of variables. Please also test using interactions (in sjlife dataset).


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
