### PR TITLE
Add percentile option to color scale numeric inputs

### DIFF
--- a/client/dom/ColorScale/ColorScale.ts
+++ b/client/dom/ColorScale/ColorScale.ts
@@ -20,7 +20,6 @@ export class ColorScale {
 	barheight: number
 	barwidth: number
 	colors: string[]
-	default?: { min: number; max: number }
 	domain: number[]
 	fontSize: number
 	numericInputs?: NumericInputs
@@ -200,12 +199,14 @@ export class ColorScale {
 				await opts.setColorsCallback!(val, idx)
 				this.updateColors()
 			}
-		if (opts.numericInputs) _opts.cutoffMode = opts.numericInputs.cutoffMode || 'auto'
-		_opts.showPercentile = opts.numericInputs?.showPercentile || false
-		_opts.setNumbersCallback = async obj => {
-			if (!obj) return
-			await opts.numericInputs!.callback(obj)
-			this.updateAxis()
+		if (opts.numericInputs) {
+			_opts.cutoffMode = opts.numericInputs.cutoffMode || 'auto'
+			if (opts.numericInputs?.defaultPercentile) _opts.percentile = opts.numericInputs?.defaultPercentile
+			_opts.setNumbersCallback = async obj => {
+				if (!obj) return
+				await opts.numericInputs!.callback(obj)
+				this.updateAxis()
+			}
 		}
 		const menu = new ColorScaleMenu(_opts)
 		return menu

--- a/client/dom/ColorScale/ColorScaleMenu.ts
+++ b/client/dom/ColorScale/ColorScaleMenu.ts
@@ -6,11 +6,10 @@ import { rgb } from 'd3-color'
 export class ColorScaleMenu {
 	domain: number[]
 	colors: string[] = ['white', 'red']
-	default?: { min: number; max: number; percentile: number }
+	default?: { min: number; max: number; percentile?: number }
 	cutoffMode?: CutoffMode
 	setColorsCallback?: (val: string, idx: number) => void
-	numInputCallback?: (f?: { cutoffMode: CutoffMode; min: number; max: number }) => void
-	showPercentile?: boolean
+	numInputCallback?: (f?: { cutoffMode: CutoffMode; min?: number; max?: number; percentile?: number }) => void
 	private tip = new Menu({ padding: '2px' })
 	constructor(opts: ColorScaleMenuOpts) {
 		this.domain = opts.domain
@@ -21,10 +20,9 @@ export class ColorScaleMenu {
 			this.cutoffMode = opts.cutoffMode
 			this.default = {
 				min: opts.domain[0],
-				max: opts.domain[opts.domain.length - 1],
-				percentile: opts.percentile || 99
+				max: opts.domain[opts.domain.length - 1]
 			}
-			this.showPercentile = opts.showPercentile
+			if (opts.percentile) this.default.percentile = opts.percentile
 		}
 		if (opts.setColorsCallback) this.setColorsCallback = opts.setColorsCallback
 
@@ -49,7 +47,7 @@ export class ColorScaleMenu {
 						{ label: 'Automatic', value: 'auto', selected: this.cutoffMode == 'auto' },
 						{ label: 'Fixed', value: 'fixed', selected: this.cutoffMode == 'fixed' }
 					]
-					if (this.showPercentile) {
+					if (this.default?.percentile) {
 						options.push({
 							label: 'Percentile',
 							value: 'percentile',
@@ -90,7 +88,7 @@ export class ColorScaleMenu {
 						.style('display', this.cutoffMode == 'percentile' ? '' : 'none')
 					if (this.default?.percentile) this.appendValueInput(percentRow, this.default.percentile)
 
-					const minMaxRow = table.append('tr').style('display', this.cutoffMode == 'auto' ? 'none' : 'table-row')
+					const minMaxRow = table.append('tr').style('display', this.cutoffMode == 'fixed' ? 'table-row' : 'none')
 					this.appendValueInput(minMaxRow.append('td'), 0)
 					this.appendValueInput(minMaxRow.append('td'), this.domain.length - 1)
 				}

--- a/client/dom/test/colorScale.unit.spec.ts
+++ b/client/dom/test/colorScale.unit.spec.ts
@@ -274,44 +274,53 @@ tape('.setColorsCallback()', async test => {
 	test.end()
 })
 
-tape.only('.numericInputs', async test => {
+tape('.numericInputs', async test => {
 	test.timeoutAfter(100)
 
 	const holder = getHolder() as any
 	const newMax = 42
 	const newMin = -10
+	const defaultPercentile = 99
+	const newPercentile = 50
 	const testColorScale = getColorScale({
 		holder,
 		numericInputs: {
-			showPercentile: true,
+			defaultPercentile,
 			callback: obj => {
-				console.log(obj)
+				test.equal(typeof obj, 'object', 'Should pass an object to the numericInputs.callback()')
+				if (obj.cutoffMode == 'fixed') {
+					test.equal(obj.min, newMin, 'Should return the correct min value to the numericInputs.callback()')
+					test.equal(obj.max, newMax, 'Should return the correct max value to the numericInputs.callback()')
+				}
+				if (obj.cutoffMode == 'percentile') {
+					test.equal(
+						obj.percentile,
+						newPercentile,
+						'Should return the correct min value to the numericInputs.callback()'
+					)
+				}
 			}
 		}
-		// setMinMaxCallback: obj => {
-		// 	test.equal(typeof obj, 'object', 'Should pass an object to the .setMinMaxCallback() callback')
-		// 	test.equal(obj.cutoffMode, 'fixed', 'Should return the correct cutoffMode to the .setMinMaxCallback() callback')
-		// 	test.equal(obj.min, newMin, 'Should return the correct min value to the .setMinMaxCallback) callback')
-		// 	test.equal(obj.max, newMax, 'Should return the correct max value to the .setMinMaxCallback() callback')
-		// }
 	})
 
-	// test.equal(
-	// 	testColorScale.menu!.cutoffMode,
-	// 	'auto',
-	// 	'Should set cutoffMode = "auto" when not specified and .setMinMaxCallback() is provided.'
-	// )
-	// test.true(
-	// 	typeof testColorScale.menu!.default == 'object' &&
-	// 		testColorScale.menu!.default.min == 0 &&
-	// 		testColorScale.menu!.default.max == 1,
-	// 	'Should set auto to default values when not specified and .setMinMaxCallback() is provided.'
-	// )
+	test.equal(
+		testColorScale.menu!.cutoffMode,
+		'auto',
+		'Should set cutoffMode = "auto" when not specified and numericInputs.callback() is provided.'
+	)
+	test.true(
+		typeof testColorScale.menu!.default == 'object' &&
+			testColorScale.menu!.default.min == 0 &&
+			testColorScale.menu!.default.max == 1,
+		'Should set auto to default values when not specified and numericInputs.callback() is provided.'
+	)
 
-	// if (testColorScale.setMinMaxCallback)
-	// 	await testColorScale.setMinMaxCallback({ cutoffMode: 'fixed', min: newMin, max: newMax })
+	if (testColorScale?.menu?.numInputCallback) {
+		await testColorScale.menu.numInputCallback({ cutoffMode: 'fixed', min: newMin, max: newMax })
+		await testColorScale.menu.numInputCallback({ cutoffMode: 'percentile', percentile: newPercentile })
+	}
 
-	// if (test['_ok']) holder.remove()
+	if (test['_ok']) holder.remove()
 	test.end()
 })
 

--- a/client/dom/test/colorScale.unit.spec.ts
+++ b/client/dom/test/colorScale.unit.spec.ts
@@ -274,7 +274,7 @@ tape('.setColorsCallback()', async test => {
 	test.end()
 })
 
-tape.skip('.numericInputs', async test => {
+tape.only('.numericInputs', async test => {
 	test.timeoutAfter(100)
 
 	const holder = getHolder() as any
@@ -282,12 +282,18 @@ tape.skip('.numericInputs', async test => {
 	const newMin = -10
 	const testColorScale = getColorScale({
 		holder,
-		setMinMaxCallback: obj => {
-			test.equal(typeof obj, 'object', 'Should pass an object to the .setMinMaxCallback() callback')
-			test.equal(obj.cutoffMode, 'fixed', 'Should return the correct cutoffMode to the .setMinMaxCallback() callback')
-			test.equal(obj.min, newMin, 'Should return the correct min value to the .setMinMaxCallback) callback')
-			test.equal(obj.max, newMax, 'Should return the correct max value to the .setMinMaxCallback() callback')
+		numericInputs: {
+			showPercentile: true,
+			callback: obj => {
+				console.log(obj)
+			}
 		}
+		// setMinMaxCallback: obj => {
+		// 	test.equal(typeof obj, 'object', 'Should pass an object to the .setMinMaxCallback() callback')
+		// 	test.equal(obj.cutoffMode, 'fixed', 'Should return the correct cutoffMode to the .setMinMaxCallback() callback')
+		// 	test.equal(obj.min, newMin, 'Should return the correct min value to the .setMinMaxCallback) callback')
+		// 	test.equal(obj.max, newMax, 'Should return the correct max value to the .setMinMaxCallback() callback')
+		// }
 	})
 
 	// test.equal(

--- a/client/dom/test/colorScale.unit.spec.ts
+++ b/client/dom/test/colorScale.unit.spec.ts
@@ -13,7 +13,8 @@ ColorScale
 	- ColorScale.updateColors()
 	- markedValue - Show value in color bar and update
 	- ColorScale.updateAxis()
-	- .setMinMaxCallback() and .setColorsCallback()
+	- .setColorsCallback()
+	- .numericInputs
 	- (skipped) Show ticks in scientific notation
 
 Helpers
@@ -252,21 +253,35 @@ tape('ColorScale.updateScale()', test => {
 	test.end()
 })
 
-tape('.setMinMaxCallback() and .setColorsCallback()', async test => {
+tape('.setColorsCallback()', async test => {
 	test.timeoutAfter(100)
 
 	const holder = getHolder() as any
 	const newColor = 'blue'
 	const newIdx = 0
-	const newMax = 42
-	const newMin = -10
 	const testColorScale = getColorScale({
 		holder,
 		setColorsCallback: (value: string, idx: number) => {
 			test.equal(value, newColor, 'Should return the correct color to the .setColorsCallback()')
 			test.equal(idx, newIdx, 'Should return the correct index to the .setColorsCallback()')
 			return value
-		},
+		}
+	})
+	if (!testColorScale.menu) test.fail('Should create a menu when .setMinMaxCallback() is provided.')
+	if (testColorScale.setColorsCallback) await testColorScale.setColorsCallback(newColor, newIdx)
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape.skip('.numericInputs', async test => {
+	test.timeoutAfter(100)
+
+	const holder = getHolder() as any
+	const newMax = 42
+	const newMin = -10
+	const testColorScale = getColorScale({
+		holder,
 		setMinMaxCallback: obj => {
 			test.equal(typeof obj, 'object', 'Should pass an object to the .setMinMaxCallback() callback')
 			test.equal(obj.cutoffMode, 'fixed', 'Should return the correct cutoffMode to the .setMinMaxCallback() callback')
@@ -274,24 +289,23 @@ tape('.setMinMaxCallback() and .setColorsCallback()', async test => {
 			test.equal(obj.max, newMax, 'Should return the correct max value to the .setMinMaxCallback() callback')
 		}
 	})
-	if (!testColorScale.menu) test.fail('Should create a menu when .setMinMaxCallback() is provided.')
-	test.equal(
-		testColorScale.menu!.cutoffMode,
-		'auto',
-		'Should set cutoffMode = "auto" when not specified and .setMinMaxCallback() is provided.'
-	)
-	test.true(
-		typeof testColorScale.menu!.default == 'object' &&
-			testColorScale.menu!.default.min == 0 &&
-			testColorScale.menu!.default.max == 1,
-		'Should set auto to default values when not specified and .setMinMaxCallback() is provided.'
-	)
 
-	if (testColorScale.setColorsCallback) await testColorScale.setColorsCallback(newColor, newIdx)
-	if (testColorScale.setMinMaxCallback)
-		await testColorScale.setMinMaxCallback({ cutoffMode: 'fixed', min: newMin, max: newMax })
+	// test.equal(
+	// 	testColorScale.menu!.cutoffMode,
+	// 	'auto',
+	// 	'Should set cutoffMode = "auto" when not specified and .setMinMaxCallback() is provided.'
+	// )
+	// test.true(
+	// 	typeof testColorScale.menu!.default == 'object' &&
+	// 		testColorScale.menu!.default.min == 0 &&
+	// 		testColorScale.menu!.default.max == 1,
+	// 	'Should set auto to default values when not specified and .setMinMaxCallback() is provided.'
+	// )
 
-	if (test['_ok']) holder.remove()
+	// if (testColorScale.setMinMaxCallback)
+	// 	await testColorScale.setMinMaxCallback({ cutoffMode: 'fixed', min: newMin, max: newMax })
+
+	// if (test['_ok']) holder.remove()
 	test.end()
 })
 

--- a/client/dom/types/colorScale.ts
+++ b/client/dom/types/colorScale.ts
@@ -72,8 +72,7 @@ export type ColorScaleMenuOpts = {
 	domain: number[]
 	percentile?: number
 	setColorsCallback?: (val: string, idx: number) => void
-	setNumbersCallback?: (f?: { cutoffMode: CutoffMode; min: number; max: number }) => void
-	showPercentile?: boolean
+	setNumbersCallback?: (f?: { cutoffMode: CutoffMode; min?: number; max?: number; percentile?: number }) => void
 }
 
 export type GetInterpolatedArg = {
@@ -105,8 +104,9 @@ export type CutoffMode = 'auto' | 'fixed' | 'percentile'
 export type NumericInputs = {
 	/** Default cutoff mode on init */
 	cutoffMode: CutoffMode
-	/** Enable percentile option */
-	showPercentile?: boolean
+	/** If default percentile value provided, 'Percentile' added to dropdown.
+	 * Value is show by default. */
+	defaultPercentile?: number
 	/** Creates inputs for the user to set the min and max or use the percentile
 	 *  Use the callback to update the plot/track/app/etc.
 	 * 'Auto' mode is the absolute min and max values provided to the data array
@@ -117,10 +117,10 @@ export type NumericInputs = {
 		/** Which mode the user selected */
 		cutoffMode: CutoffMode
 		/** Returns the min and max for 'fixed' and 'auto' modes */
-		min: number
+		min?: number
 		/** Returns the min and max for 'fixed' and 'auto' modes */
-		max: number
+		max?: number
 		/** If percentile is enabled, return value */
-		percent?: number
+		percentile?: number
 	}) => void
 }

--- a/client/dom/types/colorScale.ts
+++ b/client/dom/types/colorScale.ts
@@ -1,4 +1,4 @@
-import type { SvgG, SvgSvg, SvgText } from '../../types/d3'
+import type { SvgG, SvgLine, SvgSvg, SvgText } from '../../types/d3'
 import type { Selection } from 'd3-selection'
 import type { ScaleLinear } from 'd3-scale'
 
@@ -10,11 +10,6 @@ export type ColorScaleOpts = {
 	/** Optional but highly recommend. Default is a white to red scale.
 	 * The length of the array must match the domain array. */
 	colors?: string[]
-	/** Specifies the default min and max mode if setMinMaxCallback is provided
-	 * If 'auto', renders the default min and max set on init
-	 * if 'fixed', renders the min and max set by the user.
-	 */
-	cutoffMode?: 'auto' | 'fixed'
 	/** Required. Specifies the values to show along a number line.
 	 * The length must equal the colors array length.
 	 */
@@ -29,6 +24,7 @@ export type ColorScaleOpts = {
 	/** Optional. Shows a value in the color bar for the default, bottom axis
 	 * This value cannot be zero at initialization.*/
 	markedValue?: number
+	numericInputs?: NumericInputs
 	/** Optional. Show a static text on either side of the color scale */
 	labels?: {
 		/** Label at the beginning of the scale, on the left */
@@ -45,12 +41,6 @@ export type ColorScaleOpts = {
 	height?: number
 	/** If present, creates a menu on click to change the colors */
 	setColorsCallback?: (val: string, idx: number) => void
-	/** Creates inputs for the user to set the min and max values
-	 * Use the callback to update the plot/track/app/etc.
-	 * 'Auto' mode is the absolute min and max values provided to the data array
-	 * 'Fixed mode is the min and max values set by the user.
-	 */
-	setMinMaxCallback?: (f?: { cutoffMode: 'auto' | 'fixed'; min: number; max: number }) => void
 	/** Optional. Suggested number of ticks to show. Cannot be zero. Default is 5.
 	 * NOTE: D3 considers this a ** suggested ** count. d3-axis will ultimateluy render the
 	 * ticks based on the available space of each label.
@@ -68,10 +58,8 @@ export type ColorScaleDom = {
 	gradient: GradientElem
 	scale: ScaleLinear<number, number, never>
 	scaleAxis: SvgG
-	/** Present when important value is indicated in opts */
-	//TODO: Replace with d3 type when merged
 	label?: SvgText
-	line?: Selection<SVGLineElement, any, any, any>
+	line?: SvgLine
 }
 
 export type GradientElem = Selection<SVGLinearGradientElement, any, any, any>
@@ -80,10 +68,11 @@ export type ColorScaleMenuOpts = {
 	scaleSvg: SvgSvg
 	barG: SvgG
 	colors: string[]
-	cutoffMode: 'auto' | 'fixed'
+	cutoffMode?: CutoffMode
 	domain: number[]
 	setColorsCallback?: (val: string, idx: number) => void
-	setMinMaxCallback?: (f?: { cutoffMode: 'auto' | 'fixed'; min: number; max: number }) => void
+	setNumbersCallback?: (f?: { cutoffMode: CutoffMode; min: number; max: number }) => void
+	showPercentile?: boolean
 }
 
 export type GetInterpolatedArg = {
@@ -108,4 +97,29 @@ export type GetInterpolatedArg = {
 export type InterpolatedDomainRange = {
 	values: number[]
 	colors: string[]
+}
+
+export type CutoffMode = 'auto' | 'fixed' | 'percentile'
+
+export type NumericInputs = {
+	/** Default cutoff mode on init */
+	cutoffMode: CutoffMode
+	/** Enable percentile option */
+	showPercentile?: boolean
+	/** Creates inputs for the user to set the min and max or use the percentile
+	 *  Use the callback to update the plot/track/app/etc.
+	 * 'Auto' mode is the absolute min and max values provided to the data array
+	 * 'Fixed' mode is the min and max values set by the user.
+	 * 'Percentile' mode is the cutoff set by the user.
+	 */
+	callback: (f?: {
+		/** Which mode the user selected */
+		cutoffMode: CutoffMode
+		/** Returns the min and max for 'fixed' and 'auto' modes */
+		min: number
+		/** Returns the min and max for 'fixed' and 'auto' modes */
+		max: number
+		/** If percentile is enabled, return value */
+		percent?: number
+	}) => void
 }

--- a/client/dom/types/colorScale.ts
+++ b/client/dom/types/colorScale.ts
@@ -70,6 +70,7 @@ export type ColorScaleMenuOpts = {
 	colors: string[]
 	cutoffMode?: CutoffMode
 	domain: number[]
+	percentile?: number
 	setColorsCallback?: (val: string, idx: number) => void
 	setNumbersCallback?: (f?: { cutoffMode: CutoffMode; min: number; max: number }) => void
 	showPercentile?: boolean

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -875,15 +875,17 @@ function may_create_cnv(tk, block) {
 		ticks: 4,
 		tickSize: 6,
 		topTicks: true,
-		setMinMaxCallback: obj => {
-			if (obj.cutoffMode == 'auto') {
-				delete tk.cnv.presetMax
-			} else if (obj.cutoffMode == 'fixed') {
-				tk.cnv.presetMax = Math.abs(obj.max)
-			} else {
-				throw 'unknown cutoffMode value'
+		numericInputs: {
+			callback: obj => {
+				if (obj.cutoffMode == 'auto') {
+					delete tk.cnv.presetMax
+				} else if (obj.cutoffMode == 'fixed') {
+					tk.cnv.presetMax = Math.abs(obj.max)
+				} else {
+					throw 'unknown cutoffMode value'
+				}
+				tk.load()
 			}
-			tk.load()
 		}
 	})
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features: 
+- Enabled additional percentile option in the dom ColorScale component. 


### PR DESCRIPTION
## Description
Closes issue #2448. 

Changes: 
The callback for changing the min and max refactored to a dropdown and option to use 'Percentile'. The return obj for the callback now includes `percentile` when cutoff == 'percentile`.

Test: 
1. Updated `.numericInputs` unit test in http://localhost:3000/testrun.html?dir=dom&name=colorScale.unit. Demo the callback by commenting out line 323 in `client/dom/test/colorScale.unit.spec.ts`. 
2. [Mds3 track](http://localhost:3000/?genome=hg38&gene=bcr&mds3=ASH) -> The menu that appears by clicking on the cnv scale now shows the dropdown. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
