### PR TITLE
fix: disco plot CancerGeneCensus filtering is now controlled by ds se…

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -354,12 +354,16 @@ async function createDiscoInSandbox(tk, block, sample, thisMutation) {
 	}
 	sandbox.header.text(headerTexts.join(''))
 	try {
-		;(await import('#plots/plot.disco.js')).default(tk.mds, tk.mds.label, sample, sandbox.body, block.genome, {
-			downloadImgName: headerTexts.join('') + ' Disco', // file name of svg downloaded from disco
-			Disco: {
-				prioritizeGeneLabelsByGeneSets: true // TODO control this at dataset
+		;(await import('#plots/plot.disco.js')).default(
+			tk.mds.termdbConfig,
+			tk.mds.label,
+			sample,
+			sandbox.body,
+			block.genome,
+			{
+				downloadImgName: headerTexts.join('') + ' Disco' // file name of svg downloaded from disco
 			}
-		})
+		)
 	} catch (e) {
 		sandbox.body.append('div').text('Error: ' + (e.message || e))
 		if (e.stack) console.log(e.stack)

--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -339,12 +339,7 @@ export function setInteractivity(self) {
 						self.state.vocab.dslabel,
 						sample,
 						sandbox.body,
-						self.app.opts.genome,
-						{
-							Disco: {
-								prioritizeGeneLabelsByGeneSets: true // TODO control this at dataset-level
-							}
-						}
+						self.app.opts.genome
 					)
 					menuDiv.remove()
 					self.dom.clickMenu.d.selectAll('*').remove()

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- disco plot CancerGeneCensus filtering is now controlled by ds setting

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -205,7 +205,7 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 	if (q.singleSampleMutation) {
 		q2.singleSampleMutation = {
 			sample_id_key: q.singleSampleMutation.sample_id_key,
-			discoSkipChrM: q.singleSampleMutation.discoSkipChrM
+			discoPlot: q.singleSampleMutation.discoPlot
 		}
 	}
 	if (q.singleSampleGenomeQuantification) {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -286,9 +286,13 @@ type SingleSampleMutationQuery = {
 	sample_id_key: string
 	/** only required for src=native */
 	folder?: string
-	/** quick fix to hide chrM from disco, due to reason e.g. this dataset doesn't
-	 * have data on chrM */
-	discoSkipChrM?: true
+	/** disco plot will be launched when singleSampleMutation is enabled. supply customization options here */
+	discoPlot?: {
+		/** if true, disco plot will hide chrM, due to reason e.g. this dataset doesn't have data on chrM */
+		skipChrM?: true
+		/** if true, filter mutations by predefined geneset by default */
+		prioritizeGeneLabelsByGeneSets?: true
+	}
 }
 
 type NIdataQuery = {


### PR DESCRIPTION
…tting

## Description

closes #2534 

cleaned up previously hardcoded params from matrix/mds3 when launching Disco. now it's driven by ds-level setting and is centrally processed at plots/plot.disco.js

see corresponding ppgdc PR: https://github.com/stjude/ppgdc/pull/6

following are tested to work:
1. launch mbmeta2 mass ui, launch prebuilt matrix. select a sample with CTNNB1 mutation and launch Disco. the disco plot shows expected CTNNB1 gene label and others. same is from launching disco via [lollipop](http://localhost:3000/?genome=hg38&gene=kbtbd4&mds3=MB_meta_analysis2)
2. launch [gdc lollipop](http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC), click a dot > disco, the disco plot applies to proper filter
3. same for gdc oncomatrix

all mds3 tests and matrix CI pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
