### PR TITLE
Allow sorting for bar plots in table.js

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -302,14 +302,7 @@ export function renderTable({
 			if (header?.allowSort) {
 				//Only create sort button for columns with data
 				//(i.e. not html columns)
-				if (c.sortable) {
-					const callback = (opt: string) => sortTableCallBack(i, rows, opt)
-					const updateTable = (newRows: any) => {
-						rows = newRows
-						updateRows()
-					}
-					createSortButton(th, callback, updateTable)
-				}
+				if (c.sortable) addSort(th, i)
 			}
 			if (header?.style) {
 				for (const k in header.style) th.style(k, header.style[k])
@@ -319,10 +312,20 @@ export function renderTable({
 				th.text('') // quick fix; th.text() has been assigned above in order that sort button can show. here clear the text to render axis svg instead
 				prepareBarPlot(c.barplot, i, rows)
 				drawBarplotAxis(c, th)
+				if (c.sortable) addSort(th, i) //Add the sort after the scale and title is created
 				continue
 			}
 		}
 	}
+	function addSort(th, i) {
+		const callback = (opt: string) => sortTableCallBack(i, rows, opt)
+		const updateTable = (newRows: any) => {
+			rows = newRows
+			updateRows()
+		}
+		createSortButton(th, callback, updateTable)
+	}
+
 	const tbody = table.append('tbody')
 	function updateRows() {
 		tbody.selectAll('tr').remove()

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -760,6 +760,7 @@ function drawBarplotInCell(value: number, td: any, c: Barplot) {
 		.attr('width', 2 * (c.xpadding ?? 0) + (c.axisWidth ?? 0))
 		.attr('height', height)
 		.append('rect')
+		.attr('data-testid', 'sjpp-table-barplot-item')
 		.attr('x', x1)
 		.attr('y', 0)
 		.attr('width', Math.max(1, x2 - x1)) // avoid bar width of fraction of pixel

--- a/client/dom/test/table.unit.spec.js
+++ b/client/dom/test/table.unit.spec.js
@@ -288,16 +288,44 @@ tape('Return correct rows on button click', async test => {
 	test.end()
 })
 
+tape('Bar plot rendering', async test => {
+	test.timeoutAfter(100)
+
+	const holder = getHolder()
+	const testCopy = structuredClone(testOpts)
+	testCopy.div = holder
+	testCopy.columns.push({ label: 'Bar plot', barplot: { colorNegative: 'red', colorPositive: 'green' } })
+	testCopy.rows[0].push({ value: -5 })
+	testCopy.rows[1].push({ value: 5 })
+	testCopy.rows[2].push({ value: 1 })
+	renderTable(testCopy)
+
+	const foundBarplots = holder.selectAll('rect[data-testid="sjpp-table-barplot-item"]').nodes()
+	test.equal(foundBarplots.length, testCopy.rows.length, 'Should display bar plots')
+
+	if (test._ok) holder.remove()
+	test.end()
+})
+
 tape('Sort button', async test => {
 	test.timeoutAfter(100)
 
 	const holder = getHolder()
-	testOpts.div = holder
+	const testCopy = structuredClone(testOpts)
+	testCopy.div = holder
+	testCopy.columns.push({
+		label: 'Bar plot',
+		barplot: { colorNegative: 'red', colorPositive: 'green' },
+		sortable: true
+	})
+	testCopy.rows[0].push({ value: -5 })
+	testCopy.rows[1].push({ value: 5 })
+	testCopy.rows[2].push({ value: 1 })
+	renderTable(testCopy)
 
-	renderTable(testOpts)
 	test.equal(
 		holder.selectAll('.sjpp-table-sort-button').nodes().length,
-		testOpts.columns.length,
+		testCopy.columns.length,
 		'Should display sort buttons'
 	)
 
@@ -320,25 +348,6 @@ tape('fillCell', async test => {
 		const text = 'fillCell called at ' + i
 		test.equal(row[1].__td.node().innerHTML, text, text)
 	}
-
-	if (test._ok) holder.remove()
-	test.end()
-})
-
-tape('Bar plot rendering', async test => {
-	test.timeoutAfter(100)
-
-	const holder = getHolder()
-	const testCopy = structuredClone(testOpts)
-	testCopy.div = holder
-	testCopy.columns.push({ label: 'Bar plot', barplot: { colorNegative: 'red', colorPositive: 'green' } })
-	testCopy.rows[0].push({ value: -5 })
-	testCopy.rows[1].push({ value: 5 })
-	testCopy.rows[2].push({ value: 1 })
-	renderTable(testCopy)
-
-	const foundBarplots = holder.selectAll('rect[data-testid="sjpp-table-barplot-item"]').nodes()
-	test.equal(foundBarplots.length, testCopy.rows.length, 'Should display bar plots')
 
 	if (test._ok) holder.remove()
 	test.end()

--- a/client/dom/test/table.unit.spec.js
+++ b/client/dom/test/table.unit.spec.js
@@ -324,3 +324,22 @@ tape('fillCell', async test => {
 	if (test._ok) holder.remove()
 	test.end()
 })
+
+tape('Bar plot rendering', async test => {
+	test.timeoutAfter(100)
+
+	const holder = getHolder()
+	const testCopy = structuredClone(testOpts)
+	testCopy.div = holder
+	testCopy.columns.push({ label: 'Bar plot', barplot: { colorNegative: 'red', colorPositive: 'green' } })
+	testCopy.rows[0].push({ value: -5 })
+	testCopy.rows[1].push({ value: 5 })
+	testCopy.rows[2].push({ value: 1 })
+	renderTable(testCopy)
+
+	const foundBarplots = holder.selectAll('rect[data-testid="sjpp-table-barplot-item"]').nodes()
+	test.equal(foundBarplots.length, testCopy.rows.length, 'Should display bar plots')
+
+	if (test._ok) holder.remove()
+	test.end()
+})

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+ - Allow sorting on barplot columns in tables. 


### PR DESCRIPTION
## Description
Closes issue #2902. 

Changes: 
1. Added missing test for the bar plot rendering
2. Enabled sorting for bar plots 

Test: 
See updated sorting test in client/dom/test/table.unit.spec.js via http://localhost:3000/testrun.html?dir=dom&name=table.unit

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
