### PR TITLE
bug fix for optional function

### DIFF
--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -146,7 +146,7 @@ export class Vocab {
 	async trackDsAction({ action, details }) {
 		const headers = { 'x-sjppds-sessionid': this.sessionId }
 		// NOTE: do not hardcode the .termdb route here, there may be more tracked actions later
-		const jwt = this.opts.getDatasetAccessToken('termdb')
+		const jwt = this.opts.getDatasetAccessToken?.('termdb')
 		if (jwt) headers.authorization = 'Bearer ' + btoa(jwt)
 		await dofetch3('/authorizedActions', {
 			method: 'POST',


### PR DESCRIPTION
## Description

closes #2928 
test at http://localhost:3000/?massnative=hg38-test,TermdbTest
at data download, add tp53 gene exp and can download

tested to work with auth (password and jwt)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
