### PR TITLE
Updated HWE test script to function again and added documentation of tests

### DIFF
--- a/server/utils/test/Rscripts.spec.js
+++ b/server/utils/test/Rscripts.spec.js
@@ -77,14 +77,11 @@ tape('hwe.R', async function (test) {
 	const inputString = validInput.join('\n')
 	const output = await run_R(path.join(__dirname, '../hwe.R'), inputString)
 
-	// Split the output string into an array of strings, one per line and trim any empty lines
-	const outputArray = output.split('\n').filter(line => line.trim() !== '')
-
-	// Convert each string to a number
-	const numericOutput = outputArray.map(Number)
+	// Split the output string into an array of strings, then convert to numbers
+	const outputArray = output.split('\n').map(Number)
 
 	// Compare calculated p-values with expected results
-	test.deepEqual(numericOutput, [0.515367, 0.000006269428, 1.385241e-24, 0.07429809], 'should match expected output')
+	test.deepEqual(outputArray, [0.515367, 0.000006269428, 1.385241e-24, 0.07429809], 'should match expected output')
 	test.end()
 })
 


### PR DESCRIPTION
## Description
Updated/refactored the HWE tests so that they now work with `run_R`. Also added thorough documentation for both the hwe and correlation tests.

## To test
From `server/` run `npx tape -r '@babel/register' utils/test/Rscripts.spec.js`. We will expect that all tests pass and that specifically the tests related to hwe pass. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
