### PR TITLE
Gdc await catch

### DIFF
--- a/server/src/initGdc.js
+++ b/server/src/initGdc.js
@@ -43,6 +43,7 @@ any error is considered critical and must be presented in server log for diagnos
 */
 
 export async function initGDCdictionary(ds) {
+	// TODO: should include this in versioned cache and auto-retries on recoverable error
 	await buildGDCdictionary(ds)
 
 	if (serverconfig.features.await4completeGdcCaseCache) {

--- a/server/src/initGdc.js
+++ b/server/src/initGdc.js
@@ -43,14 +43,18 @@ any error is considered critical and must be presented in server log for diagnos
 */
 
 export async function initGDCdictionary(ds) {
-	await buildGDCdictionary(ds) //.catch(e => {throw e})
+	await buildGDCdictionary(ds).catch(e => {
+		throw e
+	})
 
 	if (serverconfig.features.await4completeGdcCaseCache) {
 		// only use on dev environment. here as soon as server is launched,
 		// it will signal client to refresh (sse). if still caching asyncly,
 		// a gdc view may break due to incomplete cache, thus await a bit for cache to complete.
 		// also should use extApiCache
-		await runRemainingWithoutAwait(ds) //.catch(e => {throw e})
+		await runRemainingWithoutAwait(ds).catch(e => {
+			throw e
+		})
 	} else {
 		// use on prod, not to hold up container launch by caching
 		runRemainingWithoutAwait(ds)

--- a/server/src/initGdc.js
+++ b/server/src/initGdc.js
@@ -1,6 +1,6 @@
 import serverconfig from './serverconfig.js'
-import {buildGDCdictionary} from './initGdc.termdb.js'
-import {runRemainingWithoutAwait} from './initGdc.cache.js'
+import { buildGDCdictionary } from './initGdc.termdb.js'
+import { runRemainingWithoutAwait } from './initGdc.cache.js'
 
 /*
 ********************   Comment   *****************
@@ -42,16 +42,15 @@ any error is considered critical and must be presented in server log for diagnos
 - periodic check of stale cache and re-cache above
 */
 
-
 export async function initGDCdictionary(ds) {
-	await buildGDCdictionary(ds)
+	await buildGDCdictionary(ds) //.catch(e => {throw e})
 
 	if (serverconfig.features.await4completeGdcCaseCache) {
 		// only use on dev environment. here as soon as server is launched,
 		// it will signal client to refresh (sse). if still caching asyncly,
 		// a gdc view may break due to incomplete cache, thus await a bit for cache to complete.
 		// also should use extApiCache
-		await runRemainingWithoutAwait(ds)
+		await runRemainingWithoutAwait(ds) //.catch(e => {throw e})
 	} else {
 		// use on prod, not to hold up container launch by caching
 		runRemainingWithoutAwait(ds)

--- a/server/src/initGdc.js
+++ b/server/src/initGdc.js
@@ -43,18 +43,14 @@ any error is considered critical and must be presented in server log for diagnos
 */
 
 export async function initGDCdictionary(ds) {
-	await buildGDCdictionary(ds).catch(e => {
-		throw e
-	})
+	await buildGDCdictionary(ds)
 
 	if (serverconfig.features.await4completeGdcCaseCache) {
 		// only use on dev environment. here as soon as server is launched,
 		// it will signal client to refresh (sse). if still caching asyncly,
 		// a gdc view may break due to incomplete cache, thus await a bit for cache to complete.
 		// also should use extApiCache
-		await runRemainingWithoutAwait(ds).catch(e => {
-			throw e
-		})
+		await runRemainingWithoutAwait(ds)
 	} else {
 		// use on prod, not to hold up container launch by caching
 		runRemainingWithoutAwait(ds)

--- a/server/src/initGdc.termdb.js
+++ b/server/src/initGdc.termdb.js
@@ -144,7 +144,7 @@ export async function buildGDCdictionary(ds) {
 		const { body } = await cachedFetch(dictUrl, { headers })
 		re = body
 	} catch (e) {
-		ds.__gdc.cacheError = 'buildGDCdictionary() ssm_occurrences/_mapping'
+		ds.__gdc.recoverableError = 'buildGDCdictionary() ssm_occurrences/_mapping'
 		console.log(e)
 		throw 'failed to get GDC API _mapping: ' + (e.message || e)
 	}
@@ -263,7 +263,7 @@ export async function buildGDCdictionary(ds) {
 	try {
 		await assignDefaultBins(id2term, ds)
 	} catch (e) {
-		ds.__gdc.cacheError = 'assignDefaultBins()'
+		ds.__gdc.recoverableError = 'assignDefaultBins()'
 		console.log(e)
 		// must abort launch upon err. lack of term.bins system app will not work
 		throw 'assignDefaultBins() failed: ' + (e.message || e)
@@ -428,7 +428,7 @@ async function assignDefaultBins(id2term, ds) {
 		method: 'POST',
 		body: { query, variables }
 	}).catch(e => {
-		ds.__gdc.cacheError = 'assignDefaultBins() host.graphql'
+		ds.__gdc.recoverableError = 'assignDefaultBins() host.graphql'
 		throw e
 	})
 	if (typeof re.data?.viewer?.explore?.cases?.aggregations != 'object')

--- a/server/src/initGdc.termdb.js
+++ b/server/src/initGdc.termdb.js
@@ -138,9 +138,9 @@ export async function buildGDCdictionary(ds) {
 	const { host, headers } = ds.getHostHeaders()
 	const dictUrl = joinUrl(host.rest, 'ssm_occurrences/_mapping')
 	const { body: re } = await cachedFetch(dictUrl, { headers }).catch(e => {
+		console.log(e)
 		if (isRecoverableError(e)) {
 			ds.__gdc.recoverableError = 'buildGDCdictionary() ${dictUrl}'
-			console.log(e)
 		}
 		// should still throw to stop code execution here and allow caller to catch
 		throw 'failed to get GDC API _mapping: ' + (e.message || e)

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -408,7 +408,6 @@ export async function initGenomesDs(serverconfig) {
 		*/
 			if (d.skip) continue
 			if (!d.name) throw 'a nameless dataset from ' + genomename
-			if (d.name != 'GDC') continue
 			if (g.datasets[d.name]) throw genomename + ' has duplicating dataset name: ' + d.name
 			if (!d.jsfile) throw 'jsfile not available for dataset ' + d.name + ' of ' + genomename
 

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -41,7 +41,7 @@ import { getResult } from '#src/gene.js'
 import { validate_query_getTopTermsByType } from '#routes/termdb.topTermsByType.ts'
 import { validate_query_getSampleImages } from '#routes/termdb.sampleImages.ts'
 import { validate_query_getSampleWSImages } from '#routes/samplewsimages.ts'
-import { preInit } from '#src/mds3.preInit.ts'
+import { mayRetryDsPreInit } from '#src/mds3.preInit.ts'
 
 /*
 init
@@ -116,10 +116,14 @@ export async function init(ds, genome, _servconfig) {
 		}
 	}
 
-	// must validate termdb first
-	await validate_termdb(ds).catch(e => {
+	try {
+		// must validate termdb first
+		await validate_termdb(ds).catch(e => {
+			throw e
+		})
+	} catch (e) {
 		throw e
-	})
+	}
 
 	if (ds.queries) {
 		// must validate snvindel query before variant2sample
@@ -238,7 +242,7 @@ export async function validate_termdb(ds) {
 	tdb.sampleTypes = {}
 
 	if (ds.preInit) {
-		const response = await preInit(ds).catch(e => {
+		const response = await mayRetryDsPreInit(ds).catch(e => {
 			throw e
 		})
 		if (response?.status != 'OK') throw response?.message || `ds.preInit() failed: unknown error`

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -117,7 +117,9 @@ export async function init(ds, genome, _servconfig) {
 	}
 
 	// must validate termdb first
-	await validate_termdb(ds)
+	await validate_termdb(ds).catch(e => {
+		throw e
+	})
 
 	if (ds.queries) {
 		// must validate snvindel query before variant2sample
@@ -236,11 +238,16 @@ export async function validate_termdb(ds) {
 	tdb.sampleTypes = {}
 
 	if (ds.preInit) {
-		const response = await preInit(ds)
+		const response = await preInit(ds).catch(e => {
+			throw e
+		})
+		if (response?.status != 'OK') throw response?.message || `ds.preInit() failed: unknown error`
 	}
 
 	if (tdb?.dictionary?.gdcapi) {
-		await initGDCdictionary(ds)
+		await initGDCdictionary(ds).catch(e => {
+			throw e
+		})
 		/*
 		creates ds.cohort.termdb.q={}
 		*****************************

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -116,15 +116,8 @@ export async function init(ds, genome, _servconfig) {
 		}
 	}
 
-	try {
-		// must validate termdb first
-		await validate_termdb(ds).catch(e => {
-			throw e
-		})
-	} catch (e) {
-		throw e
-	}
-
+	// must validate termdb first
+	await validate_termdb(ds)
 	if (ds.queries) {
 		// must validate snvindel query before variant2sample
 		// as vcf header must be parsed to supply samples for variant2samples
@@ -242,16 +235,12 @@ export async function validate_termdb(ds) {
 	tdb.sampleTypes = {}
 
 	if (ds.preInit) {
-		const response = await mayRetryDsPreInit(ds).catch(e => {
-			throw e
-		})
+		const response = await mayRetryDsPreInit(ds)
 		if (response?.status != 'OK') throw response?.message || `ds.preInit() failed: unknown error`
 	}
 
 	if (tdb?.dictionary?.gdcapi) {
-		await initGDCdictionary(ds).catch(e => {
-			throw e
-		})
+		await initGDCdictionary(ds)
 		/*
 		creates ds.cohort.termdb.q={}
 		*****************************

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -116,6 +116,12 @@ export async function init(ds, genome, _servconfig) {
 		}
 	}
 
+	if (ds.preInit) {
+		// will not allow to move to validate_termdb until ds.preInit.getStatus() is okay
+		const response = await mayRetryDsPreInit(ds)
+		if (response?.status != 'OK') throw response?.message || `ds.preInit() failed: unknown error`
+	}
+
 	// must validate termdb first
 	await validate_termdb(ds)
 	if (ds.queries) {
@@ -233,11 +239,6 @@ export async function validate_termdb(ds) {
 	v: {name, plural_name, parent_id}
 	*/
 	tdb.sampleTypes = {}
-
-	if (ds.preInit) {
-		const response = await mayRetryDsPreInit(ds)
-		if (response?.status != 'OK') throw response?.message || `ds.preInit() failed: unknown error`
-	}
 
 	if (tdb?.dictionary?.gdcapi) {
 		await initGDCdictionary(ds)

--- a/server/src/mds3.preInit.ts
+++ b/server/src/mds3.preInit.ts
@@ -2,15 +2,17 @@ import serverconfig from '#src/serverconfig.js'
 import type { Mds3 } from '#types'
 
 /**
- * Tests the GDC API status and returns true if the status is OK.
- * If serverconfig.features.runRemainingWithoutAwait is false, it will throw an error if the status is not OK.
- * If serverconfig.features.runRemainingWithoutAwait is true, it will retry the request up to retryMax times.
+ * Tests the dataset readiness for initialization and data queries,
+ * for example checking if the GDC API is healthy before querying data for caching.
+ * If a raw dataset entry (in serverconfig.genomes[].datasets[]) has
+ * awaitMds3Init === true, it will throw an error if the status is not OK
+ * otherwise, it will retry the request up to retryMax times.
  * @param ds
  * @param retryDelay
  * @param retryMax
  */
 
-export async function preInit(ds: Mds3): Promise<any> {
+export async function mayRetryDsPreInit(ds: Mds3): Promise<any> {
 	if (!ds.preInit) throw `missing ds.preInit{}`
 	if (typeof ds.preInit.getStatus != 'function') throw `ds.preInit.getStatus must be a function`
 	const retryDelay = ds.preInit.retryDelay || 5000
@@ -20,17 +22,21 @@ export async function preInit(ds: Mds3): Promise<any> {
 	try {
 		// first try is not on a loop
 		const response = await ds.preInit.getStatus()
-		if (response?.status !== 'OK') {
-			console.log(`gdc api /status:`, response)
-			throw new Error('status is not OK: ' + response.message )
-		}
+		if (response?.status !== 'OK') throw response
 		return response
-	} catch (error: any) {
-		// TODO: should this 
+	} catch (response: any) {
+		if (response.status != 'recoverableError') {
+			// should not retry on fatal error
+			console.log(`fatal error: ${ds.label} ds.preInit.getStatus()`, response)
+			throw new Error('status is not OK: ' + response.message)
+		}
+
 		if (retryMax < 1) {
-			throw new Error('GDC API status error: ' + (error.message || error))
+			console.log('35 mayRetryDsPreInit()', response)
+			throw new Error('GDC API status error: ' + (response.message || response))
 		} else {
-			console.warn(`First GDC status request failed. (${retryMax} attempts left)`)
+			// ok to retry on recoverable error
+			console.warn(`First ${ds.label} preInit.getStatus() request failed. (${retryMax} attempts left)`)
 			// subsequent retries uses a loop via setInterval
 			// NOTE: Using await with recursive function may have memory performance penalties,
 			// since a new promise gets created with each recursion and its not clear how

--- a/server/src/mds3.preInit.ts
+++ b/server/src/mds3.preInit.ts
@@ -25,6 +25,7 @@ export async function mayRetryDsPreInit(ds: Mds3): Promise<any> {
 		if (response?.status !== 'OK') throw response
 		return response
 	} catch (response: any) {
+		// may retry depending on ds.preInit configuration
 		if (response.status != 'recoverableError') {
 			// should not retry on fatal error
 			console.log(`fatal error: ${ds.label} ds.preInit.getStatus()`, response)

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -28,6 +28,8 @@ export async function validate_variant2samples(ds) {
 	if (!vs) return
 
 	if (ds.preInit?.getStatus) {
+		// should wait for dataset or API to be "healthy" before attempting to validate,
+		// otherwise network-based datasets would fail to validate with unhealthy API
 		const response = await ds.preInit.getStatus().catch(e => {
 			throw e
 		})

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -27,8 +27,10 @@ export async function validate_variant2samples(ds) {
 	const vs = ds.variant2samples
 	if (!vs) return
 
-	if (ds.preInit?.isReady) {
-		const response = await ds.preInit.isReady()
+	if (ds.preInit?.getStatus) {
+		const response = await ds.preInit.getStatus().catch(e => {
+			throw e
+		})
 		if (response.status != 'OK') throw response
 	}
 

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -794,7 +794,7 @@ export function boxplot_getvalue(lst) {
 	return { w1, w2, p05, p25, p50, p75, p95, iqr, out }
 }
 
-// only use this helper when catching errors that may due
+// only use this helper when catching errors that may be due to
 // external API server errors or network connection failures;
 // the `e` argument is expected to have a network-related error code, some of which
 // may be recovered from (temp maintenance or disconnect), others are fatal
@@ -809,7 +809,7 @@ export function isRecoverableError(e) {
 	// recoverable.
 	//
 	// code=ENOTFOUND below is from undici when local wifi is down,
-	// it's not an HTTP status code from an API
+	// it's not an HTTP response status code from an API
 	return code == 'ENOTFOUND'
 }
 

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -889,7 +889,7 @@ export async function cachedFetch(url, opts = {}, use = {}) {
 					.then(async r => {
 						const contentType = r.headers.get('content-type')
 						const payload = contentType == 'application/json' ? await r.json() : await r.text()
-						if (!r.ok || (typeof r.status == 'number' && r.status > 299))
+						if (!r.ok || (typeof r?.status == 'number' && r?.status > 399))
 							throw `error from ${url}: ` + (payload.message || payload.error || JSON.stringify(payload))
 						return payload
 					})

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1541,19 +1541,56 @@ export type Mds = BaseMds & {
 }
 
 type PreInitStatus = {
+	/**
+	 * status: 'OK' indicates a valid response
+	 *
+	 * status: 'recoverableError' may cause the server code to retry until the response is healthy,
+	 * depending on the server startup code flow
+	 *
+	 * other status will be considered fatal error
+	 * */
 	status: string
+	/** response message as related to the status */
 	message?: string
+	/** arbitrary response payload properties that is specific to a dataset */
 	[props: string]: any
 }
 
 export type PreInit = {
+	/**
+	  getStatus() is used to make sure that data sources are ready before starting to query data;
+		for example, wait on GDC API server to be healthy before starting to initialize, 
+		or wait for intermittent network errors to clear on a network mount; 
+		HTTP connection timeout errors or status 5xx are considered recoverable,
+		status 4xx are not considered recoverable (client-related request errors)
+	*/
 	getStatus: () => Promise<PreInitStatus>
+	/** number of milliseconds to wait before calling th preInit.getStatus() again */
 	retryDelay?: number
+	/** maximum number of times to call preInit.getStatus() before giving up */
 	retryMax?: number
+	/**
+	 * optional callback to send notifications of pre-init errors
+	 * for St. Jude, this may reuse code that post to Slack channel;
+	 * in dev and other portals, this may use custom callbacks
+	 * */
 	errorCallback?: (response: PreInitStatus) => void
+	/**
+	 * dev only, used to test preInit handling by simulating different
+	 * responses in a known sequence of steps that may edit the preInit
+	 * response
+	 */
 	test?: {
+		/** the current number of calls to preInit.getStatus() */
 		numCalls: number
+		/**
+		 * an arbitrary response payload property that is edited in mayEditResponse()
+		 * for example, this is used to simulate a stale or current GDC version
+		 * */
 		minor: number
+		/**
+		 * a callback to potentially edit the preInit.getStatus() response
+		 */
 		mayEditResponse: (response: any) => any
 	}
 }
@@ -1563,7 +1600,7 @@ export type PreInit = {
 	- the callback can have arbitrary logic based on requirements from this ds
 	- can supply ()=>false to hide charts that will otherwise shown
 	- can define arbitrary chart type names for purpose-specific charts
-*/
+
 export type isSupportedChartCallbacks = {
 	[chartType: string]: (f: any, auth: any) => boolean | undefined
 }
@@ -1600,3 +1637,4 @@ export type Mds3 = BaseMds & {
 export type Mds3WithCohort = Mds3 & {
 	cohort: Cohort
 }
+*/

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1600,6 +1600,7 @@ export type PreInit = {
 	- the callback can have arbitrary logic based on requirements from this ds
 	- can supply ()=>false to hide charts that will otherwise shown
 	- can define arbitrary chart type names for purpose-specific charts
+*/
 
 export type isSupportedChartCallbacks = {
 	[chartType: string]: (f: any, auth: any) => boolean | undefined
@@ -1637,4 +1638,3 @@ export type Mds3 = BaseMds & {
 export type Mds3WithCohort = Mds3 & {
 	cohort: Cohort
 }
-*/


### PR DESCRIPTION
## Description

This update attempts to expand auto-recovery for recoverable errors besides the initial healthy GDC API detection.  Previously, retries only applied to detecting a healthy `/status` response, and the server crashed if any subsequent caching requests failed due to connectivity issues or API 5xx status (server maintenance). 

To test:
- set `serverconfig.features.gdcCacheCheckWait=9000` 
- use `npx tsx server.ts` from sjpp instead of `npm start` to more clearly see server crash
- and uncomment one of the test `.then()` lines in `initGdc.cache.js`
  - line ~136: HTTP 4xx should cause an immediate crash on initial cache attempt, client request must be fixed
  - line ~450: HTTP 5xx should not cause a crash, API may be under maintenance and will be healthy again
  - line ~552: error code='ENOTFOUND' is assumed to be caused by a temporary network issue that will be resolved
  - line ~82: one of the preceding `.then()` recoverable errors has to be active, which will be converted to a non-recoverable error on retry: should cancel all subsequent retries

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
