### PR TITLE
Box plot UI improvements and violin fix

### DIFF
--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -30,6 +30,7 @@ export type BoxPlotSettings = {
 	boxplotWidth: number
 	/** Default is common plot color.  */
 	color: string
+	/** Toggle between a white and black background */
 	darkMode: boolean
 	/** Padding between the left hand label and boxplot */
 	labelPad: number

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -14,8 +14,6 @@ import getMaxLabelLgth from './viewModel/MaxLabelLength'
 
 /** TODOs:
  *	Add functionality to change orientation
- *	Add controls for: 
-	- multicolor boxplots when !term2
  */
 
 type TdbBoxPlotOpts = {

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -68,6 +68,19 @@ export class BoxPlotInteractions {
 		})
 	}
 
+	/** Callback for color picker in plot(s) label menu */
+	updatePlotColor(plot: RenderedPlot, color: string) {
+		if (!plot.seriesId) return
+		const plotConfig = this.app.getState().plots.find(p => p.id === this.id)
+		const config = structuredClone(plotConfig)
+		config.term2.term.values[plot.seriesId].color = color
+		this.app.dispatch({
+			type: 'plot_edit',
+			id: this.id,
+			config
+		})
+	}
+
 	clearDom() {
 		this.dom.error.style('padding', '').text('')
 		this.dom.plotTitle.text('')

--- a/client/plots/boxplot/interactions/ListSamples.ts
+++ b/client/plots/boxplot/interactions/ListSamples.ts
@@ -3,7 +3,6 @@ import type { RenderedPlot } from '../view/RenderedPlot'
 import type { TermWrapper } from '#types'
 import type { AnnotatedSampleData } from '../../../types/termdb'
 import { roundValueAuto } from '#shared/roundValue.js'
-import { isNumericTerm } from '#shared/terms.js'
 
 export class ListSamples {
 	app: MassAppApi
@@ -136,9 +135,6 @@ export class ListSamples {
 				this.createTvsTerm(tw2, tvslst)
 				tvslst.lst[0].tvs.ranges = this.assignPlotRangeRanges()
 				if (getRange) this.createTvsLstRanges(tw1, tvslst, rangeStart, rangeStop, 1)
-			} else if (isNumericTerm(tw1.term) && isNumericTerm(tw2.term)) {
-				this.createTvsLstRanges(tw2, tvslst, rangeStart, rangeStop, 0)
-				if (getRange) this.createTvsLstRanges(tw1, tvslst, rangeStart, rangeStop, 1)
 			} else {
 				this.createTvsLstValues(tw2, tvslst, 0)
 				if (getRange) this.createTvsLstRanges(tw1, tvslst, rangeStart, rangeStop, 1)
@@ -146,6 +142,7 @@ export class ListSamples {
 		} else {
 			if (getRange) this.createTvsLstRanges(tw1, tvslst, rangeStart, rangeStop, 0)
 		}
+
 		return tvslst
 	}
 }

--- a/client/plots/boxplot/interactions/ListSamples.ts
+++ b/client/plots/boxplot/interactions/ListSamples.ts
@@ -20,11 +20,15 @@ export class ListSamples {
 		const plotConfig = state.plots.find((p: { id: string }) => p.id === id)
 		if (!plotConfig) throw 'Box plot not found [ListSamples]'
 
-		const min = plot.descrStats.find(d => d.id === 'min')!.value
-		const max = plot.descrStats.find(d => d.id === 'max')!.value
-		if (Number.isNaN(min) || Number.isNaN(max)) throw 'Min or max not found [ListSamples]'
+		try {
+			//ids 'min' and 'max' are always present in the descrStats{}
+			const min = plot.descrStats.find(d => d.id === 'min')!.value
+			const max = plot.descrStats.find(d => d.id === 'max')!.value
+			this.tvslst = this.getTvsLst(min, max, getRange, plotConfig.term, plotConfig.term2)
+		} catch (e: any) {
+			console.error(e.message || e)
+		}
 
-		this.tvslst = this.getTvsLst(min, max, getRange, plotConfig.term, plotConfig.term2)
 		this.term = plotConfig.term.q?.mode === 'continuous' ? plotConfig.term : plotConfig.term2
 
 		const filter = {

--- a/client/plots/boxplot/test/boxplot.integration.spec.ts
+++ b/client/plots/boxplot/test/boxplot.integration.spec.ts
@@ -3,9 +3,10 @@ import * as helpers from '../../../test/front.helpers.js'
 
 /*
 Tests:
-	- Default boxplot
-	- Boxplot with overlay term = sex
-	- Boxplot with continuous overlay term = agedx
+	- Default box plot
+	- Box plot with overlay term = sex
+	- Box plot with continuous overlay term = agedx
+	- Box plot with user settings
  */
 
 /*************************
@@ -34,7 +35,7 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('Default boxplot', test => {
+tape('Default box plot', test => {
 	test.timeoutAfter(3000)
 
 	runpp({
@@ -71,7 +72,7 @@ tape('Default boxplot', test => {
 	}
 })
 
-tape('Boxplot with overlay term = sex', test => {
+tape('Box plot with overlay term = sex', test => {
 	test.timeoutAfter(3000)
 
 	runpp({
@@ -113,7 +114,7 @@ tape('Boxplot with overlay term = sex', test => {
 	}
 })
 
-tape('Boxplot with continuous overlay term = agedx', test => {
+tape('Box plot with continuous overlay term = agedx', test => {
 	test.timeoutAfter(3000)
 
 	runpp({
@@ -155,54 +156,59 @@ tape('Boxplot with continuous overlay term = agedx', test => {
 	}
 })
 
-// tape.skip('Boxplot with user settings', test => {
-// 	//All the settings available to the user
-// 	test.timeoutAfter(3000)
+tape('Box plot with user settings', test => {
+	//All the settings available to the user
+	test.timeoutAfter(3000)
 
-// 	const settings = {
-// 		boxplotWidth: 550,
-// 		color: 'purple',
-// 		labelPad: 40,
-// 		rowHeight: 30,
-// 		rowSpace: 20
-// 	}
+	const settings = {
+		boxplotWidth: 300,
+		color: 'yellow',
+		labelPad: 40,
+		rowHeight: 30,
+		rowSpace: 20,
+		darkMode: true
+	}
 
-// 	runpp({
-// 		state: {
-// 			plots: [
-// 				{
-// 					chartType: 'summary',
-// 					childType: 'boxplot',
-// 					term: {
-// 						id: 'agedx',
-// 						q: { mode: 'continuous' }
-// 					},
-// 					settings: {
-// 						boxplot: settings
-// 					}
-// 				}
-// 			]
-// 		},
-// 		boxplot: {
-// 			callbacks: {
-// 				'postRender.test': runTests
-// 			}
-// 		}
-// 	})
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary',
+					childType: 'boxplot',
+					term: {
+						id: 'agedx',
+						q: { mode: 'continuous' }
+					},
+					settings: {
+						boxplot: settings
+					}
+				}
+			]
+		},
+		boxplot: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
 
-// 	async function runTests(boxplot) {
-// 		boxplot.on('postRender.test', null)
-// 		const dom = boxplot.Inner.dom
-// 		const bp = dom.boxplots.selectAll("g[id^='sjpp-boxplot-']")
-// 		const lines = bp.selectAll('line').nodes()
-// 		test.true(
-// 			lines.some(d => {
-// 				d.attributes.stroke.value != settings.color
-// 			}),
-// 			`Should render boxplot with ${settings.color} lines.`
-// 		)
+	async function runTests(boxplot) {
+		boxplot.on('postRender.test', null)
+		const dom = boxplot.Inner.dom
+		const bp = dom.boxplots.selectAll("g[id^='sjpp-boxplot-']")
+		const lines = bp.selectAll('line').nodes()
+		let wrongColorLine = 0
+		for (const line of lines) {
+			if (line.attributes.stroke.value !== settings.color) wrongColorLine++
+		}
+		test.equal(wrongColorLine, 0, `Should render boxplot with ${settings.color} lines.`)
 
-// 		if (test['_ok']) boxplot.Inner.app.destroy()
-// 		test.end()
-// 	}
-// })
+		test.true(
+			dom.div.style('background-color') == 'black' && dom.yAxis.select('path').attr('stroke') == 'white',
+			`Should render boxplot with dark background and white text when darkMode is ${settings.darkMode}.`
+		)
+
+		if (test['_ok']) boxplot.Inner.app.destroy()
+		test.end()
+	}
+})

--- a/client/plots/boxplot/view/BoxPlotLabelMenu.ts
+++ b/client/plots/boxplot/view/BoxPlotLabelMenu.ts
@@ -3,6 +3,7 @@ import type { MassAppApi, MassState } from '#mass/types/mass'
 import type { BoxPlotInteractions } from '../interactions/BoxPlotInteractions'
 import type { RenderedPlot } from './RenderedPlot'
 import { renderTable } from '#dom'
+import { rgb } from 'd3-color'
 
 export class BoxPlotLabelMenu {
 	constructor(plot: RenderedPlot, app: MassAppApi, interactions: BoxPlotInteractions, tip: Menu) {
@@ -52,6 +53,20 @@ export class BoxPlotLabelMenu {
 					.on('click', () => {
 						tip.hide()
 						opt.callback()
+					})
+			}
+			if (plot.color) {
+				tip.d
+					.append('div')
+					.style('padding', '5px 10px')
+					.style('display', 'inline-block')
+					.text('Color:')
+					.append('input')
+					.attr('type', 'color')
+					.property('value', rgb(plot.color).formatHex())
+					.on('change', event => {
+						interactions.updatePlotColor(plot, event.target.value)
+						tip.hide()
 					})
 			}
 		})

--- a/client/plots/boxplot/view/BoxPlotLabelMenu.ts
+++ b/client/plots/boxplot/view/BoxPlotLabelMenu.ts
@@ -5,26 +5,26 @@ import type { RenderedPlot } from './RenderedPlot'
 import { renderTable } from '#dom'
 import { rgb } from 'd3-color'
 
+/** Menu is available when more than one boxplot is rendered. */
 export class BoxPlotLabelMenu {
 	constructor(plot: RenderedPlot, app: MassAppApi, interactions: BoxPlotInteractions, tip: Menu) {
 		const options = [
-			//TODO: Filter option? Group?
+			{
+				text: `Add filter: ${plot.key}`,
+				isVisible: () => true,
+				callback: () => interactions.addFilter(plot)
+			},
 			{
 				text: `Hide ${plot.key}`,
 				isVisible: () => true,
-				callback: () => {
-					interactions.hidePlot(plot)
-				}
+				callback: () => interactions.hidePlot(plot)
 			},
 			{
 				text: `List samples`,
 				isVisible: (state: MassState) => state.termdbConfig.displaySampleIds && app.vocabApi.hasVerifiedToken(),
 				callback: async () => {
 					tip.clear().showunder(plot.boxplot.labelG.node())
-					const min = plot.descrStats.find(s => s.id === 'min')!.value
-					const max = plot.descrStats.find(s => s.id === 'max')!.value
-					if (!min || !max) throw `Missing min or max value for ${plot.key}`
-					const rows = await interactions.listSamples(plot, min, max)
+					const rows = await interactions.listSamples(plot)
 
 					const tableDiv = tip.d.append('div')
 					const columns = [{ label: 'Sample' }, { label: 'Value' }]
@@ -45,6 +45,7 @@ export class BoxPlotLabelMenu {
 			tip.clear().showunder(plot.boxplot.labelG.node())
 			const state = app.getState()
 			for (const opt of options) {
+				//Adds all the menu options before the color picker
 				if (!opt.isVisible(state)) continue
 				tip.d
 					.append('div')

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -4,7 +4,7 @@ import type { ScaleLinear } from 'd3-scale'
 import { axisstyle } from '#src/client'
 import { axisTop } from 'd3-axis'
 import type { BoxPlotDom, BoxPlotSettings } from '../BoxPlot'
-import type { ViewData } from '../viewModel/ViewModel'
+import type { ViewData, PlotDimensions } from '../viewModel/ViewModel'
 import type { MassAppApi } from '#mass/types/mass'
 import type { BoxPlotInteractions } from '../interactions/BoxPlotInteractions'
 import type { RenderedPlot } from './RenderedPlot'
@@ -48,7 +48,7 @@ export class View {
 		if (data.legend) new LegendRenderer(dom.legend, data.legend, this.interactions, plotDim.textColor)
 	}
 
-	renderDom(plotDim: any, dom: BoxPlotDom, yScale: ScaleLinear<number, number, never>) {
+	renderDom(plotDim: PlotDimensions, dom: BoxPlotDom, yScale: ScaleLinear<number, number, never>) {
 		//Title of the plot
 		dom.plotTitle
 			.attr('id', 'sjpp-boxplot-title')

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -34,7 +34,12 @@ export class View {
 
 		dom.div.style('background-color', plotDim.backgroundColor)
 
-		dom.svg.transition().attr('width', plotDim.svgWidth).attr('height', plotDim.svgHeight)
+		dom.svg
+			.transition()
+			.attr('width', plotDim.svgWidth)
+			.attr('height', plotDim.svgHeight)
+			//Fix for white background when downloading darkMode image.
+			.style('fill', plotDim.backgroundColor)
 
 		const yScale = scaleLinear().domain(plotDim.domain).range([0, settings.boxplotWidth])
 

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -122,7 +122,7 @@ export class ViewModel {
 				x: totalLabelWidth,
 				y: this.topPad + this.incrTopPad + 20
 			},
-			backgroundColor: settings.darkMode ? '#353839' : 'white',
+			backgroundColor: settings.darkMode ? 'black' : 'white',
 			textColor: settings.darkMode ? 'white' : 'black'
 		}
 		return plotDim

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,5 @@
+Fixes
+- Restored 'List samples' label menu option in both the violin and box plot. The filter label menu option restored as well.
 
+Features
+- Color picker for individual box plots and filter added. Click on the box plot label to see the new menu options. 

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -187,6 +187,6 @@ function setUncomputableValues(values: Record<string, number>) {
 }
 
 function numericBins(overlayTerm, data) {
-	const overlayBins = data.refs.byTermId[overlayTerm?.term?.id]?.bins ?? []
+	const overlayBins = data.refs.byTermId[overlayTerm?.$id]?.bins ?? []
 	return new Map(overlayBins.map(bin => [bin.label, bin]))
 }

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -335,7 +335,8 @@ for the case e.g. '0' is for "Not exposed", range.value can be either '0' or 0, 
 as it cannot be decided what client will provide
 so here need to allow both string and number as range.value
 */
-	if (!tvs.ranges) throw '.ranges{} missing'
+	if (!tvs.ranges)
+		throw `tvs.ranges{} missing, tvs.ranges = ${tvs.ranges} [server/src/termdb.filter.js get_numerical()]`
 	const values = [tvs.term.id]
 	// get term object
 	const term = ds.cohort.termdb.q.termjsonByOneid(tvs.term.id)

--- a/server/src/termdb.violin.js
+++ b/server/src/termdb.violin.js
@@ -82,7 +82,8 @@ export async function wilcoxon(divideTw, result) {
 // TODO: handle .keyOrder as an alternative to .bins ???
 function numericBins(overlayTerm, data) {
 	const divideTwBins = new Map()
-	const divideBins = data.refs.byTermId[overlayTerm?.term?.id]?.bins
+	/** Fix for broken `list samples` option no longer work for numeric terms */
+	const divideBins = data.refs.byTermId[overlayTerm?.$id]?.bins
 	if (divideBins) {
 		for (const bin of divideBins) {
 			divideTwBins.set(bin.label, bin)


### PR DESCRIPTION
## Description

Changes: 
1. Fixed broken `List samples` label menu options for numeric terms in both the violin and box plot. This also fixed the broken filter menu option in the violin plot. 
2. Added color picker and filter menu options to the box plot label menu. 
3. Fixed the download when dark mode is applied. 

Test: 
1. [Numeric example with mbmeta](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22MB_meta_analysis2%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22childType%22:%22boxplot%22,%22term%22:{%22id%22:%22Age%22,%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22Confidence%20Score%22}}]}) -> test the 'List samples' and 'Add filter' options for both the violin and box plot. 
2. [Categorical example with sjlife](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22childType%22:%22boxplot%22,%22term%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22diaggrp%22}}]}) -> should work exactly the same as master. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
