### PR TITLE
Fix for density brush and input

### DIFF
--- a/client/dom/numericRangeInput.ts
+++ b/client/dom/numericRangeInput.ts
@@ -5,7 +5,7 @@ type TvsRange = FullyBoundedBin & { value?: number }
 
 export class NumericRangeInput {
 	callback: (f: any) => void
-	private input: Input
+	input: Input
 	range: any
 
 	constructor(holder: Elem, range: any, callback: () => void) {

--- a/client/dom/numericRangeInput.ts
+++ b/client/dom/numericRangeInput.ts
@@ -1,5 +1,5 @@
-import { Elem, Input } from '../types/d3'
-import { FullyBoundedBin } from '#types'
+import type { Elem, Input } from '../types/d3'
+import type { FullyBoundedBin } from '#types'
 
 type TvsRange = FullyBoundedBin & { value?: number }
 

--- a/client/dom/numericRangeInput.ts
+++ b/client/dom/numericRangeInput.ts
@@ -24,7 +24,7 @@ export class NumericRangeInput {
 					this.setRange()
 				}
 			})
-		this.range = this.setRange(range)
+		this.setRange(range)
 		this.callback = callback
 	}
 

--- a/client/dom/test/numericrange.unit.spec.ts
+++ b/client/dom/test/numericrange.unit.spec.ts
@@ -1,5 +1,10 @@
 import tape from 'tape'
-import { parseRange } from '../numericRangeInput'
+import * as d3s from 'd3-selection'
+import { parseRange, NumericRangeInput } from '../numericRangeInput'
+
+function getHolder() {
+	return d3s.select('body').append('div').style('padding', '5px').style('margin', '5px')
+}
 
 /**
  * Test Suite: parseRange()
@@ -60,6 +65,7 @@ tape('\n', function (test) {
  * Basic Value Tests *
  **********************/
 tape('parseRange function', function (test) {
+	test.timeoutAfter(500)
 	// Testing exact value inputs - checks both possible formats
 	test.test('handles exact value input', function (test) {
 		// First format: "x = value"
@@ -413,5 +419,31 @@ tape('parseRange function', function (test) {
 		test.end()
 	})
 
+	test.end()
+})
+
+tape('NumericRangeInput', function (test) {
+	test.timeoutAfter(100)
+	const holder = getHolder()
+	const mockRange = {
+		index: 0,
+		start: 0,
+		startinclusive: true,
+		startunbounded: false,
+		stop: 0.6,
+		stopinclusive: false,
+		stopunbounded: false
+	}
+	const callback = () => {
+		//So ts doesn't complain
+		console.log('test')
+	}
+
+	const input = new NumericRangeInput(holder.append('div') as any, mockRange, callback)
+
+	test.deepEqual(input.getRange(), mockRange, 'Should set range to input')
+	test.equal(input.input.node()!.value, `0 <= x <= 0.6`, 'Should return correct string to display in the input box')
+
+	if (test['_ok']) holder.remove()
 	test.end()
 })

--- a/client/filter/tvs.density.js
+++ b/client/filter/tvs.density.js
@@ -152,8 +152,8 @@ export function updateTempRanges(xscale, s, range, inputRange, minvalue, maxvalu
  */
 
 export function setStartStopDisplays(range, inputRange) {
-	const start = range.startunbounded ? '' : inputRange?.startinclusive ? `${range.start} <=` : `${range.start} <`
-	const stop = range.stopunbounded ? '' : inputRange?.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
+	const start = range.startunbounded ? '' : inputRange.startinclusive ? `${range.start} <=` : `${range.start} <`
+	const stop = range.stopunbounded ? '' : inputRange.stopinclusive ? `<= ${range.stop}` : `< ${range.stop}`
 
 	return [start, stop]
 }


### PR DESCRIPTION
## Description
Closes issue #2671. Along with the fix, added a unit test for the class itself and updated the import statements. 

Test by: 
1. Open any ds, add a numeric filter such as Asparaginase LC50 in all pharma, and change the lower limit to 0 <= or upper limit to >= [#].
2. Click out to anything (change tab, open chart, etc.)
3. Go back to the filter and edit. The error is gone and the input should remain the same. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
