### PR TITLE
feat: scrna: allow to show extra properties in sample tab

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -44,14 +44,13 @@ class singleCellPlot {
 	}
 
 	async init(appState) {
-		// generate sample table in init but not main is because sample table is constant and no need to update it on dispatch
+		// generate sample table in init() but not main() is because sample table is constant and no need to update it on dispatch
 		// TODO sample table still needs to be changed when gdc (external portal) cohort changes
 
 		const state = this.getState(appState)
 
 		const body = { genome: state.genome, dslabel: state.dslabel, filter0: state.termfilter.filter0 || null }
 		const result = await dofetch3('termdb/singlecellSamples', { body })
-		console.log(result.samples)
 		if (result.error) throw result.error
 
 		this.samples = result.samples

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- scrna: allow to show extra properties in sample tab

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -258,7 +258,8 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 			samples: {
 				firstColumnName: q.singleCell.samples.firstColumnName,
 				sampleColumns: q.singleCell.samples.sampleColumns,
-				experimentColumns: q.singleCell.samples.experimentColumns
+				experimentColumns: q.singleCell.samples.experimentColumns,
+				extraSampleTabLabel: q.singleCell.samples.extraSampleTabLabel
 			},
 			images: q.singleCell.images,
 			data: {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -597,6 +597,8 @@ export type SingleCellSamples = {
 	or is missing, to be added at launch with built-in logic (samples are found by looking through singleCell.data.plots[].folder)
 	*/
 	get?: (q: any) => any
+	/** extra label to show along with sample, it becomes `sample.sample+' '+sample[newProp]` */
+	extraSampleTabLabel?: string
 }
 
 export type SingleCellDataGdc = {


### PR DESCRIPTION
## Description

closes #2712 
please pull ppgdc https://github.com/stjude/ppgdc/pull/12
test at http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22GDC%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22singleCellPlot%22}]}, see project name is shown in first tab

ball-scrna still works

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
