### PR TITLE
return a boolean and not session info from the isInSession() helper

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -317,8 +317,15 @@ export function setAuth(opts) {
 	includeEmbedder = opts.dsAuth?.length > 0 || false
 }
 
+// check if a user is logged in, usually checked together with requiredAuth in termdb/config,
+// so access to unprotected ds/routes should not be affected by this check
 export function isInSession(dslabel, route) {
-	return dslabel && [...dsAuthOk].find(d => d.dslabel == dslabel && d.route == route)
+	if (!dslabel) return false
+	for (const a of dsAuthOk) {
+		if (a.dslabel == dslabel && a.route == route) return true
+	}
+	// no matching sessions found for this dslabel and route
+	return false
 }
 
 /* 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1,6 +1,6 @@
 import { q_to_param } from './vocabulary'
 import { Vocab } from './Vocab'
-import { dofetch3, isInSession } from '../common/dofetch'
+import { dofetch3 } from '../common/dofetch'
 import { getNormalRoot } from '#filter'
 import { isUsableTerm, graphableTypes } from '#shared/termdb.usecase.js'
 import { throwMsgWithFilePathAndFnName } from '../dom/sayerror'


### PR DESCRIPTION
## Description

This will avoid calling the optional `getDatasetAccessToken()` if a user is already logged in. Can check using http://localhost:3000/profile/?role=admin: in the browser's Network tab, there should only be one request to `/jwt-status`, and `sjpp/public/profile/index.html` should not need a `getDatasetAccessToken()` argument, since there is already a `login()` function there. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
