### PR TITLE
Sort violin plots by median 

### DIFF
--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -145,6 +145,18 @@ class ViolinPlot {
 				]
 			},
 			{
+				label: 'Order by',
+				title: 'Order violin plots by parameters',
+				type: 'radio',
+				chartType: 'violin',
+				settingsKey: 'orderByMedian',
+				options: [
+					{ label: 'Default', value: false },
+					{ label: 'Median', value: true }
+				],
+				getDisplayStyle: () => (this.data.plots.length > 1 ? '' : 'none')
+			},
+			{
 				label: 'Symbol size',
 				type: 'number',
 				chartType: 'violin',
@@ -340,7 +352,8 @@ class ViolinPlot {
 			rightMargin: s.rightMargin,
 			unit: s.unit,
 			isKDE: s.method == 0,
-			ticks: s.ticks
+			ticks: s.ticks,
+			orderByMedian: s.orderByMedian
 		}
 
 		if (this.opts.mode == 'minimal') {
@@ -393,7 +406,8 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		medianThickness: 3,
 		ticks: 20,
 		defaultColor: plotColor,
-		method: 0
+		method: 0,
+		orderByMedian: false
 	}
 	return Object.assign(defaults, overrides)
 }

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -40,6 +40,11 @@ export default function setViolinRenderer(self) {
 
 		//filter out hidden values and only keep plots which are not hidden in term2.q.hiddenvalues
 		self.data.plots = self.data.plots.filter(p => !termNum?.q?.hiddenValues?.[p.label || p.seriesId])
+		if (settings.orderByMedian == true) {
+			self.data.plots.sort(
+				(a, b) => a.summaryStats.find(x => x.id === 'median').value - b.summaryStats.find(x => x.id === 'median').value
+			)
+		}
 		this.k2c = getColors(self.data.plots.length)
 		if (self.legendRenderer) self.legendRenderer(getLegendGrps(termNum, self))
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Feature
+- New control add to sort the violin plots by either the default or median values. 


### PR DESCRIPTION
## Description
Closes issue #2786. 

Changes: 
If more than one violin plot is present, a new `Order by` control appears. This allows the user to sort by the default order returned from the server or median value in descending order. 

Test: 
Any violin plot from http://localhost:3000/url.html. Please test that the control ought not to appear when only one plot is present and that it works properly otherwise. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
