### PR TITLE
detect if is the case of gene not found in hdf5 and throw short msg

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -609,7 +609,6 @@ class singleCellPlot {
 			this.dom.loadingDiv.style('display', '').append('div').attr('class', 'sjpp-spinner')
 			this.data = await this.getData()
 			if (this.data.error) throw this.data.error
-			console.log('singleCellPlot data:', this.data)
 			this.dom.loadingDiv.style('display', 'none')
 			await this.renderPlots(this.data)
 			this.showActiveTab()
@@ -713,7 +712,6 @@ class singleCellPlot {
 	}
 
 	renderPlot(plot) {
-		console.log('renderPlot:', plot)
 		if (!plot.plotDiv) {
 			const plotDiv = this.dom.plotsDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')
 			const leftDiv = plotDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -47,13 +47,8 @@ class singleCellPlot {
 		const state = this.getState(appState)
 
 		const body = { genome: state.genome, dslabel: state.dslabel, filter0: state.termfilter.filter0 || null }
-		let result
-		try {
-			result = await dofetch3('termdb/singlecellSamples', { body })
-			if (result.error) throw result.error
-		} catch (e) {
-			throw e
-		}
+		const result = await dofetch3('termdb/singlecellSamples', { body })
+		if (result.error) throw result.error
 
 		this.samples = result.samples
 		// need to set the this.samples based on the current filter0
@@ -614,6 +609,7 @@ class singleCellPlot {
 			this.dom.loadingDiv.style('display', '').append('div').attr('class', 'sjpp-spinner')
 			this.data = await this.getData()
 			if (this.data.error) throw this.data.error
+			console.log('singleCellPlot data:', this.data)
 			this.dom.loadingDiv.style('display', 'none')
 			await this.renderPlots(this.data)
 			this.showActiveTab()
@@ -623,7 +619,7 @@ class singleCellPlot {
 		} catch (e) {
 			this.app.tip.hide()
 			this.dom.loadingDiv.style('display', 'none')
-			this.dom.plotsDiv.style('display', 'none')
+			this.dom.plotsDiv.selectAll('*').remove()
 			if (e.stack) console.log(e.stack)
 			sayerror(this.dom.errorDiv, e)
 		}
@@ -717,6 +713,7 @@ class singleCellPlot {
 	}
 
 	renderPlot(plot) {
+		console.log('renderPlot:', plot)
 		if (!plot.plotDiv) {
 			const plotDiv = this.dom.plotsDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')
 			const leftDiv = plotDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -251,6 +251,14 @@ function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 			}
 		} catch (e) {
 			// arg should be an error string; if needed generate sanitised version by not showing file path
+
+			// possible for gene not found in hdf5. in such case rust will return lengthy error including file path which we do not want to show on client.
+			if (typeof e == 'string') {
+				const geneNotFound = `Gene '${q.gene}' not found in the HDF5 file`
+				// if the substring exists in rust error, means the gene is not found. throw a simple msg to alert downstream
+				if (e.includes(geneNotFound)) throw 'Gene not found'
+			}
+			// encountered other error
 			console.log(e)
 			throw 'error reading h5 file: ' + e
 		}

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -256,7 +256,7 @@ function validateGeneExpressionNative(G: SingleCellGeneExpressionNative) {
 			if (typeof e == 'string') {
 				const geneNotFound = `Gene '${q.gene}' not found in the HDF5 file`
 				// if the substring exists in rust error, means the gene is not found. throw a simple msg to alert downstream
-				if (e.includes(geneNotFound)) throw 'Gene not found'
+				if (e.includes(geneNotFound)) throw 'No expression data for this gene'
 			}
 			// encountered other error
 			console.log(e)


### PR DESCRIPTION
## Description

closes #2691 

this avoids showing unintuitive err msg on client 

[test link](http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22BALL-scrna%22,%22plots%22:[{%22chartType%22:%22singleCellPlot%22,%22sample%22:%22SJBALL030036_D1%22}]})
search PAX3, and displays a simpler err message

however, searching a different gene continue to err out which shouldn't. scrna ui should detect if gene exp data search failed and allow user to resume using the ui

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
