### PR TITLE
Fix for parent term and usecase in search

### DIFF
--- a/client/termdb/search.js
+++ b/client/termdb/search.js
@@ -284,7 +284,7 @@ function setRenderers(self) {
 
 					if (term.type == 'geneVariant' && self.opts.handleGeneVariant) {
 						self.opts.handleGeneVariant(term)
-					} else if (isNonDictionaryType(term.type)) {
+					} else if (term.type && isNonDictionaryType(term.type)) {
 						self.app.dispatch({
 							type: 'app_refresh',
 							state: {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- clicking on a parent term in search results will no longer break and will allow user to view child terms

--- a/server/src/initGdc.termdb.js
+++ b/server/src/initGdc.termdb.js
@@ -637,7 +637,7 @@ function makeTermdbQueries(ds, id2term) {
 		return terms
 	}
 
-	q.findTermByName = async (searchStr, vocab, treeFilter = null, usecase = null) => {
+	q.findTermByName = async (searchStr, vocab, usecase = null, treeFilter = null) => {
 		searchStr = searchStr.toLowerCase() // convert to lowercase
 		// replace space with _ to match with id of terms
 		if (searchStr.includes(' ')) searchStr = searchStr.replace(/\s/g, '_')

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -215,7 +215,7 @@ async function trigger_findterm(q, res, termdb, ds, genome) {
 				}
 			}
 		} else if (q.targetType == TermTypeGroups.DICTIONARY_VARIABLES) {
-			const _terms = await termdb.q.findTermByName(str, q.cohortStr, q.treeFilter, q.usecase)
+			const _terms = await termdb.q.findTermByName(str, q.cohortStr, q.usecase, q.treeFilter)
 
 			terms.push(..._terms.map(copy_term))
 		} else if (q.targetType == TermTypeGroups.METABOLITE_INTENSITY) {


### PR DESCRIPTION
## Description

Fixes https://github.com/stjude/proteinpaint/issues/2430

Clicking on parent term in search menu no longer breaks. Can test by clicking on any parent term in search menu.

Also, `usecase` is now correctly passed to `findTermByName()` allowing search results to be properly filtered. Can test by searching for `cardi` in cumulative incidence search box and only condition terms should appear.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
