### PR TITLE
Speed up SC violin rerendering by adding $id for caching

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -398,6 +398,7 @@ class singleCellPlot {
 						chartType: 'violin',
 						settings: { violin: { plotThickness: 50 } },
 						term: {
+							$id: `${gene}-${this.state.config.sample}-${this.state.config.experimentID}`,
 							term: {
 								type: TermTypes.SINGLECELL_GENE_EXPRESSION,
 								id: gene,
@@ -410,6 +411,8 @@ class singleCellPlot {
 							}
 						},
 						term2: {
+							$id: `${colorBy}-${this.state.config.sample}-${this.state.config.experimentID}`,
+
 							term: {
 								type: TermTypes.SINGLECELL_CELLTYPE,
 								id: colorBy,

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -310,6 +310,7 @@ class singleCellPlot {
 			case VIOLIN_TAB:
 				this.dom.geDiv.style('display', 'inline-block')
 				this.renderViolinTab()
+				this.dom.searchbox.node().focus()
 				break
 		}
 	}

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -13,6 +13,7 @@ import { Tabs } from '../dom/toggleButtons.js'
 import * as THREE from 'three'
 import { getThreeCircle } from './sampleScatter.rendererThree.js'
 import { renderContours } from './sampleScatter.renderer.js'
+import { digestMessage } from '../termsetting/termsetting'
 /*
 this
 
@@ -398,7 +399,7 @@ class singleCellPlot {
 						chartType: 'violin',
 						settings: { violin: { plotThickness: 50 } },
 						term: {
-							$id: `${gene}-${this.state.config.sample}-${this.state.config.experimentID}`,
+							$id: digestMessage(`${gene}-${this.state.config.sample}-${this.state.config.experimentID}`),
 							term: {
 								type: TermTypes.SINGLECELL_GENE_EXPRESSION,
 								id: gene,
@@ -411,7 +412,7 @@ class singleCellPlot {
 							}
 						},
 						term2: {
-							$id: `${colorBy}-${this.state.config.sample}-${this.state.config.experimentID}`,
+							$id: digestMessage(`${colorBy}-${this.state.config.sample}-${this.state.config.experimentID}`),
 
 							term: {
 								type: TermTypes.SINGLECELL_CELLTYPE,


### PR DESCRIPTION
## Description

Added $id as suggested by @siosonel to use cache on the violin request and speed up the plot rerender

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
