### PR TITLE
Fixed washed out colors in the plot looking lighter than in the legend

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1483,6 +1483,10 @@ class singleCellPlot {
 
 		const renderer = plot.renderer
 
+		//WebGLRenderer.outputColorSpace property determines the color space of the final rendered output. By default this is set to THREE.SRGBColorSpace, so that the rendered image is correctly displayed on standard monitors.
+		//There are times where you may want to set the output color space to THREE.LinearSRGBColorSpace, so that color information is not altered before post processing effects are applied.
+		//This fixes the issue where the colors are washed out and look lighter than in the legend
+		renderer.outputColorSpace = THREE.LinearSRGBColorSpace
 		const DragControls = await import('three/examples/jsm/controls/DragControls.js')
 
 		const fov = this.settings.threeFOV


### PR DESCRIPTION
## Description

I spent hours trying to solve this issue but it was worth it. After changing the renderer outputColorSpace we can see the original colors. The plots look prettier! We should deploy it for GDC. Closes #2777. See plots before and after.

Before:
<img width="918" alt="Screenshot 2025-02-18 at 10 49 32 PM" src="https://github.com/user-attachments/assets/fc39592b-5402-4ca3-a425-85b5be82a853" />

After:
<img width="918" alt="Screenshot 2025-02-18 at 10 49 05 PM" src="https://github.com/user-attachments/assets/3ee9c7b3-c89c-431c-babd-448e0015fdc0" />



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
