### PR TITLE
process multipart maf response

### DIFF
--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -321,9 +321,10 @@ async function getFilesAndShowTable(obj) {
 		columns: tableColumns,
 		resize: true,
 		div: obj.tableDiv.append('div'),
-		selectAll: true,
+		selectAll: true, // comment out for quicker testing
 		dataTestId: 'sja_mafFileTable',
 		header: { allowSort: true },
+		selectedRows: [], //[198], // comment out for quicker testing
 		buttons: [
 			{
 				text: 'Aggregate selected MAF files and download',
@@ -368,22 +369,39 @@ async function getFilesAndShowTable(obj) {
 
 		let data
 		try {
+			// expect multipart response, as preprocessed by dofetch into an array of response data entries
+			// [
+			// 	 {
+			//	   headers: {'content-type': '...', [key?]: string}, 
+			//     body: any
+		  //   }
+			// ] 
 			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } })
-			if (data.error) throw data.error
+			const err = data.find(d => d.body?.error)
+			if (err) throw err.body.error || err.body.message
 		} catch (e) {
 			sayerror(obj.errDiv, e)
 			button.innerHTML = oldText
 			button.disabled = false
-
 			return
 		}
 
 		button.innerHTML = oldText
 		button.disabled = false
 
+		const confirm = data.pop()
+		if (!confirm?.body?.ok) {
+			console.log(confirm, data)
+			throw confirm?.body?.message || 'error in maf data processing'
+		} // else console.log(392, confirm.body)
+
 		// download the file to client
+		const octetData = data.find(d => d.headers['content-type'] == 'application/octet-stream')
+		if (!octetData) throw 'missing octet data' 
+		const href = URL.createObjectURL(octetData.body)
+		// console.log(394, [octetData?.body.size, href.length, href], octetData)
 		const a = document.createElement('a')
-		a.href = URL.createObjectURL(data)
+		a.href = href
 		a.download = `cohortMAF.${new Date().toISOString().split('T')[0]}.maf.gz`
 		a.style.display = 'none'
 		document.body.appendChild(a)

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -324,7 +324,7 @@ async function getFilesAndShowTable(obj) {
 		selectAll: true, // comment out for quicker testing
 		dataTestId: 'sja_mafFileTable',
 		header: { allowSort: true },
-		selectedRows: [], //[198], // comment out for quicker testing
+		selectedRows: [], //[198], // uncomment out for quicker testing
 		buttons: [
 			{
 				text: 'Aggregate selected MAF files and download',
@@ -377,8 +377,9 @@ async function getFilesAndShowTable(obj) {
 		  //   }
 			// ] 
 			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } })
-			const err = data.find(d => d.body?.error)
-			if (err) throw err.body.error || err.body.message
+			// console.log(380, 'gdc/mafBuild response', data)
+			const err = data.find(d => d.body?.error || d.body?.errors)
+			// if (err) throw err.body.error || JSON.stringify(err.body.errors, null, '  ') || err.body.message
 		} catch (e) {
 			sayerror(obj.errDiv, e)
 			button.innerHTML = oldText
@@ -391,8 +392,12 @@ async function getFilesAndShowTable(obj) {
 
 		const confirm = data.pop()
 		if (!confirm?.body?.ok) {
-			console.log(confirm, data)
-			throw confirm?.body?.message || 'error in maf data processing'
+			// console.log(394, confirm, data)
+			if (confirm.body?.error || confirm.body?.errors || confirm.body?.message) {
+				sayerror(obj.errDiv, JSON.stringify(confirm.body, null, '  '))
+				//return
+			}
+			//throw confirm?.body?.message || 'error in maf data processing'
 		} // else console.log(392, confirm.body)
 
 		// download the file to client

--- a/client/src/notify.ts
+++ b/client/src/notify.ts
@@ -306,15 +306,17 @@ function handleMessageData(_data, opts = {} as any) {
 		if (refresh.mode == 'none') {
 			// console.log(`skipped refresh in sessionRefresh.mode='none'`)
 		} else if (refresh.mode == 'appOnly') {
+			console.clear()
 			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)
 			// debounce
 			refresh.pendingCall = setTimeout(refresh.callback, 500)
 		} else if (refresh.mode == 'full') {
-			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)
+			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)//
 			// debounce
 			refresh.pendingCall = setTimeout(() => window.location.reload(), 500)
 		} else if (!refresh.modeOptions[refresh.mode]) {
 			console.warn(`invalid value ${refresh.key}='${refresh.mode}', triggering refresh instead`)
+			console.clear()
 			//refresh.callback()
 			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)
 			// debounce

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- handle stderr from rust code in node js stream_rust() helper and route handler

--- a/rust/src/gdcmaf.rs
+++ b/rust/src/gdcmaf.rs
@@ -13,17 +13,25 @@
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use serde_json::Value;
+use serde_json::{Value,json};
 use std::path::Path;
 use futures::StreamExt;
 use std::io::{self,Read,Write};
+use std::sync::Mutex;
 
 
+// Struct to hold error information
+#[derive(serde::Serialize)]
+struct ErrorEntry {
+    url: String,
+    error: String,
+}
 
-fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
+fn select_maf_col(d:String,columns:&Vec<String>,url:&str,errors: &Mutex<Vec<ErrorEntry>>) -> (Vec<u8>,i32) {
     let mut maf_str: String = String::new();
     let mut header_indices: Vec<usize> = Vec::new();
     let lines = d.trim_end().split("\n");
+    let mut mafrows = 0;
     for line in lines {
         if line.starts_with("#") {
             continue
@@ -33,6 +41,11 @@ fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
                 if let Some(index) = header.iter().position(|x| x == col) {
                     header_indices.push(index);
                 } else {
+                    let error_msg = format!("Column {} was not found", col);
+                    errors.lock().unwrap().push(ErrorEntry {
+                        url: url.to_string().clone(),
+                        error: error_msg.clone(),
+                    });
                     panic!("{} was not found!",col);
                 }
             }
@@ -44,14 +57,17 @@ fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
             };
             maf_str.push_str(maf_out_lst.join("\t").as_str());
             maf_str.push_str("\n");
+            mafrows += 1;
         }
     };
-    maf_str.as_bytes().to_vec()
+    (maf_str.as_bytes().to_vec(),mafrows)
 }
 
 
 #[tokio::main]
 async fn main() -> Result<(),Box<dyn std::error::Error>> {
+    // Create a thread-container for errors
+    let errors = Mutex::new(Vec::<ErrorEntry>::new());
     // Accepting the piped input json from jodejs and assign to the variable
     // host: GDC host
     // url: urls to download single maf files
@@ -75,49 +91,121 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
                 .map(|v| v.to_string().replace("\"",""))
                 .collect::<Vec<String>>();
         } else {
+            errors.lock().unwrap().push(ErrorEntry {
+                url: String::new(),
+                error: "The columns of arg is not an array".to_string(),
+            });
             panic!("Columns is not an array");
         }
     } else {
+        errors.lock().unwrap().push(ErrorEntry {
+            url: String::new(),
+            error: "The key columns is missed from arg".to_string(),
+        });
         panic!("Columns was not selected");
     };
     
     //downloading maf files parallelly and merge them into single maf file
     let download_futures = futures::stream::iter(
         url.into_iter().map(|url|{
+            let errors = &errors;
             async move {
-                let result = reqwest::get(&url).await;
-                if let Ok(resp) = result {
-                    let content = resp.bytes().await.unwrap();
-                    let mut decoder = GzDecoder::new(&content[..]);
-                    let mut decompressed_content = Vec::new();
-                    let read_content = decoder.read_to_end(&mut decompressed_content);
-                    if let Ok(_) = read_content {
-                        let text = String::from_utf8_lossy(&decompressed_content).to_string();
-                        text
-                    } else {
-                        let error_msg = "Failed to read content downloaded from: ".to_string() + &url;
-                        error_msg
+                match reqwest::get(&url).await {
+                    Ok(resp) if resp.status().is_success() => {
+                        match resp.bytes().await {
+                            Ok(content) => {
+                                let mut decoder = GzDecoder::new(&content[..]);
+                                let mut decompressed_content = Vec::new();
+                                match decoder.read_to_end(&mut decompressed_content) {
+                                    Ok(_) => {
+                                        let text = String::from_utf8_lossy(&decompressed_content).to_string();
+                                        return Ok((url.clone(),text))
+                                    }
+                                    Err(e) => {
+                                        let error_msg = format!("Decompression failed: {}", e);
+                                        errors.lock().unwrap().push(ErrorEntry {
+                                            url: url.clone(),
+                                            error: error_msg.clone(),
+                                        });
+                                        return Err((url.clone(), error_msg))
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                let error_msg = format!("Decompression failed: {}", e);
+                                errors.lock().unwrap().push(ErrorEntry {
+                                    url: url.clone(),
+                                    error: error_msg.clone(),
+                                });
+                                return Err((url.clone(), error_msg))
+                            }
+                        }
                     }
-                } else {
-                    let error_msg = "Failed to download: ".to_string() + &url;
-                    error_msg
+                    Ok(resp) => {
+                        let error_msg = format!("HTTP error: {}", resp.status());
+                        errors.lock().unwrap().push(ErrorEntry {
+                            url: url.clone(),
+                            error: error_msg.clone(),
+                        });
+                        return Err((url.clone(), error_msg))
+                    }
+                    Err(e) => {
+                        let error_msg = format!("Server request failed: {}", e);
+                        errors.lock().unwrap().push(ErrorEntry {
+                            url: url.clone(),
+                            error: error_msg.clone(),
+                        });
+                        return Err((url.clone(), error_msg))
+                    }
                 }
             }
         })
     );
 
-    // output
+    // binary output
     let mut encoder = GzEncoder::new(io::stdout(), Compression::default());
     let _ = encoder.write_all(&maf_col.join("\t").as_bytes().to_vec()).expect("Failed to write header");
     let _ = encoder.write_all(b"\n").expect("Failed to write newline");
-    download_futures.buffer_unordered(20).for_each(|item| {
-        if item.starts_with("Failed") {
-            eprintln!("{}",item);
-        } else {
-            let maf_bit = select_maf_col(item,&maf_col);
-            let _ = encoder.write_all(&maf_bit).expect("Failed to write file");
-        };
-        async {}
-    }).await;
+
+    // Collect all results before processing
+    let results = download_futures.buffer_unordered(50).collect::<Vec<_>>().await;
+
+    // Process results after all downloads are complete
+    for result in results {
+        match result {
+            Ok((url, content)) => {
+                let (maf_bit,mafrows) = select_maf_col(content, &maf_col, &url, &errors);
+                if mafrows > 0 {
+                    let _  = encoder.write_all(&maf_bit).expect("Failed to write file");
+                } else {
+                    errors.lock().unwrap().push(ErrorEntry {
+                        url: url.clone(),
+                        error: "Empty maf file".to_string(),
+                    });
+                }
+            }
+            Err((url, _error)) => {
+                eprintln!("{}",url);
+            }
+        }
+    };
+
+    // Finalize output and printing errors
+    encoder.finish().expect("Maf file output error!");
+
+    // Manually flush stdout
+    io::stdout().flush().expect("Failed to flush stdout");
+    
+    // After processing all downloads, output the errors as JSON to stderr
+    let errors = errors.lock().unwrap();
+    if !errors.is_empty() {
+        let error_json = json!({
+            "errors": errors.iter().collect::<Vec<&ErrorEntry>>()
+        });
+        let mut stderr = io::stderr();
+        writeln!(stderr, "{}", error_json).expect("Failed to output stderr!");
+        io::stderr().flush().expect("Failed to flush stderr");
+    };
+
     Ok(())
 }

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -1,6 +1,6 @@
 import ky from 'ky'
 import { joinUrl } from '#shared/joinUrl.js'
-import { run_rust_stream } from '@sjcrh/proteinpaint-rust'
+import { stream_rust } from '@sjcrh/proteinpaint-rust'
 import type { GdcMafBuildRequest, RouteApi } from '#types'
 import { gdcMafPayload } from '#types/checkers'
 import { maxTotalSizeCompressed } from './gdc.maf.ts'
@@ -36,6 +36,14 @@ function init({ genomes }) {
 	}
 }
 
+type EmitJsonDataArg = string | {
+	status?: 'string'
+	ok?: boolean
+	error?: string
+	errors?: any[] 
+	message?: string
+}
+
 /*
 q{}
 res{}
@@ -52,39 +60,29 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		columns: q.columns,
 		host: joinUrl(host.rest, 'data') // must use the /data/ endpoint from current host
 	}
-	const boundary = 'GDC_MAF_MULTIPART_BOUNDARY_2025'
+	// uncomment for manual error testing
+	// const arg = {"host": "https://api.gdc.cancer.gov/data/","columns": ["Hugo_Symbol", "Entrez_Gene_Id", "Center", "NCBI_Build", "Chromosome", "Start_Position"], "fileIdLst": ["8b31d6d1-56f7-4aa8-b026-c64bafd531e7", "83ea587b-1e92-41b3-a8e3-12df30496724"]}; 
+
+	const boundary = 'GDC_MAF_MULTIPART_BOUNDARY'
 	res.setHeader('content-type', `multipart/mixed; boundary=${boundary}`)
 	res.write(`--${boundary}`)
 	res.write('\ncontent-disposition: attachment; filename=cohort.maf.gz')
 	res.write('\ncontent-type: application/octet-stream\n\n')
 	res.flush() // header text should be sent as a separate chunk from the content that will be streamed next
 
-	const rustStream = run_rust_stream('gdcmaf', JSON.stringify(arg))
+	const rustStream = stream_rust('gdcmaf', JSON.stringify(arg), emitJson)
 	rustStream.pipe(res, { end: false })
 
-	rustStream.on('end', () => {
+	function emitJson(data?: EmitJsonDataArg, end: boolean = true) {
 		res.write(`\n--${boundary}`)
 		res.write('\ncontent-type: application/json')
-		res.flush()
-		res.write('\n\n' + JSON.stringify({ ok: true, status: 'ok', message: 'Processing complete' }))
-		res.flush()
+		const json = typeof data === 'string' ? data : JSON.stringify(data || {ok: true, status: 'ok'})
+		res.write('\n\n' + json)
 		res.write(`\n--${boundary}--`)
 		// report amount of time taken to run rust
 		mayLog('rust gdcmaf', Date.now() - t0)
-		res.end()
-	})
-
-	rustStream.on('error', error => {
-		res.write(`\n--${boundary}`)
-		res.write('\ncontent-type: application/json')
-		res.flush()
-		res.write('\n\n' + JSON.stringify({ status: 'error', error }))
-		res.flush()
-		res.write(`\n--${boundary}--`)
-		console.error(error)
-		res.statusCode = 500
-		res.end('Internal Server Error')
-	})
+		if (end) res.end()
+	}
 }
 
 /*


### PR DESCRIPTION
## Description

To test:
- in `rust` dir, `npm run build`
- test rust binary directly with `echo '{"host": "https://api.gdc.cancer.gov/data/","columns": ["Hugo_Symbol", "Entrez_Gene_Id", "Center", "NCBI_Build", "Chromosome", "Start_Position"], "fileIdLst": ["8b31d6d1-56f7-4aa8-b026-c64bafd531e7", "83ea587b-1e92-41b3-a8e3-12df30496724"]}'|./target/release/gdcmaf`
- simulate error in app by uncommenting fake arg (~line 64) in `gdc.mafBuild.ts` , load  http://localhost:3000/example.gdc.maf.html, and click download. 

![Screenshot 2025-03-07 at 10 23 21 PM](https://github.com/user-attachments/assets/0b5ba0e4-4ff2-4f36-8a66-3c06b9518cbb)

![Screenshot 2025-03-07 at 10 25 16 PM](https://github.com/user-attachments/assets/54aa9b46-ffb6-425a-8855-83da075cc0b1)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
