### PR TITLE
Tabs cleanup

### DIFF
--- a/client/dom/toggleButtons.ts
+++ b/client/dom/toggleButtons.ts
@@ -281,7 +281,7 @@ function setRenderers(self) {
 		self.update(activeTabIndex)
 	}
 
-	self.update = (activeTabIndex = 0, config = {}) => {
+	self.update = (activeTabIndex = 0) => {
 		self.tabs.forEach((tab, i) => {
 			tab.active = activeTabIndex === i
 		})
@@ -290,23 +290,9 @@ function setRenderers(self) {
 			.data(self.tabs)
 			.classed('sjpp-active', tab => tab.active)
 			.each(tab => {
+				const isVisible = tab.isVisible ? tab.isVisible() : true
 				tab.wrapper.classed('sjpp-active', tab.active)
-				if (tab.isVisible) tab.wrapper.style('display', tab => (config && tab.isVisible() ? '' : 'none'))
-				if (tab.contentHolder) tab.contentHolder.style('display', tab.active ? 'block' : 'none')
-				tab.tab.style('color', tab.active ? '#1575ad' : '#757373')
-				tab.line.style('visibility', tab.active ? 'visible' : 'hidden')
-				tab.tab.html(tab.label) // re-print tab label since the label value could have been updated by outside code
-			})
-	}
-
-	self.updateInactive = (index, config = {}) => {
-		self.dom.tabsHolder
-			.selectAll('button')
-			.data(self.tabs)
-			.classed('sjpp-active', tab => tab.active)
-			.each(tab => {
-				tab.wrapper.classed('sjpp-active', tab.active)
-				if (tab.isVisible) tab.wrapper.style('display', tab => (config && tab.isVisible() ? '' : 'none'))
+				if (tab.isVisible) tab.wrapper.style('display', isVisible ? '' : 'none')
 				if (tab.contentHolder) tab.contentHolder.style('display', tab.active ? 'block' : 'none')
 				tab.tab.style('color', tab.active ? '#1575ad' : '#757373')
 				tab.line.style('visibility', tab.active ? 'visible' : 'hidden')

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -173,7 +173,7 @@ class singleCellPlot {
 			.append('div')
 			.style('display', 'inline-block')
 			.style('vertical-align', 'top')
-			.style('padding', '10px')
+			.style('padding-left', '10px')
 		this.tabsComp = await new Tabs({
 			holder: contentDiv,
 			tabsPosition: 'horizontal',
@@ -447,7 +447,7 @@ class singleCellPlot {
 		const index = this.tabs.findIndex(t => t.id == id)
 		const tab = this.tabs[index]
 		tab.active = true
-		this.tabsComp.update(index, tab)
+		this.tabsComp.update(index)
 
 		this.dom.deDiv.style('display', 'none')
 		this.dom.geDiv.style('display', 'none')
@@ -698,11 +698,9 @@ class singleCellPlot {
 			i++
 		}
 		this.DETable = { rows, columns }
+		const index = this.tabs.findIndex(t => t.id == DIFFERENTIAL_EXPRESSION_TAB)
+		this.tabsComp.update(index) //rerun isVisible() for GSEA tab to show
 
-		const index = this.tabs.findIndex(t => t.id == GSEA_TAB)
-		const gseaTab = this.tabs[index]
-		gseaTab.active = false
-		this.tabsComp.updateInactive(index, gseaTab)
 		renderTable({
 			rows,
 			columns,

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -75,7 +75,7 @@ class SummaryPlot {
 		this.render()
 
 		const activeTabIndex = this.tabsData.findIndex(tab => tab.childType == this.config.childType)
-		this.chartToggles.update(activeTabIndex, this.config)
+		this.chartToggles.update(activeTabIndex)
 
 		//Only show tabs when more than one are present
 		const numVisTabs = this.tabsData.filter(d => d.isVisible()).length


### PR DESCRIPTION
## Description

When updating the tabs there is no need to provide a config. Just rerun the isVisible method on each tab if provided. This change allows to use this method to update the tabs and remove the method updateInactive (added by me and adding duplicated logic not needed). These changes do not seem to break any previous logic. The summary plot that is the only place where isVisible was being passed works as expected (config was always true).  When isVisible is not passed the code changes here do not apply. Please check.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
