### PR TITLE
fix: GDC scrna UI shows sample submitter id

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -16,6 +16,9 @@ import { digestMessage } from '#termsetting'
 /*
 
 hardcoded behaviors when this.samples[].experiments[] is present:
+
+- all samples must either have or not have .experiments[]
+- experiments[] supports tracking multiple experiments done on same sample
 - an experiment must be {experimentID,sampleName} along with optional prop
 - state tracks experimentID as well as this.samples[].sample
 - in sample table, both experimentID and sampleName are shown
@@ -30,14 +33,10 @@ this
 			sample: str
 			<termid>: <term value>
 			experiments?: []
-				experimentID: str // hardcoded and required
-				sampleName: str // hardcoded and required
+				experimentID: str // required to track which table row is selected and for backend to retrieve data for
+				sampleName: str // for display
 		}
 
-		all samples should either have or not have .experiments[]:
-		- if present, the sample may have more than 1 experiments that will be shown as different rows on sample table;
-		- otherwise, each sample obj is a single experiment and show as one row
-		
 
 	legendRendered=bool
 
@@ -1381,8 +1380,9 @@ class singleCellPlot {
 
 		// if samples are using experiments, add the hardcoded experiment column
 		if (samples.some(i => i.experiments)) {
-			columns.push({ label: 'Sample' })
-			columns.push({ label: 'Experiment' })
+			// two hardcoded column names
+			columns.push({ label: 'Sample' }) // corresponds to this.samples[].experiments[].sampleName
+			columns.push({ label: 'Experiment' }) // corresponds to this.samples[].experiments[].experimentID
 		}
 
 		//const index = columnNames.length == 1 ? 0 : columnNames.length - 1

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC scrna UI shows sample submitter id

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -607,7 +607,7 @@ export type SingleCellSamples = {
 	or is missing, to be added at launch with built-in logic (samples are found by looking through singleCell.data.plots[].folder)
 	*/
 	get?: (q: any) => any
-	/** extra label to show along with sample, it becomes `sample.sample+' '+sample[newProp]` */
+	/** extra label to show along with sample, must be a term id as in sampleColumns[] and allow to retrieve value from sample object */
 	extraSampleTabLabel?: string
 }
 


### PR DESCRIPTION
## Description

closes #2752 

gdc and non-gdc ds both works

it's reasonable to hardcode that an experiment will have `sampleName` property, and is easiest to implement without resorting to ds configurations

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
