### PR TITLE
fix: improve roundValueAuto to allow to only return numbers for computing

### DIFF
--- a/client/filter/test/tvs.density.unit.spec.ts
+++ b/client/filter/test/tvs.density.unit.spec.ts
@@ -70,8 +70,8 @@ tape('\n', test => {
 })
 
 tape('updateTempRanges', test => {
-	//test.timeoutAfter(100)
-	//test.plan(4)
+	test.timeoutAfter(100)
+	test.plan(4)
 
 	const holder = getHolder()
 	const testSelf = createTestSelf(holder)

--- a/client/filter/test/tvs.density.unit.spec.ts
+++ b/client/filter/test/tvs.density.unit.spec.ts
@@ -70,8 +70,8 @@ tape('\n', test => {
 })
 
 tape('updateTempRanges', test => {
-	test.timeoutAfter(100)
-	test.plan(4)
+	//test.timeoutAfter(100)
+	//test.plan(4)
 
 	const holder = getHolder()
 	const testSelf = createTestSelf(holder)
@@ -85,8 +85,11 @@ tape('updateTempRanges', test => {
 		startunbounded: false,
 		stopunbounded: false
 	} as any
+
 	const origRange1 = structuredClone(range1)
+
 	updateTempRanges(testSelf.num_obj.xscale, s, range1, range1, 1962, 2012, 'integer')
+
 	test.ok(
 		range1.start != origRange1.start && range1.start == 1988,
 		'Should update start value in the original range and round to integer'
@@ -98,17 +101,16 @@ tape('updateTempRanges', test => {
 
 	//Non integer term
 	const range2 = {
-		start: '1987.3678',
-		stop: '1997.823476',
+		start: 1987.3678,
+		stop: 1997.823476,
 		index: 0,
 		startunbounded: false,
 		stopunbounded: false
 	} as any
 	const origRange2 = structuredClone(range2)
-	updateTempRanges(testSelf.num_obj.xscale, s, range2, range2, 1962, 2012, 'discrete')
-	test.ok(
-		range2.start != origRange2.start && range2.start == 1987.9,
-		'Should update start value in the original range.'
-	)
-	test.ok(range2.stop != origRange2.stop && range2.stop == 1997.9, 'Should update stop value in the original range.')
+	updateTempRanges(testSelf.num_obj.xscale, s, range2, range2, 1962, 2012, 'float')
+	test.ok(range2.start != origRange2.start && range2.start == 1988, 'Should update start value in the original range.')
+	test.ok(range2.stop != origRange2.stop && range2.stop == 1998, 'Should update stop value in the original range.')
+
+	test.end()
 })

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -1,6 +1,6 @@
 import { select } from 'd3-selection'
 import { brushX } from 'd3-brush'
-import { roundValueAuto } from '#shared/roundValue.js'
+import { roundValueAuto, roundValue2 } from '#shared/roundValue.js'
 
 /*
 ********************** EXPORTED
@@ -133,8 +133,8 @@ export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalu
 }
 
 function convertRangeValue(xscale, sidx) {
-	let value = Number(xscale.invert(sidx))
-	return roundValueAuto(value)
+	const value = Number(xscale.invert(sidx))
+	return roundValue2(value)
 }
 
 //Add new blank range temporary, save after entering values

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -146,6 +146,9 @@ export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalu
 
 /** Set the start and stop displayed to the user
  * Encapsulated and exported to verify usage via testing and CI.
+ *
+ * range: range object to update. Note this is already altered by updateTempRanges
+ * inputRange: input range object
  */
 
 export function setStartStopDisplays(range, inputRange) {

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -130,6 +130,10 @@ export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalu
 	range.stop = convertRangeValue(xscale, s[1])
 	const min = roundValueAuto(Number(minvalue))
 	const max = roundValueAuto(Number(maxvalue))
+	//If the user inputs a value outside the brush, limit it to the brush
+	//Otherwise the input displays a calculated position closest to the value.
+	if (range.start < min) range.start = min
+	if (range.stop > max) range.stop = max
 	//Limit by the brush, not by the user
 	range.startunbounded = min == range.start && inputRange.startunbounded
 	range.stopunbounded = max == range.stop && inputRange.stopunbounded

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -85,8 +85,7 @@ function applyBrush(self, elem, brush) {
 			//update temp_ranges
 			updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalue, self.tvs.term.type)
 
-			const start = range.startunbounded ? '' : inputRange.startinclusive ? `${range.start} <=` : `${range.start} <`
-			const stop = range.stopunbounded ? '' : inputRange.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
+			const [start, stop] = setStartStopDisplays(range, inputRange)
 			// update inputs from brush move
 			brush.rangeInput.getInput().node().value = `${start} x ${stop}`
 		})
@@ -115,7 +114,16 @@ function applyBrush(self, elem, brush) {
 }
 
 /** Updates the number range returned from the brushing into
- * rounded values or integers. Exported for testing only.
+ * rounded values or integers.  Encapsulated and exported to verify
+ * usage via testing and CI.
+ *
+ * xscale: d3 scale for x-axis
+ * s: selection from brush, [start, stop]
+ * range: range object to update
+ * inputRange: input range object
+ * minValue: min value of the density plot
+ * maxValue: max value of the density plot
+ * termType: term type
  */
 export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalue, type) {
 	range.start = convertRangeValue(xscale, s[0])
@@ -130,6 +138,17 @@ export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalu
 		range.start = range.startunbounded ? '' : Math.round(range.start)
 		range.stop = range.stopunbounded ? '' : Math.round(range.stop)
 	}
+}
+
+/** Set the start and stop displayed to the user
+ * Encapsulated and exported to verify usage via testing and CI.
+ */
+
+export function setStartStopDisplays(range, inputRange) {
+	const start = range.startunbounded ? '' : inputRange.startinclusive ? `${range.start} <=` : `${range.start} <`
+	const stop = range.stopunbounded ? '' : inputRange.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
+
+	return [start, stop]
 }
 
 function convertRangeValue(xscale, sidx) {

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -1,6 +1,6 @@
 import { select } from 'd3-selection'
 import { brushX } from 'd3-brush'
-import { roundValueAuto, roundValue2 } from '#shared/roundValue.js'
+import { roundValueAuto } from '#shared/roundValue.js'
 
 /*
 ********************** EXPORTED
@@ -153,7 +153,7 @@ export function setStartStopDisplays(range, inputRange) {
 
 function convertRangeValue(xscale, sidx) {
 	const value = Number(xscale.invert(sidx))
-	return roundValue2(value)
+	return roundValueAuto(value)
 }
 
 //Add new blank range temporary, save after entering values

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- add roundValue2 to return rounded value with higher precision for computing
+- add roundValue2 to return rounded value with higher precision to resolve tvs denisity brushing error

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -168,15 +168,15 @@ function setDescrStats(boxplot: BoxPlotData, sortedValues: number[]) {
 
 	return [
 		{ id: 'total', label: 'Total', value: sortedValues.length },
-		{ id: 'min', label: 'Minimum', value: roundValueAuto(sortedValues[0]) },
-		{ id: 'p25', label: '1st quartile', value: roundValueAuto(boxplot.p25) },
-		{ id: 'median', label: 'Median', value: roundValueAuto(boxplot.p50) },
-		{ id: 'mean', label: 'Mean', value: roundValueAuto(mean) },
-		{ id: 'p75', label: '3rd quartile', value: roundValueAuto(boxplot.p75) },
-		{ id: 'max', label: 'Maximum', value: roundValueAuto(sortedValues[sortedValues.length - 1]) },
-		{ id: 'sd', label: 'Standard deviation', value: isNaN(sd) ? null : roundValueAuto(sd) },
-		{ id: 'variance', label: 'Variance', value: roundValueAuto(variance) },
-		{ id: 'iqr', label: 'Inter-quartile range', value: roundValueAuto(boxplot.iqr) }
+		{ id: 'min', label: 'Minimum', value: roundValueAuto(sortedValues[0], true) },
+		{ id: 'p25', label: '1st quartile', value: roundValueAuto(boxplot.p25, true) },
+		{ id: 'median', label: 'Median', value: roundValueAuto(boxplot.p50, true) },
+		{ id: 'mean', label: 'Mean', value: roundValueAuto(mean, true) },
+		{ id: 'p75', label: '3rd quartile', value: roundValueAuto(boxplot.p75, true) },
+		{ id: 'max', label: 'Maximum', value: roundValueAuto(sortedValues[sortedValues.length - 1], true) },
+		{ id: 'sd', label: 'Standard deviation', value: isNaN(sd) ? null : roundValueAuto(sd, true) },
+		{ id: 'variance', label: 'Variance', value: roundValueAuto(variance, true) },
+		{ id: 'iqr', label: 'Inter-quartile range', value: roundValueAuto(boxplot.iqr, true) }
 	]
 }
 

--- a/shared/utils/src/descriptive.stats.js
+++ b/shared/utils/src/descriptive.stats.js
@@ -42,15 +42,15 @@ export default function summaryStats(array) {
 	return {
 		values: [
 			{ id: 'total', label: 'Total', value: n },
-			{ id: 'min', label: 'Minimum', value: roundValueAuto(min) },
-			{ id: 'p25', label: '1st quartile', value: roundValueAuto(p25) },
-			{ id: 'median', label: 'Median', value: roundValueAuto(median) },
-			{ id: 'mean', label: 'Mean', value: roundValueAuto(mean(arr)) },
-			{ id: 'p75', label: '3rd quartile', value: roundValueAuto(p75) },
-			{ id: 'max', label: 'Maximum', value: roundValueAuto(max) },
-			{ id: 'SD', label: 'Standard deviation', value: roundValueAuto(stdDev) },
-			{ id: 'variance', label: 'Variance', value: roundValueAuto(variance) },
-			{ id: 'IQR', label: 'Inter-quartile range', value: roundValueAuto(IQR) }
+			{ id: 'min', label: 'Minimum', value: roundValueAuto(min, true) },
+			{ id: 'p25', label: '1st quartile', value: roundValueAuto(p25, true) },
+			{ id: 'median', label: 'Median', value: roundValueAuto(median, true) },
+			{ id: 'mean', label: 'Mean', value: roundValueAuto(mean(arr), true) },
+			{ id: 'p75', label: '3rd quartile', value: roundValueAuto(p75, true) },
+			{ id: 'max', label: 'Maximum', value: roundValueAuto(max, true) },
+			{ id: 'SD', label: 'Standard deviation', value: roundValueAuto(stdDev, true) },
+			{ id: 'variance', label: 'Variance', value: roundValueAuto(variance, true) },
+			{ id: 'IQR', label: 'Inter-quartile range', value: roundValueAuto(IQR, true) }
 		]
 	}
 }

--- a/shared/utils/src/roundValue.js
+++ b/shared/utils/src/roundValue.js
@@ -11,19 +11,20 @@ digits: number of digits to round to
 export function roundValue(value, digits) {
 	const v = Number(value)
 	if (Number.isInteger(v)) return v
-	const abs = Math.abs(v)
-	if (abs < 1 || abs > 9999) {
-		//Number() reverts positive values less than 10^21 to a whole number
-		return abs > 9999 ? Number(v.toPrecision(digits)) : Number(v.toPrecision(digits))
-	}
+	if (Math.abs(v) < 1) return Number(v.toPrecision(digits))
 	return Number(v.toFixed(digits))
 }
 
-export function roundValueAuto(value) {
+/** Rounds numbers to the appropriate decimal point
+ * if format is true, returns either a number or string in
+ * scientific notation.
+ */
+
+export function roundValueAuto(value, format = false) {
 	if (!value && value != 0) return value
 	const dp = decimalPlacesUntilFirstNonZero(value)
 	const digits = Math.abs(value) > 1 ? 2 : dp > 0 ? dp + 1 : 2
-
+	if (format) return formatValue(value, digits)
 	return roundValue(value, digits)
 }
 
@@ -72,4 +73,18 @@ export function roundValue2(value) {
 	if (abs > 0.1) return Number(value.toFixed(3)) // 0.12345 to 0.123
 	if (abs > 0.01) return Number(value.toFixed(4)) // 0.012345 to 0.0123
 	return value // as is
+}
+
+/** Use to return displayed values in scientific notation
+ * Do not use for values intented for calculation later.
+ */
+export function formatValue(value, digits) {
+	const v = Number(value)
+	if (Number.isInteger(v)) return v
+	const abs = Math.abs(v)
+	if (abs < 1 || abs > 9999) {
+		//Number() reverts positive values less than 10^21 to a whole number
+		return abs > 9999 ? v.toPrecision(digits) : Number(v.toPrecision(digits))
+	}
+	return Number(v.toFixed(digits))
 }

--- a/shared/utils/src/roundValue.js
+++ b/shared/utils/src/roundValue.js
@@ -14,7 +14,7 @@ export function roundValue(value, digits) {
 	const abs = Math.abs(v)
 	if (abs < 1 || abs > 9999) {
 		//Number() reverts positive values less than 10^21 to a whole number
-		return abs > 9999 ? v.toPrecision(digits) : Number(v.toPrecision(digits))
+		return abs > 9999 ? Number(v.toPrecision(digits)) : Number(v.toPrecision(digits))
 	}
 	return Number(v.toFixed(digits))
 }
@@ -51,4 +51,25 @@ export function decimalPlacesUntilFirstNonZero(number) {
 	}
 
 	return decimalPlaces
+}
+
+/* 
+simple logic to return a number close to original while rounding up decimals.
+supplements roundValueAuto which rounds 12345 to 1.2e4 which is only suitable for human quick glance but not subsequent computing
+
+TODO:
+10000 and 10001 to 1e4
+0.00001 to 1e-5
+1.00001 to 1
+*/
+export function roundValue2(value) {
+	if (!Number.isFinite(value)) return value // not a number
+	if (Number.isInteger(value)) return value // is integer, do not convert
+	const abs = Math.abs(value)
+	if (abs > 100) return Math.round(value) // 12345.1234 to 12345 (compared to 1.2e4 from roundValueAuto)
+	if (abs > 10) return Number(value.toFixed(1)) // 99.1234 to 99.1
+	if (abs > 1) return Number(value.toFixed(2)) // 9.1234 to 9.12
+	if (abs > 0.1) return Number(value.toFixed(3)) // 0.12345 to 0.123
+	if (abs > 0.01) return Number(value.toFixed(4)) // 0.012345 to 0.0123
+	return value // as is
 }

--- a/shared/utils/src/roundValue.js
+++ b/shared/utils/src/roundValue.js
@@ -76,7 +76,7 @@ export function roundValue2(value) {
 }
 
 /** Use to return displayed values in scientific notation
- * Do not use for values intented for calculation later.
+ * Do not use for values intended for calculation later.
  */
 export function formatValue(value, digits) {
 	const v = Number(value)
@@ -84,6 +84,7 @@ export function formatValue(value, digits) {
 	const abs = Math.abs(v)
 	if (abs < 1 || abs > 9999) {
 		//Number() reverts positive values less than 10^21 to a whole number
+		//To return the value in scientific notation, use toPrecision without Number()
 		return abs > 9999 ? v.toPrecision(digits) : Number(v.toPrecision(digits))
 	}
 	return Number(v.toFixed(digits))

--- a/shared/utils/src/roundValue.js
+++ b/shared/utils/src/roundValue.js
@@ -18,6 +18,8 @@ export function roundValue(value, digits) {
 /** Rounds numbers to the appropriate decimal point
  * if format is true, returns either a number or string in
  * scientific notation.
+ *
+ * TODO: Review digit logic.
  */
 
 export function roundValueAuto(value, format = false) {

--- a/shared/utils/src/test/roundvalue.unit.spec.js
+++ b/shared/utils/src/test/roundvalue.unit.spec.js
@@ -16,15 +16,29 @@ tape('\n', function (test) {
 })
 
 tape('roundValueAuto()', function (test) {
+	/** Note: Test messages in the console are slightly different
+	 * than actual mock data. Javascript in the browser converts
+	 * small numbers into scientific notation. For example a value
+	 * of 0.0000005 will appear as 5e-7 in the console.
+	 */
 	let value, rounded, formatted
 
 	value = 1.23456789e-10
 	rounded = 1.2e-10
 	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
-
+	test.equal(
+		roundValueAuto(value, true),
+		rounded,
+		`Should return rounded value=${rounded} for input value=${value} when format=true`
+	)
 	value = 1.2345
 	rounded = 1.23
 	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		rounded,
+		`Should return rounded value=${rounded} for input value=${value} when format=true`
+	)
 
 	value = 10549.23556789
 	rounded = 10549.24
@@ -33,16 +47,26 @@ tape('roundValueAuto()', function (test) {
 	test.equal(
 		roundValueAuto(value, true),
 		formatted,
-		`Should return formatted value=${formatted} for input value=${value}`
+		`Should return formatted value=${formatted} for input value=${value} when format=true`
 	)
 
 	value = 1549.23556789
 	rounded = 1549.24
 	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		rounded,
+		`Should return rounded value=${rounded} for input value=${value} when format=true`
+	)
 
 	value = 549.23556789
 	rounded = 549.24
 	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		rounded,
+		`Should return rounded value=${rounded} for input value=${value} when format=true`
+	)
 
 	value = -89378.345862
 	rounded = -89378.35
@@ -51,32 +75,51 @@ tape('roundValueAuto()', function (test) {
 	test.equal(
 		roundValueAuto(value, true),
 		formatted,
-		`Should return formatted value=${formatted} for input value=${value}`
+		`Should return formatted value=${formatted} for input value=${value} when format=true`
 	)
 
 	value = -0.006
 	test.equal(roundValueAuto(value), value, `Should return input value=${value} unchanged`)
+	test.equal(roundValueAuto(value, true), value, `Should return input value=${value} unchanged when format=true`)
 
 	value = 1000
 	test.equal(roundValueAuto(value), value, `Should return input value=${value} unchanged`)
+	test.equal(roundValueAuto(value, true), value, `Should return input value=${value} unchanged when format=true`)
 
 	value = 1000.1234
 	rounded = 1000.12
 	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		rounded,
+		`Should return rounded value=${rounded} for input value=${value} when format=true`
+	)
 
 	value = -0.0001
-	test.equal(roundValueAuto(value), value, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(roundValueAuto(value), value, `Should return input value=${value} unchanged`)
+	test.equal(roundValueAuto(value, true), value, `Should return input value=${value} unchanged when format=true`)
 
 	value = 0.00001
 	test.equal(roundValueAuto(value), value, `Should return input value=${value} unchanged`)
+	test.equal(roundValueAuto(value, true), value, `Should return input value=${value} unchanged when format=true`)
 
 	value = 0.000056
 	rounded = 5.6e-5
 	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		rounded,
+		`Should return rounded value=${rounded} for input value=${value} when format=true`
+	)
 
 	value = 0.0000005
 	rounded = 5e-7
 	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		rounded,
+		`Should return rounded value=${rounded} for input value=${value} when format=true`
+	)
 
 	test.end()
 })

--- a/shared/utils/src/test/roundvalue.unit.spec.js
+++ b/shared/utils/src/test/roundvalue.unit.spec.js
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { roundValueAuto } from '../roundValue.js'
+import { roundValueAuto, roundValue2 } from '../roundValue.js'
 
 /**************
  test sections
@@ -13,47 +13,68 @@ tape('roundValue tests', function (test) {
 	let value = 1.23456789e-10
 	let rounded = 1.2e-10
 	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), value, `is unchanged`)
 
 	value = 1.2345
 	rounded = 1.23
 	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), rounded, `should return ${rounded}`)
+
+	value = 10549.23556789
+	rounded = 1.1e4
+	let r2 = 10549
+	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), r2, `should return ${r2}`)
+
+	value = 1549.23556789
+	rounded = 1549.24
+	r2 = 1549
+	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), r2, `should return ${r2}`)
+
+	value = 549.23556789
+	rounded = 549.24
+	r2 = 549
+	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), r2, `should return ${r2}`)
+
+	value = -89378.345862
+	rounded = -8.9e4
+	r2 = -89378
+	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), r2, `should return ${r2}`)
+
+	value = -0.006
+	test.equal(roundValueAuto(value), value, `should return ${value}`)
+	test.equal(roundValue2(value), value, `should return ${value}`)
+
+	value = 1000
+	test.equal(roundValueAuto(value), value, `should return ${value}`)
+	test.equal(roundValue2(value), value, `should return ${value}`)
+
+	value = 1000.1234
+	rounded = 1000.12
+	r2 = 1000
+	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), r2, `should return ${r2}`)
+
+	value = -0.0001
+	test.equal(roundValueAuto(value), value, `should return ${rounded}`)
+	test.equal(roundValue2(value), value, `should return ${value}`)
+
+	value = 0.00001
+	test.equal(roundValueAuto(value), value, `should return ${value}`)
+	test.equal(roundValue2(value), value, `should return ${value}`)
 
 	value = 0.000056
 	rounded = 5.6e-5
 	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), rounded, `should return ${rounded}`)
 
-	value = 10549.23556789
-	rounded = '1.1e+4'
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-
-	value = -89378.345862
-	rounded = '-8.9e+4'
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-
-	value = -0.006
-	rounded = -0.006
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-
-	value = 1000
-	rounded = 1000
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-
-	value = 1000.123
-	rounded = 1000.12
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-
-	value = -0.0001
-	rounded = -0.0001
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-
-	value = 0.00001
-	rounded = 0.00001
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-
-	//JavaScript represents numbers smaller than 1e-6 in scientific notation
 	value = 0.0000005
 	rounded = 5e-7
 	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValue2(value), value, `should return ${value}`)
 
 	test.end()
 })

--- a/shared/utils/src/test/roundvalue.unit.spec.js
+++ b/shared/utils/src/test/roundvalue.unit.spec.js
@@ -21,9 +21,9 @@ tape('roundValue tests', function (test) {
 	test.equal(roundValue2(value), rounded, `should return ${rounded}`)
 
 	value = 10549.23556789
-	rounded = 1.1e4
+	rounded = '1.1e+4'
 	let r2 = 10549
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValueAuto(value, true), rounded, `should return ${rounded}`)
 	test.equal(roundValue2(value), r2, `should return ${r2}`)
 
 	value = 1549.23556789
@@ -39,9 +39,9 @@ tape('roundValue tests', function (test) {
 	test.equal(roundValue2(value), r2, `should return ${r2}`)
 
 	value = -89378.345862
-	rounded = -8.9e4
+	rounded = '-8.9e+4'
 	r2 = -89378
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
+	test.equal(roundValueAuto(value, true), rounded, `should return ${rounded}`)
 	test.equal(roundValue2(value), r2, `should return ${r2}`)
 
 	value = -0.006

--- a/shared/utils/src/test/roundvalue.unit.spec.js
+++ b/shared/utils/src/test/roundvalue.unit.spec.js
@@ -1,6 +1,12 @@
 import tape from 'tape'
 import { roundValueAuto, roundValue2 } from '../roundValue.js'
 
+/**
+ * Tests
+ * 		roundValueAuto()
+ * 		roundValue2()
+ */
+
 /**************
  test sections
 ***************/
@@ -9,72 +15,121 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('roundValue tests', function (test) {
-	let value = 1.23456789e-10
-	let rounded = 1.2e-10
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), value, `is unchanged`)
+tape('roundValueAuto()', function (test) {
+	let value, rounded, formatted
+
+	value = 1.23456789e-10
+	rounded = 1.2e-10
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
 
 	value = 1.2345
 	rounded = 1.23
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), rounded, `should return ${rounded}`)
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
 
 	value = 10549.23556789
-	rounded = '1.1e+4'
-	let r2 = 10549
-	test.equal(roundValueAuto(value, true), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), r2, `should return ${r2}`)
+	rounded = 10549.24
+	formatted = '1.1e+4'
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		formatted,
+		`Should return formatted value=${formatted} for input value=${value}`
+	)
 
 	value = 1549.23556789
 	rounded = 1549.24
-	r2 = 1549
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), r2, `should return ${r2}`)
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
 
 	value = 549.23556789
 	rounded = 549.24
-	r2 = 549
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), r2, `should return ${r2}`)
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
 
 	value = -89378.345862
-	rounded = '-8.9e+4'
-	r2 = -89378
-	test.equal(roundValueAuto(value, true), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), r2, `should return ${r2}`)
+	rounded = -89378.35
+	formatted = '-8.9e+4'
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+	test.equal(
+		roundValueAuto(value, true),
+		formatted,
+		`Should return formatted value=${formatted} for input value=${value}`
+	)
 
 	value = -0.006
-	test.equal(roundValueAuto(value), value, `should return ${value}`)
-	test.equal(roundValue2(value), value, `should return ${value}`)
+	test.equal(roundValueAuto(value), value, `Should return input value=${value} unchanged`)
 
 	value = 1000
-	test.equal(roundValueAuto(value), value, `should return ${value}`)
-	test.equal(roundValue2(value), value, `should return ${value}`)
+	test.equal(roundValueAuto(value), value, `Should return input value=${value} unchanged`)
 
 	value = 1000.1234
 	rounded = 1000.12
-	r2 = 1000
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), r2, `should return ${r2}`)
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
 
 	value = -0.0001
-	test.equal(roundValueAuto(value), value, `should return ${rounded}`)
-	test.equal(roundValue2(value), value, `should return ${value}`)
+	test.equal(roundValueAuto(value), value, `Should return rounded value=${rounded} for input value=${value}`)
 
 	value = 0.00001
-	test.equal(roundValueAuto(value), value, `should return ${value}`)
-	test.equal(roundValue2(value), value, `should return ${value}`)
+	test.equal(roundValueAuto(value), value, `Should return input value=${value} unchanged`)
 
 	value = 0.000056
 	rounded = 5.6e-5
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), rounded, `should return ${rounded}`)
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
 
 	value = 0.0000005
 	rounded = 5e-7
-	test.equal(roundValueAuto(value), rounded, `should return ${rounded}`)
-	test.equal(roundValue2(value), value, `should return ${value}`)
+	test.equal(roundValueAuto(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	test.end()
+})
+
+tape('roundValue2()', function (test) {
+	let value, rounded
+
+	value = 1.23456789e-10
+	test.equal(roundValue2(value), value, `Should return input value=${value} unchanged`)
+
+	value = 1.2345
+	rounded = 1.23
+	test.equal(roundValue2(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	value = 10549.23556789
+	rounded = 10549
+	test.equal(roundValue2(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	value = 1549.23556789
+	rounded = 1549
+	test.equal(roundValue2(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	value = 549.23556789
+	rounded = 549
+	test.equal(roundValue2(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	value = -89378.345862
+	rounded = -89378
+	test.equal(roundValue2(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	value = -0.006
+	test.equal(roundValue2(value), value, `Should return input value=${value} unchanged`)
+
+	value = 1000
+	test.equal(roundValue2(value), value, `Should return input value=${value} unchanged`)
+
+	value = 1000.1234
+	rounded = 1000
+	test.equal(roundValue2(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	value = -0.0001
+	test.equal(roundValue2(value), value, `Should return input value=${value} unchanged`)
+
+	value = 0.00001
+	test.equal(roundValue2(value), value, `Should return input value=${value} unchanged`)
+
+	value = 0.000056
+	rounded = 5.6e-5
+	test.equal(roundValue2(value), rounded, `Should return rounded value=${rounded} for input value=${value}`)
+
+	value = 0.0000005
+	rounded = 5e-7
+	test.equal(roundValue2(value), value, `Should return input value=${value} unchanged`)
 
 	test.end()
 })


### PR DESCRIPTION


## Description

closes #2434 
[test link](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:3%7D,%22termfilter%22:%7B%22filter%22:%7B%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22aaclassic_5%22,%22name%22:%22Cumulative%20Alkylating%20Agent%20(Cyclophosphamide%20Equivalent%20Dose)%22,%22type%22:%22float%22,%22values%22:%7B%22-8888%22:%7B%22label%22:%22Exposed%20but%20dose%20unknown%22,%22uncomputable%22:true%7D,%22-9999%22:%7B%22label%22:%22Unknown%20treatment%20record%22,%22uncomputable%22:true%7D%7D%7D,%22ranges%22:%5B%7B%22startunbounded%22:true,%22stop%22:10000,%22stopinclusive%22:true%7D%5D%7D%7D%5D%7D%7D%7D), in tvs ui, INPUT box no longer shows scientific values e.g. 12345 rounds to 1.2e4 which is unreasonable and breaks ui (ui cannot parse scientific numbers)

all CI passed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
