### PR TITLE
Scatter improvements

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -332,7 +332,7 @@ class Scatter {
 				chartType: 'sampleScatter',
 				settingsKey: 'showContour',
 				title:
-					"Shows the density of point clouds. If 'Z/Divide by' is added in continous mode, it uses this to weight the points when calculating the density contours"
+					"Shows the density of point clouds. If 'Color' is used in continous mode, it uses it to weight the points when calculating the density contours. If 'Z/Divide by' is added in continous mode, it used it instead."
 			}
 		]
 		if (this.settings.showContour)

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -138,7 +138,7 @@ class Scatter {
 			else this.createChart(key, data, 0)
 		}
 		this.initRanges()
-		this.is3D = this.config.term && this.config.term0?.q.mode == 'continuous'
+		this.is3D = this.config.term0?.q.mode == 'continuous'
 		if (!this.config.colorColumn) await this.setControls()
 		await this.processData()
 		this.render()
@@ -377,7 +377,7 @@ class Scatter {
 				title: 'Categories to divide by',
 				label: !isPremade && this.config.term0?.q?.mode == 'continuous' ? 'Z' : 'Divide by',
 				vocabApi: this.app.vocabApi,
-				numericEditMenuVersion: !isPremade && this.app.hasWebGL?.() ? ['discrete', 'continuous'] : ['discrete'],
+				numericEditMenuVersion: ['discrete', 'continuous'],
 				processInput: tw => {
 					if (!isPremade && isNumericTerm(tw?.term) && !tw.q.mode) tw.q = { mode: 'continuous' }
 				}

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -374,12 +374,12 @@ class Scatter {
 				configKey: 'term0',
 				chartType: 'sampleScatter',
 				usecase: { target: 'sampleScatter', detail: 'term0' },
-				title: 'Categories to divide by',
-				label: !isPremade && this.config.term0?.q?.mode == 'continuous' ? 'Z' : 'Divide by',
+				title: 'Term to to divide by categories or to use as Z coordinate',
+				label: 'Z / Divide by',
 				vocabApi: this.app.vocabApi,
 				numericEditMenuVersion: ['discrete', 'continuous'],
 				processInput: tw => {
-					if (!isPremade && isNumericTerm(tw?.term) && !tw.q.mode) tw.q = { mode: 'continuous' }
+					if (!isPremade && isNumericTerm(tw?.term) && !tw.q.mode) tw.q = { mode: 'continuous' } //use continuous mode by default if not premade plot
 				}
 			})
 		} else {

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -258,12 +258,14 @@ export function setRenderers(self) {
 	self.renderContours = function (chart) {
 		const contourG = chart.serie
 		let zAxisScale
-		if (self.config.colorTW?.q.mode == 'continuous')
-			zAxisScale = d3Linear().domain([chart.zMin, chart.zMax]).range([0, 1])
+		if (self.config.colorTW?.q.mode == 'continuous') {
+			const [zMin, zMax] = extent(chart.data.samples, d => d.category)
+			zAxisScale = d3Linear().domain([zMin, zMax]).range([0, 1])
+		}
+
 		const data = chart.data.samples.map(s => {
 			return { x: chart.xAxisScale(s.x), y: chart.yAxisScale(s.y), z: zAxisScale ? zAxisScale(s.category) : 1 }
 		})
-
 		renderContours(contourG, data, self.settings.svgw, self.settings.svgh, self.settings.colorContours)
 	}
 

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -257,8 +257,11 @@ export function setRenderers(self) {
 
 	self.renderContours = function (chart) {
 		const contourG = chart.serie
+		let zAxisScale
+		if (self.config.colorTW?.q.mode == 'continuous')
+			zAxisScale = d3Linear().domain([chart.zMin, chart.zMax]).range([0, 1])
 		const data = chart.data.samples.map(s => {
-			return { x: chart.xAxisScale(s.x), y: chart.yAxisScale(s.y), z: 1 }
+			return { x: chart.xAxisScale(s.x), y: chart.yAxisScale(s.y), z: zAxisScale ? zAxisScale(s.category) : 1 }
 		})
 
 		renderContours(contourG, data, self.settings.svgw, self.settings.svgh, self.settings.colorContours)
@@ -545,11 +548,9 @@ export function setRenderers(self) {
 
 	self.setTools = function () {
 		if (!self.charts[0]) return
-		const inline = self.config.settings.controls.isOpen
 		const toolsDiv = self.dom.toolsDiv.style('background-color', 'white')
 		toolsDiv.selectAll('*').remove()
 		let display = 'block'
-		if (inline) display = 'inline-block'
 		// const helpDiv = toolsDiv
 		// 	.insert('div')
 		// 	.style('display', display)

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -133,7 +133,9 @@ export function setRenderersThree(self) {
 			.attr('height', self.settings.svgh)
 			.append('g')
 			.attr('transform', 'translate(20, 20)')
-		//self.renderLegend(chart)
+		let step = Math.min((20 * 40) / chart.colorLegend.size, 20)
+
+		self.renderLegend(chart, step)
 		const fov = self.settings.fov
 		const near = 0.1
 		const far = 1000

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -19,7 +19,6 @@ export function setRenderersThree(self) {
 		chart.chartDiv.style('margin', '20px 20px')
 		chart.legendDiv = self.mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
 		let step = Math.min((20 * 40) / chart.colorLegend.size, 20)
-		console.log(step)
 		if (step < 12) step = 12
 		const height = (chart.colorLegend.size + 6) * step
 		chart.legendG = chart.legendDiv
@@ -226,7 +225,7 @@ export function setRenderersThree(self) {
 			// Create a plane geometry
 			const geometry = new THREE.PlaneGeometry(2, 2)
 			// Create a material using the loaded texture
-			const material = new THREE.MeshBasicMaterial({ map: texture, transparent: true })
+			const material = new THREE.MeshBasicMaterial({ map: texture, transparent: true, color: 0x141414 })
 			// Create a mesh with the geometry and material
 			const plane = new THREE.Mesh(geometry, material)
 			// Position the plane

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -19,6 +19,7 @@ export function setRenderersThree(self) {
 		chart.chartDiv.style('margin', '20px 20px')
 		chart.legendDiv = self.mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
 		let step = Math.min((20 * 40) / chart.colorLegend.size, 20)
+		console.log(step)
 		if (step < 12) step = 12
 		const height = (chart.colorLegend.size + 6) * step
 		chart.legendG = chart.legendDiv
@@ -133,7 +134,7 @@ export function setRenderersThree(self) {
 			.attr('height', self.settings.svgh)
 			.append('g')
 			.attr('transform', 'translate(20, 20)')
-		self.renderLegend(chart)
+		//self.renderLegend(chart)
 		const fov = self.settings.fov
 		const near = 0.1
 		const far = 1000
@@ -144,7 +145,7 @@ export function setRenderersThree(self) {
 		scene.background = whiteColor
 		const tex = getThreeCircle(256)
 		const material = new THREE.PointsMaterial({
-			size: self.settings.threeSize * 4,
+			size: self.settings.threeSize * 8,
 			sizeAttenuation: true,
 			transparent: true,
 			opacity: self.settings.opacity,
@@ -160,10 +161,9 @@ export function setRenderersThree(self) {
 			const controls = new OrbitControls.OrbitControls(camera, self.canvas)
 			controls.enableZoom = false
 			controls.update()
-
+			const axesHelper = new THREE.AxesHelper(1)
+			scene.add(axesHelper)
 			if (self.settings.showAxes) {
-				const axesHelper = new THREE.AxesHelper(1)
-				scene.add(axesHelper)
 				self.addLabels(scene, chart)
 			}
 
@@ -193,8 +193,9 @@ export function setRenderersThree(self) {
 		const yAxisScale = d3Linear().domain([chart.yMax, chart.yMin]).range([0, this.settings.svgh])
 		const zCoords = chart.data.samples.map(s => zAxisScale(s.z))
 		const colorGenerator = zAxisScale.copy().range(['#aaa', self.settings.defaultColor])
-		console.log(zCoords)
-		const colors = zCoords.map(z => colorGenerator(z))
+		const colors = self.config.colorTW
+			? chart.data.samples.map(s => self.getColor(s, chart))
+			: zCoords.map(z => colorGenerator(z))
 		const colors3D = []
 		for (const color of colors) {
 			const color3D = new THREE.Color(color)
@@ -239,7 +240,7 @@ export function setRenderersThree(self) {
 
 	self.addLabels = async function (scene) {
 		const intensity = 0.7
-		let textGeo = getTextGeo(self.config.term.term.name)
+		let textGeo = getTextGeo(self.config.term?.term?.name || 'X')
 		let textMesh = new THREE.Mesh(
 			textGeo,
 			new THREE.MeshBasicMaterial({ color: new THREE.Color(intensity, intensity / 4, intensity / 4) })
@@ -247,8 +248,8 @@ export function setRenderersThree(self) {
 		textMesh.position.x = 0.01
 		textMesh.position.y = -0.03
 		scene.add(textMesh)
-
-		textGeo = getTextGeo(self.config.term2.term.name)
+		const ytext = self.config.term2?.term?.name || 'Y'
+		textGeo = getTextGeo(ytext)
 		textGeo.rotateZ(Math.PI / 2)
 		textMesh = new THREE.Mesh(
 			textGeo,
@@ -257,8 +258,8 @@ export function setRenderersThree(self) {
 		textMesh.position.x = -0.03
 		textMesh.position.y = 0.01
 		scene.add(textMesh)
-
-		textGeo = getTextGeo(self.config.term0.term.name)
+		const ztext = self.config.term0?.term?.name
+		textGeo = getTextGeo(ztext)
 		textGeo.rotateY(Math.PI / 2)
 		textMesh = new THREE.Mesh(
 			textGeo,

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1274,7 +1274,7 @@ sandbox header
     opacity: 0;
     z-index: 10000;
     width: max-content;
-    max-width: 300px;
+    max-width: 350px;
     white-space: wrap;
     pointer-events: none;
     box-shadow: 0px 2px 4px 1px #999;

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -223,7 +223,7 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 		let isLast = false
 		if ((q.colorTW && !hasValue(dbSample, q.colorTW)) || (q.shapeTW && !hasValue(dbSample, q.shapeTW))) continue
 		let divideBy = 'Default'
-		if (q.divideByTW && q.divideByTW.q.mode != 'continuous') {
+		if (q.divideByTW) {
 			sample.z = 0
 			if (q.divideByTW.term.type == 'geneVariant' && q.divideByTW.q.type == 'values') {
 				divideBy = getMutation(true, dbSample, q.divideByTW)
@@ -235,7 +235,8 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 				const field = q.divideByTW.$id
 				const key = dbSample[field]?.key
 				if (key == null) continue
-				divideBy = q.divideByTW.term.values?.[key]?.label || key
+				if (q.divideByTW.q.mode != 'continuous') divideBy = q.divideByTW.term.values?.[key]?.label || key
+				else sample.z = key
 			}
 		}
 		if (!results[divideBy]) {


### PR DESCRIPTION
## Description

Supported adding Z coordinate in continuous mode for premade plots (3D plot). If no color specified, colored particles building color scale from z coords.
If color in continous mode enabled for 2D scatter plots used it when calculating contour maps  to weight coordinates.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
