### PR TITLE
Render cubic spline plot as svg instead of png

### DIFF
--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -347,10 +347,7 @@ function setRenderers(self) {
 			return 0
 		})
 		for (const plot of result.splinePlots) {
-			const plotDiv = div.append('div').style('margin', '20px 50px 0px 0px')
-			if (plot.title) {
-				plotDiv.append('div').style('text-align', 'center').style('margin', '0px 0px 10px 50px').text(plot.title)
-			}
+			const plotDiv = div.append('div').style('margin', '0px 50px 5px 0px')
 			plotDiv.append('img').attr('src', plot.src).style('width', plot.size.width).style('height', plot.size.height)
 		}
 	}

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -339,8 +339,19 @@ function setRenderers(self) {
 	self.mayshow_splinePlots = result => {
 		if (!result.splinePlots) return
 		const div = self.newDiv('Cubic spline plots')
+		div.style('display', 'flex').style('align-items', 'center')
+		result.splinePlots.sort((a, b) => {
+			// univariate plots should appear before multivariate plots
+			if (a.type == 'univariate' && b.type == 'multivariate') return -1
+			if (a.type == 'multivariate' && b.type == 'univariate') return 1
+			return 0
+		})
 		for (const plot of result.splinePlots) {
-			div.append('img').attr('src', plot.src).style('width', plot.size.width).style('height', plot.size.height)
+			const plotDiv = div.append('div').style('margin', '20px 50px 0px 0px')
+			if (plot.title) {
+				plotDiv.append('div').style('text-align', 'center').style('margin', '0px 0px 10px 50px').text(plot.title)
+			}
+			plotDiv.append('img').attr('src', plot.src).style('width', plot.size.width).style('height', plot.size.height)
 		}
 	}
 

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -727,11 +727,7 @@ async function parseRoutput(Rinput, Routput, id2originalId, q, result) {
 					size: imagesize(file)
 				}
 				const type = path.basename(file, '.svg').split('_')[1]
-				if (type == 'univariate' || type == 'multivariate') {
-					const title = type == 'univariate' ? 'Univariate' : 'Multivariable-adjusted'
-					obj.type = type
-					obj.title = title
-				}
+				if (type == 'univariate' || type == 'multivariate') obj.type = type
 				analysisResult.data.splinePlots.push(obj)
 				fs.unlink(file, err => {
 					if (err) throw err

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -720,22 +720,19 @@ async function parseRoutput(Rinput, Routput, id2originalId, q, result) {
 		// plots
 		if (data.splinePlotFiles) {
 			if (!analysisResult.data.splinePlots) analysisResult.data.splinePlots = []
-			// univariate plots should appear before multivariate plots
-			data.splinePlotFiles.sort((a, b) => {
-				const file_a = path.basename(a, '.png')
-				const file_b = path.basename(b, '.png')
-				const type_a = file_a.split('_')[1]
-				const type_b = file_b.split('_')[1]
-				if (type_a == 'univariate' && type_b == 'multivariate') return -1
-				if (type_a == 'multivariate' && type_b == 'univariate') return 1
-				else return 0
-			})
 			for (const file of data.splinePlotFiles) {
 				const plot = await fs.promises.readFile(file)
-				analysisResult.data.splinePlots.push({
-					src: 'data:image/png;base64,' + new Buffer.from(plot).toString('base64'),
+				const obj = {
+					src: 'data:image/svg+xml;base64,' + new Buffer.from(plot).toString('base64'),
 					size: imagesize(file)
-				})
+				}
+				const type = path.basename(file, '.svg').split('_')[1]
+				if (type == 'univariate' || type == 'multivariate') {
+					const title = type == 'univariate' ? 'Univariate' : 'Multivariable-adjusted'
+					obj.type = type
+					obj.title = title
+				}
+				analysisResult.data.splinePlots.push(obj)
 				fs.unlink(file, err => {
 					if (err) throw err
 				})

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -516,19 +516,21 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   
   # plot data
   plotfile <- paste0(cachedir, "splinePlot_", ifelse(is.null(formulatype), "", paste0(formulatype, "_")), createRandString(), ".svg")
-  svg(filename = plotfile, width = 5, height = 5, pointsize = 20)
-  par(mar = c(2, 2, 0, 0) + 0.1, mgp = c(1, 1, 0))
+  svg(filename = plotfile, width = 6.7, height = 5, pointsize = 20)
+  par(mar = c(2, 2, 0, 5) + 0.1, mgp = c(1, 1, 0))
   if (regtype == "linear" | regtype == "logistic") {
     if (regtype == "linear") {
       # for linear, plot predicted values
       pointtype <- 16
       pointsize <- 0.3
+      pointalpha <- 0.8
       ylab <- outcome$name
     } else {
       # for logistic, plot predicted probabilities
       preddat_ci_adj <- 1/(1+exp(-preddat_ci_adj))
       pointtype <- 124
-      pointsize <- 0.7
+      pointsize <- 0.9
+      pointalpha <- 0.5
       ylab <- paste0("Pr(", outcome$name, " ", outcome$categories$nonref, ")")
     }
     # use only finite predicted data
@@ -548,7 +550,7 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
            dat[,outcome$id],
            pch = pointtype,
            cex = pointsize,
-           col = adjustcolor("#ce768e", 0.8)
+           col = adjustcolor("#ce768e", alpha.f = pointalpha)
     )
   } else if (regtype == "cox") {
     # for cox, plot hazard ratios
@@ -557,16 +559,15 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
     toKeep <- rowSums(!is.finite(preddat_ci_adj)) == 0
     preddat_ci_adj <- preddat_ci_adj[toKeep,]
     newdat <- newdat[toKeep,,drop = F]
-    pointtype <- 16
-    pointsize <- 0.3
     ylab <- "Hazard Ratio"
     # plot only predicted data
     # do not also plot actual data (like for linear/logistic) because cox outcome data is time-to-event and will not be comparable to the predicted hazard ratios
     plot(newdat[,splineVariable$id],
          preddat_ci_adj[,"fit"],
          ylim = c(min(preddat_ci_adj[,"lwr"]), max(preddat_ci_adj[,"upr"])),
-         cex.axis = 0.5,
          ann = F,
+         xaxt = "n",
+         yaxt = "n",
          type = "n"
     )
   } else {
@@ -600,26 +601,30 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   lines(newdat[,splineVariable$id],
         preddat_ci_adj[,"fit"],
         col = "blue",
-        lwd = 1.5
+        lwd = 1.7
   )
   
   # legend for lines
   legend("topright",
+         inset = c(-0.37, 0),
          cex = 0.5,
          legend = c("knots", "cubic spline fit", "95% CI"),
          text.col = "white",
          lty = c(2, 1, NA),
-         col = c("grey60", "blue", NA)
+         col = c("grey60", "blue", NA),
+         xpd = TRUE
   )
   
   # legend for ci
   legend("topright",
+         inset = c(-0.37, 0),
          cex = 0.5,
          legend = c("knots", "cubic spline fit", "95% CI"),
          text.col = "black",
          bty = "n",
          fill = c(NA, NA, adjustcolor("grey", alpha.f = 0.8)),
-         border = c(NA, NA, NA)
+         border = c(NA, NA, NA),
+         xpd = TRUE
   )
   dev.off()
   return(plotfile)

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -529,7 +529,7 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
       # for logistic, plot predicted probabilities
       preddat_ci_adj <- 1/(1+exp(-preddat_ci_adj))
       pointtype <- 124
-      pointsize <- 0.9
+      pointsize <- 0.7
       pointalpha <- 0.5
       ylab <- paste0("Pr(", outcome$name, " ", outcome$categories$nonref, ")")
     }
@@ -606,7 +606,7 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   
   # legend for lines
   legend("topright",
-         inset = c(-0.37, 0),
+         inset = c(-0.39, 0),
          cex = 0.5,
          legend = c("knots", "cubic spline fit", "95% CI"),
          text.col = "white",
@@ -617,7 +617,7 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   
   # legend for ci
   legend("topright",
-         inset = c(-0.37, 0),
+         inset = c(-0.39, 0),
          cex = 0.5,
          legend = c("knots", "cubic spline fit", "95% CI"),
          text.col = "black",

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -515,9 +515,9 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   preddat_ci_adj <- preddat_ci + sum(apply(newdat2, 1, prod), na.rm = T)
   
   # plot data
-  plotfile <- paste0(cachedir, "splinePlot_", ifelse(is.null(formulatype), "", paste0(formulatype, "_")), createRandString(), ".png")
-  png(filename = plotfile, width = 950, height = 550, res = 200)
-  par(mar = c(3, 2.5, 1, 5) + 0.1, mgp = c(0.5, 0.5, 0), xpd = T)
+  plotfile <- paste0(cachedir, "splinePlot_", ifelse(is.null(formulatype), "", paste0(formulatype, "_")), createRandString(), ".svg")
+  svg(filename = plotfile, width = 5, height = 5, pointsize = 20)
+  par(mar = c(2, 2, 0, 0) + 0.1, mgp = c(1, 1, 0))
   if (regtype == "linear" | regtype == "logistic") {
     if (regtype == "linear") {
       # for linear, plot predicted values
@@ -539,14 +539,16 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
     # predicted data will be overlayed later
     plot(dat[,splineVariable$id],
          dat[,outcome$id],
-         cex.axis = 0.5,
          ann = F,
+         xaxt = "n",
+         yaxt = "n",
          type = "n"
     )
     points(dat[,splineVariable$id],
            dat[,outcome$id],
            pch = pointtype,
-           cex = pointsize
+           cex = pointsize,
+           col = adjustcolor("#ce768e", 0.8)
     )
   } else if (regtype == "cox") {
     # for cox, plot hazard ratios
@@ -571,23 +573,19 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
     stop("unrecognized regression type")
   }
   
+  # axes
+  axis(1, cex.axis = 0.5, mgp = c(0, 0.2, 0))
+  axis(2, cex.axis = 0.5, mgp = c(0, 0.5, 0))
+
   # titles
-  if (is.null(formulatype)) title <- NULL
-  else if (formulatype == "univariate") title <- "Univariate"
-  else if (formulatype == "multivariate") title <- "Multivariable-adjusted"
-  else stop("unexpected formula type")
-  title(main = title, cex.main = 0.6)
-  title(xlab = splineVariable$name,
-        ylab = ylab,
-        line = 1.5,
-        cex.lab = 0.5
-  )
+  title(xlab = splineVariable$name, line = 1, cex.lab = 0.5)
+  title(ylab = ylab, line = 1.5, cex.lab = 0.5)
   
   # knots
   abline(v = splineVariable$spline$knots[[1]],
          col = "grey60",
          lty = 2,
-         lwd = 0.8,
+         lwd = 1,
          xpd = F
   )
   
@@ -601,24 +599,22 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   # regression line
   lines(newdat[,splineVariable$id],
         preddat_ci_adj[,"fit"],
-        col = "red",
-        lwd = 2
+        col = "blue",
+        lwd = 1.5
   )
   
   # legend for lines
   legend("topright",
          cex = 0.5,
-         inset = c(-0.3, 0.1),
          legend = c("knots", "cubic spline fit", "95% CI"),
          text.col = "white",
          lty = c(2, 1, NA),
-         col = c("grey60", "red", NA)
+         col = c("grey60", "blue", NA)
   )
   
   # legend for ci
   legend("topright",
          cex = 0.5,
-         inset = c(-0.3, 0.1),
          legend = c("knots", "cubic spline fit", "95% CI"),
          text.col = "black",
          bty = "n",

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -516,8 +516,8 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   
   # plot data
   plotfile <- paste0(cachedir, "splinePlot_", ifelse(is.null(formulatype), "", paste0(formulatype, "_")), createRandString(), ".svg")
-  svg(filename = plotfile, width = 6.7, height = 5, pointsize = 20)
-  par(mar = c(2, 2, 0, 5) + 0.1, mgp = c(1, 1, 0))
+  svg(filename = plotfile, width = 6.7, height = ifelse(is.null(formulatype),5.25,5.35), pointsize = 20)
+  par(mar = c(2, 2, ifelse(is.null(formulatype),0.7,1), 5) + 0.1, mgp = c(1, 1, 0))
   if (regtype == "linear" | regtype == "logistic") {
     if (regtype == "linear") {
       # for linear, plot predicted values
@@ -581,6 +581,12 @@ plot_spline <- function(splineVariable, dat, outcome, res, regtype, formulatype,
   # titles
   title(xlab = splineVariable$name, line = 1, cex.lab = 0.5)
   title(ylab = ylab, line = 1.5, cex.lab = 0.5)
+  if (!is.null(formulatype)) {
+    if (formulatype == "univariate") plotTitle <- "Univariate"
+    else if (formulatype == "multivariate") plotTitle <- "Multivariable-adjusted"
+    else stop("unexpected formula type")
+    title(main = plotTitle, cex.main = 0.5, line = 0.45)
+  }
   
   # knots
   abline(v = splineVariable$spline$knots[[1]],


### PR DESCRIPTION
## Description

In local master, cubic spline plot is rendered as a png image ([example](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22BP_SBP1%22},%22independent%22:[{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22spline%22,%22knots%22:[{%22value%22:1},{%22value%22:4.5},{%22value%22:8.64},{%22value%22:17}]}},{%22id%22:%22sex%22}]}]})).

In docker container master, cublic spline plot is rendered as a lower quality png image (follow [these instructions](https://github.com/stjude/proteinpaint/wiki/Buiding-a-deps-image#simulate-the-docker-build) to run docker container locally).

The reason for this difference is because R on Mac generates png images of type `quartz`, while R on docker container generates png images of type `cairo`. I could not figure out how to improve the png plot on docker container to an appropriate quality, so instead I changed the code to generate an svg image instead of a png image. The quality of the image is now much higher on both local and docker container.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
