### PR TITLE
Do not show violin plots with a sample size less than 5

### DIFF
--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -628,7 +628,7 @@ tape('term1 as numeric and term2 numeric, change median size', function (test) {
 		const medianEle = await detectGte({
 			elem: violinDiv.node(),
 			selector: '.sjpp-median-line',
-			count: 6,
+			count: 5,
 			async trigger() {
 				await violin.Inner.app.dispatch({
 					type: 'plot_edit',
@@ -762,7 +762,7 @@ tape('term1=numeric, term2=condition', function (test) {
 		test.end()
 	}
 	async function testConditionTermOrder(violin, violinDiv) {
-		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 8 })
+		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 6 })
 		test.ok(groups, 'Condition groups exist')
 		test.deepEqual(
 			groups.filter((k, i) => i % 2 == 0).map(k => k.__data__.label),
@@ -1091,7 +1091,7 @@ tape('term=agedx, term2=geneExp with regular bins', function (test) {
 		 * one violin plot  */
 		test.equal(
 			numViolinPaths.length / 2,
-			violin.Inner.data.plots.length - 1,
+			violin.Inner.data.plots.length,
 			'Should render the correct number of plots per the default bins for a gene expression term'
 		)
 

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -514,6 +514,8 @@ function getLegendGrps(termNum, self) {
 			? t1
 			: t2?.q.mode === 'continuous' && t2?.q.hiddenValues && Object.keys(t2?.q.hiddenValues).length > 0
 			? t2
+			: t2 && self.data.uncomputableValues
+			? t2
 			: null,
 		legendGrps,
 		headingStyle,

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fix
+- Violin with less than five samples will appear as uncomputable. 

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -132,6 +132,19 @@ function divideValues(q: ViolinRequest, data: ValidGetDataResponse, sampleType: 
 	const useLog = q.unit == 'log'
 
 	const { absMax, absMin, key2values, uncomputableValues } = parseValues(q, data, sampleType, useLog, overlayTerm)
+
+	//Do not show a violin plot for values with less than 5 samples
+	//Instead, add as an uncomputable value and show in legend
+	for (const [k, v] of key2values) {
+		if (v.length < 5) {
+			let label
+			if (overlayTerm) label = overlayTerm?.term?.values?.[k]?.label || k
+			else label = q.tw.term.values[k].label
+			key2values.delete(k)
+			uncomputableValues[label] = v.length
+		}
+	}
+
 	return {
 		key2values,
 		min: absMin,


### PR DESCRIPTION
## Description
Closes issue #2618. Will show the item as uncomputable in the legend instead. 

Test with [this violin example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22,%22name%22:%22TP53%22%7D,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%22term2%22:%7B%22id%22:%22diaggrp%22%7D%7D%5D%7D)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
