### PR TITLE
fix: Color shown in the track config menu is the correct

### DIFF
--- a/client/src/block.tk.bedj.js
+++ b/client/src/block.tk.bedj.js
@@ -2,6 +2,7 @@ import * as client from './client'
 import { bplen } from '#shared/common.js'
 import { legend_newrow } from './block.legend'
 import { make_one_checkbox } from '../dom/checkbox'
+import { rgb } from 'd3-color'
 
 /*
 bedj can only be loaded from POST but not GET
@@ -226,7 +227,7 @@ function configpanel(tk, block) {
 		row.append('span').html('Color&nbsp;')
 		row
 			.append('input')
-			.property('value', tk.color)
+			.property('value', rgb(tk.color).formatHex())
 			.attr('type', 'color')
 			.on('change', event => {
 				tk.color = event.target.value

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Color shown in the track config menu is the correct


### PR DESCRIPTION
## Description
Color picker in the config menu did not show the correct color for the track. Click on the config menu for the first example in the bedj card here: https://proteinpaint.stjude.org/?appcard=bedj. The color appears black. This simple change accurately reflects the color in the menu. 

Test with http://localhost:3000/?appcard=bedj. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
