### PR TITLE
Fixed bug building the color or shape legend for a gene

### DIFF
--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -1222,13 +1222,21 @@ export function setRenderers(self) {
 			.style('font-weight', 'bold')
 
 		offsetX += step
-		const mutations = chart.cohortSamples[0]['cat_info'][cname]
+		const mutations = []
+		for (const [key, value] of map)
+			if (value.mutation)
+				//if no mutation is Ref
+				mutations.push(value.mutation)
+
+		const mutationsLabels = new Set()
 		offsetY += 10
 		for (const mutation of mutations) {
-			offsetY += 15
 			const dt = mutation.dt
 			const origin = morigin[mutation.origin]?.label
 			const dtlabel = origin ? `${origin[0]} ${dt2label[dt]}` : dt2label[dt]
+			if (!mutationsLabels.has(dtlabel)) mutationsLabels.add(dtlabel)
+			else continue
+			offsetY += 15
 
 			G.append('text')
 				.attr('x', offsetX - step)
@@ -1239,7 +1247,9 @@ export function setRenderers(self) {
 			for (const [key, category] of map) {
 				if (key == 'Ref') continue
 				if (!key.includes(dtlabel)) continue
-				const mkey = key.split(', ')[0]
+				const [mkey, cat_dtlabel] = key.split(', ')
+
+				if (!cat_dtlabel.includes(dtlabel)) continue
 				const itemG = G.append('g')
 				if (cname == 'shape') {
 					const index = category.shape % shapes.length

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -313,12 +313,11 @@ function assignGeneVariantValue(dbSample, sample, tw, categoryMap, category) {
 
 			let mapValue
 			if (categoryMap[value] == undefined) {
-				mapValue = { color: class_info.color, sampleCount: 1, hasOrigin: 'origin' in mutation, key: value }
+				mapValue = { color: class_info.color, sampleCount: 1, mutation, key: value }
 				categoryMap[value] = mapValue
 			} else {
 				mapValue = categoryMap[value]
 				mapValue.sampleCount = mapValue.sampleCount + 1
-				mapValue.hasOrigin = mapValue.hasOrigin || 'origin' in mutation
 			}
 		}
 		sample[category] = getMutation(true, dbSample, tw) || getMutation(false, dbSample, tw)


### PR DESCRIPTION
## Description

The list of mutations was assumed to be the same for all samples before, this fix may add more mutations in the scatters! 
Now the mutation for each category is passed to the client and used to build the legend. Please check. Closes #2733

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
