### PR TITLE
improve samplescatter getPlotConfig() to include default settings…

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -623,9 +623,7 @@ export async function getPlotConfig(opts, app) {
 			const p = app.vocabApi?.termdbConfig?.scatterplots?.find(i => i.name == opts.name)
 			if (p) defaultConfig = p
 		}
-		if (defaultConfig.colorTW && opts.colorTW) delete defaultConfig.colorTW //priority to opts.colorTW
-		if (defaultConfig.shapeTW && opts.shapeTW) delete defaultConfig.shapeTW //priority to opts.shapeTW
-		copyMerge(plot, opts, defaultConfig)
+		copyMerge(plot, defaultConfig, opts)
 
 		if (plot.colorTW) await fillTermWrapper(plot.colorTW, app.vocabApi)
 		if (plot.shapeTW) await fillTermWrapper(plot.shapeTW, app.vocabApi)

--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -623,6 +623,8 @@ export async function getPlotConfig(opts, app) {
 			const p = app.vocabApi?.termdbConfig?.scatterplots?.find(i => i.name == opts.name)
 			if (p) defaultConfig = p
 		}
+		if (defaultConfig.colorTW && opts.colorTW) delete defaultConfig.colorTW //priority to opts.colorTW
+		if (defaultConfig.shapeTW && opts.shapeTW) delete defaultConfig.shapeTW //priority to opts.shapeTW
 		copyMerge(plot, opts, defaultConfig)
 
 		if (plot.colorTW) await fillTermWrapper(plot.colorTW, app.vocabApi)

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -906,7 +906,7 @@ export function setRenderers(self) {
 
 					// Initialize the color scale with current settings
 					colorScale.updateScale()
-					offsetY += step
+					offsetY += step * 2
 				} else {
 					for (const [key, category] of chart.colorLegend) {
 						if (key == 'Ref') continue

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -149,7 +149,7 @@ function addScatterplots(c, ds) {
 			colorColumn: p.colorColumn,
 			sampleType: p.sampleType,
 			coordsColumns: p.coordsColumns,
-			settings: p.settings,
+			settings: { sampleScatter: p.settings }, //the client settings are under sampleScatter so we add it here to avoid adding it in the dataset
 			sampleCategory: p.sampleCategory
 		}
 	})


### PR DESCRIPTION
… from ds

## Description

closes #2865 
(closed previous branch to rebase on master for tsc fix)

[color gradient](http://localhost:3000/?mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:{%22id%22:%22Age%22,%22q%22:{%22mode%22:%22continuous%22}},%22shapeTW%22:{%22id%22:%22chr1p%22}}]}) is still not working properly. please take a look when you have time. not urgent

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
