### PR TITLE
Sc misc fixes

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -480,8 +480,7 @@ export function renderTable({
 	return api
 }
 
-export async function downloadTable(rows, cols) {
-	const filename = `table.tsv`
+export async function downloadTable(rows, cols, filename = 'table.tsv') {
 	let lines = ''
 	for (const column of cols) {
 		lines += `${column.label}\t`

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -162,7 +162,7 @@ class singleCellPlot {
 			.append('div')
 			.style('display', 'inline-block')
 			.style('vertical-align', 'top')
-			.style('padding-top', '10px')
+			.style('padding', '10px')
 		this.tabsComp = await new Tabs({
 			holder: contentDiv,
 			tabsPosition: 'horizontal',
@@ -398,6 +398,7 @@ class singleCellPlot {
 						const height = 800
 						settings.svgh = width / selectedCount
 						settings.svgw = height / selectedCount
+						settings.contourBandwidth = 10
 					}
 					this.app.dispatch({
 						type: 'plot_edit',

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -13,6 +13,8 @@ import * as THREE from 'three'
 import { getThreeCircle } from './sampleScatter.rendererThree.js'
 import { renderContours } from './sampleScatter.renderer.js'
 import { digestMessage } from '#termsetting'
+import { downloadTable } from '../dom/table'
+
 /*
 
 hardcoded behaviors when this.samples[].experiments[] is present:
@@ -687,6 +689,7 @@ class singleCellPlot {
 			if (gene.name == this.state.config.gene) selectedRows.push(i)
 			i++
 		}
+		this.DETable = { rows, columns }
 
 		const index = this.tabs.findIndex(t => t.id == GSEA_TAB)
 		const gseaTab = this.tabs[index]
@@ -849,8 +852,21 @@ class singleCellPlot {
 			})
 		}
 		this.components.controls.on('downloadClick.singleCellPlot', () => {
-			for (const plot of this.plots) this.downloadPlot(plot)
+			if (this.state.config.activeTab == GENE_EXPRESSION_TAB || this.state.config.activeTab == PLOTS_TAB)
+				for (const plot of this.plots) this.downloadPlot(plot)
+			else {
+				if (this.state.config.activeTab == DIFFERENTIAL_EXPRESSION_TAB)
+					if (this.DETable) this.downloadSCTable('DE.tsv', this.DETable)
+				if (!this.state.config.activeTab || this.state.config.activeTab == SAMPLES_TAB)
+					this.downloadSCTable('samples.tsv', this.samplesTable)
+
+				//download tables on table tabs, image on image tab, violin on violin tab
+			}
 		})
+	}
+
+	downloadSCTable(name, table) {
+		downloadTable(table.rows, table.columns, name)
 	}
 
 	downloadPlot(plot) {
@@ -1311,6 +1327,7 @@ class singleCellPlot {
 
 		div.selectAll('*').remove()
 		const [rows, columns] = await this.getTableData(state)
+		this.samplesTable = { rows, columns }
 		const selectedRows = []
 		let sampleIdx = 0 // the first sample/experiment is selected by default on app launch
 		{

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -8,12 +8,20 @@ import { select } from 'd3-selection'
 import { rgb, create, extent, color } from 'd3'
 import { roundValueAuto } from '#shared/roundValue.js'
 import { TermTypes } from '#shared/terms.js'
-import { ColorScale, icons as icon_functions, addGeneSearchbox, renderTable, sayerror, Menu, Tabs } from '#dom'
+import {
+	ColorScale,
+	icons as icon_functions,
+	addGeneSearchbox,
+	renderTable,
+	sayerror,
+	Menu,
+	Tabs,
+	downloadTable
+} from '#dom'
 import * as THREE from 'three'
 import { getThreeCircle } from './sampleScatter.rendererThree.js'
 import { renderContours } from './sampleScatter.renderer.js'
 import { digestMessage } from '#termsetting'
-import { downloadTable } from '../dom/table'
 
 /*
 

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1348,8 +1348,10 @@ class singleCellPlot {
 				const config = {
 					chartType: 'singleCellPlot',
 					sample, // track sample name to identify it in this.samples[]
-					activeTab: PLOTS_TAB // on selecting a sample from table, auto switch to plots to directly show this sample's plots, to save user a click
+					activeTab: PLOTS_TAB, // on selecting a sample from table, auto switch to plots to directly show this sample's plots, to save user a click
+					cluster: null // reset cluster
 				}
+				this.genes = null // reset DE genes
 				if (rows[index][0].__experimentID) {
 					config.experimentID = rows[index][0].__experimentID
 				}

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -92,6 +92,7 @@ class singleCellPlot {
 		this.tabs.push({
 			label: 'Samples',
 			id: SAMPLES_TAB,
+			isVisible,
 			active: activeTab == SAMPLES_TAB,
 			callback: () => this.setActiveTab(SAMPLES_TAB)
 		})

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -217,7 +217,7 @@ export function runproteinpaint(arg) {
 				await appHeader.makeheader()
 			}
 
-			app.holder0 = app.holder.append('div').style('margin', '20px')
+			app.holder0 = app.holder.append('div').style('margin', '10px')
 
 			const subapp = await parseEmbedThenUrl(arg, app)
 			const appInstance = subapp || app

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,7 @@
 
+Features
+- On the SC plot: 
+  Download content based on the active tab. It allows to download DE table and fixes broken download. 
+  Updated default contours bandwidth when the plot size is automatically reduced. 
+  Hided Samples tab on init, when the sample is not selected. 
+  Cleared DE calculation when the sample is changed.


### PR DESCRIPTION
## Description

Download content based on the active tab, it allows to download DE table and fixes breaking code. Updated default contours bandwidth when the plot size is automatically reduced. Hided Samples tab on init, when the sample is not selected. Cleared DE calculation when the sample is changed.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
