### PR TITLE
fix: support gdc/singlecell state overrides, such as for demo mode

### DIFF
--- a/.github/actions/publish-docker/action.yml
+++ b/.github/actions/publish-docker/action.yml
@@ -66,10 +66,11 @@ runs:
       with:
         path: server
 
-#    - name: Run deploy action
-#      uses: peter-evans/repository-dispatch@v2
-#      with:
-#        token: ${{ inputs.PAT }}
-#        repository: stjude/sj-pp
-#        event-type: version-update
-#        client-payload: '{"pp_version": "${{ steps.pp-version.outputs.current-version }}", "front_version": "${{ steps.front-version.outputs.current-version }}", "server_version": "${{ steps.server-version.outputs.current-version}}", "docker_version": "${{ steps.docker-publish.outputs.docker_version}}", "branch": "${{ steps.docker-publish.outputs.branch }}"}'
+   - name: Run deploy action
+     uses: peter-evans/repository-dispatch@v2
+     if: ${{ !startsWith(github.ref_name, 'release') }}
+     with:
+       token: ${{ inputs.PAT }}
+       repository: stjude/sj-pp
+       event-type: version-update
+       client-payload: '{"pp_version": "${{ steps.pp-version.outputs.current-version }}", "front_version": "${{ steps.front-version.outputs.current-version }}", "server_version": "${{ steps.server-version.outputs.current-version}}", "docker_version": "${{ steps.docker-publish.outputs.docker_version}}", "branch": "${{ steps.docker-publish.outputs.branch }}"}'

--- a/client/gdc/singlecell.js
+++ b/client/gdc/singlecell.js
@@ -34,7 +34,7 @@ export async function init(arg, holder, genomes) {
 			genome: gdcGenome,
 			dslabel: gdcDslabel,
 			termfilter: { filter0: arg.filter0 },
-			plots: [{ chartType: 'singleCellPlot' }]
+			plots: arg.state?.plots || [{chartType: 'singleCellPlot'}]
 		},
 		noheader: true,
 		nobox: true,
@@ -66,7 +66,9 @@ export async function init(arg, holder, genomes) {
 			},
 			arg.opts?.app || {}
 		),
-		singleCellPlot: arg.opts?.singleCell || {}
+		opts: {
+			singleCellPlot: arg.opts?.singleCellPlot || {}
+		}
 	})
 	const api = {
 		update: async updateArg => {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- support gdc/singlecell state overrides, such as for demo mode


### PR DESCRIPTION
## Description

Addresses https://gdc-ctds.atlassian.net/browse/SV-2572
- can test in local GFF by pulling branch `jira-sv-2572`
- or pull `sjpp/master` and simulate using http://localhost:3000/example.gdc.scRNAseq.html?isDemoMode=true

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
