### PR TITLE
fix: scrna gene exp loader will throw to pass err to client; delete rds support

### DIFF
--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import { read_file } from '#src/utils.js'
-import run_R from '#src/run_R.js'
 import { joinUrl, mayLog } from '#src/helpers.ts'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
 import serverconfig from '#src/serverconfig.js'

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -231,10 +231,9 @@ function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 
 		let out // object of barcodes as keys, and values as value
 		try {
-			const time1 = new Date().valueOf()
+			const time1 = Date.now()
 			const rust_output = await run_rust('readHDF5', JSON.stringify(read_hdf5_input_type))
-			const time2 = new Date().valueOf()
-			console.log('Time taken to query HDF5 file:', time2 - time1, 'ms')
+			mayLog('Time taken to query HDF5 file:', Date.now() - time1, 'ms')
 			for (const line of rust_output.split('\n')) {
 				if (line.startsWith('output_string:')) {
 					out = JSON.parse(line.replace('output_string:', ''))
@@ -245,7 +244,7 @@ function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 		} catch (e) {
 			// arg should be an error string; if needed generate sanitised version by not showing file path
 			console.log(e)
-			throw 'error reading h5 file: ' + _
+			throw 'error reading h5 file: ' + e
 		}
 
 		return out

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -229,6 +229,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any) {
 }
 
 function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
+	G.sample2gene2expressionBins = {} // cache for binning gene expression values
 	// per-sample rds files are not validated up front, and simply used as-is on the fly
 
 	if (G.storage_type == 'RDS' || !G.storage_type) {
@@ -295,6 +296,7 @@ function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 }
 
 function gdc_validateGeneExpression(G, ds, genome) {
+	G.sample2gene2expressionBins = {} // cache for binning gene expression values
 	// client actually queries /termdb/singlecellData route for gene exp data
 	G.get = async (q: TermdbSingleCellDataRequest) => {
 		// q {sample: {eID: str, sID: str}, gene:str}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -567,10 +567,9 @@ export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNa
 
 export type SingleCellGeneExpressionNative = {
 	src: 'native'
-	/** path to R rds or HDF5 files, each is a gene-by-cell matrix for a sample, with ".rdx" suffix. missing files are detected and handled */
+	/** path to HDF5 files. for now only hdf5 is supported.
+	each is a gene-by-cell matrix for a sample, with ".h5" suffix. missing files are detected and handled */
 	folder: string
-	/** HDF5 or RDS file, will deprecate RDS file later */
-	storage_type: 'HDF5' | 'RDS'
 	/** dynamically added getter */
 	get?: (q: any) => any
 	/** cached gene exp bins */

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -573,6 +573,8 @@ export type SingleCellGeneExpressionNative = {
 	storage_type: 'HDF5' | 'RDS'
 	/** dynamically added getter */
 	get?: (q: any) => any
+	/** cached gene exp bins */
+	sample2gene2expressionBins?: { [sample: string]: { [gene: string]: any } }
 }
 
 export type SingleCellGeneExpressionGdc = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -573,8 +573,6 @@ export type SingleCellGeneExpressionNative = {
 	storage_type: 'HDF5' | 'RDS'
 	/** dynamically added getter */
 	get?: (q: any) => any
-	/** cached gene exp bins */
-	sample2gene2expressionBins?: { [sample: string]: { [gene: string]: any } }
 }
 
 export type SingleCellGeneExpressionGdc = {


### PR DESCRIPTION
## Description

closes #2639 
to test with [this sjpp PR](https://github.com/stjude/sjpp/pull/632)

both gdc and native ds works
no tsc err in both repos

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
