### PR TITLE
Hides exact p-value warning when spearman option is selected

### DIFF
--- a/server/utils/corr.R
+++ b/server/utils/corr.R
@@ -19,7 +19,9 @@ coeffs <- c()
 pvalues <- c()
 sample_sizes <- c()
 for (i in 1:length(v1)) {
-    cor <- cor.test(as.numeric(unlist(v1[i])), as.numeric(unlist(v2[i])), method = input$method)
+    suppressWarnings({
+        cor <- cor.test(as.numeric(unlist(v1[i])), as.numeric(unlist(v2[i])), method = input$method)
+    })    
     coeffs <- c(coeffs, cor$estimate)
     pvalues <- c(pvalues, cor$p.value)
     sample_sizes <- c(sample_sizes, length(as.numeric(unlist(v1[i]))))


### PR DESCRIPTION
## Description
Fixes the R bug when spearman option is selected in Correlation Volcano plot. the exact p-value warning is now suppressed which was breaking the output JSON.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
