### PR TITLE
native sc.sample.get() checks plot folder to find samples with sc data

### DIFF
--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -124,7 +124,7 @@ async function validateSamplesNative(S: SingleCellSamplesNative, D: SingleCellDa
 				samples.set(sid, { sample: sampleName })
 			}
 		} catch (e) {
-			console.log('cannot readdir on singleCell.data.plot[].folder')
+			console.log('cannot readdir on singleCell.data.plot[].folder', e)
 			// may register as ds init err
 		}
 	}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -517,7 +517,18 @@ export type SingleCellGeneExpressionGdc = {
 
 export type SingleCellSamplesNative = {
 	src: 'native'
+	/** kept to prevent tsc err */
+	firstColumnName?: string
+	/** any columns to be added to sample table. each is a term id */
+	sampleColumns?: { termid: string }[]
+	/** used on client but not on ds */
+	experimentColumns?: { label: string }[]
+	get?: (q: any) => any
+}
 
+export type SingleCellSamplesGdc = {
+	src: 'gdcapi'
+	/** if missing refer to the samples as 'sample', this provides override e.g. 'case' */
 	/** logic to decide sample table columns (the one shown on singlecell app ui, displaying a table of samples with sc data)
 a sample table will always have a sample column, to show sample.sample value
 firstColumnName allow to change name of 1st column from "Sample" to different, e.g. "Case" for gdc
@@ -525,24 +536,11 @@ the other two properties allow to declare additional columns to be shown in tabl
 when sample.experiments[] are used, a last column of experiment id will be auto added
 */
 	firstColumnName?: string
-
-	/** do not use for native ds! gdc-only property. kept as optional to avoid tsc err */
-	experimentColumns?: string
-
-	/** any other columns to be added to sample table. each is a term id */
+	/** same as SingleCellSamplesNative */
 	sampleColumns?: { termid: string }[]
-
-	/** dynamically added getter */
-	get?: (q: any) => any
-}
-
-export type SingleCellSamplesGdc = {
-	src: 'gdcapi'
-	get?: (q: any) => any
-	/** if missing refer to the samples as 'sample', this provides override e.g. 'case' */
-	firstColumnName?: string
-	sampleColumns?: { termid: string }[]
+	/** used on client but not on ds */
 	experimentColumns?: { label: string }[]
+	get?: (q: any) => any
 }
 
 export type SingleCellDataGdc = {


### PR DESCRIPTION
## Description

replaces a quick fix: samples with sc data is no longer being defined via any dictionary term. this easily enables a ds with subset of samples with sc data rather than complete. this allows to easily add some test sc data for termdbtest

closes #2563 
[test link](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22BALL-scrna%22,%22nav%22:{%22header_mode%22:%22only_buttons%22},%22plots%22:[{%22chartType%22:%22singleCellPlot%22,%22sample%22:%22SJBALL030036_D1%22}]})
gdc is not affected

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
