### PR TITLE
Violin and box plot route improvements

### DIFF
--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -197,6 +197,9 @@ tape('term1 as numeric and term2 categorical, test median rendering', function (
 	test.timeoutAfter(3000)
 	runpp({
 		state: {
+			nav: {
+				header_mode: 'hidden'
+			},
 			plots: [open_state]
 		},
 		violin: {
@@ -219,26 +222,20 @@ tape('term1 as numeric and term2 categorical, test median rendering', function (
 			count: 2
 		})
 		test.ok(median, 'Median exists')
-
 		test.equal(
 			median.length,
 			violin.Inner.data.plots.length,
 			'Number of median lines rendered should be/is equal to number of plots rendered'
 		)
-		const medianValues = median.map(
-			({
-				__data__: {
-					summaryStats: { values }
-				}
-			}) => {
-				const { value } = values.find(c => c.id === 'median')
-				return value
-			}
-		)
-		const sumStatsValues = violin.Inner.data.plots.map(({ summaryStats: { values } }) => {
-			const { value } = values.find(c => c.id === 'median')
+		const medianValues = median.map(({ __data__: { summaryStats } }) => {
+			const { value } = summaryStats.find(c => c.id === 'median')
 			return value
 		})
+		const sumStatsValues = violin.Inner.data.plots.map(({ summaryStats }) => {
+			const { value } = summaryStats.find(c => c.id === 'median')
+			return value
+		})
+
 		test.equal(
 			medianValues[0],
 			sumStatsValues[0],

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -1211,7 +1211,7 @@ tape('test uncomputable categories legend', function (test) {
 	}
 
 	async function testUncomputableCategories(violin, legendDiv) {
-		const keys = Object.keys(violin.Inner.data.uncomputableValueObj)
+		const keys = Object.keys(violin.Inner.data.uncomputableValues)
 		const categories = await detectGte({ elem: legendDiv.node(), selector: '.legend-row', count: 9 })
 		test.ok(categories, 'Uncomputable categories exist')
 
@@ -1223,7 +1223,7 @@ tape('test uncomputable categories legend', function (test) {
 				.find(c => c.__data__.text.startsWith(keys[0]))
 				?.__data__.text.split(',')
 				.pop(),
-			' n = ' + violin.Inner.data.uncomputableValueObj[keys[0]],
+			' n = ' + violin.Inner.data.uncomputableValues[keys[0]],
 			`Uncomputable category '${keys[0]}' rendered with the correct count`
 		)
 		test.equal(
@@ -1231,7 +1231,7 @@ tape('test uncomputable categories legend', function (test) {
 				.find(c => c.__data__.text.startsWith(keys[1]))
 				?.__data__.text.split(',')
 				.pop(),
-			' n = ' + violin.Inner.data.uncomputableValueObj[keys[1]],
+			' n = ' + violin.Inner.data.uncomputableValues[keys[1]],
 			`Uncomputable category '${keys[1]}' rendered with the correct count`
 		)
 	}

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -572,9 +572,9 @@ function addUncomputableValues(term, legendGrps, headingStyle, self) {
 	if (term?.term.values) {
 		const items = []
 		for (const k in term.term.values) {
-			if (self.data.uncomputableValueObj?.[term.term.values[k]?.label]) {
+			if (self.data.uncomputableValues?.[term.term.values[k]?.label]) {
 				items.push({
-					text: `${term.term.values[k].label}, n = ${self.data.uncomputableValueObj[term.term.values[k].label]}`,
+					text: `${term.term.values[k].label}, n = ${self.data.uncomputableValues[term.term.values[k].label]}`,
 					noIcon: true,
 					/** Need to specify that this is a hidden value for
 					 * text styling in the legend but not a plot to avoid

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -3,7 +3,7 @@ import { scaleLinear, scaleLog } from 'd3-scale'
 import { curveBasis, line } from 'd3-shape'
 import { getColors } from '#shared/common.js'
 import { brushX, brushY } from 'd3-brush'
-import { renderTable, Menu } from '#dom'
+import { renderTable, Menu, table2col } from '#dom'
 import { rgb } from 'd3'
 import { format as d3format } from 'd3-format'
 import { TermTypes } from '#shared/terms.js'
@@ -75,19 +75,18 @@ export default function setViolinRenderer(self) {
 
 	self.displaySummaryStats = function (d, event, tip) {
 		if (!d.summaryStats) return
+		tip.clear().show(event.clientX, event.clientY)
 
-		const rows = [
-			`<tr><td colspan=2 style='padding:3px; text-align:center'>${d.label.split(',')[0]}</td></tr>`,
-			...d.summaryStats.map(
-				({ id, label, value }) => `<tr>
-				<td style='padding:3px; color:#aaa'>${label}</td>
-				<td style='padding:3px; text-align:center'>${value}</td>
-			</tr>`
-			)
-		]
-
-		const tableHtml = `<table class='sja_simpletable'>${rows.join('')}</table>`
-		tip.show(event.clientX, event.clientY).d.html(tableHtml)
+		const table = table2col({ holder: tip.d.append('div') })
+		//Sample label
+		const [th1, _] = table.addRow()
+		th1.attr('colspan', '2').style('color', 'black').style('text-align', 'center').text(d.label)
+		//Summary stat rows
+		for (const stat of d.summaryStats) {
+			const [td1, td2] = table.addRow()
+			td1.text(stat.label)
+			td2.style('text-align', 'center').text(stat.value ?? 0)
+		}
 	}
 
 	self.getPlotThickness = function () {

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -77,7 +77,7 @@ export default function setViolinRenderer(self) {
 		let rows = []
 
 		if (d.summaryStats) {
-			const summaryValues = d.summaryStats.values
+			const summaryValues = d.summaryStats
 
 			rows = [
 				`<tr><td colspan=2 style='padding:3px; text-align:center'>${d.label.split(',')[0]}</td></tr>`,
@@ -416,22 +416,10 @@ export default function setViolinRenderer(self) {
 				.style('stroke-width', s.medianThickness)
 				.style('stroke', 'red')
 				.style('opacity', '1')
-				.attr(
-					'y1',
-					isH ? -s.medianLength : svgData.axisScale(plot.summaryStats.values.find(x => x.id === 'median').value)
-				)
-				.attr(
-					'y2',
-					isH ? s.medianLength : svgData.axisScale(plot.summaryStats.values.find(x => x.id === 'median').value)
-				)
-				.attr(
-					'x1',
-					isH ? svgData.axisScale(plot.summaryStats.values.find(x => x.id === 'median').value) : -s.medianLength
-				)
-				.attr(
-					'x2',
-					isH ? svgData.axisScale(plot.summaryStats.values.find(x => x.id === 'median').value) : s.medianLength
-				)
+				.attr('y1', isH ? -s.medianLength : svgData.axisScale(plot.summaryStats.find(x => x.id === 'median').value))
+				.attr('y2', isH ? s.medianLength : svgData.axisScale(plot.summaryStats.find(x => x.id === 'median').value))
+				.attr('x1', isH ? svgData.axisScale(plot.summaryStats.find(x => x.id === 'median').value) : -s.medianLength)
+				.attr('x2', isH ? svgData.axisScale(plot.summaryStats.find(x => x.id === 'median').value) : s.medianLength)
 		} else return
 	}
 

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -74,21 +74,17 @@ export default function setViolinRenderer(self) {
 	}
 
 	self.displaySummaryStats = function (d, event, tip) {
-		let rows = []
+		if (!d.summaryStats) return
 
-		if (d.summaryStats) {
-			const summaryValues = d.summaryStats
-
-			rows = [
-				`<tr><td colspan=2 style='padding:3px; text-align:center'>${d.label.split(',')[0]}</td></tr>`,
-				...summaryValues.map(
-					({ id, label, value }) => `<tr>
-					<td style='padding:3px; color:#aaa'>${label}</td>
-					<td style='padding:3px; text-align:center'>${value}</td>
-				</tr>`
-				)
-			]
-		}
+		const rows = [
+			`<tr><td colspan=2 style='padding:3px; text-align:center'>${d.label.split(',')[0]}</td></tr>`,
+			...d.summaryStats.map(
+				({ id, label, value }) => `<tr>
+				<td style='padding:3px; color:#aaa'>${label}</td>
+				<td style='padding:3px; text-align:center'>${value}</td>
+			</tr>`
+			)
+		]
 
 		const tableHtml = `<table class='sja_simpletable'>${rows.join('')}</table>`
 		tip.show(event.clientX, event.clientY).d.html(tableHtml)

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -181,7 +181,7 @@ export function parseValues(q: any, data: ValidGetDataResponse, sampleType: stri
 	let absMin: number | null = null,
 		absMax: number | null = null
 
-	for (const val of Object.values(data.samples as Record<string, { key: number; value: number }>)) {
+	for (const val of Object.values(data.samples)) {
 		const value = val[q.tw.$id]
 		if (!Number.isFinite(value?.value)) continue
 

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -136,7 +136,7 @@ function divideValues(q: ViolinRequest, data: ValidGetDataResponse, sampleType: 
 		key2values,
 		min: absMin,
 		max: absMax,
-		uncomputableValueObj: sortObj(uncomputableValues)
+		uncomputableValues: sortObj(uncomputableValues)
 	}
 }
 
@@ -175,7 +175,6 @@ function setResponse(valuesObject: any, data: ValidGetDataResponse, q: ViolinReq
 		plotValueCount: number
 		color?: string
 		divideTwBins?: any
-		uncomputableValueObj?: { [index: string]: number } | null
 	}[] = []
 
 	for (const [key, values] of sortKey2values(data, valuesObject.key2values, overlayTerm)) {
@@ -186,9 +185,7 @@ function setResponse(valuesObject: any, data: ValidGetDataResponse, q: ViolinReq
 				seriesId: key,
 				plotValueCount: values?.length,
 				color: overlayTerm?.term?.values?.[key]?.color || null,
-				divideTwBins: isNumericTerm(overlayTerm.term) ? numericBins(overlayTerm, data) : null,
-				uncomputableValueObj:
-					Object.keys(valuesObject.uncomputableValueObj).length > 0 ? valuesObject.uncomputableValueObj : null
+				divideTwBins: isNumericTerm(overlayTerm.term) ? numericBins(overlayTerm, data) : null
 			})
 		} else {
 			const plot = {
@@ -206,8 +203,7 @@ function setResponse(valuesObject: any, data: ValidGetDataResponse, q: ViolinReq
 		max: valuesObject.max,
 		plots,
 		pvalues: [],
-		uncomputableValueObj:
-			Object.keys(valuesObject.uncomputableValueObj).length > 0 ? valuesObject.uncomputableValueObj : null
+		uncomputableValues: Object.keys(valuesObject.uncomputableValues).length > 0 ? valuesObject.uncomputableValues : null
 	}
 
 	return result

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -188,13 +188,11 @@ function setResponse(valuesObject: any, data: ValidGetDataResponse, q: ViolinReq
 				divideTwBins: isNumericTerm(overlayTerm.term) ? numericBins(overlayTerm, data) : null
 			})
 		} else {
-			const plot = {
+			plots.push({
 				label: sampleType,
 				values,
 				plotValueCount: values.length
-			}
-
-			plots.push(plot)
+			})
 		}
 	}
 
@@ -279,11 +277,10 @@ function createCanvasImg(q: ViolinRequest, result: { [index: string]: any }, ds:
 
 		plot.src = canvas.toDataURL()
 		// create bins for violins
-		const isKDE = q.isKDE
-		plot.density = getBinsDensity(axisScale, plot, isKDE, q.ticks)
+		plot.density = getBinsDensity(axisScale, plot, q.isKDE, q.ticks)
 
 		//generate summary stat values
-		plot.summaryStats = summaryStats(plot.values)
+		plot.summaryStats = summaryStats(plot.values).values
 		delete plot.values
 	}
 }

--- a/server/routes/test/README.md
+++ b/server/routes/test/README.md
@@ -1,0 +1,5 @@
+# Testing reusable functions in routes
+DO NOT create test scripts for the route request and response here! Use .examples[{request:{}, response:{}}]
+in the RoutePayload (see examples in shared/types/src/routes/* files)
+
+Instead, create test scripts for reusable functions in route code here. 

--- a/server/routes/test/parseValues.unit.spec.ts
+++ b/server/routes/test/parseValues.unit.spec.ts
@@ -1,0 +1,93 @@
+import tape from 'tape'
+import { termjson } from '../../test/testdata/termjson.js'
+import { parseValues } from '../termdb.boxplot.ts'
+
+/**
+ * Tests
+ *  - parseValues()
+ */
+
+const mockTerm1$id = 'ansdkfljas-+'
+const mockTerm2$id = 'asldkfj-+'
+const mockSampleType = 'All samples'
+
+const mockRequest = {
+	tw: { term: termjson.agedx, $id: mockTerm1$id },
+	overlayTw: { term: termjson.sex, $id: mockTerm2$id }
+}
+
+const mockGetDataResponse = {
+	sampleType: {
+		plural_name: 'samples'
+	},
+	refs: {
+		bySampleId: {},
+		byTermId: {}
+	},
+	samples: {
+		1: {
+			sample: '80',
+			[mockTerm1$id]: { key: 1, value: 1 },
+			[mockTerm2$id]: { key: 'Male', value: 'M' }
+		},
+		2: {
+			sample: '81',
+			[mockTerm1$id]: { key: 1.75, value: 1.75 },
+			[mockTerm2$id]: { key: 'Female', value: 'F' }
+		},
+		3: {
+			sample: '82',
+			[mockTerm1$id]: { key: 3, value: 3 },
+			[mockTerm2$id]: { key: 'Female', value: 'F' }
+		},
+		4: {
+			sample: '83',
+			[mockTerm1$id]: { key: -1, value: -1 },
+			[mockTerm2$id]: { key: 'Male', value: 'M' }
+		}
+	}
+}
+
+tape('parseValues()', test => {
+	test.timeoutAfter(100)
+
+	let result, key2valuesMap, expected
+
+	result = parseValues(mockRequest, mockGetDataResponse as any, mockSampleType, false)
+	key2valuesMap = new Map()
+	key2valuesMap.set(mockSampleType, [1, 1.75, 3, -1])
+	expected = {
+		absMax: 3,
+		absMin: -1,
+		key2values: key2valuesMap,
+		uncomputableValues: {}
+	}
+	test.deepEqual(result, expected, 'Should parse all values correctly')
+
+	result = parseValues(mockRequest, mockGetDataResponse as any, mockSampleType, true)
+	key2valuesMap = new Map()
+	key2valuesMap.set(mockSampleType, [1, 1.75, 3])
+	expected = {
+		absMax: 3,
+		absMin: 1,
+		key2values: key2valuesMap,
+		uncomputableValues: {}
+	}
+
+	test.deepEqual(result, expected, 'Should parse values correctly and remove negative values for log scales')
+
+	result = parseValues(mockRequest, mockGetDataResponse as any, mockSampleType, false, mockRequest.overlayTw)
+	key2valuesMap = new Map()
+	key2valuesMap.set('Male', [1, -1])
+	key2valuesMap.set('Female', [1.75, 3])
+	expected = {
+		absMax: 3,
+		absMin: -1,
+		key2values: key2valuesMap,
+		uncomputableValues: {}
+	}
+
+	test.deepEqual(result, expected, 'Should create key2values map for overlay term')
+
+	test.end()
+})

--- a/server/test/testdata/termjson.js
+++ b/server/test/testdata/termjson.js
@@ -1,4 +1,4 @@
-exports.termjson = {
+export const termjson = {
 	diaggrp: {
 		id: 'diaggrp',
 		name: 'Diagnosis Group',
@@ -69,6 +69,7 @@ exports.termjson = {
 				}
 			}
 		},
+		values: {},
 		isleaf: true
 	},
 	Arrhythmias: {
@@ -106,13 +107,13 @@ exports.termjson = {
 			}
 		},
 		values: {
-			'0': { label: '0: No condition' },
-			'1': { label: '1: Mild' },
-			'2': { label: '2: Moderate' },
-			'3': { label: '3: Severe' },
-			'4': { label: '4: Life-threatening' },
-			'5': { label: '5: Death' },
-			'9': { label: 'Unknown status', uncomputable: true }
+			0: { label: '0: No condition' },
+			1: { label: '1: Mild' },
+			2: { label: '2: Moderate' },
+			3: { label: '3: Severe' },
+			4: { label: '4: Life-threatening' },
+			5: { label: '5: Death' },
+			9: { label: 'Unknown status', uncomputable: true }
 		}
 	},
 	aaclassic_5: {
@@ -136,7 +137,7 @@ exports.termjson = {
 			}
 		},
 		values: {
-			'0': { label: 'Not exposed', uncomputable: true },
+			0: { label: 'Not exposed', uncomputable: true },
 			'-8888': { label: 'Exposed but dose unknown', uncomputable: true },
 			'-9999': { label: 'Unknown treatment record', uncomputable: true }
 		},
@@ -169,7 +170,7 @@ exports.termjson = {
 			}
 		},
 		values: {
-			'0': { label: 'Not exposed', uncomputable: true },
+			0: { label: 'Not exposed', uncomputable: true },
 			'-8888': { label: 'Exposed but dose unknown', uncomputable: true },
 			'-9999': { label: 'Unknown treatment record', uncomputable: true }
 		}
@@ -210,13 +211,13 @@ exports.termjson = {
 			}
 		},
 		values: {
-			'0': { label: '0: No condition' },
-			'1': { label: '1: Mild' },
-			'2': { label: '2: Moderate' },
-			'3': { label: '3: Severe' },
-			'4': { label: '4: Life-threatening' },
-			'5': { label: '5: Death' },
-			'9': { label: 'Unknown status', uncomputable: true }
+			0: { label: '0: No condition' },
+			1: { label: '1: Mild' },
+			2: { label: '2: Moderate' },
+			3: { label: '3: Severe' },
+			4: { label: '4: Life-threatening' },
+			5: { label: '5: Death' },
+			9: { label: 'Unknown status', uncomputable: true }
 		}
 	}
 }

--- a/shared/types/src/routes/termdb.boxplot.ts
+++ b/shared/types/src/routes/termdb.boxplot.ts
@@ -62,11 +62,11 @@ export type BoxPlotData = {
 }
 
 export type BoxPlotDescrStatsEntry = {
-	/** Use lower case for sanity check
-	 * 'total' | 'min' | 'p25' | 'median' | 'mean' | 'p75' | 'max' | 'sd' | 'variance' | 'iqr'
-	 */
-	id: string
+	/** Short hand for summary stat. Use lower case for sanity check */
+	id: 'total' | 'min' | 'p25' | 'median' | 'mean' | 'p75' | 'max' | 'sd' | 'variance' | 'iqr' | string
+	/** Full label displayed to the user */
 	label: string
+	/** Calculated value. */
 	value: number
 }
 

--- a/shared/types/src/routes/termdb.violin.ts
+++ b/shared/types/src/routes/termdb.violin.ts
@@ -89,10 +89,8 @@ export type ViolinPlotEntry = {
 	seriesId: string
 	/** Plot image to display */
 	src: string
-	summaryStats: {
-		/** Descriptive stats (i.e. min, max, sd, etc.) */
-		values: ValuesEntries[]
-	}
+	/** Descriptive stats (i.e. min, max, sd, etc.) */
+	summaryStats: ValuesEntries[]
 }
 
 export type ViolinResponse = ValidResponse | ErrorResponse

--- a/shared/types/src/routes/termdb.violin.ts
+++ b/shared/types/src/routes/termdb.violin.ts
@@ -93,7 +93,6 @@ export type ViolinPlotEntry = {
 		/** Descriptive stats (i.e. min, max, sd, etc.) */
 		values: ValuesEntries[]
 	}
-	uncomputableValueObj: { [index: string]: number } | null
 }
 
 export type ViolinResponse = ValidResponse | ErrorResponse
@@ -105,7 +104,7 @@ type ValidResponse = {
 	max: number
 	plots: ViolinPlotEntry[]
 	pvalues?: PValueEntries[][]
-	uncomputableValueObj: { [index: string]: number }[] | null
+	uncomputableValues: { [index: string]: number }[] | null
 }
 
 export const violinPayload: RoutePayload = {

--- a/shared/types/src/termdb.matrix.ts
+++ b/shared/types/src/termdb.matrix.ts
@@ -6,20 +6,21 @@
  * Use this type for that purpose.
  */
 
+type SampleEntry = {
+	/** stringified integer sample id  */
+	sample: string | number
+} & {
+	/** key and values for terms, separated by tw.$id */
+	[index: string]: {
+		key: number
+		value: number
+	}
+}
+
 export type ValidGetDataResponse = {
-	samples: Record<
-		string,
-		{
-			/** stringified integer sample id  */
-			key: number
-			/** value: { 
-			sample: integerId,
-			<tw.$id>: {key, value},
-			<more terms...>
-		} */
-			value: number
-		}
-	>
+	samples: {
+		[index: string | number]: SampleEntry
+	}
 	/** Metadata */
 	refs: {
 		/** metadata about terms


### PR DESCRIPTION
## Description
Continuation of https://github.com/stjude/proteinpaint/issues/2589. Removed data unnecessarily returned in the violin response and cleaned up the response object further. Added a unit test for the shared `parseValues` function. 

Test with any box plot and/or violin example from http://localhost:3000/url.html. Also for the new unit tests, run: 
```
cd proteinpaint
npm run test:unit --workspace="server"
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
