### PR TITLE
delete prior hardcoded GDC host.geneExp

### DIFF
--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -208,7 +208,7 @@ function gdcValidateQuery(ds: any, genome: any) {
 		try {
 			// cachedFetch will only cache a response if an external API URL is enabled in serverconfig.features.extApiCache
 			const response = await cachedFetch(
-				joinUrl(host.geneExp, '/gene_expression/gene_selection'),
+				joinUrl(host.rest, '/gene_expression/gene_selection'),
 				{
 					method: 'POST',
 					headers,

--- a/server/src/initGdc.cache.js
+++ b/server/src/initGdc.cache.js
@@ -538,7 +538,7 @@ async function fetchIdsFromGdcApi(ds, size, from, ref, aliquot_id) {
 
 async function getCasesWithGeneExpression(ds, ref) {
 	const { host, headers } = ds.getHostHeaders()
-	const url = joinUrl(host.geneExp, 'gene_expression/availability')
+	const url = joinUrl(host.rest, 'gene_expression/availability')
 
 	try {
 		const idLst = [...ref.caseIds]

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -218,7 +218,7 @@ async function geneExpression_getGenes(genes, cases4clustering, genome, ds, q) {
 		const { host, headers } = ds.getHostHeaders(q)
 
 		// test code to use native fetch
-		// const _re = await fetch(`${host.geneExp}/gene_expression/gene_selection`, {
+		// const _re = await fetch(`${host.rest}/gene_expression/gene_selection`, {
 		// 		headers,
 		// 		method: 'POST',
 		// 		//timeout: false, // instead of 10 second default
@@ -230,7 +230,7 @@ async function geneExpression_getGenes(genes, cases4clustering, genome, ds, q) {
 		// 		})
 		// 	}).then(r => r.json()).catch(e => {throw e})
 
-		const re = await nodeFetch(`${host.geneExp}/gene_expression/gene_selection`, {
+		const re = await nodeFetch(`${host.rest}/gene_expression/gene_selection`, {
 			method: 'POST',
 			headers,
 			timeout: false, // instead of 10 second default
@@ -302,10 +302,10 @@ async function getExpressionData(q, gene_ids, cases4clustering, ensg2symbol, ter
 	//
 	// --- keeping previous request code below for reference ---
 	//
-	// const re = await ky.post(`${host.geneExp}/gene_expression/values`, { timeout: false, headers, json: arg }).text()
+	// const re = await ky.post(`${host.rest}/gene_expression/values`, { timeout: false, headers, json: arg }).text()
 	// const lines = re.trim().split('\n')
 	//
-	// const response = await got.post(`${host.geneExp}/gene_expression/values`, {
+	// const response = await got.post(`${host.rest}/gene_expression/values`, {
 	// 	headers,
 	// 	body: JSON.stringify(arg)
 	// })
@@ -313,7 +313,7 @@ async function getExpressionData(q, gene_ids, cases4clustering, ensg2symbol, ter
 	// const lines = response.body.trim().split('\n')
 	//
 
-	const re = await nodeFetch(`${host.geneExp}/gene_expression/values`, {
+	const re = await nodeFetch(`${host.rest}/gene_expression/values`, {
 		method: 'POST',
 		timeout: false,
 		headers,


### PR DESCRIPTION
## Description

closes #2596 
use sjpp PR https://github.com/stjude/ppgdc/pull/7

test with GDC gene exp examples [link 1](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22and%22,%22content%22:[{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}]}},%22plots%22:[{%22chartType%22:%22hierCluster%22,%22dataType%22:%22geneExpression%22,%22terms%22:[{%22gene%22:%22MMP1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22TERT%22,%22type%22:%22geneExpression%22},{%22gene%22:%22YAP1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CDK4%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CDK6%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CDKN1A%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CDKN2A%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MGMT%22,%22type%22:%22geneExpression%22},{%22gene%22:%22E2F1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22EGF%22,%22type%22:%22geneExpression%22},{%22gene%22:%22EGFR%22,%22type%22:%22geneExpression%22},{%22gene%22:%22AKT1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PIK3R5%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MTOR%22,%22type%22:%22geneExpression%22},{%22gene%22:%22GRB2%22,%22type%22:%22geneExpression%22},{%22gene%22:%22HRAS%22,%22type%22:%22geneExpression%22},{%22gene%22:%22IGF1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22IGF1R%22,%22type%22:%22geneExpression%22},{%22gene%22:%22NOTCH3%22,%22type%22:%22geneExpression%22},{%22gene%22:%22KRAS%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MDM2%22,%22type%22:%22geneExpression%22},{%22gene%22:%22NRAS%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PDGFA%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PDGFB%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PDGFRA%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PIK3CA%22,%22type%22:%22geneExpression%22},{%22gene%22:%22ATRX%22,%22type%22:%22geneExpression%22},{%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PIK3R1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MAPK1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MAP2K1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PTEN%22,%22type%22:%22geneExpression%22},{%22gene%22:%22RAF1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22RB1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CCND1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22SHC1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22SOS1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22IDH1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22ROS1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22BRAF%22,%22type%22:%22geneExpression%22},{%22gene%22:%22TGFA%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CAMK2A%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CAMK2B%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PIK3R3%22,%22type%22:%22geneExpression%22},{%22gene%22:%22ALDH1A3%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CD109%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CD34%22,%22type%22:%22geneExpression%22}],%22termgroups%22:[{%22name%22:%22Variables%22,%22lst%22:[{%22id%22:%22case.disease_type%22},{%22id%22:%22case.demographic.gender%22},{%22id%22:%22case.project.project_id%22}]}]}]}), [link2](http://localhost:3000/example.gdc.exp.html?cohort=Gliomas), [link3](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22GAPDH%22},%22q%22:{%22mode%22:%22discrete%22}}}]})



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
