### PR TITLE
Enabled density contour  with weights for 3D plots

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -332,7 +332,7 @@ class Scatter {
 				chartType: 'sampleScatter',
 				settingsKey: 'showContour',
 				title:
-					'Shows the density of point clouds. If Z/Divide by is added with continous mode uses it to weight the points when calculating the density contours'
+					"Shows the density of point clouds. If 'Z/Divide by' is added in continous mode, it uses this to weight the points when calculating the density contours"
 			}
 		]
 		if (this.settings.showContour)

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -331,7 +331,8 @@ class Scatter {
 				type: 'checkbox',
 				chartType: 'sampleScatter',
 				settingsKey: 'showContour',
-				title: 'Show contour map'
+				title:
+					'Shows the density of point clouds. If Z/Divide by is added with continous mode uses it to weight the points when calculating the density contours'
 			}
 		]
 		if (this.settings.showContour)

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -324,8 +324,24 @@ class Scatter {
 				type: 'number',
 				chartType: 'sampleScatter',
 				settingsKey: 'svgh'
+			},
+			{
+				label: 'Show contour map',
+				boxLabel: '',
+				type: 'checkbox',
+				chartType: 'sampleScatter',
+				settingsKey: 'showContour',
+				title: 'Show contour map'
 			}
 		]
+		if (this.settings.showContour)
+			inputs.push({
+				label: 'Color contours',
+				boxLabel: '',
+				type: 'checkbox',
+				chartType: 'sampleScatter',
+				settingsKey: 'colorContours'
+			})
 		if (this.config.sampleCategory) {
 			const options = Object.values(this.config.sampleCategory.tw.term.values).map(v => ({
 				label: v.label || v.key,
@@ -427,28 +443,18 @@ class Scatter {
 					if (hasRef) inputs.splice(7, 0, refSizeOption)
 				}
 
-				inputs.push(
-					{
-						label: 'Show regression',
-						type: 'dropdown',
-						chartType: 'sampleScatter',
-						settingsKey: 'regression',
-						options: [
-							{ label: 'None', value: 'None' },
-							//{ label: 'Loess', value: 'Loess' },
-							{ label: 'Lowess', value: 'Lowess' },
-							{ label: 'Polynomial', value: 'Polynomial' }
-						]
-					},
-					{
-						label: 'Show contour map',
-						boxLabel: '',
-						type: 'checkbox',
-						chartType: 'sampleScatter',
-						settingsKey: 'showContour',
-						title: 'Show contour map'
-					}
-				)
+				inputs.push({
+					label: 'Show regression',
+					type: 'dropdown',
+					chartType: 'sampleScatter',
+					settingsKey: 'regression',
+					options: [
+						{ label: 'None', value: 'None' },
+						//{ label: 'Loess', value: 'Loess' },
+						{ label: 'Lowess', value: 'Lowess' },
+						{ label: 'Polynomial', value: 'Polynomial' }
+					]
+				})
 			} else {
 				inputs.push({
 					label: 'Chart depth',
@@ -484,24 +490,9 @@ class Scatter {
 				inputs.splice(4, 0, shapeSizeOption)
 				if (hasRef) inputs.splice(5, 0, refSizeOption)
 			}
-			inputs.push(showAxes, {
-				label: 'Show contour map',
-				boxLabel: '',
-				type: 'checkbox',
-				chartType: 'sampleScatter',
-				settingsKey: 'showContour',
-				title: 'Show contour map'
-			})
+			inputs.push(showAxes)
 		}
 
-		if (this.settings.showContour)
-			inputs.push({
-				label: 'Color contours',
-				boxLabel: '',
-				type: 'checkbox',
-				chartType: 'sampleScatter',
-				settingsKey: 'colorContours'
-			})
 		this.components = {
 			controls: await controlsInit({
 				app: this.app,

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -200,7 +200,7 @@ export function setRenderersThree(self) {
 			const color3D = new THREE.Color(color)
 			colors3D.push(color3D.r, color3D.g, color3D.b)
 		}
-		camera.position.set(0, 0, 2.5)
+		camera.position.set(0, 0, 2.5) // Sets the position of the camera on the z axis, 2.5 units away from the scene/particles
 		camera.lookAt(scene.position)
 
 		const geometry = new THREE.BufferGeometry()


### PR DESCRIPTION
## Description

Enabled density contours for 3D plots. It can be used as another way to see 3D plots and allows to compare density plots with and without weights. See scatter with contour  of Cyclophosphamide vs Age

<img width="1017" alt="Screenshot 2025-01-10 at 11 26 23 AM" src="https://github.com/user-attachments/assets/afbea89f-0e4e-4904-b791-dfba22dac54c" />


See density contours adding Average dose to heart:

<img width="1152" alt="Screenshot 2025-01-10 at 11 13 46 AM" src="https://github.com/user-attachments/assets/06fd65bf-cc00-4ede-a6df-978db8de0576" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
