### PR TITLE
Do not show violin plots with a group size <= 5 

### DIFF
--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -688,7 +688,7 @@ tape('term1=categorical, term2=numeric', function (test) {
 		test.end()
 	}
 	async function testViolin(violin, violinDiv) {
-		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 6 })
+		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 2 })
 		test.ok(groups, 'Categorical groups exist')
 	}
 })
@@ -762,11 +762,11 @@ tape('term1=numeric, term2=condition', function (test) {
 		test.end()
 	}
 	async function testConditionTermOrder(violin, violinDiv) {
-		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 8 })
+		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 1 })
 		test.ok(groups, 'Condition groups exist')
 		test.deepEqual(
 			groups.filter((k, i) => i % 2 == 0).map(k => k.__data__.label),
-			violin.Inner.data.plots.filter(plot => plot.plotValueCount > 1).map(k => k.label),
+			violin.Inner.data.plots.filter(plot => plot.plotValueCount > 5).map(k => k.label),
 			'Order of conditional categories in term2 is accurate'
 		)
 	}
@@ -806,7 +806,7 @@ tape('term1=geneExp, term2=categorical', function (test) {
 		test.end()
 	}
 	async function testViolin(violin, violinDiv) {
-		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 6 })
+		const groups = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path', count: 2 })
 		test.ok(groups, 'categorical groups exist')
 	}
 })
@@ -1091,7 +1091,7 @@ tape('term=agedx, term2=geneExp with regular bins', function (test) {
 		 * one violin plot  */
 		test.equal(
 			numViolinPaths.length / 2,
-			violin.Inner.data.plots.length - 1,
+			violin.Inner.data.plots.filter(p => p.plotValueCount > 5).length,
 			'Should render the correct number of plots per the default bins for a gene expression term'
 		)
 

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -4,9 +4,11 @@ import { curveBasis, line } from 'd3-shape'
 import { getColors } from '#shared/common.js'
 import { brushX, brushY } from 'd3-brush'
 import { renderTable, Menu, getMaxLabelWidth, table2col } from '#dom'
-import { rgb, create } from 'd3'
+import { rgb } from 'd3'
 import { format as d3format } from 'd3-format'
 import { TermTypes } from '#shared/terms.js'
+
+const minSampleSize = 5 // a group below cutoff will not render a violin plot
 
 export default function setViolinRenderer(self) {
 	self.render = function () {
@@ -214,8 +216,8 @@ export default function setViolinRenderer(self) {
 
 		const margin = createMargins(labelsize, settings, isH, self.opts.mode == 'minimal')
 		const plotThickness = self.getPlotThicknessWithPadding()
-		const plotsWViolin = self.data.plots.filter(p => p.plotValueCount > 5)
-		const plotsWOutViolin = self.data.plots.filter(p => p.plotValueCount <= 5)
+		const plotsWViolin = self.data.plots.filter(p => p.plotValueCount > minSampleSize)
+		const plotsWOutViolin = self.data.plots.filter(p => p.plotValueCount <= minSampleSize)
 		const width =
 			margin.left +
 			margin.top +
@@ -371,7 +373,7 @@ export default function setViolinRenderer(self) {
 	function renderArea(violinG, plot, areaBuilder) {
 		if (plot.density.densityMax == 0) return
 		//Do not render the violin if there are less than 5 values (only beans)
-		if (plot.plotValueCount <= 5) return
+		if (plot.plotValueCount <= minSampleSize) return
 		violinG
 			.append('path')
 			.attr('class', 'sjpp-vp-path')

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -214,10 +214,16 @@ export default function setViolinRenderer(self) {
 
 		const margin = createMargins(labelsize, settings, isH, self.opts.mode == 'minimal')
 		const plotThickness = self.getPlotThicknessWithPadding()
+		const plotsWViolin = self.data.plots.filter(p => p.plotValueCount > 5)
+		const plotsWOutViolin = self.data.plots.filter(p => p.plotValueCount <= 5)
 		const width =
-			margin.left + margin.top + (isH ? settings.svgw : plotThickness * self.data.plots.length + t1.term.name.length)
+			margin.left +
+			margin.top +
+			(isH ? settings.svgw : plotThickness * plotsWViolin.length + plotsWOutViolin.length * 30 + t1.term.name.length)
 		const height =
-			margin.bottom + margin.top + (isH ? plotThickness * self.data.plots.length : settings.svgw + t1.term.name.length)
+			margin.bottom +
+			margin.top +
+			(isH ? plotThickness * plotsWViolin.length + plotsWOutViolin.length * 30 : settings.svgw + t1.term.name.length)
 
 		violinSvg
 			.attr('width', width)
@@ -364,6 +370,8 @@ export default function setViolinRenderer(self) {
 
 	function renderArea(violinG, plot, areaBuilder) {
 		if (plot.density.densityMax == 0) return
+		//Do not render the violin if there are less than 5 values (only beans)
+		if (plot.plotValueCount <= 5) return
 		violinG
 			.append('path')
 			.attr('class', 'sjpp-vp-path')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes 
+- Do not render a violin for plots with less than or equal to five samples. 

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -5,6 +5,8 @@ import { boxplot_getvalue } from '../src/utils.js'
 import { sortKey2values } from './termdb.violin.ts'
 import { roundValueAuto } from '#shared/roundValue.js'
 
+const minSampleSize = 5 // a group below cutoff will not compute boxplot
+
 export const api: RouteApi = {
 	endpoint: 'termdb/boxplot',
 	methods: {
@@ -131,7 +133,7 @@ function setHiddenPlots(term: any, plots: any) {
 
 function setDescrStats(boxplot: BoxPlotData, sortedValues: number[]) {
 	/** Return the total value for legend rendering */
-	if (sortedValues.length < 5) return [{ id: 'total', label: 'Total', value: sortedValues.length }]
+	if (sortedValues.length < minSampleSize) return [{ id: 'total', label: 'Total', value: sortedValues.length }]
 	//boxplot_getvalue() already returns calculated stats
 	//Format data rather than recalculate
 	const mean = sortedValues.reduce((s, i) => s + i, 0) / sortedValues.length

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -250,7 +250,7 @@ function createCanvasImg(q: ViolinRequest, result: { [index: string]: any }, ds:
 		ctx.globalAlpha = 0.5
 		// No violin is rendered when the values is less than 5
 		//Render in black so the user can see the data
-		ctx.fillStyle = plot.values.length < 5 ? 'black' : '#ffe6e6'
+		ctx.fillStyle = plot.values.length <= 5 ? 'black' : '#ffe6e6'
 
 		//scaling for sharper image
 		if (q.devicePixelRatio != 1) {

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -10,6 +10,8 @@ import { isNumericTerm } from '#shared/terms.js'
 import { getBinsDensity } from '#shared/violin.bins.js'
 import { numericBins, parseValues } from './termdb.boxplot.ts'
 
+const minSampleSize = 5 // a group below cutoff will not compute violin
+
 export const api: RouteApi = {
 	endpoint: 'termdb/violin',
 	methods: {
@@ -248,9 +250,9 @@ function createCanvasImg(q: ViolinRequest, result: { [index: string]: any }, ds:
 		ctx.strokeStyle = 'rgba(0,0,0,0.8)'
 		ctx.lineWidth = q.strokeWidth / q.devicePixelRatio
 		ctx.globalAlpha = 0.5
-		// No violin is rendered when the values is less than 5
+		// No violin is rendered when the values is less than cutoff
 		//Render in black so the user can see the data
-		ctx.fillStyle = plot.values.length <= 5 ? 'black' : '#ffe6e6'
+		ctx.fillStyle = plot.values.length <= minSampleSize ? 'black' : '#ffe6e6'
 
 		//scaling for sharper image
 		if (q.devicePixelRatio != 1) {

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -248,7 +248,9 @@ function createCanvasImg(q: ViolinRequest, result: { [index: string]: any }, ds:
 		ctx.strokeStyle = 'rgba(0,0,0,0.8)'
 		ctx.lineWidth = q.strokeWidth / q.devicePixelRatio
 		ctx.globalAlpha = 0.5
-		ctx.fillStyle = '#ffe6e6'
+		// No violin is rendered when the values is less than 5
+		//Render in black so the user can see the data
+		ctx.fillStyle = plot.values.length < 5 ? 'black' : '#ffe6e6'
 
 		//scaling for sharper image
 		if (q.devicePixelRatio != 1) {


### PR DESCRIPTION
## Description
Closes issue #2618.

The violin is not created for plots with a group/sample size <= 5. 

Current presentation: 
<img width="741" alt="Screenshot 2025-03-07 at 12 03 28 PM" src="https://github.com/user-attachments/assets/b4dea834-2639-417c-a7cc-e7e5c1e5dc4c" />

Proposed changes: 
<img width="753" alt="Screenshot 2025-03-07 at 12 02 22 PM" src="https://github.com/user-attachments/assets/4de804c6-f85b-4930-8a5a-eb8439e9b1ba" />

Test with [TermdbTest violin example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22,%22name%22:%22TP53%22%7D,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D,%22term2%22:%7B%22id%22:%22diaggrp%22%7D%7D%5D%7D)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
