### PR TITLE
SC fixes

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -279,7 +279,8 @@ class singleCellPlot {
 		const index = this.tabs.findIndex(t => t.id == id)
 		const tab = this.tabs[index]
 		tab.active = true
-		if (id == SAMPLES_TAB) this.tabsComp.tabs[0].label = this.getSamplesTabLabel(this.state)
+		this.tabsComp.tabs[0].label = this.getSamplesTabLabel(this.state)
+		this.tabsComp.updateInactive(0, this.tabs[0])
 		this.tabsComp.update(index, tab)
 
 		this.dom.deDiv.style('display', 'none')
@@ -1235,7 +1236,7 @@ class singleCellPlot {
 		div.selectAll('*').remove()
 		const [rows, columns] = await this.getTableData(state)
 		const selectedRows = []
-		let maxHeight = '70vh'
+		let maxHeight = '60vh'
 		const selectedSample = state.config.sample
 		const selectedRow = this.samples.findIndex(s => s.sample == selectedSample)
 		const selectedRowIndex = selectedRow == -1 ? 0 : selectedRow
@@ -1250,7 +1251,7 @@ class singleCellPlot {
 			maxHeight,
 			noButtonCallback: index => {
 				const sample = rows[index][0].value
-				const config = { chartType: 'singleCellPlot', sample }
+				const config = { chartType: 'singleCellPlot', sample, activeTab: PLOTS_TAB }
 				if (rows[index][0].__experimentID) {
 					config.experimentID = rows[index][0].__experimentID
 				}


### PR DESCRIPTION
## Description

Showed sample at the top of each tab and renamed the samples tab to Samples. This was suggested by Himanso and I thought it looks better this way. After selecting a sample navigate to its Plots. Added misc fixes. Please check.

UI changes:

<img width="1512" alt="Screenshot 2025-02-06 at 9 00 21 AM" src="https://github.com/user-attachments/assets/7544e5ec-f6df-4d9e-a1b4-61dcbcd7be85" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
