### PR TITLE
fix: fix tar error handling.

### DIFF
--- a/container/full/app-full.mjs
+++ b/container/full/app-full.mjs
@@ -57,9 +57,20 @@ if (!serverconfig.URL) serverconfig.URL = process.env.URL || serverconfig.url ||
 
 console.log(`generating public/bin for ${serverconfig.URL}`)
 const publicBinOnly = process.argv.includes('--publicBinOnly')
-spawnSync('npx', ['proteinpaint-front', serverconfig.URL, publicBinOnly ? '--publicBinOnly' : 'allPublic'], {
-	encoding: 'utf-8'
-})
+const result = spawnSync(
+	'npx',
+	['proteinpaint-front', serverconfig.URL, publicBinOnly ? '--publicBinOnly' : 'allPublic'],
+	{
+		encoding: 'utf-8'
+	}
+)
+if (result.stderr) {
+	console.warn(result.stderr)
+}
+if (result.status !== 0) {
+	console.error(`Process exited with non-zero status code: ${result.status}`)
+	process.exit(1)
+}
 // since the npx command generated non-root owned js files inside the public/bin folder , we need to change the owner of the folder and files to root
 spawnSync('chown', ['-R', 'root:root', './public/bin'], { encoding: 'utf8' })
 

--- a/front/init.js
+++ b/front/init.js
@@ -36,20 +36,26 @@ try {
 		}
 	}
 	const tar = ps.spawnSync('tar', [`-xzf`, `${__dirname}/bundles.tgz`, `-C`, `${CWD}`], { encoding: 'utf8' })
-	if (tar.stderr) throw tar.stderr
+	if (tar.status !== 0) {
+		throw new Error(`Tar command failed with exit code ${tar.status}: ${tar.stderr}`)
+	}
+	if (tar.stderr) {
+		console.warn('Tar command warnings:', tar.stderr)
+	}
 	console.log(`Setting the dynamic bundle path to ${URLPATH}`)
 	const codeFile = `${CWD}/public/bin/proteinpaint.js`
 	// remember the modified time before setting the bundle public path
 	const mtime = fs.statSync(codeFile).mtime
 	const code = fs.readFileSync(codeFile, { encoding: 'utf8' })
 	const newcode = code.replace(`__PP_URL__`, `${URLPATH}/bin/`)
-	fs.writeFileSync(codeFile, newcode, { encoding: 'utf8' }, () => {})
+	fs.writeFileSync(codeFile, newcode, { encoding: 'utf8' })
 	try {
 		// reset the atime and mtime to the original mtime before setting the bundle publit path
-		fs.utimesSync(codepath, mtime, mtime)
+		fs.utimesSync(codeFile, mtime, mtime)
 	} catch (e) {
 		console.log('--- !!! unable to reset the mtime for the extracted proteinpaint bundle: ', e)
 	}
 } catch (e) {
 	console.error(e)
+	throw e
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- fix tar error handling.


### PR DESCRIPTION
## Description

On my machine, which is Apple M2 Pro with  when the front module prepack command is executed:

"prepack": "rm -rf public/bin && rm -rf *.tgz && webpack && tar -czf bundles.tgz public/bin",

I get some warnings related to mac specific tar tags and when the tar command inside of the init.js script gets executed there are warnings about the same Apple tags:

`tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance`

These warnings were breaking the build without any message in the logs.

Now, the warnings are printed out and the build continues. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
