### PR TITLE
Showed SC controls only in the Plots and Gene Expression tabs. Added download icon in table 

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -1,7 +1,6 @@
 import { select } from 'd3-selection'
 import { icons, Menu } from '#dom'
 import type { Th } from '../types/d3'
-import { icons as icon_functions } from '#dom'
 
 export type Cell = {
 	/** to print in <a> element */
@@ -187,7 +186,7 @@ export function renderTable({
 			.style('padding', '5px')
 			.style('vertical-align', 'top')
 
-		icon_functions['download'](downloadDiv, {
+		icons['download'](downloadDiv, {
 			width: 15,
 			height: 15,
 			title: 'Download table',

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -1,6 +1,7 @@
 import { select } from 'd3-selection'
 import { icons, Menu } from '#dom'
 import type { Th } from '../types/d3'
+import { icons as icon_functions } from '#dom'
 
 export type Cell = {
 	/** to print in <a> element */
@@ -172,8 +173,21 @@ export function renderTable({
 	}
 
 	const uniqueInputName = inputName || getUniqueNameOrId('input')
+	const parentDiv = div.append('div').style('background-color', 'white').style('display', 'inline-block')
+	const downloadDiv = div
+		.append('div')
+		.style('display', 'inline-block')
+		.style('padding-left', '5px')
+		.style('vertical-align', 'top')
 
-	const parentDiv = div.append('div').style('background-color', 'white')
+	icon_functions['download'](downloadDiv, {
+		width: 15,
+		height: 15,
+		title: 'Download table',
+		handler: () => {
+			downloadTable(rows, columns)
+		}
+	})
 
 	if (resize) {
 		if (rows.length > 15) parentDiv.style('height', maxHeight)

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -110,6 +110,7 @@ export type TableArgs = {
 	 * as the <input name=?> if the same name is always used, multiple tables
 	 * created in one page will conflict in row selection */
 	dataTestId?: any
+	showDownload?: boolean
 }
 
 /** incremented input ID will guarantee no collision from using getUniqueNameOrId()*/
@@ -147,7 +148,7 @@ export function renderTable({
 	selectedRowStyle = {},
 	inputName = null,
 	dataTestId = null,
-	hideDownload = false
+	showDownload = false
 }: TableArgs) {
 	validateInput()
 	let _selectedRowStyle = selectedRowStyle
@@ -175,7 +176,7 @@ export function renderTable({
 
 	const uniqueInputName = inputName || getUniqueNameOrId('input')
 	const parentDiv = div.append('div').style('background-color', 'white').style('display', 'inline-block')
-	if (!hideDownload) {
+	if (showDownload) {
 		const downloadDiv = div
 			.append('div')
 			.style('display', 'inline-block')

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -110,6 +110,7 @@ export type TableArgs = {
 	 * as the <input name=?> if the same name is always used, multiple tables
 	 * created in one page will conflict in row selection */
 	dataTestId?: any
+	/** Show download icon that allows to download the table content */
 	showDownload?: boolean
 }
 

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -177,7 +177,7 @@ export function renderTable({
 	const downloadDiv = div
 		.append('div')
 		.style('display', 'inline-block')
-		.style('padding-left', '5px')
+		.style('padding', '5px')
 		.style('vertical-align', 'top')
 
 	icon_functions['download'](downloadDiv, {

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -112,6 +112,8 @@ export type TableArgs = {
 	dataTestId?: any
 	/** Show download icon that allows to download the table content */
 	showDownload?: boolean
+	/** Optional filename for the file downloaded */
+	downloadFilename?: string
 }
 
 /** incremented input ID will guarantee no collision from using getUniqueNameOrId()*/
@@ -149,7 +151,8 @@ export function renderTable({
 	selectedRowStyle = {},
 	inputName = null,
 	dataTestId = null,
-	showDownload = false
+	showDownload = false,
+	downloadFilename = 'table.tsv'
 }: TableArgs) {
 	validateInput()
 	let _selectedRowStyle = selectedRowStyle
@@ -189,7 +192,7 @@ export function renderTable({
 			height: 15,
 			title: 'Download table',
 			handler: () => {
-				downloadTable(rows, columns)
+				downloadTable(rows, columns, downloadFilename)
 			}
 		})
 	}

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -146,7 +146,8 @@ export function renderTable({
 	resize = false,
 	selectedRowStyle = {},
 	inputName = null,
-	dataTestId = null
+	dataTestId = null,
+	hideDownload = false
 }: TableArgs) {
 	validateInput()
 	let _selectedRowStyle = selectedRowStyle
@@ -174,20 +175,22 @@ export function renderTable({
 
 	const uniqueInputName = inputName || getUniqueNameOrId('input')
 	const parentDiv = div.append('div').style('background-color', 'white').style('display', 'inline-block')
-	const downloadDiv = div
-		.append('div')
-		.style('display', 'inline-block')
-		.style('padding', '5px')
-		.style('vertical-align', 'top')
+	if (!hideDownload) {
+		const downloadDiv = div
+			.append('div')
+			.style('display', 'inline-block')
+			.style('padding', '5px')
+			.style('vertical-align', 'top')
 
-	icon_functions['download'](downloadDiv, {
-		width: 15,
-		height: 15,
-		title: 'Download table',
-		handler: () => {
-			downloadTable(rows, columns)
-		}
-	})
+		icon_functions['download'](downloadDiv, {
+			width: 15,
+			height: 15,
+			title: 'Download table',
+			handler: () => {
+				downloadTable(rows, columns)
+			}
+		})
+	}
 
 	if (resize) {
 		if (rows.length > 15) parentDiv.style('height', maxHeight)

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -744,7 +744,7 @@ class singleCellPlot {
 		this.DETable = { rows, columns }
 		const index = this.tabs.findIndex(t => t.id == DIFFERENTIAL_EXPRESSION_TAB)
 		this.tabsComp.update(index) //rerun isVisible() for GSEA tab to show
-
+		const downloadFilename = `${await this.getSampleFilename(this.state)}_DE_GENES.tsv`
 		renderTable({
 			rows,
 			columns,
@@ -766,7 +766,8 @@ class singleCellPlot {
 			},
 			selectedRows,
 			resize: true,
-			showDownload: true
+			showDownload: true,
+			downloadFilename
 		})
 		notesDiv.append('div').style('padding-bottom', '10px').text('Select a gene to view its expression:')
 		this.dom.loadingDiv.style('display', 'none')

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -718,7 +718,11 @@ class singleCellPlot {
 			return
 		}
 
-		const columns = [{ label: 'Gene' }, { label: 'Log2FC' }, { label: 'Adjusted P-value' }]
+		const columns = [
+			{ label: 'Gene', width: '15vw' },
+			{ label: 'Log2FC', width: '12vw' },
+			{ label: 'Adjusted P-value', width: '12vw' }
+		]
 		const rows = []
 		this.genes = []
 		this.fold_changes = []
@@ -745,7 +749,6 @@ class singleCellPlot {
 			rows,
 			columns,
 			maxHeight: '50vh',
-			maxWidth: '45vw',
 			div: DETableDiv,
 			singleMode: true,
 			noButtonCallback: (i, node) => {
@@ -1381,7 +1384,7 @@ class singleCellPlot {
 			resize: true,
 			singleMode: true,
 			div,
-			maxWidth: columns.length > 3 ? '90vw' : '40vw',
+			maxWidth: columns.length > 3 ? '95vw' : '40vw',
 			maxHeight: '50vh',
 			noButtonCallback: index => {
 				// NOTE that "index" is not array index of this.samples[]

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -762,7 +762,8 @@ class singleCellPlot {
 				})
 			},
 			selectedRows,
-			resize: true
+			resize: true,
+			showDownload: true
 		})
 		notesDiv.append('div').style('padding-bottom', '10px').text('Select a gene to view its expression:')
 		this.dom.loadingDiv.style('display', 'none')
@@ -1401,7 +1402,7 @@ class singleCellPlot {
 			selectedRows,
 			striped: true,
 			header: { style: { 'text-transform': 'capitalize' } }, // to show header in title case; if it results in a conflict (e.g. a sample name showing in 1st tab has to be lower case), then use sampleColumns[].columnHeader as override of term name
-			hideDownload: true
+			showDownload: false
 		})
 	}
 

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -491,6 +491,7 @@ class singleCellPlot {
 		this.dom.violinSelectDiv.style('display', 'none')
 		this.dom.samplesTableDiv.style('display', 'none').style('padding-bottom', '10px')
 		this.dom.samplesPromptDiv.style('display', 'none')
+		this.dom.controlsHolder.style('display', 'none')
 		switch (id) {
 			case SAMPLES_TAB:
 				this.dom.samplesTableDiv.style('display', 'block')
@@ -499,9 +500,11 @@ class singleCellPlot {
 			case PLOTS_TAB:
 				await this.renderPlots()
 				this.dom.showDiv.style('display', 'inline-block')
+				this.dom.controlsHolder.style('display', 'block')
 				break
 
 			case GENE_EXPRESSION_TAB:
+				this.dom.controlsHolder.style('display', 'block')
 				await this.renderPlots()
 				this.dom.geDiv.style('display', 'inline-block')
 				this.dom.searchbox.node().focus()
@@ -687,6 +690,7 @@ class singleCellPlot {
 	async renderDETable() {
 		const DEDiv = this.dom.plotsDiv.append('div').style('width', '100%')
 		const notesDiv = DEDiv.append('div')
+
 		const DETableDiv = DEDiv.append('div').style('padding-bottom', '10px')
 
 		//first plot
@@ -898,14 +902,6 @@ class singleCellPlot {
 			const filename = await this.getSampleFilename(this.state)
 			if (this.state.config.activeTab == GENE_EXPRESSION_TAB || this.state.config.activeTab == PLOTS_TAB)
 				for (const plot of this.plots) this.downloadPlot(plot, filename)
-			else {
-				if (this.state.config.activeTab == DIFFERENTIAL_EXPRESSION_TAB)
-					if (this.DETable) this.downloadSCTable(`${filename}_DETABLE.tsv`, this.DETable)
-				if (!this.state.config.activeTab || this.state.config.activeTab == SAMPLES_TAB)
-					this.downloadSCTable('samples.tsv', this.samplesTable)
-
-				//download tables on table tabs, image on image tab, violin on violin tab
-			}
 		})
 	}
 

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1400,7 +1400,8 @@ class singleCellPlot {
 			},
 			selectedRows,
 			striped: true,
-			header: { style: { 'text-transform': 'capitalize' } } // to show header in title case; if it results in a conflict (e.g. a sample name showing in 1st tab has to be lower case), then use sampleColumns[].columnHeader as override of term name
+			header: { style: { 'text-transform': 'capitalize' } }, // to show header in title case; if it results in a conflict (e.g. a sample name showing in 1st tab has to be lower case), then use sampleColumns[].columnHeader as override of term name
+			hideDownload: true
 		})
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,5 @@
+Features
 
+- SC plot: Showed control settings only in Plots and Gene Expression. Showed Sample column after Case. Added download icon in the DE table. The downloaded plots now 
+contain the sample info in the filename.
+- Table: Added download table option


### PR DESCRIPTION
## Description

Showed SC controls only in the Plots and Gene Expression tabs as discussed. Added download icon to table to allow downloading the content. See UI:

<img width="1256" alt="Screenshot 2025-02-11 at 2 23 03 PM" src="https://github.com/user-attachments/assets/106b40a1-42fa-4cf1-9571-ab653a21e198" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
