### PR TITLE
Fix position of percentile input in color scale menu

### DIFF
--- a/client/dom/ColorScale/ColorScaleMenu.ts
+++ b/client/dom/ColorScale/ColorScaleMenu.ts
@@ -50,6 +50,13 @@ export class ColorScaleMenu {
 					.text('Press ENTER to submit')
 					.style('display', 'none')
 
+				const percentRow = table
+					.append('tr')
+					.style('padding', '5px')
+					.append('td')
+					.attr('colspan', '2')
+					.style('display', this.cutoffMode == 'percentile' ? '' : 'none')
+
 				const minMaxPromptRow = table
 					.append('tr')
 					.style('text-align', 'center')
@@ -79,13 +86,6 @@ export class ColorScaleMenu {
 						.text(d => d.label)
 						.property('value', d => d.value)
 						.property('selected', d => d.selected)
-
-					const percentRow = table
-						.append('tr')
-						.style('padding', '5px')
-						.append('td')
-						.attr('colspan', '2')
-						.style('display', this.cutoffMode == 'percentile' ? '' : 'none')
 
 					const percentInput = this.appendValueInput(percentRow, this.percentile || null)
 


### PR DESCRIPTION
## Description
This is very minor. The input for percentile is now above the Min and Max prompts. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
