### PR TITLE
Sc contour map

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -548,25 +548,36 @@ class singleCellPlot {
 		]
 		//if more than 50K cells do not allow contour as it may fail, excludes fetalCerebellum
 		if (this.colorByGene && this.state.config.gene && !this.maxCellsExceeded) {
-			inputs.push(
-				{
-					label: 'Show contour map',
-					boxLabel: '',
-					type: 'checkbox',
-					chartType: 'singleCellPlot',
-					settingsKey: 'showContour',
-					title: 'Show contour map'
-				},
-				{
-					label: 'Contour grid size',
-					type: 'number',
-					chartType: 'singleCellPlot',
-					settingsKey: 'gridSize',
-					min: 5,
-					max: 50,
-					step: 5
-				}
-			)
+			inputs.push({
+				label: 'Show contour map',
+				boxLabel: '',
+				type: 'checkbox',
+				chartType: 'singleCellPlot',
+				settingsKey: 'showContour',
+				title: 'Show contour map'
+			})
+			if (this.settings.showContour) {
+				inputs.push(
+					{
+						label: 'Contour grid size',
+						type: 'number',
+						chartType: 'singleCellPlot',
+						settingsKey: 'contourGridSize',
+						min: 5,
+						max: 50,
+						step: 5
+					},
+					{
+						label: 'Contour thresholds',
+						type: 'number',
+						chartType: 'singleCellPlot',
+						settingsKey: 'contourThresholds',
+						min: 3,
+						max: 10,
+						step: 1
+					}
+				)
+			}
 		}
 
 		this.components = {
@@ -1207,11 +1218,11 @@ class singleCellPlot {
 	}
 
 	async renderContourMap(scene, umapCoords, geneExpression, plot) {
-		const gridSize = this.settings.gridSize
+		const gridSize = this.settings.contourGridSize
 		let densityMap = createDensityMap(umapCoords, geneExpression, gridSize, plot)
 		densityMap = normalizeDensityMap(densityMap)
 		const data = densityMap.flat()
-		const thresholds = 5
+		const thresholds = this.settings.contourThresholds
 		const width = this.settings.svgw
 		const height = this.settings.svgh
 		let [min, max] = extent(data)
@@ -1219,6 +1230,7 @@ class singleCellPlot {
 		const contoursFunc = contours()
 			.size([gridSize, gridSize])
 			.thresholds(range(min, max, (max - min) / thresholds))
+			.smooth(true)
 		const contoursData = contoursFunc(data)
 		const projection = geoIdentity().fitSize([width, height], contoursData[0])
 		const path = geoPath().projection(projection)
@@ -1415,6 +1427,7 @@ export function getDefaultSingleCellSettings() {
 		opacity: 1,
 		showNoExpCells: false,
 		showContour: false,
-		gridSize: 20
+		contourGridSize: 20,
+		contourThresholds: 5
 	}
 }


### PR DESCRIPTION
## Description

This PR enables contour map. Calculated contour map using d3. Used resulting svg as background image in the three js canvas. Added choice to show contour map when overlaying a gene. Added contour parameters gridSize and thresholds. The contour is smoothed but still looks raw. Anyways, I feel this is good enough for now. It was a lot of work to find this solution, that does not require calling R, exporting data, saving images, etc.
`
	const contoursFunc = contours()
	.size([gridSize, gridSize])
	.thresholds(range(min, max, (max - min) / thresholds))
	.smooth(true)
`
See UI

<img width="1323" alt="Screenshot 2024-12-19 at 4 41 37 PM" src="https://github.com/user-attachments/assets/e5cb02cb-4f61-43f1-8530-e5f634918947" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
