### PR TITLE
Fix data browser unit tests

### DIFF
--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -24,6 +24,7 @@ blank or dash in required data column
 missing k=v in values (dictionary format)
 uncomputable category is a string but not number
 uncomputable category is empty string but not number
+add additional attributes to term
 
 *****************/
 
@@ -42,7 +43,6 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 		`B\tB.1\tB.1.a\tB1a\tcategorical\t{ "0": {"label": "Not treated" }, "1": { "label": "Treated" } }`
 	].join('\n')
 
-	const holder = getHolder()
 	const results = parseDictionary(tsv)
 	const expected = [
 		{
@@ -92,7 +92,6 @@ tape('levels before variable, type, and categories - no gaps', function (test) {
 		{ id: 'B.1', name: 'B.1', isleaf: false, child_order: 1, parent_id: 'B' }
 	]
 	test.deepEqual(results.terms, expected, 'should output the expected terms array')
-	test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
 	test.end()
 })
 
@@ -108,7 +107,6 @@ tape('levels after variable, type, categories - with gap', function (test) {
 
 	const message = 'should output the expected terms array'
 	try {
-		const holder = getHolder()
 		const results = parseDictionary(tsv)
 		const expected = [
 			{
@@ -159,7 +157,6 @@ tape('levels after variable, type, categories - with gap', function (test) {
 			{ id: 'B.1', name: 'B.1', isleaf: false, child_order: 1, parent_id: 'B' }
 		]
 		test.deepEqual(results.terms, expected, message)
-		test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
 	} catch (e) {
 		test.fail(message + ': ' + e)
 	}
@@ -176,7 +173,6 @@ tape('empty variable', function (test) {
 		`B\tB.1\tB.1.a\tB1a\tcategorical\t{ "0": {"label": "Not treated" }, "1": { "label": "Treated" } }`
 	].join('\n')
 
-	const holder = getHolder()
 	const results = parseDictionary(tsv)
 	const expected = [
 		{
@@ -226,7 +222,6 @@ tape('empty variable', function (test) {
 		{ id: 'B.1', name: 'B.1', isleaf: false, child_order: 1, parent_id: 'B' }
 	]
 	test.deepEqual(results.terms, expected, 'should use the variable name as term.id')
-	test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
 	test.end()
 })
 
@@ -242,7 +237,6 @@ tape('extra, non essential column', function (test) {
 
 	const message = `should display data properly, no errors`
 	try {
-		const holder = getHolder()
 		const results = parseDictionary(tsv)
 		const expected = [
 			{
@@ -292,7 +286,6 @@ tape('extra, non essential column', function (test) {
 			{ id: 'B.1', name: 'B.1', isleaf: false, child_order: 1, parent_id: 'B' }
 		]
 		test.deepEqual(results.terms, expected, message)
-		test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
 	} catch (e) {
 		test.fail(message + ': ' + e)
 	}
@@ -311,7 +304,6 @@ tape('no level columns', function (test) {
 
 	const message = `should display dictionary with variable name (i.e. id) as name`
 	try {
-		const holder = getHolder()
 		const results = parseDictionary(tsv)
 		const expected = [
 			{
@@ -356,14 +348,13 @@ tape('no level columns', function (test) {
 			}
 		]
 		test.deepEqual(results.terms, expected, message)
-		test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display dictionary, no errors')
 	} catch (e) {
 		test.fail(message + ': ' + e)
 	}
 	test.end()
 })
 
-tape('repeated level names, same line', function (test) {
+tape.skip('repeated level names, same line', function (test) {
 	test.timeoutAfter(100)
 	const tsv = [
 		`level_1\tlevel_2\tlevel_3\tvariable\ttype\tcategories`,
@@ -373,11 +364,9 @@ tape('repeated level names, same line', function (test) {
 		`B\tB.1\tB.1.a\tB1a\tcategorical\t{ "0": {"label": "Not treated" }, "1": { "label": "Treated" } }`
 	].join('\n')
 
-	const holder = getHolder()
 	const message = 'should display an error for repeated level names in the same line'
 	try {
 		const results = parseDictionary(tsv)
-		test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display dictionary, no errors')
 	} catch (e) {
 		test.fail(message + ': ' + e)
 	}
@@ -647,7 +636,6 @@ tape('add unit to term', function (test) {
 	].join('\n')
 	const message = `Should add unit to term`
 	try {
-		const holder = getHolder()
 		const results = parseDictionary(tsv)
 		const expected = [
 			{
@@ -694,7 +682,6 @@ tape('add unit to term', function (test) {
 			}
 		]
 		test.deepEqual(results.terms, expected, message)
-		test.equal(holder.selectAll('.sja_errorbar').size(), 0, 'should not display any errors')
 	} catch (e) {
 		test.fail(message + ': ' + e)
 	}
@@ -718,16 +705,3 @@ tape('add additional attributes to term', function (test) {
 	}
 	test.end()
 })
-
-/***********************************
- reusable helper vars and functions
-************************************/
-
-function getHolder() {
-	return d3s
-		.select('body')
-		.append('div')
-		.style('border', '1px solid #aaa')
-		.style('padding', '5px')
-		.style('margin', '5px')
-}

--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -1,30 +1,32 @@
 import tape from 'tape'
 import { parseDictionary } from '../dictionary.parse'
-import * as d3s from 'd3-selection'
 
 /****************
- Dictionary Tests
+Tests
 
-levels before variable, type, and categories - no gaps
-levels after variable, type, categories - with gap
-empty variable
-extra, non essential column
-no level columns
-repeated level names, same line
-dash between levels
-missing type
-repeated intermediate terms for diff branches, whole dataset
-missing Variable header
-missing Type header
-missing parent_id header
-missing name header
-missing type header
-missing values header
-blank or dash in required data column
-missing k=v in values (dictionary format)
-uncomputable category is a string but not number
-uncomputable category is empty string but not number
-add additional attributes to term
+- Phenotree parsing tests
+	levels before variable, type, and categories - no gaps
+	levels after variable, type, categories - with gap
+	empty variable
+	extra, non essential column
+	no level columns
+	repeated level names, same line
+	dash between levels
+	missing type
+	repeated intermediate terms for diff branches, whole dataset
+	missing Variable header
+	missing Type header
+	uncomputable category is a string but not number
+	uncomputable category is empty string but not number
+	add additional attributes to term
+
+- Data dictionary parsing tests
+	missing parent_id header
+	missing name header
+	missing type header
+	missing values header
+	blank or dash in required data column
+	missing k=v in values (dictionary format)
 
 *****************/
 
@@ -32,6 +34,10 @@ tape('\n', function (test) {
 	test.pass('-***- dictionary, phenotree parsing -***-')
 	test.end()
 })
+
+/**************
+Phenotree tests
+***************/
 
 tape('levels before variable, type, and categories - no gaps', function (test) {
 	test.timeoutAfter(100)
@@ -354,21 +360,22 @@ tape('no level columns', function (test) {
 	test.end()
 })
 
-tape.skip('repeated level names, same line', function (test) {
+tape('repeated level names, same line', function (test) {
 	test.timeoutAfter(100)
 	const tsv = [
 		`level_1\tlevel_2\tlevel_3\tvariable\ttype\tcategories`,
-		`A\tA.1\tA.1.a\tA1a\tcategorical\t{ "0": { "label": "No" }, "1": { "label": "Yes" } }`,
+		`A\tA\tA.1.a\tA1a\tcategorical\t{ "0": { "label": "No" }, "1": { "label": "Yes" } }`,
 		`A\tA.1\tA.1.b\tA1b\tcategorical\t{ "0": { "label": "No" }, "1": { "label": "Yes" } }`,
 		`A\tA.2\tA.2.a\tA2a\tcategorical\t{ "0": {"label": "Not treated" }, "1": { "label": "Treated" } }`,
 		`B\tB.1\tB.1.a\tB1a\tcategorical\t{ "0": {"label": "Not treated" }, "1": { "label": "Treated" } }`
 	].join('\n')
 
-	const message = 'should display an error for repeated level names in the same line'
+	const message = 'Should display an error for repeated level names in the same line'
 	try {
-		const results = parseDictionary(tsv)
+		parseDictionary(tsv) //parsePhenoTree()
+		test.fail(message)
 	} catch (e) {
-		test.fail(message + ': ' + e)
+		test.pass(message + ': ' + e)
 	}
 	test.end()
 })
@@ -473,6 +480,118 @@ tape('missing Type header', function (test) {
 	}
 	test.end()
 })
+
+tape('uncomputable category is a string but not number', function (test) {
+	test.timeoutAfter(100)
+	// user can totally encode missing numeric values with words like "unk". our system requires those to be coded as number instead otherwise it crashes our sql query. in below "unk" key is rejected
+	const tsv = [`variable\ttype\tcategories`, `A1a\tinteger\t{ "unk": { "label": "unknown" } }`].join('\n')
+
+	const message = 'Should throw on uncomputable category not being number'
+	try {
+		parseDictionary(tsv)
+		test.fail(message)
+	} catch (e) {
+		test.pass(message + ': ' + e)
+	}
+	test.end()
+})
+
+tape('uncomputable category is empty string but not number', function (test) {
+	test.timeoutAfter(100)
+	const tsv = [`variable\ttype\tcategories`, `A1a\tinteger\t{ "": { "label": "empty!!" } }`].join('\n')
+
+	const message = 'Should throw on uncomputable category not being number'
+	try {
+		parseDictionary(tsv)
+		test.fail(message)
+	} catch (e) {
+		test.pass(message + ': ' + e)
+	}
+	test.end()
+})
+
+tape('add unit to term', function (test) {
+	test.timeoutAfter(100)
+	const tsv = [
+		`Level_1\tLevel_2\tLevel_3\tLevel_4\tLevel_5\tVariable\ttype\tCategories\tUnit`,
+		`Root\tL2\tL3\t-\t-\tdiaggrp\tcategorical\t`,
+		`Root\tAge at Sample\t-\t-\t-\tsnp6_sample_age\tinteger\t{\"999\":{\"label\":\"N/A:CCSS\"}}\tyears`
+	].join('\n')
+	const message = `Should add unit to term`
+	try {
+		const results = parseDictionary(tsv)
+		const expected = [
+			{
+				id: 'diaggrp',
+				name: 'L3',
+				type: 'categorical',
+				values: {},
+				groupsetting: {
+					disabled: true
+				},
+				child_order: 1,
+				isleaf: true,
+				parent_id: 'L2'
+			},
+			{
+				id: 'snp6_sample_age',
+				name: 'Age at Sample',
+				type: 'integer',
+				groupsetting: undefined,
+				values: {
+					999: {
+						label: 'N/A:CCSS',
+						uncomputable: true
+					}
+				},
+				child_order: 2,
+				isleaf: true,
+				unit: 'years',
+				parent_id: 'Root'
+			},
+			{
+				id: 'Root',
+				name: 'Root',
+				isleaf: false,
+				child_order: 1,
+				parent_id: null
+			},
+			{
+				id: 'L2',
+				name: 'L2',
+				isleaf: false,
+				child_order: 1,
+				parent_id: 'Root'
+			}
+		]
+		test.deepEqual(results.terms, expected, message)
+	} catch (e) {
+		test.fail(message + ': ' + e)
+	}
+
+	test.end()
+})
+
+tape('add additional attributes to term', function (test) {
+	test.timeoutAfter(100)
+	const tsv = [
+		`Level_1\tLevel_2\tVariable\ttype\tCategories\tadditional attributes`,
+		`Root\tTerm 2\tterm2\tinteger\t{\"999\":{\"label\":\"N/A:CCSS\"}}\t{"xx":"yy"}`
+	].join('\n')
+	try {
+		const results = parseDictionary(tsv)
+		const term = results.terms.find(i => i.id == 'term2')
+		test.ok(term, 'term is found by id=term2')
+		test.equal(term.xx, 'yy', 'new property found: term.xx=yy')
+	} catch (e) {
+		test.fail('additional attributes: ' + e)
+	}
+	test.end()
+})
+
+/*********************
+Data Dictionary tests
+*********************/
 
 tape('missing parent_id header', function (test) {
 	test.timeoutAfter(100)
@@ -594,114 +713,6 @@ tape('missing k=v in values (dictionary format)', function (test) {
 		test.fail(message)
 	} catch (e) {
 		test.pass(message + ': ' + e)
-	}
-	test.end()
-})
-
-tape('uncomputable category is a string but not number', function (test) {
-	test.timeoutAfter(100)
-	// user can totally encode missing numeric values with words like "unk". our system requires those to be coded as number instead otherwise it crashes our sql query. in below "unk" key is rejected
-	const tsv = [`variable\ttype\tcategories`, `A1a\tinteger\t{ "unk": { "label": "unknown" } }`].join('\n')
-
-	const message = 'Should throw on uncomputable category not being number'
-	try {
-		parseDictionary(tsv)
-		test.fail(message)
-	} catch (e) {
-		test.pass(message + ': ' + e)
-	}
-	test.end()
-})
-
-tape('uncomputable category is empty string but not number', function (test) {
-	test.timeoutAfter(100)
-	const tsv = [`variable\ttype\tcategories`, `A1a\tinteger\t{ "": { "label": "empty!!" } }`].join('\n')
-
-	const message = 'Should throw on uncomputable category not being number'
-	try {
-		parseDictionary(tsv)
-		test.fail(message)
-	} catch (e) {
-		test.pass(message + ': ' + e)
-	}
-	test.end()
-})
-
-tape('add unit to term', function (test) {
-	test.timeoutAfter(100)
-	const tsv = [
-		`Level_1\tLevel_2\tLevel_3\tLevel_4\tLevel_5\tVariable\ttype\tCategories\tUnit`,
-		`Root\tL2\tL3\t-\t-\tdiaggrp\tcategorical\t`,
-		`Root\tAge at Sample\t-\t-\t-\tsnp6_sample_age\tinteger\t{\"999\":{\"label\":\"N/A:CCSS\"}}\tyears`
-	].join('\n')
-	const message = `Should add unit to term`
-	try {
-		const results = parseDictionary(tsv)
-		const expected = [
-			{
-				id: 'diaggrp',
-				name: 'L3',
-				type: 'categorical',
-				values: {},
-				groupsetting: {
-					disabled: true
-				},
-				child_order: 1,
-				isleaf: true,
-				parent_id: 'L2'
-			},
-			{
-				id: 'snp6_sample_age',
-				name: 'Age at Sample',
-				type: 'integer',
-				groupsetting: undefined,
-				values: {
-					999: {
-						label: 'N/A:CCSS',
-						uncomputable: true
-					}
-				},
-				child_order: 2,
-				isleaf: true,
-				unit: 'years',
-				parent_id: 'Root'
-			},
-			{
-				id: 'Root',
-				name: 'Root',
-				isleaf: false,
-				child_order: 1,
-				parent_id: null
-			},
-			{
-				id: 'L2',
-				name: 'L2',
-				isleaf: false,
-				child_order: 1,
-				parent_id: 'Root'
-			}
-		]
-		test.deepEqual(results.terms, expected, message)
-	} catch (e) {
-		test.fail(message + ': ' + e)
-	}
-
-	test.end()
-})
-
-tape('add additional attributes to term', function (test) {
-	test.timeoutAfter(100)
-	const tsv = [
-		`Level_1\tLevel_2\tVariable\ttype\tCategories\tadditional attributes`,
-		`Root\tTerm 2\tterm2\tinteger\t{\"999\":{\"label\":\"N/A:CCSS\"}}\t{"xx":"yy"}`
-	].join('\n')
-	try {
-		const results = parseDictionary(tsv)
-		const term = results.terms.find(i => i.id == 'term2')
-		test.ok(term, 'term is found by id=term2')
-		test.equal(term.xx, 'yy', 'new property found: term.xx=yy')
-	} catch (e) {
-		test.fail('additional attributes: ' + e)
 	}
 	test.end()
 })


### PR DESCRIPTION
## Description
Closes issue #2487.

Changes: 
1. Removes holder function and error bar tests
2. Fixed test
3. Arranged tests into sections for the phenotree and data dictionary parsing.  

Test: 
1. http://localhost:3000/testrun.html?dir=src/databrowser&name=databrowser.unit 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
