### PR TITLE
Hide cnv controls and legend in disco plot when no data

### DIFF
--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -96,7 +96,7 @@ export default class Disco {
 			configInputsOptions.push(...filterMutationsGenesCheckbox)
 		}
 
-		const mandatoryConfigInputOptions = [
+		const cnvConfigInputOptions = [
 			{
 				label: 'CNV capping',
 				type: 'number',
@@ -128,7 +128,7 @@ export default class Disco {
 			}
 		]
 
-		configInputsOptions.push(...mandatoryConfigInputOptions)
+		if (viewModel.cnvMaxValue != 0 && viewModel.cnvMinValue != 0) configInputsOptions.push(...cnvConfigInputOptions)
 
 		return configInputsOptions
 	}

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -128,7 +128,7 @@ export default class Disco {
 			}
 		]
 
-		if (viewModel.cnvMaxValue != 0 && viewModel.cnvMinValue != 0) configInputsOptions.push(...cnvConfigInputOptions)
+		if (viewModel.cnvMaxValue !== 0 || viewModel.cnvMinValue !== 0) configInputsOptions.push(...cnvConfigInputOptions)
 
 		return configInputsOptions
 	}

--- a/client/plots/disco/legend/LegendJSONMapper.ts
+++ b/client/plots/disco/legend/LegendJSONMapper.ts
@@ -169,15 +169,17 @@ export default class LegendJSONMapper {
 					)
 				}
 			}
-
-			cnvItems.push({
-				termid: legend.cnvTitle,
-				key: CnvType.Cap,
-				text: `Capping: ${cap.value}`,
-				color: cap.color,
-				order: cnvOrder++,
-				border: '1px solid #ccc'
-			})
+			//Only show capping if there are cnv values
+			if (gain.value > 0 || loss.value < 0) {
+				cnvItems.push({
+					termid: legend.cnvTitle,
+					key: CnvType.Cap,
+					text: `Capping: ${cap.value}`,
+					color: cap.color,
+					order: cnvOrder++,
+					border: '1px solid #ccc'
+				})
+			}
 
 			legendJSON.push({
 				name: legend.cnvTitle,


### PR DESCRIPTION
## Description
Closes issue #2449. 

Changes: 
1. The controls for the cnv data are hidden if no cnv data is present. 
2. Combined with the recent changes, no cnv legend items appear if no cnv data is present. 

Test:
1. [Disco plot without cnv data](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=MMRF_2642_1_BM_CD138pos)
2. [Disco plot with cnv data](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-AP-A059-01A)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
