### PR TITLE
Do not show plot tooltip or change cursor for non clickable legend items

### DIFF
--- a/client/dom/html.legend.js
+++ b/client/dom/html.legend.js
@@ -175,7 +175,7 @@ export default function htmlLegend(legendDiv, viz = { settings: {}, handlers: {}
 			.classed('sjpp-htmlLegend', true)
 			.style('display', 'inline-block')
 			.style('margin-left', d.svg ? '1px' : '3px')
-			.style('cursor', d.isHidden ? 'pointer' : 'default')
+			.style('cursor', handleCursor(d))
 			.style('font-size', s.legendFontSize)
 			.style('line-height', s.legendFontSize)
 			.style('vertical-align', d.svg ? 'top' : null)
@@ -189,4 +189,16 @@ export default function htmlLegend(legendDiv, viz = { settings: {}, handlers: {}
 	}
 
 	return render
+}
+
+/** In some instances a legend item maybe hidden but not clickable
+ * (e.g. uncomputable items in violin plot). In such cases, isHidden = true
+ * for styling and isClickable = false to prevent cursor change, thus
+ * avoiding user confusion.
+ */
+function handleCursor(d) {
+	if ('isClickable' in d) {
+		return d.isClickable ? 'pointer' : 'default'
+	}
+	return 'isHidden' in d ? 'pointer' : 'default'
 }

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -239,7 +239,7 @@ export function setInteractivity(self) {
 			.on('mouseover', event => {
 				const q = event.target.__data__
 				if (q === undefined) return
-				if (q.isHidden === true) {
+				if (q.isHidden === true && q.isClickable === true) {
 					self.dom.tip.d.html('Click to unhide plot')
 					self.dom.tip.show(event.clientX, event.clientY)
 				}

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -570,7 +570,12 @@ function addUncomputableValues(term, legendGrps, headingStyle, self) {
 				items.push({
 					text: `${term.term.values[k].label}, n = ${self.data.uncomputableValueObj[term.term.values[k].label]}`,
 					noIcon: true,
+					/** Need to specify that this is a hidden value for
+					 * text styling in the legend but not a plot to avoid
+					 * rendering a tooltip or click events.
+					 */
 					isHidden: true,
+					isClickable: false,
 					hiddenOpacity: 1
 				})
 			}
@@ -591,7 +596,12 @@ function addHiddenValues(term, legendGrps, headingStyle) {
 		items.push({
 			text: `${key}`,
 			noIcon: true,
+			/** Need to specify that this is a hidden value for
+			 * text styling in the legend and  a plot for
+			 * rendering a tooltip or click events.
+			 */
 			isHidden: true,
+			isClickable: true,
 			hiddenOpacity: 1
 		})
 	}


### PR DESCRIPTION
## Description
Closes issue #2367. 

Changes: 
Prevents the tooltip appearing for non clickable legend items (e.g. uncomputable values) in the violin plot. Also avoids changing the cursor into a pointer. 

Test: 
1. [Violin example from issue](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22hrtavg%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D,%22nav%22:%7B%22activeTab%22:1%7D%7D)
2. Any violin plot example from http://localhost:3000/url.html. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
