### PR TITLE
Correlation volcano improvements

### DIFF
--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -182,7 +182,7 @@ class CorrelationVolcano extends RxComponentInner {
 		}
 
 		/** Format returned data for rendering */
-		const viewModel = new ViewModel(config, data, settings, this.variableTwLst)
+		const viewModel = new ViewModel(config, data, this.dom, settings, this.variableTwLst)
 
 		/** Render correlation volcano plot */
 		new View(this.dom, viewModel.viewData, this.interactions, settings)

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -1,5 +1,8 @@
+import type { TermWrapper } from '#types'
 import { to_svg } from '#src/client'
+import { getReadableType } from '#shared/terms.js'
 
+//TODO - finish typing this file
 export class CorrVolcanoInteractions {
 	app: any
 	dom: any
@@ -13,7 +16,7 @@ export class CorrVolcanoInteractions {
 		this.variableTwLst = []
 	}
 
-	setVars(app, id, variableTwLst) {
+	setVars(app: any, id: string, variableTwLst: TermWrapper[]) {
 		/** This is a hack
 		 * app and id are set after init and therefore not available
 		 * until plot init completes. Need to fix. */
@@ -28,13 +31,13 @@ export class CorrVolcanoInteractions {
 	}
 
 	//When clicking on dot, launch the sample scatter by gene and drug
-	launchSampleScatter(item) {
+	launchSampleScatter(item: any) {
 		const config = this.app.getState()
 		const plot = config.plots.find(p => p.id === this.id)
 		const term2 = this.variableTwLst.find((t: any) => t.$id === item.tw$id).term
 		const scatterConfig = {
 			chartType: 'sampleScatter',
-			name: `${plot.featureTw.term.name} v ${term2.name}`,
+			name: `${plot.featureTw.term.name} ${getReadableType(plot.featureTw.term.type)} v ${term2.name}`,
 			term: { term: plot.featureTw.term },
 			term2,
 			filter: config.termfilter.filter

--- a/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
@@ -1,4 +1,5 @@
 import tape from 'tape'
+import * as d3s from 'd3-selection'
 import { ViewModel } from '../viewModel/ViewModel'
 import type { CorrVolcanoSettings } from '../CorrelationVolcanoTypes'
 
@@ -6,6 +7,16 @@ import type { CorrVolcanoSettings } from '../CorrelationVolcanoTypes'
  * Tests
  *   - Default ViewModel
  */
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+		.node()
+}
 
 const mockData = {
 	variableItems: [
@@ -84,8 +95,12 @@ tape('\n', function (test) {
 
 tape('Default ViewModel', test => {
 	test.timeoutAfter(100)
+	const holder = getHolder() as any
+	const dom = {
+		plot: holder?.append('svg')?.append('g')
+	}
 
-	const viewModel = new ViewModel(mockConfig, mockData, mockSettings, mockVariableTwLst as any)
+	const viewModel = new ViewModel(mockConfig, mockData, dom as any, mockSettings, mockVariableTwLst as any)
 	test.equal(viewModel.defaultMinRadius, 5, `Should set default minimum radius to 5`)
 	test.equal(viewModel.defaultMaxRadius, 20, `Should set default maximum radius to 20`)
 	test.equal(viewModel.bottomPad, 60, `Should set bottom padding to 60`)
@@ -115,7 +130,9 @@ tape('Default ViewModel', test => {
 				label: 'Asparaginase LC50 (normalized)',
 				x: 547.2727272727273,
 				y: 81.66666666666669,
-				radius: 20
+				radius: 20,
+				previousX: 547.2727272727273,
+				previousY: 81.66666666666669
 			},
 			{
 				tw$id: 'test$id3',
@@ -128,7 +145,9 @@ tape('Default ViewModel', test => {
 				label: 'Bortezomib LC50 (normalized)',
 				x: 291.42857142857144,
 				y: 498.3333333333333,
-				radius: 5
+				radius: 5,
+				previousX: 291.42857142857144,
+				previousY: 498.3333333333333
 			}
 		],
 		legendData: [

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -12,22 +12,23 @@ export class ItemToolTip {
 			//Header
 			const [th, _] = table.addRow()
 			th.attr('colspan', '2').style('text-align', 'center').text(item.label)
-			//Show p value
-			const [td1, td2] = table.addRow()
-			td1.text(`${settings.isAdjustedPValue ? 'Adjusted' : 'Original'} p value`)
-			const value = settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue
-			td2.text(roundValue(value, 5))
-			const [td3, td4] = table.addRow()
 			//Show correlation
-			td3.text('Correlation')
-			td4.text(item.correlation)
+			this.addLine(table, 'Correlation (&#961;)', item.correlation)
+			//Show p value
+			const pValueText = settings.isAdjustedPValue ? 'Adjusted p value' : 'Original p value'
+			const pValue = settings.isAdjustedPValue ? item.adjusted_pvalue : item.original_pvalue
+			this.addLine(table, pValueText, roundValue(pValue, 5))
 			//Show sample size
-			const [td5, td6] = table.addRow()
-			td5.text('Sample size')
-			td6.text(item.sampleSize)
+			this.addLine(table, 'Sample size', item.sampleSize)
 		})
 		circle.on('mouseout', () => {
 			tip.hide()
 		})
+	}
+
+	addLine(table: any, text: string, value: number) {
+		const [td1, td2] = table.addRow()
+		td1.html(text)
+		td2.text(value)
 	}
 }

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -32,7 +32,7 @@ export class View {
 		const plotDim = viewData.plotDim
 		this.renderDom(plotDim)
 		// Draw all circles for variables
-		this.renderVariables(this.viewData.variableItems, settings, interactions)
+		this.renderVariables(plotDim.divideLine.x, this.viewData.variableItems, settings, interactions)
 		this.renderLegend(viewData.legendData)
 	}
 
@@ -100,7 +100,7 @@ export class View {
 		})
 	}
 
-	renderVariables(variableItems, settings: CorrVolcanoSettings, interactions: CorrVolcanoInteractions) {
+	renderVariables(x, variableItems, settings: CorrVolcanoSettings, interactions: CorrVolcanoInteractions) {
 		for (const item of variableItems) {
 			const circle = this.dom.plot
 				.append('circle')
@@ -108,8 +108,8 @@ export class View {
 				.attr('stroke', item.color)
 				.attr('fill', item.color)
 				.attr('fill-opacity', 0.5)
-				.attr('cx', item.x)
-				.attr('cy', item.y)
+				.attr('cx', x)
+				.attr('cy', 0)
 				.attr('r', 0)
 				.on('click', () => {
 					interactions.launchSampleScatter(item)
@@ -117,7 +117,7 @@ export class View {
 
 			new ItemToolTip(item, circle, this.dom.tip, settings)
 			//Animate the circle to its final radius
-			circle.transition().duration(500).attr('r', item.radius)
+			circle.transition().duration(500).attr('cx', item.x).attr('cy', item.y).attr('r', item.radius)
 		}
 	}
 

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -10,7 +10,10 @@ import type {
 import type { CorrVolcanoInteractions } from '../interactions/CorrVolcanoInteractions'
 import { ItemToolTip } from './ItemToolTip'
 
-/** Using the data formated in ViewModel, renders the correlation
+/**
+ * TODO - finish typing this file
+ *
+ * Using the data formated in ViewModel, renders the correlation
  * volcano plot. */
 export class View {
 	dom: CorrVolcanoDom
@@ -56,14 +59,14 @@ export class View {
 			.style('font-weight', 600)
 			.attr('text-anchor', 'middle')
 			.attr('transform', `translate(${plotDim.xAxisLabel.x}, ${plotDim.xAxisLabel.y})`)
-			.text('Correlation Coefficient')
+			.html('Correlation Coefficient (&#961;)') //unicode for rho
 
 		//Y, left scale
 		this.renderScale(plotDim.yScale, true)
 		//X, bottom scale
 		this.renderScale(plotDim.xScale)
 
-		// Draw the line dividing the plot
+		// Draw a line demarcating correlation and anticorrelation
 		this.dom.svg
 			.append('line')
 			.attr('class', 'sjpp-corr-volcano-divide-line')
@@ -75,7 +78,7 @@ export class View {
 			.attr('y1', plotDim.divideLine.y1)
 			.attr('y2', plotDim.divideLine.y2)
 
-		//Draw the threshold line indicating statiscally significant values
+		//Draw threshold indicating statiscally significant values
 		this.dom.svg
 			.append('line')
 			.attr('class', 'sjpp-corr-volcano-threshold-line')
@@ -107,17 +110,18 @@ export class View {
 				.attr('fill-opacity', 0.5)
 				.attr('cx', item.x)
 				.attr('cy', item.y)
-				.attr('r', item.radius)
+				.attr('r', 0)
 				.on('click', () => {
 					interactions.launchSampleScatter(item)
 				})
 
 			new ItemToolTip(item, circle, this.dom.tip, settings)
+			//Animate the circle to its final radius
+			circle.transition().duration(500).attr('r', item.radius)
 		}
 	}
 
 	renderLegend(legendData: LegendDataEntry[]) {
-		//Show min radius for sample size
 		const svg = this.dom.legend
 			.attr('width', 100)
 			.attr('height', 100)

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -139,7 +139,7 @@ export class ViewModel {
 			.domain([absSampleMin, absSampleMax])
 			.range([this.defaultMinRadius, this.defaultMaxRadius])
 		const renderedCircles = dom.plot
-			.selectAll('circle')
+			?.selectAll('circle')
 			.nodes()
 			.map((d: any) => d.__data__)
 		for (const item of data.variableItems) {
@@ -148,7 +148,7 @@ export class ViewModel {
 			item.x = plotDim.xScale.scale(item.correlation) + this.horizPad
 			item.y = plotDim.yScale.scale(item[`transformed_${key}`]) + this.topPad
 			item.radius = radiusScale(item.sampleSize)
-			if (renderedCircles.length > 0) {
+			if (renderedCircles?.length > 0) {
 				const findRenderdCircle = renderedCircles.find((d: any) => d.tw$id === item.tw$id) as any
 				if (findRenderdCircle) {
 					item.previousX = findRenderdCircle.x


### PR DESCRIPTION
## Description
Closes issue #2653 . 

Changes: 
1. Tooltip: Correlation appears first
2. Rho is added to the tooltip and x axis label
3. Animation for circles

Test with [all pharma example](http://localhost:3000/?noheader=1&mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22correlationVolcano%22,%22featureTw%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22KRAS%22}}}]}).


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
