### PR TITLE
feat: prototype cnv-only mode using mds3 tk

### DIFF
--- a/client/mds3/cnv.js
+++ b/client/mds3/cnv.js
@@ -21,11 +21,19 @@ logic:
 use same sample number cutoff values in scale and capping
 */
 const maxRowHeight = 10
-const maxTkHeight = 200 // cnv sub track shouldn't exceed this height
+const maxTkHeight = 200 // cnv tk max height when skewer is present
 function getRowHeight(rows, tk) {
-	// if tk is cnv-only, double max height for cnv tk
+	let maxh = maxTkHeight
+	if (tk.subtk2height.skewer == 0) {
+		/* assumes that skewer subtk is already rendered and height already determined. if skewer height=0, allow to double cnv max height due to:
+		- tk is hardcoded cnv-only
+		- there's no skewer data in view range
+		*/
+		maxh *= 2
+	}
+
 	// v is computed row height and used for deriving actual row height
-	const v = (maxTkHeight * (tk.hardcodeCnvOnly ? 2 : 1)) / rows.length
+	const v = maxh / rows.length
 	if (v > maxRowHeight) return [maxRowHeight, 1] // small enough number of rows. use max height
 	if (v > 3) return [Math.floor(v), 1] // big enough height, round to small integer with spacing
 	if (v > 1) return [Math.floor(v), 0] // same above, no spacing

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -10,8 +10,7 @@ makeSampleLabel()
 	click label to view summaries about samples that have mutation data in the view range
 
 makeSampleFilterLabel()
-
-getFilterName
+createSubTk()
 */
 
 export function makeSampleLabel(data, tk, block, laby) {
@@ -278,10 +277,14 @@ function createSubTk(tk, block, tvs) {
 		showCloseLeftlabel: true,
 		filterObj: getNewFilter(tk, tvs),
 		allow2selectSamples: tk.allow2selectSamples,
-		onClose: tk.onClose
+		onClose: tk.onClose,
+		hardcodeCnvOnly: tk.hardcodeCnvOnly
 	}
 	if (tk.cnv?.presetMax) tkarg.cnv = { presetMax: tk.cnv.presetMax } // preset value is present, pass to subtk
-	// TODO mclass
+	if (tk.legend.mclass?.hiddenvalues?.size) {
+		tkarg.legend = { mclass: { hiddenvalues: new Set() } }
+		for (const v of tk.legend.mclass.hiddenvalues) tkarg.legend.mclass.hiddenvalues.add(v)
+	}
 	const tk2 = block.block_addtk_template(tkarg)
 	block.tk_load(tk2)
 }

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -100,7 +100,8 @@ function menu_variants(tk, block) {
 			listVariantData(tk, block)
 		})
 
-	if (tk.skewer) {
+	if (tk.skewer && !tk.hardcodeCnvOnly) {
+		// these are skewer-specific options, if hardcoded cnv-only, do not show;
 		if (tk.skewer.hlssmid) {
 			tk.menutip.d
 				.append('div')

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -81,6 +81,10 @@ function create_mclass(tk, block) {
 	if (!tk.legend.mclass.hiddenvalues) tk.legend.mclass.hiddenvalues = new Set()
 
 	tk.legend.mclass.row = tk.legend.table.append('tr')
+	if (tk.hardcodeCnvOnly) {
+		// in cnv-only mode, keep mutation legend invisible and still create tk.legend.mclass{} to avoid breaking logic
+		tk.legend.mclass.row.style('display', 'none')
+	}
 
 	tk.legend.mclass.row
 		.append('td')
@@ -503,9 +507,10 @@ function may_update_infoFields(data, tk) {
 }
 
 function update_mclass(tk) {
+	if (tk.hardcodeCnvOnly) return // legend is permanently hidden, no need to update
 	if (!tk.legend.mclass.currentData || tk.legend.mclass.currentData.length == 0) return
-	/* currentData[]: each element is an entry to show in legend [ [class=str, count], [dt=integer, count] ]
-	[0] of an element can be either string or integer:
+	/* currentData[]: each element is shown as an entry in legend [ [class=str, count], [dt=integer, count] ]
+	element is length=2 array. ele[0] can be either string or integer:
 	- string: mclass key for snvindel
 	- integer: a dt value e.g. dtcnv, those dt that doesn't have a corresponding mclass key
 	*/

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -266,7 +266,7 @@ function loadTk_finish_closure(tk, block) {
 					if (block.usegm && block.gmmode != 'genomic') context = block.usegm.name || block.usegm.isoform
 					tk.skewer.g
 						.append('text')
-						.text('No mutation in ' + context)
+						.text('No data in ' + context)
 						.attr('y', 25)
 						.attr('x', block.width / 2)
 						.attr('text-anchor', 'middle')

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -11,6 +11,7 @@ Official data on TP53, extensive ui test
 Official - mclass filtering
 Official - sample summaries table, create subtrack (tk.filterObj)
 Official - allow2selectSamples
+Official - hardcodeCnvOnly
 Incorrect dslabel
 Custom cnv only, no sample
 Custom ssm only, no sample
@@ -47,7 +48,7 @@ tape('Official data on TP53, extensive ui test', test => {
 		tracks: [{ type: 'mds3', dslabel: 'TermdbTest', callbackOnRender }]
 	})
 	async function callbackOnRender(tk, bb) {
-		// tk is gdc mds3 track object; bb is block object
+		// tk is mds3 track object; bb is block object
 		test.equal(bb.usegm.name, gene, 'block.usegm.name=' + gene)
 		test.equal(bb.tklst.length, 2, 'should have two tracks')
 		test.ok(tk.skewer.rawmlst.length > 0, 'mds3 tk should have loaded many data points')
@@ -475,6 +476,29 @@ must use a gene with both single and multi occurrence mutations to test
 		test.end()
 	}
 }
+
+tape('Official - hardcodeCnvOnly', test => {
+	const holder = getHolder()
+	const gene = 'TP53'
+	runproteinpaint({
+		holder,
+		genome: 'hg38-test',
+		gene,
+		tracks: [{ type: 'mds3', dslabel: 'TermdbTest', hardcodeCnvOnly: true, callbackOnRender }]
+	})
+	async function callbackOnRender(tk, bb) {
+		test.equal(bb.usegm.name, gene, 'block.usegm.name=' + gene)
+		test.equal(bb.tklst.length, 2, 'should have two tracks')
+		test.ok(tk.skewer.rawmlst.length == 0, 'cnv-only: skewer.rawmlst.length ==0')
+		test.ok(tk.cnv.cnvLst.length > 0, 'cnv-only: cnv.cnvLst.length >0')
+		test.ok(tk.leftlabels.doms.variants, 'tk.leftlabels.doms.variants is set')
+		test.ok(tk.leftlabels.doms.samples, 'tk.leftlabels.doms.samples is set')
+		test.ok(tk.legend.cnv, 'tk.legend.cnv{} is set')
+		// todo: more tests
+		if (test._ok) holder.remove()
+		test.end()
+	}
+})
 
 tape('Incorrect dslabel', test => {
 	const holder = getHolder()

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -14,9 +14,14 @@ loadTk
 			rangequery_rglst
 rangequery_add_variantfilters
 
-callbacks that are attached to tkobj:
+********** properties attached to tkobj ************
+
 - callbackOnRender()
 - onClose()
+- allow2selectSamples{}
+- hardcodeCnvOnly=true: trigger cnv-only mode as a special case. used for gdc cnv tool. this is intended to be supplied
+      via pp react wrapper in GFF e.g. runpp({tklst[{hardcodeCnvOnly:true}]})
+      this flag shouldn't be set in gdc ds, that will permanently disable skewer (lollipop and cnv tool are based on same ds)
 */
 
 export async function loadTk(tk, block) {
@@ -71,7 +76,8 @@ function getParameter(tk, block) {
 		// including skewer or non-skewer
 		forTrack: 1,
 		// may not pass skewerRim if it is not in use (turn off)
-		skewerRim: tk.mds.queries?.snvindel?.skewerRim // instructions for counting rim counts per variant
+		skewerRim: tk.mds.queries?.snvindel?.skewerRim, // instructions for counting rim counts per variant
+		hardcodeCnvOnly: tk.hardcodeCnvOnly
 	}
 
 	const headers = { 'Content-Type': 'application/json', Accept: 'application/json' }

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -19,9 +19,12 @@ rangequery_add_variantfilters
 - callbackOnRender()
 - onClose()
 - allow2selectSamples{}
-- hardcodeCnvOnly=true: trigger cnv-only mode as a special case. used for gdc cnv tool. this is intended to be supplied
-      via pp react wrapper in GFF e.g. runpp({tklst[{hardcodeCnvOnly:true}]})
+- hardcodeCnvOnly=true:
+      special case to only show cnv. used for gdc cnv tool which won't show anything other than cnv.
+	  this is intended to be supplied via pp react wrapper in GFF e.g. runpp({tklst[{hardcodeCnvOnly:true}]})
       this flag shouldn't be set in gdc ds, that will permanently disable skewer (lollipop and cnv tool are based on same ds)
+	  this mode will not allow reenabling snvindel, and will hide skewer-specific menu options
+	  this is similar to user "show only" cnv via legend option on a regular tk, but is reversible
 */
 
 export async function loadTk(tk, block) {

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -625,6 +625,7 @@ export async function get_tklst(urlp, genomeobj) {
 			}
 			if (urlp.has('token')) tk.token = urlp.get('token') // temporary
 			if (urlp.has('filterobj')) tk.filterObj = urlp.get('filterobj')
+			if (urlp.has('cnvonly')) tk.hardcodeCnvOnly = true // quick fix for testing cnv-only mode via url param; in actual use this flag should be set in runpp()
 			tklst.push(tk)
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- prototype cnv-only mode using mds3 tk

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -243,7 +243,8 @@ async function load_driver(q, ds) {
 			// get skewer data
 			result.skewer = [] // for skewer track
 
-			if (ds.queries.snvindel) {
+			if (ds.queries.snvindel && !q.hardcodeCnvOnly) {
+				// !!
 				// the query will resolve to list of mutations, to be flattened and pushed to .skewer[]
 				const mlst = await query_snvindel(q, ds)
 				/* mlst=[], each element:
@@ -256,13 +257,13 @@ async function load_driver(q, ds) {
 				result.skewer.push(...mlst)
 			}
 
-			if (ds.queries.svfusion) {
+			if (ds.queries.svfusion && !q.hardcodeCnvOnly) {
 				// todo
 				const d = await query_svfusion(q, ds)
 				result.skewer.push(...d)
 			}
 
-			if (ds.queries.geneCnv) {
+			if (ds.queries.geneCnv && !q.hardcodeCnvOnly) {
 				// just a test; can allow gene-level cnv to be indicated as leftlabel
 				// can disable this step if not to show it in skewer tk
 				// trouble is that it's using case id as event.samples[].sample_id
@@ -271,6 +272,7 @@ async function load_driver(q, ds) {
 				// this is not appended to result.skewer[]
 				result.geneCnv = lst
 			}
+
 			if (ds.queries.cnv) {
 				if (q.hiddenmclass?.has(dtcnv)) {
 					// cnv is hidden, do not load


### PR DESCRIPTION
## Description
closes #2485 and 
test [link](http://localhost:3000/?genome=hg38&block=1&position=chr2:208248128-208248783&mds3=ASH&cnvonly=1) by adding `&cnvonly=1` param to url
the ash tk gives an idea what the gdc cnv tool will look like. won't work for gdc yet for lack of cnv segment data

all mds3 tests pass


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
