### PR TITLE
SC fixes

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -325,6 +325,12 @@ export function renderTable({
 						}
 					})
 
+				if (i === selectedRows[0]) {
+					setTimeout(() => {
+						td.node().parentNode.scrollIntoView({ behavior: 'smooth', block: 'center' })
+					}, 500)
+				}
+
 				const checked = checkbox.property('checked')
 				for (const key in selectedRowStyle) {
 					tr.style(key, checked ? selectedRowStyle[key] : '')

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -326,6 +326,8 @@ export function renderTable({
 					})
 
 				if (i === selectedRows[0]) {
+					// if there is at least one selected row, scroll to that table row,
+					// so that it's visible and obvious to the user which rows are pre-selected
 					setTimeout(() => {
 						td.node().parentNode.scrollIntoView({ behavior: 'smooth', block: 'center' })
 					}, 500)

--- a/client/dom/toggleButtons.ts
+++ b/client/dom/toggleButtons.ts
@@ -200,9 +200,9 @@ function setRenderers(self) {
 						.append('div')
 						.style('display', self.opts.linePosition == 'right' ? 'inline-flex' : 'flex')
 				}
-
+				const isVisible = tab.isVisible ? tab.isVisible() : true
 				if (tab.disabled && tab.isVisible) {
-					tab.wrapper.style('cursor', tab.disabled() == true && tab.isVisible() == true ? 'not-allowed' : 'pointer')
+					tab.wrapper.style('cursor', tab.disabled() == true && isVisible ? 'not-allowed' : 'pointer')
 				}
 
 				tab.tab //Button text
@@ -210,6 +210,8 @@ function setRenderers(self) {
 					.style('text-align', textAlign)
 					.style('padding', '5px')
 					.html(tab.label)
+				tab.wrapper.style('display', isVisible ? 'inline-block' : 'none')
+
 				tab.line //Bolded, blue line indicating the active button
 					.style('background-color', '#1575ad')
 					.style('visibility', tab.active ? 'visible' : 'hidden')

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -84,6 +84,9 @@ class singleCellPlot {
 		})
 		this.tabs = []
 		const activeTab = state.config.activeTab
+		// shared isVisible function for tabs that require config.sample
+		const isVisible = () => this.state?.config.sample
+
 		this.tabs.push({
 			label: 'Samples',
 			id: SAMPLES_TAB,
@@ -94,7 +97,7 @@ class singleCellPlot {
 			label: 'Plots',
 			id: PLOTS_TAB,
 			active: activeTab == PLOTS_TAB,
-			isVisible: () => state.config.sample != undefined || this.state?.config.sample,
+			isVisible,
 			callback: () => this.setActiveTab(PLOTS_TAB)
 		})
 		if (state.termdbConfig.queries?.singleCell?.DEgenes) {
@@ -102,7 +105,7 @@ class singleCellPlot {
 				label: 'Differential Expression',
 				id: DIFFERENTIAL_EXPRESSION_TAB,
 				active: activeTab == DIFFERENTIAL_EXPRESSION_TAB,
-				isVisible: () => state.config.sample != undefined || this.state?.config.sample,
+				isVisible,
 				callback: () => this.setActiveTab(DIFFERENTIAL_EXPRESSION_TAB)
 			})
 			if (this.app.opts.genome.termdbs)
@@ -119,7 +122,7 @@ class singleCellPlot {
 			label: 'Gene Expression',
 			id: GENE_EXPRESSION_TAB,
 			active: activeTab == GENE_EXPRESSION_TAB,
-			isVisible: () => state.config.sample != undefined || this.state?.config.sample,
+			isVisible,
 			callback: () => this.setActiveTab(GENE_EXPRESSION_TAB)
 		})
 
@@ -127,7 +130,7 @@ class singleCellPlot {
 			label: 'Summary',
 			id: VIOLIN_TAB,
 			active: activeTab == VIOLIN_TAB,
-			isVisible: () => state.config.sample != undefined || this.state?.config.sample,
+			isVisible,
 			callback: () => this.setActiveTab(VIOLIN_TAB)
 		})
 
@@ -136,7 +139,7 @@ class singleCellPlot {
 				label: state.termdbConfig.queries.singleCell.images.label,
 				id: IMAGES_TAB,
 				active: activeTab == IMAGES_TAB,
-				isVisible: () => state.config.sample != undefined || this.state?.config.sample,
+				isVisible,
 				callback: () => this.setActiveTab(IMAGES_TAB)
 			})
 		const q = state.termdbConfig.queries

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -163,6 +163,12 @@ class singleCellPlot {
 
 		const headerDiv = contentDiv.append('div').style('display', 'inline-block').style('padding-bottom', '10px')
 
+		const samplesPromptDiv = headerDiv
+			.append('div')
+			.style('display', 'none')
+			.text('Select a sample below to see its plots')
+			.style('font-size', '1.1em')
+			.style('padding-right', '40px')
 		const showDiv = headerDiv.append('div').style('padding-bottom', '10px')
 
 		if (state.config.plots.length > 1) this.renderShowPlots(showDiv, state)
@@ -177,7 +183,6 @@ class singleCellPlot {
 			.style('padding', '10px 20px')
 		const plotsDivParent = contentDiv.append('div')
 		const samplesTableDiv = plotsDivParent.append('div').style('display', 'none')
-		this.renderSamplesTable(samplesTableDiv, state)
 
 		const plotsDiv = plotsDivParent
 			.append('div')
@@ -197,6 +202,7 @@ class singleCellPlot {
 
 		this.dom = {
 			sampleDiv,
+			samplesPromptDiv,
 			samplesTableDiv,
 			showDiv,
 			mainDiv,
@@ -211,6 +217,8 @@ class singleCellPlot {
 			plotsDivParent,
 			errorDiv
 		}
+		this.renderSamplesTable(samplesTableDiv, state)
+
 		if (q.singleCell?.geneExpression) this.renderGeneExpressionControls(geDiv, state)
 
 		const offsetX = 80
@@ -426,9 +434,11 @@ class singleCellPlot {
 		this.dom.showDiv.style('display', 'none')
 		this.dom.violinSelectDiv.style('display', 'none')
 		this.dom.samplesTableDiv.style('display', 'none')
+		this.dom.samplesPromptDiv.style('display', 'none')
 		switch (id) {
 			case SAMPLES_TAB:
 				this.dom.samplesTableDiv.style('display', 'block')
+				this.dom.samplesPromptDiv.style('display', 'inline-block')
 				break
 			case PLOTS_TAB:
 				await this.renderPlots()
@@ -1288,12 +1298,6 @@ class singleCellPlot {
 		}
 
 		div.selectAll('*').remove()
-		const headerDiv = div
-			.append('div')
-			.text('Select a sample to view its data:')
-			.style('font-size', '1.1em')
-			.style('margin-bottom', '10px')
-		const tableDiv = div.append('div')
 		const [rows, columns] = await this.getTableData(state)
 		let sampleIdx = 0 // the first sample/experiment is selected by default on app launch
 		{
@@ -1305,9 +1309,9 @@ class singleCellPlot {
 			columns,
 			resize: true,
 			singleMode: true,
-			div: tableDiv,
+			div,
 			maxWidth: columns.length > 3 ? '90vw' : '40vw',
-			maxHeight: '65vh',
+			maxHeight: '60vh',
 			noButtonCallback: index => {
 				// NOTE that "index" is not array index of this.samples[]
 				const sample = rows[index][0].value

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1059,7 +1059,12 @@ class singleCellPlot {
 				}
 			}
 
-			legendSVG = plot.plotDiv.append('svg').attr('width', 250).attr('height', height).style('vertical-align', 'top')
+			legendSVG = plot.plotDiv
+				.append('svg')
+				.attr('width', 250)
+				.attr('height', height)
+				.style('display', 'inline-block')
+				.style('vertical-align', 'top')
 
 			plot.legendSVG = legendSVG
 		}
@@ -1407,7 +1412,8 @@ class singleCellPlot {
 
 	renderLargePlotThree = async function (plot) {
 		if (!plot.canvas) {
-			plot.canvas = plot.plotDiv.append('canvas').node()
+			const canvas = plot.plotDiv.append('canvas').style('display', 'inline-block').style('vertical-align', 'top')
+			plot.canvas = canvas.node()
 			plot.canvas.width = this.settings.svgw
 			plot.canvas.height = this.settings.svgh
 			plot.renderer = new THREE.WebGLRenderer({ antialias: true, canvas: plot.canvas, preserveDrawingBuffer: true })

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -85,7 +85,7 @@ class singleCellPlot {
 		this.tabs = []
 		const activeTab = state.config.activeTab
 		// shared isVisible function for tabs that require config.sample
-		const isVisible = () => this.state?.config.sample
+		const isVisible = () => state.config.sample || this.state?.config.sample
 
 		this.tabs.push({
 			label: 'Samples',

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -173,8 +173,7 @@ class singleCellPlot {
 		const samplesPromptDiv = headerDiv
 			.append('div')
 			.style('display', 'none')
-			.text('Select a sample below to see its data')
-			.style('font-size', '1.1em')
+			.text('Select a sample below to see its data:')
 			.style('padding-right', '40px')
 		const showDiv = headerDiv.append('div').style('padding-bottom', '10px')
 
@@ -637,8 +636,8 @@ class singleCellPlot {
 
 	async renderDETable() {
 		const DEDiv = this.dom.plotsDiv.append('div').style('width', '100%')
-		const DETableDiv = DEDiv.append('div')
 		const notesDiv = DEDiv.append('div')
+		const DETableDiv = DEDiv.append('div')
 
 		//first plot
 		this.dom.deselect.selectAll('*').remove()
@@ -692,7 +691,7 @@ class singleCellPlot {
 		renderTable({
 			rows,
 			columns,
-			maxHeight: '60vh',
+			maxHeight: '50vh',
 			maxWidth: '45vw',
 			div: DETableDiv,
 			singleMode: true,
@@ -711,11 +710,7 @@ class singleCellPlot {
 			},
 			selectedRows
 		})
-		notesDiv
-			.append('div')
-			.style('font-size', '0.9rem')
-			.style('padding-top', '15px')
-			.text('Select a gene to view its expression.')
+		notesDiv.append('div').style('padding-bottom', '10px').text('Select a gene to view its expression:')
 		this.dom.loadingDiv.style('display', 'none')
 	}
 
@@ -1324,7 +1319,7 @@ class singleCellPlot {
 			singleMode: true,
 			div,
 			maxWidth: columns.length > 3 ? '90vw' : '40vw',
-			maxHeight: '60vh',
+			maxHeight: '50vh',
 			noButtonCallback: index => {
 				// NOTE that "index" is not array index of this.samples[]
 				const sample = rows[index][0].value

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1088,7 +1088,7 @@ class singleCellPlot {
 			.style('font-weight', 'bold')
 			.text(`${plot.colorBy}`)
 		let step = 25
-		if (height < 400) {
+		if (height < 500) {
 			plot.legendSVG.style('font-size', '0.8em')
 			step = 20
 		}

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -82,7 +82,6 @@ class singleCellPlot {
 			if (result == 1 || result == -1) return result
 			else return elem1.sample.localeCompare(elem2.sample)
 		})
-		const initialSample = state.config.sample != undefined
 		this.tabs = []
 		const activeTab = state.config.activeTab
 		this.tabs.push({
@@ -95,7 +94,7 @@ class singleCellPlot {
 			label: 'Plots',
 			id: PLOTS_TAB,
 			active: activeTab == PLOTS_TAB,
-			isVisible: () => initialSample || this.state?.config.sample,
+			isVisible: () => state.config.sample != undefined || this.state?.config.sample,
 			callback: () => this.setActiveTab(PLOTS_TAB)
 		})
 		if (state.termdbConfig.queries?.singleCell?.DEgenes) {
@@ -103,7 +102,7 @@ class singleCellPlot {
 				label: 'Differential Expression',
 				id: DIFFERENTIAL_EXPRESSION_TAB,
 				active: activeTab == DIFFERENTIAL_EXPRESSION_TAB,
-				isVisible: () => initialSample || this.state?.config.sample,
+				isVisible: () => state.config.sample != undefined || this.state?.config.sample,
 				callback: () => this.setActiveTab(DIFFERENTIAL_EXPRESSION_TAB)
 			})
 			if (this.app.opts.genome.termdbs)
@@ -120,7 +119,7 @@ class singleCellPlot {
 			label: 'Gene Expression',
 			id: GENE_EXPRESSION_TAB,
 			active: activeTab == GENE_EXPRESSION_TAB,
-			isVisible: () => initialSample || this.state?.config.sample,
+			isVisible: () => state.config.sample != undefined || this.state?.config.sample,
 			callback: () => this.setActiveTab(GENE_EXPRESSION_TAB)
 		})
 
@@ -128,7 +127,7 @@ class singleCellPlot {
 			label: 'Summary',
 			id: VIOLIN_TAB,
 			active: activeTab == VIOLIN_TAB,
-			isVisible: () => initialSample || this.state?.config.sample,
+			isVisible: () => state.config.sample != undefined || this.state?.config.sample,
 			callback: () => this.setActiveTab(VIOLIN_TAB)
 		})
 
@@ -137,7 +136,7 @@ class singleCellPlot {
 				label: state.termdbConfig.queries.singleCell.images.label,
 				id: IMAGES_TAB,
 				active: activeTab == IMAGES_TAB,
-				isVisible: () => initialSample || this.state?.config.sample,
+				isVisible: () => state.config.sample != undefined || this.state?.config.sample,
 				callback: () => this.setActiveTab(IMAGES_TAB)
 			})
 		const q = state.termdbConfig.queries

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -82,7 +82,7 @@ class singleCellPlot {
 			if (result == 1 || result == -1) return result
 			else return elem1.sample.localeCompare(elem2.sample)
 		})
-
+		const initialSample = state.config.sample != undefined
 		this.tabs = []
 		const activeTab = state.config.activeTab
 		this.tabs.push({
@@ -95,6 +95,7 @@ class singleCellPlot {
 			label: 'Plots',
 			id: PLOTS_TAB,
 			active: activeTab == PLOTS_TAB,
+			isVisible: () => initialSample || this.state?.config.sample,
 			callback: () => this.setActiveTab(PLOTS_TAB)
 		})
 		if (state.termdbConfig.queries?.singleCell?.DEgenes) {
@@ -102,6 +103,7 @@ class singleCellPlot {
 				label: 'Differential Expression',
 				id: DIFFERENTIAL_EXPRESSION_TAB,
 				active: activeTab == DIFFERENTIAL_EXPRESSION_TAB,
+				isVisible: () => initialSample || this.state?.config.sample,
 				callback: () => this.setActiveTab(DIFFERENTIAL_EXPRESSION_TAB)
 			})
 			if (this.app.opts.genome.termdbs)
@@ -118,6 +120,7 @@ class singleCellPlot {
 			label: 'Gene Expression',
 			id: GENE_EXPRESSION_TAB,
 			active: activeTab == GENE_EXPRESSION_TAB,
+			isVisible: () => initialSample || this.state?.config.sample,
 			callback: () => this.setActiveTab(GENE_EXPRESSION_TAB)
 		})
 
@@ -125,6 +128,7 @@ class singleCellPlot {
 			label: 'Summary',
 			id: VIOLIN_TAB,
 			active: activeTab == VIOLIN_TAB,
+			isVisible: () => initialSample || this.state?.config.sample,
 			callback: () => this.setActiveTab(VIOLIN_TAB)
 		})
 
@@ -133,6 +137,7 @@ class singleCellPlot {
 				label: state.termdbConfig.queries.singleCell.images.label,
 				id: IMAGES_TAB,
 				active: activeTab == IMAGES_TAB,
+				isVisible: () => initialSample || this.state?.config.sample,
 				callback: () => this.setActiveTab(IMAGES_TAB)
 			})
 		const q = state.termdbConfig.queries
@@ -166,7 +171,7 @@ class singleCellPlot {
 		const samplesPromptDiv = headerDiv
 			.append('div')
 			.style('display', 'none')
-			.text('Select a sample below to see its plots')
+			.text('Select a sample below to see its data')
 			.style('font-size', '1.1em')
 			.style('padding-right', '40px')
 		const showDiv = headerDiv.append('div').style('padding-bottom', '10px')
@@ -333,8 +338,8 @@ class singleCellPlot {
 	}
 
 	async getSamplesTabLabel(state) {
-		const sampleIdx = state.config.sample ? this.samples.findIndex(i => i.sample == state.config.sample) : 0
-		if (sampleIdx == -1) throw 'sample not found in this.samples[]'
+		const sampleIdx = this.samples.findIndex(i => i.sample == state.config.sample)
+		if (sampleIdx == -1) return ''
 
 		const extraText = [] // extra text to show alongside sample name
 
@@ -1299,10 +1304,11 @@ class singleCellPlot {
 
 		div.selectAll('*').remove()
 		const [rows, columns] = await this.getTableData(state)
+		const selectedRows = []
 		let sampleIdx = 0 // the first sample/experiment is selected by default on app launch
 		{
 			const i = this.samples.findIndex(i => i.sample == state.config.sample)
-			if (i != -1) sampleIdx = i // select sample already tracked in state
+			if (i != -1) selectedRows.push(i)
 		}
 		renderTable({
 			rows,
@@ -1326,7 +1332,7 @@ class singleCellPlot {
 
 				this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 			},
-			selectedRows: [sampleIdx],
+			selectedRows,
 			striped: true,
 			header: { style: { 'text-transform': 'capitalize' } } // to show header in title case; if it results in a conflict (e.g. a sample name showing in 1st tab has to be lower case), then use sampleColumns[].columnHeader as override of term name
 		})

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -390,8 +390,8 @@ class singleCellPlot {
 					let settings = { svgw: 800, svgh: 800 }
 
 					if (selectedCount > 1) {
-						const width = 900
-						const height = 900
+						const width = 800
+						const height = 800
 						settings.svgh = width / selectedCount
 						settings.svgw = height / selectedCount
 					}

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -439,7 +439,7 @@ class singleCellPlot {
 		this.dom.geDiv.style('display', 'none')
 		this.dom.showDiv.style('display', 'none')
 		this.dom.violinSelectDiv.style('display', 'none')
-		this.dom.samplesTableDiv.style('display', 'none')
+		this.dom.samplesTableDiv.style('display', 'none').style('padding-bottom', '10px')
 		this.dom.samplesPromptDiv.style('display', 'none')
 		switch (id) {
 			case SAMPLES_TAB:
@@ -637,7 +637,7 @@ class singleCellPlot {
 	async renderDETable() {
 		const DEDiv = this.dom.plotsDiv.append('div').style('width', '100%')
 		const notesDiv = DEDiv.append('div')
-		const DETableDiv = DEDiv.append('div')
+		const DETableDiv = DEDiv.append('div').style('padding-bottom', '10px')
 
 		//first plot
 		this.dom.deselect.selectAll('*').remove()
@@ -708,7 +708,8 @@ class singleCellPlot {
 					}
 				})
 			},
-			selectedRows
+			selectedRows,
+			resize: true
 		})
 		notesDiv.append('div').style('padding-bottom', '10px').text('Select a gene to view its expression:')
 		this.dom.loadingDiv.style('display', 'none')

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -84,8 +84,10 @@ class singleCellPlot {
 		})
 		this.tabs = []
 		const activeTab = state.config.activeTab
-		// shared isVisible function for tabs that require config.sample
-		const isVisible = () => state.config.sample || this.state?.config.sample
+		// shared isVisible function for tabs that require config.sample;
+		// note that tab.isVisible() will be called on tab.update(), which
+		// is called in main() -> showActiveTab() below
+		const isVisible = () => this.state?.config.sample
 
 		this.tabs.push({
 			label: 'Samples',


### PR DESCRIPTION
## Description

Do not preselect  a sample but show only Samples tabs until a sample is selected. Improved sample heading. Aligned legend with plot for GDC. Added  subtype in BALL [sjpp](https://github.com/stjude/sjpp/pull/656). I used the idea about hiding other tabs that we discussed @siosonel to do as GDC asked.

<img width="1485" alt="Screenshot 2025-02-07 at 12 18 17 PM" src="https://github.com/user-attachments/assets/869186f8-8102-4bec-9f4b-7ac47a68ce0e" />


Two plots in a row with the legend besides the plot:

<img width="1485" alt="Screenshot 2025-02-07 at 1 36 25 PM" src="https://github.com/user-attachments/assets/d232b513-f5d2-41ff-8a66-70223d5839f1" />



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
