### PR TITLE
fix: Charts tab now correctly shows the number of plots created

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -193,7 +193,7 @@ function getChartTypeList(self, state) {
 		////////////////////// PROFILE PLOTS END //////////////////////
 		{
 			label: 'Data Dictionary',
-			clickTo: self.prepPlot,
+			clickTo: self.createPlot,
 			chartType: 'dictionary',
 			config: {
 				chartType: 'dictionary'
@@ -201,7 +201,7 @@ function getChartTypeList(self, state) {
 		},
 		{
 			label: 'Sample View',
-			clickTo: self.prepPlot,
+			clickTo: self.createPlot,
 			chartType: 'sampleView',
 			config: {
 				chartType: 'sampleView'
@@ -255,7 +255,7 @@ function getChartTypeList(self, state) {
 
 		{
 			label: 'Data Download',
-			clickTo: self.prepPlot,
+			clickTo: self.createPlot,
 			chartType: 'dataDownload',
 			config: {
 				chartType: 'dataDownload',
@@ -564,6 +564,15 @@ function setRenderers(self) {
 	*/
 	self.prepPlot = function (chart) {
 		const action = { type: 'plot_prep', config: chart.config, id: getId() }
+		self.app.dispatch(action)
+	}
+
+	/** ALl data selection occurs within the plot (i.e. no external plot controls are needed).
+	 * Launch the plot directly.
+	 * This is a fix for the charts tab not correctly displaying the number of plots.
+	 */
+	self.createPlot = function (chart) {
+		const action = { type: 'plot_create', config: chart.config, id: getId() }
 		self.app.dispatch(action)
 	}
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Charts tab now correctly shows the number of plots created


### PR DESCRIPTION
## Description
Closes issue #2603 . 

There's no need to `prep` these specific plots. They all launch directly with no other menu, control, etc. Changed the action to `plot_create`. 

Test by adding the Data Dictionary, Sample View, and/or Data Download to http://localhost:3000/?noheader=1&massnative=hg38-test,TermdbTest. The Charts tab should update accordingly. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
