### PR TITLE
Added Fixed and Percentile Mode to SampleScatter 

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -1,6 +1,6 @@
 import { getCompInit, copyMerge } from '../rx'
 import { fillTermWrapper } from '#termsetting'
-import { Menu, shapesArray, select2Terms } from '#dom'
+import { Menu, shapesArray, select2Terms, ColorScale } from '#dom'
 import { controlsInit } from './controls'
 import { setRenderers } from './sampleScatter.renderer'
 import { setInteractivity } from './sampleScatter.interactivity'
@@ -691,6 +691,19 @@ export function getDefaultScatterSettings() {
 		fov: 50,
 		threeSize: 0.003,
 		threeFOV: 70,
+		// Color scale configuration settings
+		// These settings control how numerical values are mapped to colors
+		colorScaleMode: 'auto', // Default to automatic scaling based on data range
+		// Other options: 'fixed' (user-defined range) or
+		// 'percentile' (scale based on data distribution)
+
+		colorScalePercentile: 95, // Default percentile for percentile mode
+		// This means we'll scale colors based on values
+		// up to the 95th percentile by default
+		colorScaleMinFixed: null, // User-defined minimum value for fixed mode
+		// Null indicates this hasn't been set yet
+		colorScaleMaxFixed: null, // User-defined maximum value for fixed mode
+		// Null indicates this hasn't been set yet
 		//3D Plot settings
 		showContour: false,
 		colorContours: false

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -1,6 +1,6 @@
 import { getCompInit, copyMerge } from '../rx'
 import { fillTermWrapper } from '#termsetting'
-import { Menu, shapesArray, select2Terms, ColorScale } from '#dom'
+import { Menu, shapesArray, select2Terms } from '#dom'
 import { controlsInit } from './controls'
 import { setRenderers } from './sampleScatter.renderer'
 import { setInteractivity } from './sampleScatter.interactivity'

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -83,6 +83,11 @@ export function setRenderers(self) {
 
 		// Handle continuous color scaling when color term wrapper is in continuous mode
 		if (self.config.colorTW?.q.mode === 'continuous') {
+			// Synchronize the chart's internal mode state with the application config.
+			// This ensures the color scale UI correctly reflects the current mode
+			// when switching between auto, fixed, and percentile modes.
+			chart.cutoffMode = self.config.settings.sampleScatter.colorScaleMode || 'auto'
+			chart.percentile = self.config.settings.sampleScatter.colorScalePercentile || 95
 			// Extract and sort all sample values for our calculations
 			// We filter out any values that are explicitly defined in the term values
 			// This gives us the raw numerical data we need for scaling
@@ -90,7 +95,7 @@ export function setRenderers(self) {
 				.filter(s => !self.config.colorTW.term.values || !(s.category in self.config.colorTW.term.values))
 				.map(s => s.category)
 				.sort((a, b) => a - b)
-			chart.colorValues = colorValues //to use it in renderLegend
+			chart.colorValues = colorValues // to use it in renderLegend
 			// Determine min/max based on current mode
 			let min, max
 			const settings = self.config.settings.sampleScatter

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -132,7 +132,6 @@ export function setRenderers(self) {
 
 			// Create the color generator using d3's linear scale
 			// This maps our numerical range to a color gradient
-			console.log('min', min, 'max', max)
 			chart.colorGenerator = d3Linear()
 				.domain([min, max])
 				.range([self.config.startColor[chart.id], self.config.stopColor[chart.id]])

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -90,7 +90,7 @@ export function setRenderers(self) {
 				.filter(s => !self.config.colorTW.term.values || !(s.category in self.config.colorTW.term.values))
 				.map(s => s.category)
 				.sort((a, b) => a - b)
-
+			chart.colorValues = colorValues //to use it in renderLegend
 			// Determine min/max based on current mode
 			let min, max
 			const settings = self.config.settings.sampleScatter
@@ -823,10 +823,7 @@ export function setRenderers(self) {
 					// Extract and sort all sample values for our calculations
 					// We filter out any values that are explicitly defined in the term values
 					// This gives us the raw numerical data we need for scaling
-					const colorValues = chart.cohortSamples
-						.filter(s => !self.config.colorTW.term.values || !(s.category in self.config.colorTW.term.values))
-						.map(s => s.category)
-						.sort((a, b) => a - b)
+					const colorValues = chart.colorValues
 
 					// Create a ColorScale component with enhanced mode functionality
 					const colorScale = new ColorScale({

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -68,17 +68,20 @@ export function setRenderers(self) {
 
 		chart.axisLeft = axisLeft(chart.yAxisScale)
 
-		const gradientColor = self.config.settings.sampleScatter.defaultColor
-
-		if (!self.config.startColor) self.config.startColor = self.config.stopColor = {}
+		const gradientColor = rgb(self.config.settings.sampleScatter.defaultColor)
+		if (!self.config.startColor) {
+			self.config.startColor = {}
+			self.config.stopColor = {}
+		}
 		// supply start and stop color, if term has hardcoded colors, use; otherwise use default
 		if (!self.config.startColor[chart.id]) {
 			self.config.startColor[chart.id] =
-				self.config.colorTW?.term.continuousColorScale?.minColor || rgb(gradientColor).brighter().brighter().toString()
+				self.config.colorTW?.term.continuousColorScale?.minColor || gradientColor.brighter().brighter().toString()
 		}
+
 		if (!self.config.stopColor[chart.id]) {
 			self.config.stopColor[chart.id] =
-				self.config.colorTW?.term.continuousColorScale?.maxColor || rgb(gradientColor).darker().toString()
+				self.config.colorTW?.term.continuousColorScale?.maxColor || gradientColor.darker().toString()
 		}
 
 		// Handle continuous color scaling when color term wrapper is in continuous mode
@@ -129,6 +132,7 @@ export function setRenderers(self) {
 
 			// Create the color generator using d3's linear scale
 			// This maps our numerical range to a color gradient
+			console.log('min', min, 'max', max)
 			chart.colorGenerator = d3Linear()
 				.domain([min, max])
 				.range([self.config.startColor[chart.id], self.config.stopColor[chart.id]])

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -15,7 +15,6 @@ import { addNewGroup } from '../mass/groups.js'
 import { setRenderersThree } from './sampleScatter.rendererThree.js'
 import { shapes } from './sampleScatter.js'
 import { roundValueAuto } from '#shared/roundValue.js'
-import { config } from 'process'
 
 export function setRenderers(self) {
 	setRenderersThree(self)
@@ -87,7 +86,7 @@ export function setRenderers(self) {
 			// Extract and sort all sample values for our calculations
 			// We filter out any values that are explicitly defined in the term values
 			// This gives us the raw numerical data we need for scaling
-			const values = chart.cohortSamples
+			const colorValues = chart.cohortSamples
 				.filter(s => !self.config.colorTW.term.values || !(s.category in self.config.colorTW.term.values))
 				.map(s => s.category)
 				.sort((a, b) => a - b)
@@ -106,20 +105,19 @@ export function setRenderers(self) {
 
 				case 'percentile':
 					// Percentile mode: Scale based on data distribution
-					// We start at 0 to maintain a consistent baseline
-					min = values[0] // Start at the first value of the array for percentile mode
+					min = colorValues[0] // Start at the first value of the array for percentile mode
 					// Calculate the value at the specified percentile
 					// This helps handle outliers by focusing on the main distribution
-					const index = Math.floor((values.length * settings.colorScalePercentile) / 100)
-					max = values[index]
+					const index = Math.floor((colorValues.length * settings.colorScalePercentile) / 100)
+					max = colorValues[index]
 					break
 
 				case 'auto':
 				default:
 					// Auto mode (default): Use the full range of the data
 					// This gives the most accurate representation of the actual data distribution
-					min = values[0]
-					max = values[values.length - 1] // Since the values are already sorted in ascending
+					min = colorValues[0]
+					max = colorValues[colorValues.length - 1] // Since the values are already sorted in ascending
 					// order just get the first and last values
 					break
 			}
@@ -822,11 +820,11 @@ export function setRenderers(self) {
 					// These values represent the minimum and maximum values in our dataset
 					let [min, max] = chart.colorGenerator.domain()
 
-					// Extract and sort all sample values for percentile calculations
-					// We filter for samples with sampleId to exclude reference data points
-					// This creates an array of numerical values that we can use for our different scaling modes
-					const values = chart.data.samples
-						.filter(s => 'sampleId' in s)
+					// Extract and sort all sample values for our calculations
+					// We filter out any values that are explicitly defined in the term values
+					// This gives us the raw numerical data we need for scaling
+					const colorValues = chart.cohortSamples
+						.filter(s => !self.config.colorTW.term.values || !(s.category in self.config.colorTW.term.values))
 						.map(s => s.category)
 						.sort((a, b) => a - b)
 
@@ -863,15 +861,15 @@ export function setRenderers(self) {
 							callback: obj => {
 								// Handle different modes for color scaling
 								if (obj.cutoffMode === 'auto') {
-									min = values[0]
-									max = values[values.length - 1]
+									min = colorValues[0]
+									max = colorValues[colorValues.length - 1]
 								} else if (obj.cutoffMode === 'fixed') {
 									min = obj.min
 									max = obj.max
 								} else if (obj.cutoffMode === 'percentile') {
-									min = values[0]
-									const index = Math.floor((values.length * obj.percentile) / 100)
-									max = values[index]
+									min = colorValues[0]
+									const index = Math.floor((colorValues.length * obj.percentile) / 100)
+									max = colorValues[index]
 								}
 
 								// Update the color generator with new range

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -357,6 +357,10 @@ export async function getPlotConfig(opts, app) {
 		await fillTermWrapper(opts.term, app.vocabApi)
 		if (opts.term2) await fillTermWrapper(opts.term2, app.vocabApi)
 		if (opts.term0) await fillTermWrapper(opts.term0, app.vocabApi)
+		// dynamic scatterplot is a child type of summary and following args are possible; if present, initialize them
+		if (opts.colorTW) await fillTermWrapper(opts.colorTW, app.vocabApi)
+		if (opts.shapeTW) await fillTermWrapper(opts.shapeTW, app.vocabApi)
+		if (opts.scaleDotTW) await fillTermWrapper(opts.scaleDotTW, app.vocabApi)
 	} catch (e) {
 		throw `${e} [summary getPlotConfig()]`
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Added fixed and percentile modes to samplescatter when colorTW mode=continuous

--- a/shared/types/src/terms/numeric.ts
+++ b/shared/types/src/terms/numeric.ts
@@ -1,4 +1,4 @@
-import { MinBaseQ, BaseTW, TermValues, BaseTerm } from '../index.ts'
+import type { MinBaseQ, BaseTW, TermValues, BaseTerm } from '../index.ts'
 
 export type RawRegularBin = Partial<RegularNumericBinConfig> & { preferredBins?: string }
 

--- a/shared/types/src/terms/numeric.ts
+++ b/shared/types/src/terms/numeric.ts
@@ -38,15 +38,13 @@ export type NumericTerm = BaseTerm & {
 	bins: PresetNumericBins
 	values?: TermValues
 	unit?: string
+	/** tailored color scale for this term, so that when the term is used for color gradient in scatter, this set of colors will be used by default */
+	continuousColorScale?: { minColor: string; maxColor: string }
 	/*densityNotAvailable?: boolean //Not used?
 	logScale?: string | number
 	max?: number
 	min?: number
-	name?: string
 	skip0forPercentile?: boolean
-	tvs?: Tvs
-	values?: TermValues
-	unit?: string
 	valueConversion?: ValueConversion*/
 }
 


### PR DESCRIPTION
## Description
Added "Fixed" and "Percentile" modes to SampleScatter when colorTW=continuous. It is in the same style as the legend menu seen in the scRNA viewer when overlaying gene expression data.

## To Test 
Go [here](http://localhost:3000/?mass=%7B%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:%5B%7B%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:%7B%22id%22:%22Age%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%7D%5D%7D)

## Closes
Closes #2677 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
