### PR TITLE
DE option and app to access groups from opt.settings.groups but not s…

### DIFF
--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -211,6 +211,7 @@ class MassGroups {
 		let row = menuDiv.append('div')
 
 		addMatrixMenuItems(this.tip, menuDiv, samplelstTW, this.app, id, this.state, () => this.newId)
+
 		if (this.state.currentCohortChartTypes.includes('DEanalysis') && samplelstTW.q.groups.length == 2)
 			addDEPlotMenuItem(menuDiv, this, this.state, samplelstTW)
 
@@ -314,7 +315,7 @@ function addDEPlotMenuItem(div, self, state, samplelstTW, tip) {
 	// small text to explain which is case/control
 	div
 		.append('div')
-		.text(`Case: ${self.state.groups[1].name}, control: ${self.state.groups[0].name}`)
+		.text(`Case: ${samplelstTW.q.groups[1].name}, control: ${samplelstTW.q.groups[0].name}`)
 		.style('font-size', '0.8em')
 		.style('text-align', 'right')
 		.style('opacity', 0.8)

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -21,6 +21,13 @@ opts{}
 this{}
 	app{}
 		vocabApi
+	config
+		samplelst
+			groups[] // length of 2
+		settings
+			DEanalysis{}
+	state
+		// this is the mass state
 */
 
 const hlcolor = '#ffa200'
@@ -235,9 +242,9 @@ class DEanalysis {
 		output.high_sample_size_cutoff = 30 // high sample size cutoff for method toggle to not appear, so that very high sample-size groups are not analyzed by edgeR. The exact cutoff value will need to be determined with more examples.
 		await this.setControls(output)
 		this.dom.header.html(
-			this.config.state.groups[0].name +
+			this.config.samplelst.groups[0].name +
 				' vs ' +
-				this.config.state.groups[1].name +
+				this.config.samplelst.groups[1].name +
 				' <span style="font-size:.8em;opacity:.7">DIFFERENTIAL GENE EXPRESSION</span>'
 		)
 		render_volcano(this, output)
@@ -483,11 +490,11 @@ add:
 				value: num_significant_genes + num_non_significant_genes
 			},
 			{
-				label: self.config.state.groups[0].name + ' sample size (control group)',
+				label: self.config.samplelst.groups[0].name + ' sample size (control group)',
 				value: sample_size1
 			},
 			{
-				label: self.config.state.groups[1].name + ' sample size (treatment group)',
+				label: self.config.samplelst.groups[1].name + ' sample size (treatment group)',
 				value: sample_size2
 			}
 		]


### PR DESCRIPTION
…tate.groups

## Description

closes #2703 

[single group](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22LC50%3C0.2%22,%22filter%22:{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22ranges%22:[{%22startunbounded%22:true,%22stop%22:0.2}]}}]}}]})

[two groups](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22LC50%3C0.2%22,%22filter%22:{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22ranges%22:[{%22startunbounded%22:true,%22stop%22:0.2}]}}]}},{%22name%22:%22LC50%3E0.8%22,%22filter%22:{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22ranges%22:[{%22stopunbounded%22:true,%22start%22:0.8}]}}]}}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
