### PR TITLE
Allow to zoom out further in the scatter

### DIFF
--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -680,7 +680,7 @@ export function setRenderers(self) {
 
 		const mainG = self.charts[0].mainG
 		const zoom = d3zoom()
-			.scaleExtent([0.5, self.config.scaleDotTW ? 4 : 10])
+			.scaleExtent([0.1, self.config.scaleDotTW ? 4 : 10])
 			.on('zoom', handleZoom)
 			.filter(event => {
 				if (event.type === 'wheel') return event.ctrlKey


### PR DESCRIPTION
## Description

Allow to zoom out further to help visualizing scatters that appear zoomed because of  filters like the one reported in the issue #674. @karishma-gangwani if you increase the particle size a lot and zoom out, like here,  you can see the original cluster. The scatter always renders the samples provided in the plot space, so when adding this filter it causes this zoom effect

<img width="1344" alt="Screenshot 2025-02-20 at 9 47 57 AM" src="https://github.com/user-attachments/assets/a423b61f-7759-42b7-83c3-e1b164476c0f" />




## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
