### PR TITLE
Do not show hidden values in the barchart `List sample` label menu option results

### DIFF
--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -540,11 +540,22 @@ async function listSamples(event, self, seriesId, dataId, chartId) {
 	for (const sample of data.lst) {
 		const sampleName = data.refs.bySampleId[Number(sample.sample)].label
 		const row = [{ value: sampleName }]
+		/** Don't show hidden values in the results
+		 * May not be caught in server request for custom variables
+		 * with user supplied keys */
+		if (self.config.term.q?.hiddenValues && `${sample[self.config.term.$id].key}` in self.config.term.q.hiddenValues)
+			continue
 		if (termIsNumeric) {
 			const value = sample[self.config.term.$id]?.value
 			row.push({ value: roundValueAuto(value) })
 		}
 		if (self.config.term2) {
+			//Don't show hidden values in the results
+			if (
+				self.config.term2.q?.hiddenValues &&
+				`${sample[self.config.term2.$id].key}` in self.config.term2.q.hiddenValues
+			)
+				continue
 			let value = sample[self.config.term2.$id]
 			if (!value) row.push({ value: '' })
 			else {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Do not show hidden values in the barchart `List sample` label menu option results.


### PR DESCRIPTION
## Description
Closes issue #2583.

Catches custom hidden variables as categories before displaying them on the client. Will send data to use for testing in All-pharmacotyping example: http://localhost:3000/?noheader=1&massnative=hg38,ALL-pharmacotyping. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
