### PR TITLE
Scatter shapes fix

### DIFF
--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -299,13 +299,13 @@ async function colorAndShapeSamples(refSamples, cohortSamples, data, q) {
 			}
 		}
 		let i = 0
-		for (const [category, value] of Object.entries(result.shapeMap)) {
+		const shapes = Object.entries(result.shapeMap).sort((a, b) => a[0].localeCompare(b[0]))
+		for (const [category, value] of shapes) {
 			if ('shape' in value) continue
 			if (q.shapeTW.term.values?.[value.key]?.shape != undefined) value.shape = q.shapeTW.term.values?.[value.key].shape
 			else value.shape = i
 			i++
 		}
-
 		result.colorLegend = q.colorTW
 			? order(result.colorMap, q.colorTW, data.refs)
 			: [['Default', { sampleCount: cohortSamples.length, color: 'blue', key: 'Default' }]]
@@ -431,10 +431,7 @@ function order(map, tw, refs) {
 		for (const [category, value] of Object.entries(map))
 			if (!entries.some(e => e[0] === category)) entries.push([category, value])
 	} else {
-		entries.sort((a, b) => {
-			if (a[1].sampleCount > b[1].sampleCount) return -1
-			else return 1
-		})
+		entries.sort((a, b) => a[0].localeCompare(b[0]))
 	}
 	return entries
 }


### PR DESCRIPTION
## Description
Solves second issue reported [here](https://github.com/stjude/sjpp/issues/640)

If no order is provided, order categories alphabetically instead of by sample count, that is variable, to favor  the same positions in the legend order. When assigning shapes ordered categories to favor same shape for the category




## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
