### PR TITLE
Resolve R error when filtering in correlation volcano plot

### DIFF
--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -203,9 +203,9 @@ class CorrelationVolcano extends RxComponentInner {
 		/** Request data from the server*/
 		const model = new Model(config, this.state, this.app, settings, this.variableTwLst)
 		const data = await model.getData()
-		if (!data || data.error) {
+		if (!data || data.error || !data.variableItems.length) {
 			this.interactions.clearDom()
-			this.dom.error.text(data.error || 'No data returned from server')
+			this.dom.error.style('padding', '20px 20px 20px 60px').text(data.error || 'No correlation data to render.')
 			return
 		}
 

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -129,6 +129,7 @@ export type VariableItem = {
 export type LegendData = {
 	absMin: number
 	absMax: number
+	invalidTerms: { label: string }[]
 }
 
 /** Formated response data passed from the view model

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -129,7 +129,7 @@ export type VariableItem = {
 export type LegendData = {
 	absMin: number
 	absMax: number
-	invalidTerms: { label: string }[]
+	skippedVariables: { label: string }[]
 }
 
 /** Formated response data passed from the view model

--- a/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
@@ -18,6 +18,7 @@ function getHolder() {
 }
 
 const mockData = {
+	skippedVariables: [],
 	variableItems: [
 		{
 			tw$id: 'test$id2',
@@ -151,7 +152,8 @@ tape('Default ViewModel', test => {
 		],
 		legendData: {
 			absMin: 373,
-			absMax: 726
+			absMax: 726,
+			skippedVariables: []
 		}
 	}
 

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -120,6 +120,7 @@ export class View {
 	) {
 		const svg = this.dom.legend
 			.attr('width', 400)
+			//TODO: calculate the height based on the number of skipped terms and max radius
 			.attr('height', 400)
 			.style('display', 'inline-block')
 			.style('vertical-align', 'top')
@@ -146,15 +147,19 @@ export class View {
 		})
 
 		/** Show terms with no data to the user */
-		if (legendData.invalidTerms.length > 0) {
+		if (legendData.skippedVariables.length > 0) {
 			const newYPos = startYPos + settings.radiusMax + 60
 			let incrY = 30
-			const invalidTermsG = svg.append('g').attr('transform', `translate(${startXPos}, ${newYPos})`)
+			const skippedVariablesG = svg.append('g').attr('transform', `translate(${startXPos}, ${newYPos})`)
 			//Styling matches the legend circle reference
-			invalidTermsG.append('text').style('font-weight', 'bold').style('font-size', '0.8em').text('Invalid Terms')
+			skippedVariablesG
+				.append('text')
+				.style('font-weight', 'bold')
+				.style('font-size', '0.8em')
+				.text('Skipped Variables')
 
-			for (const term of legendData.invalidTerms) {
-				invalidTermsG
+			for (const term of legendData.skippedVariables) {
+				skippedVariablesG
 					.append('text')
 					.attr('transform', `translate(${startXPos}, ${incrY})`)
 					.style('font-size', '0.8em')

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -120,13 +120,16 @@ export class View {
 	) {
 		const svg = this.dom.legend
 			.attr('width', 400)
-			.attr('height', 100)
+			.attr('height', 400)
 			.style('display', 'inline-block')
 			.style('vertical-align', 'top')
 			.style('padding-top', '20px')
 
+		const startXPos = 20
+		const startYPos = 20
+
 		new LegendCircleReference({
-			g: svg.append('g').attr('transform', 'translate(20, 20)'),
+			g: svg.append('g').attr('transform', `translate(${startXPos}, ${startYPos})`),
 			inputMax: defaultMaxRadius,
 			inputMin: defaultMinRadius,
 			maxLabel: legendData.absMax,
@@ -141,6 +144,24 @@ export class View {
 				}
 			}
 		})
+
+		/** Show terms with no data to the user */
+		if (legendData.invalidTerms.length > 0) {
+			const newYPos = startYPos + settings.radiusMax + 60
+			let incrY = 30
+			const invalidTermsG = svg.append('g').attr('transform', `translate(${startXPos}, ${newYPos})`)
+			//Styling matches the legend circle reference
+			invalidTermsG.append('text').style('font-weight', 'bold').style('font-size', '0.8em').text('Invalid Terms')
+
+			for (const term of legendData.invalidTerms) {
+				invalidTermsG
+					.append('text')
+					.attr('transform', `translate(${startXPos}, ${incrY})`)
+					.style('font-size', '0.8em')
+					.text(term.label)
+				incrY += 20
+			}
+		}
 	}
 }
 

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -30,7 +30,7 @@ export class ViewModel {
 		this.viewData = {
 			plotDim,
 			variableItems: this.setVariablesData(absSampleMax, absSampleMin, d, dom, pValueKey, plotDim, settings),
-			legendData: this.setLegendData(absSampleMin, absSampleMax, data.invalidTerms)
+			legendData: this.setLegendData(absSampleMin, absSampleMax, data.skippedVariables)
 		}
 	}
 
@@ -151,14 +151,14 @@ export class ViewModel {
 		return data.variableItems
 	}
 
-	setLegendData(absSampleMin: number, absSampleMax: number, invalidTerms: { tw$id: string }[]) {
+	setLegendData(absSampleMin: number, absSampleMax: number, skippedVariables: { tw$id: string }[]) {
 		const opts = {
 			absMin: absSampleMin,
 			absMax: absSampleMax,
-			invalidTerms:
-				invalidTerms.length == 0
+			skippedVariables:
+				skippedVariables.length == 0
 					? []
-					: invalidTerms.map((t: any) => {
+					: skippedVariables.map((t: any) => {
 							return { label: this.variableTwLst.find(tw => tw.$id == t.tw$id)!.term.name }
 					  })
 		}

--- a/server/routes/correlationVolcano.ts
+++ b/server/routes/correlationVolcano.ts
@@ -68,19 +68,19 @@ async function compute(q: CorrelationVolcanoRequest, ds: any, genome: any) {
 
 	//Ensure terms have at least 2 vectors in each array to calculate correlation
 	//If not, show term in legend on client
-	const [validTerms, invalidTerms] = Array.from(vtid2array.values()).reduce(
-		([valid, invalid], t) => {
-			const v = t.v1.length > 1 && t.v2.length > 1 ? valid : invalid
-			if (v === valid) valid.push(t)
-			if (v === invalid) invalid.push({ tw$id: t.id })
-			return [valid, invalid]
+	const [acceptedVariables, skippedVariables] = Array.from(vtid2array.values()).reduce(
+		([accepted, skipped], t) => {
+			const v = t.v1.length > 1 && t.v2.length > 1 ? accepted : skipped
+			if (v === accepted) accepted.push(t)
+			if (v === skipped) skipped.push({ tw$id: t.id })
+			return [accepted, skipped]
 		},
 		[[], []] as [{ v1: string; v2: string; id: string }[], { tw$id: string }[]]
 	)
 
 	const input = {
 		method: q.correlationMethod || 'pearson',
-		terms: validTerms
+		terms: acceptedVariables
 	}
 
 	//console.log("input:",input)
@@ -94,7 +94,7 @@ async function compute(q: CorrelationVolcanoRequest, ds: any, genome: any) {
 		terms: JSON.parse(await run_R(path.join(serverconfig.binpath, 'utils', 'corr.R'), JSON.stringify(input)))
 	}
 	mayLog('Time taken to run correlation analysis:', Date.now() - time1)
-	const result: CorrelationVolcanoResponse = { invalidTerms, variableItems: [] }
+	const result: CorrelationVolcanoResponse = { skippedVariables, variableItems: [] }
 	for (const t of output.terms) {
 		const t2 = {
 			tw$id: t.id,

--- a/shared/types/src/routes/correlationVolcano.ts
+++ b/shared/types/src/routes/correlationVolcano.ts
@@ -19,7 +19,7 @@ export type CorrelationVolcanoRequest = {
 
 export type CorrelationVolcanoResponse = {
 	/** Terms with not enough vectors to calculate correlation to be shown in legend */
-	invalidTerms: {
+	skippedVariables: {
 		/** matching tw $id */
 		tw$id: string
 	}[]

--- a/shared/types/src/routes/correlationVolcano.ts
+++ b/shared/types/src/routes/correlationVolcano.ts
@@ -18,6 +18,11 @@ export type CorrelationVolcanoRequest = {
 }
 
 export type CorrelationVolcanoResponse = {
+	/** Terms with not enough vectors to calculate correlation to be shown in legend */
+	invalidTerms: {
+		/** matching tw $id */
+		tw$id: string
+	}[]
 	/** each element is test result of one variable corresponding to variableTwLst */
 	variableItems: {
 		/** correlation coefficient, -1 to 1 */

--- a/shared/utils/src/violin.bins.js
+++ b/shared/utils/src/violin.bins.js
@@ -117,7 +117,7 @@ function mean(data) {
 	return data.reduce((sum, value) => sum + value, 0) / data.length
 }
 
-function stdDev(data) {
+export function stdDev(data) {
 	const meanValue = mean(data)
 	const squaredDifferences = data.map(value => Math.pow(value - meanValue, 2))
 	const variance = squaredDifferences.reduce((sum, value) => sum + value, 0) / data.length


### PR DESCRIPTION
## Description
Closes issue #2834

Changes: 
1. Only variables with enough vector values are evaluated. Otherwise the variables are skipped and shown on the client in the legend. 
2. If no variables are acceptable for correlation calculation, message appears that no data is available to render. 

Test: 
[All pharma example](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22correlationVolcano%22,%22featureTw%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22KRAS%22}}}]}) -> Filter tab -> `Clinical Attributes` -> `Molecular Subtype` -> choose `High hyperdiploid (n=200)` -> Should see plot re-render and skipped variable displayed in the legend underneath the dot scale reference. Selecting a term with a small sample size should show a message that no data is available. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
