### PR TITLE
Supported density contours for 2d scatter plots

### DIFF
--- a/client/mass/test/sampleScatter.integration.spec.js
+++ b/client/mass/test/sampleScatter.integration.spec.js
@@ -819,7 +819,7 @@ tape('Check/uncheck Show axes from menu', function (test) {
 				opacity: `${opacity}`
 			},
 			trigger() {
-				const axesCheckbox = scatter.Inner.dom.controlsHolder.select('input[type="checkbox"]')
+				const axesCheckbox = scatter.Inner.dom.controlsHolder.select('input[id="showAxes"]')
 				axesCheckbox.property('checked', isvisible)
 				axesCheckbox.node().dispatchEvent(new Event('change'))
 			}

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -552,6 +552,7 @@ function setCheckboxInput(opts) {
 
 	self.dom.input = label
 		.append('input')
+		.attr('id', opts.inputId)
 		.attr('type', 'checkbox')
 		.on('change', () => {
 			const value = self.dom.input.property('checked')

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -282,12 +282,13 @@ class Scatter {
 			min: 0
 		}
 		const showAxes = {
-			boxLabel: 'Visible',
+			boxLabel: '',
 			label: 'Show axes',
 			type: 'checkbox',
 			chartType: 'sampleScatter',
 			settingsKey: 'showAxes',
-			title: `Option to show/hide plot axes`
+			title: `Option to show/hide plot axes`,
+			inputId: 'showAxes'
 		}
 
 		const inputs = [

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -323,6 +323,14 @@ class Scatter {
 				type: 'number',
 				chartType: 'sampleScatter',
 				settingsKey: 'svgh'
+			},
+			{
+				label: 'Show contour map',
+				boxLabel: '',
+				type: 'checkbox',
+				chartType: 'sampleScatter',
+				settingsKey: 'showContour',
+				title: 'Show contour map'
 			}
 		]
 		if (this.config.sampleCategory) {
@@ -451,15 +459,8 @@ class Scatter {
 					type: 'number',
 					chartType: 'sampleScatter',
 					settingsKey: 'fov'
-				}),
-					inputs.push({
-						label: 'Show contour map',
-						boxLabel: '',
-						type: 'checkbox',
-						chartType: 'sampleScatter',
-						settingsKey: 'showContour',
-						title: 'Show contour map'
-					})
+				})
+
 				if (this.settings.showContour) {
 					inputs.push(
 						{

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -222,11 +222,13 @@ export function setRenderers(self) {
 
 		const g = chart.serie
 		const data = chart.data
+		chart.serie.selectAll('*').remove()
+		if (self.settings.showContour) self.renderContours(chart)
+
 		// remove all symbols as there is no data id for privacy
 		//g.selectAll('path').remove()
 
 		const symbols = g.selectAll('path[name="serie"]').data(data.samples)
-		symbols.exit().remove()
 		symbols
 			.transition()
 			.duration(duration)
@@ -251,7 +253,6 @@ export function setRenderers(self) {
 			.transition()
 			.duration(duration)
 		self.mayRenderRegression()
-		if (self.settings.showContour) self.renderContours(chart)
 	}
 
 	self.renderContours = function (chart) {
@@ -282,12 +283,12 @@ export function setRenderers(self) {
 			.attr('fill', 'none')
 			.attr('stroke', '#aaa')
 			.attr('stroke-linejoin', 'round')
+			.style('fill-opacity', 0.5)
 			.selectAll()
 			.data(contours)
 			.join('path')
 			.attr('stroke-width', (d, i) => (i % 5 ? 0.25 : 1))
 			.attr('d', geoPath())
-			.style('fill-opacity', 0.5)
 	}
 
 	self.getStrokeWidth = function (c) {
@@ -596,13 +597,19 @@ export function setRenderers(self) {
 			.style('display', display)
 			.style('margin', '20px')
 			.attr('name', 'sjpp-zoom-in-btn') //For unit tests
-		icon_functions['zoomIn'](zoomInDiv, { handler: zoomIn, title: 'Zoom in' })
+		icon_functions['zoomIn'](zoomInDiv, {
+			handler: zoomIn,
+			title: 'Zoom in. You can also zoom in pressing the Ctrl key and using the mouse wheel'
+		})
 		const zoomOutDiv = toolsDiv
 			.insert('div')
 			.style('display', display)
 			.style('margin', '20px')
 			.attr('name', 'sjpp-zoom-out-btn') //For unit tests
-		icon_functions['zoomOut'](zoomOutDiv, { handler: zoomOut, title: 'Zoom out' })
+		icon_functions['zoomOut'](zoomOutDiv, {
+			handler: zoomOut,
+			title: 'Zoom out. You can also zoom out pressing the Ctrl key and using the mouse wheel'
+		})
 		const searchDiv = toolsDiv.insert('div').style('display', display).style('margin', '20px')
 		const lassoDiv = toolsDiv.insert('div').style('display', display).style('margin', '20px')
 		if (!(self.is2DLarge || self.is3D)) {

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1351,7 +1351,6 @@ export function createDensityMap(umapCoords, geneExpression, gridSize, plot) {
 
 		if (cellX >= 0 && cellX < gridSize && cellY >= 0 && cellY < gridSize) {
 			let geneExp = geneExpression[k]
-			if (geneExp > plot.max) geneExp = plot.max
 			if (densityMap[cellY][cellX] < geneExp) densityMap[cellY][cellX] = geneExp
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
 
+Features
+- Supported density contours for 2d scatter


### PR DESCRIPTION
## Description

Supported density contours for 2d scatter plots. See example UI:

<img width="1240" alt="Screenshot 2025-01-03 at 2 15 32 PM" src="https://github.com/user-attachments/assets/c22ff5b2-5589-4207-97ab-78067bc95f86" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
