### PR TITLE
Show dictionary when featureTw isn't supplied to corr volcano

### DIFF
--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -155,7 +155,7 @@ class CorrelationVolcano extends RxComponentInner {
 	}
 
 	async init(appState: MassState) {
-		await this.setControls()
+		if (this.getState(appState).config['featureTw']) await this.setControls()
 		//Hack because obj not returning in getState(). Will fix later.
 		this.dsCorrVolcano = appState.termdbConfig.correlationVolcano
 
@@ -171,8 +171,12 @@ class CorrelationVolcano extends RxComponentInner {
 		const config = structuredClone(this.state.config)
 		if (config.childType != this.type && config.chartType != this.type) return
 
-		const settings = config.settings.correlationVolcano
+		if (config.featureTw == null) {
+			this.interactions.showTree()
+			return
+		}
 
+		const settings = config.settings.correlationVolcano
 		/** Request data from the server*/
 		const model = new Model(config, this.state, this.app, settings, this.variableTwLst)
 		const data = await model.getData()
@@ -210,17 +214,20 @@ export async function getPlotConfig(opts: CorrVolcanoOpts, app: MassAppApi) {
 	//See logic in shared/utils/src/termdb.usecase.js for how tree is limited
 	//May change this later
 	if (opts.numeric && !opts.featureTw) opts.featureTw = { term: opts.numeric.term } as any
-	if (!opts.featureTw) throw 'opts.featureTw{} missing [correlationVolcano getPlotConfig()]'
-	try {
-		await fillTermWrapper(opts.featureTw, app.vocabApi)
-	} catch (e) {
-		console.error(new Error(`${e} [correlationVolcano getPlotConfig()]`))
-		throw `correlationVolcano getPlotConfig() failed`
+	/** If featureTw is passed, the plot will load per usual
+	 * else a UI will appear allowing the uses to select the feature */
+	if (opts.featureTw) {
+		try {
+			await fillTermWrapper(opts.featureTw, app.vocabApi)
+		} catch (e) {
+			console.error(new Error(`${e} [correlationVolcano getPlotConfig()]`))
+			throw `correlationVolcano getPlotConfig() failed`
+		}
 	}
 
 	const config = {
 		chartType: 'correlationVolcano',
-		featureTw: opts.featureTw,
+		featureTw: opts.featureTw ?? null,
 		settings: {
 			controls: {
 				term2: null,

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -1,6 +1,7 @@
 import type { TermWrapper } from '#types'
 import { to_svg } from '#src/client'
 import { getReadableType } from '#shared/terms.js'
+import { appInit } from '#termdb/app'
 
 //TODO - finish typing this file
 export class CorrVolcanoInteractions {
@@ -28,6 +29,33 @@ export class CorrVolcanoInteractions {
 	download() {
 		const svg = this.dom.svg.node() as Node
 		to_svg(svg, `correlationVolcano`, { apply_dom_styles: true })
+	}
+
+	//If no featureTw is set, show the tree to select a feature
+	async showTree() {
+		this.dom.div.selectAll('*').remove()
+		await appInit({
+			vocabApi: this.app.vocabApi,
+			holder: this.dom.div,
+			state: this.app.getState(),
+			tree: {
+				click_term: _term => {
+					const term = _term.term || _term
+					this.app.dispatch({
+						type: 'plot_create',
+						config: {
+							chartType: 'correlationVolcano',
+							featureTw: _term.term ? _term : { term }
+						}
+					})
+
+					this.app.dispatch({
+						type: 'plot_delete',
+						id: this.id
+					})
+				}
+			}
+		})
 	}
 
 	//When clicking on dot, launch the sample scatter by gene and drug

--- a/client/plots/corrVolcano/test/corrVolcano.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.spec.ts
@@ -6,6 +6,7 @@ DO NOT ENABLE THIS FILE ON CI. ITS FOR PROTOTYPING ONLY
 
 Tests:
     - Default correlation volcano plot
+	- No featureTw
  */
 
 /*************************
@@ -76,7 +77,7 @@ tape('Default correlation volcano', test => {
 		testPlot(dom.plot)
 		testLegend(dom.legend)
 
-		// if (test['_ok']) correlationVolcano.Inner.app.destroy()
+		if (test['_ok']) correlationVolcano.Inner.app.destroy()
 		test.end()
 	}
 
@@ -91,5 +92,32 @@ tape('Default correlation volcano', test => {
 		const legendCircles = legend.selectAll('circle').size()
 		const expected = 2
 		test.equal(legendCircles, expected, `Should display ${expected} circles in the legend`)
+	}
+})
+
+tape.skip('No featureTw', test => {
+	test.timeoutAfter(3000)
+
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'correlationVolcano'
+				}
+			]
+		},
+		correlationVolcano: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	async function runTests(correlationVolcano: any) {
+		correlationVolcano.on('postRender.test', null)
+		//TODO
+
+		// if (test['_ok']) correlationVolcano.Inner.app.destroy()
+		test.end()
 	}
 })

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Feature
+- If featureTw isn't provided to the correlation volcano plot, the dictionary will render so user may select the feature of interest.


### PR DESCRIPTION
## Description
Addresses final feature request and closes issue #2626 . 

Changes:
If featureTw isn't specified in `runpp()`, the sandbox will render with the dictionary for the user to select the feature of interest. 

Test: 
Unskip the test `No featureTw` test in `client/plots/corrVolcano/test/corrVolcano.spec.ts` to see the UI. Note the tests are broken in this non-CI file. Several changes need to merge so I can efficiently update them. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
