### PR TITLE
Fix cnvs  when chr is unknown or not in reference chromosomes in DataMapper.ts

### DIFF
--- a/client/plots/disco/cnv/CnvArcsMapper.ts
+++ b/client/plots/disco/cnv/CnvArcsMapper.ts
@@ -90,11 +90,6 @@ export default class CnvArcsMapper {
 		const arcs: Array<CnvArc> = []
 
 		arcData.forEach(data => {
-			if (!data.chr || this.reference.chromosomesOrder.indexOf(data.chr) == -1) {
-				// when chr is unknown or not in reference chromosomes (chr1-22, X, Y), do not render arc
-				return
-			}
-
 			let startAngle = this.calculateStartAngle(data)
 			let endAngle = this.calculateEndAngle(data)
 

--- a/client/plots/disco/data/DataMapper.ts
+++ b/client/plots/disco/data/DataMapper.ts
@@ -303,6 +303,11 @@ export default class DataMapper {
 
 	private filterCnvs(data: Data) {
 		if (this.cnvFilter(data)) {
+			if (!data.chr || this.reference.chromosomesOrder.indexOf(data.chr) == -1) {
+				// when chr is unknown or not in reference chromosomes (chr1-22, X, Y), do not render arc
+				return
+			}
+
 			if (this.cnvGainMaxValue == undefined || this.cnvGainMaxValue < data.value) {
 				this.cnvGainMaxValue = data.value
 			}
@@ -310,7 +315,6 @@ export default class DataMapper {
 			if (this.cnvLossMaxValue == undefined || this.cnvLossMaxValue > data.value) {
 				this.cnvLossMaxValue = data.value
 			}
-
 			this.cnvData.push(data)
 		}
 	}


### PR DESCRIPTION
Rewrites the fix from:

https://github.com/stjude/proteinpaint/issues/2769


## Description

It's cleaner to filter out cnvs in DataMapper.ts, since it can affect the calculation of `cnvGainMaxValue` and `cnvLossMaxValue`. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
