### PR TITLE
mass about tab supports descriptionByCohort{}

### DIFF
--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -115,7 +115,17 @@ export class MassAbout {
 
 	async main() {
 		await this.renderCohortsTable()
-		if (this.opts.selectCohort?.description) this.dom.cohortDescription.html(this.opts.selectCohort.description)
+		if (this.opts.selectCohort) {
+			if (this.opts.selectCohort.description) {
+				this.dom.cohortDescription.html(this.opts.selectCohort.description)
+			} else if (this.opts.selectCohort.descriptionByCohort) {
+				this.dom.cohortDescription.html(
+					this.opts.selectCohort.descriptionByCohort[
+						this.state.termdbConfig.selectCohort.values[this.state.activeCohort].keys.join(',')
+					]
+				)
+			}
+		}
 	}
 
 	initCohort = appState => {

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -320,6 +320,11 @@ function getSelectCohort(ds, req) {
 	if (ds.cohort.termdb.selectCohort.descriptionByUser) {
 		copy.description = ds.cohort.termdb.selectCohort.descriptionByUser(authApi.getNonsensitiveInfo(req))
 		delete copy.descriptionByUser
+	} else if (ds.cohort.termdb.selectCohort.descriptionByCohortBasedOnUserRole) {
+		copy.descriptionByCohort = ds.cohort.termdb.selectCohort.descriptionByCohortBasedOnUserRole(
+			authApi.getNonsensitiveInfo(req)
+		)
+		delete copy.descriptionByCohortBasedOnUserRole
 	}
 	return copy
 }

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -851,8 +851,14 @@ export type SelectCohortEntry = {
 	/** cohort-related static html shown in about tab */
 	description?: string
 	/** If the description is dependent on the user's role, 
-	define this callback to return description based on auth */
+	define this callback to return description based on auth
+	returns a static description
+	*/
 	descriptionByUser?: (auth: any) => string
+	/** similar to descriptionByUser but returns an object with one description per cohort,
+	about tab will switch description based on user-selected cohort
+	*/
+	descriptionByCohortBasedOnUserRole?: (auth: any) => object
 	/** subtext shown at the very bottom of the cohort/about tab subheader */
 	asterisk?: string
 	//The profile has clearOnChange. The terms used in the plots are not always the same for the profile.


### PR DESCRIPTION
## Description

closes #2672 
termdbtest not affected http://localhost:3000/?noheader=1&massnative=hg38-test,TermdbTest
please test all profile cases (need a new case with a user has access to full but not abbreviated)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
