### PR TITLE
Vioin r speedup

### DIFF
--- a/client/dom/violinRenderer.js
+++ b/client/dom/violinRenderer.js
@@ -15,7 +15,7 @@ export class violinRenderer {
 			.append('svg')
 			.attr('width', `${width + 50}px`)
 			.attr('height', `${height + 50}px`)
-		this.axisScale = scaleLinear().domain([plot.xMin, plot.xMax]).range([0, width])
+		this.axisScale = scaleLinear().domain([plot.minvalue, plot.maxvalue]).range([0, width])
 		this.axisScaleUI = scaleLinear()
 			.domain([plot.minvalue * scaleFactor, plot.maxvalue * scaleFactor])
 			.range([0, width])

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -233,8 +233,6 @@ export function convertViolinData(vd) {
 		densityMax: p.density.densityMax,
 		densityMin: p.density.densityMin,
 		density: p.density.bins,
-		xMin: p.density.xMin, //R xMin and xMax are not the same as minvalue and maxvalue
-		xMax: p.density.xMax,
 		valuesImg: p.src
 	}
 	return dd

--- a/client/mass/test/summary.integration.spec.js
+++ b/client/mass/test/summary.integration.spec.js
@@ -179,7 +179,7 @@ tape('Barchart tab only, term: "diaggrp"', test => {
 })
 
 tape('Barchart & violin toggles, term: "diaggrp", term2: "agedx"', test => {
-	test.timeoutAfter(5000)
+	test.timeoutAfter(3000)
 
 	runpp({
 		state: {
@@ -243,7 +243,7 @@ tape('Barchart & violin toggles, term: "diaggrp", term2: "agedx"', test => {
 })
 
 tape('Barchart & violin toggles, term: "agedx", term2: "diaggrp"', test => {
-	test.timeoutAfter(5000)
+	test.timeoutAfter(3000)
 
 	runpp({
 		state: {
@@ -321,7 +321,7 @@ tape('Barchart & violin toggles, term: "agedx", term2: "diaggrp"', test => {
 })
 
 tape('Barchart, violin, and scatter toggles, term: "agedx", term2: "hrtavg"', test => {
-	test.timeoutAfter(4000)
+	test.timeoutAfter(3000)
 
 	runpp({
 		state: {

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -194,7 +194,7 @@ tape('render violin plot', function (test) {
 })
 
 tape('term1 as numeric and term2 categorical, test median rendering', function (test) {
-	test.timeoutAfter(4000)
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			nav: {
@@ -250,7 +250,7 @@ tape('term1 as numeric and term2 categorical, test median rendering', function (
 })
 
 tape('test basic controls', function (test) {
-	test.timeoutAfter(6000)
+	test.timeoutAfter(4000)
 	runpp({
 		state: {
 			nav: {
@@ -512,7 +512,7 @@ tape('test label clicking, filtering and hovering', function (test) {
 })
 
 tape('test hide option on label clicking', function (test) {
-	test.timeoutAfter(4000)
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			nav: {
@@ -583,7 +583,7 @@ tape('test hide option on label clicking', function (test) {
 })
 
 tape('term1 as numeric and term2 numeric, change median size', function (test) {
-	test.timeoutAfter(5000)
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			nav: {
@@ -657,7 +657,7 @@ tape('term1 as numeric and term2 numeric, change median size', function (test) {
 })
 
 tape('term1=categorical, term2=numeric', function (test) {
-	test.timeoutAfter(6000)
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			plots: [
@@ -694,7 +694,7 @@ tape('term1=categorical, term2=numeric', function (test) {
 })
 
 tape.skip('term1=numeric, term2=survival', function (test) {
-	test.timeoutAfter(4000)
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			plots: [
@@ -730,7 +730,7 @@ tape.skip('term1=numeric, term2=survival', function (test) {
 })
 
 tape('term1=numeric, term2=condition', function (test) {
-	test.timeoutAfter(4000)
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			nav: { header_mode: 'hide_search' },
@@ -773,7 +773,7 @@ tape('term1=numeric, term2=condition', function (test) {
 })
 
 tape('term1=geneExp, term2=categorical', function (test) {
-	test.timeoutAfter(5000)
+	test.timeoutAfter(2000)
 	runpp({
 		state: {
 			nav: {
@@ -813,7 +813,7 @@ tape('term1=geneExp, term2=categorical', function (test) {
 
 // TODO FIX
 tape.skip('term1=geneExp, term2=survival', function (test) {
-	test.timeoutAfter(2000)
+	test.timeoutAfter(1000)
 	runpp({
 		state: {
 			nav: {
@@ -1046,7 +1046,7 @@ tape('test samplelst term2', function (test) {
 })
 
 tape('term=agedx, term2=geneExp with regular bins', function (test) {
-	test.timeoutAfter(6000)
+	test.timeoutAfter(4000)
 	runpp({
 		state: {
 			nav: {
@@ -1103,7 +1103,7 @@ tape('term=agedx, term2=geneExp with regular bins', function (test) {
 })
 
 tape('term=agedx, term2=geneExp with custom bins', function (test) {
-	test.timeoutAfter(3000)
+	test.timeoutAfter(2000)
 	runpp({
 		state: {
 			nav: {
@@ -1173,7 +1173,7 @@ tape('term=agedx, term2=geneExp with custom bins', function (test) {
 })
 
 tape('test uncomputable categories legend', function (test) {
-	test.timeoutAfter(4000)
+	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			nav: {
@@ -1237,7 +1237,7 @@ tape('test uncomputable categories legend', function (test) {
 })
 
 tape('Load linear regression-violin UI', function (test) {
-	test.timeoutAfter(2000)
+	test.timeoutAfter(1000)
 	runpp({
 		state: {
 			nav: {
@@ -1281,7 +1281,7 @@ tape('Load linear regression-violin UI', function (test) {
 })
 
 tape('test change in plot length and thickness for custom group variable', function (test) {
-	test.timeoutAfter(6000)
+	test.timeoutAfter(5000)
 	runpp({
 		state: {
 			nav: {

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -524,7 +524,7 @@ tape('Incorrect dslabel', test => {
 })
 
 tape('Custom ssm only, no sample', test => {
-	test.timeoutAfter(3000)
+	test.timeoutAfter(2000)
 	const holder = getHolder()
 
 	const gene = 'TP53',
@@ -604,7 +604,7 @@ tape('Custom ssm only, no sample', test => {
 })
 
 tape('Custom variants, missing or invalid mclass', test => {
-	test.timeoutAfter(4000)
+	test.timeoutAfter(3000)
 	const holder = getHolder()
 
 	const custom_variants = [

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -310,10 +310,10 @@ export default function setViolinRenderer(self) {
 		renderArea(violinG, plot, isH ? areaBuilder.y(d => -wScale(d.density)) : areaBuilder.x(d => -wScale(d.density)))
 
 		renderSymbolImage(self, violinG, plot, isH, imageOffset)
-		if (self.opts.mode != 'minimal') renderMedian(violinG, isH, plot, xScale, self)
+		if (self.opts.mode != 'minimal') renderMedian(violinG, isH, plot, svgData, self)
 		renderLines(violinG, isH, self.config.settings.violin.lines, svgData)
-		if (self.state.config.value) {
-			const value = xScale(self.state.config.value)
+		if ('value' in self.state.config) {
+			const value = svgData.axisScale(self.state.config.value)
 			const s = self.config.settings.violin
 			violinG
 				.append('line')
@@ -394,7 +394,7 @@ export default function setViolinRenderer(self) {
 			.attr('transform', isH ? `translate(0, -${imageOffset})` : `translate(-${imageOffset}, 0)`)
 	}
 
-	function renderMedian(violinG, isH, plot, xAxisScale, self) {
+	function renderMedian(violinG, isH, plot, svgData, self) {
 		const s = self.config.settings.violin
 		//render median values on plots
 		const median = plot.summaryStats.find(x => x.id === 'median').value
@@ -411,8 +411,8 @@ export default function setViolinRenderer(self) {
 				.style('opacity', '1')
 				.attr('y1', isH ? -s.medianLength : median)
 				.attr('y2', isH ? s.medianLength : median)
-				.attr('x1', isH ? xAxisScale(median) : -s.medianLength)
-				.attr('x2', isH ? xAxisScale(median) : s.medianLength)
+				.attr('x1', isH ? svgData.axisScale(median) : -s.medianLength)
+				.attr('x2', isH ? svgData.axisScale(median) : s.medianLength)
 		} else return
 	}
 

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -68,7 +68,6 @@ export default function setViolinRenderer(self) {
 		const thickness = self.settings.plotThickness || self.getAutoThickness()
 		for (const [plotIdx, plot] of self.data.plots.entries()) {
 			//R x values are not the same as the plot values, so we need to use a scale to map them to the plot values
-			const xAxisScale = scaleLinear().domain([plot.density.xMin, plot.density.xMax]).range([0, settings.svgw])
 			// The scale uses half of the plotThickness as the maximum value as the image is symmetrical
 			// Only one half of the image is computed and the other half is mirrored
 			const wScale = scaleLinear()
@@ -80,16 +79,16 @@ export default function setViolinRenderer(self) {
 			if (isH) {
 				areaBuilder = line()
 					.curve(curveBasis)
-					.x(d => xAxisScale(d.x0))
+					.x(d => svgData.axisScale(d.x0))
 					.y(d => wScale(d.density))
 			} else {
 				areaBuilder = line()
 					.curve(curveBasis)
 					.x(d => wScale(d.density))
-					.y(d => xAxisScale(d.x0))
+					.y(d => svgData.axisScale(d.x0))
 			}
 			//if only one plot pass area builder to calculate the exact height of the plot
-			const { violinG, height } = renderViolinPlot(svgData, plot, isH, xAxisScale, wScale, areaBuilder, y, imageOffset)
+			const { violinG, height } = renderViolinPlot(svgData, plot, isH, wScale, areaBuilder, y, imageOffset)
 			y += height
 			if (self.opts.mode != 'minimal') renderLabels(t1, t2, violinG, plot, isH, settings, tip)
 
@@ -288,7 +287,7 @@ export default function setViolinRenderer(self) {
 		}
 	}
 
-	function renderViolinPlot(svgData, plot, isH, xScale, wScale, areaBuilder, y, imageOffset) {
+	function renderViolinPlot(svgData, plot, isH, wScale, areaBuilder, y, imageOffset) {
 		const label = plot.label?.split(',')[0]
 		const catTerm = self.config.term.q.mode == 'discrete' ? self.config.term : self.config.term2
 		const category = catTerm?.term.values ? Object.values(catTerm.term.values).find(o => o.label == label) : null
@@ -397,7 +396,7 @@ export default function setViolinRenderer(self) {
 	function renderMedian(violinG, isH, plot, svgData, self) {
 		const s = self.config.settings.violin
 		//render median values on plots
-		const median = plot.summaryStats.find(x => x.id === 'median').value
+		const median = svgData.axisScale(plot.summaryStats.find(x => x.id === 'median').value)
 		if (plot.plotValueCount >= 2) {
 			violinG
 				.append('line')
@@ -411,8 +410,8 @@ export default function setViolinRenderer(self) {
 				.style('opacity', '1')
 				.attr('y1', isH ? -s.medianLength : median)
 				.attr('y2', isH ? s.medianLength : median)
-				.attr('x1', isH ? svgData.axisScale(median) : -s.medianLength)
-				.attr('x2', isH ? svgData.axisScale(median) : s.medianLength)
+				.attr('x1', isH ? median : -s.medianLength)
+				.attr('x2', isH ? median : s.medianLength)
 		} else return
 	}
 

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -247,13 +247,15 @@ async function createCanvasImg(q: ViolinRequest, result: { [index: string]: any 
 	const densities = await getDensities(plot2Values)
 	for (const plot of result.plots) {
 		// item: { label=str, values=[v1,v2,...] }
-
+		// set  the plot density
+		plot.density = densities[plot.label]
 		//backend rendering bean/rug plot on top of violin plot based on orientation of chart
 		const canvas = createCanvas(width, height)
 		const ctx = canvas.getContext('2d')
-		ctx.strokeStyle = 'rgba(0,0,0,0.8)'
+		const symbolOpacity = plot.density.densityMax == 0 ? 1 : 0.8
+		ctx.strokeStyle = `rgba(0,0,0,${symbolOpacity})`
 		ctx.lineWidth = q.strokeWidth / q.devicePixelRatio
-		ctx.globalAlpha = 0.5
+		ctx.globalAlpha = symbolOpacity
 		// No violin is rendered when the values is less than cutoff
 		//Render in black so the user can see the data
 		ctx.fillStyle = plot.values.length <= minSampleSize ? 'black' : '#ffe6e6'
@@ -284,8 +286,6 @@ async function createCanvasImg(q: ViolinRequest, result: { [index: string]: any 
 			})
 
 		plot.src = canvas.toDataURL()
-		// create bins for violins
-		plot.density = densities[plot.label]
 
 		//generate summary stat values
 		plot.summaryStats = summaryStats(plot.values).values

--- a/server/src/mds3.densityPlot.js
+++ b/server/src/mds3.densityPlot.js
@@ -22,12 +22,6 @@ export async function get_densityplot(term, samples) {
 			continue
 		}
 		values.push(v)
-		if (minvalue === null) {
-			minvalue = maxvalue = v
-		} else {
-			minvalue = Math.min(minvalue, v)
-			maxvalue = Math.max(maxvalue, v)
-		}
 	}
 
 	const density = await getDensity(values)
@@ -35,10 +29,8 @@ export async function get_densityplot(term, samples) {
 	if (density.bins.length == 0) throw 'getDensity returns an empty array'
 
 	const result = {
-		minvalue,
-		maxvalue,
-		xMin: density.xMin, //R xMin and xMax are not the same as minvalue and maxvalue
-		xMax: density.xMax,
+		minvalue: density.minvalue,
+		maxvalue: density.maxvalue,
 		densityMax: density.densityMax,
 		densityMin: density.densityMin,
 		density: density.bins,

--- a/server/utils/density.R
+++ b/server/utils/density.R
@@ -1,18 +1,29 @@
 library(jsonlite)
 library(ggplot2)
-# This script reads in a json string from stdin, calculates the density of the data and returns the density as a json string
-# The input json string is an array of numbers
-# The output json string is an object with the following fields {x: [x density values], y: [y density values]}
-# In order to test it you can run from the command line replacing the array with your own: echo "[1.2, 2, 3]" | Rscript ./density.R
+# This script reads in a json string from stdin, calculates the densities of each plot and returns the densities as a json string
+# The input json string is a dictionary where each field maps to an array of numbers
+# The output json string is a dictionary  with the density for each plot. The density is represented like {x: [x density values], y: [y density values]}
+# In order to test it you can run this from the command line replacing the arrays with your own: 
+# echo "{plotA: [1.2, 2, 3], plotB: [4.5, 5, 6]}" | Rscript ./density.R
 
 con <- file("stdin", "r")
 json <- readLines(con)
 close(con)
 data <- fromJSON(json)
-den = density(x = data)
-x = den$x
-y = den$y
-result = list(x=x, y=y) #This will be read in javascript like a dictionary with two keys x and y that are number arrays
-toJSON(result, digits = NA, na = "string") # will  return a json like {x:[...], y: [...]}
+densities <- list()
+for(plot in names(data)){
+    values = data[[plot]]
+    if(length(values) <= 5){
+        y = rep(0, length(values))
+        densities[[plot]] <- list(x=values, y=y)
+        next
+    }
+    den = density(x = values)
+    x = den$x
+    y = den$y
+    result = list(x=x, y=y) #This is an object  with two keys x and y that are number arrays
+    densities[[plot]] <- result
+}
+toJSON(densities, digits = NA, na = "string") # will  return a json like { plotA: {x:[...], y: [...]}}
 
 

--- a/server/utils/density.R
+++ b/server/utils/density.R
@@ -13,7 +13,8 @@ data <- fromJSON(json)
 densities <- list()
 for(plot in names(data)){
     values = data[[plot]]
-    if(length(values) <= 5){
+    # If the plot has less than 5 values or all the values are the same, we will return a flat line
+    if(length(values) <= 5 | length(unique(values)) == 1){
         y = rep(0, length(values))
         densities[[plot]] <- list(x=values, y=y)
         next

--- a/server/utils/density.R
+++ b/server/utils/density.R
@@ -1,5 +1,4 @@
 library(jsonlite)
-library(ggplot2)
 # This script reads in a json string from stdin, calculates the densities of each plot and returns the densities as a json string
 # The input json string is a dictionary where each field maps to an array of numbers
 # The output json string is a dictionary  with the density for each plot. The density is represented like {x: [x density values], y: [y density values]}
@@ -19,7 +18,7 @@ for(plot in names(data)){
         densities[[plot]] <- list(x=values, y=y)
         next
     }
-    den = density(x = values)
+    den = density(x = values, from=min(values), to=max(values))
     x = den$x
     y = den$y
     result = list(x=x, y=y) #This is an object  with two keys x and y that are number arrays

--- a/server/utils/density.R
+++ b/server/utils/density.R
@@ -4,7 +4,7 @@ library(ggplot2)
 # The input json string is a dictionary where each field maps to an array of numbers
 # The output json string is a dictionary  with the density for each plot. The density is represented like {x: [x density values], y: [y density values]}
 # In order to test it you can run this from the command line replacing the arrays with your own: 
-# echo "{plotA: [1.2, 2, 3], plotB: [4.5, 5, 6]}" | Rscript ./density.R
+# echo '{"plotA": [1.2, 2, 3], "plotB": [4.5, 5, 6]}' | Rscript ./density.R
 
 con <- file("stdin", "r")
 json <- readLines(con)


### PR DESCRIPTION
## Description

When the violin is divided into categories calculate all of them in the same R process. When all values are the same do not plot a violin. Reduced timeouts increased now that the violin with categories is rendered faster.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
