### PR TITLE
Make regression tooltips an optional feature. Add statement about statistical significance.

### DIFF
--- a/server/test/serverconfig.json
+++ b/server/test/serverconfig.json
@@ -4,6 +4,7 @@
   "defaultgenome": "hg38-test",
   "features": {
     "skip_checkDependenciesAndVersions": 1,
+    "regressionResultMsgs": true,
     "extApiCache": {
        "fake.org": "fake-test"
     }


### PR DESCRIPTION
## Description

Tooltip explanations in regression result UI are now an optional feature until they are verified by Yutaka/Qian.

Add `"regressionResultMsgs": true` to `features{}` in serverconfig to enable regression result tooltips. Will also add this flag in serverconfig of pp-irt.

Also added a statement about statistical significance to the tooltip message.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
