### PR TITLE
Fixed scatter 3D zoom

### DIFF
--- a/client/plots/sampleScatter.rendererThree.js
+++ b/client/plots/sampleScatter.rendererThree.js
@@ -165,9 +165,14 @@ export function setRenderersThree(self) {
 				self.addLabels(scene, chart)
 			}
 
-			document.addEventListener('mousewheel', event => {
-				controls.enableZoom = event.ctrlKey
-			})
+			document.addEventListener(
+				'wheel',
+				event => {
+					if (event.ctrlKey) event.preventDefault()
+					controls.enableZoom = event.ctrlKey
+				},
+				{ passive: false }
+			)
 
 			const geometry = new THREE.BufferGeometry()
 			geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
@@ -186,7 +191,7 @@ export function setRenderersThree(self) {
 		function animate() {
 			requestAnimationFrame(animate)
 			// required if controls.enableDamping or controls.autoRotate are set to true
-			controls.enableZoom = false
+
 			renderer.render(scene, camera)
 		}
 		animate()


### PR DESCRIPTION
## Description

Improved zoom handling. When using the mouse wheel + Ctrl over the plot it should zoom in/out. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
