### PR TITLE
fix for minimal violin breaking on 'group samples by' pill term under samples button in matrix chart

### DIFF
--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -475,7 +475,7 @@ export async function getSamples(q, rows) {
 	return samples
 
 	function addSample(sample, term_id, key, value) {
-		if (limitMutatedSamples && !limitMutatedSamples.has(sample)) return // this sample is not mutated for given genes
+		// if (limitMutatedSamples && !limitMutatedSamples.has(sample)) return // this sample is not mutated for given genes
 		if (!samples[sample]) samples[sample] = { sample }
 		// this assumes unique term key/value for a given sample
 		// samples[sample][term_id] = { key, value }


### PR DESCRIPTION
## Description

in all-pharmacotyping ds, load entire matrix cohort example, group samples by 'age at diagnosis' and click on the term pill > edit, breaks rendering of minimal violin and other UI functionalities because getSamples in termdb.matrix.js is not supplying samples to termdb.violin.ts due to this 'limitMutatedSamples' check in getSamples()

@airenzp could you help improve this? not sure if this is the ideal solution. I will share a session file to test on slack. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
