### PR TITLE
Support new dataRelease property from dataset

### DIFF
--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -243,7 +243,7 @@ export class MassAbout {
 				.append('div')
 				.style('margin-left', '10px')
 				.style('padding-top', '20px')
-				.style('padding-bottom', '20px')
+				.style('padding-bottom', '30px')
 				.style('font-size', 'small')
 				.text(this.selectCohort.asterisk)
 		}
@@ -347,7 +347,9 @@ export class MassAbout {
 	}
 
 	showServerInfo = () => {
-		if (!this.app.opts.pkgver && !this.app.opts.launchDate) return
+		const state = this.app.getState()
+		const dataRelease = state.termdbConfig.massNav?.tabs?.about?.dataRelease
+		if (!dataRelease && !this.app.opts.pkgver && !this.app.opts.launchDate) return
 		const div = this.subheader
 			.append('div')
 			.attr('data-testid', 'sjpp-about-server-info')
@@ -355,12 +357,24 @@ export class MassAbout {
 			.style('padding-bottom', '5px')
 			.style('font-size', '.8em')
 
+		if (dataRelease) {
+			div
+				.append('div')
+				.attr('data-testid', 'sjpp-about-data-release')
+				.style('display', 'inline-block')
+				.text('Data Release: ')
+				.append('a')
+				.property('href', dataRelease.link)
+				.property('target', '_blank')
+				.text(dataRelease.version)
+		}
+
 		if (this.app.opts.pkgver) {
 			div
 				.append('div')
-				.attr('data-testid', 'sjpp-about-release')
+				.attr('data-testid', 'sjpp-about-software-release')
 				.style('display', 'inline-block')
-				.text('Release version: ')
+				.text(`${dataRelease ? '; ' : ''}Software Release: `)
 				.append('a')
 				.property('href', 'https://github.com/stjude/proteinpaint/pkgs/container/ppfull')
 				.property('target', `${this.app.opts.pkgver}`)
@@ -372,7 +386,7 @@ export class MassAbout {
 				.append('div')
 				.attr('data-testid', 'sjpp-about-server')
 				.style('display', 'inline-block')
-				.text(`${this.app.opts.pkgver ? ', ' : ''}server launched: ${this.app.opts.launchDate}`)
+				.text(`${this.app.opts.pkgver ? '; ' : ''}Server Launched: ${this.app.opts.launchDate}`)
 		}
 	}
 }

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -348,8 +348,10 @@ export class MassAbout {
 
 	showServerInfo = () => {
 		const state = this.app.getState()
-		const dataRelease = state.termdbConfig.massNav?.tabs?.about?.dataRelease
-		if (!dataRelease && !this.app.opts.pkgver && !this.app.opts.launchDate) return
+		const about = state.termdbConfig.massNav?.tabs?.about
+		if (!about && !this.app.opts.pkgver && !this.app.opts.launchDate) return
+		const dataRelease = about?.dataRelease
+		const additionalInfo = about?.additionalInfo
 		const div = this.subheader
 			.append('div')
 			.attr('data-testid', 'sjpp-about-server-info')
@@ -357,37 +359,22 @@ export class MassAbout {
 			.style('padding-bottom', '5px')
 			.style('font-size', '.8em')
 
+		const htmlArr: string[] = []
 		if (dataRelease) {
-			div
-				.append('div')
-				.attr('data-testid', 'sjpp-about-data-release')
-				.style('display', 'inline-block')
-				.text('Data Release: ')
-				.append('a')
-				.property('href', dataRelease.link)
-				.property('target', '_blank')
-				.text(dataRelease.version)
+			htmlArr.push(`Data Release: <a href=${dataRelease.link} target=_blank>${dataRelease.version}</a>`)
 		}
-
 		if (this.app.opts.pkgver) {
-			div
-				.append('div')
-				.attr('data-testid', 'sjpp-about-software-release')
-				.style('display', 'inline-block')
-				.text(`${dataRelease ? '; ' : ''}Software Release: `)
-				.append('a')
-				.property('href', 'https://github.com/stjude/proteinpaint/pkgs/container/ppfull')
-				.property('target', `${this.app.opts.pkgver}`)
-				.text(`${this.app.opts.pkgver}`)
+			htmlArr.push(
+				`Software Release: <a href=https://github.com/stjude/proteinpaint/pkgs/container/ppfull target=_blank>${this.app.opts.pkgver}</a>`
+			)
 		}
-
 		if (this.app.opts.launchDate) {
-			div
-				.append('div')
-				.attr('data-testid', 'sjpp-about-server')
-				.style('display', 'inline-block')
-				.text(`${this.app.opts.pkgver ? '; ' : ''}Server Launched: ${this.app.opts.launchDate}`)
+			htmlArr.push(`Server Launched: ${this.app.opts.launchDate}`)
 		}
+		if (additionalInfo) {
+			htmlArr.push(additionalInfo)
+		}
+		div.append('div').html(htmlArr.join('; '))
 	}
 }
 

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -241,10 +241,8 @@ export class MassAbout {
 		if (this.selectCohort.asterisk) {
 			this.dom.cohortAsterisk = this.subheader
 				.append('div')
-				.style('margin-left', '10px')
-				.style('padding-top', '20px')
-				.style('padding-bottom', '30px')
-				.style('font-size', 'small')
+				.style('margin', '10px')
+				.style('font-size', '.8em')
 				.text(this.selectCohort.asterisk)
 		}
 	}
@@ -355,8 +353,7 @@ export class MassAbout {
 		const div = this.subheader
 			.append('div')
 			.attr('data-testid', 'sjpp-about-server-info')
-			.style('margin-left', '10px')
-			.style('padding-bottom', '5px')
+			.style('margin', '10px')
 			.style('font-size', '.8em')
 
 		const htmlArr: string[] = []

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -363,30 +363,6 @@ function setRenderers(self) {
 					self.getSessionFile(event)
 				})
 		}
-
-		const helpPages = appState.termdbConfig.massNav?.tabs?.about?.helpPages
-		if (helpPages) {
-			// if help pages are defined, then show a help button
-			self.dom.helpBtn = self.dom.helpDiv
-				.style('display', 'inline-block')
-				.append('button')
-				.style('margin', '10px')
-				.html('Help &#9660;')
-				.on('click', event => {
-					const tip = headtip.clear()
-					const div = tip.d.append('div')
-					for (const page of helpPages) {
-						div
-							.append('div')
-							.style('margin', '15px')
-							.append('a')
-							.attr('href', page.url)
-							.attr('target', '_blank')
-							.text(page.label)
-					}
-					tip.showunder(event.target)
-				})
-		}
 	}
 
 	self.deletePlots = () => {

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -364,7 +364,7 @@ function setRenderers(self) {
 				})
 		}
 
-		const helpPages = appState.termdbConfig.helpPages
+		const helpPages = appState.termdbConfig.massNav?.tabs?.about?.helpPages
 		if (helpPages) {
 			// if help pages are defined, then show a help button
 			self.dom.helpBtn = self.dom.helpDiv
@@ -373,11 +373,8 @@ function setRenderers(self) {
 				.style('margin', '10px')
 				.html('Help &#9660;')
 				.on('click', event => {
-					const p = event.target.getBoundingClientRect()
-					const div = headtip
-						.clear()
-						.show(p.left - 0, p.top + p.height + 5)
-						.d.append('div')
+					const tip = headtip.clear()
+					const div = tip.d.append('div')
 					for (const page of helpPages) {
 						div
 							.append('div')
@@ -387,6 +384,7 @@ function setRenderers(self) {
 							.attr('target', '_blank')
 							.text(page.label)
 					}
+					tip.showunder(event.target)
 				})
 		}
 	}

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -30,18 +30,13 @@ export default {
 	cohort: {
 		massNav: {
 			tabs: {
-				// about: {
-				// 	hide: true,
-				// 	order: 4,
-				// 	top: 'test',
-				// 	mid: 'test about',
-				// 	btm: 'test',
-				// 	html: 'Test'
-				// },
-				// charts: {
-				// 	top: 'test charts',
-				// 	mid: 'mid test'
-				// }
+				about: {
+					dataRelease: {
+						version: '?',
+						link: 'testLink'
+					},
+					additionalInfo: '<a href=testLink>Tutorial</a> <a href=testLink>Get help</a>'
+				}
 			}
 		},
 		db: {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1379,7 +1379,13 @@ type MassNav = {
 			 * maybe used for other tabs as well.
 			 */
 			html?: string
-			dataRelease?: DataRelease
+			/** declare data release. should only use for "about" */
+			dataRelease?: {
+				/** data release version */
+				version: string
+				/** link to data release page */
+				link: string
+			}
 			/** html string, can include links to other
 			 * pages (e.g., tutorials, google group) */
 			additionalInfo?: string
@@ -1394,13 +1400,6 @@ type MassNav = {
 	activeColor?: string
 	/** customize background color of active navigation tab on hover */
 	activeColorHover?: string
-}
-
-type DataRelease = {
-	/** data release version */
-	version: string
-	/** link to data release page */
-	link: string
 }
 
 type ActiveItem = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1380,11 +1380,9 @@ type MassNav = {
 			 */
 			html?: string
 			dataRelease?: DataRelease
-			/** array of links to help pages
-			 * will be displayed in drop-down menu of help button
-			 * if undefined, then help button will not appear
-			 */
-			helpPages?: HelpPage[]
+			/** html string, can include links to other
+			 * pages (e.g., tutorials, google group) */
+			additionalInfo?: string
 			/** "active" items, shown as clickable buttons in about tab. click an item to launch a plot */
 			activeItems?: {
 				items: ActiveItem[]

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1379,6 +1379,7 @@ type MassNav = {
 			 * maybe used for other tabs as well.
 			 */
 			html?: string
+			dataRelease?: DataRelease
 			/** "active" items, shown as clickable buttons in about tab. click an item to launch a plot */
 			activeItems?: {
 				items: ActiveItem[]
@@ -1390,6 +1391,13 @@ type MassNav = {
 	activeColor?: string
 	/** customize background color of active navigation tab on hover */
 	activeColorHover?: string
+}
+
+type DataRelease = {
+	/** data release version */
+	version: string
+	/** link to data release page */
+	link: string
 }
 
 type ActiveItem = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1380,6 +1380,11 @@ type MassNav = {
 			 */
 			html?: string
 			dataRelease?: DataRelease
+			/** array of links to help pages
+			 * will be displayed in drop-down menu of help button
+			 * if undefined, then help button will not appear
+			 */
+			helpPages?: HelpPage[]
 			/** "active" items, shown as clickable buttons in about tab. click an item to launch a plot */
 			activeItems?: {
 				items: ActiveItem[]
@@ -1398,6 +1403,13 @@ type DataRelease = {
 	version: string
 	/** link to data release page */
 	link: string
+}
+
+type HelpPage = {
+	/** label of link */
+	label: string
+	/** link of help page */
+	url: string
 }
 
 type ActiveItem = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1403,13 +1403,6 @@ type DataRelease = {
 	link: string
 }
 
-type HelpPage = {
-	/** label of link */
-	label: string
-	/** link of help page */
-	url: string
-}
-
 type ActiveItem = {
 	/** string or html to show inside the button for the item, potentially allow to include <image> as logo */
 	title: string


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/2870

Support new dataRelease property described in sjpp PR: https://github.com/stjude/sjpp/pull/680

Can test by opening sjlife portal: http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22}

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
