### PR TITLE
Disco cnv UI updates 

### DIFF
--- a/client/plots/disco/cnv/CnvHeatmapRenderer.ts
+++ b/client/plots/disco/cnv/CnvHeatmapRenderer.ts
@@ -49,11 +49,6 @@ export class CnvHeatmapRenderer {
 					c1.text('Position')
 					c2.text(cnv.chr + ':' + cnv.start + '-' + cnv.stop)
 				}
-				{
-					const [c1, c2] = table.addRow()
-					c1.text('Unit')
-					c2.text(cnv.value)
-				}
 
 				menu.show(mouseEvent.x, mouseEvent.y)
 			})

--- a/client/plots/disco/label/LabelsRenderer.ts
+++ b/client/plots/disco/label/LabelsRenderer.ts
@@ -101,13 +101,20 @@ export default class LabelsRenderer implements IRenderer {
 					const [td1, td2] = table.addRow()
 
 					td1.text('Consequence')
-					td2.append('span').text(mutation.mname)
-					td2.append('span').style('margin-left', '5px').style('color', mutation.color).text(mutation.dataClass)
+					td2
+						.append('span')
+						.style('margin-left', '5px')
+						.style('color', mutation.color)
+						.text(`${mutation.dataClass}`)
+						.append('span')
+						.style('color', 'black')
+						.text(` ${mutation.chr}:${mutation.position}`)
 				}
 				{
 					const [td1, td2] = table.addRow()
+
 					td1.text('Mutation')
-					td2.append('span').text(`${mutation.chr}:${mutation.position}`)
+					td2.append('span').style('margin-left', '5px').text(mutation.mname)
 				}
 			})
 		}
@@ -135,13 +142,9 @@ export default class LabelsRenderer implements IRenderer {
 			label.cnvTooltip.forEach((cnv: CnvTooltip) => {
 				const [td1, td2] = table.addRow()
 				td1.text('CNV')
-				td2
-					.append('span')
-					.style('color', cnv.color)
-					.text(cnv.value)
-					.append('span')
-					.style('margin-left', '5px')
-					.text(`${cnv.chr}:${cnv.start}-${cnv.stop}`)
+				td2.html(
+					`<span style="background:${cnv.color}; margin-left: 5px;">&nbsp;&nbsp;</span> ${cnv.value}, ${cnv.chr}:${cnv.start}-${cnv.stop}`
+				)
 			})
 		}
 	}

--- a/client/plots/disco/label/LabelsRenderer.ts
+++ b/client/plots/disco/label/LabelsRenderer.ts
@@ -100,21 +100,20 @@ export default class LabelsRenderer implements IRenderer {
 				{
 					const [td1, td2] = table.addRow()
 
-					td1.text('Consequence')
+					td1.text('Mutation')
 					td2
+						.append('span')
+						.style('margin-left', '5px')
+						.text(mutation.mname)
 						.append('span')
 						.style('margin-left', '5px')
 						.style('color', mutation.color)
 						.text(`${mutation.dataClass}`)
 						.append('span')
+						.style('margin-left', '5px')
 						.style('color', 'black')
+						.style('font-size', '0.8em')
 						.text(` ${mutation.chr}:${mutation.position}`)
-				}
-				{
-					const [td1, td2] = table.addRow()
-
-					td1.text('Mutation')
-					td2.append('span').style('margin-left', '5px').text(mutation.mname)
 				}
 			})
 		}
@@ -142,9 +141,16 @@ export default class LabelsRenderer implements IRenderer {
 			label.cnvTooltip.forEach((cnv: CnvTooltip) => {
 				const [td1, td2] = table.addRow()
 				td1.text('CNV')
-				td2.html(
-					`<span style="background:${cnv.color}; margin-left: 5px;">&nbsp;&nbsp;</span> ${cnv.value}, ${cnv.chr}:${cnv.start}-${cnv.stop}`
-				)
+				td2.append('span').style('margin-left', '5px').style('background-color', cnv.color).html('&nbsp;&nbsp;')
+
+				td2
+					.append('span')
+					.style('margin-left', '7.5px')
+					.text(cnv.value)
+					.append('span')
+					.style('margin-left', '7.5px')
+					.style('font-size', '0.8em')
+					.text(`${cnv.chr}:${cnv.start}-${cnv.stop}`)
 			})
 		}
 	}

--- a/client/plots/disco/legend/LegendJSONMapper.ts
+++ b/client/plots/disco/legend/LegendJSONMapper.ts
@@ -175,18 +175,6 @@ export default class LegendJSONMapper {
 					)
 				}
 			}
-			//Only show capping if there are cnv values
-			if (gain.value > 0 || loss.value < 0) {
-				cnvItems.push({
-					termid: legend.cnvTitle,
-					key: CnvType.Cap,
-					text: `Capping: ${cap.value}`,
-					color: cap.color,
-					order: cnvOrder++,
-					border: '1px solid #ccc'
-				})
-			}
-
 			legendJSON.push({
 				name: legend.cnvTitle,
 				order: order,


### PR DESCRIPTION
## Description

Closes issue #2555.

Minor changes:
1. Removed cnv capping as a legend item
2. The `Unit` row in the cnv tooltip is removed as the value is already present in the first row. 

Test: 
1. [GDC example](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-85-7710-01A)
2. [PNET example](http://localhost:3000/?genome=hg19&dslabel=PNET&disco=1&sample=SJBT032239_D1)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
