### PR TITLE
add default control label for custom grouping if gene expression data…

### DIFF
--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -731,34 +731,25 @@ export function addMatrixMenuItems(menu, menuDiv, tw, app, id, state, newId) {
 }
 
 export function addNewGroup(app, filter, groups) {
-	groups = JSON.parse(JSON.stringify(groups));
-    
-    // Check if any group already has the "default control" label
-    const hasDefaultControl = groups.some(g => g.name.includes('default control'));
-    
-    let name = !hasDefaultControl && app.vocabApi.termdbConfig.allowedTermTypes.includes('geneExpression') 
-        ? 'New group (default control)' 
-        : 'New group';
-    
-    let i = 1; // Start numbering from 1
-    while (1) {
-        const name2 = name + (i === 1 ? '' : ' ' + i); 
-        if (!groups.find(g => g.name === name2)) break;
-        i++;
-    }
-    
-    name = name + (i === 1 ? '' : ' ' + i);
-    const newGroup = {
-        name,
-        filter,
-        color: rgb(colorScale(groups.length)).formatHex()
-    };
-    
-    groups.push(newGroup);
-    app.dispatch({
-        type: 'app_refresh',
-        state: { groups }
-    });
+	groups = JSON.parse(JSON.stringify(groups))
+	let name = 'New group'
+	let i = 0
+	while (1) {
+		const name2 = name + (i == 0 ? '' : ' ' + i)
+		if (!groups.find(g => g.name == name2)) break
+		i++
+	}
+	name = name + (i == 0 ? '' : ' ' + i)
+	const newGroup = {
+		name,
+		filter,
+		color: rgb(colorScale(groups.length)).formatHex()
+	}
+	groups.push(newGroup)
+	app.dispatch({
+		type: 'app_refresh',
+		state: { groups }
+	})
 }
 
 export function getSamplelstTWFromIds(ids) {

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -731,25 +731,34 @@ export function addMatrixMenuItems(menu, menuDiv, tw, app, id, state, newId) {
 }
 
 export function addNewGroup(app, filter, groups) {
-	groups = JSON.parse(JSON.stringify(groups))
-	let name = 'New group'
-	let i = 0
-	while (1) {
-		const name2 = name + (i == 0 ? '' : ' ' + i)
-		if (!groups.find(g => g.name == name2)) break
-		i++
-	}
-	name = name + (i == 0 ? '' : ' ' + i)
-	const newGroup = {
-		name,
-		filter,
-		color: rgb(colorScale(groups.length)).formatHex()
-	}
-	groups.push(newGroup)
-	app.dispatch({
-		type: 'app_refresh',
-		state: { groups }
-	})
+	groups = JSON.parse(JSON.stringify(groups));
+    
+    // Check if any group already has the "default control" label
+    const hasDefaultControl = groups.some(g => g.name.includes('default control'));
+    
+    let name = !hasDefaultControl && app.vocabApi.termdbConfig.allowedTermTypes.includes('geneExpression') 
+        ? 'New group (default control)' 
+        : 'New group';
+    
+    let i = 1; // Start numbering from 1
+    while (1) {
+        const name2 = name + (i === 1 ? '' : ' ' + i); 
+        if (!groups.find(g => g.name === name2)) break;
+        i++;
+    }
+    
+    name = name + (i === 1 ? '' : ' ' + i);
+    const newGroup = {
+        name,
+        filter,
+        color: rgb(colorScale(groups.length)).formatHex()
+    };
+    
+    groups.push(newGroup);
+    app.dispatch({
+        type: 'app_refresh',
+        state: { groups }
+    });
 }
 
 export function getSamplelstTWFromIds(ids) {

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -236,7 +236,7 @@ class MassGroups {
 				this.tip
 			)
 		})
-		
+
 		//show scatterplots for custom variable options
 		if (this.state.termdbConfig.scatterplots)
 			for (const plot of this.state.termdbConfig.scatterplots) {
@@ -270,8 +270,8 @@ class MassGroups {
 						})
 			}
 
-			//show option to delete custom variable
-			row = menuDiv
+		//show option to delete custom variable
+		row = menuDiv
 			.append('div')
 			.attr('class', 'sja_menuoption sja_sharp_border')
 			.text('Delete variable')
@@ -290,10 +290,7 @@ function addDEPlotMenuItem(div, self, state, samplelstTW, tip) {
 	div
 		.append('div')
 		.attr('class', 'sja_menuoption sja_sharp_border')
-		.text('Differential expression')
-		.append('div')
-		.html(self.state.groups[0].name + ' (control)' + ' vs ' + self.state.groups[1].name + ' (case)') //Add fine print "control vs case" under the text "Differential expression"
-		.style('font-size', '0.8em')
+		.text('Differential gene expression analysis')
 		.on('click', e => {
 			const groups = []
 			for (const group of samplelstTW.q.groups) {
@@ -314,6 +311,14 @@ function addDEPlotMenuItem(div, self, state, samplelstTW, tip) {
 				config
 			})
 		})
+	// small text to explain which is case/control
+	div
+		.append('div')
+		.text(`Case: ${self.state.groups[1].name}, control: ${self.state.groups[0].name}`)
+		.style('font-size', '0.8em')
+		.style('text-align', 'right')
+		.style('opacity', 0.8)
+		.style('padding', '3px')
 }
 
 function initUI(self) {

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -291,6 +291,9 @@ function addDEPlotMenuItem(div, self, state, samplelstTW, tip) {
 		.append('div')
 		.attr('class', 'sja_menuoption sja_sharp_border')
 		.text('Differential expression')
+		.append('div')
+		.html(self.state.groups[0].name + ' (control)' + ' vs ' + self.state.groups[1].name + ' (case)') //Add fine print "control vs case" under the text "Differential expression"
+		.style('font-size', '0.8em')
 		.on('click', e => {
 			const groups = []
 			for (const group of samplelstTW.q.groups) {


### PR DESCRIPTION
… is available

## Description

If gene expression data is available then the first group created under 'groups' tab should show 'default control' in parentheses, otherwise the regular grouping names show up. can test using ALL-pharma, IHG datasets. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
