### PR TITLE
SC cluster aliases

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -612,7 +612,7 @@ class singleCellPlot {
 		const uniqueColorColumns = new Set()
 		if (this.dom.colorBySelect) {
 			this.dom.colorBySelect.selectAll('*').remove()
-			for (const plot of this.state.termdbConfig?.queries.singleCell.data.plots) {
+			for (const plot of this.state.config.plots) {
 				const colorColumn = this.state.config.colorBy?.[plot.name] || plot.colorColumns[0]
 				if (!uniqueColorColumns.has(colorColumn) && plot.selected) {
 					this.dom.colorBySelect.append('option').text(colorColumn)
@@ -851,6 +851,8 @@ class singleCellPlot {
 		const step = 20
 		let y = 50
 		let x = 0
+		const configPlot = this.state.config.plots.find(p => p.name == plot.name)
+		const aliases = configPlot.colorColumns.find(c => c.name == plot.colorBy)?.aliases
 		for (const cluster in colorMap) {
 			const clusterCells = plot.cells.filter(item => item.category == cluster)
 			const hidden = this.config.hiddenClusters.includes(cluster)
@@ -868,6 +870,8 @@ class singleCellPlot {
 							? this.state.termdbConfig.queries.singleCell.data.refName
 							: cluster == 'query'
 							? this.state.config.sample
+							: aliases
+							? aliases[cluster]
 							: cluster
 					} n=${n}`
 				)

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -869,7 +869,7 @@ class singleCellPlot {
 						cluster == 'ref'
 							? this.state.termdbConfig.queries.singleCell.data.refName
 							: cluster == 'query'
-							? this.state.config.sample
+							? this.state.config.sample || this.samples[0].sample
 							: aliases
 							? aliases[cluster]
 							: cluster

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -684,6 +684,7 @@ class singleCellPlot {
 	renderPlots(result) {
 		this.dom.plotsDiv.selectAll('*').remove()
 		this.plots = []
+		if (result.nodata) return
 		for (const plot of result.plots) {
 			this.plots.push(plot)
 			const expCells = plot.expCells.sort((a, b) => a.geneExp - b.geneExp)

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -265,7 +265,7 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 				refName: q.singleCell.data.refName,
 				settings: q.singleCell.data.settings,
 				plots: q.singleCell.data.plots.map(p => {
-					return { name: p.name, colorColumns: p.colorColumns.map(c => c.name), selected: p.selected }
+					return { name: p.name, colorColumns: p.colorColumns, selected: p.selected }
 				})
 			}
 		}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -641,6 +641,7 @@ type ColorColumn = {
 	name: string
 	/** column values (categories) to color mapping */
 	colorMap?: { [index: string]: string }
+	aliases?: { [index: string]: string }
 }
 
 /** defines a tsne type of plot for cells from one sample */


### PR DESCRIPTION
## Description

Allowed to define aliases for clusters to show in legend. It allows to show the projection legend as requested by Ilaria. Fixed bugs. See corresponding [PR](https://github.com/stjude/sjpp/pull/626).
Please check if the plot conveys what she wanted:

<img width="1319" alt="Screenshot 2025-01-21 at 7 45 00 PM" src="https://github.com/user-attachments/assets/ae9304e1-acfc-40bb-8342-033ad91f2b1b" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
