### PR TITLE
Fix for `List samples` option failing after category is hidden

### DIFF
--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -23,6 +23,11 @@ export default function getHandlers(self) {
 			id: self.id,
 			config: {
 				term: {
+					//Fix for list samples options not working
+					//after hiding a category
+					$id: term?.$id,
+					id: term.id,
+
 					isAtomic: true,
 					term: term.term,
 					q: getUpdatedQfromClick(d, term, true)
@@ -331,6 +336,11 @@ export function hideCategory(d, self, isHidden) {
 		id: self.id,
 		config: {
 			[termNum]: {
+				//Fix for list samples options not working
+				//after hiding a category
+				$id: term?.$id,
+				id: term.id,
+
 				isAtomic: true,
 				term: term.term,
 				q: getUpdatedQfromClick(d, term, isHidden)

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -264,6 +264,8 @@ function handleColorClick(d, self, color) {
 		id: self.id,
 		config: {
 			[termNum]: {
+				$id: term.$id,
+				id: term.id,
 				isAtomic: true,
 				term: term.term,
 				q: getUpdatedQfromClick(d, term, d.isHidden, binColored)
@@ -399,6 +401,8 @@ function handle_click(event, self, chart) {
 					id: self.id,
 					config: {
 						term: {
+							$id: term.$id,
+							id: term.id,
 							isAtomic: true,
 							term: term.term,
 							q: getUpdatedQfromClick({ id: d.seriesId, type: 'col' }, term, true)


### PR DESCRIPTION
## Description
Closes issue #2442. 

Minor change to consistently keep the tw.$id and tw.id for vocab queries. 

Test: 
1. [Barchart example from issue](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22MB_meta_analysis%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22Age%22}}],%22nav%22:{%22activeTab%22:1}})
 -> hide and show any bar -> click on the bar and choose List samples
2. Repeat with any barchart example from http://localhost:3000/url.html, save those using TermdbTest. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
