### PR TITLE
Format tick values when box plot is shown in log scale

### DIFF
--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -77,7 +77,8 @@ export class View {
 		 * renders the axis from max - min. Render the box plots, then change
 		 * the scale vector to match. */
 		if (settings.isVertical) scale.range([scale.range()[1], scale.range()[0]])
-
+		const ticks = scale.ticks()
+		const tickValues = plotDim.axis.values(ticks)
 		dom.axis
 			.attr('id', 'sjpp-boxplot-axis')
 			.attr('transform', `translate(${plotDim.axis.x}, ${plotDim.axis.y})`)
@@ -85,9 +86,12 @@ export class View {
 			.call(
 				this.settings.isVertical
 					? axisLeft(scale)
-							.tickPadding(6)
+							.tickValues(tickValues)
 							.tickFormat(d => plotDim.axis.format(d as number))
-					: axisTop(scale).tickFormat(d => plotDim.axis.format(d as number))
+							.tickPadding(8)
+					: axisTop(scale)
+							.tickValues(tickValues)
+							.tickFormat(d => plotDim.axis.format(d as number))
 			)
 
 		axisstyle({

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -146,17 +146,15 @@ export class ViewModel {
 
 	filterTickValues(ticks: number[]) {
 		const signifcantLessThanOne = ticks.filter(t => t < 1).length / ticks.length
+		const range = ticks[ticks.length - 1] - ticks[0]
+		const spread = range > 1000 ? 4 : range > 100 ? 3 : 2
 		const formattedTicks = ticks.filter((t, i) => {
-			if (t === 0) return format('.0f')(t)
-			if (signifcantLessThanOne > 0.5) {
+			if (t === 0 || (i == ticks.length - 1 && i % spread !== 0)) return t
+			else if (t <= 1 && signifcantLessThanOne > 0.5) {
 				/** Scales with a significant number of values under 1
 				 * require more space. Show every fifth value if under 1 */
-				if (t < 1 && i % 5 === 0) return t
-				else if (i % 2 === 0) return t
-			}
-			const range = ticks[ticks.length - 1] - ticks[0]
-			const spread = range > 1000 ? 4 : range > 100 ? 3 : 2
-			if (i % spread === 0) return t
+				if (i % 5 === 0) return t
+			} else if (i % spread === 0) return t
 		})
 		return formattedTicks
 	}


### PR DESCRIPTION
## Description
Closes issue #2688 .

Test with this [specific example](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22childType%22:%22boxplot%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22,%22name%22:%22TP53%22%7D,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%22term2%22:%7B%22id%22:%22diaggrp%22%7D,%22settings%22:%7B%22boxplot%22:%7B%22isLogScale%22:true%7D%7D%7D%5D%7D) and with any box plot in http://localhost:3000/url.html. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
