### PR TITLE
do not crash the server if no datasets loaded and there are no server…

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -202,12 +202,11 @@ function processTrackedDs(trackedDatasets) {
 	const nonblocking = trackedDatasets.filter(
 		ds => ds.init.status === 'nonblocking' || ds.init.status == 'recoverableError'
 	)
-	// if no dataset loaded successfully, assume that there may be something wrong
-	// with serverconfig and/or code, not with dataset js/ts files, and
-	// crash the server to trigger rollback
 	if (!done.length && !nonblocking.length) {
-		// this should trigger a rollback notification
-		throw `${serverconfig.URL}: there were no datasets that loaded successfully`
+		// if no dataset loaded successfully, and only if there are genome + dataset entries,
+		// then assume that there may be something wrong with serverconfig and/or code,
+		// not with dataset js/ts files, and crash the server to trigger rollback
+		if (trackedDatasets.length) throw `${serverconfig.URL}: there were no datasets that loaded successfully`
 	} else {
 		if (done.length) {
 			console.log(`\n--- these datasets finished loading ---`)


### PR DESCRIPTION
…config dataset entries

## Description

Can test that the server doesn't crash by removing all dataset entires or using `serverconfig.features.dsLabelFilter: ['fake-ds-name']`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
