### PR TITLE
Log scale in box plot

### DIFF
--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -144,7 +144,7 @@ class TdbBoxplot extends RxComponentInner {
 				settingsKey: 'isLogScale',
 				options: [
 					{ label: 'Linear', value: false },
-					{ label: 'Log', value: true }
+					{ label: 'Log10', value: true }
 				]
 			},
 			{

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -30,6 +30,9 @@ export type BoxPlotSettings = {
 	darkMode: boolean
 	/** Padding between the left hand label and boxplot */
 	labelPad: number
+	/** Toggle between a linear and log scale
+	 * When true, renders a log scale. Default is false */
+	isLogScale: boolean
 	/** Toggle between vertical and horizontal orientation.
 	 * The default is false */
 	isVertical: boolean
@@ -134,14 +137,25 @@ class TdbBoxplot extends RxComponentInner {
 				getDisplayStyle: (plot: PlotConfig) => (plot.term2 ? '' : 'none')
 			},
 			{
+				label: 'Scale',
+				title: 'Change the axis scale',
+				type: 'radio',
+				chartType: 'boxplot',
+				settingsKey: 'isLogScale',
+				options: [
+					{ label: 'Linear', value: false },
+					{ label: 'Log', value: true }
+				]
+			},
+			{
 				label: 'Orientation',
 				title: 'Change the orientation of the box plots',
 				type: 'radio',
 				chartType: 'boxplot',
 				settingsKey: 'isVertical',
 				options: [
-					{ label: 'Horizontal', value: false },
-					{ label: 'Vertical', value: true }
+					{ label: 'Vertical', value: true },
+					{ label: 'Horizontal', value: false }
 				]
 			},
 			{
@@ -244,6 +258,7 @@ class TdbBoxplot extends RxComponentInner {
 	async main() {
 		try {
 			const config = structuredClone(this.state.config)
+			console.log(this.app.vocabApi.termdbConfig.logscaleBase2)
 			if (config.childType != this.type && config.chartType != this.type) return
 
 			const settings = config.settings.boxplot
@@ -301,6 +316,7 @@ export function getDefaultBoxplotSettings(app, overrides = {}) {
 		color: plotColor,
 		darkMode: false,
 		labelPad: 10,
+		isLogScale: false,
 		isVertical: false,
 		orderByMedian: false,
 		rowHeight: 50,

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -258,7 +258,6 @@ class TdbBoxplot extends RxComponentInner {
 	async main() {
 		try {
 			const config = structuredClone(this.state.config)
-			console.log(this.app.vocabApi.termdbConfig.logscaleBase2)
 			if (config.childType != this.type && config.chartType != this.type) return
 
 			const settings = config.settings.boxplot

--- a/client/plots/boxplot/model/Model.ts
+++ b/client/plots/boxplot/model/Model.ts
@@ -36,6 +36,7 @@ export class Model {
 			opts.overlayTw = this.getContinousTerm() == this.config.term ? this.config.term2 : this.config.term
 
 		opts.orderByMedian = this.settings.orderByMedian
+		opts.isLogScale = this.settings.isLogScale
 
 		return opts
 	}

--- a/client/plots/boxplot/test/boxplot.unit.spec.ts
+++ b/client/plots/boxplot/test/boxplot.unit.spec.ts
@@ -34,6 +34,7 @@ const mockSettings = {
 	color: 'blue',
 	darkMode: false,
 	labelPad: 10,
+	isLogScale: false,
 	isVertical: false,
 	orderByMedian: false,
 	rowHeight: 20,

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -43,7 +43,7 @@ export class View {
 			//Fix for white background when downloading darkMode image.
 			.style('fill', plotDim.backgroundColor)
 
-		const setScaleFunc = settings.isLogScale ? scaleLog().base(2) : scaleLinear()
+		const setScaleFunc = settings.isLogScale ? scaleLog().base(10) : scaleLinear()
 		const scale = setScaleFunc.domain(plotDim.domain).range(plotDim.range)
 
 		this.renderTitle(plotDim, dom)
@@ -82,7 +82,13 @@ export class View {
 			.attr('id', 'sjpp-boxplot-axis')
 			.attr('transform', `translate(${plotDim.axis.x}, ${plotDim.axis.y})`)
 			.transition()
-			.call(this.settings.isVertical ? axisLeft(scale).tickPadding(5) : axisTop(scale))
+			.call(
+				this.settings.isVertical
+					? axisLeft(scale)
+							.tickPadding(6)
+							.tickFormat(d => plotDim.axis.format(d as number))
+					: axisTop(scale).tickFormat(d => plotDim.axis.format(d as number))
+			)
 
 		axisstyle({
 			axis: dom.axis,

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -1,6 +1,6 @@
 import type { ScaleLinear } from 'd3-scale'
 import { drawBoxplot, Menu } from '#dom'
-import { scaleLinear } from 'd3-scale'
+import { scaleLinear, scaleLog } from 'd3-scale'
 import { axisstyle } from '#src/client'
 import { axisTop, axisLeft } from 'd3-axis'
 import type { BoxPlotDom, BoxPlotSettings } from '../BoxPlot'
@@ -43,7 +43,8 @@ export class View {
 			//Fix for white background when downloading darkMode image.
 			.style('fill', plotDim.backgroundColor)
 
-		const scale = scaleLinear().domain(plotDim.domain).range(plotDim.range)
+		const setScaleFunc = settings.isLogScale ? scaleLog().base(2) : scaleLinear()
+		const scale = setScaleFunc.domain(plotDim.domain).range(plotDim.range)
 
 		this.renderTitle(plotDim, dom)
 		this.renderBoxPlots(dom, data, scale, settings)

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -52,7 +52,7 @@ export type PlotDimensions = {
 	/** Title of the plot and coordinates */
 	title: { x: number; y: number; text: string }
 	/** axis coordinates */
-	axis: { x: number; y: number }
+	axis: { x: number; y: number; format: (d: number) => string }
 }
 
 export class ViewModel {
@@ -121,7 +121,13 @@ export class ViewModel {
 			title: this.setTitleDimensions(config, settings, svg.height),
 			axis: {
 				x: settings.isVertical ? this.horizPad / 2 + this.incrPad + this.topPad : this.totalLabelSize,
-				y: this.topPad + (settings.isVertical ? settings.labelPad : this.incrPad + 20)
+				y: this.topPad + (settings.isVertical ? settings.labelPad : this.incrPad + 20),
+				format: settings.isLogScale
+					? d => {
+							// Only return values that are exact powers of 10
+							return d === 0 || Math.log10(d) % 1 === 0 ? d.toString() : ''
+					  }
+					: d => d.toString()
 			},
 			backgroundColor: settings.darkMode ? 'black' : 'white',
 			textColor: settings.darkMode ? 'white' : 'black'

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -141,7 +141,7 @@ class ViolinPlot {
 				settingsKey: 'unit',
 				options: [
 					{ label: 'Linear', value: 'abs' },
-					{ label: 'Log', value: 'log' }
+					{ label: 'Log10', value: 'log' }
 				]
 			},
 			{

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Enable toggling between a linear and log axis scale in the mass box plot

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -42,12 +42,11 @@ function init({ genomes }) {
 
 			const sampleType = `All ${data.sampleType?.plural_name || 'samples'}`
 			const overlayTerm = q.overlayTw
-			const isLog = false // TODO: implement rendering plots in a log scale (q.isLog)
 			const { absMin, absMax, key2values, uncomputableValues } = parseValues(
 				q,
 				data as ValidGetDataResponse,
 				sampleType,
-				isLog,
+				q.isLogScale,
 				overlayTerm
 			)
 

--- a/shared/types/src/routes/termdb.boxplot.ts
+++ b/shared/types/src/routes/termdb.boxplot.ts
@@ -9,6 +9,8 @@ export type BoxPlotRequest = {
 	tw: TermWrapper
 	genome: string
 	dslabel: string
+	/** if true, only return positive values */
+	isLogScale: boolean
 	/** sort plots by median value */
 	orderByMedian: boolean
 	/** term2 */


### PR DESCRIPTION
## Description
I wanted to finish this before leaving for a few weeks and the branch falling behind. Added a toggle between a linear and log scale for the box plot. Test with any box plot from http://localhost:3000/url.html. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
