### PR TITLE
fix: correctly detect the boundary text between binary and json text …

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -182,6 +182,9 @@ export function dofetch2(path, init = {}, opts = {}) {
 	})
 }
 
+// define regex in variable for efficiency on repeated tests
+const regex_multipart = /multipart/i
+const regex_boundary = /boundary\s*=\s*"?([^"\s;]+)"?/i
 /* 
 r: a native fetch response argument
 
@@ -199,8 +202,9 @@ async function processResponse(r) {
 	if (ct.includes('/text')) {
 		return r.text()
 	}
-	if (ct.includes('multipart')) {
-		const boundary = ct.split('boundary=')[1]
+	if (regex_multipart.test(ct)) {
+		const boundary = ct.match(regex_boundary)?.[1]?.trim()
+		if (!boundary) throw 'Invalid multipart response: Missing boundary'
 		return processMultiPart(r, boundary)
 	}
 	// call blob() as catch-all

--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -235,7 +235,7 @@ async function processMultiPart(res, _boundary) {
     let text = (decoder.decode(chunk)).trimStart()
     // console.log(chunk.byteLength, text.length, text.slice(0, 16), ' ... ', text.slice(0, 16))
 		
-		if (text.endsWith(boundary + '--')) {
+		if (!text.startsWith(boundary) && text.endsWith(boundary + '--')) {
     	// find the previous (middle) boundary from the end
     	const i = text.indexOf(boundary)
 			for(let j=i; j < text.length; j++) {

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -406,7 +406,7 @@ async function getFilesAndShowTable(obj) {
 		button.innerHTML = oldText
 		button.disabled = false
 
-		const runStatus = data.find(d => d.headers['content-type'] == 'application/json' && (d.errors || d.error))
+		const runStatus = data.find(d => d.headers['content-type'] == 'application/json' && (d.body?.errors || d.body?.error))
 		if (runStatus && !runStatus?.body?.ok) {
 			// revise if run status is changed
 			if (Array.isArray(runStatus.body?.errors)) displayRunStatusErrors(runStatus.body.errors)

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -394,8 +394,8 @@ async function getFilesAndShowTable(obj) {
 			 ] 
 			*/
 			data = await dofetch3('gdc/mafBuild', { body: { fileIdLst, columns: outColumns } })
-			if(!Array.isArray(data)) throw `server didn't return multipart`
-			if(!data.length) throw 'server returned blank multipart'
+			if (!Array.isArray(data)) throw `server didn't return multipart`
+			if (!data.length) throw 'server returned blank multipart'
 		} catch (e) {
 			sayerror(obj.errDiv, e)
 			button.innerHTML = oldText
@@ -406,7 +406,9 @@ async function getFilesAndShowTable(obj) {
 		button.innerHTML = oldText
 		button.disabled = false
 
-		const runStatus = data.find(d => d.headers['content-type'] == 'application/json' && (d.body?.errors || d.body?.error))
+		const runStatus = data.find(
+			d => d.headers['content-type'] == 'application/json' && (d.body?.errors || d.body?.error)
+		)
 		if (runStatus && !runStatus?.body?.ok) {
 			// revise if run status is changed
 			if (Array.isArray(runStatus.body?.errors)) displayRunStatusErrors(runStatus.body.errors)

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - protect against missing error payload or empty data when handling the maf multipart response
+- correctly detect the boundary text between binary and json text in the same octet chunk


### PR DESCRIPTION
## Description

…in the same octet chunk

To test: 
- after pulling the PR branch, run `npm ci` in the proteinpaint branch (will need to do `npm run reset` when switching back to `master`)
- use http://localhost:3000/example.gdc.maf.html or similar link
- in the Network tab, choose `Fast G`, `Slow 4G`, or other slower speeds in the Throttling dropdown. This will cause smaller chunks that would almost always cause the boundary to be preceded by binary data in the same chunk. 

![Screenshot 2025-03-13 at 4 50 24 AM](https://github.com/user-attachments/assets/e627026b-c835-4dac-a237-9fec0eb07ff4)



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
