### PR TITLE
For running parametric DE on all sample sizes added serverconfig.features.run_parametricDE

### DIFF
--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -108,19 +108,8 @@ class DEanalysis {
 					{ label: 'adjusted', value: 'adjusted' },
 					{ label: 'original', value: 'original' }
 				]
-			}
-		]
-
-		if (
-			(output.mid_sample_size_cutoff >= output.sample_size1 &&
-				output.mid_sample_size_cutoff < output.sample_size2 &&
-				output.sample_size2 < output.high_sample_size_cutoff) ||
-			(output.mid_sample_size_cutoff >= output.sample_size2 &&
-				output.mid_sample_size_cutoff < output.sample_size1 &&
-				output.sample_size1 < output.high_sample_size_cutoff)
-		) {
-			// Invoked only when one sample size is low than the mid_sample_size_cutoff and the other one is higher but the higher sample size is lower than the high cutoff so that the DE computation does not take a lot of time on the server
-			inputs.push({
+			},
+			{
 				label: 'Method',
 				type: 'radio',
 				chartType: 'DEanalysis',
@@ -130,10 +119,32 @@ class DEanalysis {
 					{ label: 'edgeR', value: 'edgeR' },
 					{ label: 'wilcoxon', value: 'wilcoxon' }
 				]
-			})
-			this.settings.method = output.method
-			this.state.config = output.method
-		}
+			}
+		]
+
+		//if (
+		//	(output.mid_sample_size_cutoff >= output.sample_size1 &&
+		//		output.mid_sample_size_cutoff < output.sample_size2 &&
+		//		output.sample_size2 < output.high_sample_size_cutoff) ||
+		//	(output.mid_sample_size_cutoff >= output.sample_size2 &&
+		//		output.mid_sample_size_cutoff < output.sample_size1 &&
+		//		output.sample_size1 < output.high_sample_size_cutoff)
+		//) {
+		//	// Invoked only when one sample size is low than the mid_sample_size_cutoff and the other one is higher but the higher sample size is lower than the high cutoff so that the DE computation does not take a lot of time on the server
+		//	inputs.push({
+		//		label: 'Method',
+		//		type: 'radio',
+		//		chartType: 'DEanalysis',
+		//		settingsKey: 'method',
+		//		title: 'Toggle between edgeR and wilcoxon test',
+		//		options: [
+		//			{ label: 'edgeR', value: 'edgeR' },
+		//			{ label: 'wilcoxon', value: 'wilcoxon' }
+		//		]
+		//	})
+		//	this.settings.method = output.method
+		//	this.state.config = output.method
+		//}
 
 		if (this.app.opts.genome.termdbs) {
 			// Check if genome build contains termdbs, only then enable gene ora
@@ -644,7 +655,7 @@ export async function getPlotConfig(opts, app) {
 					min_total_count: 15,
 					pvaluetable: false,
 					adjusted_original_pvalue: 'adjusted',
-					method: undefined,
+					method: 'wilcoxon',
 					gene_ora: undefined,
 					gsea: undefined
 				}

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -108,8 +108,19 @@ class DEanalysis {
 					{ label: 'adjusted', value: 'adjusted' },
 					{ label: 'original', value: 'original' }
 				]
-			},
-			{
+			}
+		]
+
+		if (
+			JSON.parse(sessionStorage.getItem('optionalFeatures')).run_parametricDE == true || // edgeR (and other parametric methods to be added in the future) option is always shown when serverconfig.features.run_parametricDE is set to true. This has been added so as to make this functionality available only in select few production servers for now.
+			(output.mid_sample_size_cutoff >= output.sample_size1 && // Invoked only when one sample size is low than the mid_sample_size_cutoff and the other one is higher but the higher sample size is lower than the high cutoff so that the DE computation does not take a lot of time on the server
+				output.mid_sample_size_cutoff < output.sample_size2 &&
+				output.sample_size2 < output.high_sample_size_cutoff) ||
+			(output.mid_sample_size_cutoff >= output.sample_size2 &&
+				output.mid_sample_size_cutoff < output.sample_size1 &&
+				output.sample_size1 < output.high_sample_size_cutoff)
+		) {
+			inputs.push({
 				label: 'Method',
 				type: 'radio',
 				chartType: 'DEanalysis',
@@ -119,8 +130,8 @@ class DEanalysis {
 					{ label: 'edgeR', value: 'edgeR' },
 					{ label: 'wilcoxon', value: 'wilcoxon' }
 				]
-			}
-		]
+			})
+		}
 
 		//if (
 		//	(output.mid_sample_size_cutoff >= output.sample_size1 &&

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -486,11 +486,11 @@ add:
 				value: num_significant_genes + num_non_significant_genes
 			},
 			{
-				label: self.config.state.groups[0].name + ' sample size',
+				label: self.config.state.groups[0].name + ' sample size (control group)',
 				value: sample_size1
 			},
 			{
-				label: self.config.state.groups[1].name + ' sample size',
+				label: self.config.state.groups[1].name + ' sample size (treatment group)',
 				value: sample_size2
 			}
 		]
@@ -661,7 +661,7 @@ export async function getPlotConfig(opts, app) {
 			settings: {
 				DEanalysis: {
 					pvalue: 0.05,
-					foldchange: 2,
+					foldchange: 0,
 					min_count: 10,
 					min_total_count: 15,
 					pvaluetable: false,

--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -40,9 +40,9 @@ function init({ genomes }) {
 async function run_DE(param: DERequest, ds: any) {
 	/*
 param{}
-        samplelst{}
-                groups[]
-                        values[] // using integer sample id
+    samplelst{}
+            groups[]
+                    values[] // using integer sample id
 */
 	if (param.samplelst?.groups?.length != 2) throw '.samplelst.groups.length!=2'
 	if (param.samplelst.groups[0].values?.length < 1) throw 'samplelst.groups[0].values.length<1'
@@ -108,9 +108,9 @@ param{}
 	} as ExpressionInput
 
 	//console.log('expression_input:', expression_input)
-	//fs.writeFile('test.txt', JSON.stringify(expression_input), function (err) {
-	//	// For catching input to rust pipeline, in case of an error
-	//	if (err) return console.log(err)
+	//fs.writeFile('test.txt', JSON.stringify(expression_input), function(err) {
+	//    // For catching input to rust pipeline, in case of an error
+	//    if (err) return console.log(err)
 	//})
 
 	const sample_size_limit = 8 // Cutoff to determine if parametric estimation using edgeR should be used or non-parametric estimation using wilcoxon test
@@ -118,11 +118,17 @@ param{}
 	if ((group1names.length <= sample_size_limit && group2names.length <= sample_size_limit) || param.method == 'edgeR') {
 		// edgeR will be used for DE analysis
 		const time1 = new Date().valueOf()
-		result = JSON.parse(
-			await run_R(path.join(serverconfig.binpath, 'utils', 'edge.R'), JSON.stringify(expression_input))
-		)
+		const r_output = await run_R(path.join(serverconfig.binpath, 'utils', 'edge.R'), JSON.stringify(expression_input))
 		const time2 = new Date().valueOf()
 		console.log('Time taken to run edgeR:', time2 - time1, 'ms')
+		for (const line of r_output.split('\n')) {
+			if (line.startsWith('adjusted_p_values:')) {
+				//console.log("line1:", line.replace('adjusted_p_values:', ''))
+				result = JSON.parse(line.replace('adjusted_p_values:', ''))
+			} else {
+				//console.log("line:", line)
+			}
+		}
 		param.method = 'edgeR'
 		//console.log("result:",result)
 	} else if (param.method == 'wilcoxon') {
@@ -154,6 +160,6 @@ param{}
 		console.log('Time taken to run rust DE pipeline:', time2 - time1, 'ms')
 		param.method = 'wilcoxon'
 	}
-	//console.log("result:",result)
+	//console.log("result:", result)
 	return { data: result, sample_size1: sample_size1, sample_size2: sample_size2, method: param.method } as DEResponse
 }

--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -98,8 +98,8 @@ param{}
 	const cases_string = group1names.map(i => i).join(',')
 	const controls_string = group2names.map(i => i).join(',')
 	const expression_input = {
-		case: cases_string,
-		control: controls_string,
+		case: controls_string,
+		control: cases_string,
 		data_type: 'do_DE',
 		input_file: q.file,
 		min_count: param.min_count,

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -114,14 +114,20 @@ keep <- filterByExpr(y, min.count = input$min_count, min.total.count = input$min
 y <- y[keep, keep.lib.sizes = FALSE]
 y <- calcNormFactors(y, method = "TMM")
 #print (y)
-#calculate_DE_time_start <- Sys.time()
+calculate_dispersion_time_start <- Sys.time()
 suppressWarnings({
   suppressMessages({
       dge <- estimateDisp(y = y)
   })
 })
+calculate_dispersion_time_stop <- Sys.time()
+print("Dispersion Time")
+print (calculate_dispersion_time_stop - calculate_dispersion_time_start)
+calculate_exact_test_time_start <- Sys.time()
 et <- exactTest(object = dge)
-calculate_DE_time_stop <- Sys.time()
+calculate_exact_test_time_stop <- Sys.time()
+print("Exact Time")
+print(calculate_exact_test_time_stop - calculate_exact_test_time_start)
 #print ("Time to calculate DE")
 #print (calculate_DE_time_stop - calculate_DE_time_start)
 #print (et)
@@ -139,8 +145,8 @@ names(output)[2] <- "gene_symbol"
 names(output)[3] <- "fold_change"
 names(output)[4] <- "original_p_value"
 names(output)[5] <- "adjusted_p_value"
-
-toJSON(output)
+#write_csv(output,"DE_output.txt")
+cat(paste0("adjusted_p_values:",toJSON(output)))
 #output_json <- toJSON(output)
 #print ("output_json")
 #output_file <- paste0(input$output_path,"/r_output.txt")


### PR DESCRIPTION
## Description
1) Added serverconfig.features.run_parametricDE to enable edgeR on all cases irrespective of sample sizes.
2) Other small changes so as to only parse the JSON string from edge.R script. This helps in printing out other output from the R script.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
