### PR TITLE
reuse getData in termdb.regression.js

### DIFF
--- a/client/mass/test/regression.integration.spec.js
+++ b/client/mass/test/regression.integration.spec.js
@@ -46,7 +46,6 @@ tape('Linear: continuous outcome = "agedx", cat. independents = "sex" + "genetic
 	})
 
 	async function runTests(regression) {
-		console.log(regression)
 		const data = await getData(regression)
 		const regDom = regression.Inner.dom
 

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -143,7 +143,7 @@ export class RegressionResults {
 	}
 
 	getIndependentInput(tid) {
-		/* arg is independent term id
+		/* arg is independent tw $id
 		return input instance
 		for accessing input.orderedLabels and input.term{refGrp, term{}, q{}} which is term-wrapper
 
@@ -190,7 +190,7 @@ export class RegressionResults {
 					}
 				}
 			}
-			if (i.term.term.id == tid || i.term.term.name == tid) return i
+			if (i.term.$id == tid) return i
 		}
 		// given tid does not match with an Input
 		// can be an ancestry PC which is automatically added by serverside and not recorded on client

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -36,12 +36,7 @@ const useCasesExcluded = {
 	survival: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
 	default: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
-	regression: [
-		TermTypeGroups.SNP_LIST,
-		TermTypeGroups.SNP_LOCUS,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
-	],
+	regression: [TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS],
 	metaboliteIntensity: [
 		TermTypeGroups.SNP_LOCUS,
 		TermTypeGroups.SNP_LIST,

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -298,6 +298,7 @@ export class TermdbVocab extends Vocab {
 				return {
 					// TODO: refactor backend code to not have to pass
 					// term.id, term.type, and term.values separately
+					$id: tw.$id,
 					id: t.term.id,
 					q,
 					term: t.term,

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -55,7 +55,7 @@ export function handle_request_closure(genomes) {
 			if (q.getsamples) return await trigger_getsamples(q, res, ds)
 			if (q.getcuminc) return await trigger_getincidence(q, res, ds)
 			if (q.getsurvival) return await trigger_getsurvival(q, res, ds)
-			if (q.getregression) return await trigger_getregression(q, res, ds)
+			if (q.getregression) return await trigger_getregression(q, res, ds, genome)
 			if (q.validateSnps) return res.send(await snpValidate(q, tdb, ds, genome))
 			if (q.getvariantfilter) return getvariantfilter(res, ds)
 			if (q.getLDdata) return await LDoverlay(q, ds, res)
@@ -282,8 +282,8 @@ async function trigger_getsurvival(q, res, ds) {
 	res.send(data)
 }
 
-async function trigger_getregression(q, res, ds) {
-	const data = await get_regression(q, ds)
+async function trigger_getregression(q, res, ds, genome) {
+	const data = await get_regression(q, ds, genome)
 	res.send(data)
 }
 

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -3,7 +3,6 @@ import { get_samples, get_term_cte, interpolateSqlValues, get_active_groupset } 
 import { getFilterCTEs } from './termdb.filter'
 import serverconfig from './serverconfig'
 import { read_file } from './utils'
-import { getSampleData_snplstOrLocus } from './termdb.regression'
 import {
 	TermTypes,
 	isDictionaryType,
@@ -689,4 +688,242 @@ async function findListOfBins(q, tw, ds) {
 		return lst
 	}
 	throw 'unknown tw.q.type when q.mode is discrete'
+}
+
+/*
+tw{}
+	type
+	q{}
+		cacheid
+		alleleType: 0/1
+		geneticModel: 0/1/2/3
+		missingGenotype: 0/1
+		snp2effAle{}
+		snp2refGrp{}
+samples {Map}
+	contains all samples that have valid data for all dict terms
+	only get genotype data for these samples,
+	but do not introduce new samples to this map
+	as those will miss value for dict terms and ineligible for analysis
+
+useAllSamples true/false
+	if true
+		-populate "samples" with all of those from cache file
+		-do not perform imputation
+*/
+async function getSampleData_snplstOrLocus(tw, samples, useAllSamples) {
+	const lines = (await read_file(path.join(serverconfig.cache_snpgt.dir, tw.q.cacheid))).split('\n')
+	// cols: snpid, chr, pos, ref, alt, eff, <s1>, <s2>,...
+
+	// array of sample ids from the cache file; note cache file contains all the samples from the dataset
+	const cachesampleheader = lines[0]
+		.split('\t')
+		.slice(serverconfig.cache_snpgt.sampleColumn) // from 7th column
+		.map(Number) // sample ids are integer
+
+	if (useAllSamples) {
+		for (const i of cachesampleheader) samples.set(i, { id2value: new Map() })
+	}
+
+	// make a list of true/false, same length of cachesampleheader
+	// to tell if a cache file column (a sample) is in use
+	// do not apply q.filter here
+	// as samples{} is already computed with q.filter in getSampleData_dictionaryTerms
+	const sampleinfilter = cachesampleheader.map(i => samples.has(i))
+
+	// load cache file data into this temporary structure for computing in this function
+	const snp2sample = new Map()
+	// k: snpid
+	// v: { effAle, refAle, altAles, samples: map { k: sample id, v: gt } }
+
+	// load cache file to snp2sample
+	for (let i = 1; i < lines.length; i++) {
+		const l = lines[i].split('\t')
+
+		const snpid = l[0] // snpid is used as "term id"
+
+		const snpObj = {
+			// get effect allele from q, but not from cache file
+			// column [5] is for user-assigned effect allele
+			refAle: l[3],
+			altAles: l[4].split(','),
+			samples: new Map()
+		}
+
+		if (tw.q.snp2effAle) {
+			snpObj.effAle = tw.q.snp2effAle[snpid]
+		} else {
+			// this is missing when generated from data download ui (called from getData)
+			// fill in effAle using first ALT so it can return data
+			snpObj.effAle = snpObj.altAles[0]
+		}
+
+		snp2sample.set(snpid, snpObj)
+
+		for (const [j, sampleid] of cachesampleheader.entries()) {
+			if (!sampleinfilter[j]) {
+				// this sample is filtered out
+				continue
+			}
+			const gt = l[j + serverconfig.cache_snpgt.sampleColumn]
+			if (gt) {
+				snp2sample.get(snpid).samples.set(sampleid, gt)
+			}
+		}
+	}
+
+	// imputation
+	if (tw.type == 'snplst' && !useAllSamples) {
+		doImputation(snp2sample, tw, cachesampleheader, sampleinfilter)
+	}
+
+	// for all snps, count samples by genotypes, keep in snpgt2count, for showing as result.headerRow
+	tw.snpgt2count = new Map()
+	// k: snpid, v:{gt:INT}
+	for (const [snpid, o] of snp2sample) {
+		const gt2count = new Map()
+		for (const [sampleid, gt] of o.samples) {
+			// count gt for this snp
+			gt2count.set(gt, 1 + (gt2count.get(gt) || 0))
+		}
+		tw.snpgt2count.set(snpid, gt2count)
+	}
+
+	categorizeSnpsByAF(tw, snp2sample)
+	// tw.lowAFsnps, tw.highAFsnps, tw.monomorphicLst, tw.snpid2AFstr are created
+
+	// for highAFsnps, write data into "samples{}" for model-fitting
+	for (const [snpid, o] of tw.highAFsnps) {
+		for (const [sampleid, gt] of o.samples) {
+			// for this sample, convert gt to value
+			const [gtA1, gtA2] = gt.split('/') // assuming diploid
+			const v = applyGeneticModel(tw, o.effAle, gtA1, gtA2)
+			// sampleid must be present in samples{map}, no need to check
+			samples.get(sampleid).id2value.set(snpid, { key: v, value: v })
+		}
+	}
+}
+
+/* categorize variants to three groups:
+lower than cutoff:
+	create tw.lowAFsnps and store these, later to be analyzed by Fisher/Wilcox
+higher than cutoff:
+	keep in snp2sample
+monomorphic:
+	delete from snp2sample, do not analyze
+	// TODO: may report this to user
+
+prev comments on this func:
+ creates following on the tw{} to divide the snps
+ tw.lowAFsnps{} tw.highAFsnps{} tw.monomorphicLst[] tw.snpid2AFstr{}
+ sample data for high-AF snps are kept in sampledata[]
+*/
+function categorizeSnpsByAF(tw, snp2sample) {
+	// same as snp2sample, to store snps with AF<cutoff, later to use for Fisher
+	tw.lowAFsnps = new Map()
+	// same as snp2sample, to store snps with AF>=cutoff, to be used for model-fitting
+	tw.highAFsnps = new Map()
+	// list of snpid for monomorphic ones
+	tw.monomorphicLst = []
+	tw.snpid2AFstr = new Map()
+	// k: snpid, v: af string, '5.1%', for display only, not for computing
+
+	for (const [snpid, o] of snp2sample) {
+		if (tw.snpgt2count.get(snpid).size == 1) {
+			// monomorphic, not to be used for any analysis
+			tw.monomorphicLst.push(snpid)
+			continue
+		}
+
+		const totalsamplecount = o.samples.size
+		// o.effAle is effect allele
+		let effAleCount = 0 // count number of effect alleles across samples
+		for (const [sampleid, gt] of o.samples) {
+			const [a1, a2] = gt.split('/') // assuming diploid
+			effAleCount += (a1 == o.effAle ? 1 : 0) + (a2 == o.effAle ? 1 : 0)
+		}
+
+		const af = effAleCount / (totalsamplecount * 2)
+		tw.snpid2AFstr.set(snpid, (af * 100).toFixed(1) + '%')
+
+		if (af < tw.q.AFcutoff / 100) {
+			// AF lower than cutoff, will not use for model-fitting
+			// move this snp from snp2sample to lowAFsnps
+			tw.lowAFsnps.set(snpid, o)
+		} else {
+			// AF above cutoff, use for model-fitting
+			tw.highAFsnps.set(snpid, o)
+		}
+	}
+}
+
+function doImputation(snp2sample, tw, cachesampleheader, sampleinfilter) {
+	if (tw.q.missingGenotype == 0) {
+		// as homozygous major/ref allele, which is not effect allele
+		for (const o of snp2sample.values()) {
+			// { effAle, refAle, altAles, samples }
+			// find an allele from this snp that is not effect allele
+			let notEffAle
+			if (o.refAle != o.effAle) {
+				notEffAle = o.refAle
+			} else {
+				for (const a of o.altAles) {
+					if (a != o.effAle) {
+						notEffAle = a
+						break
+					}
+				}
+			}
+			if (!notEffAle) throw 'not finding a non-effect allele' // not possible
+			for (const [i, sampleid] of cachesampleheader.entries()) {
+				if (!sampleinfilter[i]) continue
+				if (!o.samples.has(sampleid)) {
+					// this sample is missing gt call for this snp
+					o.samples.set(sampleid, notEffAle + '/' + notEffAle)
+				}
+			}
+		}
+		return
+	}
+	if (tw.q.missingGenotype == 1) {
+		// drop sample
+		const incompleteSamples = new Set() // any samples with missing gt
+		for (const { samples } of snp2sample.values()) {
+			for (const [i, sampleid] of cachesampleheader.entries()) {
+				if (!sampleinfilter[i]) continue
+				if (!samples.has(sampleid)) {
+					// this sample is missing gt
+					incompleteSamples.add(sampleid)
+				}
+			}
+		}
+		// delete incomplete samples from all snps
+		for (const { samples } of snp2sample.values()) {
+			for (const s of incompleteSamples) {
+				samples.delete(s)
+			}
+		}
+		return
+	}
+	throw 'invalid missingGenotype value'
+}
+
+function applyGeneticModel(tw, effAle, a1, a2) {
+	switch (tw.q.geneticModel) {
+		case 0:
+			// additive
+			return (a1 == effAle ? 1 : 0) + (a2 == effAle ? 1 : 0)
+		case 1:
+			// dominant
+			if (a1 == effAle || a2 == effAle) return 1
+			return 0
+		case 2:
+			// recessive
+			return a1 == effAle && a2 == effAle ? 1 : 0
+		case 3:
+			// by genotype
+			return a1 + '/' + a2
+		default:
+			throw 'unknown geneticModel option'
+	}
 }


### PR DESCRIPTION
## Description

closes #1626 

reusing getData() in termdb.regression.js addressed a longtime issue of redundant and unmaintainable code (for now they are commented off, can delete in later branches when fully tested)

all regression CI passed. if u have broken test:
1. lack of "regressionResultMsgs" feature flag
2. didn't install X11 (spline image render crash)

[all-pharm with gene exp works](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22independent%22:[{%22id%22:%22Age%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22Molecular%20subtype%22},{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22ASNS%22}}]}]})

can replicate [SF36~amputation](https://proteinpaint.stjude.org/survivorship/paper2024/figures/sf36-regression.html) with recently built sjlife db (not latest)

can replicate the [simple mbmeta one](https://proteinpaint.stjude.org/?mass-session-file=files/hg38/mbmeta/figure-sessions/figure-2/figure_2_regression.txt), the complex one should be manually tested

things not working and will be fixed in new branch:
1. adding multiple gene exp terms breaks client
2. adding expression and mutation of same gene likely to break client; solution is to change client to track terms by tw.$id
4. interaction term relationship should be recorded by tw.$id but not tw.term.id
5. spline (needs testing by someone with X11)
6. snplst and snplocus, should test with latest sjlife db

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
