### PR TITLE
fix: conditionally enable regression methods based on term type and s…

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -51,9 +51,8 @@ class MassCharts {
 			chartType: 'regression',
 			clickTo: this.loadChartSpecificMenu
 		}
-		/* following detects if the ds has just one method, if so will customize obj{} so that the button directly show the available method name, and click on it to directly launch the ui without showing a menu
-		alternatively, this logic could be implemented inside makeChartBtnMenu() of the chart itself and eliminate chart-specific logic in here (ideal)
-		but there lacks a way for makeChartBtnMenu to customize the button label
+		/* following detects if the ds has just one method, if so will customize obj{} so that the button directly show the available method name, and click on it to directly launch the ui without showing a menu, and will not trigger makeChartBtnMenu()
+		TODO move this logic to regression makeChartBtnMenu() to keep chart-specific logic out of here, but there lacks a way for makeChartBtnMenu to customize obj.label
 		*/
 		const lst = getCurrentCohortChartTypes(state)
 		if (!lst.includes('regression')) return obj // regression is hidden. still return obj to maintain proper charts array and the button will be hidden later
@@ -64,20 +63,20 @@ class MassCharts {
 		if (availableMethods.length > 1) return obj // more than 1 regression methods. do not modify original obj
 		if (availableMethods.length == 1) {
 			// has only one method. customized button label and click behavior
-			const m = availableMethods[0]
-			obj.label = (m == 'linear' ? 'Linear' : m == 'cox' ? 'Cox' : 'Logistic') + ' Regression'
+			obj.label =
+				(availableMethods[0] == 'linear' ? 'Linear' : availableMethods[0] == 'cox' ? 'Cox' : 'Logistic') + ' Regression'
 			obj.clickTo = () => {
 				this.dom.tip.hide()
 				this.prepPlot({
 					config: {
 						chartType: 'regression',
-						regressionType: m,
+						regressionType: availableMethods[0],
 						independent: []
 					}
 				})
 			}
 		}
-		// no method (exception?)
+		// no method (exception?) this is handled by regression makeChartBtnMenu
 		return obj
 	}
 }

--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -210,18 +210,15 @@ export function makeChartBtnMenu(holder, chartsInstance) {
 	/*
 	holder: the holder in the tooltip
 	chartsInstance: MassCharts instance
-		termdbConfig is accessible at chartsInstance.state.termdbConfig{}
-		mass option is accessible at chartsInstance.app.opts{}
 	*/
-
-	const lst = [
+	const allMethods = [
 		{ label: 'Linear', type: 'linear' },
 		{ label: 'Logistic', type: 'logistic' },
 		{ label: 'Cox', type: 'cox' }
 	]
-
-	for (const { label, type } of lst) {
-		if (!chartsInstance.state.currentCohortChartTypes.includes(type)) continue
+	const useMethods = allMethods.filter(i => chartsInstance.state.currentCohortChartTypes.includes(i.type))
+	if (useMethods.length == 0) return holder.append('div').text('Error: no methods available')
+	for (const { label, type } of useMethods) {
 		holder
 			.append('div')
 			.attr('class', 'sja_menuoption sja_sharp_border')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- conditionally enable regression methods based on term type and show customized Regression chart button if a single method is available

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -582,9 +582,15 @@ const defaultCommonCharts: isSupportedChartCallbacks = {
 	summary: () => true,
 	matrix: () => true,
 	regression: () => true,
-	linear: () => true,
-	logistic: () => true,
-	cox: () => true,
+	// linear/logistic/cox can be considered "child types" for regression, their availability can be separately determined to be more user friendly
+	linear: ({ cohortTermTypes }) => {
+		return cohortTermTypes.numeric > 0 // numeric term present and could be used as linear outcome
+	},
+	logistic: () => true, // consider both numeric & categorical can be logistic outcome
+	cox: ({ cohortTermTypes }) => {
+		// requires either survival or condition term as cox outcome
+		return (cohortTermTypes.survival || 0) + (cohortTermTypes.condition || 0) > 0
+	},
 	facet: () => true,
 	survival: ({ cohortTermTypes }) => cohortTermTypes.survival > 0,
 	cuminc: ({ cohortTermTypes }) => cohortTermTypes.condition > 0,

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -581,20 +581,29 @@ const defaultCommonCharts: isSupportedChartCallbacks = {
 	dictionary: () => true,
 	summary: () => true,
 	matrix: () => true,
+
+	/*
+	parent type: regression
+	child types: linear/logistic/cox
+	- if parent is disabled, all child types are not accessible
+	- when parent is accessible, availability of each child type is individually calculated based on data types and allows for ds override for customization
+	*/
 	regression: () => true,
-	// linear/logistic/cox can be considered "child types" for regression, their availability can be separately determined to be more user friendly
-	linear: ({ cohortTermTypes }) => {
-		return cohortTermTypes.numeric > 0 // numeric term present and could be used as linear outcome
-	},
-	logistic: () => true, // consider both numeric & categorical can be logistic outcome
+	linear: ({ cohortTermTypes }) => cohortTermTypes.numeric > 0, // numeric term present and could be used as linear outcome
+	logistic: () => true, // always enabled by default because: numeric/categorical/condition terms could all be used as outcome. later we will support custom samplelst term of two groups as outcome. a ds can provide an override to hide it if needed
 	cox: ({ cohortTermTypes }) => {
 		// requires either survival or condition term as cox outcome
 		return (cohortTermTypes.survival || 0) + (cohortTermTypes.condition || 0) > 0
 	},
+
 	facet: () => true,
 	survival: ({ cohortTermTypes }) => cohortTermTypes.survival > 0,
 	cuminc: ({ cohortTermTypes }) => cohortTermTypes.condition > 0,
 
+	/*
+	parent type: sampleScatter
+	child type: dynamicScatter
+	*/
 	sampleScatter: ({ ds, cohortTermTypes }) => {
 		// corresponds to the "Scatter Plot" chart button. it covers both premade scatter plots, as well as dynamic scatter input ui on clicking the "Scatter Plot" chart button
 		if (ds.cohort.scatterplots) return true
@@ -611,6 +620,7 @@ const defaultCommonCharts: isSupportedChartCallbacks = {
 		if (cohortTermTypes.numeric > 1) return true // numeric is always prefilled for convenience, does not have to check if property exists
 		return false
 	},
+
 	genomeBrowser: ({ ds }) => {
 		// will need to add more logic
 		if (ds.queries?.snvindel || ds.queries?.trackLst) return true


### PR DESCRIPTION
…how customized Regression chart button if a single method is available

## Description

at [termdbtest](http://localhost:3000/?noheader=1&massnative=hg38-test,TermdbTest), it shows `Regression Analysis` button with 3 options
at [mbmeta](http://localhost:3000/?noheader=1&massnative=hg38,MB_meta_analysis2), it shows `Cox Regression` and directly launches ui
at [allpharm](http://localhost:3000/?noheader=1&massnative=hg38,ALL-pharmacotyping), Cox option no longer shows

nav CI passes

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
