### PR TITLE
3d scatter contour and color scale improvements

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -451,7 +451,37 @@ class Scatter {
 					type: 'number',
 					chartType: 'sampleScatter',
 					settingsKey: 'fov'
-				})
+				}),
+					inputs.push({
+						label: 'Show contour map',
+						boxLabel: '',
+						type: 'checkbox',
+						chartType: 'sampleScatter',
+						settingsKey: 'showContour',
+						title: 'Show contour map'
+					})
+				if (this.settings.showContour) {
+					inputs.push(
+						{
+							label: 'Contour grid size',
+							type: 'number',
+							chartType: 'sampleScatter',
+							settingsKey: 'contourGridSize',
+							min: 5,
+							max: 100,
+							step: 5
+						},
+						{
+							label: 'Contour thresholds',
+							type: 'number',
+							chartType: 'sampleScatter',
+							settingsKey: 'contourThresholds',
+							min: 3,
+							max: 10,
+							step: 1
+						}
+					)
+				}
 			}
 			inputs.push(showAxes)
 
@@ -661,7 +691,11 @@ export function getDefaultScatterSettings() {
 		regression: 'None',
 		fov: 50,
 		threeSize: 0.003,
-		threeFOV: 70
+		threeFOV: 70,
+		//3D Plot settings
+		showContour: false,
+		contourGridSize: 50,
+		contourThresholds: 10
 	}
 }
 

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -695,7 +695,7 @@ export function getDefaultScatterSettings() {
 		//3D Plot settings
 		showContour: false,
 		contourGridSize: 50,
-		contourThresholds: 10
+		contourThresholds: 5
 	}
 }
 

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -45,8 +45,9 @@ export function setRenderers(self) {
 		if (chart.data.samples.length == 0) return
 		const offsetX = self.axisOffset.x
 		const offsetY = self.axisOffset.y
-		const extraSpaceX = (chart.xMax - chart.xMin) * 0.05 //extra space added to avoid clipping the particles on the X axis
-		const extraSpaceY = (chart.yMax - chart.yMin) * 0.05 //extra space added to avoid clipping the particles on the Y axis
+
+		const extraSpaceX = (chart.xMax - chart.xMin) * 0.01 //extra space added to avoid clipping the particles on the X axis
+		const extraSpaceY = (chart.yMax - chart.yMin) * 0.01 //extra space added to avoid clipping the particles on the Y axis
 
 		chart.xAxisScale = d3Linear()
 			.domain([chart.xMin - extraSpaceX, chart.xMax + extraSpaceX])

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -256,7 +256,7 @@ export function setRenderersThree(self) {
 		const gridSize = this.settings.contourGridSize
 		const xyCoords = chart.data.samples.map((s, i) => [xAxisScale(s.x), -yAxisScale(s.y)])
 		const zCoords = chart.data.samples.map(s => zAxisScale(s.z))
-		const densityMap = createDensityMap(xyCoords, zCoords, gridSize, chart)
+		const densityMap = createDensityMap(xyCoords, zCoords, gridSize, chart, false)
 		const thresholds = this.settings.contourThresholds
 		const width = this.settings.svgw
 		const height = this.settings.svgh

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -256,7 +256,7 @@ export function setRenderersThree(self) {
 		const gridSize = this.settings.contourGridSize
 		const xyCoords = chart.data.samples.map((s, i) => [xAxisScale(s.x), -yAxisScale(s.y)])
 		const zCoords = chart.data.samples.map(s => zAxisScale(s.z))
-		const densityMap = createDensityMap(xyCoords, zCoords, gridSize, chart, false)
+		const densityMap = createDensityMap(xyCoords, zCoords, gridSize, chart)
 		const thresholds = this.settings.contourThresholds
 		const width = this.settings.svgw
 		const height = this.settings.svgh

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1234,8 +1234,6 @@ class singleCellPlot {
 			const material = new THREE.MeshBasicMaterial({ map: texture })
 			// Create a mesh with the geometry and material
 			const plane = new THREE.Mesh(geometry, material)
-			// Position the plane
-			plane.position.z = 0 // Adjust z-position as needed
 			// Add the plane to the scene
 			scene.add(plane)
 			plot.plane = plane

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -5,7 +5,7 @@ import { getColors, plotColor } from '#shared/common.js'
 import { controlsInit } from './controls'
 import { downloadSingleSVG } from '../common/svg.download.js'
 import { select } from 'd3-selection'
-import { extent, range, rgb, contours, geoIdentity, geoPath, create, scaleSequential, interpolateTurbo } from 'd3'
+import { extent, range, rgb, contours, geoIdentity, geoPath, create, scaleSequential, interpolateRgbBasis } from 'd3'
 import { roundValueAuto } from '#shared/roundValue.js'
 import { TermTypes } from '#shared/terms.js'
 import { ColorScale, icons as icon_functions, addGeneSearchbox, renderTable, sayerror, Menu } from '#dom'
@@ -1294,8 +1294,16 @@ export function getContourImage(densityMap, width, height, thresholds, gridSizeX
 	const contoursData = contoursFunc(data)
 	const projection = geoIdentity().fitSize([width, height], contoursData[0])
 	const path = geoPath().projection(projection)
-	const color = scaleSequential(interpolateTurbo).domain([min, max]).nice()
-	const svg = create('svg').attr('width', width).attr('height', height).style('fill', 'white')
+
+	const color = scaleSequential(interpolateRgbBasis(['white', '#ffde1a', '#ffce00', '#ffa700', '	#ff8d00', '#ff7400']))
+		.domain([min, max])
+		.nice()
+	const svg = create('svg')
+		.attr('width', width)
+		.attr('height', height)
+		.style('fill', 'white')
+		.style('stroke', 'transparent')
+		.style('stroke-width', 0)
 	svg
 		.selectAll('path')
 		.data(contoursData)

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1221,7 +1221,7 @@ class singleCellPlot {
 	async renderContourMap(scene, xCoords, yCoords, zCoords, plot) {
 		const umapCoords = xCoords.map((x, i) => [x, -yCoords[i]]) //y is inverted in d3
 		const gridSize = this.settings.contourGridSize
-		const densityMap = createDensityMap(umapCoords, zCoords, gridSize, plot)
+		const densityMap = createDensityMap(umapCoords, zCoords, gridSize, plot, false)
 		const thresholds = this.settings.contourThresholds
 		const width = this.settings.svgw
 		const height = this.settings.svgh
@@ -1320,7 +1320,7 @@ export function getContourImage(densityMap, width, height, thresholds, gridSizeX
 // - geneExpression: Array of gene expression values for each cell ([value1, value2, ...])
 
 // Function to create a 2D density map
-export function createDensityMap(umapCoords, geneExpression, gridSize, plot) {
+export function createDensityMap(umapCoords, geneExpression, gridSize, plot, sum = true) {
 	const densityMap = []
 	const minX = Math.min(...umapCoords.map(coord => coord[0]))
 	const maxX = Math.max(...umapCoords.map(coord => coord[0]))
@@ -1345,7 +1345,8 @@ export function createDensityMap(umapCoords, geneExpression, gridSize, plot) {
 		if (cellX >= 0 && cellX < gridSize && cellY >= 0 && cellY < gridSize) {
 			let geneExp = geneExpression[k]
 			if (geneExp > plot.max) geneExp = plot.max
-			densityMap[cellY][cellX] += geneExp
+			if (sum) densityMap[cellY][cellX] += geneExp
+			else if (densityMap[cellY][cellX] < geneExp) densityMap[cellY][cellX] = geneExp
 		}
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
 
+Features
+- Added support for drawing contour maps on 3d plots


### PR DESCRIPTION
## Description

Supported contour map in 3D plots. Improved color scale that now starts on white and removes path borders, giving a more smooth look and feel.  When building the density matrix used max value for the cell, instead of the sum of the values. Refactoring and cleanup. Looking like this now:

<img width="1134" alt="Screenshot 2025-01-02 at 12 04 02 PM" src="https://github.com/user-attachments/assets/c3f7a032-52ae-4dd0-bc9f-e0465e30879f" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
