### PR TITLE
add multipart to buildMaf

### DIFF
--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -375,7 +375,7 @@ async function getFilesAndShowTable(obj) {
 			//     body: any
 		  //   }
 			// ] 
-			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } }); console.log(374, data)
+			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } })
 			if (data.find(d => d.body?.error)) throw data.error
 		} catch (e) {
 			sayerror(obj.errDiv, e)
@@ -390,7 +390,7 @@ async function getFilesAndShowTable(obj) {
 
 		// download the file to client
 		const a = document.createElement('a')
-		const octetData = data.find(d => d.headers['content-type'] == 'application/octet-stream'); console.log(389, octetData)
+		const octetData = data.find(d => d.headers['content-type'] == 'application/octet-stream')
 		a.href = URL.createObjectURL(octetData.body)
 		a.download = `cohortMAF.${new Date().toISOString().split('T')[0]}.gz`
 		a.style.display = 'none'

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -368,8 +368,15 @@ async function getFilesAndShowTable(obj) {
 
 		let data
 		try {
-			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } })
-			if (data.error) throw data.error
+			// expect multipart response, as preprocessed by dofetch into an array of response data entries
+			// [
+			// 	 {
+			//	   headers: {'content-type': '...', [key?]: string}, 
+			//     body: any
+		  //   }
+			// ] 
+			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } }); console.log(374, data)
+			if (data.find(d => d.body?.error)) throw data.error
 		} catch (e) {
 			sayerror(obj.errDiv, e)
 			button.innerHTML = oldText
@@ -383,7 +390,8 @@ async function getFilesAndShowTable(obj) {
 
 		// download the file to client
 		const a = document.createElement('a')
-		a.href = URL.createObjectURL(data)
+		const octetData = data.find(d => d.headers['content-type'] == 'application/octet-stream'); console.log(389, octetData)
+		a.href = URL.createObjectURL(octetData.body)
 		a.download = `cohortMAF.${new Date().toISOString().split('T')[0]}.gz`
 		a.style.display = 'none'
 		document.body.appendChild(a)

--- a/rust/src/gdcmaf.rs
+++ b/rust/src/gdcmaf.rs
@@ -13,17 +13,25 @@
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use serde_json::Value;
+use serde_json::{Value,json};
 use std::path::Path;
 use futures::StreamExt;
 use std::io::{self,Read,Write};
+use std::sync::Mutex;
 
 
+// Struct to hold error information
+#[derive(serde::Serialize)]
+struct ErrorEntry {
+    url: String,
+    error: String,
+}
 
-fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
+fn select_maf_col(d:String,columns:&Vec<String>,url:&str,errors: &Mutex<Vec<ErrorEntry>>) -> (Vec<u8>,i32) {
     let mut maf_str: String = String::new();
     let mut header_indices: Vec<usize> = Vec::new();
     let lines = d.trim_end().split("\n");
+    let mut mafrows = 0;
     for line in lines {
         if line.starts_with("#") {
             continue
@@ -33,6 +41,11 @@ fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
                 if let Some(index) = header.iter().position(|x| x == col) {
                     header_indices.push(index);
                 } else {
+                    let error_msg = format!("Column {} was not found", col);
+                    errors.lock().unwrap().push(ErrorEntry {
+                        url: url.to_string().clone(),
+                        error: error_msg.clone(),
+                    });
                     panic!("{} was not found!",col);
                 }
             }
@@ -44,14 +57,17 @@ fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
             };
             maf_str.push_str(maf_out_lst.join("\t").as_str());
             maf_str.push_str("\n");
+            mafrows += 1;
         }
     };
-    maf_str.as_bytes().to_vec()
+    (maf_str.as_bytes().to_vec(),mafrows)
 }
 
 
 #[tokio::main]
 async fn main() -> Result<(),Box<dyn std::error::Error>> {
+    // Create a thread-container for errors
+    let errors = Mutex::new(Vec::<ErrorEntry>::new());
     // Accepting the piped input json from jodejs and assign to the variable
     // host: GDC host
     // url: urls to download single maf files
@@ -75,49 +91,118 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
                 .map(|v| v.to_string().replace("\"",""))
                 .collect::<Vec<String>>();
         } else {
+            errors.lock().unwrap().push(ErrorEntry {
+                url: String::new(),
+                error: "The columns of arg is not an array".to_string(),
+            });
             panic!("Columns is not an array");
         }
     } else {
+        errors.lock().unwrap().push(ErrorEntry {
+            url: String::new(),
+            error: "The key columns is missed from arg".to_string(),
+        });
         panic!("Columns was not selected");
     };
     
     //downloading maf files parallelly and merge them into single maf file
     let download_futures = futures::stream::iter(
         url.into_iter().map(|url|{
+            let errors = &errors;
             async move {
-                let result = reqwest::get(&url).await;
-                if let Ok(resp) = result {
-                    let content = resp.bytes().await.unwrap();
-                    let mut decoder = GzDecoder::new(&content[..]);
-                    let mut decompressed_content = Vec::new();
-                    let read_content = decoder.read_to_end(&mut decompressed_content);
-                    if let Ok(_) = read_content {
-                        let text = String::from_utf8_lossy(&decompressed_content).to_string();
-                        text
-                    } else {
-                        let error_msg = "Failed to read content downloaded from: ".to_string() + &url;
-                        error_msg
+                match reqwest::get(&url).await {
+                    Ok(resp) if resp.status().is_success() => {
+                        match resp.bytes().await {
+                            Ok(content) => {
+                                let mut decoder = GzDecoder::new(&content[..]);
+                                let mut decompressed_content = Vec::new();
+                                match decoder.read_to_end(&mut decompressed_content) {
+                                    Ok(_) => {
+                                        let text = String::from_utf8_lossy(&decompressed_content).to_string();
+                                        return Ok((url.clone(),text))
+                                    }
+                                    Err(e) => {
+                                        let error_msg = format!("Decompression failed: {}", e);
+                                        errors.lock().unwrap().push(ErrorEntry {
+                                            url: url.clone(),
+                                            error: error_msg.clone(),
+                                        });
+                                        return Err((url.clone(), error_msg))
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                let error_msg = format!("Decompression failed: {}", e);
+                                errors.lock().unwrap().push(ErrorEntry {
+                                    url: url.clone(),
+                                    error: error_msg.clone(),
+                                });
+                                return Err((url.clone(), error_msg))
+                            }
+                        }
                     }
-                } else {
-                    let error_msg = "Failed to download: ".to_string() + &url;
-                    error_msg
+                    Ok(resp) => {
+                        let error_msg = format!("HTTP error: {}", resp.status());
+                        errors.lock().unwrap().push(ErrorEntry {
+                            url: url.clone(),
+                            error: error_msg.clone(),
+                        });
+                        return Err((url.clone(), error_msg))
+                    }
+                    Err(e) => {
+                        let error_msg = format!("Server request failed: {}", e);
+                        errors.lock().unwrap().push(ErrorEntry {
+                            url: url.clone(),
+                            error: error_msg.clone(),
+                        });
+                        return Err((url.clone(), error_msg))
+                    }
                 }
             }
         })
     );
 
     // output
+    // boundary
+    println!("Content-Type: application/octet-stream\r\n");
+    println!("\r\n");
+
+    // binary output
     let mut encoder = GzEncoder::new(io::stdout(), Compression::default());
     let _ = encoder.write_all(&maf_col.join("\t").as_bytes().to_vec()).expect("Failed to write header");
     let _ = encoder.write_all(b"\n").expect("Failed to write newline");
-    download_futures.buffer_unordered(20).for_each(|item| {
-        if item.starts_with("Failed") {
-            eprintln!("{}",item);
-        } else {
-            let maf_bit = select_maf_col(item,&maf_col);
-            let _ = encoder.write_all(&maf_bit).expect("Failed to write file");
-        };
+    download_futures.buffer_unordered(50).for_each(|result| {
+        match result {
+            Ok((url, content)) => {
+                let (maf_bit,mafrows) = select_maf_col(content, &maf_col, &url, &errors);
+                if mafrows > 0 {
+                    let _  = encoder.write_all(&maf_bit).expect("Failed to write file");
+                } else {
+                    errors.lock().unwrap().push(ErrorEntry {
+                        url: url.clone(),
+                        error: "Empty maf file".to_string(),
+                    });
+                }
+            }
+            Err((url, _error)) => {
+                eprintln!("{}",url);
+            }
+        }
         async {}
     }).await;
+
+    println!("GDC_MAF_MULTIPART_BOUNDARY_2025\r\n");
+    println!("Content-Type: application/json\r\n");
+    println!("\r\n");
+
+    // After processing all downloads, output the errors as JSON to stderr
+    let errors = errors.lock().unwrap();
+    if !errors.is_empty() {
+        let error_json = json!({
+            "errors": errors.iter().collect::<Vec<&ErrorEntry>>()
+        });
+        println!("{}", serde_json::to_string_pretty(&error_json)?);
+    };
+
     Ok(())
 }

--- a/rust/src/gdcmaf.rs
+++ b/rust/src/gdcmaf.rs
@@ -163,9 +163,9 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
     );
 
     // output
-    // boundary
-    println!("Content-Type: application/octet-stream\r\n");
-    println!("\r\n");
+    println!("\r\nContent-Disposition: attachment; filename=cohort.maf.gz");
+    println!("Content-Type: application/octet-stream");
+    println!("");
 
     // binary output
     let mut encoder = GzEncoder::new(io::stdout(), Compression::default());
@@ -191,17 +191,17 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
         async {}
     }).await;
 
-    println!("GDC_MAF_MULTIPART_BOUNDARY_2025\r\n");
-    println!("Content-Type: application/json\r\n");
-    println!("\r\n");
-
     // After processing all downloads, output the errors as JSON to stderr
     let errors = errors.lock().unwrap();
     if !errors.is_empty() {
+    		println!("\r\nGDC_MAF_MULTIPART_BOUNDARY_2025");
+		    println!("Content-Type: application/json");
+		    println!("");
+
         let error_json = json!({
             "errors": errors.iter().collect::<Vec<&ErrorEntry>>()
         });
-        println!("{}", serde_json::to_string_pretty(&error_json)?);
+        println!("{}", serde_json::to_string(&error_json)?);
     };
 
     Ok(())

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -5,7 +5,6 @@ import type { GdcMafBuildRequest, RouteApi } from '#types'
 import { gdcMafPayload } from '#types/checkers'
 import { maxTotalSizeCompressed } from './gdc.maf.ts'
 import { mayLog } from '#src/helpers.ts'
-import express from 'express'
 
 export const api: RouteApi = {
 	endpoint: 'gdc/mafBuild',


### PR DESCRIPTION
## Description
1. add multipart to buildMaf
2. gdcmaf.rs with mixed output wit binary maf and json stderr

To test:
- in `rust` dir, `npm run build`
- open http://localhost:3000/example.gdc.maf.html in your browser
- select 1 or 2 small files, then click the download button in the lower right
- the downloaded `.gz` should be extractable and not corrupted 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
