### PR TITLE
Save subheader display option in the state

### DIFF
--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -24,7 +24,8 @@ const navHeaderModes = new Set([
 const defaultState = {
 	nav: {
 		header_mode: 'with_tabs',
-		activeTab: 0
+		activeTab: 0,
+		displaySubheader: true
 	},
 	// will be ignored if there is no dataset termdb.selectCohort
 	// or value will be set to match a filter node that has been tagged
@@ -238,6 +239,7 @@ TdbStore.prototype.actions = {
 	},
 	tab_set(action) {
 		this.state.nav.activeTab = action.activeTab
+		this.state.nav.displaySubheader = action.displaySubheader
 	},
 	cohort_set(action) {
 		this.state.activeCohort = action.activeCohort


### PR DESCRIPTION
## Description
Closes issue #2599. Whether or not the subheader should be shown is saved in the state. Test with http://localhost:3000/?noheader=1&massnative=hg38-test,TermdbTest -> click About tab -> Share session -> shouldn't see the subheader. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
