### PR TITLE
Jira sv 2552

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -288,6 +288,8 @@ export function renderTable({
 				}
 				tr.on('click', clickHandler)
 				tr.on('keydown', event => {
+					// ignore this event if it bubbled up from a descendant element
+					if (event.target.tagName != 'TR') return
 					if (event.key == 'Enter') clickHandler(event)
 				})
 			}

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -260,7 +260,7 @@ export function renderTable({
 		tbody.selectAll('tr').remove()
 		for (const [i, row] of rows.entries()) {
 			let checkbox
-			const tr = tbody.append('tr').attr('class', 'sjpp_row_wrapper')
+			const tr = tbody.append('tr').attr('class', 'sjpp_row_wrapper').attr('tabindex', 0)
 			if (striped && i % 2 == 1) tr.style('background-color', 'rgb(245,245,245)')
 
 			// for Section 508 compliance: always create an aria-labelledby attribute on an input
@@ -271,8 +271,8 @@ export function renderTable({
 			// and should create an element id on it as needed
 			if (!row.ariaLabelledBy && row[0] && !row[0].elemId) row[0].elemId = ariaLabelledBy
 
-			if (buttons || noButtonCallback)
-				tr.on('click', (e: any) => {
+			if (buttons || noButtonCallback) {
+				const clickHandler = (e: any) => {
 					// fix for clicking on <a> check/unchecking box to the left
 					if (e.target.tagName == 'A') {
 						e.stopPropagation()
@@ -285,7 +285,13 @@ export function renderTable({
 						else checkbox.node().checked = !checkbox.node().checked
 						checkbox.dispatch('change')
 					}
+				}
+				tr.on('click', clickHandler)
+				tr.on('keydown', event => {
+					if (event.key == 'Enter') clickHandler(event)
 				})
+			}
+
 			if (showLines) {
 				tr.append('td')
 					.text(i + 1)

--- a/client/dom/toggleButtons.ts
+++ b/client/dom/toggleButtons.ts
@@ -159,7 +159,9 @@ function setRenderers(self) {
 			.style('background-color', 'transparent')
 			.style('display', self.opts.tabsPosition == 'vertical' ? 'flex' : 'inline-grid')
 			.property('disabled', tab => (tab.disabled ? tab.disabled() : false))
-			.each(async function (this: any, tab) {
+			.each(async function (this: any, tab, index) {
+				if (index === 0) this.focus()
+
 				/* The whole button is clickable (i.e. the white space where the blue, 'active' line
 				is not visible). The event is on the button (i.e. tab.wrapper). The style changes 
 				when the button is active/inactive are on the text (i.e. tab.tab) and line 
@@ -249,9 +251,22 @@ function setRenderers(self) {
 				self.update(activeTabIndex)
 				if (tab.callback) await tab.callback(event, tab)
 			})
+			.on('keydown', async function (this: HTMLElement, event, tab) {
+				if (event.target.tagName == 'BUTTON') self.keyEventTarget = event.target
+				if (event.key == 'Escape') {
+					self.dom.holder.remove()
+					return false
+				} else if (event.key == 'Enter') {
+					// default behavior equals click event
+				} else if (event.key == 'ArrowDown') {
+					;(select(this) as any).on('click')(event, tab)
+					return false
+				}
+			})
 		const activeTabIndex = self.tabs.findIndex(t => t.active) //Fix for non-Rx implementations
 		self.update(activeTabIndex)
 	}
+
 	self.update = (activeTabIndex = 0, config = {}) => {
 		self.tabs.forEach((tab, i) => {
 			tab.active = activeTabIndex === i

--- a/client/mds3/itemtable.js
+++ b/client/mds3/itemtable.js
@@ -221,6 +221,7 @@ async function itemtable_multiItems(arg) {
 		const div = rows[i][0].__td
 			.append('div')
 			.attr('class', 'sja_menuoption')
+			.attr('tabindex', 0)
 			.on('click', () => {
 				tableDiv.style('display', 'none')
 				goBackButton.style('display', '')

--- a/client/mds3/leftlabel.js
+++ b/client/mds3/leftlabel.js
@@ -1,4 +1,5 @@
 import { makeVariantLabel } from './leftlabel.variant'
+import { select } from 'd3-selection'
 // variant label is always made. sample label is optional and dynamically loads script when needed
 
 const labyspace = 5
@@ -107,7 +108,7 @@ export function positionLeftlabelg(tk, block) {
 }
 
 export function makelabel(tk, block, y) {
-	return tk.leftlabels.g
+	const text = tk.leftlabels.g
 		.append('text')
 		.attr('font-size', block.labelfontsize)
 		.attr('font-family', font)
@@ -117,4 +118,10 @@ export function makelabel(tk, block, y) {
 		.attr('class', 'sja_clbtext2')
 		.attr('fill', 'black')
 		.attr('x', block.tkleftlabel_xshift)
+		.attr('tabindex', 0)
+		.on('keydown', function (event) {
+			if (event.key == 'Enter') text.node().dispatchEvent(new Event('click'))
+		})
+
+	return text
 }

--- a/client/mds3/leftlabel.js
+++ b/client/mds3/leftlabel.js
@@ -120,8 +120,11 @@ export function makelabel(tk, block, y) {
 		.attr('x', block.tkleftlabel_xshift)
 		.attr('tabindex', 0)
 		.on('keydown', function (event) {
-			if (event.key == 'Enter') text.node().dispatchEvent(new Event('click'))
+			// ignore this event if it bubbled up from a descendant element
+			if (event.target != textElem) return
+			if (event.key == 'Enter') textElem.dispatchEvent(new Event('click'))
 		})
 
+	const textElem = text.node()
 	return text
 }

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -122,7 +122,25 @@ async function showSummary4terms(data, div, tk, block) {
 				tk.mds.variant2samples.twLst.find(i => i.term.id == termid).term.name +
 				(numbycategory
 					? `<span style="font-size:.8em;float:right;margin-left: 5px;">n=${numbycategory.length}</span>`
-					: '')
+					: ''),
+			callback: function () {
+				setTimeout(() => {
+					const tr = this.contentHolder.select('tbody').select('tr').node()
+					if (!tr) return
+					// to support keyboard navigation, automatically highlight the first table row
+					// after this tab/button is clicked, use setTimeout() to ensure the table has
+					// finished rendering
+					//
+					// TODO: support violin plot range selection, which does not use table rows,
+					//       should use start-stop input there
+					//
+					tr.focus()
+					// blur the row highlight almost immediately, purpose is to just briefly indicate
+					// that the first row is selected by keyboard navivation, which implies that
+					// pressing enter key is equivalent to clicking the first row
+					setTimeout(() => tr.blur(), 2000)
+				}, 100)
+			}
 		})
 	}
 

--- a/client/mds3/leftlabel.sample.js
+++ b/client/mds3/leftlabel.sample.js
@@ -123,7 +123,7 @@ async function showSummary4terms(data, div, tk, block) {
 				(numbycategory
 					? `<span style="font-size:.8em;float:right;margin-left: 5px;">n=${numbycategory.length}</span>`
 					: ''),
-			callback: function () {
+			keydownCallback: function (event) {
 				setTimeout(() => {
 					const tr = this.contentHolder.select('tbody').select('tr').node()
 					if (!tr) return
@@ -135,10 +135,6 @@ async function showSummary4terms(data, div, tk, block) {
 					//       should use start-stop input there
 					//
 					tr.focus()
-					// blur the row highlight almost immediately, purpose is to just briefly indicate
-					// that the first row is selected by keyboard navivation, which implies that
-					// pressing enter key is equivalent to clicking the first row
-					setTimeout(() => tr.blur(), 2000)
 				}, 100)
 			}
 		})

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -90,15 +90,19 @@ export function makeVariantLabel(data, tk, block, laby) {
 }
 
 function menu_variants(tk, block) {
-	tk.menutip.d
+	const listDiv = tk.menutip.d
 		.append('div')
 		.text('List')
 		.attr('class', 'sja_menuoption')
 		.attr('data-testid', 'sjpp_mds3tk_variantleftlabel_list')
+		.attr('tabindex', 0)
 		.style('border-radius', '0px')
 		.on('click', () => {
 			listVariantData(tk, block)
 		})
+
+	listDiv.node().focus()
+	setTimeout(() => listDiv.node().blur(), 2000)
 
 	if (tk.skewer && !tk.hardcodeCnvOnly) {
 		// these are skewer-specific options, if hardcoded cnv-only, do not show;
@@ -108,6 +112,7 @@ function menu_variants(tk, block) {
 				.text('Cancel highlight')
 				.style('border-radius', '0px')
 				.attr('class', 'sja_menuoption')
+				.attr('tabindex', 0)
 				.on('click', () => {
 					delete tk.skewer.hlssmid
 					tk.skewer.hlBoxG.selectAll('*').remove()
@@ -137,6 +142,7 @@ function menu_variants(tk, block) {
 					.text('Collapse')
 					.attr('class', 'sja_menuoption')
 					.attr('data-testid', 'sja_collapse_menuoption') // mds3tk_variantleftlabel_collapse
+					.attr('tabindex', 0)
 					.style('border-radius', '0px')
 					.on('click', () => {
 						fold_glyph(tk.skewer.data, tk)
@@ -148,6 +154,7 @@ function menu_variants(tk, block) {
 					.text('Expand')
 					.attr('class', 'sja_menuoption')
 					.attr('data-testid', 'sja_expand_menuoption') // mds3tk_variantleftlabel_expand
+					.attr('tabindex', 0)
 					.style('border-radius', '0px')
 					.on('click', () => {
 						settle_glyph(tk, block)
@@ -159,6 +166,7 @@ function menu_variants(tk, block) {
 				.append('div')
 				.text(tk.skewer.pointup ? 'Point down' : 'Point up')
 				.attr('class', 'sja_menuoption')
+				.attr('tabindex', 0)
 				.style('border-radius', '0px')
 				.on('click', () => {
 					tk.skewer.pointup = !tk.skewer.pointup
@@ -174,6 +182,7 @@ function menu_variants(tk, block) {
 					.text('Change variant shape')
 					.style('vertical-align', 'middle')
 					.attr('class', 'sja_menuoption')
+					.attr('tabindex', 0)
 					.on('click', () => {
 						if (called == false) {
 							called = true
@@ -198,6 +207,7 @@ function menu_variants(tk, block) {
 				.append('div')
 				.text(tk.skewer.hideDotLabels ? 'Show all variant labels' : 'Hide all variant labels')
 				.attr('class', 'sja_menuoption')
+				.attr('tabindex', 0)
 				.style('border-radius', '0px')
 				.on('click', () => {
 					tk.skewer.hideDotLabels = !tk.skewer.hideDotLabels
@@ -213,6 +223,7 @@ function menu_variants(tk, block) {
 			.append('div')
 			.text('Download')
 			.attr('class', 'sja_menuoption')
+			.attr('tabindex', 0)
 			.attr('data-testid', 'sjpp_mds3tk_variantdownload_menuoption')
 			.style('border-radius', '0px')
 			.on('click', () => {
@@ -220,6 +231,11 @@ function menu_variants(tk, block) {
 				tk.menutip.hide()
 			})
 	}
+
+	tk.menutip.d.on('keydown', function (event) {
+		if (event.key != 'Enter' || !event.target.className.includes('sja_menuoption')) return
+		event.target.dispatchEvent(new KeyboardEvent('click'))
+	})
 
 	mayAddSkewerModeOption(tk, block)
 }

--- a/client/src/block.js
+++ b/client/src/block.js
@@ -4582,7 +4582,7 @@ seekrange(chr,start,stop) {
 				.style('padding', '10px')
 				.style('margin', '20px 0px 20px 0px')
 			const row = div.append('div')
-			row.append('span').text('Highlight').style('opacity', 0.5).style('padding-right', '10px')
+			row.append('span').text('Highlight').style('opacity', 0.75).style('padding-right', '10px')
 			row
 				.append('button')
 				.text('Select a region')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- improve navigation-by-keyboard of md3 leftlabel sample, variant buttons and lists; more text contrast in More menu


### PR DESCRIPTION
## Description

Fixes these remaining unaddressed issues in https://gdc-ctds.atlassian.net/browse/SV-2552:
- bullet 5 screenshot: scroll-by-keyboard of Samples pane, from clicking left label, then clicking enter should highlight first table row, click tab or shift+tab to select down or up the table rows, or **arrow-up/down to scroll within this pane**
- bullet 7 screenshot: 'Highlight' text contrast, as scanned by axe devtools

This fix addresses a bit more than the issues described above. The `dom/table.js` and `toggleButtons`/tab helpers can now handle navigation by keyboard, using `tab` (or `shit+tab`) to reach a tab or table row, and clicking enter on the highlighted row/tab to trigger click for users who do not navigate by cursor/mouse. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
