### PR TITLE
on api failure, GDC cache init will retry (Jira sv 2590)

### DIFF
--- a/server/src/initGdc.cache.js
+++ b/server/src/initGdc.cache.js
@@ -306,7 +306,8 @@ function getCacheRef(ds) {
 		casesWithExpData: new Set(),
 		gdcOpenProjects: new Set(), // names of open-access projects
 		scrnaAnalysis2hdf5: new Map(), // for scrna, k: seurat.analysis.tsv uuid, v: hdf5/loom uuid. maps a analysis tvs file to loom file, latter is required for querying scrna gene exp data
-		doneCaching: false
+		doneCaching: false,
+		cacheTimes: {}
 	}
 
 	return ref
@@ -374,7 +375,7 @@ async function cacheMappingOnNewRelease(ds) {
 		ds.__pendingCacheVersion = version
 		ref.data_release_version = version
 		const date = new Date()
-		ds.__gdc.cacheTimes = {start: {unixTime: Date.now(), local: date.toLocaleDateString() + ' ' + date.toLocaleTimeString()}}
+		ds.__gdc.cacheTimes.start = {unixTime: Date.now(), local: date.toLocaleDateString() + ' ' + date.toLocaleTimeString()}
 		await getOpenProjects(ds, ref)
 		const size = 1000 // fetch 1000 ids at a time
 		const totalCases = await fetchIdsFromGdcApi(ds, 1, 0, ref)


### PR DESCRIPTION
## Description

This fix will force the initial GDC caching to be retried, regardless of error being fatal or recoerable.

To test, need a way to simulate the case where GDC API is not ready yet when the PP server starts up. Suggested temp changes to simulate
- add `let numTries = 0` in line 10
- change to `joinUrl(host.rest, numTries < 3 ? '--files' : 'files'); numTries++` in line 141
- change to `5000` in line 108, so `cacheCheckWait` doesn't too long to observer caching retry loop
- save and when the pp server restarts, there should be two times when `"force retries of cacheMappingOnNewRelease()"` will be logged, then `GDC: cache is stale. Re-caching... 0` to proceed to the normal caching.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
