### PR TITLE
fix: scrna gene exp violin disables brushing and label menu

### DIFF
--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -1,9 +1,9 @@
 import { filterJoin, getFilterItemByTag } from '#filter'
-import { renderTable } from '../dom/table'
+import { renderTable, niceNumLabels } from '#dom'
 import { to_svg } from '#src/client'
 import { roundValueAuto } from '#shared/roundValue.js'
 import { rgb } from 'd3'
-import { niceNumLabels } from '../dom/niceNumLabels'
+import { TermTypes } from '#shared/terms.js'
 
 export function setInteractivity(self) {
 	self.download = () => {
@@ -25,9 +25,8 @@ export function setInteractivity(self) {
 	}
 
 	self.displayLabelClickMenu = function (t1, t2, plot, event) {
-		if (!t2 || self.data.plots.length === 1) {
-			return
-		}
+		if (!t2 || self.data.plots.length === 1) return // when no term 2 and just one violin, do not show options on the sole violin label
+		if (self.config.term.term.type == TermTypes.SINGLECELL_GENE_EXPRESSION) return // is sc gene exp data, none of the options below work, thus disable
 
 		const label = t1.q.mode === 'continuous' ? 'term2' : 'term'
 		const options = [

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -3,10 +3,10 @@ import { scaleLinear, scaleLog } from 'd3-scale'
 import { curveBasis, line } from 'd3-shape'
 import { getColors } from '#shared/common.js'
 import { brushX, brushY } from 'd3-brush'
-import { renderTable } from '../dom/table'
-import { Menu } from '../dom/menu'
+import { renderTable, Menu } from '#dom'
 import { rgb } from 'd3'
 import { format as d3format } from 'd3-format'
+import { TermTypes } from '#shared/terms.js'
 
 export default function setViolinRenderer(self) {
 	self.render = function () {
@@ -62,7 +62,13 @@ export default function setViolinRenderer(self) {
 			const violinG = createViolinG(svgData, plot, plotIdx, isH)
 			if (self.opts.mode != 'minimal') renderLabels(t1, t2, violinG, plot, isH, settings, tip)
 			renderViolinPlot(plot, self, isH, svgData, plotIdx, violinG, imageOffset)
-			if (self.opts.mode != 'minimal') renderBrushing(t1, t2, violinG, settings, plot, isH, svgData)
+
+			if (self.config.term.term.type == TermTypes.SINGLECELL_GENE_EXPRESSION) {
+				// is sc data, disable brushing for now because 1) no use 2) avoid bug of listing cells
+			} else {
+				// enable brushing
+				if (self.opts.mode != 'minimal') renderBrushing(t1, t2, violinG, settings, plot, isH, svgData)
+			}
 			self.labelHideLegendClicking(t2, plot)
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- scrna gene exp violin disables brushing and label menu


### PR DESCRIPTION
## Description

closes #2438 
violin CI passes, scrna views (native and gdc) works

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
