### PR TITLE
Moved x to the left in error message and improved styling

### DIFF
--- a/client/dom/sayerror.ts
+++ b/client/dom/sayerror.ts
@@ -21,15 +21,18 @@ export function sayerror(holder: any, o: any) {
 		msg = o.message || o.error
 		if (o.stack) console.log(o.stack) // print out stack
 	}
-	const div = holder.append('div').attr('class', 'sja_errorbar')
-	// msg can contain injected XSS, so never do .html(msg)
-	div.append('div').text(msg)
+	holder.style('padding-left', '10px') //to align with sandbox padding
+	const div = holder.append('div').attr('class', 'sja_errorbar').style('border-radius', '5px')
 	div
 		.append('div')
+		.style('padding-right', '8px')
 		.html('&#10005;')
+		.style('display', 'inline-block')
 		.on('click', () => {
 			disappear(div, true)
 		})
+	// msg can contain injected XSS, so never do .html(msg)
+	div.append('div').style('display', 'inline-block').text(msg)
 }
 
 export function throwMsgWithFilePathAndFnName(message: string) {
@@ -72,6 +75,16 @@ export function showErrorsWithCounter(errs: string | string[], holder: any) {
 			errorsDiv.style('display', showErrors ? 'block' : 'none')
 		})
 
+	// Close button
+	wrapper
+		.append('div')
+		.style('padding-right', '8px')
+		.style('display', 'inline-block')
+		.html('&#10005;')
+		.on('click', () => {
+			disappear(wrapper, true)
+		})
+
 	// Counter
 	const counterTextDiv = wrapper.append('div').style('display', 'inline-block')
 
@@ -86,16 +99,6 @@ export function showErrorsWithCounter(errs: string | string[], holder: any) {
 
 	// Text
 	counterTextDiv.append('div').text('errors found.').style('padding', '3px').style('display', 'inline-block')
-
-	// Close button
-	wrapper
-		.append('div')
-		.style('display', 'inline-block')
-		.style('float', 'right')
-		.html('&#10005;')
-		.on('click', () => {
-			disappear(wrapper, true)
-		})
 
 	//Error messages
 	const errorsDiv = wrapper.append('div').style('display', 'none').style('margin-left', '10px')

--- a/client/mass/test/sampleScatter.integration.spec.js
+++ b/client/mass/test/sampleScatter.integration.spec.js
@@ -412,7 +412,7 @@ tape('Invalid colorTW.term', async function (test) {
 				]
 			}
 		})
-		const errorbar = await detectGte({ elem: holder.node(), selector: '.sja_errorbar' })
+		const errorbar = await detectGte({ elem: holder.node(), selector: '.sja_errorbar > div:nth-child(2)' })
 		const error = 'Error: Error: Type is not defined [sampleScatter getPlotConfig()]'
 		test.true(errorbar[0].innerText.startsWith(error), `Should display, "${error}...".`)
 	} catch (e) {

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -194,13 +194,7 @@ by normalize.css are covered here
     /*border-width: 1px 0px;*/
 }
 
-.sja_errorbar>:nth-child(2) {
-    position: absolute;
-    padding: 5px 10px;
-    cursor: default;
-    top: 0px;
-    right: 10px;
-}
+
 
 .sja_inset_a {
     background-color: #ebedeb;

--- a/client/termdb/test/store.integration.spec.js
+++ b/client/termdb/test/store.integration.spec.js
@@ -40,7 +40,7 @@ tape('init errors', function (test) {
 		}
 	})
 	function testMissingState(app) {
-		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div')
+		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div:nth-child(2)')
 		setTimeout(() => {
 			test.equal(d.text(), 'Error: .state{} missing', 'should be displayed for missing .state{}')
 		}, 200)
@@ -59,7 +59,7 @@ tape('init errors', function (test) {
 		}
 	})
 	function testMissingGenome(app) {
-		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div')
+		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div:nth-child(2)')
 		setTimeout(() => {
 			test.equal(d.text(), 'Error: .state[.vocab].genome missing', 'should be displayed for missing .state.genome')
 		}, 200)
@@ -78,7 +78,7 @@ tape('init errors', function (test) {
 		}
 	})
 	function testMissingDslabel(app) {
-		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div')
+		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div:nth-child(2)')
 		setTimeout(() => {
 			test.equal(d.text(), 'Error: .state[.vocab].dslabel missing', 'should be displayed for missing .state.dslabel')
 			test.end()

--- a/client/termdb/test/tree.integration.spec.js
+++ b/client/termdb/test/tree.integration.spec.js
@@ -361,7 +361,7 @@ tape('error handling', function (test) {
 		}
 	})
 	function testWrongGenome(app) {
-		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div')
+		const d = app.Inner.dom.errdiv.selectAll('.sja_errorbar').select('div:nth-child(2)')
 		test.equal(d.text(), 'Error: invalid genome', 'should show for invalid genome')
 	}
 
@@ -375,7 +375,7 @@ tape('error handling', function (test) {
 		}
 	})
 	function testWrongDslabel(app) {
-		const d = app.Inner.dom.errdiv.select('.sja_errorbar').select('div')
+		const d = app.Inner.dom.errdiv.select('.sja_errorbar').select('div:nth-child(2)')
 		test.equal(d.text(), 'Error: invalid dslabel', 'should show for genome-level termdb not available')
 	}
 })


### PR DESCRIPTION
## Description

In error messages, moved x to the left in error message and improved styling. Please check if it looks ok and check case using showErrorsWithCounter, as I did not know how to test this case. See UI
<img width="1119" alt="Screenshot 2025-02-20 at 10 31 22 PM" src="https://github.com/user-attachments/assets/b9d19a6d-516c-4cac-be63-8b327eea58a4" />





## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
