### PR TITLE
3d and 2D large scatter improvements

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -393,7 +393,7 @@ class Scatter {
 		}
 
 		if (!this.is2DLarge) {
-			const isPremade = this.config.name !== undefined
+			const isPremade = this.config.name !== undefined && !this.config.term
 			inputs.unshift({
 				type: 'term',
 				configKey: 'term0',
@@ -404,7 +404,7 @@ class Scatter {
 				vocabApi: this.app.vocabApi,
 				numericEditMenuVersion: ['discrete', 'continuous'],
 				processInput: tw => {
-					if (!isPremade && isNumericTerm(tw?.term) && !tw.q.mode) tw.q = { mode: 'continuous' } //use continuous mode by default if not premade plot
+					if (!isPremade && isNumericTerm(tw?.term)) tw.q = { mode: 'continuous' } //use continuous mode by default if not premade plot
 				}
 			})
 		} else {

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -714,7 +714,7 @@ export function getDefaultScatterSettings() {
 		defaultColor: plotColor,
 		regression: 'None',
 		fov: 50,
-		threeSize: 0.003,
+		threeSize: 0.005,
 		threeFOV: 70,
 		// Color scale configuration settings
 		// These settings control how numerical values are mapped to colors

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -155,7 +155,7 @@ export function setRenderersThree(self) {
 		const controls = new OrbitControls.OrbitControls(camera, self.canvas)
 		if (self.settings.showContour) self.renderContourMap(scene, camera, material, vertices, zAxisScale, chart)
 		else {
-			camera.position.set(1, 1, 2)
+			camera.position.set(1.5, 1.2, 1.8)
 			camera.lookAt(scene.position)
 			camera.updateMatrix()
 			controls.update()

--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -5,7 +5,6 @@ import HelvetikerFont from 'three/examples/fonts/helvetiker_regular.typeface.jso
 import * as THREE from 'three'
 import { scaleLinear as d3Linear } from 'd3-scale'
 import { getContourImage } from './singleCellPlot.js'
-import { min } from 'd3'
 
 export function setRenderersThree(self) {
 	self.render2DSerieLarge = async function (chart) {
@@ -18,8 +17,8 @@ export function setRenderersThree(self) {
 		self.canvas.height = self.settings.svgh
 		chart.chartDiv.style('margin', '20px 20px')
 		chart.legendDiv = self.mainDiv.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
-		let step = Math.min((20 * 40) / chart.colorLegend.size, 20)
-		if (step < 12) step = 12
+		let step = Math.min((20 * 40) / chart.colorLegend.size, 25)
+		if (step < 15) step = 15
 		const height = (chart.colorLegend.size + 6) * step
 		chart.legendG = chart.legendDiv
 			.append('svg')
@@ -153,20 +152,22 @@ export function setRenderersThree(self) {
 			map: tex,
 			vertexColors: true
 		})
-
+		const controls = new OrbitControls.OrbitControls(camera, self.canvas)
 		if (self.settings.showContour) self.renderContourMap(scene, camera, material, vertices, zAxisScale, chart)
 		else {
 			camera.position.set(1, 1, 2)
 			camera.lookAt(scene.position)
 			camera.updateMatrix()
-			const controls = new OrbitControls.OrbitControls(camera, self.canvas)
-			controls.enableZoom = false
 			controls.update()
 			const axesHelper = new THREE.AxesHelper(1)
 			scene.add(axesHelper)
 			if (self.settings.showAxes) {
 				self.addLabels(scene, chart)
 			}
+
+			document.addEventListener('mousewheel', event => {
+				controls.enableZoom = event.ctrlKey
+			})
 
 			const geometry = new THREE.BufferGeometry()
 			geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
@@ -178,12 +179,14 @@ export function setRenderersThree(self) {
 		const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: self.canvas, preserveDrawingBuffer: true })
 		renderer.setSize(self.settings.svgw, self.settings.svgh)
 		renderer.setPixelRatio(window.devicePixelRatio)
+		renderer.outputColorSpace = THREE.LinearSRGBColorSpace
+
 		//document.addEventListener( 'pointermove', onPointerMove );
 
 		function animate() {
 			requestAnimationFrame(animate)
 			// required if controls.enableDamping or controls.autoRotate are set to true
-
+			controls.enableZoom = false
 			renderer.render(scene, camera)
 		}
 		animate()


### PR DESCRIPTION
## Description

Allowed zoom on 3D plots when using Ctrl key. Fixed washed out color in 3D. Showed controls with some options for 2D large plots. When adding a 3rd coordinate in a 2d dynamic scatter use continous mode by default. Improved default plot view by updating camera position

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
