### PR TITLE
In GSEA fixed bug on download image and updated labels requested by GDC

### DIFF
--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -185,6 +185,7 @@ class gsea {
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings.gsea
+		this.imageUrl = null // Reset the image URL
 		await this.setControls()
 		if (this.dom.header)
 			this.dom.header.html(

--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -232,7 +232,7 @@ class singleCellPlot {
 		if (q.singleCell?.DEgenes) {
 			const label = this.dom.deDiv
 				.append('label')
-				.html('View DE genes for cells of a cluster versus rest of the cells:&nbsp;')
+				.html('View differentially expressed genes for cells of a cluster versus rest of the cells:&nbsp;')
 			this.dom.deselect = label.append('select').on('change', e => {
 				const display = this.dom.deselect.node().value ? 'inline-block' : 'none'
 				const cluster = this.dom.deselect.node().value.split(' ')[1]
@@ -722,7 +722,7 @@ class singleCellPlot {
 		if (this.app.opts.genome.termdbs) {
 			// assumption is that can run gsea on the differential genes, when the genome-level termdb is available (which is right now geneset dbs)
 			tabs.push({
-				label: 'Gene Set Enrichment Analysis',
+				label: 'Gene Set Enrichment Analysis(GSEA)',
 				id: DE_GSEA_TAB,
 				active: false,
 				callback: () => showActiveDETab(DE_GSEA_TAB)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fix
+- Updated labels requested on [JIRA] (FEAT-857)
+- Fixed bug in the download image in GSEA


### PR DESCRIPTION
## Description

Fix on the the image downloaded from the burguer menu icon,  it is updated every time a table row is selected but it needs to be cleared on main to avoid downloading a wrong image (jira-sv-2571) .


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
