### PR TITLE
blur an auto-focused tab, so that there is not distracting border hig…

### DIFF
--- a/client/dom/toggleButtons.ts
+++ b/client/dom/toggleButtons.ts
@@ -163,7 +163,16 @@ function setRenderers(self) {
 			.style('display', self.opts.tabsPosition == 'vertical' ? 'flex' : 'inline-grid')
 			.property('disabled', tab => (tab.disabled ? tab.disabled() : false))
 			.each(async function (this: any, tab, index) {
-				if (index === 0) this.focus()
+				if (tab.active) {
+					// assume that an active tabbed content div should receive focus when first rendered,
+					// otherwise using tabs to navigate would not be intuitive or user-friendly if it
+					// starts far away from recently rendered content
+					this.focus()
+					// blur the forced autofocus right away, only want the menu/pane to have priority when
+					// navigating by keyboard, don't want the browser's default element highlight
+					// (blue border in Chrome) to be distracting
+					this.blur()
+				}
 
 				/* The whole button is clickable (i.e. the white space where the blue, 'active' line
 				is not visible). The event is on the button (i.e. tab.wrapper). The style changes 


### PR DESCRIPTION
…hlight around a tab

## Description

This should stop the automatic border highlight for the `Samples` (first tab) in the singlecell plot. When navigating by keyboar (`tab` or `shift+tab`), the browser's autohighlight will still show up.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
