### PR TITLE
Implement legend component into correlation volcano plot

### DIFF
--- a/client/dom/LegendCircleReference.ts
+++ b/client/dom/LegendCircleReference.ts
@@ -16,7 +16,9 @@ export class LegendCircleReference {
 	inputMax: number
 	inputMin: number
 	isAscending: boolean
+	maxLabel: number
 	maxRadius: number
+	minLabel: number
 	minRadius: number
 	menu?: {
 		minMaxLabel?: string
@@ -36,7 +38,9 @@ export class LegendCircleReference {
 		this.inputMax = opts.inputMax
 		this.inputMin = opts.inputMin
 		this.isAscending = opts.isAscending ?? true
+		this.maxLabel = opts.maxLabel ?? opts.maxRadius
 		this.maxRadius = opts.maxRadius
+		this.minLabel = opts.minLabel ?? opts.minRadius
 		this.minRadius = opts.minRadius
 
 		if (opts.menu) this.menu = opts.menu
@@ -54,20 +58,20 @@ export class LegendCircleReference {
 	renderLegendComponent() {
 		this.g.selectAll('*').remove()
 
-		if (this.title) this.g.append('text').style('font-weight', 'bold').text(this.title)
+		if (this.title) this.g.append('text').style('font-weight', 'bold').style('font-size', '0.8em').text(this.title)
 
 		const minG = this.g.append('g').attr('transform', `translate(${this.x},${this.y})`)
 		const maxG = this.g.append('g').attr('transform', `translate(${this.x + this.width},${this.y})`)
 
 		//Starting text and circle element
 		const startRadius = this.isAscending ? this.minRadius : this.maxRadius
-		this.renderLabel(minG, -startRadius - this.shift, this.minRadius)
+		this.renderLabel(minG, -startRadius - this.shift, this.minLabel)
 		this.renderReferenceCircle(minG, startRadius)
 
 		//Ending text and circle element
 		const endRadius = this.isAscending ? this.maxRadius : this.minRadius
 		this.renderReferenceCircle(maxG, endRadius)
-		this.renderLabel(maxG, endRadius + this.shift, this.maxRadius)
+		this.renderLabel(maxG, endRadius + this.shift, this.maxLabel)
 
 		//Lines connecting the top and bottom of the circles
 		this.renderScalingLine(minG, this.minRadius, this.maxRadius)

--- a/client/dom/test/LegendCircleReference.unit.spec.ts
+++ b/client/dom/test/LegendCircleReference.unit.spec.ts
@@ -6,7 +6,7 @@ import { LegendCircleReference } from '#dom'
  reusable helper functions
 **************************/
 function getHolder() {
-	return select('body').append('div').style('max-width', '800px').style('border', '1px solid #555')
+	return select('body').append('div').style('max-width', '800px')
 }
 
 /**************
@@ -45,6 +45,6 @@ tape('Default LegendCircleReference', test => {
 	test.equal(ui.g.selectAll('line').size(), 2, 'Should render 2 line elements')
 	test.equal(ui.g.selectAll('rect').size(), 1, 'Should render 1 rect element')
 
-	// if (test['_ok']) holder.remove()
+	if (test['_ok']) holder.remove()
 	test.end()
 })

--- a/client/dom/test/LegendCircleReference.unit.spec.ts
+++ b/client/dom/test/LegendCircleReference.unit.spec.ts
@@ -24,19 +24,19 @@ tape('Default LegendCircleReference', test => {
 	const svg = holder.append('svg').attr('width', 300).attr('height', 300)
 
 	const ui = new LegendCircleReference({
-		g: svg.append('g').attr('transform', 'translate(10, 10)'),
+		g: svg.append('g').attr('transform', 'translate(20, 20)'),
 		inputMax: 20,
 		inputMin: 5,
 		isAscending: true,
 		maxRadius: 20,
 		minRadius: 5,
-		prompt: 'Pixels',
 		title: 'Test title',
-		dotScaleCallback: () => {
-			test.pass('dotScaleCallback')
-		},
-		minMaxCallback: () => {
-			test.pass('minMaxCallback')
+		menu: {
+			minMaxLabel: 'Pixels',
+			showOrder: true,
+			callback: obj => {
+				console.log(obj) // so ts doesn't complain
+			}
 		}
 	})
 
@@ -45,6 +45,6 @@ tape('Default LegendCircleReference', test => {
 	test.equal(ui.g.selectAll('line').size(), 2, 'Should render 2 line elements')
 	test.equal(ui.g.selectAll('rect').size(), 1, 'Should render 1 rect element')
 
-	if (test['_ok']) holder.remove()
+	// if (test['_ok']) holder.remove()
 	test.end()
 })

--- a/client/dom/types/LegendCircleReference.ts
+++ b/client/dom/types/LegendCircleReference.ts
@@ -10,19 +10,21 @@ export type LegendCircleReferenceOpts = {
 	inputMax: number
 	/** Lower limit user can input for size */
 	inputMin: number
+	maxLabel?: number
 	/** Default max radius in pixels or a scale */
 	maxRadius: number
 	/** If provided, renders a menu on click */
 	menu: {
 		/** If provided, displays a prompt (e.g. pixels, scales, etc.)
 		 * next to the min and max inputs*/
-		minMaxLabel: string
+		minMaxLabel?: string
 		/** If provided, an UI renderes to switch between an
 		 * ascending and descending scale. */
-		showOrder: boolean
+		showOrder?: boolean
 		/** Code executed when min, max, or order is changed */
 		callback: (obj: { min: number; max: number; isAscending: boolean }) => void
 	}
+	minLabel?: number
 	/** Default min radius in pixels or a scale */
 	minRadius: number
 	/** If provided, presents the user with the option

--- a/client/dom/types/LegendCircleReference.ts
+++ b/client/dom/types/LegendCircleReference.ts
@@ -12,22 +12,23 @@ export type LegendCircleReferenceOpts = {
 	inputMin: number
 	/** Default max radius in pixels or a scale */
 	maxRadius: number
+	/** If provided, renders a menu on click */
+	menu: {
+		/** If provided, displays a prompt (e.g. pixels, scales, etc.)
+		 * next to the min and max inputs*/
+		minMaxLabel: string
+		/** If provided, an UI renderes to switch between an
+		 * ascending and descending scale. */
+		showOrder: boolean
+		/** Code executed when min, max, or order is changed */
+		callback: (obj: { min: number; max: number; isAscending: boolean }) => void
+	}
 	/** Default min radius in pixels or a scale */
 	minRadius: number
 	/** If provided, presents the user with the option
 	 * to reverse the scale. */
 	isAscending?: boolean
-	/** Displays the kind of input, for example pixels
-	 * or scale to the user. */
-	minMaxLabel?: string
-	/** If provided, displays a prompt to the user. */
-	prompt?: string
 	/** If provided, displays a title above the
 	 * the circle reference. */
 	title?: string
-	/** If provided, an UI renderes to switch between an
-	 * ascending and descending scale. */
-	dotScaleCallback?: () => void
-	/** Code executed when min or max is changed */
-	minMaxCallback?: (min: number, max: number) => void
 }

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -18,6 +18,10 @@ import { CorrVolcanoInteractions } from './interactions/CorrVolcanoInteractions'
 class CorrelationVolcano extends RxComponentInner {
 	readonly type = 'correlationVolcano'
 	private components: { controls: any }
+	/** Max radius user may enter in control or legend menu */
+	readonly defaultInputMaxRadius = 35
+	/** Min radius user may enter in control or legend menu */
+	readonly defaultInputMinRadius = 1
 	dom: CorrVolcanoDom
 	dsCorrVolcano: any
 	variableTwLst: any
@@ -111,6 +115,26 @@ class CorrelationVolcano extends RxComponentInner {
 				debounceInterval: 0.05
 			},
 			{
+				label: 'Maximum radius size',
+				title: 'Set maximum radius size in pixels',
+				type: 'number',
+				chartType: 'correlationVolcano',
+				settingsKey: 'radiusMax',
+				min: this.defaultInputMinRadius,
+				max: this.defaultInputMaxRadius,
+				debounceInterval: 500
+			},
+			{
+				label: 'Minimum radius size',
+				title: 'Set minimum radius size in pixels',
+				type: 'number',
+				chartType: 'correlationVolcano',
+				settingsKey: 'radiusMin',
+				min: this.defaultInputMinRadius,
+				max: this.defaultInputMaxRadius,
+				debounceInterval: 500
+			},
+			{
 				label: 'Height',
 				title: 'Set the height of the plot',
 				type: 'number',
@@ -185,7 +209,14 @@ class CorrelationVolcano extends RxComponentInner {
 		const viewModel = new ViewModel(config, data, this.dom, settings, this.variableTwLst)
 
 		/** Render correlation volcano plot */
-		new View(this.dom, viewModel.viewData, this.interactions, settings)
+		new View(
+			this.dom,
+			viewModel.viewData,
+			this.interactions,
+			settings,
+			this.defaultInputMaxRadius,
+			this.defaultInputMinRadius
+		)
 	}
 }
 
@@ -200,7 +231,9 @@ export function getDefaultCorrVolcanoSettings(overrides = {}) {
 		method: 'pearson',
 		threshold: 0.05,
 		height: 500,
-		width: 500
+		width: 500,
+		radiusMax: 20,
+		radiusMin: 5
 	}
 	return Object.assign(defaults, overrides)
 }

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -26,6 +26,10 @@ export type CorrVolcanoSettings = {
 	isAdjustedPValue: boolean
 	/** Correlation method */
 	method: 'pearson' | 'spearman'
+	/** Maximum radius of the circles Default is 20. */
+	radiusMax: number
+	/** Minimum radius of the circles. Default is 5.  */
+	radiusMin: number
 	/** statistically significant p value the user can alter
 	 * Default is 0.05 */
 	threshold: number
@@ -122,15 +126,9 @@ export type VariableItem = {
 }
 
 /** Dimensions of sample size circles */
-export type LegendDataEntry = {
-	/** Coorresponding ample size */
-	label: number
-	/** x coordinate */
-	x: number
-	/** y coordinate */
-	y: number
-	/** radius of the circle */
-	radius: number
+export type LegendData = {
+	absMin: number
+	absMax: number
 }
 
 /** Formated response data passed from the view model
@@ -140,5 +138,5 @@ export type ViewData = {
 	plotDim: PlotDimensions
 	/** Rendering specifics for each data point */
 	variableItems: VariableItem[]
-	legendData: LegendDataEntry[]
+	legendData: LegendData
 }

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -48,6 +48,22 @@ export class CorrVolcanoInteractions {
 		})
 	}
 
+	//Obj is returned from LegendCircleReference callback
+	async changeRadius(obj: { min: number; max: number }) {
+		this.app.dispatch({
+			type: 'plot_edit',
+			id: this.id,
+			config: {
+				settings: {
+					correlationVolcano: {
+						radiusMax: obj.max,
+						radiusMin: obj.min
+					}
+				}
+			}
+		})
+	}
+
 	clearDom() {
 		this.dom.error.style('padding', '').text('')
 		this.dom.plot.selectAll('*').remove()

--- a/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
@@ -15,7 +15,6 @@ function getHolder() {
 		.style('border', '1px solid #aaa')
 		.style('padding', '5px')
 		.style('margin', '5px')
-		.node()
 }
 
 const mockData = {
@@ -44,7 +43,9 @@ const mockSettings = {
 	method: 'pearson',
 	threshold: 0.05,
 	height: 500,
-	width: 500
+	width: 500,
+	radiusMax: 20,
+	radiusMin: 5
 } satisfies CorrVolcanoSettings
 
 const mockVariableTwLst = [
@@ -97,12 +98,10 @@ tape('Default ViewModel', test => {
 	test.timeoutAfter(100)
 	const holder = getHolder() as any
 	const dom = {
-		plot: holder?.append('svg')?.append('g')
+		plot: holder.append('svg').append('g')
 	}
 
 	const viewModel = new ViewModel(mockConfig, mockData, dom as any, mockSettings, mockVariableTwLst as any)
-	test.equal(viewModel.defaultMinRadius, 5, `Should set default minimum radius to 5`)
-	test.equal(viewModel.defaultMaxRadius, 20, `Should set default maximum radius to 20`)
 	test.equal(viewModel.bottomPad, 60, `Should set bottom padding to 60`)
 	test.equal(viewModel.horizPad, 70, `Should set horizontal padding to 70`)
 	test.equal(viewModel.topPad, 40, `Should set top padding to 40`)
@@ -150,10 +149,10 @@ tape('Default ViewModel', test => {
 				previousY: 498.3333333333333
 			}
 		],
-		legendData: [
-			{ label: 373, x: 25, y: 30, radius: 5 },
-			{ label: 726, x: 25, y: 70, radius: 20 }
-		]
+		legendData: {
+			absMin: 373,
+			absMax: 726
+		}
 	}
 
 	test.deepEqual(
@@ -189,5 +188,6 @@ tape('Default ViewModel', test => {
 	)
 	test.deepEqual(viewModel.viewData.legendData, expectedViewData.legendData, `Should set the legend data as expected`)
 
+	if (test['_ok']) holder.remove()
 	test.end()
 })

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -1,10 +1,11 @@
 import { axisstyle } from '#src/client'
 import { axisBottom, axisLeft } from 'd3-axis'
 import { select } from 'd3-selection'
+import { LegendCircleReference } from '#dom'
 import type {
 	CorrVolcanoDom,
 	CorrVolcanoSettings,
-	LegendDataEntry,
+	LegendData,
 	PlotDimensions,
 	ViewData
 } from '../CorrelationVolcanoTypes'
@@ -23,7 +24,9 @@ export class View {
 		dom: CorrVolcanoDom,
 		viewData: ViewData,
 		interactions: CorrVolcanoInteractions,
-		settings: CorrVolcanoSettings
+		settings: CorrVolcanoSettings,
+		defaultMaxRadius: number,
+		defaultMinRadius: number
 	) {
 		this.dom = dom
 		this.viewData = viewData
@@ -34,7 +37,7 @@ export class View {
 		this.renderDom(plotDim)
 		// Draw all circles for variables
 		renderVariables(this, settings, interactions)
-		this.renderLegend(viewData.legendData)
+		this.renderLegend(viewData.legendData, settings, interactions, defaultMaxRadius, defaultMinRadius)
 	}
 
 	renderDom(plotDim: PlotDimensions) {
@@ -101,30 +104,36 @@ export class View {
 		})
 	}
 
-	renderLegend(legendData: LegendDataEntry[]) {
+	renderLegend(
+		legendData: LegendData,
+		settings: CorrVolcanoSettings,
+		interactions: CorrVolcanoInteractions,
+		defaultMaxRadius: number,
+		defaultMinRadius: number
+	) {
 		const svg = this.dom.legend
-			.attr('width', 100)
+			.attr('width', 400)
 			.attr('height', 100)
 			.style('display', 'inline-block')
 			.style('vertical-align', 'top')
 			.style('padding-top', '20px')
-		svg.append('text').text('Sample size').attr('x', 10).attr('y', 15)
 
-		for (const c of legendData) {
-			svg
-				.append('circle')
-				.attr('fill', 'lightgrey')
-				.attr('stroke', 'lightgrey')
-				.attr('cx', c.x)
-				.attr('cy', c.y)
-				.attr('r', c.radius)
-
-			svg
-				.append('text')
-				.attr('x', c.x + 25)
-				.attr('y', c.y + 5)
-				.text(c.label)
-		}
+		new LegendCircleReference({
+			g: svg.append('g').attr('transform', 'translate(20, 20)'),
+			inputMax: defaultMaxRadius,
+			inputMin: defaultMinRadius,
+			maxLabel: legendData.absMax,
+			maxRadius: settings.radiusMax,
+			minLabel: legendData.absMin,
+			minRadius: settings.radiusMin,
+			title: 'Sample Size',
+			menu: {
+				minMaxLabel: 'pixels',
+				callback: async obj => {
+					await interactions.changeRadius(obj)
+				}
+			}
+		})
 	}
 }
 

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -6,9 +6,6 @@ import type { CorrVolcanoDom, CorrVolcanoPlotConfig, CorrVolcanoSettings, ViewDa
 
 export class ViewModel {
 	viewData: ViewData
-	//For rendering the circles and legend info
-	readonly defaultMinRadius = 5
-	readonly defaultMaxRadius = 20
 	readonly bottomPad = 60
 	/** Only one side, left or right */
 	readonly horizPad = 70
@@ -137,7 +134,7 @@ export class ViewModel {
 	) {
 		const radiusScale = scaleLinear()
 			.domain([absSampleMin, absSampleMax])
-			.range([this.defaultMinRadius, this.defaultMaxRadius])
+			.range([settings.radiusMin, settings.radiusMax])
 		const renderedCircles = dom.plot
 			?.selectAll('circle')
 			.nodes()
@@ -163,19 +160,9 @@ export class ViewModel {
 	}
 
 	setLegendData(absSampleMin: number, absSampleMax: number) {
-		return [
-			{
-				label: absSampleMin,
-				x: 25,
-				y: 30,
-				radius: this.defaultMinRadius
-			},
-			{
-				label: absSampleMax,
-				x: 25,
-				y: this.defaultMaxRadius + 50,
-				radius: this.defaultMaxRadius
-			}
-		]
+		return {
+			absMin: absSampleMin,
+			absMax: absSampleMax
+		}
 	}
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- Users may change the size of the data points in the correlation volcano plot from the control panel or the legend. Clicking on the legend menu displays a menu to change the min and max radius in pixels.


### PR DESCRIPTION
## Description
Closes issue #2648 . 

Changes: 
1. Refined the legend circle reference component. The component uses simpler arguments. 
2. Implemented the component into the correlation volcano plot. The radius can be updated from both the legend by clicking on the `Sample size` element to the right of the plot as well as the control panel. 
3. Updated the unit tests. 

Test with the [all pharma example](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22correlationVolcano%22,%22featureTw%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22KRAS%22}}}]}). 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
