### PR TITLE
fix: mds3 tk populate legend with predefined shapes

### DIFF
--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -98,6 +98,7 @@ function create_mclass(tk, block) {
 function may_create_variantShapeName(tk) {
 	if (!tk.legend.customShapeLabels || !tk.custom_variants) return
 	if (!tk.legend.variantShapeName) tk.legend.variantShapeName = []
+
 	for (const data of tk.custom_variants) {
 		if (!data.shape) data.shape = 'filledCircle' //Quick fix since legend renders simultaneously with skewers
 		const shapeObj = tk.legend.variantShapeName.find(v => v.key == data.shape)
@@ -109,6 +110,19 @@ function may_create_variantShapeName(tk) {
 			})
 		} else {
 			shapeObj.num = ++shapeObj.num
+		}
+	}
+
+	// custom_variants[] initial items may have limited set of shapes; later the items maybe dynamically reassigned with additional shape not found in variantShapeName[] that will break code; since all shapes should be declared in customShapeLabels{}, populate them into variantShapeName[] to avoid this issue
+	if (tk.legend.customShapeLabels) {
+		for (const shape in tk.legend.customShapeLabels) {
+			if (!tk.legend.variantShapeName.find(i => i.key == shape)) {
+				tk.legend.variantShapeName.push({
+					key: shape,
+					origShape: shape,
+					num: 0
+				})
+			}
 		}
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- mds3 tk populate legend with predefined shapes


### PR DESCRIPTION
## Description
closes #2524 
[test link](http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22LV_Ejection_Fraction_3D_s%22},%22independent%22:[{%22term%22:{%22type%22:%22snplocus%22},%22q%22:{%22chr%22:%22chr17%22,%22start%22:7666956,%22stop%22:7667034,%22AFcutoff%22:5,%22alleleType%22:0,%22geneticModel%22:0,%22restrictAncestry%22:{%22name%22:%22European%20ancestry%22,%22tvs%22:{%22term%22:{%22id%22:%22genetic_race_s%22,%22type%22:%22categorical%22,%22name%22:%22Genetically%20defined%20race%22},%22values%22:[{%22key%22:%22European%20Ancestry%22,%22label%22:%22European%20Ancestry%22}]}},%22variant_filter%22:{%22type%22:%22tvslst%22,%22join%22:%22and%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22Bad%22,%22key%22:%22Bad%22}],%22term%22:{%22id%22:%22QC%22,%22name%22:%22Classification%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22,%22values%22:{%22Good%22:{%22label%22:%22Good%22,%22key%22:%22Good%22},%22Bad%22:{%22label%22:%22Bad%22,%22key%22:%22Bad%22}}}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22SJcontrol_CR%22,%22name%22:%22SJLIFE%20control%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR%22,%22name%22:%22Call%20rate,%20SJLIFE+CCSS%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_sjlife%22,%22name%22:%22SJLIFE%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_ccss%22,%22name%22:%22CCSS%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22yes%22,%22key%22:%221%22}],%22term%22:{%22id%22:%22Polymer_region%22,%22name%22:%22Polymer%20region%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22}}}]}}}]}]}) zoom out 10x to show more shapes and works
all mds3 tests pass


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
