### PR TITLE
Edge r coeff

### DIFF
--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -170,14 +170,6 @@ class DEanalysis {
 							title: 'Select confounding factors to adjust for in the analysis',
 							vocabApi: this.app.vocabApi
 						},
-						{
-							label: 'Switch model analysis order',
-							type: 'checkbox',
-							chartType: 'DEanalysis',
-							settingsKey: 'flip_design_matrix',
-							title: 'Causes design matrix to analyze confounding factors first before the groups',
-							boxLabel: ''
-						}
 					)
 				}
 			}

--- a/client/plots/DEanalysis.js
+++ b/client/plots/DEanalysis.js
@@ -160,17 +160,15 @@ class DEanalysis {
 				)
 				if (this.config.term) {
 					// Only when first confounding variable 1 has been selected, the option for a second confounding variable will be shown
-					inputs.push(
-						{
-							type: 'term',
-							configKey: 'term2',
-							chartType: 'DEanalysis',
-							usecase: { target: 'DEanalysis', detail: 'term' },
-							label: 'Confounding Factor 2',
-							title: 'Select confounding factors to adjust for in the analysis',
-							vocabApi: this.app.vocabApi
-						},
-					)
+					inputs.push({
+						type: 'term',
+						configKey: 'term2',
+						chartType: 'DEanalysis',
+						usecase: { target: 'DEanalysis', detail: 'term' },
+						label: 'Confounding Factor 2',
+						title: 'Select confounding factors to adjust for in the analysis',
+						vocabApi: this.app.vocabApi
+					})
 				}
 			}
 		}
@@ -702,7 +700,6 @@ export async function getPlotConfig(opts, app) {
 					pvaluetable: false,
 					adjusted_original_pvalue: 'adjusted',
 					method: 'edgeR',
-					flip_design_matrix: false,
 					VarGenes: 3000,
 					gene_ora: undefined,
 					gsea: undefined
@@ -799,9 +796,6 @@ async function runDEanalysis(self) {
 		input.tw = self.config.term
 		self.settings.method = 'edgeR' // When adjustment of confounding variables is selected, the method should always be a parmetric method such as edgeR
 		input.method = 'edgeR'
-		if (self.settings.flip_design_matrix) {
-			input.flip_design_matrix = self.settings.flip_design_matrix
-		}
 	}
 
 	if (self.config.term2) {

--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -234,10 +234,6 @@ values[] // using integer sample id
 			// If all elements in the confounding variable are equal, throw error as R script crashes if the confounding variable has only 1 level
 			throw 'Confounding variable 1 has only one value'
 		}
-		if (param.flip_design_matrix) {
-			// Flips design matrix in edgeR so as to analyze the confounding variable(s) first before the groups (when true)
-			expression_input.flip_design_matrix = param.flip_design_matrix
-		}
 	}
 
 	if (param.tw2) {

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -189,7 +189,7 @@ if (length(input$conf1) == 0) { # No adjustment of confounding factors
     #cat("Fit time: ", fit_time[3], " seconds\n")
 
     test_statistics_time <- system.time({
-        et <- glmLRT(fit, coef = 2)
+        et <- glmLRT(fit, coef = "conditionsDiseased")
     })
     #cat("Test statistics time: ", test_statistics_time[3], " seconds\n")
 }

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -149,17 +149,13 @@ if (length(input$conf1) == 0) { # No adjustment of confounding factors
     } else { # When input$conf1_mode == "discrete" keep the vector as string.
       conf1 <- as.factor(input$conf1)
     }
- 
+
     if (length(input$conf2) == 0) { # No adjustment of confounding factor 2
           y$samples <- data.frame(conditions = conditions, conf1 = conf1)
           model_gen_time <- system.time({
-             if (length(input$flip_design_matrix) == 0) { # When flip_design_matrix is not defined analyze groups (conditions) first
                  design <- model.matrix(~ conditions + conf1, data = y$samples)
-             } else { # When flip_design_matrix is defined analyze the confounding variable first
-                 design <- model.matrix(~ conf1 + conditions, data = y$samples)
-             }    
           })
-          #cat("Time for making design matrix: ", model_gen_time[3], " seconds\n")   
+          #cat("Time for making design matrix: ", model_gen_time[3], " seconds\n")
     } else {
           # Check the type of confounding variable 2
           if (input$conf2_mode == "continuous") { # If this is float, the input conf2 vector should be converted into a numeric vector
@@ -169,14 +165,10 @@ if (length(input$conf1) == 0) { # No adjustment of confounding factors
           }
           y$samples <- data.frame(conditions = conditions, conf1 = conf1, conf2 = conf2)
           model_gen_time <- system.time({
-             if (length(input$flip_design_matrix) == 0) { # When flip_design_matrix is not defined analyze groups (conditions) first   
                  design <- model.matrix(~ conditions + conf1 + conf2, data = y$samples)
-             } else { # When flip_design_matrix is defined analyze the confounding variables first
-                 design <- model.matrix(~ conf1 + conf2 + conditions, data = y$samples)
-             }    
           })
           #cat("Time for making design matrix: ", model_gen_time[3], " seconds\n")
-    }    
+    }
 
     dispersion_time <- system.time({
         y <- estimateDisp(y, design)

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -30,13 +30,6 @@ filter_genes_by_global_variance <- function(read_counts, gene_id_symbols, num_va
    return(list(read_counts = read_counts, gene_id_symbols = gene_id_symbols))
 }
 
-# Will implement this later
-filter_genes_by_group_variance <- function(read_counts, gene_id_symbols, num_variable_genes, cases, controls) {
-    # Divide the read counts into two groups
-    case_read_counts <- read_counts[, cases]
-    control_read_counts <- read_counts[, controls]
-}
-
 # Read JSON input from stdin
 read_json_time <- system.time({
     con <- file("stdin", "r")
@@ -206,3 +199,11 @@ multiple_testing_correction_time <- system.time({
 
 # Output results
 toJSON(output)
+
+#-----------------------------------#
+# Will implement this later
+filter_genes_by_group_variance <- function(read_counts, gene_id_symbols, num_variable_genes, cases, controls) {
+    # Divide the read counts into two groups
+    case_read_counts <- read_counts[, cases]
+    control_read_counts <- read_counts[, controls]
+}

--- a/shared/types/src/routes/termdb.DE.ts
+++ b/shared/types/src/routes/termdb.DE.ts
@@ -21,8 +21,6 @@ export type DERequest = {
 	tw2?: any
 	/** Number of variable genes (defined only for parametric DE methods) */
 	VarGenes?: number
-	/** Flips design matrix in edgeR so as to analyze the confounding variable(s) first before the groups */
-	flip_design_matrix: 'false' | 'true'
 }
 
 export type ExpressionInput = {
@@ -50,8 +48,6 @@ export type ExpressionInput = {
 	conf2_mode?: 'continuous' | 'discrete'
 	/** Number of variable genes to be included for DE analysis (optional) */
 	VarGenes?: number
-	/** Flips design matrix in edgeR so as to analyze the confounding variable(s) first before the groups */
-	flip_design_matrix: 'false' | 'true'
 }
 
 export type DEResponse = {


### PR DESCRIPTION
## Description

This hardcodes the diseased column as coefficient as using numbers can give inaccurate results. In this manner, we can be sure that the design matrix is built to test against the diseased or treatment group. Additionally, now the switch design matrix is no longer needed. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
