### PR TITLE
detect and kill long running pp rust processes

### DIFF
--- a/rust/index.js
+++ b/rust/index.js
@@ -1,7 +1,10 @@
 const path = require('path'),
-	spawn = require('child_process').spawn,
+	{ spawn, exec } = require('child_process'),
 	Readable = require('stream').Readable,
-	Transform = require('stream').Transform
+	Transform = require('stream').Transform,
+	{ promisify } = require('util')
+
+const execPromise = promisify(exec)
 
 exports.run_rust = function (binfile, input_data) {
 	return new Promise((resolve, reject) => {
@@ -54,11 +57,10 @@ exports.stream_rust = function (binfile, input_data, emitJson) {
 		//reader.on('error', ps.stderr.pipe)
 		//return reader
 	} catch (error) {
-		ps.kill()
-		let errmsg = error
+		console.log(error)
+		//let errmsg = error
 		//if (stderr.length) errmsg += `killed run_rust('${binfile}'), stderr: ${stderr.join('').trim()}`
-		//reject(errmsg)
-		console.log(59, error)
+		//console.log(errmsg)
 	}
 
 	const childStream = new Transform({
@@ -67,15 +69,16 @@ exports.stream_rust = function (binfile, input_data, emitJson) {
 			callback()
 		}
 	})
+
 	ps.stdout.pipe(childStream)
 	ps.stderr.on('data', data => stderr.push(data))
-	ps.on('close', code => { //console.log(72, stderr.length)
+	ps.on('close', code => {
 		if (stderr.length) {
 			// handle rust stderr
 			const errors = stderr.join('').trim().split('\n').map(JSON.parse)
 			//const errmsg = `!!! stream_rust('${binfile}') stderr: !!!`
 			//console.log(errmsg, errors)
-			emitJson({errors})
+			emitJson({ errors })
 		} else {
 			emitJson({ ok: true, status: 'ok', message: 'Processing complete' })
 		}
@@ -83,9 +86,74 @@ exports.stream_rust = function (binfile, input_data, emitJson) {
 	ps.on('error', err => {
 		//console.log(74, `stream_rust().on('error')`, err)
 		const errors = stderr.join('').trim().split('\n').map(JSON.parse)
-		emitJson({errors})
+		emitJson({ errors })
 	})
-	// below will duplicate ps.on('close') event above
+
+	displayRustProcesses(binpath, 1) // for manual testing when kill is triggered fast
+	const psKill = () => {
+		try {
+			console.log('--- directly killing node-spawned rust process/streams ---')
+			if (process.kill(ps.pid, 0)) ps.kill()
+			childStream.end()
+		} catch (e) {
+			console.log(
+				'ignored ps.kill/childStream.end() errors, will be detected later as a long running process and killed'
+			)
+			//console.log(e)
+		}
+	}
+
+	// on('end') will duplicate ps.on('close') event above
 	// childStream.on('end', () => console.log(`-- childStream done --`))
+	// this may duplicate ps.on('error'), unless the error happened within the transformation
+	childStream.on('error', err => console.log('stream_rust childStream.on(error)', err))
 	return childStream
+}
+
+// to test, run `sleep 5555` in 1 or more terminal windows,
+// which should be all killed when making a request to gdc/MafBuild
+// const srcpath = 'sleep 5555' // uncomment to test and comment out below
+const srcpath = path.join(__dirname, 'target')
+const PROCESS_TIMEOUT = 5 * 60 // in seconds
+setInterval(detectAndKillLongRunningRustProcess, 60000) // in millseconds
+
+async function detectAndKillLongRunningRustProcess() {
+	try {
+		console.log(`\n--- detecting and killing long running rust streams (>${PROCESS_TIMEOUT} seconds) using exec() ---`)
+		const ps = await execPromise(`ps -eo pid,etime,command | grep '${srcpath}'`, {
+			encoding: 'utf-8',
+			stdio: 'inherit'
+		})
+		if (!ps.stderr && typeof ps.stdout === 'string') {
+			const lines = ps.stdout.trim().split('\n')
+			for (const line of lines) {
+				if (!line || typeof line != 'string') continue
+				if (line.includes(srcpath)) {
+					const [pid, etime, ...rest] = line
+						.split(' ')
+						.filter(f => !!f)
+						.map(v => v.trim()) //; console.log(132, rest)
+					if (rest.includes('grep')) continue
+					const [sec, min, hour] = etime.split(':').reverse() //; console.log(134, etime.split(':').reverse(), line)
+					const elapsed = Number(sec) + 60 * Number(min) + 3600 * (Number(hour) || 0) //; console.log(127, {elapsed})
+					if (elapsed >= PROCESS_TIMEOUT) {
+						//console.log(136, 'killing process')
+						execPromise(`kill -9 ${pid}`, (_, out) => console.log(out))
+					}
+				}
+			}
+		}
+		console.log('--- after detecting/killing long running process --')
+		// displayRustProcesses(srcpath)
+		console.log('--- done detecting/killing long running process --\n')
+	} catch (e) {
+		//console.log(140, e)
+		// okay to not have any process to kill
+		//console.log(e)
+	}
+}
+
+function displayRustProcesses(binpath, killTimeout = 0) {
+	exec(`ps -eo comm,pid,etime | grep "${binpath}"`, { encoding: 'utf-8' }, (err, out) => console.log(out))
+	if (killTimeout) setTimeout(detectAndKillLongRunningRustProcess, killTimeout)
 }

--- a/rust/index.js
+++ b/rust/index.js
@@ -89,10 +89,10 @@ exports.stream_rust = function (binfile, input_data, emitJson) {
 		emitJson({ errors })
 	})
 
-	displayRustProcesses(binpath, 1) // for manual testing when kill is triggered fast
+	// displayRustProcesses(binpath, 1) // uncomment for manual testing, for fast process kill
 	const psKill = () => {
 		try {
-			console.log('--- directly killing node-spawned rust process/streams ---')
+			// console.log('--- directly killing node-spawned rust process/streams ---')
 			if (process.kill(ps.pid, 0)) ps.kill()
 			childStream.end()
 		} catch (e) {
@@ -119,7 +119,7 @@ setInterval(detectAndKillLongRunningRustProcess, 60000) // in millseconds
 
 async function detectAndKillLongRunningRustProcess() {
 	try {
-		console.log(`\n--- detecting and killing long running rust streams (>${PROCESS_TIMEOUT} seconds) using exec() ---`)
+		// console.log(`\n--- detecting and killing long running rust streams (>${PROCESS_TIMEOUT} seconds) using exec() ---`)
 		const ps = await execPromise(`ps -eo pid,etime,command | grep '${srcpath}'`, {
 			encoding: 'utf-8',
 			stdio: 'inherit'
@@ -143,9 +143,9 @@ async function detectAndKillLongRunningRustProcess() {
 				}
 			}
 		}
-		console.log('--- after detecting/killing long running process --')
+		// console.log('--- after detecting/killing long running process --')
 		// displayRustProcesses(srcpath)
-		console.log('--- done detecting/killing long running process --\n')
+		// console.log('--- done detecting/killing long running process --\n')
 	} catch (e) {
 		//console.log(140, e)
 		// okay to not have any process to kill


### PR DESCRIPTION
## Description

This implements an interval loop to periodically check for rust prosses running longer than 5 minutes (hardcoded).

To test
Shared steps:
- after switching to this branch, run `npm ci` in pp dir. when switching back to master, run `npm run reset` in sjpp dir
- uncomment line ~92 to immediately trigger `displayRustProcesses()` and simulate an interval iteration
- change PROCESS_TIMEOUT to 0
-  may want to force the condition to run the interval outside of a container (around line 102)

Simulated tests
A:
- do the shared steps above
- in 1 or more terminal windows, run `sleep 5555`
- uncomment relevant `const srcpath = 'sleep 5555'` in `rust/index.js`
-  trigger a request to gdc maf download, you should see the terminal sleep process(es) terminate

B: 
- do the shared steps above
- do not use the sleep `srcpath`, 
- try to download a large maf file
- the downloaded file should be be zero or only a few bytes, since `detectAndKillLongRunningRustProcess()` would have killed it

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
