### PR TITLE
protect against missing error payload or empty data when handlin…

### DIFF
--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -404,8 +404,8 @@ async function getFilesAndShowTable(obj) {
 		button.innerHTML = oldText
 		button.disabled = false
 
-		const runStatus = data.pop()
-		if (!runStatus?.body?.ok) {
+		const runStatus = data.find(d => d.headers['content-type'] == 'application/json' && (d.errors || d.error))
+		if (runStatus && !runStatus?.body?.ok) {
 			// revise if run status is changed
 			if (Array.isArray(runStatus.body?.errors)) displayRunStatusErrors(runStatus.body.errors)
 			// other unstructured errors; display as plain text

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -394,6 +394,8 @@ async function getFilesAndShowTable(obj) {
 			 ] 
 			*/
 			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } })
+			if(!Array.isArray(data)) throw `server didn't return multipart`
+			if(!data.length) throw 'server returned blank multipart'
 		} catch (e) {
 			sayerror(obj.errDiv, e)
 			button.innerHTML = oldText

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- protect against missing error payload or empty data when handling the maf multipart response


### PR DESCRIPTION
…g the maf multipart response

## Description

To fix issues found in qa-yellow MAF download. The root cause seems to be that GFF prod bundling transforms the pp client-side code to potentially have a missing object for which a property is conditionally required.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
