### PR TITLE
Violin improvements

### DIFF
--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -196,6 +196,16 @@ class ViolinPlot {
 				debounceInterval: 1000
 			},
 			{
+				label: 'Plot padding',
+				type: 'number',
+				chartType: 'violin',
+				settingsKey: 'rowSpace',
+				step: 1,
+				max: 20,
+				min: 0,
+				debounceInterval: 1000
+			},
+			{
 				label: 'Median length',
 				title: 'Length of median',
 				type: 'number',

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -272,10 +272,6 @@ class ViolinPlot {
 		const args = this.validateArgs()
 		this.data = await this.app.vocabApi.getViolinPlotData(args)
 
-		if (this.settings.plotThickness == undefined) {
-			const thickness = this.data.plots.length == 1 ? 200 : 150
-			this.settings.plotThickness = Math.min(1400 / this.data.plots.length, thickness)
-		}
 		if (this.data.error) throw this.data.error
 		/*
 		.min
@@ -383,7 +379,7 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		lines: [],
 		unit: 'abs', // abs: absolute scale, log: log scale
 		rowSpace: 5,
-		plotThickness: undefined,
+		plotThickness: 100,
 		medianLength: 7,
 		medianThickness: 3,
 		ticks: 20,


### PR DESCRIPTION
## Description

This PR fixes #2839 by reordering the rendering logic: First render a plot, then get its size and based on that size position the next plot. It also does some cleanup in the code and adds a choice to configure the plot padding.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
