### PR TITLE
fix: mds3 tk cnv legend will handle case when no cnv data is present …

### DIFF
--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -893,8 +893,9 @@ function may_create_cnv(tk, block) {
 function may_update_cnv(tk) {
 	if (!tk.cnv) return
 	// tk is equipped with cnv. determine if cnv data is actually shown
-	if (tk.cnv.cnvLst.length == 0) {
+	if (!tk.cnv.cnvLst || tk.cnv.cnvLst.length == 0) {
 		// no cnv shown in this region. hide colorscale
+		// possible for cnvLst to be missing! e.g. on server error
 		tk.legend.cnv.colorscaleHolder.style('display', 'none')
 		tk.legend.cnv.noCnv.style('display', 'inline-block')
 	} else {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- mds3 tk cnv legend will handle case when no cnv data is present due to server error and not to crash


### PR DESCRIPTION
…due to server error and not to crash

## Description

closes #2863 
fixes a problem Jian ran into in his branch (merge this first then rebase your on master)

[test link](http://localhost:3000/?genome=hg38&gene=ctnnb1&mds3=MB_meta_analysis2&filterObj={%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%221p%22},%22values%22:[{%22key%22:%22Balanced%22}],%22isnot%22:true}}]}), to break it, at line 1224 of mds3.init.js, change to `bcfArgs.push('-s', l.join(',')+',xx')` which causes an invalid sample name to be added to bcftools query command and triggers an error

the fix allows the error msg to be displayed in track body

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
