### PR TITLE
Cherry picked maf fixes 1

### DIFF
--- a/client/src/notify.ts
+++ b/client/src/notify.ts
@@ -306,15 +306,17 @@ function handleMessageData(_data, opts = {} as any) {
 		if (refresh.mode == 'none') {
 			// console.log(`skipped refresh in sessionRefresh.mode='none'`)
 		} else if (refresh.mode == 'appOnly') {
+			console.clear()
 			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)
 			// debounce
 			refresh.pendingCall = setTimeout(refresh.callback, 500)
 		} else if (refresh.mode == 'full') {
-			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)
+			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)//
 			// debounce
 			refresh.pendingCall = setTimeout(() => window.location.reload(), 500)
 		} else if (!refresh.modeOptions[refresh.mode]) {
 			console.warn(`invalid value ${refresh.key}='${refresh.mode}', triggering refresh instead`)
+			console.clear()
 			//refresh.callback()
 			if (refresh.pendingCall) clearTimeout(refresh.pendingCall)
 			// debounce

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,4 @@
-
+Fixes:
+- handle stderr from rust code in node js stream_rust() helper and route handler
+- improve gdc maf rendering of failed/empty files to inform user about aggregation result
+- cherry-pick fixes from master to handle stderr from rust code, node js stream_rust() helper and route handler

--- a/rust/src/gdcmaf.rs
+++ b/rust/src/gdcmaf.rs
@@ -13,17 +13,25 @@
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use serde_json::Value;
+use serde_json::{Value,json};
 use std::path::Path;
 use futures::StreamExt;
 use std::io::{self,Read,Write};
+use std::sync::Mutex;
 
 
+// Struct to hold error information
+#[derive(serde::Serialize)]
+struct ErrorEntry {
+    url: String,
+    error: String,
+}
 
-fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
+fn select_maf_col(d:String,columns:&Vec<String>,url:&str,errors: &Mutex<Vec<ErrorEntry>>) -> (Vec<u8>,i32) {
     let mut maf_str: String = String::new();
     let mut header_indices: Vec<usize> = Vec::new();
     let lines = d.trim_end().split("\n");
+    let mut mafrows = 0;
     for line in lines {
         if line.starts_with("#") {
             continue
@@ -33,6 +41,11 @@ fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
                 if let Some(index) = header.iter().position(|x| x == col) {
                     header_indices.push(index);
                 } else {
+                    let error_msg = format!("Column {} was not found", col);
+                    errors.lock().unwrap().push(ErrorEntry {
+                        url: url.to_string().clone(),
+                        error: error_msg.clone(),
+                    });
                     panic!("{} was not found!",col);
                 }
             }
@@ -44,14 +57,17 @@ fn select_maf_col(d:String,columns:&Vec<String>) -> Vec<u8> {
             };
             maf_str.push_str(maf_out_lst.join("\t").as_str());
             maf_str.push_str("\n");
+            mafrows += 1;
         }
     };
-    maf_str.as_bytes().to_vec()
+    (maf_str.as_bytes().to_vec(),mafrows)
 }
 
 
 #[tokio::main]
 async fn main() -> Result<(),Box<dyn std::error::Error>> {
+    // Create a thread-container for errors
+    let errors = Mutex::new(Vec::<ErrorEntry>::new());
     // Accepting the piped input json from jodejs and assign to the variable
     // host: GDC host
     // url: urls to download single maf files
@@ -75,9 +91,17 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
                 .map(|v| v.to_string().replace("\"",""))
                 .collect::<Vec<String>>();
         } else {
+            errors.lock().unwrap().push(ErrorEntry {
+                url: String::new(),
+                error: "The columns of arg is not an array".to_string(),
+            });
             panic!("Columns is not an array");
         }
     } else {
+        errors.lock().unwrap().push(ErrorEntry {
+            url: String::new(),
+            error: "The key columns is missed from arg".to_string(),
+        });
         panic!("Columns was not selected");
     };
     
@@ -85,39 +109,89 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
     let download_futures = futures::stream::iter(
         url.into_iter().map(|url|{
             async move {
-                let result = reqwest::get(&url).await;
-                if let Ok(resp) = result {
-                    let content = resp.bytes().await.unwrap();
-                    let mut decoder = GzDecoder::new(&content[..]);
-                    let mut decompressed_content = Vec::new();
-                    let read_content = decoder.read_to_end(&mut decompressed_content);
-                    if let Ok(_) = read_content {
-                        let text = String::from_utf8_lossy(&decompressed_content).to_string();
-                        text
-                    } else {
-                        let error_msg = "Failed to read content downloaded from: ".to_string() + &url;
-                        error_msg
+                match reqwest::get(&url).await {
+                    Ok(resp) if resp.status().is_success() => {
+                        match resp.bytes().await {
+                            Ok(content) => {
+                                let mut decoder = GzDecoder::new(&content[..]);
+                                let mut decompressed_content = Vec::new();
+                                match decoder.read_to_end(&mut decompressed_content) {
+                                    Ok(_) => {
+                                        let text = String::from_utf8_lossy(&decompressed_content).to_string();
+                                        return Ok((url.clone(),text))
+                                    }
+                                    Err(e) => {
+                                        let error_msg = format!("Decompression failed: {}", e);
+                                        Err((url.clone(), error_msg))
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                let error_msg = format!("Decompression failed: {}", e);
+                                Err((url.clone(), error_msg))
+                            }
+                        }
                     }
-                } else {
-                    let error_msg = "Failed to download: ".to_string() + &url;
-                    error_msg
+                    Ok(resp) => {
+                        let error_msg = format!("HTTP error: {}", resp.status());
+                        Err((url.clone(), error_msg))
+                    }
+                    Err(e) => {
+                        let error_msg = format!("Server request failed: {}", e);
+                        Err((url.clone(), error_msg))
+                    }
                 }
             }
         })
     );
 
-    // output
+    // binary output
     let mut encoder = GzEncoder::new(io::stdout(), Compression::default());
     let _ = encoder.write_all(&maf_col.join("\t").as_bytes().to_vec()).expect("Failed to write header");
     let _ = encoder.write_all(b"\n").expect("Failed to write newline");
-    download_futures.buffer_unordered(20).for_each(|item| {
-        if item.starts_with("Failed") {
-            eprintln!("{}",item);
-        } else {
-            let maf_bit = select_maf_col(item,&maf_col);
-            let _ = encoder.write_all(&maf_bit).expect("Failed to write file");
-        };
-        async {}
-    }).await;
+
+    // Collect all results before processing
+    let results = download_futures.buffer_unordered(50).collect::<Vec<_>>().await;
+
+    // Process results after all downloads are complete
+    for result in results {
+        match result {
+            Ok((url, content)) => {
+                let (maf_bit,mafrows) = select_maf_col(content, &maf_col, &url, &errors);
+                if mafrows > 0 {
+                    let _  = encoder.write_all(&maf_bit).expect("Failed to write file");
+                } else {
+                    errors.lock().unwrap().push(ErrorEntry {
+                        url: url.clone(),
+                        error: "Empty maf file".to_string(),
+                    });
+                }
+            }
+            Err((url, error)) => {
+                errors.lock().unwrap().push(ErrorEntry {
+                    url,
+                    error,
+                })
+            }
+        }
+    };
+
+    // Finalize output and printing errors
+    encoder.finish().expect("Maf file output error!");
+
+    // Manually flush stdout
+    io::stdout().flush().expect("Failed to flush stdout");
+    
+    // After processing all downloads, output the errors as JSON to stderr
+    let errors = errors.lock().unwrap();
+    if !errors.is_empty() {
+        let error_json = json!({
+            "errors": errors.iter().collect::<Vec<&ErrorEntry>>()
+        });
+        let mut stderr = io::stderr();
+        writeln!(stderr, "{}", error_json).expect("Failed to output stderr!");
+        io::stderr().flush().expect("Failed to flush stderr");
+    };
+
     Ok(())
 }

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -1,6 +1,6 @@
 import ky from 'ky'
 import { joinUrl } from '#shared/joinUrl.js'
-import { run_rust_stream } from '@sjcrh/proteinpaint-rust'
+import { stream_rust } from '@sjcrh/proteinpaint-rust'
 import type { GdcMafBuildRequest, RouteApi } from '#types'
 import { gdcMafPayload } from '#types/checkers'
 import { maxTotalSizeCompressed } from './gdc.maf.ts'
@@ -36,6 +36,14 @@ function init({ genomes }) {
 	}
 }
 
+type EmitJsonDataArg = string | {
+	status?: 'string'
+	ok?: boolean
+	error?: string
+	errors?: any[] 
+	message?: string
+}
+
 /*
 q{}
 res{}
@@ -52,23 +60,29 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		columns: q.columns,
 		host: joinUrl(host.rest, 'data') // must use the /data/ endpoint from current host
 	}
+	// uncomment for manual error testing
+	// const arg = {"host": "https://api.gdc.cancer.gov/data/","columns": ["Hugo_Symbol", "Entrez_Gene_Id", "Center", "NCBI_Build", "Chromosome", "Start_Position"], "fileIdLst": ["8b31d6d1-56f7-4aa8-b026-c64bafd531e7", "83ea587b-1e92-41b3-a8e3-12df30496724"]}; 
 
-	const rustStream = run_rust_stream('gdcmaf', JSON.stringify(arg))
-	res.setHeader('Content-Type', 'application/octet-stream')
-	res.setHeader('Content-Disposition', 'attachment; filename=cohort.maf.gz')
-	rustStream.pipe(res)
+	const boundary = 'GDC_MAF_MULTIPART_BOUNDARY'
+	res.setHeader('content-type', `multipart/mixed; boundary=${boundary}`)
+	res.write(`--${boundary}`)
+	res.write('\ncontent-disposition: attachment; filename=cohort.maf.gz')
+	res.write('\ncontent-type: application/octet-stream\n\n')
+	res.flush() // header text should be sent as a separate chunk from the content that will be streamed next
 
-	rustStream.on('end', () => {
+	const rustStream = stream_rust('gdcmaf', JSON.stringify(arg), emitJson)
+	rustStream.pipe(res, { end: false })
+
+	function emitJson(data?: EmitJsonDataArg, end: boolean = true) {
+		res.write(`\n--${boundary}`)
+		res.write('\ncontent-type: application/json')
+		const json = typeof data === 'string' ? data : JSON.stringify(data || {ok: true, status: 'ok'})
+		res.write('\n\n' + json)
+		res.write(`\n--${boundary}--`)
 		// report amount of time taken to run rust
 		mayLog('rust gdcmaf', Date.now() - t0)
-		res.end()
-	})
-
-	rustStream.on('error', err => {
-		console.error(err)
-		res.statusCode = 500
-		res.end('Internal Server Error')
-	})
+		if (end) res.end()
+	}
 }
 
 /*


### PR DESCRIPTION
## Description

These are cherry picked fixes from closed PR branches in master:
- [handle stderr from rust code](https://github.com/stjude/proteinpaint/pull/2924)
- [improve rendering of failed and empty maf files](https://github.com/stjude/proteinpaint/pull/2934) to inform user about aggregation result

To test:
- `npm run reset` from sjpp master
- `npm ci` from proteinpaint dir, to get rid of minimatch import errors
- test downloads in http://localhost:3000/example.gdc.maf.html or similar url

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
