### PR TITLE
fix: handle missing childType when launching gene exp summary plot

### DIFF
--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -407,11 +407,21 @@ export async function getPlotConfig(opts, app) {
 				} else if (config.term?.q?.mode == 'continuous' || config.term2?.q?.mode == 'continuous') {
 					/** Fix for summary tabs switching to different plots when opening and closing
 					 * controls, changing settings, etc. */
+					config.childType = 'violin' // when mode=continuous is present, use violin by default and allow override below.
 					const state = app.getState()
-					if (state && state.plots) {
-						config.childType = state.plots.find(p => p.id === config.id).childType
-					} else config.childType = opts.childType || 'violin'
-				} else config.childType = 'barchart'
+					if (state.plots) {
+						const p = state.plots.find(p => p.id === config.id)
+						if (p && p.childType) {
+							config.childType = p.childType
+						} else {
+							// p.childType maybe missing (?), in such case do not change config.childType
+						}
+					} else if (opts.childType) {
+						config.childType = opts.childType
+					}
+				} else {
+					config.childType = 'barchart'
+				}
 			}
 		}
 	}

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -409,9 +409,9 @@ export async function getPlotConfig(opts, app) {
 					 * controls, changing settings, etc. */
 					config.childType = 'violin' // when mode=continuous is present, use violin by default and allow override below.
 					const state = app.getState()
-					if (state.plots) {
+					if (state?.plots) {
 						const p = state.plots.find(p => p.id === config.id)
-						if (p && p.childType) {
+						if (p?.childType) {
 							config.childType = p.childType
 						} else {
 							// p.childType maybe missing (?), in such case do not change config.childType

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- handle missing childType when launching gene exp summary plot


### PR DESCRIPTION
## Description

closes #2387 
at http://localhost:3000/?noheader=1&massnative=hg38-test,TermdbTest, at dict ui, select `Gene exp` tab, search p53. violin loads

all ci pass; please address my questions

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
