### PR TITLE
fix the handling of types/dist/index.js which breaks integration CI

### DIFF
--- a/shared/types/build.sh
+++ b/shared/types/build.sh
@@ -3,10 +3,14 @@
 set -euxo pipefail
 
 # npx tsx emitCheckers.ts # this is done only as needed
+rm -rf dist
 npx typia generate --input ./checkers --output ./dist
-cp ./checkers/index.js ./dist
+cp ./checkers/index.js ./dist/index.ts
 # esbuild will emit js files from ts files,
 # note that package.json:files[] only include dist/*.js;
 node esbuild.config.mjs
+# sed -i.bk "s|.ts'|.js'|g" dist/index.js
+# rm dist/index.js
+# mv dist/index.js.bk dist/index.js
 # after packing, should remove dist/*.js except dist/index.js
 # see package.json:scripts.postpack

--- a/shared/types/package.json
+++ b/shared/types/package.json
@@ -15,15 +15,15 @@
     "#shared": "@sjcrh/proteinpaint-shared"
   },
   "scripts": {
+    "generate": "node dev.mjs",
     "predev": "tsx emitCheckers.ts",
     "dev": "node --watch-path=src --watch-path=checkers dev.mjs",
     "prepare": "ts-patch install",
     "build": "./build.sh",
     "prepack": "./build.sh",
-    "postpack": "cd dist && ls *.js | grep -xvF index.js | xargs rm -f",
+    "postpack": "rm dist/*.js && mv dist/index.ts dist/index.js",
     "test": "tsc",
-    "doc": "./doc.sh",
-    "generate": "typia generate --input ./checkers --output ./dist"
+    "doc": "./doc.sh"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Description

Tested with https://github.com/stjude/proteinpaint/actions/runs/11902027997.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
