### PR TITLE
Refactored showDownload/downloadFilename into a single function

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -109,9 +109,11 @@ export type TableArgs = {
 	 * as the <input name=?> if the same name is always used, multiple tables
 	 * created in one page will conflict in row selection */
 	dataTestId?: any
-	/** Show download icon that allows to download the table content and allow
-	 * the passing of an optional filename for the file being downloaded */
-	download?: { fileName?: string }
+	/** Show download icon that allows to download the table content and allow; object allows customization options e.g. placement of the button, styling, tooltip etc */
+	download?: {
+		/** optionally, provide download file name, if missing a default one is used */
+		fileName?: string
+	}
 }
 
 /** incremented input ID will guarantee no collision from using getUniqueNameOrId()*/
@@ -149,7 +151,7 @@ export function renderTable({
 	selectedRowStyle = {},
 	inputName = null,
 	dataTestId = null,
-	download = { fileName: '' }
+	download = null
 }: TableArgs) {
 	validateInput()
 	let _selectedRowStyle = selectedRowStyle

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -177,7 +177,6 @@ export function renderTable({
 
 	const uniqueInputName = inputName || getUniqueNameOrId('input')
 	const parentDiv = div.append('div').style('background-color', 'white').style('display', 'inline-block')
-	console.log('download is: ', download)
 	if (download) {
 		const downloadDiv = div
 			.append('div')

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -109,10 +109,9 @@ export type TableArgs = {
 	 * as the <input name=?> if the same name is always used, multiple tables
 	 * created in one page will conflict in row selection */
 	dataTestId?: any
-	/** Show download icon that allows to download the table content */
-	showDownload?: boolean
-	/** Optional filename for the file downloaded */
-	downloadFilename?: string
+	/** Show download icon that allows to download the table content and allow
+	 * the passing of an optional filename for the file being downloaded */
+	download?: { fileName?: string }
 }
 
 /** incremented input ID will guarantee no collision from using getUniqueNameOrId()*/
@@ -150,8 +149,7 @@ export function renderTable({
 	selectedRowStyle = {},
 	inputName = null,
 	dataTestId = null,
-	showDownload = false,
-	downloadFilename = 'table.tsv'
+	download = { fileName: '' }
 }: TableArgs) {
 	validateInput()
 	let _selectedRowStyle = selectedRowStyle
@@ -179,7 +177,8 @@ export function renderTable({
 
 	const uniqueInputName = inputName || getUniqueNameOrId('input')
 	const parentDiv = div.append('div').style('background-color', 'white').style('display', 'inline-block')
-	if (showDownload) {
+	console.log('download is: ', download)
+	if (download) {
 		const downloadDiv = div
 			.append('div')
 			.style('display', 'inline-block')
@@ -191,7 +190,7 @@ export function renderTable({
 			height: 15,
 			title: 'Download table',
 			handler: () => {
-				downloadTable(rows, columns, downloadFilename)
+				downloadTable(rows, columns, download.fileName || 'table.tsv')
 			}
 		})
 	}

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -501,25 +501,70 @@ export function renderTable({
 	return api
 }
 
+/**
+ * Downloads table data as a TSV (Tab-Separated Values) file.
+ *
+ * @param {Array<Array<Cell>>} rows - Array of rows, where each row is an array of cell objects.
+ *        Each cell object can have one of the following properties:
+ *        - value: The primary content to display (can be string, number, including 0)
+ *        - url: A URL to be used if value is not present
+ *        - color: A color value to be used if neither value nor url is present
+ * @param {Array<Column>} cols - Array of column definition objects.
+ *        Each column object must have:
+ *        - label: string - The header text for the column
+ * @param {string} [filename='table.tsv'] - Optional custom filename for the downloaded file
+ *
+ * @example
+ * // Basic usage
+ * const rows = [
+ *   [{ value: "John" }, { value: 25 }, { value: "New York" }],
+ *   [{ value: "Jane" }, { value: 0 }, { value: "Boston" }]
+ * ];
+ * const cols = [
+ *   { label: "Name" },
+ *   { label: "Age" },
+ *   { label: "City" }
+ * ];
+ * await downloadTable(rows, cols, "users.tsv");
+ *
+ * @example
+ * // Using different cell property types
+ * const rows = [
+ *   [{ value: "Doc" }, { url: "https://example.com" }, { color: "#FF0000" }]
+ * ];
+ * const cols = [
+ *   { label: "Name" },
+ *   { label: "Link" },
+ *   { label: "Color" }
+ * ];
+ * await downloadTable(rows, cols);
+ *
+ * @returns {Promise<void>} - The function creates and triggers a download in the browser
+ */
 export async function downloadTable(rows, cols, filename = 'table.tsv') {
 	let lines = ''
+
+	// Add header row with column labels
 	for (const column of cols) {
 		lines += `${column.label}\t`
 	}
 	lines += '\n'
 
+	// Add data rows
 	for (const row of rows) {
 		for (const cell of row) {
 			let value = ''
-			if (cell.value) value = cell.value
+			// Check for cell.value existence to properly handle zero values
+			if ('value' in cell) value = cell.value
 			else if (cell.url) value = cell.url
 			else if (cell.color) value = cell.color
 			lines += `${value}\t`
 		}
 		lines += '\n'
 	}
-	const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(lines)
 
+	// Create and trigger download
+	const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(lines)
 	const link = document.createElement('a')
 	link.setAttribute('href', dataStr)
 	// If you don't know the name or want to use

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -789,8 +789,7 @@ class singleCellPlot {
 			},
 			selectedRows,
 			resize: true,
-			showDownload: true,
-			downloadFilename
+			download: { fileName: downloadFilename }
 		})
 		this.renderGSEA(GSEADiv)
 	}
@@ -1415,8 +1414,7 @@ class singleCellPlot {
 			},
 			selectedRows,
 			striped: true,
-			header: { style: { 'text-transform': 'capitalize' } }, // to show header in title case; if it results in a conflict (e.g. a sample name showing in 1st tab has to be lower case), then use sampleColumns[].columnHeader as override of term name
-			showDownload: false
+			header: { style: { 'text-transform': 'capitalize' } } // to show header in title case; if it results in a conflict (e.g. a sample name showing in 1st tab has to be lower case), then use sampleColumns[].columnHeader as override of term name
 		})
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Refactored showDownload/downloadFilename into a single function. Fixed bug with 0 values not being included in downloads


### PR DESCRIPTION
## Description
Refactored showDownload/downloadFilename into a single function. Fixed bug with 0 values not being included in downloads.

## To Test
Go [here](http://localhost:3000/?mass=%7B%22genome%22:%22hg38%22,%22dslabel%22:%22GDC%22,%22nav%22:%7B%22header_mode%22:%22hidden%22%7D,%22plots%22:%5B%7B%22chartType%22:%22singleCellPlot%22,%22sample%22:%222291%22,%22experimentID%22:%22ec99ca1d-bcdb-42a8-80f1-9bcef0af19fa%22%7D%5D%7D) and download the table.

## Closes
Closes #2795 

## Future Directions
Still need to add new tests for this. Will do in separate PR. It passes all current tests.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
