### PR TITLE
Correlation volcano plot feature requests

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -52,7 +52,7 @@ class MassCharts {
 		if (lst.includes('linear')) ms.push('linear')
 		if (lst.includes('logistic')) ms.push('logistic')
 		if (lst.includes('cox')) ms.push('cox')
-		if (ms.length > 1) return 'Regresison Analysis' // more than 1 methods. return general name
+		if (ms.length > 1) return 'Regression Analysis' // more than 1 methods. return general name
 		// only 1 method
 		return `${ms[0] == 'linear' ? 'Linear' : ms[0] == 'cox' ? 'Cox' : 'Logistic'} Regression`
 	}

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -313,6 +313,11 @@ function getChartTypeList(self, state) {
 			label: state.termdbConfig.numericDictTermCluster?.appName || 'Numeric Dictionary Term cluster',
 			chartType: 'numericDictTermCluster',
 			clickTo: self.loadChartSpecificMenu
+		},
+		{
+			label: 'Correlation Volcano',
+			chartType: 'correlationVolcano',
+			clickTo: self.loadChartSpecificMenu
 		}
 	]
 

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -317,7 +317,8 @@ function getChartTypeList(self, state) {
 		{
 			label: 'Correlation Volcano',
 			chartType: 'correlationVolcano',
-			clickTo: self.loadChartSpecificMenu
+			usecase: { target: 'correlationVolcano', detail: 'numeric' },
+			clickTo: self.showTree_select1term
 		}
 	]
 

--- a/client/mass/types/mass.ts
+++ b/client/mass/types/mass.ts
@@ -106,7 +106,7 @@ type MassNav = {
 
 export type BasePlotConfig = {
 	chartType: string
-	groups: any[]
+	groups?: any[]
 	id: string
 	term?: any //TermWrapper
 	term2?: any //

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -703,6 +703,7 @@ async function setTermInput(opts) {
 		usecase: opts.usecase,
 		getBodyParams: opts.getBodyParams,
 		defaultQ4fillTW: opts.defaultQ4fillTW,
+		geneVariantEditMenuOnlyGrp: opts.geneVariantEditMenuOnlyGrp,
 		callback: async tw => {
 			// showing "processing data ..."" before pill is set
 			if (opts.parent.dom.loadingDiv && opts.parent.dom.svg) {

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -36,6 +36,7 @@ export type CorrVolcanoDom = {
 	svg: SvgSvg
 	title: SvgText
 	tip: Menu
+	xAxisLabel: SvgText
 	yAxisLabel: SvgText
 }
 
@@ -65,7 +66,8 @@ class CorrelationVolcano extends RxComponentInner {
 			plot: svg.append('g'),
 			title: svg.append('text'),
 			yAxisLabel: svg.append('text'),
-			legend: div.append('svg'),
+			xAxisLabel: svg.append('text'),
+			legend: div.append('svg').style('display', 'inline-block'),
 			tip: new Menu({ padding: '' })
 		}
 		if (opts.header)
@@ -97,10 +99,9 @@ class CorrelationVolcano extends RxComponentInner {
 				type: 'term',
 				configKey: 'featureTw',
 				chartType: 'correlationVolcano',
-				usecase: { target: 'correlationVolcano', detail: 'featureTw' },
-				label: 'Gene',
+				usecase: { target: 'correlationVolcano', detail: 'numeric' },
+				label: 'Feature',
 				vocabApi: this.app.vocabApi,
-				geneVariantEditMenuOnlyGrp: true,
 				menuOptions: 'replace'
 			},
 			{

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -30,8 +30,9 @@ export type CorrVolcanoDom = {
 	controls: Elem
 	div: Elem
 	error: Elem
-	svg: SvgSvg
+	legend: SvgG
 	plot: SvgG
+	svg: SvgSvg
 	title: SvgText
 	tip: Menu
 	yAxisLabel: SvgText
@@ -61,6 +62,7 @@ class CorrelationVolcano extends RxComponentInner {
 			plot: svg.append('g'),
 			title: svg.append('text'),
 			yAxisLabel: svg.append('text'),
+			legend: div.append('svg'),
 			tip: new Menu({ padding: '' })
 		}
 		this.dsCorrVolcano = {}

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -17,6 +17,7 @@ import { CorrVolcanoInteractions } from './interactions/CorrVolcanoInteractions'
 
 export type CorrVolcanoSettings = {
 	height: number
+	isAdjustedPValue: boolean
 	method: 'pearson' | 'spearman'
 	width: number
 }
@@ -95,6 +96,17 @@ class CorrelationVolcano extends RxComponentInner {
 				]
 			},
 			{
+				label: 'P value',
+				title: 'Change the p value',
+				type: 'radio',
+				chartType: 'correlationVolcano',
+				settingsKey: 'isAdjustedPValue',
+				options: [
+					{ label: 'Adjusted', value: true },
+					{ label: 'Original', value: false }
+				]
+			},
+			{
 				label: 'Height',
 				title: 'Set the height of the plot',
 				type: 'number',
@@ -159,6 +171,7 @@ export const componentInit = corrVolcanoInit
 export function getDefaultCorrVolcanoSettings(overrides = {}) {
 	const defaults: CorrVolcanoSettings = {
 		height: 400,
+		isAdjustedPValue: false,
 		method: 'pearson',
 		width: 400
 	}

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -85,6 +85,16 @@ class CorrelationVolcano extends RxComponentInner {
 	async setControls() {
 		const inputs = [
 			{
+				type: 'term',
+				configKey: 'featureTw',
+				chartType: 'correlationVolcano',
+				usecase: { target: 'correlationVolcano', detail: 'featureTw' },
+				label: 'Gene',
+				vocabApi: this.app.vocabApi,
+				geneVariantEditMenuOnlyGrp: true,
+				menuOptions: 'replace'
+			},
+			{
 				label: 'Correlation method',
 				title: 'Correlation method',
 				type: 'radio',

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -161,7 +161,7 @@ class CorrelationVolcano extends RxComponentInner {
 		const viewModel = new ViewModel(config, data, settings, variableTwLst)
 
 		/** Render correlation volcano plot */
-		new View(this.dom, viewModel.viewData, interactions)
+		new View(this.dom, viewModel.viewData, interactions, settings)
 	}
 }
 

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -54,7 +54,7 @@ class CorrelationVolcano extends RxComponentInner {
 		}
 		const holder = opts.holder.classed('sjpp-corrVolcano-main', true)
 		const controls = opts.controls ? holder : holder.append('div')
-		const div = holder.append('div').style('padding', '5px')
+		const div = holder.append('div').style('padding', '5px').style('display', 'inline-block')
 		const errorDiv = div.append('div').attr('id', 'sjpp-corrVolcano-error').style('opacity', 0.75)
 		const svg = div.append('svg').style('display', 'inline-block').attr('id', 'sjpp-corrVolcano-svg')
 		this.dom = {

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -125,6 +125,20 @@ class CorrelationVolcano extends RxComponentInner {
 				chartType: 'correlationVolcano',
 				settingsKey: 'width',
 				debounceInterval: 500
+			},
+			{
+				label: 'Correlation color',
+				type: 'color',
+				chartType: 'correlationVolcano',
+				settingsKey: 'corrColor',
+				title: 'Color of correlated values'
+			},
+			{
+				label: 'Anticorrelation color',
+				type: 'color',
+				chartType: 'correlationVolcano',
+				settingsKey: 'antiCorrColor',
+				title: 'Color of anticorrelated values'
 			}
 		]
 
@@ -180,6 +194,8 @@ export const componentInit = corrVolcanoInit
 
 export function getDefaultCorrVolcanoSettings(overrides = {}) {
 	const defaults: CorrVolcanoSettings = {
+		antiCorrColor: '#ff0000', //red
+		corrColor: '#0000ff', //blue
 		isAdjustedPValue: false,
 		method: 'pearson',
 		threshold: 0.05,

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -82,7 +82,7 @@ class CorrelationVolcano extends RxComponentInner {
 			},
 			{
 				label: 'Correlation method',
-				title: 'Correlation method',
+				title: 'Change the correlation method',
 				type: 'radio',
 				chartType: 'correlationVolcano',
 				settingsKey: 'method',
@@ -103,8 +103,8 @@ class CorrelationVolcano extends RxComponentInner {
 				]
 			},
 			{
-				label: 'Significance cutoff',
-				title: 'Statistically significant p value',
+				label: 'Significant p value',
+				title: 'Set the significant p value threshold',
 				type: 'number',
 				chartType: 'correlationVolcano',
 				settingsKey: 'threshold',

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -154,13 +154,16 @@ class CorrelationVolcano extends RxComponentInner {
 		const config = structuredClone(this.state.config)
 		if (config.childType != this.type && config.chartType != this.type) return
 
-		const interactions = new CorrVolcanoInteractions(this.app, this.dom)
-
 		const settings = config.settings.correlationVolcano
+
+		//Fill the term wrapper for the drug list from the ds
 		const variableTwLst = this.dsCorrVolcano.variables.termIds.map((id: string) => {
 			return { id }
 		})
 		for (const t of variableTwLst) await fillTermWrapper(t, this.app.vocabApi)
+
+		const interactions = new CorrVolcanoInteractions(this.app, this.dom, this.id, variableTwLst)
+
 		/** Request data from the server*/
 		const model = new Model(config, this.state, this.app, settings, variableTwLst)
 		const data = await model.getData()

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -103,6 +103,14 @@ class CorrelationVolcano extends RxComponentInner {
 				]
 			},
 			{
+				label: 'Significance cutoff',
+				title: 'Statistically significant p value',
+				type: 'number',
+				chartType: 'correlationVolcano',
+				settingsKey: 'threshold',
+				debounceInterval: 0.05
+			},
+			{
 				label: 'Height',
 				title: 'Set the height of the plot',
 				type: 'number',
@@ -172,9 +180,10 @@ export const componentInit = corrVolcanoInit
 
 export function getDefaultCorrVolcanoSettings(overrides = {}) {
 	const defaults: CorrVolcanoSettings = {
-		height: 500,
 		isAdjustedPValue: false,
 		method: 'pearson',
+		threshold: 0.05,
+		height: 500,
 		width: 500
 	}
 	return Object.assign(defaults, overrides)

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -10,6 +10,11 @@ import { ViewModel } from './viewModel/ViewModel'
 import { View } from './view/View'
 import { CorrVolcanoInteractions } from './interactions/CorrVolcanoInteractions'
 
+/** TODO:
+ *  - Clean up noted tech debt
+ *  - Add tests
+ */
+
 class CorrelationVolcano extends RxComponentInner {
 	readonly type = 'correlationVolcano'
 	private components: { controls: any }
@@ -167,10 +172,10 @@ export const componentInit = corrVolcanoInit
 
 export function getDefaultCorrVolcanoSettings(overrides = {}) {
 	const defaults: CorrVolcanoSettings = {
-		height: 400,
+		height: 500,
 		isAdjustedPValue: false,
 		method: 'pearson',
-		width: 400
+		width: 500
 	}
 	return Object.assign(defaults, overrides)
 }

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -2,47 +2,17 @@ import { getCompInit, copyMerge } from '#rx'
 import { RxComponentInner } from '../../types/rx.d'
 import { fillTermWrapper } from '#termsetting'
 import type { BasePlotConfig, MassAppApi, MassState } from '#mass/types/mass'
-import type { Elem, SvgG, SvgSvg, SvgText } from '../../types/d3'
 import { controlsInit } from '../controls'
+import type { CorrVolcanoDom, CorrVolcanoOpts, CorrVolcanoSettings } from './CorrelationVolcanoTypes'
 import { Menu } from '#dom'
 import { Model } from './model/Model'
 import { ViewModel } from './viewModel/ViewModel'
 import { View } from './view/View'
 import { CorrVolcanoInteractions } from './interactions/CorrVolcanoInteractions'
 
-/**
- * TODOs:
- * - WILL DO ALL TYPING AFTER INITIAL PROTOTYPE
- */
-
-export type CorrVolcanoSettings = {
-	height: number
-	isAdjustedPValue: boolean
-	method: 'pearson' | 'spearman'
-	width: number
-}
-
-export type CorrVolcanoPlotConfig = BasePlotConfig & {
-	featureTw: any
-}
-
-export type CorrVolcanoDom = {
-	controls: Elem
-	div: Elem
-	error: Elem
-	header?: Elem
-	legend: SvgG
-	plot: SvgG
-	svg: SvgSvg
-	title: SvgText
-	tip: Menu
-	xAxisLabel: SvgText
-	yAxisLabel: SvgText
-}
-
 class CorrelationVolcano extends RxComponentInner {
 	readonly type = 'correlationVolcano'
-	components: { controls: any }
+	private components: { controls: any }
 	dom: CorrVolcanoDom
 	dsCorrVolcano: any
 	variableTwLst: any
@@ -59,7 +29,7 @@ class CorrelationVolcano extends RxComponentInner {
 		const errorDiv = div.append('div').attr('id', 'sjpp-corrVolcano-error').style('opacity', 0.75)
 		const svg = div.append('svg').style('display', 'inline-block').attr('id', 'sjpp-corrVolcano-svg')
 		this.dom = {
-			controls: controls.style('display', 'block') as Elem,
+			controls: controls.style('display', 'block'),
 			div,
 			error: errorDiv,
 			svg,
@@ -157,7 +127,7 @@ class CorrelationVolcano extends RxComponentInner {
 		})
 	}
 
-	async init(appState) {
+	async init(appState: MassState) {
 		await this.setControls()
 		//Hack because obj not returning in getState(). Will fix later.
 		this.dsCorrVolcano = appState.termdbConfig.correlationVolcano
@@ -205,11 +175,11 @@ export function getDefaultCorrVolcanoSettings(overrides = {}) {
 	return Object.assign(defaults, overrides)
 }
 
-export async function getPlotConfig(opts: any, app: MassAppApi) {
+export async function getPlotConfig(opts: CorrVolcanoOpts, app: MassAppApi) {
 	//Opts.numeric returned from tree search when clicking on charts button
 	//See logic in shared/utils/src/termdb.usecase.js for how tree is limited
 	//May change this later
-	if (opts.numeric && !opts.featureTw) opts.featureTw = opts.numeric.term
+	if (opts.numeric && !opts.featureTw) opts.featureTw = { term: opts.numeric.term } as any
 	if (!opts.featureTw) throw 'opts.featureTw{} missing [correlationVolcano getPlotConfig()]'
 	try {
 		await fillTermWrapper(opts.featureTw, app.vocabApi)

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -22,6 +22,9 @@ export type CorrVolcanoSettings = {
 	isAdjustedPValue: boolean
 	/** Correlation method */
 	method: 'pearson' | 'spearman'
+	/** statistically significant p value the user can alter
+	 * Default is 0.05 */
+	threshold: number
 	/** Desired width of the plot. */
 	width: number
 }
@@ -95,6 +98,12 @@ export type PlotDimensions = {
 		x: number
 		y1: number
 		y2: number
+	}
+	/** Line appearing at the threshold value */
+	thresholdLine: {
+		y: number
+		x1: number
+		x2: number
 	}
 }
 

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -77,13 +77,11 @@ export type PlotDimensions = {
 	}
 	/** Label below the x axis */
 	xAxisLabel: {
-		text: string
 		x: number
 		y: number
 	}
 	/** Label to the left of the y axis */
 	yAxisLabel: {
-		text: string
 		x: number
 		y: number
 	}

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -15,6 +15,10 @@ export type CorrVolcanoOpts = {
 }
 
 export type CorrVolcanoSettings = {
+	/** Color for anti correlated, negative values. Default is red. */
+	antiCorrColor: string
+	/** Color for correlated, positive values. Default is blue. */
+	corrColor: string
 	/** Desired height of the plot. */
 	height: number
 	/** User has the ability to switch between adjusted or original

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -1,0 +1,133 @@
+import type { TermWrapper } from '#types'
+import type { Elem, SvgG, SvgSvg, SvgText } from '../../types/d3.js'
+import type { Menu } from '#dom'
+import type { BasePlotConfig } from '#mass/types/mass'
+import type { ScaleLinear } from 'd3'
+
+export type CorrVolcanoOpts = {
+	chartType: 'correlationVolcano'
+	featureTw: TermWrapper
+	/** No featureTw is passed from the tree in charts button.
+	 * Use .numeric{} to create a featureTw.*/
+	numeric?: TermWrapper
+	/** Settings overrides */
+	overrides?: Partial<CorrVolcanoSettings>
+}
+
+export type CorrVolcanoSettings = {
+	/** Desired height of the plot. */
+	height: number
+	/** User has the ability to switch between adjusted or original
+	 * p values. When true, adjusted p values are used. */
+	isAdjustedPValue: boolean
+	/** Correlation method */
+	method: 'pearson' | 'spearman'
+	/** Desired width of the plot. */
+	width: number
+}
+
+export type CorrVolcanoPlotConfig = BasePlotConfig & {
+	/** Numeric term used to plot */
+	featureTw: TermWrapper
+}
+
+export type CorrVolcanoDom = {
+	/** Control panel to the left of the plot */
+	controls: Elem
+	/** Holder for the plot and legend */
+	div: Elem
+	/** Plot specific div for error messages. */
+	error: Elem
+	/** Sandbox header */
+	header?: Elem
+	/** Svg for legened items */
+	legend: SvgG
+	/** Plot. Contains everything except the axis labels and the title */
+	plot: SvgG
+	/** Holder for plot, axis labels, and title */
+	svg: SvgSvg
+	/** Text above the plot */
+	title: SvgText
+	/** Shared tooltip */
+	tip: Menu
+	/** Label appearing below the correlation axis */
+	xAxisLabel: SvgText
+	/** Label appearing to the left and vertically of the p value axis */
+	yAxisLabel: SvgText
+}
+
+export type PlotDimensions = {
+	/** Height and width of the svg */
+	svg: {
+		height: number
+		width: number
+	}
+	/** Title above the plot */
+	title: {
+		text: string
+		x: number
+		y: number
+	}
+	/** Label below the x axis */
+	xAxisLabel: {
+		text: string
+		x: number
+		y: number
+	}
+	/** Label to the left of the y axis */
+	yAxisLabel: {
+		text: string
+		x: number
+		y: number
+	}
+	xScale: {
+		scale: ScaleLinear<number, number>
+		x: number
+		y: number
+	}
+	yScale: {
+		scale: ScaleLinear<number, number>
+		x: number
+		y: number
+	}
+	/** Dashed line appearing at x = 0 */
+	divideLine: {
+		x: number
+		y1: number
+		y2: number
+	}
+}
+
+/** Attributes added to the response data */
+export type VariableItem = {
+	color: string
+	label: string
+	/** x coordinate */
+	x: number
+	/** y coordinate */
+	y: number
+	/** radius of the circle */
+	radius: number
+}
+
+/** Dimensions of sample size circles */
+export type LegendDataEntry = {
+	/** Coorresponding ample size */
+	label: number
+	/** x coordinate */
+	x: number
+	/** y coordinate */
+	y: number
+	/** radius of the circle */
+	radius: number
+}
+
+/** Formated response data passed from the view model
+ * to the view for rendering */
+export type ViewData = {
+	/** Dimensions of all the plot elements except the data points */
+	plotDim: PlotDimensions
+	/** Rendering specifics for each data point */
+	variableItems: VariableItem[]
+	legendData: LegendDataEntry[]
+}

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -1,14 +1,30 @@
+import { to_svg } from '#src/client'
+
 export class CorrVolcanoInteractions {
 	app: any
 	dom: any
 	id: string
 	variableTwLst: any
-	constructor(app, dom, id, variableTwLst) {
+	constructor(app, dom, id) {
 		this.app = app
 		this.dom = dom
 		this.id = id
 		//TODO: should be in the state somehow
+		this.variableTwLst = []
+	}
+
+	setVars(app, id, variableTwLst) {
+		/** This is a hack
+		 * app and id are set after init and therefore not available
+		 * until plot init completes. Need to fix. */
+		this.app = app
+		this.id = id
 		this.variableTwLst = variableTwLst
+	}
+
+	download() {
+		const svg = this.dom.svg.node() as Node
+		to_svg(svg, `correlationVolcano`, { apply_dom_styles: true })
 	}
 
 	//When clicking on dot, launch the sample scatter by gene and drug

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -31,11 +31,12 @@ export class CorrVolcanoInteractions {
 	launchSampleScatter(item) {
 		const config = this.app.getState()
 		const plot = config.plots.find(p => p.id === this.id)
+		const term2 = this.variableTwLst.find((t: any) => t.$id === item.tw$id).term
 		const scatterConfig = {
 			chartType: 'sampleScatter',
-			name: 'Sample Scatter',
+			name: `${plot.featureTw.term.name} v ${term2.name}`,
 			term: { term: plot.featureTw.term },
-			term2: this.variableTwLst.find((t: any) => t.$id === item.tw$id).term,
+			term2,
 			filter: config.termfilter.filter
 		}
 		this.app.dispatch({

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -9,6 +9,7 @@ export class CorrVolcanoInteractions {
 	clearDom() {
 		this.dom.error.style('padding', '').text('')
 		this.dom.plot.selectAll('*').remove()
+		this.dom.legend.selectAll('*').remove()
 		this.dom.svg.selectAll('line').remove()
 		this.dom.title.text('')
 		this.dom.yAxisLabel.text('')

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -1,9 +1,31 @@
 export class CorrVolcanoInteractions {
 	app: any
 	dom: any
-	constructor(app, dom) {
+	id: string
+	variableTwLst: any
+	constructor(app, dom, id, variableTwLst) {
 		this.app = app
 		this.dom = dom
+		this.id = id
+		//TODO: should be in the state somehow
+		this.variableTwLst = variableTwLst
+	}
+
+	//When clicking on dot, launch the sample scatter by gene and drug
+	launchSampleScatter(item) {
+		const config = this.app.getState()
+		const plot = config.plots.find(p => p.id === this.id)
+		const scatterConfig = {
+			chartType: 'sampleScatter',
+			name: 'Sample Scatter',
+			term: { term: plot.featureTw.term },
+			term2: this.variableTwLst.find((t: any) => t.$id === item.tw$id).term,
+			filter: config.termfilter.filter
+		}
+		this.app.dispatch({
+			type: 'plot_create',
+			config: scatterConfig
+		})
 	}
 
 	clearDom() {

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -52,5 +52,6 @@ export class CorrVolcanoInteractions {
 		this.dom.svg.selectAll('line').remove()
 		this.dom.title.text('')
 		this.dom.yAxisLabel.text('')
+		this.dom.xAxisLabel.text('')
 	}
 }

--- a/client/plots/corrVolcano/model/Model.ts
+++ b/client/plots/corrVolcano/model/Model.ts
@@ -1,6 +1,6 @@
 import type { TermWrapper } from '#types'
 import type { MassAppApi, MassState } from '#mass/types/mass'
-import type { CorrVolcanoPlotConfig, CorrVolcanoSettings } from '../CorrelationVolcano'
+import type { CorrVolcanoPlotConfig, CorrVolcanoSettings } from '../CorrelationVolcanoTypes'
 
 export class Model {
 	config: CorrVolcanoPlotConfig

--- a/client/plots/corrVolcano/test/corrVolcano.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.spec.ts
@@ -65,18 +65,18 @@ tape('Default correlation volcano', test => {
 		const dom = correlationVolcano.Inner.dom
 
 		//Simple rendering tests.
-		test.equal(dom.title.text(), 'KRAS', `Should display feature term wrapper name as title`)
+		test.equal(dom.title.text(), 'KRAS Gene Expression', `Should display feature term wrapper name as title`)
 		test.equal(
 			dom.xAxisLabel.text(),
 			'Correlation Coefficient',
 			`Should display 'Correlation Coefficient' as x-axis label`
 		)
-		test.equal(dom.yAxisLabel.text(), 'Gene Expression', `Should display 'Gene Expression' as y-axis label`)
+		test.equal(dom.yAxisLabel.text(), '-log10(p value)', `Should display '-log10(p value)' as y-axis label`)
 
 		testPlot(dom.plot)
 		testLegend(dom.legend)
 
-		if (test['_ok']) correlationVolcano.Inner.app.destroy()
+		// if (test['_ok']) correlationVolcano.Inner.app.destroy()
 		test.end()
 	}
 

--- a/client/plots/corrVolcano/test/corrVolcano.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.spec.ts
@@ -18,6 +18,8 @@ const runpp = helpers.getRunPp('mass', {
 			header_mode: 'hidden'
 		},
 		vocab: {
+			//Eventually need to add data to TermdbTest
+			//and switch dataset and genome
 			dslabel: 'ALL-pharmacotyping',
 			genome: 'hg38'
 		}
@@ -58,10 +60,36 @@ tape('Default correlation volcano', test => {
 		}
 	})
 
-	async function runTests(correlationVolcano) {
+	async function runTests(correlationVolcano: any) {
 		correlationVolcano.on('postRender.test', null)
+		const dom = correlationVolcano.Inner.dom
 
-		// if (test['_ok']) correlationVolcano.Inner.app.destroy()
+		//Simple rendering tests.
+		test.equal(dom.title.text(), 'KRAS', `Should display feature term wrapper name as title`)
+		test.equal(
+			dom.xAxisLabel.text(),
+			'Correlation Coefficient',
+			`Should display 'Correlation Coefficient' as x-axis label`
+		)
+		test.equal(dom.yAxisLabel.text(), 'Gene Expression', `Should display 'Gene Expression' as y-axis label`)
+
+		testPlot(dom.plot)
+		testLegend(dom.legend)
+
+		if (test['_ok']) correlationVolcano.Inner.app.destroy()
 		test.end()
+	}
+
+	function testPlot(plot) {
+		const circleNum = plot.selectAll('circle[data-testid^="sjpp-corr-volcano-circle"]').size()
+		const expected = 20
+		//TODO: Change this when testing termdbtest data
+		test.ok(circleNum > expected, `Should display more than ${expected} circles`)
+	}
+
+	function testLegend(legend) {
+		const legendCircles = legend.selectAll('circle').size()
+		const expected = 2
+		test.equal(legendCircles, expected, `Should display ${expected} circles in the legend`)
 	}
 })

--- a/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
@@ -1,0 +1,174 @@
+import tape from 'tape'
+import { ViewModel } from '../viewModel/ViewModel'
+import type { CorrVolcanoSettings } from '../CorrelationVolcanoTypes'
+
+/**
+ * Tests
+ *   - Default ViewModel
+ */
+
+const mockData = {
+	variableItems: [
+		{
+			tw$id: 'test$id2',
+			sampleSize: 726,
+			correlation: 0.07,
+			original_pvalue: 0.0593,
+			adjusted_pvalue: 0.431
+		},
+		{
+			tw$id: 'test$id3',
+			sampleSize: 373,
+			correlation: -0.0088,
+			original_pvalue: 0.8657,
+			adjusted_pvalue: 0.8657
+		}
+	]
+}
+
+const mockSettings = {
+	antiCorrColor: '#ff0000',
+	corrColor: '#0000ff',
+	isAdjustedPValue: false,
+	method: 'pearson',
+	threshold: 0.05,
+	height: 500,
+	width: 500
+} satisfies CorrVolcanoSettings
+
+const mockVariableTwLst = [
+	{
+		$id: 'test$id2',
+		id: 'Asparaginase_normalizedLC50',
+		term: {
+			name: 'Asparaginase LC50 (normalized)'
+		},
+		type: 'NumTWRegularBin'
+	},
+	{
+		$id: 'test$id3',
+		id: 'Bortezomib_normalizedLC50',
+		term: {
+			name: 'Bortezomib LC50 (normalized)'
+		},
+		type: 'NumTWRegularBin'
+	}
+]
+
+const mockConfig = {
+	id: '1',
+	chartType: 'correlationVolcano',
+	featureTw: {
+		$id: 'test$id',
+		term: {
+			id: 'testid',
+			type: 'geneExpression',
+			gene: 'KRAS',
+			name: 'KRAS'
+		},
+		q: {}
+	},
+	settings: {
+		correlationVolcano: mockSettings
+	}
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.pass('-***- plots/correlationVolcano -***-')
+	test.end()
+})
+
+tape('Default ViewModel', test => {
+	test.timeoutAfter(100)
+
+	const viewModel = new ViewModel(mockConfig, mockData, mockSettings, mockVariableTwLst as any)
+	test.equal(viewModel.defaultMinRadius, 5, `Should set default minimum radius to 5`)
+	test.equal(viewModel.defaultMaxRadius, 20, `Should set default maximum radius to 20`)
+	test.equal(viewModel.bottomPad, 60, `Should set bottom padding to 60`)
+	test.equal(viewModel.horizPad, 70, `Should set horizontal padding to 70`)
+	test.equal(viewModel.topPad, 40, `Should set top padding to 40`)
+
+	const expectedViewData = {
+		plotDim: {
+			svg: { height: 660, width: 640 },
+			title: { text: 'KRAS Gene Expression', x: 320, y: 20 },
+			xAxisLabel: { x: 320, y: 600 },
+			yAxisLabel: { x: 23.333333333333332, y: 290 },
+			xScale: { x: 70, y: 540 },
+			yScale: { x: 70, y: 40 },
+			divideLine: { x: 320, y1: 540, y2: 40 },
+			thresholdLine: { y: 55.15435619536254, x1: 70, x2: 570 }
+		},
+		variableItems: [
+			{
+				tw$id: 'test$id2',
+				sampleSize: 726,
+				correlation: 0.07,
+				original_pvalue: 0.0593,
+				adjusted_pvalue: 0.431,
+				transformed_original_pvalue: 1.2269453066357374,
+				color: '#0000ff',
+				label: 'Asparaginase LC50 (normalized)',
+				x: 547.2727272727273,
+				y: 81.66666666666669,
+				radius: 20
+			},
+			{
+				tw$id: 'test$id3',
+				sampleSize: 373,
+				correlation: -0.0088,
+				original_pvalue: 0.8657,
+				adjusted_pvalue: 0.8657,
+				transformed_original_pvalue: 0.06263258248271039,
+				color: '#ff0000',
+				label: 'Bortezomib LC50 (normalized)',
+				x: 291.42857142857144,
+				y: 498.3333333333333,
+				radius: 5
+			}
+		],
+		legendData: [
+			{ label: 373, x: 25, y: 30, radius: 5 },
+			{ label: 726, x: 25, y: 70, radius: 20 }
+		]
+	}
+
+	test.deepEqual(
+		viewModel.viewData.plotDim.svg,
+		expectedViewData.plotDim.svg,
+		`Should set the svg dimensions as expected`
+	)
+	test.deepEqual(viewModel.viewData.plotDim.title, expectedViewData.plotDim.title, `Should set the title as expected`)
+	test.deepEqual(
+		viewModel.viewData.plotDim.xAxisLabel,
+		expectedViewData.plotDim.xAxisLabel,
+		`Should set the x-axis label as expected`
+	)
+	test.deepEqual(
+		viewModel.viewData.plotDim.yAxisLabel,
+		expectedViewData.plotDim.yAxisLabel,
+		`Should set the y-axis label as expected`
+	)
+	test.deepEqual(
+		viewModel.viewData.plotDim.divideLine,
+		expectedViewData.plotDim.divideLine,
+		`Should set the divide line as expected`
+	)
+	test.deepEqual(
+		viewModel.viewData.plotDim.thresholdLine,
+		expectedViewData.plotDim.thresholdLine,
+		`Should set the threshold line as expected`
+	)
+	test.deepEqual(
+		viewModel.viewData.variableItems,
+		expectedViewData.variableItems,
+		`Should set the variable items as expected`
+	)
+	test.deepEqual(viewModel.viewData.legendData, expectedViewData.legendData, `Should set the legend data as expected`)
+
+	test.end()
+})

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -1,8 +1,25 @@
+import { table2col } from '#dom'
+
 export class ItemToolTip {
-	constructor(item, g, tip) {
+	constructor(item, g, tip, settings) {
 		g.on('mouseover', () => {
 			tip.clear().showunder(g.node())
-			tip.d.append('div').style('padding', '3px').text(item.label)
+			const table = table2col({ holder: tip.d.append('table') })
+			//Header
+			const [th, _] = table.addRow()
+			th.attr('colspan', '2').text(item.label)
+			//Show p value
+			const [td1, td2] = table.addRow()
+			td1.text(settings.isAdjustedPValue ? 'Adjusted p-value' : 'Original p-value')
+			td2.text(settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue)
+			const [td3, td4] = table.addRow()
+			//Show correlation
+			td3.text('Correlation')
+			td4.text(item.correlation)
+			//Show sample size
+			const [td5, td6] = table.addRow()
+			td5.text('Sample size')
+			td6.text(item.sampleSize)
 		})
 		g.on('mouseout', () => {
 			tip.hide()

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -7,7 +7,7 @@ export class ItemToolTip {
 			const table = table2col({ holder: tip.d.append('table') })
 			//Header
 			const [th, _] = table.addRow()
-			th.attr('colspan', '2').text(item.label)
+			th.attr('colspan', '2').style('text-align', 'center').text(item.label)
 			//Show p value
 			const [td1, td2] = table.addRow()
 			td1.text(`${settings.isAdjustedPValue ? 'Adjusted p-value ' : 'Original p-value'} (-log10)`)

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -1,10 +1,13 @@
 import { table2col } from '#dom'
 import { roundValue } from '#shared/roundValue.js'
+import type { Menu } from '#dom'
+import type { SvgCircle } from '../../../types/d3'
+import type { CorrVolcanoSettings } from '../CorrelationVolcanoTypes'
 
 export class ItemToolTip {
-	constructor(item, g, tip, settings) {
-		g.on('mouseover', () => {
-			tip.clear().showunder(g.node())
+	constructor(item: any, circle: SvgCircle, tip: Menu, settings: CorrVolcanoSettings) {
+		circle.on('mouseover', () => {
+			tip.clear().showunder(circle.node())
 			const table = table2col({ holder: tip.d.append('table') })
 			//Header
 			const [th, _] = table.addRow()
@@ -23,7 +26,7 @@ export class ItemToolTip {
 			td5.text('Sample size')
 			td6.text(item.sampleSize)
 		})
-		g.on('mouseout', () => {
+		circle.on('mouseout', () => {
 			tip.hide()
 		})
 	}

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -1,4 +1,5 @@
 import { table2col } from '#dom'
+import { roundValue } from '#shared/roundValue.js'
 
 export class ItemToolTip {
 	constructor(item, g, tip, settings) {
@@ -11,7 +12,8 @@ export class ItemToolTip {
 			//Show p value
 			const [td1, td2] = table.addRow()
 			td1.text(`${settings.isAdjustedPValue ? 'Adjusted p-value ' : 'Original p-value'} (-log10)`)
-			td2.text(settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue)
+			const value = settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue
+			td2.text(roundValue(value, 5))
 			const [td3, td4] = table.addRow()
 			//Show correlation
 			td3.text('Correlation')

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -14,7 +14,7 @@ export class ItemToolTip {
 			th.attr('colspan', '2').style('text-align', 'center').text(item.label)
 			//Show p value
 			const [td1, td2] = table.addRow()
-			td1.text(`${settings.isAdjustedPValue ? 'Adjusted p-value ' : 'Original p-value'} (-log10)`)
+			td1.text(`${settings.isAdjustedPValue ? 'Adjusted' : 'Original'} -log10(p value)`)
 			const value = settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue
 			td2.text(roundValue(value, 5))
 			const [td3, td4] = table.addRow()

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -10,7 +10,7 @@ export class ItemToolTip {
 			th.attr('colspan', '2').text(item.label)
 			//Show p value
 			const [td1, td2] = table.addRow()
-			td1.text(settings.isAdjustedPValue ? 'Adjusted p-value' : 'Original p-value')
+			td1.text(`${settings.isAdjustedPValue ? 'Adjusted p-value ' : 'Original p-value'} (-log10)`)
 			td2.text(settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue)
 			const [td3, td4] = table.addRow()
 			//Show correlation

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -14,7 +14,7 @@ export class ItemToolTip {
 			th.attr('colspan', '2').style('text-align', 'center').text(item.label)
 			//Show p value
 			const [td1, td2] = table.addRow()
-			td1.text(`${settings.isAdjustedPValue ? 'Adjusted' : 'Original'} -log10(p value)`)
+			td1.text(`${settings.isAdjustedPValue ? 'Adjusted' : 'Original'} p value`)
 			const value = settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue
 			td2.text(roundValue(value, 5))
 			const [td3, td4] = table.addRow()

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -69,11 +69,23 @@ export class View {
 			.attr('class', 'sjpp-corr-volcano-divide-line')
 			.attr('stroke', 'black')
 			.attr('stroke-dasharray', '5 4')
-			.attr('stroke-opacity', 0.5)
+			.attr('stroke-opacity', 0.4)
 			.attr('x1', plotDim.divideLine.x)
 			.attr('x2', plotDim.divideLine.x)
 			.attr('y1', plotDim.divideLine.y1)
 			.attr('y2', plotDim.divideLine.y2)
+
+		//Draw the threshold line indicating statiscally significant values
+		this.dom.svg
+			.append('line')
+			.attr('class', 'sjpp-corr-volcano-threshold-line')
+			.attr('stroke', 'black')
+			.attr('stroke-dasharray', '5 4')
+			.attr('stroke-opacity', 0.4)
+			.attr('x1', plotDim.thresholdLine.x1)
+			.attr('x2', plotDim.thresholdLine.x2)
+			.attr('y1', plotDim.thresholdLine.y)
+			.attr('y2', plotDim.thresholdLine.y)
 	}
 
 	renderScale(scale, isLeft = false) {

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -19,6 +19,7 @@ export class View {
 		this.renderDom(plotDim)
 		// Draw all circles for variables
 		this.renderVariables(this.viewData.variableItems, settings)
+		this.renderLegend(dom, viewData.legendData)
 	}
 
 	renderDom(plotDim) {
@@ -77,6 +78,28 @@ export class View {
 				.attr('r', item.radius)
 
 			new ItemToolTip(item, g, this.dom.tip, settings)
+		}
+	}
+
+	renderLegend(dom, legendData) {
+		//Show min radius for sample size
+		const svg = dom.legend.attr('width', 100).attr('height', 100)
+		svg.append('text').text('Sample size').attr('x', 10).attr('y', 15)
+
+		for (const c of legendData) {
+			svg
+				.append('circle')
+				.attr('fill', 'lightgrey')
+				.attr('stroke', 'lightgrey')
+				.attr('cx', c.x)
+				.attr('cy', c.y)
+				.attr('r', c.radius)
+
+			svg
+				.append('text')
+				.attr('x', c.x + 25)
+				.attr('y', c.y + 5)
+				.text(c.label)
 		}
 	}
 }

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -26,6 +26,7 @@ export class View {
 		this.dom.svg.attr('width', plotDim.svg.width).attr('height', plotDim.svg.height)
 
 		this.dom.title
+			.attr('class', 'sjpp-corr-volcano-title')
 			.style('font-weight', 600)
 			.attr('text-anchor', 'middle')
 			.attr('x', plotDim.title.x)
@@ -33,11 +34,18 @@ export class View {
 			.text(plotDim.title.text)
 
 		this.dom.yAxisLabel
-			.attr('class', 'sjpp-volcano-divide-line')
+			.attr('class', 'sjpp-corr-volcano-y-axis')
 			.style('font-weight', 600)
 			.attr('text-anchor', 'middle')
 			.attr('transform', `translate(${plotDim.yAxisLabel.x}, ${plotDim.yAxisLabel.y}) rotate(-90)`)
 			.text(plotDim.yAxisLabel.text)
+
+		this.dom.xAxisLabel
+			.attr('class', 'sjpp-corr-volcano-x-axis')
+			.style('font-weight', 600)
+			.attr('text-anchor', 'middle')
+			.attr('transform', `translate(${plotDim.xAxisLabel.x}, ${plotDim.xAxisLabel.y})`)
+			.text(plotDim.xAxisLabel.text)
 
 		//Y, left scale
 		this.renderScale(plotDim.yScale, true)
@@ -47,6 +55,7 @@ export class View {
 		// Draw the line dividing the plot
 		this.dom.svg
 			.append('line')
+			.attr('class', 'sjpp-corr-volcano-divide-line')
 			.attr('stroke', 'black')
 			.attr('stroke-dasharray', '5 4')
 			.attr('stroke-opacity', 0.5)
@@ -70,6 +79,7 @@ export class View {
 		for (const item of variableItems) {
 			const g = this.dom.plot
 				.append('circle')
+				.attr('data-testid', `sjpp-corr-volcano-circle-${item.label}`)
 				.attr('stroke', item.color)
 				.attr('fill', item.color)
 				.attr('fill-opacity', 0.5)
@@ -86,7 +96,12 @@ export class View {
 
 	renderLegend(dom, legendData) {
 		//Show min radius for sample size
-		const svg = dom.legend.attr('width', 100).attr('height', 100)
+		const svg = dom.legend
+			.attr('width', 100)
+			.attr('height', 100)
+			.style('display', 'inline-block')
+			.style('vertical-align', 'top')
+			.style('padding-top', '20px')
 		svg.append('text').text('Sample size').attr('x', 10).attr('y', 15)
 
 		for (const c of legendData) {

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -49,14 +49,14 @@ export class View {
 			.style('font-weight', 600)
 			.attr('text-anchor', 'middle')
 			.attr('transform', `translate(${plotDim.yAxisLabel.x}, ${plotDim.yAxisLabel.y}) rotate(-90)`)
-			.text(plotDim.yAxisLabel.text)
+			.text('-log10(p value)')
 
 		this.dom.xAxisLabel
 			.attr('class', 'sjpp-corr-volcano-x-axis')
 			.style('font-weight', 600)
 			.attr('text-anchor', 'middle')
 			.attr('transform', `translate(${plotDim.xAxisLabel.x}, ${plotDim.xAxisLabel.y})`)
-			.text(plotDim.xAxisLabel.text)
+			.text('Correlation Coefficient')
 
 		//Y, left scale
 		this.renderScale(plotDim.yScale, true)

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -1,7 +1,13 @@
 import { axisstyle } from '#src/client'
 import { axisBottom, axisLeft } from 'd3-axis'
-import type { CorrVolcanoDom } from '../CorrelationVolcano'
-import type { ViewData } from '../viewModel/ViewModel'
+import type {
+	CorrVolcanoDom,
+	CorrVolcanoSettings,
+	LegendDataEntry,
+	PlotDimensions,
+	ViewData
+} from '../CorrelationVolcanoTypes'
+import type { CorrVolcanoInteractions } from '../interactions/CorrVolcanoInteractions'
 import { ItemToolTip } from './ItemToolTip'
 
 /** Using the data formated in ViewModel, renders the correlation
@@ -9,7 +15,12 @@ import { ItemToolTip } from './ItemToolTip'
 export class View {
 	dom: CorrVolcanoDom
 	viewData: ViewData
-	constructor(dom: CorrVolcanoDom, viewData: ViewData, interactions: any, settings: any) {
+	constructor(
+		dom: CorrVolcanoDom,
+		viewData: ViewData,
+		interactions: CorrVolcanoInteractions,
+		settings: CorrVolcanoSettings
+	) {
 		this.dom = dom
 		this.viewData = viewData
 
@@ -22,7 +33,7 @@ export class View {
 		this.renderLegend(dom, viewData.legendData)
 	}
 
-	renderDom(plotDim) {
+	renderDom(plotDim: PlotDimensions) {
 		this.dom.svg.attr('width', plotDim.svg.width).attr('height', plotDim.svg.height)
 
 		this.dom.title
@@ -72,12 +83,11 @@ export class View {
 			color: 'black',
 			showline: true
 		})
-		// return scaleG
 	}
 
-	renderVariables(variableItems, settings, interactions) {
+	renderVariables(variableItems, settings: CorrVolcanoSettings, interactions: CorrVolcanoInteractions) {
 		for (const item of variableItems) {
-			const g = this.dom.plot
+			const circle = this.dom.plot
 				.append('circle')
 				.attr('data-testid', `sjpp-corr-volcano-circle-${item.label}`)
 				.attr('stroke', item.color)
@@ -90,11 +100,11 @@ export class View {
 					interactions.launchSampleScatter(item)
 				})
 
-			new ItemToolTip(item, g, this.dom.tip, settings)
+			new ItemToolTip(item, circle, this.dom.tip, settings)
 		}
 	}
 
-	renderLegend(dom, legendData) {
+	renderLegend(dom: CorrVolcanoDom, legendData: LegendDataEntry[]) {
 		//Show min radius for sample size
 		const svg = dom.legend
 			.attr('width', 100)

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -18,7 +18,7 @@ export class View {
 		const plotDim = viewData.plotDim
 		this.renderDom(plotDim)
 		// Draw all circles for variables
-		this.renderVariables(this.viewData.variableItems, settings)
+		this.renderVariables(this.viewData.variableItems, settings, interactions)
 		this.renderLegend(dom, viewData.legendData)
 	}
 
@@ -66,7 +66,7 @@ export class View {
 		// return scaleG
 	}
 
-	renderVariables(variableItems, settings) {
+	renderVariables(variableItems, settings, interactions) {
 		for (const item of variableItems) {
 			const g = this.dom.plot
 				.append('circle')
@@ -76,6 +76,9 @@ export class View {
 				.attr('cx', item.x)
 				.attr('cy', item.y)
 				.attr('r', item.radius)
+				.on('click', () => {
+					interactions.launchSampleScatter(item)
+				})
 
 			new ItemToolTip(item, g, this.dom.tip, settings)
 		}

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -9,7 +9,6 @@ import { ItemToolTip } from './ItemToolTip'
 export class View {
 	dom: CorrVolcanoDom
 	viewData: ViewData
-	readonly defaultRadius = 5
 	constructor(dom: CorrVolcanoDom, viewData: ViewData, interactions: any, settings: any) {
 		this.dom = dom
 		this.viewData = viewData
@@ -75,7 +74,7 @@ export class View {
 				.attr('fill-opacity', 0.5)
 				.attr('cx', item.x)
 				.attr('cy', item.y)
-				.attr('r', this.defaultRadius)
+				.attr('r', item.radius)
 
 			new ItemToolTip(item, g, this.dom.tip, settings)
 		}

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -30,7 +30,7 @@ export class View {
 		this.renderDom(plotDim)
 		// Draw all circles for variables
 		this.renderVariables(this.viewData.variableItems, settings, interactions)
-		this.renderLegend(dom, viewData.legendData)
+		this.renderLegend(viewData.legendData)
 	}
 
 	renderDom(plotDim: PlotDimensions) {
@@ -104,9 +104,9 @@ export class View {
 		}
 	}
 
-	renderLegend(dom: CorrVolcanoDom, legendData: LegendDataEntry[]) {
+	renderLegend(legendData: LegendDataEntry[]) {
 		//Show min radius for sample size
-		const svg = dom.legend
+		const svg = this.dom.legend
 			.attr('width', 100)
 			.attr('height', 100)
 			.style('display', 'inline-block')

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -10,7 +10,7 @@ export class View {
 	dom: CorrVolcanoDom
 	viewData: ViewData
 	readonly defaultRadius = 5
-	constructor(dom: CorrVolcanoDom, viewData: ViewData, interactions: any) {
+	constructor(dom: CorrVolcanoDom, viewData: ViewData, interactions: any, settings: any) {
 		this.dom = dom
 		this.viewData = viewData
 
@@ -18,6 +18,8 @@ export class View {
 
 		const plotDim = viewData.plotDim
 		this.renderDom(plotDim)
+		// Draw all circles for variables
+		this.renderVariables(this.viewData.variableItems, settings)
 	}
 
 	renderDom(plotDim) {
@@ -52,9 +54,6 @@ export class View {
 			.attr('x2', plotDim.divideLine.x)
 			.attr('y1', plotDim.divideLine.y1)
 			.attr('y2', plotDim.divideLine.y2)
-
-		// Draw all circles for variables
-		this.renderVariables(this.viewData.variableItems)
 	}
 
 	renderScale(scale, isLeft = false) {
@@ -67,7 +66,7 @@ export class View {
 		// return scaleG
 	}
 
-	renderVariables(variableItems) {
+	renderVariables(variableItems, settings) {
 		for (const item of variableItems) {
 			const g = this.dom.plot
 				.append('circle')
@@ -78,7 +77,7 @@ export class View {
 				.attr('cy', item.y)
 				.attr('r', this.defaultRadius)
 
-			new ItemToolTip(item, g, this.dom.tip)
+			new ItemToolTip(item, g, this.dom.tip, settings)
 		}
 	}
 }

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -37,6 +37,7 @@ export class ViewModel {
 	}
 
 	transformPValues(data, key) {
+		data.variableItems = data.variableItems.filter(v => v[key] > 0)
 		for (const item of data.variableItems) {
 			if (item[key] > 0) item[key] = -Math.log10(item[key])
 			else item[key] = null
@@ -52,7 +53,9 @@ export class ViewModel {
 	}
 
 	setPlotDimensions(config, settings, absYMax: number, absYMin: number, absXMax: number, absXMin: number) {
-		const xScale = scaleLinear().domain([absXMin, absXMax]).range([0, settings.width])
+		//Ensure the neg and pos side of the plot are equal
+		const maxXRange = Math.max(Math.abs(absXMin), absXMax)
+		const xScale = scaleLinear().domain(this.setDomain(-maxXRange, maxXRange, 0.05)).range([0, settings.width])
 		return {
 			svg: {
 				height: settings.height + this.topPad + this.bottomPad,
@@ -77,7 +80,7 @@ export class ViewModel {
 			yScale: {
 				//Do not use scaleLog() here. scaleLog is for raw values before the log transformation
 				//Using it will distort the values.
-				scale: scaleLinear().domain([absYMin, absYMax]).range([settings.height, 0]),
+				scale: scaleLinear().domain(this.setDomain(absYMin, absYMax)).range([settings.height, 0]),
 				x: this.horizPad,
 				y: this.topPad
 			},
@@ -87,6 +90,13 @@ export class ViewModel {
 				y2: this.topPad
 			}
 		}
+	}
+
+	/** Increase the domain slightly so all data points fit within the plot */
+	setDomain(min: number, max: number, percent = 0.1) {
+		const rangeInc = (max - min) * percent
+		const domain = [min - rangeInc, max + rangeInc]
+		return domain
 	}
 
 	//TODO: Add more types

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -1,5 +1,5 @@
 import type { TermWrapper } from '#types'
-import { scaleLinear, scaleLog } from 'd3-scale'
+import { scaleLinear } from 'd3-scale'
 import type { CorrVolcanoSettings } from '../CorrelationVolcano'
 
 export type ViewData = {
@@ -20,7 +20,7 @@ export class ViewModel {
 	/** Only one side, left or right */
 	readonly horizPad = 70
 	readonly bottomPad = 20
-	constructor(config, data, settings: CorrVolcanoSettings, variableTwLst: TermWrapper[]) {
+	constructor(config: any, data: any, settings: CorrVolcanoSettings, variableTwLst: TermWrapper[]) {
 		const pValueKey = settings.isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue'
 		const d = this.transformPValues(data, pValueKey)
 		const [absYMax, absYMin] = this.setMinMax(d, pValueKey)

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -19,7 +19,7 @@ export class ViewModel {
 	readonly topPad = 40
 	/** Only one side, left or right */
 	readonly horizPad = 70
-	readonly bottomPad = 20
+	readonly bottomPad = 60
 	constructor(config: any, data: any, settings: CorrVolcanoSettings, variableTwLst: TermWrapper[]) {
 		const pValueKey = settings.isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue'
 		const d = this.transformPValues(data, pValueKey)
@@ -58,14 +58,19 @@ export class ViewModel {
 		const xScale = scaleLinear().domain(this.setDomain(-maxXRange, maxXRange, 0.05)).range([0, settings.width])
 		return {
 			svg: {
-				height: settings.height + this.topPad + this.bottomPad,
+				height: settings.height + this.topPad + this.bottomPad * 2,
 				width: settings.width + this.horizPad * 2
 			},
 			title: {
+				text: config.featureTw.term.name,
+				x: this.horizPad + settings.width / 2,
+				y: this.topPad / 2
+			},
+			xAxisLabel: {
 				//TODO: If this never changes, move to View
 				text: 'Correlation Coefficient',
 				x: this.horizPad + settings.width / 2,
-				y: this.topPad / 2
+				y: this.topPad + settings.height + this.bottomPad
 			},
 			yAxisLabel: {
 				text: this.getReadableType(config.featureTw.term.type),

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -18,13 +18,13 @@ export class ViewModel {
 	readonly horizPad = 70
 	readonly bottomPad = 20
 	constructor(config, data, settings: CorrVolcanoSettings, variableTwLst: TermWrapper[]) {
-		const [absYMax, absYMin] = this.setMinMax(data, 'original_pvalue')
+		const [absYMax, absYMin] = this.setMinMax(data, settings.isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue')
 		const [absXMax, absXMin] = this.setMinMax(data, 'correlation')
 		const plotDim = this.setPlotDimensions(config, settings, absYMax, absYMin, absXMax, absXMin)
 
 		this.viewData = {
 			plotDim,
-			variableItems: this.setVariablesData(data, variableTwLst, plotDim)
+			variableItems: this.setVariablesData(data, variableTwLst, plotDim, settings.isAdjustedPValue)
 		}
 	}
 
@@ -70,12 +70,13 @@ export class ViewModel {
 		}
 	}
 
-	setVariablesData(data, variableTwLst, plotDim) {
+	setVariablesData(data, variableTwLst, plotDim, isAdjustedPValue) {
 		for (const item of data.variableItems) {
 			item.color = item.correlation > 0 ? 'blue' : 'red'
 			item.label = variableTwLst.find(t => t.$id == item.tw$id).term.name
 			item.x = plotDim.xScale.scale(item.correlation) + this.horizPad
-			item.y = Math.abs(-plotDim.yScale.scale(item.original_pvalue) - this.topPad)
+			const key = isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue'
+			item.y = Math.abs(-plotDim.yScale.scale(item[key]) - this.topPad)
 		}
 		return data.variableItems
 	}

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -1,5 +1,6 @@
 import type { TermWrapper } from '#types'
 import { scaleLinear } from 'd3-scale'
+import { getReadableType } from '#shared/terms.js'
 import type { CorrelationVolcanoResponse } from '#types'
 import type { CorrVolcanoPlotConfig, CorrVolcanoSettings, ViewData } from '../CorrelationVolcanoTypes'
 
@@ -70,18 +71,15 @@ export class ViewModel {
 				width: settings.width + this.horizPad * 2
 			},
 			title: {
-				text: config.featureTw.term.name,
+				text: `${config.featureTw.term.name} ${getReadableType(config.featureTw.term.type)}`,
 				x: this.horizPad + settings.width / 2,
 				y: this.topPad / 2
 			},
 			xAxisLabel: {
-				//TODO: If this never changes, move to View
-				text: 'Correlation Coefficient',
 				x: this.horizPad + settings.width / 2,
 				y: this.topPad + settings.height + this.bottomPad
 			},
 			yAxisLabel: {
-				text: `-log10(p value)`,
 				x: this.horizPad / 3,
 				y: this.topPad + settings.height / 2
 			},
@@ -115,18 +113,6 @@ export class ViewModel {
 		const rangeInc = (max - min) * percent
 		const domain = [min - rangeInc, max + rangeInc]
 		return domain
-	}
-
-	//TODO: Add more types
-	getReadableType(type: string) {
-		switch (type) {
-			case 'geneExpression':
-				return 'Gene Expression'
-			case 'geneVariant':
-				return 'Gene Variant'
-			default:
-				return 'Gene Expression'
-		}
 	}
 
 	setVariablesData(

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -5,12 +5,13 @@ import type { CorrVolcanoPlotConfig, CorrVolcanoSettings, ViewData } from '../Co
 
 export class ViewModel {
 	viewData: ViewData
+	//For rendering the circles and legend info
 	readonly defaultMinRadius = 5
 	readonly defaultMaxRadius = 20
-	readonly topPad = 40
+	readonly bottomPad = 60
 	/** Only one side, left or right */
 	readonly horizPad = 70
-	readonly bottomPad = 60
+	readonly topPad = 40
 	constructor(
 		config: CorrVolcanoPlotConfig,
 		data: CorrelationVolcanoResponse,
@@ -61,7 +62,8 @@ export class ViewModel {
 	) {
 		//Ensure the neg and pos side of the plot are equal
 		const maxXRange = Math.max(Math.abs(absXMin), absXMax)
-		const xScale = scaleLinear().domain(this.setDomain(-maxXRange, maxXRange, 0.05)).range([0, settings.width])
+		const xScale = scaleLinear().domain(this.setDomain(-maxXRange, maxXRange, 0.075)).range([0, settings.width])
+		const yScale = scaleLinear().domain(this.setDomain(absYMin, absYMax)).range([settings.height, 0])
 		return {
 			svg: {
 				height: settings.height + this.topPad + this.bottomPad * 2,
@@ -79,7 +81,7 @@ export class ViewModel {
 				y: this.topPad + settings.height + this.bottomPad
 			},
 			yAxisLabel: {
-				text: this.getReadableType(config.featureTw.term.type),
+				text: `-log10(p value)`,
 				x: this.horizPad / 3,
 				y: this.topPad + settings.height / 2
 			},
@@ -91,7 +93,7 @@ export class ViewModel {
 			yScale: {
 				//Do not use scaleLog() here. scaleLog is for raw values before the log transformation
 				//Using it will distort the values.
-				scale: scaleLinear().domain(this.setDomain(absYMin, absYMax)).range([settings.height, 0]),
+				scale: yScale,
 				x: this.horizPad,
 				y: this.topPad
 			},
@@ -99,6 +101,11 @@ export class ViewModel {
 				x: xScale(0) + this.horizPad,
 				y1: settings.height + this.topPad,
 				y2: this.topPad
+			},
+			thresholdLine: {
+				y: yScale(-Math.log10(settings.threshold)) + this.topPad,
+				x1: this.horizPad,
+				x2: settings.width + this.horizPad
 			}
 		}
 	}

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -59,13 +59,13 @@ export class ViewModel {
 				width: settings.width + this.horizPad * 2
 			},
 			title: {
-				text: this.getReadableType(config.featureTw.term.type),
+				//TODO: If this never changes, move to View
+				text: 'Correlation Coefficient',
 				x: this.horizPad + settings.width / 2,
 				y: this.topPad / 2
 			},
 			yAxisLabel: {
-				//TODO: If this never changes, move to View
-				text: 'Correlation Coefficient',
+				text: this.getReadableType(config.featureTw.term.type),
 				x: this.horizPad / 3,
 				y: this.topPad + settings.height / 2
 			},

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -28,7 +28,7 @@ export class ViewModel {
 
 		this.viewData = {
 			plotDim,
-			variableItems: this.setVariablesData(d, variableTwLst, plotDim, pValueKey, absSampleMax, absSampleMin),
+			variableItems: this.setVariablesData(d, settings, variableTwLst, plotDim, pValueKey, absSampleMax, absSampleMin),
 			legendData: this.setLegendData(absSampleMin, absSampleMax)
 		}
 	}
@@ -131,6 +131,7 @@ export class ViewModel {
 
 	setVariablesData(
 		data: any,
+		settings: CorrVolcanoSettings,
 		variableTwLst: any[],
 		plotDim: any,
 		key: string,
@@ -141,7 +142,7 @@ export class ViewModel {
 			.domain([absSampleMin, absSampleMax])
 			.range([this.defaultMinRadius, this.defaultMaxRadius])
 		for (const item of data.variableItems) {
-			item.color = item.correlation > 0 ? 'blue' : 'red'
+			item.color = item.correlation > 0 ? settings.corrColor : settings.antiCorrColor
 			item.label = variableTwLst.find(t => t.$id == item.tw$id).term.name
 			item.x = plotDim.xScale.scale(item.correlation) + this.horizPad
 			item.y = plotDim.yScale.scale(item[key]) + this.topPad

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -20,11 +20,20 @@ export class ViewModel {
 	constructor(config, data, settings: CorrVolcanoSettings, variableTwLst: TermWrapper[]) {
 		const [absYMax, absYMin] = this.setMinMax(data, settings.isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue')
 		const [absXMax, absXMin] = this.setMinMax(data, 'correlation')
+		const [absSampleMax, absSampleMin] = this.setMinMax(data, 'sampleSize')
+
 		const plotDim = this.setPlotDimensions(config, settings, absYMax, absYMin, absXMax, absXMin)
 
 		this.viewData = {
 			plotDim,
-			variableItems: this.setVariablesData(data, variableTwLst, plotDim, settings.isAdjustedPValue)
+			variableItems: this.setVariablesData(
+				data,
+				variableTwLst,
+				plotDim,
+				settings.isAdjustedPValue,
+				absSampleMax,
+				absSampleMin
+			)
 		}
 	}
 
@@ -70,13 +79,16 @@ export class ViewModel {
 		}
 	}
 
-	setVariablesData(data, variableTwLst, plotDim, isAdjustedPValue) {
+	setVariablesData(data, variableTwLst, plotDim, isAdjustedPValue, absSampleMax, absSampleMin) {
+		//5 and 15 are the min and max radius
+		const radiusScale = scaleLinear().domain([absSampleMin, absSampleMax]).range([5, 15])
 		for (const item of data.variableItems) {
 			item.color = item.correlation > 0 ? 'blue' : 'red'
 			item.label = variableTwLst.find(t => t.$id == item.tw$id).term.name
 			item.x = plotDim.xScale.scale(item.correlation) + this.horizPad
 			const key = isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue'
 			item.y = Math.abs(-plotDim.yScale.scale(item[key]) - this.topPad)
+			item.radius = radiusScale(item.sampleSize)
 		}
 		return data.variableItems
 	}

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -21,7 +21,7 @@ export class ViewModel {
 	) {
 		const pValueKey = settings.isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue'
 		const d = this.transformPValues(data, pValueKey)
-		const [absYMax, absYMin] = this.setMinMax(d, pValueKey)
+		const [absYMax, absYMin] = this.setMinMax(d, `transformed_${pValueKey}`)
 		const [absXMax, absXMin] = this.setMinMax(d, 'correlation')
 		const [absSampleMax, absSampleMin] = this.setMinMax(d, 'sampleSize')
 
@@ -40,7 +40,7 @@ export class ViewModel {
 		data.variableItems = data.variableItems.filter(v => v[key] > 0)
 		//For each item, transform the p value to -log10
 		for (const item of data.variableItems) {
-			if (item[key] > 0) item[key] = -Math.log10(item[key])
+			if (item[key] > 0) item[`transformed_${key}`] = -Math.log10(item[key])
 			else item[key] = null
 		}
 		return data
@@ -63,7 +63,7 @@ export class ViewModel {
 	) {
 		//Ensure the neg and pos side of the plot are equal
 		const maxXRange = Math.max(Math.abs(absXMin), absXMax)
-		const xScale = scaleLinear().domain(this.setDomain(-maxXRange, maxXRange, 0.075)).range([0, settings.width])
+		const xScale = scaleLinear().domain(this.setDomain(-maxXRange, maxXRange, 0.05)).range([0, settings.width])
 		const yScale = scaleLinear().domain(this.setDomain(absYMin, absYMax)).range([settings.height, 0])
 		return {
 			svg: {
@@ -131,7 +131,7 @@ export class ViewModel {
 			item.color = item.correlation > 0 ? settings.corrColor : settings.antiCorrColor
 			item.label = variableTwLst.find(t => t.$id == item.tw$id).term.name
 			item.x = plotDim.xScale.scale(item.correlation) + this.horizPad
-			item.y = plotDim.yScale.scale(item[key]) + this.topPad
+			item.y = plotDim.yScale.scale(item[`transformed_${key}`]) + this.topPad
 			item.radius = radiusScale(item.sampleSize)
 		}
 		return data.variableItems

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -32,13 +32,16 @@ export class ViewModel {
 		this.viewData = {
 			plotDim,
 			variableItems: this.setVariablesData(d, variableTwLst, plotDim, pValueKey, absSampleMax, absSampleMin),
-			legendData: {
-				minRad: this.defaultMinRadius,
-				maxRad: this.defaultMaxRadius,
-				minSampleSize: absSampleMin,
-				maxSampleSize: absSampleMax
-			}
+			legendData: this.setLegendData(absSampleMin, absSampleMax)
 		}
+	}
+
+	transformPValues(data, key) {
+		for (const item of data.variableItems) {
+			if (item[key] > 0) item[key] = -Math.log10(item[key])
+			else item[key] = null
+		}
+		return data
 	}
 
 	setMinMax(data: any, key: string) {
@@ -86,6 +89,18 @@ export class ViewModel {
 		}
 	}
 
+	//TODO: Add more types
+	getReadableType(type: string) {
+		switch (type) {
+			case 'geneExpression':
+				return 'Gene Expression'
+			case 'geneVariant':
+				return 'Gene Variant'
+			default:
+				return 'Gene Expression'
+		}
+	}
+
 	setVariablesData(data, variableTwLst, plotDim, key, absSampleMax, absSampleMin) {
 		//5 and 15 are the min and max radius
 		const radiusScale = scaleLinear()
@@ -101,23 +116,20 @@ export class ViewModel {
 		return data.variableItems
 	}
 
-	transformPValues(data, key) {
-		for (const item of data.variableItems) {
-			if (item[key] > 0) item[key] = -Math.log10(item[key])
-			else item[key] = null
-		}
-		return data
-	}
-
-	//TODO: Add more types
-	getReadableType(type: string) {
-		switch (type) {
-			case 'geneExpression':
-				return 'Gene Expression'
-			case 'geneVariant':
-				return 'Gene Variant'
-			default:
-				return 'Gene Expression'
-		}
+	setLegendData(absSampleMin, absSampleMax) {
+		return [
+			{
+				label: absSampleMin,
+				x: 25,
+				y: 30,
+				radius: this.defaultMinRadius
+			},
+			{
+				label: absSampleMax,
+				x: 25,
+				y: this.defaultMaxRadius + 50,
+				radius: this.defaultMaxRadius
+			}
+		]
 	}
 }

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -52,12 +52,13 @@ export class ViewModel {
 				width: settings.width + this.horizPad * 2
 			},
 			title: {
-				text: config.featureTw.term.name,
+				text: this.getReadableType(config.featureTw.term.type),
 				x: this.horizPad + settings.width / 2,
 				y: this.topPad / 2
 			},
 			yAxisLabel: {
-				text: '-log10(pvalue)',
+				//TODO: If this never changes, move to View
+				text: 'Correlation Coefficient',
 				x: this.horizPad / 3,
 				y: this.topPad + settings.height / 2
 			},
@@ -91,5 +92,15 @@ export class ViewModel {
 			item.radius = radiusScale(item.sampleSize)
 		}
 		return data.variableItems
+	}
+
+	//TODO: Add more types
+	getReadableType(type: string) {
+		switch (type) {
+			case 'geneExpression':
+				return 'Gene Expression'
+			default:
+				return 'Gene Expression'
+		}
 	}
 }

--- a/client/types/d3.d.ts
+++ b/client/types/d3.d.ts
@@ -22,6 +22,7 @@ export type _Element_ = Selection<Element, any, any, any>
 export type Elem = Selection<HTMLElement, any, any, any>
 export type Div = Selection<HTMLDivElement, any, any, any>
 export type Svg = Selection<SVGElement, any, any, any>
+export type SvgCircle = Selection<SVGCircleElement, any, any, any>
 export type SvgG = Selection<SVGGElement, any, any, any>
 export type SvgLine = Selection<SVGLineElement, any, any, any>
 export type SvgRect = Selection<SVGRectElement, any, any, any>

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- A new correlation volcano plot available through the mass UI. This plot depicts the correlation of gene features, like expression, and a predefined list of variables. The radii shown are proportionate to sample size. Plot controls include changing the feature, p value (adjusted or original), correlation method, statistical signficance, plot height, plot width, and colors. Hovering over the data points displays a tooltip with the variable name, sample size, p value, and correlation. Clicking on any data point launches the sample scatter plot. The plot is downloadable from the button in the controls. 

--- a/shared/utils/src/termdb.usecase.js
+++ b/shared/utils/src/termdb.usecase.js
@@ -181,6 +181,18 @@ export function isUsableTerm(term, _usecase, termdbConfig, ds) {
 			}
 		// no specific rule for filter. pass and use default rules
 
+		case 'correlationVolcano':
+			if (usecase.detail == 'numeric') {
+				if (isNumericTerm(term)) {
+					uses.add('plot')
+				}
+				if (hasNumericChild(child_types)) uses.add('branch')
+			} else {
+				if (graphableTypes.has(term.type)) uses.add('plot')
+				if (!term.isleaf) uses.add('branch')
+			}
+			return uses
+
 		default:
 			if (graphableTypes.has(term.type)) uses.add('plot')
 			if (!term.isleaf) uses.add('branch')

--- a/shared/utils/src/terms.js
+++ b/shared/utils/src/terms.js
@@ -184,3 +184,25 @@ export function getParentType(types, ds) {
 	}
 	return null //no parent found
 }
+
+//Returns human readable type (nice label) for the given type
+export function getReadableType(type) {
+	const typeMap = {
+		categorical: 'Categorical',
+		condition: 'Condition',
+		float: 'Numeric',
+		integer: 'Numeric',
+		geneExpression: 'Gene Expression',
+		geneVariant: 'Gene Variant',
+		metaboliteIntensity: 'Metabolite Intensity',
+		multiValue: 'Multi Value',
+		samplelst: 'Sample List',
+		singleCellGeneExpression: 'Single Cell, Gene Expression',
+		singleCellCellType: 'Single Cell, Cell Type',
+		snplocus: 'SNP Locus',
+		snp: 'SNP',
+		snplst: 'SNP List'
+	}
+
+	return typeMap[type] || 'Unknown type [shared/utils/src/terms.js getReadableType()]'
+}


### PR DESCRIPTION
## Description
Mostly addresses the feature requests and comments in issue #2626. 

Changes: 
1. The plot renders with the appropriate y log scale and equal space for correlation and anticorrelation. 
2. The size of the radii are representative of the sample sizes. The new legend to the right of the plot depicts the smallest and largest sample size and respective radius. 
3. Tooltips for each data point display the drug name, unaltered p value, correlation, and sample size.
4. Clicking on any data point launches the sample scatter plot. 
5. A new `Correlation Volcano` button is available in the charts menu. Clicking on the button launches the tree for term selection.
6. User can change the feature from term pill in the control menu (see note in considerations 3 below)
7. User can toggle between adjusted and original p values. 
8. The statistical significance is represented by a dashed line extending from the y axis. The `Significant cutoff` control changes the line location as a nice visual. 
9. There are new color pickers for the correlation and anticorrelation values in the control panel. 
10. The plot title dynamically renders the feature name and type. In `shared/utils/src/terms.js`, `getReadableType()` will return the term type in a human readable label. 
11. The plot download is enabled.  

Test:
1. [All pharma example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22correlationVolcano%22,%22featureTw%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22BCL2%22}}}]})
2. [Unit tests](http://localhost:3000/testrun.html?dir=plots/corrVolcano&name=corrVolcano.unit)
3. [Integration tests](http://localhost:3000/testrun.html?dir=plots/corrVolcano&name=corrVolcano) (not ready for CI. See note below) 

Considerations and future work: 
1. This is only works in All pharma, hence integration tests must be run manually. 
2.  The backend doesn't support the Spearman method yet. That will be completed in another PR.
3. The charts button and pill launch the tree however not every selection works yet. The tree does not support limiting by term types. Will address this in a future PR. This will also support the remaining feature request in issue #2626. 
4. Additional typing, tests, and addressing any noted tech debt will be in a future PR.
5. When this is available in production, I'll add a wiki with an info link. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
