### PR TITLE
check if cache map is empty before accessing so to return a better er…

### DIFF
--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -314,6 +314,10 @@ function gdc_validateGeneExpression(G, ds, genome) {
 		*/
 		try {
 			const fileid = q.sample.eID
+			if (ds.__gdc.scrnaAnalysis2hdf5.size == 0) {
+				// blank map. must be that gdc data caching is disabled; no need to detect if it's being cached because this particular query is very fast
+				throw 'GDC scRNA file mapping is not cached'
+			}
 			const hdf5id = ds.__gdc.scrnaAnalysis2hdf5.get(fileid)
 			if (!hdf5id) throw 'cannot map eID to hdf5 id'
 


### PR DESCRIPTION
…r msg

## Description

can test by adding `stopGdcCacheAliquot: true` to serverconfig features{} to prevent caching from happening, and test at gdc scrna gene query. previous message says cannot map id which is uninformative

does not impact normal gdc operation

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
