### PR TITLE
mds3 "mutation" legend now shows CNV entry

### DIFF
--- a/client/mds3/cnv.js
+++ b/client/mds3/cnv.js
@@ -26,6 +26,8 @@ also
 export function may_render_cnv(data, tk, block) {
 	tk.cnv?.g.selectAll('*').remove()
 	if (!data.cnv) {
+		tk.subtk2height.cnv = 0 // set to 0 in case cnv was showing before and now turned off so as to remove its space
+		if (tk.cnv) tk.cnv.cnvLst = [] // a trick to hide legend colorscale
 		return
 	}
 
@@ -38,7 +40,7 @@ export function may_render_cnv(data, tk, block) {
 	tk.cnv.colorScale = scaleLinear(
 		tk.cnv.presetMax ? [-tk.cnv.presetMax, 0, tk.cnv.presetMax] : [-absoluteMax, 0, absoluteMax],
 		[tk.cnv.lossColor, 'white', tk.cnv.gainColor]
-	).clamp( true)
+	).clamp(true)
 
 	const [rowheight, rowspace] = getRowHeight(cnvBySample || cnvLst)
 

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -504,7 +504,11 @@ function may_update_infoFields(data, tk) {
 
 function update_mclass(tk) {
 	if (!tk.legend.mclass.currentData || tk.legend.mclass.currentData.length == 0) return
-	// currentData[]: each ele is an entry to show in legend [ [class=str, count], [dt=integer, count] ]
+	/* currentData[]: each element is an entry to show in legend [ [class=str, count], [dt=integer, count] ]
+	[0] of an element can be either string or integer:
+	- string: mclass key for snvindel
+	- integer: a dt value e.g. dtcnv, those dt that doesn't have a corresponding mclass key
+	*/
 
 	tk.legend.mclass.holder.selectAll('*').remove()
 
@@ -589,6 +593,7 @@ function update_mclass(tk) {
 					{
 						isChangeShape: true,
 						isVisible: () => {
+							if (c.k == dtcnv) return false // no changing shape for cnv
 							return !tk.skewer.viewModes.find(v => v.type === 'numeric').inuse
 								? tk.mds?.termdbConfig?.tracks?.allowSkewerChanges ?? true
 								: false
@@ -602,7 +607,9 @@ function update_mclass(tk) {
 					{
 						isChangeColor: true,
 						value: color,
-						isVisible: () => true,
+						isVisible: () => {
+							return c.k != dtcnv // no changing color for cnv
+						},
 						callback: colorValue => {
 							if (!mclass[c.k].origColor) mclass[c.k].origColor = mclass[c.k].color
 							mclass[c.k].color = colorValue
@@ -942,10 +949,8 @@ function createLegendTipMenu(opts, tk, elem) {
 					 */
 					.classed('sja_menuoption', true)
 					.style('padding', '5px 10px')
-					.style('cursor', 'default')
-					.style('background-color', '#f2f2f2')
 					.style('margin', '1px')
-					.style('border-radius', '5px')
+					.style('border-radius', '0px')
 					.on('click', () => {
 						div.classed('sja_menuoption', false)
 						div.style('background-color', 'white')
@@ -962,6 +967,7 @@ function createLegendTipMenu(opts, tk, elem) {
 				tk.legend.tip.d
 					.append('div')
 					.attr('class', 'sja_menuoption')
+					.style('border-radius', '0px')
 					.text(opt.label)
 					.on('click', () => {
 						opt.callback()

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -504,7 +504,7 @@ function may_update_infoFields(data, tk) {
 
 function update_mclass(tk) {
 	if (!tk.legend.mclass.currentData || tk.legend.mclass.currentData.length == 0) return
-	// console.log(tk.legend.mclass.currentData)
+	// currentData[]: each ele is an entry to show in legend [ [class=str, count], [dt=integer, count] ]
 
 	tk.legend.mclass.holder.selectAll('*').remove()
 

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -688,7 +688,8 @@ function addV2Sgetter_native(tk, block) {
 		}
 
 		if (tk.legend.mclass?.hiddenvalues?.size) {
-			par.hiddenmclasslst = [...tk.legend.mclass.hiddenvalues].join(',')
+			// since hiddenvalues set contains mixture of mclass(str) and dt(int), pass json array instead of comma-joined string
+			par.hiddenmclasslst = JSON.stringify([...tk.legend.mclass.hiddenvalues])
 		}
 
 		const data = await dofetch3('mds3', { body: par, headers }, { serverData: tk.cache })

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -57,6 +57,10 @@ tape('Official data on TP53, extensive ui test', test => {
 		test.notOk(tk.leftlabels.doms.filterObj, 'tk.leftlabels.doms.filterObj is not set')
 		test.notOk(tk.leftlabels.doms.close, 'tk.leftlabels.doms.close is not set')
 		test.ok(tk.legend.mclass, 'tk.legend.mclass{} is set')
+		test.ok(
+			tk.legend.mclass.currentData.find(i => i[0] == 4),
+			'cnv item (dt=4) is found in legend.mclass.currentData[]'
+		) // value "4" is dtcnv
 		await findSingletonMutationTestDiscoCnvPlots(test, tk)
 		await testVariantLeftLabel(test, tk, bb)
 		if (test._ok) holder.remove()

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -142,7 +142,8 @@ function getParameter(tk, block) {
 	rangequery_rglst(tk, block, par)
 
 	if (tk.legend.mclass.hiddenvalues.size) {
-		par.hiddenmclasslst = [...tk.legend.mclass.hiddenvalues].join(',')
+		// contains mixture of mclass(str) and dt(int), pass json array instead of comma-joined string
+		par.hiddenmclasslst = JSON.stringify([...tk.legend.mclass.hiddenvalues])
 	}
 
 	if (tk.legend.bcfInfo) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- mds3 "mutation" legend now shows CNV entry

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -74,7 +74,7 @@ function init_q(req, genome) {
 
 	// cannot validate filter0 here as ds will be required and is not made yet
 	if (query.hiddenmclasslst) {
-		query.hiddenmclass = new Set(query.hiddenmclasslst.split(','))
+		query.hiddenmclass = new Set(JSON.parse(query.hiddenmclasslst))
 		delete query.hiddenmclasslst
 		// this filter set is passed to actual data querying method, after class is set for each item, will check it to decide if to drop
 	}
@@ -272,7 +272,11 @@ async function load_driver(q, ds) {
 				result.geneCnv = lst
 			}
 			if (ds.queries.cnv) {
-				result.cnv = await query_cnv(q, ds)
+				if (q.hiddenmclass?.has(dtcnv)) {
+					// cnv is hidden, do not load
+				} else {
+					result.cnv = await query_cnv(q, ds)
+				}
 			}
 
 			filter_data(q, result)

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -1,6 +1,7 @@
 import { mayCopyFromCookie, fileurl } from './utils'
 import { snvindelByRangeGetter_bcf } from './mds3.init'
 import { validate_variant2samples } from './mds3.variant2samples.js'
+import { dtcnv } from '#shared/common.js'
 
 /*
 method good for somatic variants, in skewer and gp queries:
@@ -277,6 +278,10 @@ async function load_driver(q, ds) {
 			filter_data(q, result)
 
 			result.mclass2variantcount = summarize_mclass(result.skewer)
+			// [ [ 'M', 2 ], [ 'F', 1 ], ..]
+			if (result.cnv) {
+				result.mclass2variantcount.push([dtcnv, result.cnv.length])
+			}
 		}
 
 		// add queries for new data types


### PR DESCRIPTION
## Description

start a series of fixes to improve cnv tk that's used for both ash and GDC cnv tool
closes #2242 
test at http://localhost:3000/?genome=hg38-test&gene=p53&mds3=TermdbTest. find the "CNV n=2" entry in legend. click to hide and see ui update

all mds3 tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
