### PR TITLE
GDC maf UI shows tumor descriptor+tissue type instead of deprecated sample_type

### DIFF
--- a/client/dom/table2col.js
+++ b/client/dom/table2col.js
@@ -3,15 +3,19 @@ make a html table of two columns, for showing a list of key-value pairs.
 1st column shows key in gray text, 2nd column shows value in black text, or arbitrary button/svg etc
 as rows are added, as soon as table width exceeds a limit, it auto scrolls
 
-to create new table, do:
+to create new table:
 
 	const table = table2col({holder})
 
-when a new row needs to be added, do:
+to add a new row with only text data:
+
+	table.addRow('Key', 'Value')
+
+if need to insert html and other dynamic contents instead of plain text, do this instead:
 
 	const [td1,td2] = table.addRow()
-	td1.text('Key')
-	td2.text('Value')
+	td1.html(xx)
+	td2.append('input')...
 
 
 arg{}
@@ -29,7 +33,7 @@ export function table2col(arg) {
 	return {
 		scrollDiv,
 		table,
-		addRow: () => {
+		addRow: (text1, text2) => {
 			if (table.node().offsetHeight > 500) {
 				scrollDiv
 					.style('height', '450px')
@@ -40,6 +44,8 @@ export function table2col(arg) {
 			const tr = table.append('tr')
 			const td1 = tr.append('td').style('padding', '3px').style('color', '#555')
 			const td2 = tr.append('td')
+			if (text1 != undefined) td1.text(text1)
+			if (text2 != undefined) td2.text(text2)
 			return [td1, td2]
 		}
 	}

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -1,5 +1,5 @@
 import { dofetch3 } from '#common/dofetch'
-import { make_radios, renderTable, sayerror, Menu } from '#dom'
+import { make_radios, renderTable, sayerror, Menu, table2col } from '#dom'
 import { fileSize } from '#shared/fileSize.js'
 
 /*
@@ -208,23 +208,13 @@ export async function gdcMAFui({ holder, filter0, callbacks, debugmode = false }
 }
 
 function makeControls(obj) {
-	const table = obj.controlDiv.append('table')
+	const table = table2col({ holder: obj.controlDiv })
+	table.addRow('Access', 'Open')
+	table.addRow('Workflow Type', 'Aliquot Ensemble Somatic Variant Merging and Masking')
 	{
-		const tr = table.append('tr')
-		tr.append('td').style('opacity', 0.7).text('Access')
-		tr.append('td').text('Open')
-	}
-	{
-		const tr = table.append('tr')
-		tr.append('td').style('opacity', 0.7).text('Workflow Type')
-		tr.append('td').text('Aliquot Ensemble Somatic Variant Merging and Masking')
-	}
-	{
-		const tr = table.append('tr')
-		tr.append('td').style('opacity', 0.7).text('Experimental Strategy')
-		const td = tr.append('td')
+		const [td1, td2] = table.addRow('Experimental Strategy')
 		make_radios({
-			holder: td,
+			holder: td2,
 			options: [
 				{ label: 'WXS', value: 'WXS', checked: obj.opts.experimentalStrategy == 'WXS' },
 				{
@@ -240,11 +230,10 @@ function makeControls(obj) {
 			}
 		})
 	}
+
 	{
-		const tr = table.append('tr')
-		tr.append('td').style('opacity', 0.7).text('Output Columns')
-		const td = tr.append('td')
-		const clickText = td
+		const [td1, td2] = table.addRow('Output Columns')
+		const clickText = td2
 			.append('span')
 			.attr('class', 'sja_clbtext')
 			.on('click', event => {
@@ -272,7 +261,7 @@ function makeControls(obj) {
 			clickText.text(
 				`${mafColumns.reduce((c, i) => c + (i.selected ? 1 : 0), 0)} of ${
 					mafColumns.length
-				} columns selected, click to change`
+				} columns selected. Click to change`
 			)
 		}
 	}

--- a/server/routes/gdc.maf.ts
+++ b/server/routes/gdc.maf.ts
@@ -78,7 +78,7 @@ async function listMafFiles(q: GdcMafRequest, ds: any) {
 		case_filters.content.push(q.filter0)
 	}
 
-	const { host, headers } = ds.getHostHeaders(q)
+	const { host } = ds.getHostHeaders(q)
 
 	const body: any = {
 		filters,

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -1,7 +1,6 @@
 import ky from 'ky'
 import { joinUrl } from '#shared/joinUrl.js'
 import { run_rust_stream } from '@sjcrh/proteinpaint-rust'
-import serverconfig from '#src/serverconfig.js'
 import type { GdcMafBuildRequest, RouteApi } from '#types'
 import { gdcMafPayload } from '#types/checkers'
 import { maxTotalSizeCompressed } from './gdc.maf.ts'
@@ -43,8 +42,8 @@ res{}
 */
 async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	const t0 = Date.now()
-	const { host, headers } = ds.getHostHeaders(q)
-	const fileLst2 = (await getFileLstUnderSizeLimit(q.fileIdLst, host, headers)) as string[]
+	const { host } = ds.getHostHeaders(q)
+	const fileLst2 = (await getFileLstUnderSizeLimit(q.fileIdLst, host)) as string[]
 
 	mayLog(`${fileLst2.length} out of ${q.fileIdLst.length} input MAF files accepted by size limit`, Date.now() - t0)
 
@@ -78,7 +77,7 @@ excess files are not processed in order not to crash server
 must not rely on file size sent by client, as that can be spoofed and never to be trusted
 it's inexpensive to query api for this
 */
-async function getFileLstUnderSizeLimit(lst: string[], host, headers) {
+async function getFileLstUnderSizeLimit(lst: string[], host) {
 	if (lst.length == 0) throw 'fileIdLst[] not array or blank'
 	const body = {
 		filters: {

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -306,7 +306,6 @@ function gdc_validateGeneExpression(G, ds, genome) {
 			const { host } = ds.getHostHeaders(q)
 
 			const t = Date.now()
-			//const out = await ky.post(joinUrl(host.rest, 'scrna_seq/gene_expression'), { timeout: false, json: body }).json()
 			const response = await ky.post(joinUrl(host.rest, 'scrna_seq/gene_expression'), { timeout: false, json: body })
 			if (!response.ok) throw `HTTP Error: ${response.status} ${response.statusText}`
 			const out = await response.json()

--- a/shared/types/src/routes/gdc.maf.ts
+++ b/shared/types/src/routes/gdc.maf.ts
@@ -3,7 +3,7 @@ import type { RoutePayload } from './routeApi.js'
 
 // an object representing gdc maf file, to be shown on client table
 
-export type File = {
+export type GdcMafFile = {
 	/** A string representing the file's UUID (Universally Unique Identifier) , can be accessed via https://api.gdc.cancer.gov/data/<uuid>*/
 	id: string
 	/** A string representing a submitter ID for the case associated with this file */
@@ -12,8 +12,8 @@ export type File = {
 	case_uuid: string
 	/** An integer as the byte size of this file, compressed */
 	file_size: number
-	/** Array of strings, each is a sample type, for all samples involved in generating the maf file */
-	sample_types?: string[]
+	/** Array of strings, each is 'tumor descriptor+tissue type', for all samples involved in generating the maf file */
+	sample_types: string[]
 	/** A string representing the type of workflow used to generate or process this file */
 	//workflow_type: string
 	/** A string as the project id of the case */
@@ -34,7 +34,7 @@ export type GdcMafRequest = {
 
 export type GdcMafResponse = {
 	/** List of file objects passing filter and to be displayed on client */
-	files: File[]
+	files: GdcMafFile[]
 	/** Total number of files found by API (in case bigger than files.length) */
 	filesTotal: number
 	/** Maximum total size of maf files allowed, for indicating on ui while selecting files */


### PR DESCRIPTION
## Description

closes https://gdc-ctds.atlassian.net/browse/FEAT-856; also replaced got and path.join()

test at http://localhost:3000/?gdcmaf=1

WXS and targeted MAF download all works

non-CI tests pass: http://localhost:3000/testrun.html?dir=gdc&name=maf

no tsc error

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
