### PR TITLE
fix: allow to customize table header row style

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -47,7 +47,8 @@ export type TableArgs = {
 	noRadioBtn?: boolean // true to show no radio buttons. should only use when singleMode=true
 	showLines?: boolean //Shows or hides line column.
 	striped?: boolean //When active makes the table rows to alternate bg colors
-	showHeader?: boolean //Render header or not
+	showHeader?: boolean //Render header row or not
+	headerThStyle?: object // object of key-value pairs to customize style of header <th> elements, e.g. {'font-size':'1.1em', ...}
 	maxWidth?: string //The max width of the table, 90vw by default.
 	maxHeight?: string //The max height of the table, 40vh by default
 
@@ -92,6 +93,7 @@ export function renderTable({
 	showLines = true,
 	striped = true,
 	showHeader = true,
+	headerThStyle,
 	maxWidth = '90vw',
 	maxHeight = '40vh',
 	selectedRows = [],
@@ -178,19 +180,24 @@ export function renderTable({
 				theadRow.append('th').text('Check/Uncheck All').attr('class', 'sjpp_table_header sjpp_table_item')
 		}
 	}
+
 	if (columnButtons && columnButtons.length > 0) {
-		theadRow.append('th').text('Actions').attr('class', 'sjpp_table_item sjpp_table_header')
+		const th = theadRow.append('th').text('Actions').attr('class', 'sjpp_table_item sjpp_table_header')
+		if (headerThStyle) {
+			for (const k in headerThStyle) th.style(k, headerThStyle[k])
+		}
 	}
-	if (showHeader)
+
+	if (showHeader) {
 		for (const c of columns) {
-			const th = theadRow
-				.append('th')
-				.style('font-size', '1.1em')
-				.text(c.label)
-				.attr('class', 'sjpp_table_item sjpp_table_header')
+			const th = theadRow.append('th').text(c.label).attr('class', 'sjpp_table_item sjpp_table_header')
 			if (c.width) th.style('width', c.width)
 			if (c.title) th.attr('title', c.title)
+			if (headerThStyle) {
+				for (const k in headerThStyle) th.style(k, headerThStyle[k])
+			}
 		}
+	}
 
 	const tbody = table.append('tbody')
 	for (const [i, row] of rows.entries()) {

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -235,7 +235,8 @@ export class MassAbout {
 			columns,
 			div: this.dom.cohortTable,
 			showLines: false,
-			maxHeight: '60vh'
+			maxHeight: '60vh',
+			headerThStyle: { 'font-size': '1.1em', 'font-weight': 'bold' }
 		})
 
 		this.dom.cohortTable.select('table').style('border-collapse', 'collapse')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- allow to customize table header row style


### PR DESCRIPTION
## Description

close #2496 
cohort table in mass about tab is using big header text, all other table usages are kept unchanged

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
