### PR TITLE
update option order on custom variable grouping

### DIFF
--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -236,14 +236,8 @@ class MassGroups {
 				this.tip
 			)
 		})
-		row = menuDiv
-			.append('div')
-			.attr('class', 'sja_menuoption sja_sharp_border')
-			.text('Delete variable')
-			.on('click', event => {
-				deleteCallback()
-				this.tip.hide()
-			})
+		
+		//show scatterplots for custom variable options
 		if (this.state.termdbConfig.scatterplots)
 			for (const plot of this.state.termdbConfig.scatterplots) {
 				if (plot.colorTW)
@@ -275,6 +269,16 @@ class MassGroups {
 							this.tip.hide()
 						})
 			}
+
+			//show option to delete custom variable
+			row = menuDiv
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.text('Delete variable')
+			.on('click', event => {
+				deleteCallback()
+				this.tip.hide()
+			})
 
 		this.tip.showunder(event.target)
 	}


### PR DESCRIPTION
## Description
updated the order of options when custom variable is clicked after grouping is performed for better readability. Now all analysis related options appear first and 'delete variable' appears at the bottom. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
