### PR TITLE
If iqr == 0, set whisker values to Q1

### DIFF
--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -782,10 +782,8 @@ export function boxplot_getvalue(lst) {
 
 	let w1, w2
 	if (iqr == 0) {
-		//No distribution
-		//Do not set value for whiskers
-		w1 = undefined
-		w2 = undefined
+		w1 = p25
+		w2 = p25
 	} else {
 		const i = lst.findIndex(i => i.value > p25 - iqr * 1.5)
 		w1 = lst[i == -1 ? 0 : i].value


### PR DESCRIPTION
## Description
As we discussed in team meeting yesterday, the whiskers are set to Q1 when IQR is 0. Test with[ this example](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22childType%22:%22boxplot%22,%22term%22:{%22id%22:%22Ruxolitinib_normalizedLC50%22,%22q%22:{%22mode%22:%22continuous%22}}}]}) shown in team meeting. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
