### PR TITLE
stream errors in rust maf as they occur, and handle as array in nodejs

### DIFF
--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -448,7 +448,7 @@ async function getFilesAndShowTable(obj) {
 			if (e.error.startsWith('Empty')) {
 				if (!e.url) throw 'url missing from an "Empty" entry'
 				emptyFiles.push(e.url)
-			} else if (e.error.startsWith('Server request failed')) {
+			} else if (e.error.startsWith('Server request failed') || e.error.includes('404 Not Found')) {
 				if (!e.url) throw 'url missing from a "failed" entry'
 				failedFiles.push(e.url)
 			} else {

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -354,12 +354,12 @@ async function getFilesAndShowTable(obj) {
 				: `Download ${fileSize(result.maxTotalSizeCompressed)} compressed MAF data (${fileSize(sum)} selected)`
 	}
 
-	/* after table is created, on clicking download btn for first time, create two <span> after download btn,
-	in order to show server-sent download status
-	scope them for easy access by helpers,
-	detect if these placeholders are truthy so as to only create them once
+	/* after table is created, on clicking download btn for first time, create a <span> after download btn,
+	in order to show server-sent message on problematic files (emtpy, failed, invalid)
+	scope this <span> for easy access by helpers,
+	detect if it is truthy to only create it once
 	*/
-	let serverMessage1, serverMessage2
+	let serverMessage
 
 	async function submitSelectedFiles(lst, button) {
 		const outColumns = mafColumns.filter(i => i.selected).map(i => i.column)
@@ -379,8 +379,7 @@ async function getFilesAndShowTable(obj) {
 		const oldText = button.innerHTML
 		button.innerHTML = 'Loading... Please wait'
 		button.disabled = true
-		serverMessage1.style('display', 'none')
-		serverMessage2.style('display', 'none')
+		serverMessage.style('display', 'none')
 
 		// may disable the "Aggregate" button here and re-enable later
 
@@ -429,65 +428,44 @@ async function getFilesAndShowTable(obj) {
 	}
 
 	function mayCreateServerMessageSpan(button) {
-		if (serverMessage1) return // message <span> are already created
+		if (serverMessage) return // message <span> are already created
 		const holder = select(button.parentElement)
-		serverMessage1 = holder.append('span').attr('class', 'sja_clbtext').style('display', 'none')
-		serverMessage2 = holder
-			.append('span')
-			.attr('class', 'sja_clbtext')
-			.style('margin-left', '10px')
-			.style('display', 'none')
+		serverMessage = holder.append('span').attr('class', 'sja_clbtext').style('display', 'none')
 	}
 
 	function displayRunStatusErrors(errors) {
 		// errors[] each ele: {error:str, url:str}
-		const emptyFiles = [],
-			failedFiles = []
+		const rows = [] // map errors[] to rows[] to show in table of menu
 		for (const e of errors) {
 			if (typeof e.error != 'string') throw '.error=string missing from an entry'
-			if (e.error.startsWith('Empty')) {
-				if (!e.url) throw 'url missing from an "Empty" entry'
-				emptyFiles.push(e.url)
-			} else if (e.error.startsWith('Server request failed') || e.error.includes('404 Not Found')) {
-				if (!e.url) throw 'url missing from a "failed" entry'
-				failedFiles.push(e.url)
+			if (typeof e.url != 'string') throw '.url=string missing from an entry'
+			// url should end in file uuid, which can be used to match with original record of that file
+			const l = e.url.split('/')
+			const uuid = l[l.length - 1]
+			const fo = result.files.find(i => i.id == uuid)
+			if (fo) {
+				// record is found for this failed uuid
+				rows.push([
+					{ html: `<a href=${e.url} target=_blank>${fo.case_submitter_id}</a>` },
+					{ value: fo.project_id },
+					{ value: fileSize(fo.file_size) },
+					{ value: e.error }
+				])
 			} else {
-				throw 'unknown error msg from an entry'
+				// file is not found; could happen in testing when backend hardcodes a uuid not in result.files[], or even gdc backend changes..
+				rows.push([{ value: uuid }, { value: '?' }, { value: '?' }, { value: e.error }])
 			}
 		}
-		if (emptyFiles.length) {
-			serverMessage1
-				.text(`${emptyFiles.length} empty file${emptyFiles.length > 1 ? 's' : ''}`)
-				.style('display', '')
-				.on('click', event => listFilesInMenu(emptyFiles, event.target))
-		}
-		if (failedFiles.length) {
-			serverMessage2
-				.text(`${failedFiles.length} file${failedFiles.length > 1 ? 's' : ''} failed download`)
-				.style('display', '')
-				.on('click', event => listFilesInMenu(failedFiles, event.target))
-		}
-	}
-	function listFilesInMenu(lst, div) {
-		// lst[] is array of file url, ends with file uuid
-		renderTable({
-			rows: lst.map(url => {
-				const l = url.split('/')
-				const uuid = l[l.length - 1]
-				const fo = result.files.find(i => i.id == uuid)
-				if (fo) {
-					return [
-						{ html: `<a href=${url} target=_blank>${fo.case_submitter_id}</a>` },
-						{ value: fo.project_id },
-						{ value: fileSize(fo.file_size) }
-					]
-				}
-				// file is not found; could happen in testing when backend hardcodes a uuid not in result.files[]
-				return [{ value: uuid }, { value: '?' }, { value: '?' }]
-			}),
-			columns: [{ column: '' }, { column: '' }, { column: '' }],
-			showHeader: false,
-			div: tip.clear().showunder(div).d
-		})
+		serverMessage
+			.text(`${errors.length} empty/failed file${errors.length > 1 ? 's' : ''}`)
+			.style('display', '')
+			.on('click', event => {
+				renderTable({
+					rows,
+					columns: [{ column: '' }, { column: '' }, { column: '' }, { column: '' }],
+					showHeader: false,
+					div: tip.clear().showunder(event.target).d
+				})
+			})
 	}
 }

--- a/rust/index.js
+++ b/rust/index.js
@@ -72,17 +72,18 @@ exports.stream_rust = function (binfile, input_data, emitJson) {
 	ps.on('close', code => { //console.log(72, stderr.length)
 		if (stderr.length) {
 			// handle rust stderr
-			const err = stderr.join('').trim()
-			const errmsg = `!!! stream_rust('${binfile}') stderr: !!!\n${err}`
+			const errors = stderr.join('').trim().split('\n').map(JSON.parse); console.log(75, errors)
+			const errmsg = `!!! stream_rust('${binfile}') stderr: !!!\n${errors}`
 			console.log(errmsg)
-			emitJson(err)
+			emitJson({errors})
 		} else {
 			emitJson({ ok: true, status: 'ok', message: 'Processing complete' })
 		}
 	})
 	ps.on('error', err => {
 		console.log(74, `stream_rust().on('error')`, err)
-		emitJson(stderr.join('').trim())
+		const errors = stderr.join('').trim().split('\n').map(JSON.parse)
+		emitJson({errors})
 	})
 	// below will duplicate ps.on('close') event above
 	// childStream.on('end', () => console.log(`-- childStream done --`))

--- a/rust/index.js
+++ b/rust/index.js
@@ -72,16 +72,16 @@ exports.stream_rust = function (binfile, input_data, emitJson) {
 	ps.on('close', code => { //console.log(72, stderr.length)
 		if (stderr.length) {
 			// handle rust stderr
-			const errors = stderr.join('').trim().split('\n').map(JSON.parse); console.log(75, errors)
-			const errmsg = `!!! stream_rust('${binfile}') stderr: !!!\n${errors}`
-			console.log(errmsg)
+			const errors = stderr.join('').trim().split('\n').map(JSON.parse)
+			//const errmsg = `!!! stream_rust('${binfile}') stderr: !!!`
+			//console.log(errmsg, errors)
 			emitJson({errors})
 		} else {
 			emitJson({ ok: true, status: 'ok', message: 'Processing complete' })
 		}
 	})
 	ps.on('error', err => {
-		console.log(74, `stream_rust().on('error')`, err)
+		//console.log(74, `stream_rust().on('error')`, err)
 		const errors = stderr.join('').trim().split('\n').map(JSON.parse)
 		emitJson({errors})
 	})


### PR DESCRIPTION
## Description

Stream errors in rust maf as they occur, and handle as array in nodejs. In master branch, the rust code collects the `stderr` and only emits at the end. It may be better for nodejs to capture the rust errors as they occur, so errors are now emitted by rust as they occur and nodejs can process as needed even if rust process stops abruptly.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
