### PR TITLE
Fixed SC legend clipping

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -229,16 +229,11 @@ class singleCellPlot {
 				.on('change', e => {
 					let plots = structuredClone(this.state.config.plots)
 					plots.find(p => p.name == plot.name).selected = e.target.checked
-					const selectedPlots = plots.filter(p => p.selected)
-					const width = 1000
-					const height = 1000
-					let settings = {}
-					settings.svgh = width / selectedPlots.length
-					settings.svgw = height / selectedPlots.length
+
 					this.app.dispatch({
 						type: 'plot_edit',
 						id: this.id,
-						config: { plots, settings: { singleCellPlot: settings } }
+						config: { plots }
 					})
 				})
 			showDiv.append('label').attr('for', key).text(plot.name)
@@ -850,10 +845,11 @@ class singleCellPlot {
 					})
 				})
 			}
+			const clustersHeight = 20 * Object.keys(colorMap).length + 50 //added 50 for the title and padding
 			legendSVG = plot.plotDiv
 				.append('svg')
 				.attr('width', 250)
-				.attr('height', this.settings.svgh)
+				.attr('height', Math.max(this.settings.svgh, clustersHeight))
 				.style('vertical-align', 'top')
 			plot.legendSVG = legendSVG
 		}


### PR DESCRIPTION
## Description

Closes #2665. Also when adding plots did not resized plot, until we find a fix for the contours resizing. See UI, now when the plot is smaller than the legend the lengend height is used instead as svg height

<img width="1138" alt="Screenshot 2025-01-27 at 2 58 03 PM" src="https://github.com/user-attachments/assets/79aeea89-c05a-43f1-bf9f-27bf6f87028e" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
