### PR TITLE
fix: detect debug lines from R output and console.log

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- detect debug lines from R output and output on dev, and throw on prod

--- a/server/src/run_R.js
+++ b/server/src/run_R.js
@@ -15,6 +15,10 @@ import serverconfig from './serverconfig.js'
 import { spawn } from 'child_process'
 import { Readable } from 'stream'
 
+// hardcoded debug line marker, to identify which lines of Rscript stdout are debugging/diagnostic and to be separated from actual output e.g. stringified JSON
+// NOTE that a debugging line must ends with line break
+const debugLineMarker = 'debug:'
+
 export default async function run_R(path, data, args) {
 	try {
 		await fs.promises.stat(path)
@@ -60,7 +64,33 @@ export default async function run_R(path, data, args) {
 				reject(errmsg)
 			}
 			// return standard out from R
-			resolve(stdout)
+			if (serverconfig.debugmode) {
+				/* at dev environment, split stdout into lines, and check for debugging lines, and exclude them from actual output
+				********
+				* NOTE *
+				********
+				such debugging lines must not show up in prod environment
+				*/
+				const actualOutputLines = []
+				for (const line of stdout.split('\n')) {
+					if (line.startsWith(debugLineMarker)) {
+						// line begins with hardcoded marker and will be excluded
+						console.log('<R>', line)
+						continue
+					}
+					// line doesn't begin with marker and is kept
+					actualOutputLines.push(line)
+				}
+				resolve(actualOutputLines.join('\n'))
+			} else {
+				// not dev environment; do this detection to guard against accidental introduction of debug lines
+				if (stdout.indexOf(debugLineMarker) != -1) {
+					reject(
+						'Debugging line found in R output and this is not allowd in prod environment; make sure to comment off such lines in R script'
+					)
+				}
+				resolve(stdout)
+			}
 		})
 	})
 }


### PR DESCRIPTION
… prod

## Description

closes #2931 

to test, add lines 276, 278 and 279 to server/utils/cuminc.R, and [test link](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22plots%22:[{%22chartType%22:%22cuminc%22,%22settings%22:{%22cuminc%22:{}},%22term%22:{%22id%22:%22Cardiovascular%20System%22,%22q%22:{%22breaks%22:[1]}}}],%22nav%22:{%22activeTab%22:1}}) to see the debug line outputted in server console

```R
276 t1<-Sys.time()
277 ci_results <- mclapply(X = dat, FUN = run_cuminc, startTime = startTime, mc.cores = cores)
278 t2<-Sys.time()
279 cat("debug: time:",difftime(t2,t1,units='secs'),"\n")
```

please evaluate if this is good approach and verify all portal features using R are working

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
