### PR TITLE
Prototype table sort option

### DIFF
--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -170,7 +170,6 @@ export const icons = {
 	},
 	updown: (elem, o) => {
 		return getHolder(elem, o)
-			.attr('aria-label', o.title)
 			.style('padding', '0 3px')
 			.style('color', 'rgb(100,100,255)')
 			.style('opacity', 0.9)

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -73,9 +73,14 @@ export type TableArgs = {
 	/** When active makes the table rows to alternate bg colors */
 	striped?: boolean
 	/** Render header or not */
-	showHeader: boolean
-	/**  object of key-value pairs to customize style of header <th> elements, e.g. {'font-size':'1.1em', ...} */
-	headerThStyle?: object
+	showHeader?: boolean
+	/** Options for rendering the header */
+	header?: {
+		/** allow sorting from column headers */
+		allowSort?: boolean
+		/**  object of key-value pairs to customize style of header <th> elements, e.g. {'font-size':'1.1em', ...} */
+		style?: object
+	}
 	/** The max width of the table, 90vw by default. */
 	maxWidth?: string
 	/** The max height of the table, 40vh by default */
@@ -125,7 +130,7 @@ export function renderTable({
 	showLines = true,
 	striped = true,
 	showHeader = true,
-	headerThStyle,
+	header = {},
 	maxWidth = '90vw',
 	maxHeight = '40vh',
 	selectedRows = [],
@@ -215,8 +220,8 @@ export function renderTable({
 
 	if (columnButtons && columnButtons.length > 0) {
 		const th = theadRow.append('th').text('Actions').attr('class', 'sjpp_table_item sjpp_table_header')
-		if (headerThStyle) {
-			for (const k in headerThStyle) th.style(k, headerThStyle[k])
+		if (header?.style) {
+			for (const k in header.style) th.style(k, header.style[k])
 		}
 	}
 
@@ -225,8 +230,8 @@ export function renderTable({
 			const th = theadRow.append('th').text(c.label).attr('class', 'sjpp_table_item sjpp_table_header')
 			if (c.width) th.style('width', c.width)
 			if (c.title) th.attr('title', c.title)
-			if (headerThStyle) {
-				for (const k in headerThStyle) th.style(k, headerThStyle[k])
+			if (header?.style) {
+				for (const k in header.style) th.style(k, header.style[k])
 			}
 		}
 	}

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -34,7 +34,7 @@ export type Column = {
 	title?: string
 	/** Used for sorting function
 	 * Do not use this field for html columns */
-	type: 'string' | 'number'
+	sortable?: boolean
 }
 
 export type Button = {
@@ -238,7 +238,7 @@ export function renderTable({
 			if (header?.allowSort) {
 				//Only create sort button for columns with data
 				//(i.e. not html columns)
-				if (c.type) {
+				if (c.sortable) {
 					const callback = (opt: string) => sortTableCallBack(i, rows, opt)
 					const updateTable = (newRows: any) => {
 						div.selectAll('table').remove()

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -497,7 +497,8 @@ function createSortButton(col: Column, th: Th, callback, updateTable) {
 			for (const opt of options) {
 				menu.d
 					.append('div')
-					.classed('sja_menuoption', true)
+					.attr('class', 'sja_menuoption')
+					.style('border-radius', '0px')
 					.text(`Sort ${opt}`)
 					.on('click', () => {
 						const newRows = callback(opt)

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -1,78 +1,110 @@
 import { select } from 'd3-selection'
 
 export type Cell = {
-	url?: string // to print in <a> element
-	value?: string | number // to print with .text() d3 method
-	color?: string // color code to render as a color cell or, if value provided, cell font-color
-	html?: string // to print with .html() d3 method, may be susceptible to attack
-	__td?: any //is attached to each cell object pointing to <td>, for external code to render interactive contents in it
+	/** to print in <a> element */
+	url?: string
+	/** to print with .text() d3 method */
+	value?: string | number
+	/** color code to render as a color cell or, if value provided, cell font-color */
+	color?: string
+	/** to print with .html() d3 method, may be susceptible to attack */
+	html?: string
+	/** is attached to each cell object pointing to <td>, for external code to render interactive contents in it */
+	__td?: any
 	disabled?: boolean
-	elemId?: string // may be used as a reference ID for aria-labelledby, or other use
+	/** may be used as a reference ID for aria-labelledby, or other use */
+	elemId?: string
 }
 
 export type Column = {
-	label: string //the text to show as header of a column
-	width?: string // column width
-	editCallback?: (i: number, cell: Cell) => void // Makes this column editable  and allows to notify the change through the callback.
-	//It is only allowed for cells with a value or a color field
-	nowrap?: boolean // set white-space=nowrap on all <td> of this column so strings do not wrap
-	align?: string // left, center, right. If missing it is aligned to the left by default
-	title?: string //tooltip describing column content
+	/** the text to show as header of a column */
+	label: string
+	/** column width */
+	width?: string
+	/** Makes this column editable  and allows to notify the change
+	 * through the callback. It is only allowed for cells with a value or a color field */
+	editCallback?: (i: number, cell: Cell) => void
+	/** set white-space=nowrap on all <td> of this column so strings do not wrap */
+	nowrap?: boolean
+	/** left, center, right. If missing it is aligned to the left by default */
+	align?: string
+	/** tooltip describing column content */
+	title?: string
 }
 
 export type Button = {
 	dataTestId?: any
-	text: string //the text to show in the button
-	callback: (idxs: number[], button: any) => void //called when the button is clicked. Receives selected indexes and the button dom object
+	/** the text to show in the button */
+	text: string
+	/** called when the button is clicked. Receives selected indexes and the button dom object */
+	callback: (idxs: number[], button: any) => void
 	disabled?: (index: number) => boolean
 	button: any
-	onChange?: (idx: number[], button: any) => void //Called when selecting rows, it would update the button text
-	class?: string //to customize button style or to assist detection in testing
+	/** Called when selecting rows, it would update the button text */
+	onChange?: (idx: number[], button: any) => void //
+	/** to customize button style or to assist detection in testing */
+	class?: string
 }
 
-// ariaLabelledBy is an optional attribute on the array object,
-// if present, will be used as aria-labelledby attribute on the
-// radio or checkbox input element, to address Section 508 requirement
+/** ariaLabelledBy is an optional attribute on the array object,
+ * if present, will be used as aria-labelledby attribute on the
+ * radio or checkbox input element, to address Section 508 requirement */
 export type TableRow = Cell[] & { ariaLabelledBy?: string }
 
 export type TableArgs = {
-	columns: Column[] //List of table columns
-	rows: TableRow[] //each element is an array of cells for a row, with array length must matching columns length
-
-	div: any //Holder to render the table
-	columnButtons?: Button[] //List of buttons to render in a column
-	buttons?: Button[] //List of buttons to do actions after the table is edited
-	noButtonCallback?: (i: number, node: any) => void //Function that will be called when a row is selected
-	singleMode?: boolean //	true for single-selection. use radio button instead of checkboxes for multiselect
-	noRadioBtn?: boolean // true to show no radio buttons. should only use when singleMode=true
-	showLines?: boolean //Shows or hides line column.
-	striped?: boolean //When active makes the table rows to alternate bg colors
-	showHeader?: boolean //Render header row or not
-	headerThStyle?: object // object of key-value pairs to customize style of header <th> elements, e.g. {'font-size':'1.1em', ...}
-	maxWidth?: string //The max width of the table, 90vw by default.
-	maxHeight?: string //The max height of the table, 40vh by default
-
-	selectedRows?: number[] //Preselect rows specified
-	selectAll?: boolean //Preselect all rows
-	resize?: boolean //Allow to resize the table height dragging the border
-	selectedRowStyle?: any //An object of arbitrary css key-values on how to style selected rows,
-	//for example `{text-decoration: 'line-through'}`. If a row is not
-	//selected, each css property will be set to an empty string ''
-	inputName?: any //For testing purposes
-	//optional. value is predefined input name. this allows test to work.
-	//when not available, for each table made, create a unique name to use as the <input name=?>
-	//if the same name is always used, multiple tables created in one page will conflict in row selection
+	/** List of table columns */
+	columns: Column[]
+	/** each element is an array of cells for a row, with array length must matching columns length */
+	rows: TableRow[]
+	/** Holder to render the table */
+	div: any
+	/** List of buttons to render in a column */
+	columnButtons?: Button[]
+	/** List of buttons to do actions after the table is edited */
+	buttons?: Button[]
+	/** Function that will be called when a row is selected */
+	noButtonCallback?: (i: number, node: any) => void
+	/** true for single-selection. use radio button instead of checkboxes for multiselect */
+	singleMode?: boolean
+	/** true to show no radio buttons. should only use when singleMode=true */
+	noRadioBtn?: boolean
+	/** Shows or hides line column. */
+	showLines?: boolean
+	/** When active makes the table rows to alternate bg colors */
+	striped?: boolean
+	/** Render header or not */
+	showHeader: boolean
+	/**  object of key-value pairs to customize style of header <th> elements, e.g. {'font-size':'1.1em', ...} */
+	headerThStyle?: object
+	/** The max width of the table, 90vw by default. */
+	maxWidth?: string
+	/** The max height of the table, 40vh by default */
+	maxHeight?: string
+	/** Preselect rows specified */
+	selectedRows?: number[]
+	/** Preselect all rows */
+	selectAll?: boolean
+	/** Allow to resize the table height dragging the border*/
+	resize?: boolean
+	/** An object of arbitrary css key-values on how to style selected rows,
+	 * for example `{text-decoration: 'line-through'}`. If a row is not
+	 * selected, each css property will be set to an empty string ''*/
+	selectedRowStyle?: any
+	/** For testing purposes */
+	inputName?: any
+	/** optional. value is predefined input name. this allows test to work.
+	 * when not available, for each table made, create a unique name to use
+	 * as the <input name=?> if the same name is always used, multiple tables
+	 * created in one page will conflict in row selection */
 	dataTestId?: any
-	//Optional
-	//For testing purposes
 }
 
-// incremented input ID will guarantee no collision from using getUniqueNameOrId()
+/** incremented input ID will guarantee no collision from using getUniqueNameOrId()*/
 let idIncr = 0
-// random suffix will minimize the chance of collission of other code that
-// happen to use the same prefix/beginning substring for element ID
+/** random suffix will minimize the chance of collission of other code that
+happen to use the same prefix/beginning substring for element ID  */
 const randomSuffix = Math.random()
-// generate unique input name or id string
+/** generate unique input name or id string */
 function getUniqueNameOrId(str = 'elem') {
 	return `sjpp-${str}-${idIncr++}-${randomSuffix}`
 }
@@ -214,7 +246,7 @@ export function renderTable({
 		if (!row.ariaLabelledBy && row[0] && !row[0].elemId) row[0].elemId = ariaLabelledBy
 
 		if (buttons || noButtonCallback)
-			tr.on('click', e => {
+			tr.on('click', (e: Event) => {
 				if (e.target !== checkbox.node()) {
 					if (singleMode)
 						//not a checkbox
@@ -285,7 +317,7 @@ export function renderTable({
 
 			const column = columns[colIdx]
 			if (column.editCallback && cell.value) {
-				td.on('click', event => {
+				td.on('click', (event: MouseEvent) => {
 					event.stopImmediatePropagation()
 					const isEdit = td.select('input').empty()
 					if (!isEdit) return

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -241,7 +241,7 @@ export function renderTable({
 				if (c.sortable) {
 					const callback = (opt: string) => sortTableCallBack(i, rows, opt)
 					const updateTable = (newRows: any) => {
-						div.selectAll('table').remove()
+						parentDiv.remove()
 						renderTable({
 							columns,
 							rows: newRows,

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -9,7 +9,9 @@ export type Cell = {
 	value?: string | number
 	/** color code to render as a color cell or, if value provided, cell font-color */
 	color?: string
-	/** to print with .html() d3 method, may be susceptible to attack */
+	/** to print with .html() d3 method, may be susceptible to attack
+	 * If an a tag is used, 'onclick="event.stopPropagation()"' is
+	 * added before the end of the opening tag to prevent uncheck the box. */
 	html?: string
 	/** is attached to each cell object pointing to <td>, for external code to render interactive contents in it */
 	__td?: any
@@ -368,8 +370,10 @@ export function renderTable({
 						.text(cell.value || cell.value == 0 ? cell.value : cell.url) //Fix for if .value missing, url does not display
 						.attr('href', cell.url)
 						.attr('target', '_blank')
-				} else if (cell.html) td.html(cell.html)
-				else if ('value' in cell) {
+				} else if (cell.html) {
+					const formattedHtml = addInlineClickEvent(cell.html)
+					td.html(formattedHtml)
+				} else if ('value' in cell) {
 					td.text(cell.value)
 					if (cell.color) td.style('color', cell.color)
 				} else if (cell.color) {
@@ -524,4 +528,10 @@ function sortTableCallBack(i: number, rows: any, opt: string) {
 		}
 	})
 	return newRows
+}
+
+function addInlineClickEvent(html: string) {
+	if (!html) return
+	const newHtml = html.replace(/(<a[^>]*?)>/g, '$1 onclick="event.stopPropagation()">')
+	return newHtml
 }

--- a/client/dom/test/table.unit.spec.js
+++ b/client/dom/test/table.unit.spec.js
@@ -278,9 +278,9 @@ tape('Sort button', async test => {
 	const holder = getHolder()
 	const opts = {
 		columns: [
-			{ label: 'String', type: 'string' },
-			{ label: 'Number', type: 'number' },
-			{ label: 'Date', type: 'date' }
+			{ label: 'String', sortable: true },
+			{ label: 'Number', sortable: true },
+			{ label: 'Date', sortable: true }
 		],
 		rows: [
 			[{ value: 'C' }, { value: 200 }, { value: '2021-01-01' }],

--- a/client/dom/test/table.unit.spec.js
+++ b/client/dom/test/table.unit.spec.js
@@ -10,6 +10,7 @@ import * as d3s from 'd3-selection'
 	Missing div
 	Missing and excess row data
 	Return correct rows on button click
+	Sort buttons
  */
 
 /*************************
@@ -271,7 +272,7 @@ tape('Return correct rows on button click', async test => {
 	test.end()
 })
 
-tape('allowSort header option', async test => {
+tape('Sort button', async test => {
 	test.timeoutAfter(100)
 
 	const holder = getHolder()
@@ -293,8 +294,12 @@ tape('allowSort header option', async test => {
 	}
 
 	renderTable(opts)
+	test.equal(
+		holder.selectAll('.sjpp-table-sort-button').nodes().length,
+		opts.columns.length,
+		'Should display sort buttons'
+	)
 
-	test.pass('Should allow sorting')
-
+	if (test._ok) holder.remove()
 	test.end()
 })

--- a/client/dom/test/table.unit.spec.js
+++ b/client/dom/test/table.unit.spec.js
@@ -25,10 +25,6 @@ function getHolder() {
 		.style('margin', '5px')
 }
 
-function sleep(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms))
-}
-
 /**************
  test data
 ***************/
@@ -272,5 +268,33 @@ tape('Return correct rows on button click', async test => {
 	testBtn.click()
 
 	if (test._ok) holder.remove()
+	test.end()
+})
+
+tape('allowSort header option', async test => {
+	test.timeoutAfter(100)
+
+	const holder = getHolder()
+	const opts = {
+		columns: [
+			{ label: 'String', type: 'string' },
+			{ label: 'Number', type: 'number' },
+			{ label: 'Date', type: 'date' }
+		],
+		rows: [
+			[{ value: 'C' }, { value: 200 }, { value: '2021-01-01' }],
+			[{ value: 'A' }, { value: 300 }, { value: '2021-01-02' }],
+			[{ value: 'B' }, { value: 100 }, { value: '2021-01-03' }]
+		],
+		div: holder,
+		header: {
+			allowSort: true
+		}
+	}
+
+	renderTable(opts)
+
+	test.pass('Should allow sorting')
+
 	test.end()
 })

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -304,7 +304,7 @@ async function getFilesAndShowTable(obj) {
 	for (const f of result.files) {
 		const row = [
 			{
-				html: `<a href=https://portal.gdc.cancer.gov/cases/${f.case_uuid} target=_blank>${f.case_submitter_id}</a>`,
+				html: `<a href=https://portal.gdc.cancer.gov/cases/${f.case_uuid} target=_blank onclick="event.stopPropagation()">${f.case_submitter_id}</a>`,
 				value: f.case_submitter_id
 			},
 			{ value: f.project_id },

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -304,7 +304,7 @@ async function getFilesAndShowTable(obj) {
 	for (const f of result.files) {
 		const row = [
 			{
-				html: `<a href=https://portal.gdc.cancer.gov/cases/${f.case_uuid} target=_blank onclick="event.stopPropagation()">${f.case_submitter_id}</a>`,
+				html: `<a href=https://portal.gdc.cancer.gov/cases/${f.case_uuid} target=_blank>${f.case_submitter_id}</a>`,
 				value: f.case_submitter_id
 			},
 			{ value: f.project_id },

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -303,7 +303,10 @@ async function getFilesAndShowTable(obj) {
 	const rows = []
 	for (const f of result.files) {
 		const row = [
-			{ html: `<a href=https://portal.gdc.cancer.gov/cases/${f.case_uuid} target=_blank>${f.case_submitter_id}</a>` },
+			{
+				html: `<a href=https://portal.gdc.cancer.gov/cases/${f.case_uuid} target=_blank>${f.case_submitter_id}</a>`,
+				value: f.case_submitter_id
+			},
 			{ value: f.project_id },
 			{
 				html: f.sample_types

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -1,7 +1,6 @@
 import { dofetch3 } from '#common/dofetch'
-import { make_radios, renderTable, sayerror } from '#dom'
+import { make_radios, renderTable, sayerror, Menu } from '#dom'
 import { fileSize } from '#shared/fileSize.js'
-import { Menu } from '#dom/menu'
 
 /*
 a UI to list open-access maf files from current cohort
@@ -323,6 +322,7 @@ async function getFilesAndShowTable(obj) {
 		div: obj.tableDiv.append('div'),
 		selectAll: true,
 		dataTestId: 'sja_mafFileTable',
+		header: { allowSort: true },
 		buttons: [
 			{
 				text: 'Aggregate selected MAF files and download',

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -15,7 +15,12 @@ callbacks{ postRender() }
 const tip = new Menu()
 
 // list of columns to show in MAF file table
-const tableColumns = [{ label: 'Case' }, { label: 'Project' }, { label: 'Samples' }, { label: 'File Size' }]
+const tableColumns = [
+	{ label: 'Case', sortable: true },
+	{ label: 'Project', sortable: true },
+	{ label: 'Samples' },
+	{ label: 'File Size', sortable: true }
+]
 
 // list of gdc maf file columns; selected ones are used for output
 const mafColumns = [

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -236,7 +236,7 @@ export class MassAbout {
 			div: this.dom.cohortTable,
 			showLines: false,
 			maxHeight: '60vh',
-			headerThStyle: { 'font-size': '1.1em', 'font-weight': 'bold' }
+			header: { style: { 'font-size': '1.1em', 'font-weight': 'bold' } }
 		})
 
 		this.dom.cohortTable.select('table').style('border-collapse', 'collapse')

--- a/client/types/d3.d.ts
+++ b/client/types/d3.d.ts
@@ -57,6 +57,7 @@ export type Span = Selection<HTMLSpanElement, any, any, any>
 export type Button = Selection<HTMLButtonElement, any, any, any>
 export type Input = Selection<HTMLInputElement, any, any, any>
 export type Table = Selection<HTMLTableElement, any, any, any>
+export type Th = Selection<HTMLTableHeaderCellElement, any, any, any>
 export type Tr = Selection<HTMLTableRowElement, any, any, any>
 export type Td = Selection<HTMLTableDataCellElement, any, any, any>
 export type H2 = Selection<HTMLHeadingElement, any, any, any>


### PR DESCRIPTION
## Description
Closes issue #2474 

Changes: 
1. Reformatted the comments in `dom/table` to work with typedoc
2. Prototype sorting function for table

Test: 
In `client/dom/test/table.unit.spec.js`, comment out line 303. Open http://localhost:3000/testrun.html?dir=dom&name=table.unit. Click on the up/down icons to sort the data. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
