### PR TITLE
SC improvements and scatter plot improvements

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -660,7 +660,7 @@ export function getDefaultScatterSettings() {
 		defaultColor: plotColor,
 		regression: 'None',
 		fov: 50,
-		threeSize: 0.002,
+		threeSize: 0.003,
 		threeFOV: 70
 	}
 }

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -43,7 +43,7 @@ export function setRenderersThree(self) {
 
 		geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
 		geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
-		const tex = self.getCircle(128)
+		const tex = getThreeCircle(128)
 		const material = new THREE.PointsMaterial({
 			size: self.settings.threeSize,
 			sizeAttenuation: true,
@@ -90,20 +90,6 @@ export function setRenderersThree(self) {
 			renderer.render(scene, camera)
 		}
 		animate()
-	}
-
-	self.getCircle = function (size) {
-		const c = document.createElement('canvas')
-		c.width = size
-		c.height = size
-		const ctx = c.getContext('2d')
-		ctx.clearRect(0, 0, size, size)
-		ctx.fillStyle = 'white'
-		ctx.beginPath()
-		ctx.arc(size / 2, size / 2, size / 2, 0, 2 * Math.PI)
-		ctx.fill()
-		const tex = new THREE.CanvasTexture(c)
-		return tex
 	}
 
 	self.render3DSerie = async function (chart) {
@@ -166,7 +152,7 @@ export function setRenderersThree(self) {
 
 		geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
 		geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
-		const tex = self.getCircle(128)
+		const tex = getThreeCircle(128)
 		const material = new THREE.PointsMaterial({
 			size: self.settings.threeSize * 3,
 			sizeAttenuation: true,
@@ -242,8 +228,16 @@ export function setRenderersThree(self) {
 	}
 }
 
-function onPointerMove(event) {
-	const x = (event.clientX / window.innerWidth) * 2 - 1
-	const y = -(event.clientY / window.innerHeight) * 2 + 1
-	console.log(roundValue(x, 1), roundValue(y, 1))
+export function getThreeCircle(size) {
+	const c = document.createElement('canvas')
+	c.width = size
+	c.height = size
+	const ctx = c.getContext('2d')
+	ctx.clearRect(0, 0, size, size)
+	ctx.fillStyle = 'white'
+	ctx.beginPath()
+	ctx.arc(size / 2, size / 2, size / 2, 0, 2 * Math.PI)
+	ctx.fill()
+	const tex = new THREE.CanvasTexture(c)
+	return tex
 }

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -32,19 +32,18 @@ export function setRenderersThree(self) {
 		const far = 1000
 		const camera = new THREE.PerspectiveCamera(fov, 1, near, far)
 		const scene = new THREE.Scene()
-		camera.position.set(0, 0, 1)
+		camera.position.set(0, 0, 1.5)
 		camera.lookAt(scene.position)
 		camera.updateMatrix()
 		const whiteColor = new THREE.Color('rgb(255,255,255)')
 		scene.background = whiteColor
 
 		const geometry = new THREE.BufferGeometry()
-		const pointer = new THREE.Vector2()
 		const { vertices, colors } = getVertices()
 
 		geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
 		geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
-		const tex = getCircle(128)
+		const tex = self.getCircle(128)
 		const material = new THREE.PointsMaterial({
 			size: self.settings.threeSize,
 			sizeAttenuation: true,
@@ -67,33 +66,21 @@ export function setRenderersThree(self) {
 		})
 
 		function getVertices() {
+			const xAxisScale = chart.xAxisScale.range([-1, 1])
+			const yAxisScale = chart.yAxisScale.range([-1, 1])
 			const vertices = []
 			const colors = []
 			for (const sample of chart.data.samples) {
 				const opacity = self.getOpacity(sample)
 				if (opacity == 0) continue
-				let x = (chart.xAxisScale(sample.x) - chart.xScaleMin) / self.canvas.width
-				let y = (chart.yAxisScale(sample.y) - chart.yScaleMax) / -self.canvas.height
-				let z = (chart.zAxisScale(sample.z) - chart.zScaleMin) / self.settings.svgd
-				vertices.push(x - 0.5, y + 0.7, z)
+				let x = xAxisScale(sample.x)
+				let y = yAxisScale(sample.y)
+				let z = 0
+				vertices.push(x, y, z)
 				const color = new THREE.Color(rgb(self.getColor(sample, chart)).toString())
 				colors.push(color.r, color.g, color.b)
 			}
 			return { vertices, colors }
-		}
-
-		function getCircle(size) {
-			const c = document.createElement('canvas')
-			c.width = size
-			c.height = size
-			const ctx = c.getContext('2d')
-			ctx.clearRect(0, 0, size, size)
-			ctx.fillStyle = 'white'
-			ctx.beginPath()
-			ctx.arc(size / 2, size / 2, size / 2, 0, 2 * Math.PI)
-			ctx.fill()
-			const tex = new THREE.CanvasTexture(c)
-			return tex
 		}
 
 		function animate() {
@@ -103,6 +90,20 @@ export function setRenderersThree(self) {
 			renderer.render(scene, camera)
 		}
 		animate()
+	}
+
+	self.getCircle = function (size) {
+		const c = document.createElement('canvas')
+		c.width = size
+		c.height = size
+		const ctx = c.getContext('2d')
+		ctx.clearRect(0, 0, size, size)
+		ctx.fillStyle = 'white'
+		ctx.beginPath()
+		ctx.arc(size / 2, size / 2, size / 2, 0, 2 * Math.PI)
+		ctx.fill()
+		const tex = new THREE.CanvasTexture(c)
+		return tex
 	}
 
 	self.render3DSerie = async function (chart) {
@@ -131,41 +132,53 @@ export function setRenderersThree(self) {
 		const controls = new OrbitControls.OrbitControls(camera, self.canvas)
 		controls.enableZoom = false
 		controls.update()
-		camera.position.set(1.5, 0.5, 2)
+		camera.position.set(1, 1, 2)
 		camera.lookAt(scene.position)
 
 		if (self.settings.showAxes) {
 			const axesHelper = new THREE.AxesHelper(1)
 			scene.add(axesHelper)
 			self.addLabels(scene, chart)
-
-			// const grid = new THREE.GridHelper(1)
-			// grid.position.x = 0.5
-			// grid.position.z = 0.5
-			// scene.add(grid)
 		}
 		camera.updateMatrix()
 		const whiteColor = new THREE.Color('rgb(255,255,255)')
 		scene.background = whiteColor
 
-		const light = new THREE.DirectionalLight(whiteColor, 2)
-		light.position.set(0.1, 0.1, 2)
-		scene.add(light)
-		const geometry = new THREE.SphereGeometry(0.005, 32)
+		//const geometry = new THREE.SphereGeometry(0.003, 64)
+		const xAxisScale = chart.xAxisScale.range([0, 1])
+		const yAxisScale = chart.yAxisScale.range([0, 1])
+		const zAxisScale = chart.zAxisScale.range([0, 1])
+
+		const vertices = []
+		const colors = []
 		for (const sample of chart.data.samples) {
 			const opacity = self.getOpacity(sample)
 			if (opacity == 0) continue
-			let x = chart.xMax == chart.xMin ? 0 : Math.abs((sample.x - chart.xMin) / (chart.xMax - chart.xMin))
-			let y = chart.yMax == chart.yMin ? 0 : Math.abs((sample.y - chart.yMin) / (chart.yMax - chart.yMin))
-			let z = chart.zMax == chart.zMin ? 0 : Math.abs((sample.z - chart.zMin) / (chart.zMax - chart.zMin))
+			let x = xAxisScale(sample.x)
+			let y = yAxisScale(sample.y)
+			let z = zAxisScale(sample.z)
 			const color = new THREE.Color(rgb(self.getColor(sample, chart)).toString())
-			const material = new THREE.MeshLambertMaterial({ color })
-			const circle = new THREE.Mesh(geometry, material)
-			scene.add(circle)
-			circle.position.set(x, y, z)
-			scene.add(circle)
+			vertices.push(x, y, z)
+			colors.push(color.r, color.g, color.b)
 		}
 
+		const geometry = new THREE.BufferGeometry()
+
+		geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
+		geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
+		const tex = self.getCircle(128)
+		const material = new THREE.PointsMaterial({
+			size: self.settings.threeSize * 3,
+			sizeAttenuation: true,
+			transparent: true,
+			opacity: self.settings.opacity,
+			map: tex,
+			vertexColors: true
+		})
+
+		const particles = new THREE.Points(geometry, material)
+
+		scene.add(particles)
 		const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: self.canvas, preserveDrawingBuffer: true })
 		renderer.setPixelRatio(window.devicePixelRatio)
 		//document.addEventListener( 'pointermove', onPointerMove );
@@ -219,7 +232,7 @@ export function setRenderersThree(self) {
 			const textGeo = new TextGeometry(text, {
 				font,
 				size: 0.02,
-				height: 0.005,
+				height: 0.002,
 				curveSegments: 8,
 				bevelEnabled: false
 			})

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1016,14 +1016,14 @@ class singleCellPlot {
 			cutoffMode: this.state.config.min || this.state.config.max ? 'fixed' : 'auto',
 			setColorsCallback: (val, idx) => {
 				this.changeGradientColor(plot, val, idx)
-			},
-			setMinMaxCallback: obj => {
-				if (obj.cutoffMode == 'auto') {
-					this.app.dispatch({ type: 'plot_edit', id: this.id, config: { min: null, max: null } })
-				} else if (obj.cutoffMode == 'fixed') {
-					this.app.dispatch({ type: 'plot_edit', id: this.id, config: { min: obj.min, max: obj.max } })
-				}
 			}
+			// setMinMaxCallback: obj => {
+			// 	if (obj.cutoffMode == 'auto') {
+			// 		this.app.dispatch({ type: 'plot_edit', id: this.id, config: { min: null, max: null } })
+			// 	} else if (obj.cutoffMode == 'fixed') {
+			// 		this.app.dispatch({ type: 'plot_edit', id: this.id, config: { min: obj.min, max: obj.max } })
+			// 	}
+			// }
 		})
 		colorScale.updateScale()
 

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1228,8 +1228,35 @@ class singleCellPlot {
 		const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: plot.canvas, preserveDrawingBuffer: true })
 		renderer.setPixelRatio(window.devicePixelRatio)
 
-		const controls = new DragControls.DragControls([particles], camera, renderer.domElement)
+		if (this.settings.showGrid) {
+			// Line Geometry
+			const lineMaterial = new THREE.LineBasicMaterial({ color: 0xffd3d3d3 })
 
+			const lines = 5
+			let x = -1
+			const step = 0.5
+			for (let i = 0; i < 5; i++) {
+				let points = []
+				points.push(new THREE.Vector3(x, 1, 0))
+				points.push(new THREE.Vector3(x, -1, 0))
+				let lineGeometry = new THREE.BufferGeometry().setFromPoints(points)
+				let line = new THREE.Line(lineGeometry, lineMaterial)
+				scene.add(line)
+				points = []
+				points.push(new THREE.Vector3(-1, x, 0))
+				points.push(new THREE.Vector3(1, x, 0))
+				lineGeometry = new THREE.BufferGeometry().setFromPoints(points)
+				line = new THREE.Line(lineGeometry, lineMaterial)
+				scene.add(line)
+				x += step
+			}
+		}
+
+		// Line Object
+
+		// Add line to scene
+
+		const controls = new DragControls.DragControls([particles], camera, renderer.domElement)
 		document.addEventListener('mousewheel', event => {
 			if (event.ctrlKey) camera.position.z += event.deltaY / 500
 		})

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -535,20 +535,9 @@ class singleCellPlot {
 				chartType: 'singleCellPlot',
 				settingsKey: 'sampleSize',
 				title: 'Sample size',
-				min: 0.001,
-				max: 0.1,
-				step: 0.001
-			},
-
-			{
-				label: 'Field of vision',
-				type: 'number',
-				chartType: 'singleCellPlot',
-				settingsKey: 'threeFOV',
-				title: 'When larger the plot will be more zoomed out',
-				min: 30,
-				max: 70,
-				step: 5
+				min: 1,
+				max: 3,
+				step: 0.5
 			}
 		]
 
@@ -753,7 +742,6 @@ class singleCellPlot {
 				plot.max = max
 			}
 		}
-
 		if (plot.cells.length > maxSamplesD3) {
 			this.renderLargePlotThree(plot)
 			this.renderLegend(plot)
@@ -818,7 +806,7 @@ class singleCellPlot {
 			if (this.state.config.min > d.geneExp) return 0
 			if (this.state.config.max < d.geneExp) return 0
 		}
-		return 0.8
+		return this.settings.opacity
 	}
 
 	getColor(d, plot) {
@@ -843,7 +831,7 @@ class singleCellPlot {
 		const r = 5
 		if (plot.cells.length > maxSamplesD3) {
 			plot.xAxisScale = d3Linear().domain([xMin, xMax]).range([-1, 1])
-			plot.yAxisScale = d3Linear().domain([yMax, yMin]).range([1, -1])
+			plot.yAxisScale = d3Linear().domain([yMin, yMax]).range([-1, 1])
 		} else {
 			plot.xAxisScale = d3Linear()
 				.domain([xMin, xMax])
@@ -1214,10 +1202,10 @@ class singleCellPlot {
 		geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
 		const tex = getCircle(128)
 		const material = new THREE.PointsMaterial({
-			size: this.settings.sampleSize,
+			size: this.settings.sampleSize * 0.001,
 			sizeAttenuation: true,
 			transparent: true,
-			opacity: 1,
+			opacity: this.settings.opacity,
 			map: tex,
 			vertexColors: true
 		})
@@ -1333,10 +1321,11 @@ export async function getPlotConfig(opts, app) {
 
 export function getDefaultSingleCellSettings() {
 	return {
-		svgw: 500,
-		svgh: 500,
+		svgw: 900,
+		svgh: 900,
 		showGrid: true,
-		sampleSize: 0.002,
-		threeFOV: 55
+		sampleSize: 1.5,
+		threeFOV: 55,
+		opacity: 0.8
 	}
 }

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -12,6 +12,7 @@ import { TermTypes } from '#shared/terms.js'
 import { ColorScale, icons as icon_functions, addGeneSearchbox, renderTable, sayerror, Menu } from '#dom'
 import { Tabs } from '../dom/toggleButtons.js'
 import * as THREE from 'three'
+import { getThreeCircle } from './sampleScatter.rendererThree.js'
 
 /*
 this
@@ -1215,7 +1216,7 @@ class singleCellPlot {
 
 		geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
 		geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
-		const tex = getCircle(128)
+		const tex = getThreeCircle(128)
 		const material = new THREE.PointsMaterial({
 			size: this.settings.sampleSizeThree,
 			sizeAttenuation: true,
@@ -1265,20 +1266,6 @@ class singleCellPlot {
 		document.addEventListener('mousewheel', event => {
 			if (event.ctrlKey) camera.position.z += event.deltaY / 500
 		})
-
-		function getCircle(size) {
-			const c = document.createElement('canvas')
-			c.width = size
-			c.height = size
-			const ctx = c.getContext('2d')
-			ctx.clearRect(0, 0, size, size)
-			ctx.fillStyle = 'white'
-			ctx.beginPath()
-			ctx.arc(size / 2, size / 2, size / 2, 0, 2 * Math.PI)
-			ctx.fill()
-			const tex = new THREE.CanvasTexture(c)
-			return tex
-		}
 
 		const self = this
 		function animate() {


### PR DESCRIPTION
## Description

Improved three rendering. SC rendering for large plots  with zooming and panning works better, replaced canvas with three. Please check with the [fetalCerebellumn](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22fetalCerebellum%22,%22plots%22:[{%22chartType%22:%22singleCellPlot%22,%22sample%22:%22normalized_counts%22}]}). Also added color scale min max handling to limit the cells rendered. 
The Scatter plot three rendering was improved and cleaned up. The [BALL-scrna](http://localhost:3000/?noheader=1&massnative=hg38,BALL-scrna) dataset can be used for testing, as it has 2D large plots and SC plots. Also please  check the 3D scattter plots in url.

See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/588) 



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
