### PR TITLE
all-pharma: LC50 term overlay on scatterplot uses custom color scale

### DIFF
--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -67,13 +67,18 @@ export function setRenderers(self) {
 		chart.zScaleMax = chart.zAxisScale(chart.zMax)
 
 		chart.axisLeft = axisLeft(chart.yAxisScale)
+
 		const gradientColor = self.config.settings.sampleScatter.defaultColor
+
 		if (!self.config.startColor) self.config.startColor = self.config.stopColor = {}
+		// supply start and stop color, if term has hardcoded colors, use; otherwise use default
 		if (!self.config.startColor[chart.id]) {
-			self.config.startColor[chart.id] = rgb(gradientColor).brighter().brighter().toString()
+			self.config.startColor[chart.id] =
+				self.config.colorTW.term.continuousColorScale?.minColor || rgb(gradientColor).brighter().brighter().toString()
 		}
 		if (!self.config.stopColor[chart.id]) {
-			self.config.stopColor[chart.id] = rgb(gradientColor).darker().toString()
+			self.config.stopColor[chart.id] =
+				self.config.colorTW.term.continuousColorScale?.maxColor || rgb(gradientColor).darker().toString()
 		}
 
 		if (self.config.colorTW?.q.mode === 'continuous') {

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -74,11 +74,11 @@ export function setRenderers(self) {
 		// supply start and stop color, if term has hardcoded colors, use; otherwise use default
 		if (!self.config.startColor[chart.id]) {
 			self.config.startColor[chart.id] =
-				self.config.colorTW.term.continuousColorScale?.minColor || rgb(gradientColor).brighter().brighter().toString()
+				self.config.colorTW?.term.continuousColorScale?.minColor || rgb(gradientColor).brighter().brighter().toString()
 		}
 		if (!self.config.stopColor[chart.id]) {
 			self.config.stopColor[chart.id] =
-				self.config.colorTW.term.continuousColorScale?.maxColor || rgb(gradientColor).darker().toString()
+				self.config.colorTW?.term.continuousColorScale?.maxColor || rgb(gradientColor).darker().toString()
 		}
 
 		if (self.config.colorTW?.q.mode === 'continuous') {

--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -51,7 +51,6 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 1,
 			isleaf: true,
 			parent_id: 'A.1'
@@ -62,7 +61,6 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 2,
 			isleaf: true,
 			parent_id: 'A.1'
@@ -73,7 +71,6 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 1,
 			isleaf: true,
 			parent_id: 'A.2'
@@ -84,7 +81,6 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 1,
 			isleaf: true,
 			parent_id: 'B.1'
@@ -95,6 +91,7 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 		{ id: 'B', name: 'B', isleaf: false, child_order: 2, parent_id: null },
 		{ id: 'B.1', name: 'B.1', isleaf: false, child_order: 1, parent_id: 'B' }
 	]
+	console.log(results.terms[0], expected[0])
 	test.deepEqual(results.terms, expected, 'should output the expected terms array')
 	test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
 	test.end()
@@ -121,7 +118,6 @@ tape('levels after variable, type, categories - with gap', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: 'A.1.a'
@@ -132,7 +128,6 @@ tape('levels after variable, type, categories - with gap', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 2,
 				isleaf: true,
 				parent_id: 'A.1'
@@ -143,7 +138,6 @@ tape('levels after variable, type, categories - with gap', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: 'A.2'
@@ -154,7 +148,6 @@ tape('levels after variable, type, categories - with gap', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: 'B.1'
@@ -193,7 +186,6 @@ tape('empty variable', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 1,
 			isleaf: true,
 			parent_id: 'A.1'
@@ -204,7 +196,6 @@ tape('empty variable', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 2,
 			isleaf: true,
 			parent_id: 'A.1'
@@ -215,7 +206,6 @@ tape('empty variable', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 1,
 			isleaf: true,
 			parent_id: 'A.2'
@@ -226,7 +216,6 @@ tape('empty variable', function (test) {
 			type: 'categorical',
 			values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 			groupsetting: { disabled: true },
-			additionalAttributes: {},
 			child_order: 1,
 			isleaf: true,
 			parent_id: 'B.1'
@@ -263,7 +252,6 @@ tape('extra, non essential column', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: 'A.1'
@@ -274,7 +262,6 @@ tape('extra, non essential column', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 2,
 				isleaf: true,
 				parent_id: 'A.1'
@@ -285,7 +272,6 @@ tape('extra, non essential column', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: 'A.2'
@@ -296,7 +282,6 @@ tape('extra, non essential column', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: 'B.1'
@@ -336,7 +321,6 @@ tape('no level columns', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: null
@@ -347,7 +331,6 @@ tape('no level columns', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'No' }, 1: { label: 'Yes' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 2,
 				isleaf: true,
 				parent_id: null
@@ -358,7 +341,6 @@ tape('no level columns', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 3,
 				isleaf: true,
 				parent_id: null
@@ -369,7 +351,6 @@ tape('no level columns', function (test) {
 				type: 'categorical',
 				values: { 0: { label: 'Not treated' }, 1: { label: 'Treated' } },
 				groupsetting: { disabled: true },
-				additionalAttributes: {},
 				child_order: 4,
 				isleaf: true,
 				parent_id: null
@@ -678,7 +659,6 @@ tape('add unit to term', function (test) {
 				groupsetting: {
 					disabled: true
 				},
-				additionalAttributes: {},
 				child_order: 1,
 				isleaf: true,
 				parent_id: 'L2'
@@ -694,7 +674,6 @@ tape('add unit to term', function (test) {
 						uncomputable: true
 					}
 				},
-				additionalAttributes: {},
 				child_order: 2,
 				isleaf: true,
 				unit: 'years',
@@ -721,6 +700,23 @@ tape('add unit to term', function (test) {
 		test.fail(message + ': ' + e)
 	}
 
+	test.end()
+})
+
+tape('add additional attributes to term', function (test) {
+	test.timeoutAfter(100)
+	const tsv = [
+		`Level_1\tLevel_2\tVariable\ttype\tCategories\tadditional attributes`,
+		`Root\tTerm 2\tterm2\tinteger\t{\"999\":{\"label\":\"N/A:CCSS\"}}\t{"xx":"yy"}`
+	].join('\n')
+	try {
+		const results = parseDictionary(tsv)
+		const term = results.terms.find(i => i.id == 'term2')
+		test.ok(term, 'term is found by id=term2')
+		test.equal(term.xx, 'yy', 'new property found: term.xx=yy')
+	} catch (e) {
+		test.fail('additional attributes: ' + e)
+	}
 	test.end()
 })
 

--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -91,7 +91,6 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 		{ id: 'B', name: 'B', isleaf: false, child_order: 2, parent_id: null },
 		{ id: 'B.1', name: 'B.1', isleaf: false, child_order: 1, parent_id: 'B' }
 	]
-	console.log(results.terms[0], expected[0])
 	test.deepEqual(results.terms, expected, 'should output the expected terms array')
 	test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
 	test.end()


### PR DESCRIPTION
…term obj

## Description
closes #2461 
please pull sjpp branch `pp.issue.2461`, also repull allpharm db
test at http://localhost:3000/?noheader=1&massnative=hg38,ALL-pharmacotyping by overlaying LC50 on tsne

- [x] phenotree parser supports "additional attributes" column
- [x] rebuilt all-pharma db by adding `{"continuousColorScale":{"minColor":"#fa8b2f","maxColor":"#222222"}}` as a new column named `additional attributes` for all LC50 terms
- [x] modify sampleScatter to detect term.continuousColorScale and use it


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
