### PR TITLE
Box plot UI improvements

### DIFF
--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -4,8 +4,9 @@ import { controlsInit, term0_term2_defaultQ, renderTerm1Label } from '../control
 import { RxComponentInner } from '../../types/rx.d'
 import { plotColor } from '#shared/common.js'
 import { Menu } from '#dom'
+import { isNumericTerm } from '#shared/terms.js'
 import type { Div, Elem, SvgG, SvgSvg, SvgText } from '../../types/d3'
-import type { MassAppApi } from '#mass/types/mass'
+import type { MassAppApi, PlotConfig } from '#mass/types/mass'
 import { Model } from './model/Model'
 import { ViewModel } from './viewModel/ViewModel'
 import { View } from './view/View'
@@ -31,12 +32,13 @@ export type BoxPlotSettings = {
 	darkMode: boolean
 	/** Padding between the left hand label and boxplot */
 	labelPad: number
-	/** If true, order box plots from smallest to largest median value
-	 * Default is by alphanumeric order */
-	orderByMedian: boolean
 	/** Toggle between vertical and horizontal orientation.
 	 * The default is false */
 	isVertical: boolean
+	/** If true, order box plots from smallest to largest median value
+	 * Default is by alphanumeric order or by bin
+	 * May change this later to `orderBy` if more options arise */
+	orderByMedian: boolean
 	/** Height of individual boxplots */
 	rowHeight: number
 	/** Space between the boxplots */
@@ -122,12 +124,12 @@ class TdbBoxplot extends RxComponentInner {
 				defaultQ4fillTW: term0_term2_defaultQ
 			},
 			{
-				label: 'Order by median',
-				title: 'Order box plots by median value',
-				type: 'checkbox',
+				label: 'Order by',
+				title: 'Order box plots by parameters',
+				type: 'radio',
 				chartType: 'boxplot',
-				boxLabel: '',
 				settingsKey: 'orderByMedian',
+				options: setOrderByOptions(this.app.getState().plots.find(p => p.id === this.id)),
 				getDisplayStyle: plot => (plot.term2 ? '' : 'none')
 			},
 			{
@@ -287,6 +289,14 @@ class TdbBoxplot extends RxComponentInner {
 			throw e
 		}
 	}
+}
+
+function setOrderByOptions(config: PlotConfig) {
+	if (!config || !config.term2) return []
+	return [
+		{ label: isNumericTerm(config.term2.term) ? 'Bins' : 'Sample count', value: false },
+		{ label: 'Median values', value: true }
+	]
 }
 
 export const boxplotInit = getCompInit(TdbBoxplot)

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -6,7 +6,7 @@ import { plotColor } from '#shared/common.js'
 import { Menu } from '#dom'
 import { isNumericTerm } from '#shared/terms.js'
 import type { Div, Elem, SvgG, SvgSvg, SvgText } from '../../types/d3'
-import type { MassAppApi, PlotConfig } from '#mass/types/mass'
+import type { MassAppApi, MassState, PlotConfig } from '#mass/types/mass'
 import { Model } from './model/Model'
 import { ViewModel } from './viewModel/ViewModel'
 import { View } from './view/View'
@@ -129,8 +129,8 @@ class TdbBoxplot extends RxComponentInner {
 				type: 'radio',
 				chartType: 'boxplot',
 				settingsKey: 'orderByMedian',
-				options: setOrderByOptions(this.app.getState().plots.find(p => p.id === this.id)),
-				getDisplayStyle: plot => (plot.term2 ? '' : 'none')
+				options: setOrderByOptions(this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)),
+				getDisplayStyle: (plot: PlotConfig) => (plot.term2 ? '' : 'none')
 			},
 			{
 				label: 'Orientation',
@@ -188,7 +188,7 @@ class TdbBoxplot extends RxComponentInner {
 				type: 'color',
 				chartType: 'boxplot',
 				settingsKey: 'color',
-				getDisplayStyle: plot => (plot.term2 ? 'none' : '')
+				getDisplayStyle: (plot: PlotConfig) => (plot.term2 ? 'none' : '')
 			},
 			{
 				label: 'Dark mode',
@@ -214,8 +214,8 @@ class TdbBoxplot extends RxComponentInner {
 		})
 	}
 
-	getState(appState) {
-		const config = appState.plots.find(p => p.id === this.id)
+	getState(appState: MassState) {
+		const config = appState.plots.find((p: PlotConfig) => p.id === this.id)
 		if (!config) {
 			throw `No plot with id='${this.id}' found. Did you set this.id before this.api = getComponentApi(this)?`
 		}

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -298,8 +298,8 @@ export function getDefaultBoxplotSettings(app, overrides = {}) {
 		color: plotColor,
 		darkMode: false,
 		labelPad: 10,
+		isVertical: false,
 		orderByMedian: false,
-		isVertical: true,
 		rowHeight: 50,
 		rowSpace: 15
 	}

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -1,6 +1,6 @@
 import { getCompInit, copyMerge } from '#rx'
 import { fillTermWrapper } from '#termsetting'
-import { controlsInit, term0_term2_defaultQ } from '../controls'
+import { controlsInit, term0_term2_defaultQ, renderTerm1Label } from '../controls'
 import { RxComponentInner } from '../../types/rx.d'
 import { plotColor } from '#shared/common.js'
 import { Menu } from '#dom'
@@ -103,7 +103,7 @@ class TdbBoxplot extends RxComponentInner {
 				configKey: 'term',
 				chartType: 'boxplot',
 				usecase: { target: 'boxplot', detail: 'term' },
-				label: 'Customize',
+				label: renderTerm1Label,
 				vocabApi: this.app.vocabApi,
 				menuOptions: 'edit'
 			},

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -124,11 +124,12 @@ class TdbBoxplot extends RxComponentInner {
 				type: 'checkbox',
 				chartType: 'boxplot',
 				boxLabel: '',
-				settingsKey: 'orderByMedian'
+				settingsKey: 'orderByMedian',
+				getDisplayStyle: plot => (plot.term2 ? '' : 'none')
 			},
 			{
 				label: 'Width',
-				title: 'Width of the entire plot',
+				title: 'Set the width of the entire plot',
 				type: 'number',
 				chartType: 'boxplot',
 				settingsKey: 'boxplotWidth',
@@ -136,7 +137,7 @@ class TdbBoxplot extends RxComponentInner {
 			},
 			{
 				label: 'Plot height',
-				title: 'Height of each box plot',
+				title: 'Set the height of each box plot between 20 and 50',
 				type: 'number',
 				chartType: 'boxplot',
 				settingsKey: 'rowHeight',
@@ -152,7 +153,7 @@ class TdbBoxplot extends RxComponentInner {
 			},
 			{
 				label: 'Plot padding',
-				title: 'Space between each box plot',
+				title: 'Set the space between each box plot. Number must be between 10 and 20',
 				type: 'number',
 				chartType: 'boxplot',
 				settingsKey: 'rowSpace',

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -32,6 +32,9 @@ export type BoxPlotSettings = {
 	darkMode: boolean
 	/** Padding between the left hand label and boxplot */
 	labelPad: number
+	/** If true, order box plots from smallest to largest median value
+	 * Default is by alphanumeric order */
+	orderByMedian: boolean
 	/** Height of individual boxplots */
 	rowHeight: number
 	/** Space between the boxplots */
@@ -57,6 +60,7 @@ export type BoxPlotDom = {
 	svg: SvgSvg
 	/** Y-axis shown above the boxplots */
 	yAxis: any
+	/** box plot tooltip (e.g. over the outliers) */
 	tip: Menu
 }
 
@@ -115,6 +119,14 @@ class TdbBoxplot extends RxComponentInner {
 				defaultQ4fillTW: term0_term2_defaultQ
 			},
 			{
+				label: 'Order by median',
+				title: 'Order box plots by median value',
+				type: 'checkbox',
+				chartType: 'boxplot',
+				boxLabel: '',
+				settingsKey: 'orderByMedian'
+			},
+			{
 				label: 'Width',
 				title: 'Width of the entire plot',
 				type: 'number',
@@ -163,6 +175,7 @@ class TdbBoxplot extends RxComponentInner {
 			},
 			{
 				label: 'Dark mode',
+				title: 'Apply a dark theme to the plot',
 				type: 'checkbox',
 				chartType: 'boxplot',
 				boxLabel: '',
@@ -270,6 +283,7 @@ export function getDefaultBoxplotSettings(app, overrides = {}) {
 		color: plotColor,
 		darkMode: false,
 		labelPad: 10,
+		orderByMedian: false,
 		rowHeight: 50,
 		rowSpace: 15
 	}

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -12,10 +12,7 @@ import { View } from './view/View'
 import { BoxPlotInteractions } from './interactions/BoxPlotInteractions'
 import getMaxLabelLgth from './viewModel/MaxLabelLength'
 
-/** TODOs:
- *	Add functionality to change orientation
- */
-
+/** Opts sent from mass */
 type TdbBoxPlotOpts = {
 	holder: Elem
 	controls?: Elem
@@ -23,6 +20,8 @@ type TdbBoxPlotOpts = {
 	numericEditMenuVersion?: string[]
 }
 
+/** User controlled settings. Some settings are calculated based on
+ * the number of boxplots */
 export type BoxPlotSettings = {
 	/** Width of the boxplots and scale, excluding labels */
 	boxplotWidth: number
@@ -35,12 +34,16 @@ export type BoxPlotSettings = {
 	/** If true, order box plots from smallest to largest median value
 	 * Default is by alphanumeric order */
 	orderByMedian: boolean
+	/** Toggle between vertical and horizontal orientation.
+	 * The default is false */
+	isVertical: boolean
 	/** Height of individual boxplots */
 	rowHeight: number
 	/** Space between the boxplots */
 	rowSpace: number
 }
 
+/** Descriptions of the dom elements for the box plot */
 export type BoxPlotDom = {
 	/** Div for boxplots below the scale */
 	boxplots: SvgG
@@ -59,7 +62,7 @@ export type BoxPlotDom = {
 	/** Main svg holder */
 	svg: SvgSvg
 	/** Y-axis shown above the boxplots */
-	yAxis: any
+	axis: any
 	/** box plot tooltip (e.g. over the outliers) */
 	tip: Menu
 }
@@ -69,7 +72,7 @@ class TdbBoxplot extends RxComponentInner {
 	components: { controls: any }
 	dom: BoxPlotDom
 	interactions: BoxPlotInteractions
-	useDefaultSettings = true
+	private useDefaultSettings = true
 	constructor(opts: TdbBoxPlotOpts) {
 		super()
 		this.opts = opts
@@ -87,7 +90,7 @@ class TdbBoxplot extends RxComponentInner {
 			error: errorDiv,
 			svg,
 			plotTitle: svg.append('text'),
-			yAxis: svg.append('g'),
+			axis: svg.append('g'),
 			boxplots: svg.append('g'),
 			legend: div.append('div').attr('id', 'sjpp-boxplot-legend'),
 			tip: new Menu()
@@ -126,6 +129,17 @@ class TdbBoxplot extends RxComponentInner {
 				boxLabel: '',
 				settingsKey: 'orderByMedian',
 				getDisplayStyle: plot => (plot.term2 ? '' : 'none')
+			},
+			{
+				label: 'Orientation',
+				title: 'Change the orientation of the box plots',
+				type: 'radio',
+				chartType: 'boxplot',
+				settingsKey: 'isVertical',
+				options: [
+					{ label: 'Horizontal', value: false },
+					{ label: 'Vertical', value: true }
+				]
 			},
 			{
 				label: 'Width',
@@ -285,6 +299,7 @@ export function getDefaultBoxplotSettings(app, overrides = {}) {
 		darkMode: false,
 		labelPad: 10,
 		orderByMedian: false,
+		isVertical: true,
 		rowHeight: 50,
 		rowSpace: 15
 	}

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -100,7 +100,7 @@ export class BoxPlotInteractions {
 	clearDom() {
 		this.dom.error.style('padding', '').text('')
 		this.dom.plotTitle.text('')
-		this.dom.yAxis.selectAll('*').remove()
+		this.dom.axis.selectAll('*').remove()
 		this.dom.boxplots.selectAll('*').remove()
 		this.dom.legend.selectAll('*').remove()
 	}

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -1,5 +1,5 @@
 import type { BoxPlotDom } from '../BoxPlot'
-import type { MassAppApi } from '#mass/types/mass'
+import type { MassAppApi, PlotConfig } from '#mass/types/mass'
 import type { RenderedPlot } from '../view/RenderedPlot'
 import type { LegendItemEntry } from '../viewModel/LegendDataMapper'
 import { to_svg } from '#src/client'
@@ -48,8 +48,8 @@ export class BoxPlotInteractions {
 	}
 
 	/** Option to hide a plot from the box plot label menu. */
-	hidePlot(plot) {
-		const plotConfig = this.app.getState().plots.find(p => p.id === this.id)
+	hidePlot(plot: RenderedPlot) {
+		const plotConfig = this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)
 		//Don't try to modify a frozen object
 		const config = structuredClone(plotConfig)
 		const contTerm = config.term.q.mode == 'continuous' ? 'term2' : 'term'
@@ -64,7 +64,7 @@ export class BoxPlotInteractions {
 
 	/** Trigger when clicking on a hidden plot in the legend */
 	unhidePlot(item: LegendItemEntry) {
-		const plotConfig = this.app.getState().plots.find(p => p.id === this.id)
+		const plotConfig = this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)
 		const config = structuredClone(plotConfig)
 		const contTerm = config.term.q.mode == 'continuous' ? 'term2' : 'term'
 		delete config[contTerm].q.hiddenValues[item.key]
@@ -87,7 +87,7 @@ export class BoxPlotInteractions {
 	/** Callback for color picker in plot(s) label menu */
 	updatePlotColor(plot: RenderedPlot, color: string) {
 		if (!plot.seriesId) return
-		const plotConfig = this.app.getState().plots.find(p => p.id === this.id)
+		const plotConfig = this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)
 		const config = structuredClone(plotConfig)
 		config.term2.term.values[plot.seriesId].color = color
 		this.app.dispatch({

--- a/client/plots/boxplot/model/Model.ts
+++ b/client/plots/boxplot/model/Model.ts
@@ -35,6 +35,8 @@ export class Model {
 		if (this.config.term2)
 			opts.overlayTw = this.getContinousTerm() == this.config.term ? this.config.term2 : this.config.term
 
+		opts.orderByMedian = this.settings.orderByMedian
+
 		return opts
 	}
 

--- a/client/plots/boxplot/test/boxplot.integration.spec.ts
+++ b/client/plots/boxplot/test/boxplot.integration.spec.ts
@@ -64,7 +64,7 @@ tape('Default box plot', test => {
 		const config = boxplot.Inner.state.config
 
 		test.equal(dom.plotTitle.text(), config.term.term.name, `Should render ${config.term.term.name} title`)
-		test.true(dom.yAxis.select('path'), 'Should render y axis')
+		test.true(dom.axis.select('path'), 'Should render y axis')
 		test.equal(dom.boxplots.selectAll("g[id^='sjpp-boxplot-']").size(), 1, 'Should render 1 boxplot')
 
 		if (test['_ok']) boxplot.Inner.app.destroy()
@@ -204,7 +204,7 @@ tape('Box plot with user settings', test => {
 		test.equal(wrongColorLine, 0, `Should render boxplot with ${settings.color} lines.`)
 
 		test.true(
-			dom.div.style('background-color') == 'black' && dom.yAxis.select('path').attr('stroke') == 'white',
+			dom.div.style('background-color') == 'black' && dom.axis.select('path').attr('stroke') == 'white',
 			`Should render boxplot with dark background and white text when darkMode is ${settings.darkMode}.`
 		)
 

--- a/client/plots/boxplot/test/boxplot.unit.spec.ts
+++ b/client/plots/boxplot/test/boxplot.unit.spec.ts
@@ -34,6 +34,7 @@ const mockSettings = {
 	color: 'blue',
 	darkMode: false,
 	labelPad: 10,
+	isVertical: false,
 	orderByMedian: false,
 	rowHeight: 20,
 	rowSpace: 10,
@@ -125,24 +126,26 @@ tape('Default ViewModel()', function (test) {
 tape('ViewModel.setPlotDimensions()', function (test) {
 	test.timeoutAfter(100)
 	const viewModel = getViewModel()
-	const dims = viewModel.setPlotDimensions(mockData, mockConfig, mockSettings, 170, 30)
+	const dims = viewModel.setPlotDimensions(mockData, mockConfig, mockSettings)
 	const expected = {
 		domain: [0, 101],
 		incrTopPad: 40,
-		svgWidth: 310,
-		svgHeight: 250,
-		title: { x: 180, y: 85, text: 'Age at Cancer Diagnosis' },
-		yAxis: { x: 170, y: 170 }
+		svg: {
+			width: 550,
+			height: 250
+		},
+		title: { x: 420, y: 85, text: 'Age at Cancer Diagnosis' },
+		axis: { x: 410, y: 170 }
 	}
 	test.equal(typeof dims, 'object', `Should create a plotDim object`)
 	test.deepEqual(dims.domain, expected.domain, `Should set domain = ${expected.domain}`)
-	test.equal(dims.svgWidth, expected.svgWidth, `Should set svgWidth = ${expected.svgWidth}`)
-	test.equal(dims.svgHeight, expected.svgHeight, `Should set svgHeight = ${expected.svgHeight}`)
+	test.equal(dims.svg.width, expected.svg.width, `Should set svg.width = ${expected.svg.width}`)
+	test.equal(dims.svg.height, expected.svg.height, `Should set svg.height = ${expected.svg.height}`)
 	test.equal(dims.title.x, expected.title.x, `Should set title.x = ${expected.title.x}`)
 	test.equal(dims.title.y, expected.title.y, `Should set title.y = ${expected.title.y}`)
 	test.equal(dims.title.text, expected.title.text, `Should set title text = ${expected.title.text}`)
-	test.equal(dims.yAxis.x, expected.yAxis.x, `Should set yAxis.x = ${expected.yAxis.x}`)
-	test.equal(dims.yAxis.y, expected.yAxis.y, `Should set yAxis.y = ${expected.yAxis.y}`)
+	test.equal(dims.axis.x, expected.axis.x, `Should set yAxis.x = ${expected.axis.x}`)
+	test.equal(dims.axis.y, expected.axis.y, `Should set yAxis.y = ${expected.axis.y}`)
 
 	test.end()
 })
@@ -151,7 +154,7 @@ tape('ViewModel.setPlotData()', function (test) {
 	test.timeoutAfter(100)
 
 	const viewModel = getViewModel()
-	const plots = viewModel.setPlotData(mockData, mockConfig, mockSettings, 100, 300)
+	const plots = viewModel.setPlotData(mockData, mockConfig, mockSettings)
 
 	test.equal(
 		plots[0].color,
@@ -170,7 +173,7 @@ tape('ViewModel.setPlotData()', function (test) {
 	)
 
 	test.true(
-		plots[1].x == plots[0].x && plots[1].y == plots[0].y + 300,
+		plots[1].x == plots[0].x && plots[1].y == plots[0].y + 30,
 		`Should set x the same for all plots and increment y`
 	)
 

--- a/client/plots/boxplot/test/boxplot.unit.spec.ts
+++ b/client/plots/boxplot/test/boxplot.unit.spec.ts
@@ -131,7 +131,7 @@ tape('ViewModel.setPlotDimensions()', function (test) {
 		domain: [0, 101],
 		incrTopPad: 40,
 		svg: {
-			width: 550,
+			width: 490,
 			height: 250
 		},
 		title: { x: 420, y: 85, text: 'Age at Cancer Diagnosis' },

--- a/client/plots/boxplot/view/BoxPlotLabelMenu.ts
+++ b/client/plots/boxplot/view/BoxPlotLabelMenu.ts
@@ -7,7 +7,7 @@ import { rgb } from 'd3-color'
 
 /** Menu is available when more than one boxplot is rendered. */
 export class BoxPlotLabelMenu {
-	constructor(plot: RenderedPlot, app: MassAppApi, interactions: BoxPlotInteractions, tip: Menu) {
+	constructor(plot: RenderedPlot, app: MassAppApi, interactions: BoxPlotInteractions, tip: Menu, isVertical: boolean) {
 		const options = [
 			{
 				text: `Add filter: ${plot.key}`,
@@ -22,8 +22,9 @@ export class BoxPlotLabelMenu {
 			{
 				text: `List samples`,
 				isVisible: (state: MassState) => state.termdbConfig.displaySampleIds && app.vocabApi.hasVerifiedToken(),
-				callback: async () => {
-					tip.clear().showunder(plot.boxplot.labelG.node())
+				callback: async (event: MouseEvent) => {
+					if (isVertical) tip.clear().show(event.clientX, event.clientY)
+					else tip.clear().showunder(plot.boxplot.labelG.node())
 					const rows = await interactions.listSamples(plot)
 
 					const tableDiv = tip.d.append('div')
@@ -41,8 +42,10 @@ export class BoxPlotLabelMenu {
 				}
 			}
 		]
-		plot.boxplot.labelG.on('click', () => {
-			tip.clear().showunder(plot.boxplot.labelG.node())
+		plot.boxplot.labelG.on('click', (event: MouseEvent) => {
+			tip.clear()
+			if (isVertical) tip.show(event.clientX, event.clientY)
+			else tip.showunder(plot.boxplot.labelG.node())
 			const state = app.getState()
 			for (const opt of options) {
 				//Adds all the menu options before the color picker
@@ -51,9 +54,9 @@ export class BoxPlotLabelMenu {
 					.append('div')
 					.classed('sja_menuoption', true)
 					.text(opt.text)
-					.on('click', () => {
+					.on('click', (event: MouseEvent) => {
 						tip.hide()
-						opt.callback()
+						opt.callback(event)
 					})
 			}
 			if (plot.color) {

--- a/client/plots/boxplot/view/BoxPlotToolTips.ts
+++ b/client/plots/boxplot/view/BoxPlotToolTips.ts
@@ -7,12 +7,14 @@ export class BoxPlotToolTips {
 	boxplot: RenderedBoxPlot
 	g: SvgG
 	plot: RenderedPlot
+	isVertical: boolean
 	tip: Menu
 	readonly tablePadding = '3px'
-	constructor(plot: any, g: SvgG, tip: Menu) {
+	constructor(plot: any, g: SvgG, tip: Menu, isVertical: boolean) {
 		this.plot = plot
 		this.g = g
 		this.boxplot = plot.boxplot
+		this.isVertical = isVertical
 		this.tip = tip
 
 		this.addLabelTooltip()
@@ -28,8 +30,10 @@ export class BoxPlotToolTips {
 
 	addLabelTooltip() {
 		if (this.plot.descrStats.length < 2) return
-		this.boxplot.labelG.on('mouseover', () => {
-			this.tip.clear().showunder(this.boxplot.labelG.node())
+		this.boxplot.labelG.on('mouseover', (event: MouseEvent) => {
+			this.tip.clear()
+			if (this.isVertical) this.tip.show(event.clientX, event.clientY)
+			else this.tip.showunder(this.boxplot.labelG.node())
 			const table = this.tip.d.append('table').attr('class', 'sja_simpletable')
 			table
 				.append('tr')

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -72,13 +72,16 @@ export class View {
 		scale: ScaleLinear<number, number, never>,
 		settings: BoxPlotSettings
 	) {
+		/** draw_boxplot renders the boxplot from min-max but the scale
+		 * renders the axis from max - min. Render the box plots, then change
+		 * the scale vector to match. */
 		if (settings.isVertical) scale.range([scale.range()[1], scale.range()[0]])
 
 		dom.axis
 			.attr('id', 'sjpp-boxplot-axis')
 			.attr('transform', `translate(${plotDim.axis.x}, ${plotDim.axis.y})`)
 			.transition()
-			.call(this.settings.isVertical ? axisLeft(scale).tickPadding(10) : axisTop(scale))
+			.call(this.settings.isVertical ? axisLeft(scale).tickPadding(5) : axisTop(scale))
 
 		axisstyle({
 			axis: dom.axis,
@@ -111,14 +114,20 @@ export class View {
 			const transformStr = `translate(${plot.x}, ${plot.y})${settings.isVertical ? `, rotate(-90)` : ''}`
 			g.attr('transform', transformStr)
 
-			new BoxPlotToolTips(plot, g, this.dom.tip)
+			new BoxPlotToolTips(plot, g, this.dom.tip, settings.isVertical)
 			if (data.plots.length > 1) {
 				//Do not try to use the same tip for the menu as the tooltips.
 				//When the boxplots are rendered close together, the menu
 				//disappears to show the tooltip for the next boxplot.
 				//The user can't make a selection in time.
 				const labelMenuTip = new Menu({ padding: '' })
-				new BoxPlotLabelMenu(plot as unknown as RenderedPlot, this.app, this.interactions, labelMenuTip)
+				new BoxPlotLabelMenu(
+					plot as unknown as RenderedPlot,
+					this.app,
+					this.interactions,
+					labelMenuTip,
+					settings.isVertical
+				)
 			}
 		}
 		dom.boxplots.selectAll('g[id^="sjpp-boxplot-"] > rect').style('fill', data.plotDim.backgroundColor)

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -73,12 +73,12 @@ export class View {
 		settings: BoxPlotSettings
 	) {
 		if (settings.isVertical) scale.range([scale.range()[1], scale.range()[0]])
-		//axis below the title
+
 		dom.axis
 			.attr('id', 'sjpp-boxplot-axis')
 			.attr('transform', `translate(${plotDim.axis.x}, ${plotDim.axis.y})`)
 			.transition()
-			.call(this.settings.isVertical ? axisLeft(scale) : axisTop(scale))
+			.call(this.settings.isVertical ? axisLeft(scale).tickPadding(10) : axisTop(scale))
 
 		axisstyle({
 			axis: dom.axis,

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -104,15 +104,16 @@ export class ViewModel {
 	}
 
 	setPlotDimensions(data: BoxPlotResponse, config: any, settings: BoxPlotSettings) {
+		const svg = this.setSvgDimensions(settings, data)
 		const plotDim = {
 			//Add 1 to the max is big enough so the upper line to boxplot isn't cutoff
 			//Note: ts is complaining absMax could be null. Ignore. Error in server request.
 			domain: [data.absMin, data.absMax! <= 1 ? data.absMax : data.absMax! + 1],
 			range: [0, settings.boxplotWidth],
-			svg: this.setSvgDimensions(settings, data),
-			title: this.setTitleDimensions(config, settings),
+			svg,
+			title: this.setTitleDimensions(config, settings, svg.height),
 			axis: {
-				x: settings.isVertical ? this.topPad + this.incrPad : this.totalLabelSize,
+				x: settings.isVertical ? this.horizPad / 2 + this.incrPad : this.totalLabelSize,
 				y: this.topPad + this.incrPad + 20 + (settings.isVertical ? settings.labelPad : 0)
 			},
 			backgroundColor: settings.darkMode ? 'black' : 'white',
@@ -131,11 +132,11 @@ export class ViewModel {
 		}
 	}
 
-	setTitleDimensions(config: any, settings: BoxPlotSettings) {
+	setTitleDimensions(config: any, settings: BoxPlotSettings, height: number) {
 		const depth = this.totalLabelSize + settings.boxplotWidth / 2
 		return {
-			x: settings.isVertical ? this.topPad : depth,
-			y: settings.isVertical ? depth - this.horizPad / 2 : this.topPad + this.incrPad / 2,
+			x: settings.isVertical ? this.horizPad / 2 : depth,
+			y: settings.isVertical ? height - depth - 5 : this.topPad + this.incrPad / 2,
 			text: config.term.q.mode == 'continuous' ? config.term.term.name : config.term2.term.name
 		}
 	}
@@ -157,7 +158,7 @@ export class ViewModel {
 				plot.boxplot.radius = this.outRadius
 			}
 			plot.labColor = settings.darkMode ? 'white' : 'black'
-			plot.x = settings.isVertical ? this.topPad + this.incrPad : this.totalLabelSize
+			plot.x = settings.isVertical ? this.horizPad / 2 + this.incrPad : this.totalLabelSize
 			plot.y = settings.isVertical
 				? settings.boxplotWidth + settings.labelPad + this.bottomPad * 2
 				: this.topPad + this.incrPad

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -15,8 +15,15 @@ export type ViewData = {
 	legend: { label: string; items: LegendItemEntry[] }[]
 }
 
+/** Processed box plot obj with dimensions needs for
+ * rendering in the view. */
 export type FormattedPlotEntry = BoxPlotEntry & {
-	boxplot: BoxPlotData & { label: string; radius?: number }
+	boxplot: BoxPlotData & {
+		label: string
+		/** if outliers are present, set the radius
+		 * instead of using the rather large default */
+		radius?: number
+	}
 	/** offset for the label div */
 	x: number
 	/** incrementing, descending offset for each new plot  */
@@ -113,7 +120,7 @@ export class ViewModel {
 			svg,
 			title: this.setTitleDimensions(config, settings, svg.height),
 			axis: {
-				x: settings.isVertical ? this.horizPad / 2 + this.incrPad : this.totalLabelSize,
+				x: settings.isVertical ? this.horizPad / 2 + this.incrPad + this.topPad : this.totalLabelSize,
 				y: this.topPad + this.incrPad + 20 + (settings.isVertical ? settings.labelPad : 0)
 			},
 			backgroundColor: settings.darkMode ? 'black' : 'white',
@@ -127,7 +134,7 @@ export class ViewModel {
 			data.plots.filter(p => !p.isHidden).length * this.totalRowSize + this.topPad + this.bottomPad + this.incrPad
 		const depth = settings.boxplotWidth + this.totalLabelSize + this.horizPad
 		return {
-			width: settings.isVertical ? plotsSpace : depth,
+			width: settings.isVertical ? plotsSpace + this.horizPad / 2 : depth,
 			height: settings.isVertical ? depth : plotsSpace
 		}
 	}
@@ -136,7 +143,7 @@ export class ViewModel {
 		const depth = this.totalLabelSize + settings.boxplotWidth / 2
 		return {
 			x: settings.isVertical ? this.horizPad / 2 : depth,
-			y: settings.isVertical ? height - depth - 5 : this.topPad + this.incrPad / 2,
+			y: settings.isVertical ? height - depth - 10 : this.topPad + this.incrPad / 2,
 			text: config.term.q.mode == 'continuous' ? config.term.term.name : config.term2.term.name
 		}
 	}

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -121,7 +121,7 @@ export class ViewModel {
 			title: this.setTitleDimensions(config, settings, svg.height),
 			axis: {
 				x: settings.isVertical ? this.horizPad / 2 + this.incrPad + this.topPad : this.totalLabelSize,
-				y: this.topPad + this.incrPad + 20 + (settings.isVertical ? settings.labelPad : 0)
+				y: this.topPad + (settings.isVertical ? settings.labelPad : this.incrPad + 20)
 			},
 			backgroundColor: settings.darkMode ? 'black' : 'white',
 			textColor: settings.darkMode ? 'white' : 'black'
@@ -132,9 +132,9 @@ export class ViewModel {
 	setSvgDimensions(settings: BoxPlotSettings, data: BoxPlotResponse) {
 		const plotsSpace =
 			data.plots.filter(p => !p.isHidden).length * this.totalRowSize + this.topPad + this.bottomPad + this.incrPad
-		const depth = settings.boxplotWidth + this.totalLabelSize + this.horizPad
+		const depth = settings.boxplotWidth + this.totalLabelSize + this.horizPad / 2
 		return {
-			width: settings.isVertical ? plotsSpace + this.horizPad / 2 : depth,
+			width: settings.isVertical ? plotsSpace + this.horizPad : depth,
 			height: settings.isVertical ? depth : plotsSpace
 		}
 	}
@@ -143,7 +143,7 @@ export class ViewModel {
 		const depth = this.totalLabelSize + settings.boxplotWidth / 2
 		return {
 			x: settings.isVertical ? this.horizPad / 2 : depth,
-			y: settings.isVertical ? height - depth - 10 : this.topPad + this.incrPad / 2,
+			y: settings.isVertical ? height - depth - this.horizPad / 2 : this.topPad + this.incrPad / 2,
 			text: config.term.q.mode == 'continuous' ? config.term.term.name : config.term2.term.name
 		}
 	}
@@ -166,9 +166,7 @@ export class ViewModel {
 			}
 			plot.labColor = settings.darkMode ? 'white' : 'black'
 			plot.x = settings.isVertical ? this.horizPad / 2 + this.incrPad : this.totalLabelSize
-			plot.y = settings.isVertical
-				? settings.boxplotWidth + settings.labelPad + this.bottomPad * 2
-				: this.topPad + this.incrPad
+			plot.y = this.topPad + (settings.isVertical ? settings.boxplotWidth + settings.labelPad : this.incrPad)
 			this.incrPad += this.totalRowSize
 		}
 		return plots

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Features:
 - New control to order box plots from smallest to highest median value
+- Toggle between vertical and horizontal orientation of the box plot

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- New control to order box plots from smallest to highest median value

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -122,6 +122,10 @@ function init({ genomes }) {
 			if (q.tw.term?.values) setHiddenPlots(q.tw, plots)
 			if (overlayTerm && overlayTerm.term?.values) setHiddenPlots(overlayTerm, plots)
 
+			if (q.orderByMedian == true) {
+				plots.sort((a, b) => a.boxplot.p50 - b.boxplot.p50)
+			}
+
 			const returnData: BoxPlotResponse = {
 				absMin,
 				absMax,

--- a/shared/types/src/routes/termdb.boxplot.ts
+++ b/shared/types/src/routes/termdb.boxplot.ts
@@ -1,11 +1,14 @@
 import type { RoutePayload } from './routeApi.js'
 
+/**Args set in Termdb vocab and from mass box plot */
 export type BoxPlotRequest = {
 	/** Args set in TermVocab */
 	/** term1 or term */
 	tw: any
 	genome: string
 	dslabel: string
+	/** sort plots by median value */
+	orderByMedian: boolean
 	/** term2 */
 	overlayTw?: any
 	filter: any


### PR DESCRIPTION
## Description
Addresses some feature requests in #2570. 

Changes: 
1. Term1 control label is dynamically rendered
2. New feature to order the plots by the default, either bins or sample count, or median values
3. New feature to render the box plot vertically or horiztonally
4. Added unit tests

Test: 
Use the box plot examples in http://localhost:3000/url.html. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
