### PR TITLE
apply css to use title case for experiment table

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1258,7 +1258,8 @@ class singleCellPlot {
 				this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 			},
 			selectedRows,
-			striped: true
+			striped: true,
+			header: { style: { 'text-transform': 'capitalize' } } // to show header in title case; if it results in a conflict (e.g. a sample name showing in 1st tab has to be lower case), then use sampleColumns[].columnHeader as override of term name
 		})
 	}
 


### PR DESCRIPTION
## Description

as requested by GDC
test at http://localhost:3000/example.gdc.scRNAseq.html, `Project id` is now `Project Id` (though ID will look better, but the GDC api hardcodes it as "id" in their dictionary)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
