### PR TITLE
Support $id in regression interactions

### DIFF
--- a/client/plots/regression.inputs.js
+++ b/client/plots/regression.inputs.js
@@ -321,17 +321,14 @@ function setRenderers(self) {
 			if (section.configKey == 'independent') {
 				if (!variable.interactions) variable.interactions = []
 				for (const id of variable.interactions) {
-					const tw = selected.find(i => (i.term.id || i.term.name) == id)
+					const tw = selected.find(i => i.$id == id)
 					if (!tw) throw 'interacting partner not found in independents: ' + id
 					if (!tw.interactions) tw.interactions = []
-					if (!tw.interactions.includes(variable.term.id || variable.term.name))
-						tw.interactions.push(variable.term.id || variable.term.name)
+					if (!tw.interactions.includes(variable.$id)) tw.interactions.push(variable.$id)
 				}
 			}
 
-			const input = section.inputLst.find(
-				input => input.term?.term.id == variable.term.id || input.term?.term.name == variable.term.name
-			)
+			const input = section.inputLst.find(input => input.term?.$id == variable.$id)
 			if (!input) {
 				section.inputLst.push(
 					new InputTerm({
@@ -411,8 +408,8 @@ function setInteractivity(self) {
 				// if the input.term has interaction pairs, then
 				// delete this term.id from those other input term.interactions
 				for (const other of input.section.inputLst) {
-					if (!other.term || !other.term.interactions) continue
-					const i = other.term.interactions.indexOf(input.term.term.id || input.term.term.name)
+					if (!other.term || !other.term.interactions?.length) continue
+					const i = other.term.interactions.indexOf(input.term.$id)
 					if (i != -1) other.term.interactions.splice(i, 1)
 				}
 			}
@@ -442,7 +439,7 @@ function setInteractivity(self) {
 				// this is a spline term, delete existing interactions with this term
 				for (const other of input.section.inputLst) {
 					if (!other.term || !other.term.interactions) continue
-					const i = other.term.interactions.indexOf(input.term.term.id || input.term.term.name)
+					const i = other.term.interactions.indexOf(input.term.$id)
 					if (i != -1) other.term.interactions.splice(i, 1)
 				}
 				variable.interactions = []

--- a/client/plots/regression.inputs.js
+++ b/client/plots/regression.inputs.js
@@ -316,12 +316,14 @@ function setRenderers(self) {
 		// the independent variables array will be used as-is
 		const selectedArray = Array.isArray(selected) ? selected : selected ? [selected] : []
 
+		mayConvertInteractionIds(selectedArray, section)
+
 		// process each selected variable
 		for (const variable of selectedArray) {
 			if (section.configKey == 'independent') {
 				if (!variable.interactions) variable.interactions = []
 				for (const id of variable.interactions) {
-					const tw = selected.find(i => i.$id == id)
+					const tw = selectedArray.find(i => i.$id == id)
 					if (!tw) throw 'interacting partner not found in independents: ' + id
 					if (!tw.interactions) tw.interactions = []
 					if (!tw.interactions.includes(variable.$id)) tw.interactions.push(variable.$id)
@@ -345,6 +347,26 @@ function setRenderers(self) {
 		}
 
 		mayAddBlankInput(section, self)
+	}
+
+	// interactions[] from url will contain term ids
+	// convert these to $ids
+	function mayConvertInteractionIds(selectedArray, section) {
+		if (section.configKey != 'independent') return
+		const id2$id = new Map() // id => $id
+		// first populate id2$id map
+		for (const v of selectedArray) {
+			if (v.id) id2$id.set(v.id, v.$id)
+		}
+		// then convert all ids in interactions[] to $ids
+		for (const v of selectedArray) {
+			if (v.interactions?.length) {
+				for (const [i, id] of v.interactions.entries()) {
+					const $id = id2$id.get(id)
+					if ($id) v.interactions[i] = $id
+				}
+			}
+		}
 	}
 
 	async function addInput(input) {

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -459,11 +459,7 @@ export class InputTerm {
 		self.dom.tip.d
 			.append('div')
 			.selectAll('div')
-			.data(
-				self.parent.config.independent.filter(
-					tw => tw && tw.term.id !== self.term.term.id && tw.term.name !== self.term.term.name && tw.q.mode != 'spline'
-				)
-			)
+			.data(self.parent.config.independent.filter(tw => tw && tw.$id != self.term.$id && tw.q.mode != 'spline'))
 			.enter()
 			.append('div')
 			.style('margin', '5px')
@@ -472,7 +468,7 @@ export class InputTerm {
 				const checkbox = elem
 					.append('input')
 					.attr('type', 'checkbox')
-					.property('checked', self.term.interactions.includes(tw.term.id || tw.term.name))
+					.property('checked', self.term.interactions.includes(tw.$id))
 
 				elem.append('span').text(' ' + tw.term.name)
 			})
@@ -485,15 +481,12 @@ export class InputTerm {
 				self.dom.tip.hide()
 				self.term.interactions = []
 				self.dom.tip.d.selectAll('input').each(function (tw) {
-					if (select(this).property('checked')) self.term.interactions.push(tw.term.id || tw.term.name)
+					if (select(this).property('checked')) self.term.interactions.push(tw.$id)
 				})
 				for (const tw of self.parent.config.independent) {
-					const i = tw.interactions.indexOf(self.term.term.id || self.term.term.name)
-					if (self.term.interactions.includes(tw.term.id || tw.term.name)) {
-						if (i == -1) tw.interactions.push(self.term.term.id || self.term.term.name)
-					} else if (i != -1) {
-						tw.interactions.splice(i, 1)
-					}
+					const interactions = new Set(tw.interactions)
+					self.term.interactions.includes(tw.$id) ? interactions.add(self.term.$id) : interactions.delete(self.term.$id)
+					tw.interactions = [...interactions]
 				}
 				self.parent.editConfig(self, self.term)
 			})

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -1,4 +1,4 @@
-import { termsettingInit } from '#termsetting'
+import { termsettingInit, get$id } from '#termsetting'
 import { get_bin_label } from '#shared/termdb.bins.js'
 import { InputValuesTable } from './regression.inputs.values.table'
 import { Menu } from '#dom/menu'
@@ -165,6 +165,10 @@ export class InputTerm {
 			await this.pill.main(this.getPillArgs())
 			this.renderInteractionPrompt()
 			await this.valuesTable.main()
+			// $id needs to be filled in here for non-dictionary terms
+			// TODO: should have a centralized location for filling in
+			// $id for non-dictionary terms
+			if (tw && !tw.$id) tw.$id = await get$id(this.parent.app.vocabApi.getTwMinCopy(tw))
 			const e = (tw && tw.error) || this.pill.error
 			if (e) errors.push(e)
 			if (errors.length) throw errors

--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -143,7 +143,7 @@ export class RegressionResults {
 	}
 
 	getIndependentInput(tid) {
-		/* arg is independent tw $id
+		/* arg is independent tw $id or snpid
 		return input instance
 		for accessing input.orderedLabels and input.term{refGrp, term{}, q{}} which is term-wrapper
 
@@ -1022,18 +1022,17 @@ function setRenderers(self) {
 			// variable is part of an interaction, but the current row
 			// is not an interaction row
 			for (const tid of tw.interactions) {
-				if (tid.startsWith('snplst') || tid.startsWith('snplocus')) {
-					// snplst or snplocus term id
+				const t = self.getIndependentInput(tid).term
+				if (t.term.snps) {
+					// snplst or snplocus term
 					// need to get term ids of individuals snps
-					const t = self.getIndependentInput(tid).term
-					if (!t.term.snps) throw 'expected .snps property'
 					for (const snp of t.term.snps) interactions.push(snp.snpid)
 				} else {
 					interactions.push(tid)
 				}
 			}
 			if (!interactions.length) throw 'interactions[] is empty'
-			const interactingTws = independentTws.filter(t => interactions.includes(t.term.id || t.term.name))
+			const interactingTws = independentTws.filter(t => interactions.includes(t.$id || t.id))
 			interactionsBaselines.push(...getBaselines(interactingTws))
 		}
 		if (category) {
@@ -1074,13 +1073,13 @@ function setRenderers(self) {
 
 		/** part 3: adjusting for covariates **/
 		// get term ids of current variable and any interacting variables
-		const tids = [tw.term.id || tw.term.name]
+		const tids = [tw.$id || tw.id]
 		if (tw.interactions?.length) {
-			if (tw2) tids.push(tw2.term.id || tw2.term.name)
+			if (tw2) tids.push(tw2.$id || tw2.id)
 			else tids.push(...interactions)
 		}
 		// get covariates (i.e., all other variables)
-		const covariates = independentTws.filter(t => !tids.includes(t.term.id || t.term.name)).map(t => styleVariable(t))
+		const covariates = independentTws.filter(t => !tids.includes(t.$id || t.id)).map(t => styleVariable(t))
 		if (regtype == 'cox') {
 			covariates.push(outcomeTw.q.timeScale == 'time' ? '"Years of follow-up"' : '"Attained age during follow-up"') // TODO: how to handle styling for this?
 		}

--- a/server/src/termdb.regression.js
+++ b/server/src/termdb.regression.js
@@ -447,7 +447,8 @@ function makeRvariable_snps(tw, independent, q) {
 			$id: tw.$id, // need this to retrieve data from getData() output
 			id: snpid, // need this to discriminate between snps
 			name: snpid,
-			type: tw.type
+			type: tw.type,
+			interactions: structuredClone(tw.interactions)
 		}
 		if (tw.q.geneticModel == 3) {
 			// by genotype
@@ -457,17 +458,6 @@ function makeRvariable_snps(tw, independent, q) {
 		} else {
 			// treat as numeric and do not assign refGrp
 			thisSnp.rtype = 'numeric'
-		}
-		// find out any other variable that's interacting with either this snp or this snplst term
-		// and fill into interactions array
-		// for now, do not support interactions between snps in the same snplst term
-		for (const tw2 of q.independent) {
-			if (tw2.interactions.includes(tw.$id)) {
-				// another term (tw2) is interacting with this snplst term
-				// in R input establish tw2's interaction with this snp
-				if (!thisSnp.interactions) thisSnp.interactions = []
-				thisSnp.interactions.push(tw2.$id)
-			}
 		}
 		independent.push(thisSnp)
 	}


### PR DESCRIPTION
## Description

Regression interactions now support `tw.$id`.

Can test by running [this example](http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22LV_Ejection_Fraction_3D_s%22},%22independent%22:[{%22id%22:%22agedx_s%22,%22interactions%22:[%22sex_s%22]},{%22id%22:%22sex_s%22,%22interactions%22:[%22agedx_s%22],%22refGrp%22:%222%22}]}]}) and other examples using interactions. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
