### PR TITLE
Dynamically render scatter plot width 

### DIFF
--- a/client/dom/maxLabelWidth.ts
+++ b/client/dom/maxLabelWidth.ts
@@ -35,14 +35,14 @@ import type { Svg, SvgG } from '../types/d3'
  *             for measurement. These elements are immediately removed after measuring.
  *
  * @param items - Array of strings containing label information.
- *
+ * @param size - Font size multiplier for labels. Default is 1.
  * @returns The width in pixels of the widest label in the provided items array
  */
-export function getMaxLabelWidth(svg: Svg | SvgG, items: string[]): number {
+export function getMaxLabelWidth(svg: Svg | SvgG, items: string[], size = 1): number {
 	let maxLabelLgth = 0
 	for (const item of items) {
 		// Create temporary text element for measurement
-		const label = svg.append('text').text(item)
+		const label = svg.append('text').text(item).style('font-size', `${size}em`)
 
 		// Update maximum width if current label is wider
 		maxLabelLgth = Math.max(maxLabelLgth, label.node()!.getBBox().width)

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -108,15 +108,14 @@ export function setRenderers(self) {
 		const getLegendLabelWidth = (key, svg) => {
 			const legend = chart[`${key}Legend`]
 			if (!legend) return 0
-			const labels = [
-				...Array.from(legend.values())
-					.filter(({ key }) => key !== 'Ref')
-					.map(({ key, sampleCount }) => `${key}, n=(${sampleCount})`),
-				self.config[`${key}TW`]?.term?.name ?? ''
-			]
+			const labels = []
+			for (const [k, v] of legend.entries()) {
+				if (k != 'Ref') labels.push(`${k}, n=(${v.sampleCount})`)
+			}
+			labels.push(self.config[`${key}TW`]?.term?.name ?? '')
 			const size = self.config[`${key}TW`]?.term?.type == 'geneVariant' ? 1.1 : 1
 			// Add 20 for the icon (16) and space
-			return getMaxLabelWidth(svg, labels, size) + 20
+			return getMaxLabelWidth(svg, labels, size) + 30
 		}
 		// Used later to offset the shape legend
 		chart.colorLegendWidth = getLegendLabelWidth('color', svg)

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -115,10 +115,12 @@ export function setRenderers(self) {
 			labels.push(self.config[`${key}TW`]?.term?.name ?? '')
 			const size = self.config[`${key}TW`]?.term?.type == 'geneVariant' ? 1.1 : 1
 			// Add 20 for the icon (16) and space
-			return getMaxLabelWidth(svg, labels, size) + 30
+			return getMaxLabelWidth(svg, labels, size) + 20
 		}
-		// Used later to offset the shape legend
-		chart.colorLegendWidth = getLegendLabelWidth('color', svg)
+		/** Becomes the x offset for the shape legend.
+		 * When in continuous mode, color scale renders with a
+		 * default width of 150. */
+		chart.colorLegendWidth = self.config?.colorTW?.q.mode == 'continuous' ? 175 : getLegendLabelWidth('color', svg)
 		const shapeWidth = getLegendLabelWidth('shape', svg)
 		const width = s.svgw + chart.colorLegendWidth + shapeWidth + 125
 		svg

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -120,7 +120,10 @@ export function setRenderers(self) {
 		/** Becomes the x offset for the shape legend.
 		 * When in continuous mode, color scale renders with a
 		 * default width of 150. */
-		chart.colorLegendWidth = self.config?.colorTW?.q.mode == 'continuous' ? 175 : getLegendLabelWidth('color', svg)
+		chart.colorLegendWidth =
+			self.config?.colorTW?.q.mode == 'continuous'
+				? Math.max(175, getMaxLabelWidth(svg, [self.config.colorTW.term.name]) + 20)
+				: getLegendLabelWidth('color', svg)
 		const shapeWidth = getLegendLabelWidth('shape', svg)
 		const width = s.svgw + chart.colorLegendWidth + shapeWidth + 125
 		svg

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -113,6 +113,7 @@ export function setRenderers(self) {
 				if (k != 'Ref') labels.push(`${k}, n=(${v.sampleCount})`)
 			}
 			labels.push(self.config[`${key}TW`]?.term?.name ?? '')
+			// A larger font size is applied for geneVariant terms only
 			const size = self.config[`${key}TW`]?.term?.type == 'geneVariant' ? 1.1 : 1
 			// Add 20 for the icon (16) and space
 			return getMaxLabelWidth(svg, labels, size) + 20

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -114,8 +114,9 @@ export function setRenderers(self) {
 					.map(({ key, sampleCount }) => `${key}, n=(${sampleCount})`),
 				self.config[`${key}TW`]?.term?.name ?? ''
 			]
+			const size = self.config[`${key}TW`]?.term?.type == 'geneVariant' ? 1.1 : 1
 			// Add 20 for the icon (16) and space
-			return getMaxLabelWidth(svg, labels) + 20
+			return getMaxLabelWidth(svg, labels, size) + 20
 		}
 		// Used later to offset the shape legend
 		chart.colorLegendWidth = getLegendLabelWidth('color', svg)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Dynamically render scatter plot width with legend items and reduce the space between legend sections


### PR DESCRIPTION
## Description
Closes issue #2652. Test with http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:%5B%7B%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:%7B%22id%22:%22TSNE%20Category%22%7D,%22shapeTW%22:%7B%22term%22:%7B%22gene%22:%22KRAS%22,%22type%22:%22geneVariant%22%7D%7D%7D%5D%7D. 

Test change to getMaxLabelWidth in violin and box plot [with this link](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22childType%22:%22boxplot%22,%22term%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22diaggrp%22}}]}).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
