### PR TITLE
Replace .neuroOncRegression with .regression.settings{} in regression code

### DIFF
--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -415,7 +415,7 @@ export class InputTerm {
 		if (!this.term) return // missing term
 		if (this.section.configKey != 'independent') return
 		if (this.term.q.mode == 'spline') return // not on a spline term
-		if (this.parent.app.vocabApi.termdbConfig.neuroOncRegression) return
+		if (this.parent.app.vocabApi.termdbConfig.regression?.settings?.disableInteractions) return
 		{
 			// require minimum of 2 independent terms eligible for interaction
 			let count = 0

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -1232,7 +1232,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_type3 = result => {
-		if (!result.type3 || self.app.vocabApi.termdbConfig.neuroOncRegression) return
+		if (!result.type3 || self.app.vocabApi.termdbConfig.regression?.settings?.hideType3) return
 		const div = self.newDiv(result.type3.label)
 		const table = div.append('table').style('border-spacing', '0px')
 
@@ -1285,7 +1285,7 @@ function setRenderers(self) {
 	}
 
 	self.mayshow_tests = result => {
-		if (!result.tests || self.app.vocabApi.termdbConfig.neuroOncRegression) return
+		if (!result.tests || self.app.vocabApi.termdbConfig.regression?.settings?.hideTests) return
 		const div = self.newDiv(result.tests.label)
 		const table = div.append('table').style('border-spacing', '0px')
 		const header = table.append('tr').style('opacity', 0.4)

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -103,7 +103,6 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	// when missing, the attribute will not be present as "key:undefined"
 	if (tdb.plotConfigByCohort) c.plotConfigByCohort = tdb.plotConfigByCohort
 	if (tdb.multipleTestingCorrection) c.multipleTestingCorrection = tdb.multipleTestingCorrection
-	if (tdb.neuroOncRegression) c.neuroOncRegression = tdb.neuroOncRegression
 	if (tdb.helpPages) c.helpPages = tdb.helpPages
 	if (tdb.minTimeSinceDx) c.minTimeSinceDx = tdb.minTimeSinceDx
 	if (tdb.timeUnit) c.timeUnit = tdb.timeUnit
@@ -114,6 +113,7 @@ function make(q, res, ds: Mds3WithCohort, genome) {
 	if (tdb.useCasesExcluded) c.useCasesExcluded = tdb.useCasesExcluded
 	if (tdb.excludedTermtypeByTarget) c.excludedTermtypeByTarget = tdb.excludedTermtypeByTarget
 	if (tdb.survival) c.survival = tdb.survival
+	if (tdb.regression) c.regression = tdb.regression
 	if (ds.assayAvailability) c.assayAvailability = ds.assayAvailability
 	if (ds.customTwQByType) c.customTwQByType = ds.customTwQByType
 	c.requiredAuth = authApi.getRequiredCredForDsEmbedder(q.dslabel, q.embedder)

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -951,6 +951,15 @@ type SurvivalSettings = {
 	xTickValues?: number[]
 }
 
+type RegressionSettings = {
+	/** disable interactions */
+	disableInteractions?: boolean
+	/** hide type III statistics table in results */
+	hideType3?: boolean
+	/** hide statistical tests table in results */
+	hideTests?: boolean
+}
+
 type MatrixSettings = {
 	maxSample?: number
 	svgCanvasSwitch?: number
@@ -1019,6 +1028,11 @@ type NumericDictTermCluster = {
 type Survival = {
 	/** default settings for survival plot */
 	settings?: SurvivalSettings
+}
+
+type Regression = {
+	/** default settings for regression */
+	settings?: RegressionSettings
 }
 
 type MatrixPlotsEntry = {
@@ -1132,17 +1146,13 @@ keep this setting here for reason of:
 	matrix?: Matrix
 	numericDictTermCluster?: NumericDictTermCluster
 	survival?: Survival
+	regression?: Regression
 	logscaleBase2?: boolean
 	plotConfigByCohort?: PlotConfigByCohort
 	/** Functionality */
 	dataDownloadCatch?: DataDownloadCatch
 	helpPages?: URLEntry[]
 	multipleTestingCorrection?: MultipleTestingCorrection
-	/** regression settings for neuro-oncology portals:
-- no interaction terms
-- report event counts of cox coefficients
-- hide type III stats and miscellaneous statistical tests */
-	neuroOncRegression?: boolean
 	urlTemplates?: {
 		/** gene link definition */
 		gene?: UrlTemplateBase


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/2604

Handle the new `.regression.settings{}` object from dataset file in the regression code.

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/617


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
