### PR TITLE
Added state handling when editing colorScale in the SC plot. 

### DIFF
--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -86,11 +86,6 @@ export function setRenderers(self) {
 
 		// Handle continuous color scaling when color term wrapper is in continuous mode
 		if (self.config.colorTW?.q.mode === 'continuous') {
-			// Synchronize the chart's internal mode state with the application config.
-			// This ensures the color scale UI correctly reflects the current mode
-			// when switching between auto, fixed, and percentile modes.
-			chart.cutoffMode = self.config.settings.sampleScatter.colorScaleMode || 'auto'
-			chart.percentile = self.config.settings.sampleScatter.colorScalePercentile || 95
 			// Extract and sort all sample values for our calculations
 			// We filter out any values that are explicitly defined in the term values
 			// This gives us the raw numerical data we need for scaling
@@ -870,9 +865,9 @@ export function setRenderers(self) {
 						// Configuration for our enhanced scaling modes
 						numericInputs: {
 							// Start with either the chart's current mode or default to 'auto'
-							cutoffMode: chart.cutoffMode || 'auto',
+							cutoffMode: this.settings.colorScaleMode,
 							// Default percentile value for percentile mode
-							defaultPercentile: chart.percentile || 95,
+							defaultPercentile: this.settings.colorScalePercentile,
 
 							// This callback handles all mode changes and updates
 							callback: obj => {
@@ -889,11 +884,6 @@ export function setRenderers(self) {
 									max = colorValues[index]
 								}
 
-								// Update the color generator with new range
-								chart.colorGenerator = d3Linear()
-									.domain([min, max])
-									.range([self.config.startColor[chart.id], self.config.stopColor[chart.id]])
-
 								// Dispatch the updated config
 								self.app.dispatch({
 									type: 'plot_edit',
@@ -904,7 +894,8 @@ export function setRenderers(self) {
 												colorScaleMode: obj.cutoffMode,
 												colorScaleMinFixed: obj.cutoffMode === 'fixed' ? min : null,
 												colorScaleMaxFixed: obj.cutoffMode === 'fixed' ? max : null,
-												colorScalePercentile: obj.cutoffMode === 'percentile' ? obj.percentile : null
+												colorScalePercentile:
+													obj.cutoffMode === 'percentile' ? obj.percentile : this.settings.colorScalePercentile
 											}
 										}
 									}
@@ -1307,7 +1298,6 @@ export function renderContours(contourG, data, width, height, colorContours, ban
 
 		.bandwidth(bandwidth)
 		.thresholds(thresholds)(data)
-
 
 	const colorScale = scaleSequential()
 		.domain([0, max(contours, d => d.value)])

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1104,7 +1104,6 @@ class singleCellPlot {
 			.append('text')
 			.text(`${gene} expression`)
 		const legendG = plot.legendSVG.append('g').attr('transform', `translate(20, ${2 * offsetY})`)
-		console.log(this.settings)
 		const colorScale = new ColorScale({
 			holder: legendG,
 			barwidth,

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -498,7 +498,7 @@ class singleCellPlot {
 			this.state.config.experimentID || this.state.config.sample || this.samples?.[0]?.experiments[0]?.experimentID
 		const args = { genome: this.state.genome, dslabel: this.state.dslabel, categoryName, sample, columnName }
 		this.dom.loadingDiv.selectAll('*').remove()
-		this.dom.loadingDiv.style('display', '').append('div').attr('class', 'sjpp-spinner')
+		this.dom.loadingDiv.style('display', '').append('div').text('Loading...')
 		const result = await dofetch3('termdb/singlecellDEgenes', { body: args })
 		if (result.error) {
 			DETableDiv.text(result.error)
@@ -738,7 +738,7 @@ class singleCellPlot {
 			this.plotColorByDivs = []
 			this.plots = []
 			this.dom.loadingDiv.selectAll('*').remove()
-			this.dom.loadingDiv.style('display', '').append('div').attr('class', 'sjpp-spinner')
+			this.dom.loadingDiv.style('display', '').append('div').text('Loading...')
 			this.legendRendered = false
 			this.dom.plotsDiv.selectAll('*').remove()
 			this.data = await this.getData()

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -51,7 +51,6 @@ class singleCellPlot {
 		// TODO sample table still needs to be changed when gdc (external portal) cohort changes
 
 		const state = this.getState(appState)
-		const { uiLabels } = state.config.settings.singleCellPlot
 		const body = { genome: state.genome, dslabel: state.dslabel, filter0: state.termfilter.filter0 || null }
 		const result = await dofetch3('termdb/singlecellSamples', { body })
 		if (result.error) throw result.error
@@ -64,14 +63,10 @@ class singleCellPlot {
 			else return elem1.sample.localeCompare(elem2.sample)
 		})
 
-		const extraSampleTabLabel = state.termdbConfig.queries.singleCell.samples.extraSampleTabLabel
-			? ', ' + this.samples[0][state.termdbConfig.queries.singleCell.samples.extraSampleTabLabel]
-			: ''
-
 		this.tabs = []
 		const activeTab = state.config.activeTab
 		this.tabs.push({
-			label: uiLabels.Sample + ' ' + (state.config.sample || this.samples[0].sample) + extraSampleTabLabel,
+			label: this.getSamplesTabLabel(state),
 			id: SAMPLES_TAB,
 			active: activeTab == SAMPLES_TAB,
 			callback: () => this.setActiveTab(SAMPLES_TAB)
@@ -216,6 +211,15 @@ class singleCellPlot {
 		select('.sjpp-output-sandbox-content').on('scroll', event => this.tip.hide())
 	}
 
+	getSamplesTabLabel(state) {
+		const { uiLabels } = state.config.settings.singleCellPlot
+
+		const extraSampleTabLabel = state.termdbConfig.queries.singleCell.samples.extraSampleTabLabel
+			? ', ' + this.samples[0][state.termdbConfig.queries.singleCell.samples.extraSampleTabLabel]
+			: ''
+		return uiLabels.Sample + ' ' + (state.config.sample || this.samples[0].sample) + extraSampleTabLabel
+	}
+
 	renderShowPlots(showDiv, state) {
 		showDiv.append('label').text('Plots:').style('font-size', '1.1em')
 
@@ -275,6 +279,7 @@ class singleCellPlot {
 		const index = this.tabs.findIndex(t => t.id == id)
 		const tab = this.tabs[index]
 		tab.active = true
+		if (id == SAMPLES_TAB) this.tabsComp.tabs[0].label = this.getSamplesTabLabel(this.state)
 		this.tabsComp.update(index, tab)
 
 		this.dom.deDiv.style('display', 'none')
@@ -1249,16 +1254,7 @@ class singleCellPlot {
 				if (rows[index][0].__experimentID) {
 					config.experimentID = rows[index][0].__experimentID
 				}
-				this.tabsComp.tabs[0].label =
-					sample +
-					(this.state.termdbConfig.queries.singleCell.samples.extraSampleTabLabel
-						? // index is table row (experiment) index and no longer this.samples[] array index because some samples may have >1 experiments. find the sample index by sample name
-						  ', ' +
-						  this.samples[this.samples.findIndex(i => i.sample == sample)][
-								this.state.termdbConfig.queries.singleCell.samples.extraSampleTabLabel
-						  ]
-						: '')
-				this.tabsComp.update(0, this.tabs[0])
+
 				this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 			},
 			selectedRows,

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -72,7 +72,7 @@ class singleCellPlot {
 			callback: () => this.setActiveTab(SAMPLES_TAB)
 		})
 		this.tabs.push({
-			label: 'Plots',
+			label: 'Clusters',
 			id: PLOTS_TAB,
 			active: activeTab == PLOTS_TAB,
 			callback: () => this.setActiveTab(PLOTS_TAB)

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -72,7 +72,7 @@ class singleCellPlot {
 			callback: () => this.setActiveTab(SAMPLES_TAB)
 		})
 		this.tabs.push({
-			label: 'Clusters',
+			label: 'Plots',
 			id: PLOTS_TAB,
 			active: activeTab == PLOTS_TAB,
 			callback: () => this.setActiveTab(PLOTS_TAB)


### PR DESCRIPTION
Added state handling when editing colorScale in the SC plot. Removed related logic not needed in the scatter plot. Showed sample preffix when changing tab. Changed loading div. Closes #2523 and #2734

## Description

Closes #2734

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
