### PR TITLE
Implementation for making GSEA stateless

### DIFF
--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -168,7 +168,8 @@ class DEanalysis {
 				type: 'radio',
 				chartType: 'DEanalysis',
 				settingsKey: 'gene_ora',
-				title: 'Toggle to check if certain gene sets are overrepresented among upregulated, downregulated, or both sets of genes',
+				title:
+					'Toggle to check if certain gene sets are overrepresented among upregulated, downregulated, or both sets of genes',
 				options: [
 					{ label: 'upregulated', value: 'upregulated' },
 					{ label: 'downregulated', value: 'downregulated' },
@@ -181,7 +182,7 @@ class DEanalysis {
 			// Check if genome build contains termdbs, only then enable gene ora
 			inputs.push({
 				label: 'Gene Set Enrichment Analysis',
-				type: 'checkbox',
+				type: 'radio',
 				chartType: 'DEanalysis',
 				settingsKey: 'gsea',
 				title: 'Select to check if certain gene sets are enriched among the two biological conditions',

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -259,11 +259,11 @@ add:
 						: output_keys[iter].value.fdr
 					self.gsea_table_rows.push([
 						{ value: pathway_name },
-						{ value: es },
+						//{ value: es },
 						{ value: nes },
 						{ value: output_keys[iter].value.geneset_size },
 						{ value: pval },
-						{ value: sidak },
+						//{ value: sidak },
 						{ value: fdr },
 						{ value: output_keys[iter].value.leading_edge }
 					])
@@ -294,11 +294,11 @@ add:
 						: output_keys[iter].value.fdr
 					self.gsea_table_rows.push([
 						{ value: pathway_name },
-						{ value: es },
+						//{ value: es },
 						{ value: nes },
 						{ value: output_keys[iter].value.geneset_size },
 						{ value: pval },
-						{ value: sidak },
+						//{ value: sidak },
 						{ value: fdr },
 						{ value: output_keys[iter].value.leading_edge }
 					])
@@ -311,11 +311,11 @@ add:
 		// table columns showing analysis results for each gene set
 		self.gsea_table_cols = [
 			{ label: 'Geneset' },
-			{ label: 'Enrichment Score' },
+			//{ label: 'Enrichment Score' },
 			{ label: 'Normalized Enrichment Score' },
 			{ label: 'Geneset Size' },
 			{ label: 'P value' },
-			{ label: 'Sidak' },
+			//{ label: 'Sidak' },
 			{ label: 'FDR' },
 			{ label: 'Leading Edge' }
 		]

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -235,11 +235,7 @@ add:
 		if (self.settings.fdr_or_top == 'top') {
 			// Sorting the top (top_genesets) genesets in decreasing order
 			output_keys.sort((i, j) => Number(i.value.fdr) - Number(j.value.fdr))
-			let top_genesets = self.settings.top_genesets
-			if (self.settings.top_genesets > output_keys.length) {
-				// If the length of the table is less than the top cutoff, only iterate
-				top_genesets = output_keys.length
-			}
+			const top_genesets = Math.min(self.settings.top_genesets, output_keys.length) // If the length of the table is less than the top cutoff, only iterate till the end of the table
 			for (let iter = 0; iter < top_genesets; iter++) {
 				const pathway_name = output_keys[iter].key
 				if (
@@ -338,9 +334,10 @@ add:
 					geneset_name: self.gsea_table_rows[index][0].value,
 					genes: self.config.gsea_params.genes,
 					fold_change: self.config.gsea_params.fold_change,
-					geneSetGroup: self.config.gsea_params.geneSetGroup,
+					geneSetGroup: self.settings.pathway,
 					pickle_file: output.pickle_file,
-					filter_non_coding_genes: self.settings.filter_non_coding_genes
+					filter_non_coding_genes: self.settings.filter_non_coding_genes,
+					num_permutations: self.settings.num_permutations
 				}
 				const holder = self.dom.holder
 				holder.selectAll('*').remove()

--- a/shared/types/src/routes/genesetEnrichment.ts
+++ b/shared/types/src/routes/genesetEnrichment.ts
@@ -15,8 +15,8 @@ export type GenesetEnrichmentRequest = {
 	geneset_name?: string
 	/** Pickle file to be queried for generating gsea image of a particular geneset */
 	pickle_file?: string
-	/** Number of permutations to be carried out for GSEA analysis, this variable will become compulsory once GSEA becomes stateless */
-	num_permutations?: number
+	/** Number of permutations to be carried out for GSEA analysis */
+	num_permutations: number
 }
 
 type pathway_attributes = {


### PR DESCRIPTION
## Description
PLEASE read how to test, before testing!

Implementation for making GSEA stateless.

For mimicking statelessness on a local pp (which is technically not stateless) the pickle file needs to be deleted after the initial GSEA computation but BEFORE clicking on a row in the GSEA table. This can be achieved by running the following computation after the initial GSEA computation `rm /path/to/your/serverconfig/cachedir/*.pkl`

NOTE: In the event of a re-computation, the NES values will be slightly different than what is mentioned in the table. This is because blitzgsea uses permutations to calculate the pvalues and are not completely reproducible.

Minor fixes:

1) The GSEA button in the DE app has been restored.
2) In GSEA table, ES and Sidak columns have been commented out.
   


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
