### PR TITLE
Fix for effect allele not showing in coefficients table when one snp is analyzed

### DIFF
--- a/client/mass/test/regression.integration.spec.js
+++ b/client/mass/test/regression.integration.spec.js
@@ -172,13 +172,13 @@ tape('Linear: continuous outcome = "agedx", cat. independents = "sex" + "genetic
 		test.equal(results, true, `Should render all intercept data in ${tableLabel}`)
 
 		testTerm = 'Sex'
-		const checkValues1 = ['Sex\nREFFemale', 'Male']
+		const checkValues1 = ['Sex\nREF\nFemale', 'Male']
 		checkValues1.push(...getCoefData(data.coefficients.terms.sex.categories[1]))
 		results = checkTableRow(table, 2, checkValues1)
 		test.equal(results, true, `Should render all ${testTerm} data in ${tableLabel}`)
 
 		testTerm = 'African Ancestry'
-		const checkValues2 = ['Genetically defined race\nREFEuropean Ancestry', testTerm]
+		const checkValues2 = ['Genetically defined race\nREF\nEuropean Ancestry', testTerm]
 		checkValues2.push(...getCoefData(data.coefficients.terms.genetic_race.categories[testTerm]))
 		results = checkTableRow(table, 3, checkValues2)
 		test.equal(results, true, `Should render all ${testTerm} data in ${tableLabel}`)

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -152,7 +152,6 @@ export class RegressionResults {
 		*/
 		for (const i of this.parent.inputs.independent.inputLst) {
 			if (!i.term) continue
-			if (i.term.term.id == tid || i.term.term.name == tid) return i
 			if (i.term.term && i.term.term.snps) {
 				// is a snplst or snplocus term with .snps[]
 				for (const snp of i.term.term.snps) {
@@ -186,6 +185,7 @@ export class RegressionResults {
 					}
 				}
 			}
+			if (i.term.term.id == tid || i.term.term.name == tid) return i
 		}
 		// given tid does not match with an Input
 		// can be an ancestry PC which is automatically added by serverside and not recorded on client
@@ -1399,42 +1399,40 @@ function fillTdName(td, name) {
 	}
 }
 function fillCoefficientTermname(tw, td) {
-	// fill column 1 <td> using term name, may also show refGrp and reference allele
+	// fill column 1 <td> using term name
 	fillTdName(td, tw.term.name || tid)
-
-	if (tw.q.mode != 'spline' && 'refGrp' in tw && tw.refGrp != refGrp_NA) {
-		// do not display ref for spline variable
-		const refGrpDiv = td.append('div').style('margin-top', '2px').style('font-size', '.8em')
-
-		refGrpDiv
+	// fill refGrp or effect allele, if applicable
+	const hasRefGrp = 'refGrp' in tw && tw.refGrp != refGrp_NA && tw.q.mode != 'spline'
+	if (hasRefGrp || tw.effectAllele) {
+		// has refGrp or effect allele
+		// display beneath term name
+		const bottomDiv = td
 			.append('div')
-			.style('display', 'inline-block')
-			.style('vertical-align', 'top')
+			.style('display', 'flex')
+			.style('align-items', 'center')
+			.style('margin-top', '1px')
+			.style('font-size', '.8em')
+
+		let label
+		if (hasRefGrp) {
+			label = tw.term.values && tw.term.values[tw.refGrp] ? tw.term.values[tw.refGrp].label : tw.refGrp
+		} else {
+			label = tw.effectAllele
+		}
+
+		bottomDiv
+			.append('div')
 			.style('padding', '1px 5px')
 			.style('border', '1px solid #aaa')
 			.style('border-radius', '10px')
 			.style('font-size', '.7em')
-			.text('REF')
+			.text(hasRefGrp ? 'REF' : 'EFFECT ALLELE')
 
-		refGrpDiv
+		bottomDiv
 			.append('div')
-			.attr('class', 'sjpcb-regression-results-refGrp')
-			.style('display', 'inline-block')
-			.style('vertical-align', 'top')
-			.style('margin-left', '3px')
-			.text(tw.term.values && tw.term.values[tw.refGrp] ? tw.term.values[tw.refGrp].label : tw.refGrp)
-	}
-
-	if (tw.effectAllele) {
-		// only for snplst term
-		td.append('div')
-			.style('font-size', '.8em')
-			.style('opacity', 0.6)
-			.html(
-				'<span style="padding:1px 5px;border:1px solid #aaa;border-radius:10px;font-size:.7em">EFFECT ALLELE</span> ' +
-					tw.effectAllele +
-					'</span>'
-			)
+			.attr('class', hasRefGrp ? 'sjpcb-regression-results-refGrp' : 'sjpcb-regression-results-effAle')
+			.style('padding', '1px 3px')
+			.text(label)
 	}
 }
 

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -603,7 +603,9 @@ function setRenderers(self) {
 							const [samplesize_ref, samplesize_c] = cols.shift().split('/')
 							const [eventcnt_ref, eventcnt_c] = cols.shift().split('/')
 							if (isfirst) {
-								const refGrpDiv = termNameTd.select('.sjpcb-regression-results-refGrp')
+								const variableBottomDiv = termNameTd.select('.sjpcb-coef-variable-bottom')
+								variableBottomDiv.style('align-items', 'baseline')
+								const refGrpDiv = variableBottomDiv.selectAll('div').filter((d, i) => i === 1)
 								refGrpDiv.append('div').html(`n=${samplesize_ref}<br>events=${eventcnt_ref}`)
 							}
 							td.append('div').style('font-size', '.8em').html(`n=${samplesize_c}<br>events=${eventcnt_c}`)
@@ -846,7 +848,9 @@ function setRenderers(self) {
 							const [samplesize_ref, samplesize_c] = cols.shift().split('/')
 							const [eventcnt_ref, eventcnt_c] = cols.shift().split('/')
 							if (isfirst) {
-								const refGrpDiv = termNameTd.select('.sjpcb-regression-results-refGrp')
+								const variableBottomDiv = termNameTd.select('.sjpcb-coef-variable-bottom')
+								variableBottomDiv.style('align-items', 'baseline')
+								const refGrpDiv = variableBottomDiv.selectAll('div').filter((d, i) => i === 1)
 								refGrpDiv.append('div').html(`n=${samplesize_ref}<br>events=${eventcnt_ref}`)
 							}
 							td.append('div').style('font-size', '.8em').html(`n=${samplesize_c}<br>events=${eventcnt_c}`)
@@ -1408,9 +1412,10 @@ function fillCoefficientTermname(tw, td) {
 		// display beneath term name
 		const bottomDiv = td
 			.append('div')
+			.attr('class', 'sjpcb-coef-variable-bottom')
 			.style('display', 'flex')
 			.style('align-items', 'center')
-			.style('margin-top', '1px')
+			.style('margin-top', '2px')
 			.style('font-size', '.8em')
 
 		let label
@@ -1428,11 +1433,7 @@ function fillCoefficientTermname(tw, td) {
 			.style('font-size', '.7em')
 			.text(hasRefGrp ? 'REF' : 'EFFECT ALLELE')
 
-		bottomDiv
-			.append('div')
-			.attr('class', hasRefGrp ? 'sjpcb-regression-results-refGrp' : 'sjpcb-regression-results-effAle')
-			.style('padding', '1px 3px')
-			.text(label)
+		bottomDiv.append('div').style('padding', '1px 3px').text(label)
 	}
 }
 


### PR DESCRIPTION
## Description

In snplst regression, effect allele will not show in coefficients table when one snp is analyzed, but will show when >1 snp is analyzed. This PR fixes the issue by matching independent tws using snp id before using term id/name.

Also improved the rendering code for effect allele/refGrp in coefficients table.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
