### PR TITLE
Scatter fix

### DIFF
--- a/client/plots/brainImaging.js
+++ b/client/plots/brainImaging.js
@@ -556,7 +556,7 @@ function setInteractivity(self) {
 					config: { legendFilter: [] }
 				})
 			})
-		let color = self.state.config.overlayTW.term.values[targetData.key]?.color || '#000000'
+		let color = self.state.config.overlayTW.term.values[targetData.key]?.color || 'red'
 		color = rgb(color).formatHex() //so that the color is in the correct format to be shown in the input
 		legendMenuDiv
 			.append('div')

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -367,7 +367,7 @@ export function setRenderers(self) {
 		}
 		scale = (self.zoom * scale * factor) / 3
 		const particleSize = 16 * scale
-		const x = chart.xAxisScale(c.x)
+		const x = chart.xAxisScale(c.x) - particleSize / 2
 		const y = chart.yAxisScale(c.y) - particleSize / 2
 		const transform = `translate(${x},${y}) scale(${scale})` // original icons are scaled to 0.3
 		return transform

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -45,13 +45,16 @@ export function setRenderers(self) {
 		if (chart.data.samples.length == 0) return
 		const offsetX = self.axisOffset.x
 		const offsetY = self.axisOffset.y
+		const extraSpaceX = (chart.xMax - chart.xMin) * 0.05 //extra space added to avoid clipping the particles on the X axis
+		const extraSpaceY = (chart.yMax - chart.yMin) * 0.05 //extra space added to avoid clipping the particles on the Y axis
+
 		chart.xAxisScale = d3Linear()
-			.domain([chart.xMin, chart.xMax])
+			.domain([chart.xMin - extraSpaceX, chart.xMax + extraSpaceX])
 			.range([offsetX, self.settings.svgw + offsetX])
 
 		chart.axisBottom = axisBottom(chart.xAxisScale)
 		chart.yAxisScale = d3Linear()
-			.domain([chart.yMax, chart.yMin])
+			.domain([chart.yMax + extraSpaceY, chart.yMin - extraSpaceY])
 			.range([offsetY, self.settings.svgh + offsetY])
 
 		chart.zAxisScale = d3Linear().domain([chart.zMin, chart.zMax]).range([0, self.settings.svgd])
@@ -352,8 +355,6 @@ export function setRenderers(self) {
 	}
 
 	self.transform = function (chart, c, factor = 1) {
-		const x = chart.xAxisScale(c.x)
-		const y = chart.yAxisScale(c.y)
 		const isRef = !('sampleId' in c)
 		let scale
 		if (!self.config.scaleDotTW || isRef) {
@@ -364,7 +365,11 @@ export function setRenderers(self) {
 				scale = self.settings.minShapeSize + ((c.scale - chart.scaleMin) / (chart.scaleMax - chart.scaleMin)) * range
 			else scale = self.settings.maxShapeSize - ((c.scale - chart.scaleMin) / (chart.scaleMax - chart.scaleMin)) * range
 		}
-		const transform = `translate(${x},${y}) scale(${(self.zoom * scale * factor) / 3})` // original icons are scaled to 0.3
+		scale = (self.zoom * scale * factor) / 3
+		const particleSize = 16 * scale
+		const x = chart.xAxisScale(c.x)
+		const y = chart.yAxisScale(c.y) - particleSize / 2
+		const transform = `translate(${x},${y}) scale(${scale})` // original icons are scaled to 0.3
 		return transform
 	}
 

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -285,7 +285,8 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 				if (tvalue && 'color' in tvalue) {
 					value.color = tvalue.color
 				} else if (isNumericTerm(q.colorTW.term)) {
-					const bin = data.refs.byTermId[q.colorTW.$id].bins.find(bin => bin.name == category)
+					const bins = data.refs.byTermId[q.colorTW.$id].bins
+					const bin = bins.find(bin => bin.label == category)
 					if (bin) value.color = bin.color
 					else {
 						value.color = scheme[i]

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -6,6 +6,7 @@ import { mclass, dt2label, morigin } from '#shared/common.js'
 import { authApi } from './auth.js'
 import run_R from './run_R.js'
 import { read_file } from './utils.js'
+import { isNumericTerm } from '@sjcrh/proteinpaint-shared/terms.js'
 /*
 works with "canned" scatterplots in a dataset, e.g. data from a text file of tSNE coordinates from a pre-analyzed cohort (contrary to on-the-fly analysis)
 
@@ -283,7 +284,8 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 
 				if (tvalue && 'color' in tvalue) {
 					value.color = tvalue.color
-				} else if (data?.refs?.byTermId[q.colorTW.term.id]?.bins) {
+				} else if (isNumericTerm(q.colorTW.term)) {
+					const bin = data.refs.byTermId[q.colorTW.$id].bins.find(bin => bin.name == category)
 					if (bin) value.color = bin.color
 					else {
 						value.color = scheme[i]
@@ -420,8 +422,8 @@ function order(map, tw, refs) {
 			else if (v1 < v2) return -1
 			return 0
 		})
-	} else if (refs?.byTermId[tw.term.id]?.bins) {
-		const bins = refs.byTermId[tw.term.id].bins
+	} else if (refs?.byTermId[tw.$id]?.bins) {
+		const bins = refs.byTermId[tw.$id].bins
 		for (const bin of bins) if (map[bin.name]) entries.push([bin.name, map[bin.name]])
 		//If some category is not defined in the bins, should be added
 		for (const [category, value] of Object.entries(map))


### PR DESCRIPTION
## Description

I noticed getData indexes refs.byTermId using $id, so I fixed the way to access the bins on the scatter. Also solved #2381  by adding extra space on the X and Y axis and considering particle size when positioning it in the transform method.
And there is a small fix on the default color when editing the brainImaging legend. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
