### PR TITLE
SC show active sample on tab

### DIFF
--- a/client/dom/toggleButtons.ts
+++ b/client/dom/toggleButtons.ts
@@ -266,7 +266,7 @@ function setRenderers(self) {
 				if (tab.contentHolder) tab.contentHolder.style('display', tab.active ? 'block' : 'none')
 				tab.tab.style('color', tab.active ? '#1575ad' : '#757373')
 				tab.line.style('visibility', tab.active ? 'visible' : 'hidden')
-				tab.tab.html(tab.label)
+				tab.tab.html(tab.label) // re-print tab label since the label value could have been updated by outside code
 			})
 	}
 }

--- a/client/dom/toggleButtons.ts
+++ b/client/dom/toggleButtons.ts
@@ -266,6 +266,7 @@ function setRenderers(self) {
 				if (tab.contentHolder) tab.contentHolder.style('display', tab.active ? 'block' : 'none')
 				tab.tab.style('color', tab.active ? '#1575ad' : '#757373')
 				tab.line.style('visibility', tab.active ? 'visible' : 'hidden')
+				tab.tab.html(tab.label)
 			})
 	}
 }

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -65,13 +65,12 @@ class singleCellPlot {
 
 		this.tabs = []
 		const activeTab = state.config.activeTab
-		if (this.samples.length > 1)
-			this.tabs.push({
-				label: 'Samples',
-				id: SAMPLES_TAB,
-				active: activeTab == SAMPLES_TAB,
-				callback: () => this.setActiveTab(SAMPLES_TAB)
-			})
+		this.tabs.push({
+			label: state.config.sample || this.samples[0].sample,
+			id: SAMPLES_TAB,
+			active: activeTab == SAMPLES_TAB,
+			callback: () => this.setActiveTab(SAMPLES_TAB)
+		})
 		if (state.config.plots.length > 1)
 			this.tabs.push({
 				label: 'Plots',
@@ -118,7 +117,8 @@ class singleCellPlot {
 			holder: contentDiv,
 			tabsPosition: 'horizontal',
 			tabs: this.tabs
-		}).main()
+		})
+		this.tabsComp.main()
 
 		const headerDiv = contentDiv.append('div').style('display', 'inline-block').style('padding-bottom', '20px')
 		const showDiv = headerDiv.append('div').style('padding-bottom', '10px')
@@ -1068,7 +1068,8 @@ class singleCellPlot {
 				if (rows[index][0].__experimentID) {
 					config.experimentID = rows[index][0].__experimentID
 				}
-
+				this.tabsComp.tabs[0].label = sample
+				this.tabsComp.update(0, this.tabs[0])
 				this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 			},
 			selectedRows,


### PR DESCRIPTION
## Description

Showed active sample on tab. Supported updating the label on the Tabs component

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
