### PR TITLE
Jwt unsave

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -317,8 +317,10 @@ export function setAuth(opts) {
 	includeEmbedder = opts.dsAuth?.length > 0 || false
 }
 
-export async function getRequiredAuth(dslabel, route) {
-	return dsAuth.find(d => d.dslabel == dslabel && d.route == route)
+export function getRequiredAuth(dslabel, route) {
+	for (const a of dsAuth) {
+		if (a.dslabel == dslabel && a.route == route) return a
+	}
 }
 
 // check if a user is logged in, usually checked together with requiredAuth in termdb/config,

--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -124,7 +124,7 @@ export function dofetch2(path, init = {}, opts = {}) {
 	*/
 	return mayShowAuthUi(init, url).then(async () => {
 		if (!jwt) mayAddJwtToRequest(init, body, url)
-		const dataName = url + ' | ' + init.method + ' | ' + init.body
+		const dataName = url + ' | ' + init.method + ' | ' + init.body + ' | ' + init.headers?.authorization
 
 		if (opts.serverData) {
 			let result
@@ -315,6 +315,10 @@ export function setAuth(opts) {
 		if (auth.insession) dsAuthOk.add(auth)
 	}
 	includeEmbedder = opts.dsAuth?.length > 0 || false
+}
+
+export async function getRequiredAuth(dslabel, route) {
+	return dsAuth.find(d => (d.dslabel = dslabel && d.route == route))
 }
 
 // check if a user is logged in, usually checked together with requiredAuth in termdb/config,

--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -444,7 +444,7 @@ export function getTokenDefaults(dslabel, route = '') {
 		// server-generated jwt that has more suitable/reliable
 		// persistence to improve user experience
 		getDatasetAccessToken: route => {
-			return this.jwtByRoute[route]
+			return jwtByRoute[route]
 		}
 	}
 }

--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -318,6 +318,7 @@ export function setAuth(opts) {
 }
 
 export function getRequiredAuth(dslabel, route) {
+	if (!dsAuth || !Array.isArray(dsAuth)) return
 	for (const a of dsAuth) {
 		if (a.dslabel == dslabel && a.route == route) return a
 	}

--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -407,7 +407,7 @@ async function defaultAuthUi(dslabel, auth) {
 					mask.remove()
 					dsAuthOk.add(auth)
 					if (res.jwt) {
-						setTokenByDsRoute(dslabel, route, res.jwt)
+						setTokenByDsRoute(dslabel, res.route, res.jwt)
 					}
 					resolve(dslabel)
 				})

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -3,7 +3,7 @@ import * as client from './client'
 import { loadstudycohort } from './tp.init'
 import { string2pos } from './coord'
 import * as mdsjson from './app.mdsjson'
-import { getTokenDefaults } from '#common/dofetch'
+import { getSavedToken } from '#common/dofetch'
 import urlmap from '#common/urlmap'
 import { first_genetrack_tolist } from '#common/1stGenetk'
 import { corsMessage } from '#common/embedder-helpers'
@@ -224,8 +224,8 @@ upon error, throw err message as a string
 				fetchOpts.body.dslabel = dslabel
 				fetchOpts.body.route = route
 				fetchOpts.body.route = route
-				const jwt = getTokenDefaults(dslabel, route)
-				fetchOpts.headers.authorization = `Bearer ${btoa(jwt)}`
+				const jwt = getSavedToken(dslabel, route)
+				if (jwt) fetchOpts.headers.authorization = `Bearer ${btoa(jwt)}`
 			}
 			res = await client.dofetch3(`/massSession`, fetchOpts)
 			if (res.error) throw res.error

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -3,6 +3,7 @@ import * as client from './client'
 import { loadstudycohort } from './tp.init'
 import { string2pos } from './coord'
 import * as mdsjson from './app.mdsjson'
+import { getTokenDefaults } from '#common/dofetch'
 import urlmap from '#common/urlmap'
 import { first_genetrack_tolist } from '#common/1stGenetk'
 import { corsMessage } from '#common/embedder-helpers'
@@ -223,10 +224,7 @@ upon error, throw err message as a string
 				fetchOpts.body.dslabel = dslabel
 				fetchOpts.body.route = route
 				fetchOpts.body.route = route
-
-				const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
-				this.jwtByDsRoute = JSON.parse(jwtByDsRouteStr)
-				const jwt = this.jwtByDsRoute[dslabel][route]
+				const jwt = getTokenDefaults(dslabel, route)
 				fetchOpts.headers.authorization = `Bearer ${btoa(jwt)}`
 			}
 			res = await client.dofetch3(`/massSession`, fetchOpts)

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -16,7 +16,9 @@ export class TermdbVocab extends Vocab {
 			await this.maySetVerifiedToken(this.state.vocab.dslabel)
 		}
 
+		const headers = this.mayGetAuthHeaders('termdb')
 		const data = await dofetch3('termdb/config', {
+			headers,
 			body: {
 				genome: this.vocab.genome,
 				dslabel: this.vocab.dslabel,
@@ -1082,7 +1084,7 @@ export class TermdbVocab extends Vocab {
 	async getSamplesByName(opts) {
 		// the scatter plot may still render when not in session,
 		// but not have an option to list samples
-		const headers = this.mayGetAuthHeaders('termb')
+		const headers = this.mayGetAuthHeaders('termdb')
 
 		// dofetch* mayAdjustRequest() will automatically
 		// convert to GET query params or POST body, as needed

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -10,6 +10,12 @@ import { fillTermWrapper } from '#termsetting'
 export class TermdbVocab extends Vocab {
 	// migrated from termdb/store
 	async getTermdbConfig() {
+		if (this.opts.getDatasetAccessToken) {
+			// mass app init may need clientAuthResult, so need to trigger
+			// login so termdb/config response would match the user log-in status
+			await this.maySetVerifiedToken(this.state.vocab.dslabel)
+		}
+
 		const data = await dofetch3('termdb/config', {
 			body: {
 				genome: this.vocab.genome,

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -43,7 +43,7 @@ export class Vocab {
 		const protectedRoute = 'termdb'
 		const auth =
 			this.state.termdbConfig?.requiredAuth.find(a => a.route == protectedRoute) ||
-			(await getRequiredAuth(this.state.vocab.dslabel, protectedRoute))
+			getRequiredAuth(this.state.vocab.dslabel, protectedRoute)
 
 		if (!auth) {
 			this.verifiedToken = true
@@ -120,14 +120,18 @@ export class Vocab {
 	}
 
 	mayGetAuthHeaders(route = '') {
-		const auth = this.state.termdbConfig?.requiredAuth
+		const auth =
+			this.state.termdbConfig?.requiredAuth?.find(a => a.route == route) ||
+			getRequiredAuth(this.state.vocab.dslabel, route)
+
 		if (!auth) return {}
 		if (!this.verifiedToken) {
 			this.tokenVerificationMessage = `requires login for this data`
 			return
 		}
 		const headers = {}
-		if (auth.headerKey) headers[auth.headerKey] = this.verifiedToken
+		// TODO: may remove custom header later, after extensive testing that nothing would break in prod
+		if (auth.headerKey && typeof this.verifiedToken == 'string') headers[auth.headerKey] = this.verifiedToken
 		// in cases where CORS prevents an http-domain based session cookie from being passed to the PP server,
 		// then this header will be used by the PP server
 		if (this.sessionId) headers['x-sjppds-sessionid'] = this.sessionId

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -73,11 +73,6 @@ export class Vocab {
 						embedder: location.hostname
 					}
 				})
-				// NOTE: data.jwt is a more persistent, session-like token that
-				// "replaces" the embedder's jwt, which may have a much more limited
-				// expiration date or other concerns that prevents effective/performant
-				// reuse, for example, we don't want a user to login every 5 minutes
-				// if an embedder's jwt expires quickly
 
 				// TODO: later may check against expiration time in response if included
 				this.verifiedToken = data.status === 'ok' //&& token
@@ -90,7 +85,17 @@ export class Vocab {
 						(auth.headerKey && data[auth.headerKey]) || data['x-sjppds-sessionid'] || data['x-ds-access-token']
 					delete this.tokenVerificationMessage
 					delete this.tokenVerificationPayload
-					if (!this.getDatasetAccessToken && data.jwt) {
+					if (data.jwt) {
+						// NOTE:
+						// - must save token in localStorage, so that mayAddJwtToRequest()
+						//   in dofetch can add it as header.authorization: Bearer token,
+						//   which addresses unshared login/session state in a multi-server farm
+						//
+						// - data.jwt is a more persistent, session-like token that
+						//   "replaces" the embedder's jwt, which may have a much more limited
+						//   expiration date or other concerns that prevents effective/performant
+						//   reuse, for example, we don't want a user to login every 5 minutes
+						//   if an embedder's jwt expires quickly
 						setTokenByDsRoute(dslabel, data.route, data.jwt)
 					}
 				}

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -219,7 +219,7 @@ async function maySetAuthRoutes(app, basepath = '', _serverconfig = null) {
 	// !!! do not use or save sessions data from/to a file !!!
 	// always start with an empty sessions tracking object,
 	// will fill-in as requests with auth or x-ds-*-token are received
-	const sessions = {}
+	let sessions = {}
 
 	// no need to setup additional middlewares and routes
 	// if there are no protected datasets

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -139,7 +139,7 @@ tape(`initialization`, async test => {
 		)
 		test.deepEqual(
 			authApi.getDsAuth({ query: { embedder: 'localhost' } }),
-			[{ dslabel: 'testds', route: '/**', type: 'basic', insession: false }],
+			[{ dslabel: 'testds', route: '/**', type: 'basic', headerKey: undefined, insession: false }],
 			'should return all dslabels that require authorization for a given embedder'
 		)
 
@@ -260,8 +260,8 @@ tape(`auth methods`, async test => {
 	test.deepEqual(
 		authApi.getDsAuth(req0),
 		[
-			{ dslabel: 'ds100', route: 'termdb', type: 'jwt', insession: undefined },
-			{ dslabel: 'ds100', route: 'burden', type: 'forbidden', insession: false }
+			{ dslabel: 'ds100', route: 'termdb', type: 'jwt', headerKey: 'x-ds-access-token', insession: undefined },
+			{ dslabel: 'ds100', route: 'burden', type: 'forbidden', headerKey: undefined, insession: false }
 		],
 		`should return the expected dsAuth array for a termdb-specified embedder`
 	)
@@ -269,7 +269,7 @@ tape(`auth methods`, async test => {
 	const req1 = { query: { embedder: 'some.domain', dslabel: 'ds100' }, get: () => 'localhost' }
 	test.deepEqual(
 		authApi.getDsAuth(req1),
-		[{ dslabel: 'ds100', route: 'burden', type: 'forbidden', insession: false }],
+		[{ dslabel: 'ds100', route: 'burden', type: 'forbidden', headerKey: undefined, insession: false }],
 		`should return the expected dsAuth array for a specified embedder`
 	)
 	test.deepEqual(
@@ -339,7 +339,7 @@ tape(`a valid request`, async test => {
 
 tape(`mismatched ip address in /jwt-status`, async test => {
 	test.timeoutAfter(500)
-	test.plan(2)
+	test.plan(4)
 
 	const app = appInit()
 	const serverconfig = {
@@ -377,7 +377,9 @@ tape(`mismatched ip address in /jwt-status`, async test => {
 				)
 			},
 			header(key, val) {
-				test.fail('should NOT set a session cookie')
+				console.log(379, key, val)
+				test.equal(key, 'Set-Cookie', 'should clear session cookie on unsuccessful login')
+				test.true(val.toLowerCase().includes('max-age=0'), 'should cause a session cookie to expire')
 			},
 			status(num) {
 				test.equal(num, 401, 'should set a 401 status')
@@ -392,7 +394,7 @@ tape(`mismatched ip address in /jwt-status`, async test => {
 
 tape(`invalid embedder`, async test => {
 	test.timeoutAfter(500)
-	test.plan(2)
+	test.plan(4)
 
 	const app = appInit()
 	const serverconfig = {
@@ -433,7 +435,8 @@ tape(`invalid embedder`, async test => {
 				)
 			},
 			header(key, val) {
-				test.fail('should NOT set a session cookie')
+				test.equal(key, 'Set-Cookie', 'should clear session cookie on unsuccessful login')
+				test.true(val.toLowerCase().includes('max-age=0'), 'should cause a session cookie to expire')
 			},
 			headers: {},
 			status(num) {
@@ -449,7 +452,7 @@ tape(`invalid embedder`, async test => {
 
 tape(`invalid dataset access`, async test => {
 	test.timeoutAfter(500)
-	test.plan(2)
+	test.plan(4)
 
 	const app = appInit()
 	const serverconfig = {
@@ -486,7 +489,8 @@ tape(`invalid dataset access`, async test => {
 				)
 			},
 			header(key, val) {
-				test.fail('should NOT set a session cookie')
+				test.equal(key, 'Set-Cookie', 'should clear session cookie on unsuccessful login')
+				test.true(val.toLowerCase().includes('max-age=0'), 'should cause a session cookie to expire')
 			},
 			headers: {},
 			status(num) {
@@ -502,7 +506,7 @@ tape(`invalid dataset access`, async test => {
 
 tape(`invalid jwt`, async test => {
 	test.timeoutAfter(500)
-	test.plan(6)
+	test.plan(12)
 
 	const app = appInit()
 	const serverconfig = {
@@ -540,7 +544,8 @@ tape(`invalid jwt`, async test => {
 				)
 			},
 			header(key, val) {
-				test.fail('should NOT set a session cookie')
+				test.equal(key, 'Set-Cookie', 'should clear session cookie on unsuccessful login')
+				test.true(val.toLowerCase().includes('max-age=0'), 'should cause a session cookie to expire')
 			},
 			headers: {},
 			status(num) {
@@ -567,7 +572,8 @@ tape(`invalid jwt`, async test => {
 				)
 			},
 			header(key, val) {
-				test.fail('should NOT set a session cookie')
+				test.equal(key, 'Set-Cookie', 'should clear session cookie on unsuccessful login')
+				test.true(val.toLowerCase().includes('max-age=0'), 'should cause a session cookie to expire')
 			},
 			headers: {},
 			status(num) {
@@ -595,7 +601,8 @@ tape(`invalid jwt`, async test => {
 				)
 			},
 			header(key, val) {
-				test.fail('should NOT set a session cookie')
+				test.equal(key, 'Set-Cookie', 'should clear session cookie on unsuccessful login')
+				test.true(val.toLowerCase().includes('max-age=0'), 'should cause a session cookie to expire')
 			},
 			headers: {},
 			status(num) {

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -377,7 +377,6 @@ tape(`mismatched ip address in /jwt-status`, async test => {
 				)
 			},
 			header(key, val) {
-				console.log(379, key, val)
 				test.equal(key, 'Set-Cookie', 'should clear session cookie on unsuccessful login')
 				test.true(val.toLowerCase().includes('max-age=0'), 'should cause a session cookie to expire')
 			},


### PR DESCRIPTION
## Description

This update:
- triggers a jwt login before a `/termdb/config` request, to ensure the response would have the appropriate `clientAuthResult` available when a mass app is initialized
- uses `getDatasetAccessToken()` if supplied as a runpp() argument, instead of reusing `jwtByDsRoute` from `localStorage`. This avoids requiring user logouts to clear irrelevant jwt, with the assumption that `getDatasetAccessToken()` would supply the most uo-to-date token when loading apps.

To test:
- @airenzp please test with http://localhost:3000/profile, use the same `jwt-unsave` branch in the `sjpp` repo
- @congyu-lu please test with `mbmeta` password login, just to make sure that server auth and client jwt handling changes did not break the login locally
- also tested with `serverconfig.features.sessionTracking: "jwt-only"`, to simulate server farm setup that does not share user session state

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
