### PR TITLE
TEST, don't merge. Revert runner to ubuntu-latest.

### DIFF
--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build:
     if: (github.event_name == 'workflow_call') || (github.event_name == 'push' && github.event.head_commit.author.email != 'PPTeam@STJUDE.ORG') || (github.event_name == 'pull_request')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -66,6 +66,7 @@ headtip.d.style('z-index', 5555)
 // headtip must get a crazy high z-index so it can stay on top of all, no matter if server config has base_zindex or not
 
 export function runproteinpaint(arg) {
+	const test = 'test'
 	// polyfill
 	if (!window.structuredClone) window.structuredClone = val => JSON.parse(JSON.stringify(val))
 	/*


### PR DESCRIPTION
## Description

Checking if tape-run is still crashing on ubuntu-latest.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
