### PR TITLE
mass navigation misc options are shown on right

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -202,6 +202,7 @@ function setRenderers(self) {
 			.style('vertical-align', 'top')
 			.style('margin', '10px')
 			.style('display', 'inline-block')
+			.style('float', 'right')
 		self.opts.holder.attr('class', 'sjpp-nav')
 		self.dom = {
 			holder: self.opts.holder,
@@ -231,17 +232,6 @@ function setRenderers(self) {
 			handler: self.deletePlots,
 			title: 'Delete all plots. To revert, click Undo button'
 		})
-
-		if (appState.nav.header_mode == 'only_buttons') {
-			// may retire this?
-			self.dom.tabDiv.style('display', 'none')
-			self.dom.recoverDiv.style('display', 'none')
-			titleDiv.style('margin-top', '95px').style('font-size', '0.9em')
-			if (massNav?.title?.link)
-				titleDiv
-					.on('click', () => window.open(massNav.title?.link, '_blank'))
-					.on('mouseover', () => titleDiv.style('cursor', 'pointer'))
-		}
 
 		if (self.opts.header_mode === 'with_cohortHtmlSelect') {
 			// not part of filter div
@@ -426,12 +416,7 @@ function setRenderers(self) {
 		}
 		const selectCohort = self.state.termdbConfig.selectCohort
 		const massNav = self.state.termdbConfig.massNav
-		self.dom.searchDiv.style(
-			'display',
-			(selectCohort && self.activeCohort == -1) || self.state.nav.header_mode == 'only_buttons'
-				? 'none'
-				: 'inline-block'
-		)
+		self.dom.searchDiv.style('display', selectCohort && self.activeCohort == -1 ? 'none' : 'inline-block')
 		//self.dom.holder.style('margin-bottom', self.state.nav.header_mode === 'with_tabs' ? '20px' : '')//To be checked why it was needed
 		self.dom.header.style('border-bottom', self.state.nav.header_mode === 'with_tabs' ? '1px solid #000' : '')
 		self.dom.tds

--- a/client/mass/search.js
+++ b/client/mass/search.js
@@ -56,10 +56,7 @@ class MassSearch {
 
 	async main() {
 		// show/hide search input from the tree
-		this.dom.holder.style(
-			'display',
-			this.state.search.isVisible && this.state.nav.header_mode != 'only_buttons' ? 'inline-block' : 'none'
-		)
+		this.dom.holder.style('display', this.state.search.isVisible ? 'inline-block' : 'none')
 	}
 
 	async doSearch(str) {

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -18,7 +18,6 @@ const navHeaderModes = new Set([
 	'hidden', // no header
 	'search_only', // ?
 	'hide_search', // ?
-	'only_buttons', // show only chart buttons and hide the tabs and search, to tailor header appearance for some ds
 	'with_cohortHtmlSelect' // only show cohort toggle as <select>
 ])
 

--- a/client/mass/types/mass.ts
+++ b/client/mass/types/mass.ts
@@ -99,7 +99,7 @@ type MassNav = {
 	activeTab: number
 	/** -1: unselected, 0,1,2...: selected */
 	activeCohort: number
-	header_mode: 'only_buttons' | 'with_tabs' | 'search_only' | 'hidden' | 'hide_search' | 'with_cohortHtmlSelect'
+	header_mode: 'with_tabs' | 'search_only' | 'hidden' | 'hide_search' | 'with_cohortHtmlSelect'
 }
 
 export type PlotConfig = {

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -29,7 +29,6 @@ export default {
 	isMds3: true,
 	cohort: {
 		massNav: {
-			title: { text: '' }, //it will show cohorts instead
 			tabs: {
 				// about: {
 				// 	hide: true,

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1291,9 +1291,6 @@ export type Cohort = {
 
 /** Customizations specific to the mass nav component */
 type MassNav = {
-	/** optional title of this ds, if missing use ds.label. shown on mass nav header.
-	 * use blank string to not to show a label*/
-	title?: Title
 	/** Customization for the tabs*/
 	tabs?: {
 		/** supported keys: about, charts, groups, filter


### PR DESCRIPTION
## Description

Aligned navigation controls to the right as agreed. Removed only_buttons handling no longer needed (previously used only by BALL-scrna). Removed title support. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/614)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
