### PR TITLE
Contour bandwidth and thresholds config added and default values reduced

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -336,13 +336,35 @@ class Scatter {
 			}
 		]
 		if (this.settings.showContour)
-			inputs.push({
-				label: 'Color contours',
-				boxLabel: '',
-				type: 'checkbox',
-				chartType: 'sampleScatter',
-				settingsKey: 'colorContours'
-			})
+			inputs.push(
+				{
+					label: 'Color contours',
+					boxLabel: '',
+					type: 'checkbox',
+					chartType: 'sampleScatter',
+					settingsKey: 'colorContours'
+				},
+				{
+					label: 'Contour bandwidth',
+					type: 'number',
+					chartType: 'sampleScatter',
+					settingsKey: 'contourBandwidth',
+					title: 'Reduce to increase resolution. ',
+					min: 5,
+					max: 50,
+					step: 5
+				},
+				{
+					label: 'Contour thresholds',
+					type: 'number',
+					chartType: 'sampleScatter',
+					settingsKey: 'contourThresholds',
+					title: 'Dot size',
+					min: 5,
+					max: 50,
+					step: 5
+				}
+			)
 		if (this.config.sampleCategory) {
 			const options = Object.values(this.config.sampleCategory.tw.term.values).map(v => ({
 				label: v.label || v.key,
@@ -706,7 +728,9 @@ export function getDefaultScatterSettings() {
 		// Null indicates this hasn't been set yet
 		//3D Plot settings
 		showContour: false,
-		colorContours: false
+		colorContours: false,
+		contourBandwidth: 20,
+		contourThresholds: 10
 	}
 }
 

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -729,7 +729,7 @@ export function getDefaultScatterSettings() {
 		//3D Plot settings
 		showContour: false,
 		colorContours: false,
-		contourBandwidth: 20,
+		contourBandwidth: 30,
 		contourThresholds: 10
 	}
 }

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -361,7 +361,7 @@ class Scatter {
 					settingsKey: 'contourThresholds',
 					title: 'Dot size',
 					min: 5,
-					max: 50,
+					max: 30,
 					step: 5
 				}
 			)

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -338,7 +338,15 @@ export function setRenderers(self) {
 		const data = chart.data.samples.map(s => {
 			return { x: chart.xAxisScale(s.x), y: chart.yAxisScale(s.y), z: zAxisScale ? zAxisScale(s.category) : 1 }
 		})
-		renderContours(contourG, data, self.settings.svgw, self.settings.svgh, self.settings.colorContours)
+		renderContours(
+			contourG,
+			data,
+			self.settings.svgw,
+			self.settings.svgh,
+			self.settings.colorContours,
+			self.settings.contourBandwidth,
+			self.settings.contourThresholds
+		)
 	}
 
 	self.getStrokeWidth = function (c) {
@@ -1280,7 +1288,7 @@ export function setRenderers(self) {
 	}
 }
 
-export function renderContours(contourG, data, width, height, colorContours) {
+export function renderContours(contourG, data, width, height, colorContours, bandwidth, thresholds) {
 	// Create the horizontal and vertical scales.
 	const x = d3Linear()
 		.domain(extent(data, s => s.x))
@@ -1295,8 +1303,9 @@ export function renderContours(contourG, data, width, height, colorContours) {
 		.y(s => s.y)
 		.weight(s => s.z)
 		.size([width, height])
-		.bandwidth(30)
-		.thresholds(30)(data)
+		.cellSize(2)
+		.bandwidth(bandwidth)
+		.thresholds(thresholds)(data)
 
 	const colorScale = scaleSequential()
 		.domain([0, max(contours, d => d.value)])

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -568,13 +568,35 @@ class singleCellPlot {
 			title: 'Show contour map'
 		})
 		if (this.settings.showContour)
-			inputs.push({
-				label: 'Color contours',
-				boxLabel: '',
-				type: 'checkbox',
-				chartType: 'singleCellPlot',
-				settingsKey: 'colorContours'
-			})
+			inputs.push(
+				{
+					label: 'Color contours',
+					boxLabel: '',
+					type: 'checkbox',
+					chartType: 'singleCellPlot',
+					settingsKey: 'colorContours'
+				},
+				{
+					label: 'Contour bandwidth',
+					type: 'number',
+					chartType: 'singleCellPlot',
+					settingsKey: 'contourBandwidth',
+					title: 'Reduce to increase resolution. ',
+					min: 5,
+					max: 50,
+					step: 5
+				},
+				{
+					label: 'Contour thresholds',
+					type: 'number',
+					chartType: 'singleCellPlot',
+					settingsKey: 'contourThresholds',
+					title: 'Dot size',
+					min: 5,
+					max: 50,
+					step: 5
+				}
+			)
 		if (
 			(this.state.config.activeTab == GENE_EXPRESSION_TAB ||
 				this.state.config.activeTab == DIFFERENTIAL_EXPRESSION_TAB) &&
@@ -1304,7 +1326,14 @@ class singleCellPlot {
 	async renderContourMap(scene, xCoords, yCoords, zCoords, plot) {
 		const data = xCoords.map((x, i) => ({ x, y: yCoords[i], z: zCoords[i] }))
 		// Create the data URL
-		const imageUrl = getContourImage(data, this.settings.svgw, this.settings.svgh, this.settings.colorContours)
+		const imageUrl = getContourImage(
+			data,
+			this.settings.svgw,
+			this.settings.svgh,
+			this.settings.colorContours,
+			this.settings.contourBandwidth,
+			this.settings.contourThresholds
+		)
 		const loader = new THREE.TextureLoader()
 		loader.load(imageUrl, texture => {
 			// Create a plane geometry
@@ -1367,10 +1396,10 @@ class singleCellPlot {
 	}
 }
 
-export function getContourImage(data, width, height, colorContours) {
+export function getContourImage(data, width, height, colorContours, bandwidth, thresholds) {
 	const svg = create('svg').attr('width', width).attr('height', height)
 
-	renderContours(svg.append('g'), data, width, height, colorContours)
+	renderContours(svg.append('g'), data, width, height, colorContours, bandwidth, thresholds)
 
 	// Serialize the SVG element
 	const svgString = new XMLSerializer().serializeToString(svg.node())
@@ -1436,6 +1465,8 @@ export function getDefaultSingleCellSettings() {
 		opacity: 0.8,
 		showNoExpCells: false,
 		showContour: false,
-		colorContours: false
+		colorContours: false,
+		contourBandwidth: 20,
+		contourThresholds: 10
 	}
 }

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -593,7 +593,7 @@ class singleCellPlot {
 					settingsKey: 'contourThresholds',
 					title: 'Dot size',
 					min: 5,
-					max: 50,
+					max: 30,
 					step: 5
 				}
 			)


### PR DESCRIPTION
## Description

When reducing the plot size the contours bandwidth needs to be reduced to improve the contours resolution. This solves #2721. Also default bandwidth updated to 20 for the SC plot and thresholds reduced to 10 to get more details by default and less contours. 


See example: Plot size 400x400 with bandwidth 10
<img width="1303" alt="Screenshot 2025-01-31 at 5 46 42 PM" src="https://github.com/user-attachments/assets/7e17e723-83fe-49ea-9f6c-d5aa088e8b91" />



The default plot of size 800x800:
<img width="1303" alt="Screenshot 2025-01-31 at 5 46 21 PM" src="https://github.com/user-attachments/assets/ff2dd1b4-cf4b-478d-a1cd-ecdea0140adb" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
