### PR TITLE
Turn $id into mandatory term wrapper attribute

### DIFF
--- a/client/termsetting/handlers/snplst.ts
+++ b/client/termsetting/handlers/snplst.ts
@@ -19,6 +19,7 @@ and prevent snps from being included in regression request string
 instance attributes
 
 self.term{}
+	.$id: str
 	.id: str, not really used
 	.type: "snplst"
 	.snps[ {} ]
@@ -608,9 +609,14 @@ async function makeSampleSummary(self) {
 
 	const filter = { type: 'tvslst', join: 'and', lst: [...extraFilters] }
 	if (f) filter.lst.push(f)
-
 	const data = await self.vocabApi.getCategories(self.term as SnpsTerm, filter, body)
-	mayRunSnplstTask({ term: self.term as SnpsTerm, q: self.q as SnpsQ }, data)
+	mayRunSnplstTask(
+		{
+			term: self.term as SnpsTerm,
+			q: self.q as SnpsQ
+		} as any, //quick fix for $id being required in BaseTw type
+		data
+	)
 }
 
 function validateQ(data: any) {

--- a/client/tw/test/TwRouter.integration.spec.ts
+++ b/client/tw/test/TwRouter.integration.spec.ts
@@ -66,6 +66,7 @@ async function getTws() {
 	const twlst: TermWrapper[] = [
 		await TwRouter.fill({ id: 'sex' }, { vocabApi }),
 		{
+			$id: 'test.$id',
 			type: 'CatTWPredefinedGS',
 			term: getTermWithGS(),
 			isAtomic: true as const,

--- a/client/tw/test/TwRouter.unit.spec.ts
+++ b/client/tw/test/TwRouter.unit.spec.ts
@@ -129,7 +129,7 @@ tape('initRaw() categorical', async test => {
 		)
 		test.deepEqual(
 			Object.keys(xtw).sort(),
-			['isAtomic', 'q', 'term', 'type'],
+			['$id', 'isAtomic', 'q', 'term', 'type'],
 			`should have the expected enumerable keys`
 		)
 	}
@@ -155,7 +155,7 @@ tape('initRaw() categorical', async test => {
 		)
 		test.deepEqual(
 			Object.keys(xtw).sort(),
-			['isAtomic', 'q', 'term', 'type'],
+			['$id', 'isAtomic', 'q', 'term', 'type'],
 			`should have the expected enumerable keys`
 		)
 	}

--- a/client/tw/test/TwRouter.unit.spec.ts
+++ b/client/tw/test/TwRouter.unit.spec.ts
@@ -104,6 +104,7 @@ tape('initRaw() categorical', async test => {
 	{
 		const term = getTermWithGS()
 		const tw: RawCatTW = {
+			$id: 'test.$id',
 			term,
 			isAtomic: true as const,
 			q: {}
@@ -115,6 +116,7 @@ tape('initRaw() categorical', async test => {
 	{
 		const term = getTermWithGS()
 		const tw: RawCatTW = {
+			$id: 'test.$id',
 			term,
 			isAtomic: true as const,
 			q: { type: 'predefined-groupset', isAtomic: true as const, predefined_groupset_idx: 0 }
@@ -135,6 +137,7 @@ tape('initRaw() categorical', async test => {
 	{
 		const term = getTermWithGS()
 		const tw: RawCatTW = {
+			$id: 'test.$id',
 			term,
 			isAtomic: true as const,
 			q: {

--- a/client/tw/test/categorical.unit.spec.ts
+++ b/client/tw/test/categorical.unit.spec.ts
@@ -69,6 +69,7 @@ tape('\n', function (test) {
 tape('fill(invalid tw)', async test => {
 	// not typing with RawCatTW since these are not valid fill() argument
 	const tw = {
+		$id: 'test.$id',
 		term: { id: 'abc', type: 'integer' }
 	}
 	{
@@ -86,6 +87,7 @@ tape('fill(invalid tw)', async test => {
 
 tape(`fill() default q.type='values'`, async test => {
 	const tw: RawCatTW = {
+		$id: 'test.$id',
 		term: termjson.diaggrp,
 		q: { isAtomic: true },
 		isAtomic: true
@@ -96,6 +98,7 @@ tape(`fill() default q.type='values'`, async test => {
 		test.deepEqual(
 			fullTw,
 			{
+				$id: 'test.$id',
 				term: tw.term,
 				q: {
 					type: 'values',
@@ -118,6 +121,7 @@ tape(`fill() default q.type='values'`, async test => {
 tape('fill() predefined-groupset', async test => {
 	const term = getTermWithGS()
 	const tw: RawCatTW = {
+		$id: 'test.$id',
 		term,
 		q: { isAtomic: true, type: 'predefined-groupset', predefined_groupset_idx: 0 },
 		isAtomic: true
@@ -128,6 +132,7 @@ tape('fill() predefined-groupset', async test => {
 		test.deepEqual(
 			fullTw,
 			{
+				$id: 'test.$id',
 				term: tw.term,
 				q: {
 					type: 'predefined-groupset',
@@ -150,6 +155,7 @@ tape('fill() predefined-groupset', async test => {
 
 tape('fill() custom-groupset', async test => {
 	const tw: RawCatTW = {
+		$id: 'test.$id',
 		term: termjson.diaggrp,
 		q: {
 			isAtomic: true,
@@ -161,6 +167,7 @@ tape('fill() custom-groupset', async test => {
 	}
 
 	const expected = {
+		$id: 'test.$id',
 		term: tw.term, // term is not filled-in, so ok to reuse raw tw.term here
 		q: {
 			isAtomic: true,

--- a/client/tw/test/fake/app.ts
+++ b/client/tw/test/fake/app.ts
@@ -36,6 +36,7 @@ export class FakeApp {
 			below works, see the detailed examples and explanations in
 			https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
 		*/
+		if (!tw.$id) tw.$id = 'test.$id'
 		if (!tw.type) throw `missing tw.type`
 		if (tw.type in addons) {
 			// example using addons

--- a/client/tw/test/numeric.xtw.unit.spec.ts
+++ b/client/tw/test/numeric.xtw.unit.spec.ts
@@ -39,6 +39,7 @@ tape('fill(invalid tw)', async test => {
 
 tape(`fill() default q.type='regular-bin'`, async test => {
 	const tw: RawNumTW = {
+		$id: 'test.$id',
 		term: termjson.agedx,
 		q: { isAtomic: true },
 		isAtomic: true
@@ -72,6 +73,7 @@ tape(`fill() default q.type='regular-bin'`, async test => {
 
 tape.skip(`fill() q.type=custom-bin opts.defaultQ.preferredBins='median'`, async test => {
 	const tw: RawNumTW = {
+		$id: 'test.$id',
 		term: termjson.agedx,
 		q: {
 			type: 'custom-bin',

--- a/shared/types/src/terms/term.ts
+++ b/shared/types/src/terms/term.ts
@@ -147,7 +147,7 @@ export type TermGroupSetting =
 
 export type BaseTW = {
 	id?: string
-	$id?: string
+	$id: string
 	isAtomic?: true
 	// plot-specific customizations that are applied to a tw copy
 	// todo: should rethink these


### PR DESCRIPTION
## Description
Addresses failures from integrations test last night as well as reflects the current usage of `tw.$id`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
