### PR TITLE
Rm wait after successful track load

### DIFF
--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -291,6 +291,7 @@ async function makeLeftsideTabMenu(card, contentHolder, examplesOnly, sandboxDiv
 					tab.rendered = true
 					const crumbIndex = tabs.findIndex(t => t == tab)
 					sandboxDiv.header.trail.update(crumbIndex)
+					wait.remove()
 				} catch (e) {
 					wait.text('Error: ' + (e.message || e))
 				}


### PR DESCRIPTION
## Description
Closes issue #2520. Fixes a new `Loading...` appears after init, clicking on a second example, and returning to first example.Test by clicking between example here:  http://localhost:3000/?appcard=Splice%20Junction. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
