### PR TITLE
Show enter prompt to user and focus on input for different cutoff modes

### DIFF
--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -204,7 +204,7 @@ export default function svgLegend(opts) {
 				holder: g,
 				id: colorGradientId,
 				position: `${bbox.width + 25},${yPos}`,
-				ticks: domainRange > 3 ? 3 : 2,
+				ticks: 3,
 				tickSize: 2,
 				topTicks: true
 			}


### PR DESCRIPTION
## Description
Closes issue #2533. 

Test: 
1. [Disco example](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-85-7710-01A) -> see the focused inputs when changing the dropdowns. 
2. [Small tick ranges example](http://localhost:3000/?genome=hg19&dslabel=PNET&disco=1&sample=SJBT032239_D1)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
