### PR TITLE
fix: mds3 tk will not commit subtk filter to state when it equals mas…

### DIFF
--- a/client/filter/filter.utils.js
+++ b/client/filter/filter.utils.js
@@ -150,7 +150,8 @@ lst:[]
   rest of the array will be joined to the first one under "and"
 */
 export function filterJoin(lst) {
-	if (!lst || lst.length == 0) return
+	if (!Array.isArray(lst)) throw 'filterJoin() arg is not array'
+	if (!lst[0]) return
 	let f = JSON.parse(JSON.stringify(lst[0]))
 	if (lst.length == 1) return f
 	// more than 1 item, will join

--- a/client/mds3/leftlabel.js
+++ b/client/mds3/leftlabel.js
@@ -60,6 +60,7 @@ export async function make_leftlabels(data, tk, block) {
 							block.tk_remove(i)
 						}
 					}
+					tk.onClose?.() // run if present
 				})
 		}
 		// Close label is present, increment laby

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -225,23 +225,11 @@ function showSummary4oneTerm(termid, div, numbycategory, tk, block) {
 			}
 		}
 
-		const newTvs = {
+		const tvs = {
 			type: 'tvs',
 			tvs: { term, values: [{ key: category }] }
 		}
-
-		const tkarg = {
-			type: 'mds3',
-			dslabel: tk.dslabel,
-			filter0: tk.filter0,
-			showCloseLeftlabel: true,
-			filterObj: getNewFilter(tk, newTvs),
-			allow2selectSamples: tk.allow2selectSamples
-		}
-		if(tk.cnv?.presetMax) tkarg.cnv={presetMax: tk.cnv.presetMax} // preset value is present, pass to subtk
-		// TODO mclass
-		const tk2 = block.block_addtk_template(tkarg)
-		block.tk_load(tk2)
+		createSubTk(tk, block, tvs)
 	}
 }
 
@@ -274,20 +262,28 @@ async function showDensity4oneTerm(termid, div, data, tk, block) {
 			type: 'tvs',
 			tvs: { term, ranges: [{ start: range.range_start, stop: range.range_end }] }
 		}
-		const tkarg = {
-			type: 'mds3',
-			dslabel: tk.dslabel,
-			filter0: tk.filter0,
-			showCloseLeftlabel: true,
-			filterObj: getNewFilter(tk, tvs),
-			allow2selectSamples: tk.allow2selectSamples
-		}
-		const tk2 = block.block_addtk_template(tkarg)
-		block.tk_load(tk2)
+		createSubTk(tk, block, tvs)
 	}
 	const scaleFactor = term.valueConversion ? term.valueConversion.scaleFactor : 1
 	const vr = new violinRenderer(div, data.density_data, 400, 100, 10, 20, callback, scaleFactor)
 	vr.render()
+}
+
+function createSubTk(tk, block, tvs) {
+	// pass properties from main tk to subtk
+	const tkarg = {
+		type: 'mds3',
+		dslabel: tk.dslabel,
+		filter0: tk.filter0,
+		showCloseLeftlabel: true,
+		filterObj: getNewFilter(tk, tvs),
+		allow2selectSamples: tk.allow2selectSamples,
+		onClose: tk.onClose
+	}
+	if (tk.cnv?.presetMax) tkarg.cnv = { presetMax: tk.cnv.presetMax } // preset value is present, pass to subtk
+	// TODO mclass
+	const tk2 = block.block_addtk_template(tkarg)
+	block.tk_load(tk2)
 }
 
 function menu_listSamples(buttonrow, data, tk, block) {

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -226,6 +226,15 @@ export async function makeTk(tk, block) {
 	} catch (e) {
 		console.error(e)
 	}
+
+	// validate optional callbacks directly attached to tkobj
+	if (tk.onClose) {
+		if (typeof tk.onClose != 'function') throw '.onClose() is not function'
+		// this only takes effect if tk shows the "Close" handle, e.g. on subtk
+	}
+	if (tk.callbackOnRender) {
+		if (typeof tk.callbackOnRender != 'function') throw '.callbackOnRender() is not function'
+	}
 }
 
 function loadTk_finish_closure(tk, block) {
@@ -291,9 +300,7 @@ function loadTk_finish_closure(tk, block) {
 		block.block_setheight()
 		block.setllabel()
 
-		if (typeof tk.callbackOnRender == 'function') {
-			tk.callbackOnRender(tk, block)
-		}
+		tk.callbackOnRender?.(tk, block) // run if present
 	}
 }
 
@@ -339,14 +346,14 @@ function mayInitCnv(tk) {
 		}
 	}
 	if (!cfg) return // lack this. no cnv from this tk
-	if(!tk.cnv) tk.cnv={} // preserve
-	tk.cnv.g= tk.glider.append('g')
-	tk.cnv.cnvMaxLength= cfg.cnvMaxLength // if missing do not filter
-	tk.cnv.cnvGainCutoff= cfg.cnvGainCutoff // if missing do not filter
-	tk.cnv.cnvLossCutoff= cfg.cnvLossCutoff
-	tk.cnv.absoluteValueRenderMax= cfg.absoluteValueRenderMax || 5
-	tk.cnv.gainColor= cfg.gainColor || '#D6683C'
-	tk.cnv.lossColor= cfg.lossColor || '#67a9cf'
+	if (!tk.cnv) tk.cnv = {} // preserve
+	tk.cnv.g = tk.glider.append('g')
+	tk.cnv.cnvMaxLength = cfg.cnvMaxLength // if missing do not filter
+	tk.cnv.cnvGainCutoff = cfg.cnvGainCutoff // if missing do not filter
+	tk.cnv.cnvLossCutoff = cfg.cnvLossCutoff
+	tk.cnv.absoluteValueRenderMax = cfg.absoluteValueRenderMax || 5
+	tk.cnv.gainColor = cfg.gainColor || '#D6683C'
+	tk.cnv.lossColor = cfg.lossColor || '#67a9cf'
 }
 
 function setSkewerMode(tk) {

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -13,6 +13,10 @@ loadTk
 		getParameter
 			rangequery_rglst
 rangequery_add_variantfilters
+
+callbacks that are attached to tkobj:
+- callbackOnRender()
+- onClose()
 */
 
 export async function loadTk(tk, block) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- mds3 tk will not commit subtk filter to state when it equals mass filter; fix filterJoin usage


### PR DESCRIPTION
…s filter; fix filterJoin usage

## Description

closes #2429 
fixed wrong filterJoin() usage and added detection, so to detect and report wrong usage of `filterJoin(a,b)`
also fixed wrong logic in genomebrowser app to track mds3 subtk filter objects

[test link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22geneSymbol%22:%22BCR%22}}]}). at Filter, add sex=male, then AND any other tvs. client will not break

all mds3 tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
