### PR TITLE
Improved bins generated 

### DIFF
--- a/shared/utils/src/termdb.initbinconfig.js
+++ b/shared/utils/src/termdb.initbinconfig.js
@@ -34,11 +34,10 @@ export default function initBinConfig(data, opts = {}) {
 		const l = data.length
 		const min = data[0]
 		const max = data[l - 1]
-		let p5idx = Math.round(l * 0.05) - 1
-		const p98idx = Math.round(l * 0.98) - 1
+		let p5idx = Math.ceil(l * 0.05) - 1
+		const p98idx = Math.ceil(l * 0.98) - 1
 		const binSize = (data[p98idx] - data[p5idx]) / 8 //calculate bin size using the 98th percentile to reduce outlier influence
 		// first bin stop will equal either (minimum + bin size) or (5th percentile), whichever is larger.
-		if (p5idx < 0) p5idx = 0
 		const p5 = data[p5idx]
 		const firstBinStop = Math.max(min + binSize, p5)
 		// round the bin values

--- a/shared/utils/src/termdb.initbinconfig.js
+++ b/shared/utils/src/termdb.initbinconfig.js
@@ -34,9 +34,10 @@ export default function initBinConfig(data, opts = {}) {
 		const l = data.length
 		const min = data[0]
 		const max = data[l - 1]
-		const binSize = (max - min) / 8
-		// first bin stop will equal either (minimum + bin size) or (5th percentile), whichever is larger.
 		let p5idx = Math.round(l * 0.05) - 1
+		const p98idx = Math.round(l * 0.98) - 1
+		const binSize = (data[p98idx] - data[p5idx]) / 8 //calculate bin size using the 98th percentile to reduce outlier influence
+		// first bin stop will equal either (minimum + bin size) or (5th percentile), whichever is larger.
 		if (p5idx < 0) p5idx = 0
 		const p5 = data[p5idx]
 		const firstBinStop = Math.max(min + binSize, p5)

--- a/shared/utils/src/test/termdb.initbinconfig.unit.spec.js
+++ b/shared/utils/src/test/termdb.initbinconfig.unit.spec.js
@@ -227,8 +227,9 @@ tape('large test data: integers', function (test) {
 		{
 			type: 'regular-bin',
 			startinclusive: true,
-			bin_size: 5,
-			first_bin: { stop: 5 }
+			bin_size: 1,
+			first_bin: { stop: 1 },
+			last_bin: { start: 7 }
 		},
 		'should match expected output'
 	)
@@ -257,8 +258,9 @@ tape('large test data: floats', function (test) {
 		{
 			type: 'regular-bin',
 			startinclusive: true,
-			bin_size: 0.5,
-			first_bin: { stop: 0.5 },
+			bin_size: 0.2,
+			first_bin: { stop: 0.2 },
+			last_bin: { start: 1.4 },
 			rounding: '.1f'
 		},
 		'should match expected output'


### PR DESCRIPTION
## Description

Using 98th percentile - 5th percentile to calculate bin size and improve bins predicted. Tested regenerating buildTermdb for the sjcares dataset and with  the tests. @gavrielm you may want to test this change regenerating the db for sjlife?

See bins:

<img width="549" alt="Screenshot 2025-03-03 at 11 11 17 AM" src="https://github.com/user-attachments/assets/35dcbcc5-1a7c-43e5-bc36-30748e09a9c0" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
