### PR TITLE
SC improvements

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -219,7 +219,7 @@ class singleCellPlot {
 		if (q.singleCell?.DEgenes) {
 			const label = this.dom.deDiv
 				.append('label')
-				.html('View differentially expressed genes for cells of a cluster versus rest of the cells:&nbsp;')
+				.html('View DE genes for cells of a cluster versus rest of the cells:&nbsp;')
 			this.dom.deselect = label.append('select').on('change', e => {
 				const display = this.dom.deselect.node().value ? 'inline-block' : 'none'
 				const cluster = this.dom.deselect.node().value.split(' ')[1]
@@ -676,6 +676,7 @@ class singleCellPlot {
 			rows,
 			columns,
 			maxHeight: '70vh',
+			maxWidth: '45vw',
 			div: DETableDiv,
 			singleMode: true,
 			noButtonCallback: (i, node) => {
@@ -815,12 +816,12 @@ class singleCellPlot {
 			this.state.config.gene
 		)
 			inputs.unshift({
-				label: 'Show not expressed',
+				label: 'Show unexpressed cells',
 				boxLabel: '',
 				type: 'checkbox',
 				chartType: 'singleCellPlot',
 				settingsKey: 'showNoExpCells',
-				title: 'Show cells not expressed'
+				title: 'Show cells not expressing the selected gene'
 			})
 		this.components = {
 			controls: await controlsInit({

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -675,7 +675,7 @@ class singleCellPlot {
 		renderTable({
 			rows,
 			columns,
-			maxHeight: '70vh',
+			maxHeight: '60vh',
 			maxWidth: '45vw',
 			div: DETableDiv,
 			singleMode: true,
@@ -1307,7 +1307,7 @@ class singleCellPlot {
 			singleMode: true,
 			div: tableDiv,
 			maxWidth: columns.length > 3 ? '90vw' : '40vw',
-			maxHeight: '50vh',
+			maxHeight: '65vh',
 			noButtonCallback: index => {
 				// NOTE that "index" is not array index of this.samples[]
 				const sample = rows[index][0].value
@@ -1375,7 +1375,7 @@ class singleCellPlot {
 		for (const c of s.sampleColumns || []) {
 			columns.push({
 				label: (await this.app.vocabApi.getterm(c.termid)).name,
-				width: '15vw'
+				width: '14vw'
 			})
 		}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,5 @@
 
+Features
+- On the SC plot sample info now shows on every plot at the top after the tab controls. Used yellow color as starting color in the color scale and
+ increased the default sample size to improve the visualization. Contours only enabled when overlaying a gene to avoid the confusion with the
+ cluster contours that do not use color info. Adjusted contour bandwidth after reducing default plot size. 


### PR DESCRIPTION
## Description

Showed sample info to the right of the other heading controls to save space. Showed contour options only when on gene expression tab. Used light yellow as starting color in the color scale and increased particle size to improve the visualization. Adjusted default bandwidth now that the default plot is smaller to improve contour. Please check.

UI changes:
<img width="1324" alt="Screenshot 2025-02-06 at 4 25 29 PM" src="https://github.com/user-attachments/assets/ef3a2f14-4821-4ead-8dcb-3d254563803b" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
