### PR TITLE
Remove snplocus block after editing variables

### DIFF
--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -901,13 +901,13 @@ function setRenderers(self) {
 				// header for estimate column
 				const est = h
 				const estTd = tr.append('td').style('padding', '8px').text(est)
-				const estInfo = estTd.append('sup').style('cursor', 'default').html('&nbsp;&#9432;')
+				/*const estInfo = estTd.append('sup').style('cursor', 'default').html('&nbsp;&#9432;')
 				estInfo.on('mouseover', event => {
 					const tip = self.dom.tip.clear()
 					tip.d.append('div').text('View interpretations of results by hovering over each value')
 					tip.showunder(event.target)
 				})
-				estInfo.on('mouseout', () => self.dom.tip.hide())
+				estInfo.on('mouseout', () => self.dom.tip.hide())*/
 			} else {
 				// headers for all other data columns
 				const td = tr.append('td').text(h).style('padding', '8px')
@@ -934,16 +934,20 @@ function setRenderers(self) {
 		const { tr, cols, tw } = arg
 		// estimate (Beta/OR/HR) column
 		const est = cols.shift()
-		const estSpan = tr.append('td').style('padding', '8px').style('cursor', 'default').append('span').text(est)
+		const estSpan = tr
+			.append('td')
+			.style('padding', '8px') /*.style('cursor', 'default')*/
+			.append('span')
+			.text(est)
 		// on mouseover, display explanation of estimate value
-		estSpan.on('mouseover', event => {
+		/*estSpan.on('mouseover', event => {
 			if (tw && (!tw.term.type || tw.q.mode == 'spline')) return // TODO: support non-dictionary and cubic spline variables
 			const tip = self.dom.tip.clear()
 			const estimateMsg = self.getEstimateMsg(Object.assign({ est: Number(est) }, arg))
 			tip.d.append('div').style('max-width', '500px').html(estimateMsg)
 			tip.showunder(event.target)
 		})
-		estSpan.on('mouseout', () => self.dom.tip.hide())
+		estSpan.on('mouseout', () => self.dom.tip.hide())*/
 		// 95% CI column
 		tr.append('td').html(`${cols.shift()} &ndash; ${cols.shift()}`).style('padding', '8px')
 		// rest of columns

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- Do not run a regression analysis multiple times after editing a variant locus variable


### PR DESCRIPTION
## Description

When running snplocus regression, the snplocus block gets stored in `self`. When editing the snplocus variable, the analysis will be run twice. This PR fixes this issue by removing the snplocus block when any variable edits are made.

Can test by running this [analysis](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22LV_Ejection_Fraction_3D%22},%22independent%22:[{%22id%22:%22sex%22,%22refGrp%22:%222%22},{%22term%22:{%22type%22:%22snplocus%22},%22q%22:{%22chr%22:%22chr17%22,%22start%22:7664218,%22stop%22:7671018,%22AFcutoff%22:5,%22alleleType%22:0,%22geneticModel%22:0,%22restrictAncestry%22:{%22name%22:%22European%20ancestry%22,%22tvs%22:{%22term%22:{%22id%22:%22genetic_race%22,%22type%22:%22categorical%22,%22name%22:%22Genetically%20defined%20race%22},%22values%22:[{%22key%22:%22European%20Ancestry%22,%22label%22:%22European%20Ancestry%22}]}},%22variant_filter%22:{%22type%22:%22tvslst%22,%22join%22:%22and%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22Bad%22,%22key%22:%22Bad%22}],%22term%22:{%22id%22:%22QC%22,%22name%22:%22Classification%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22,%22values%22:{%22Good%22:{%22label%22:%22Good%22,%22key%22:%22Good%22},%22Bad%22:{%22label%22:%22Bad%22,%22key%22:%22Bad%22}}}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22SJcontrol_CR%22,%22name%22:%22SJLIFE%20control%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR%22,%22name%22:%22Call%20rate,%20SJLIFE+CCSS%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_sjlife%22,%22name%22:%22SJLIFE%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_ccss%22,%22name%22:%22CCSS%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22yes%22,%22key%22:%221%22}],%22term%22:{%22id%22:%22Polymer_region%22,%22name%22:%22Polymer%20region%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22}}}]}}}]}]}) and then editing the snplocus variable by using new coordinates (e.g., `chr17:7661778-7700000`)

Also fixed rendering the cox estimate value in variant tooltip.

Temporarily disabling coefficient table tooltips until this fix is deployed.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
