### PR TITLE
Monitor and kill expired rust process by pid

### DIFF
--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -411,7 +411,13 @@ async function getFilesAndShowTable(obj) {
 		)
 		if (runStatus && !runStatus?.body?.ok) {
 			// revise if run status is changed
-			if (Array.isArray(runStatus.body?.errors)) displayRunStatusErrors(runStatus.body.errors)
+			const errors = runStatus.body?.errors || []
+			if (Array.isArray(errors)) {
+				const fileErrors = errors.filter(d => d.url)
+				if (fileErrors.length) displayRunStatusErrors(fileErrors)
+				const nonFileErrors = errors.filter(d => !d.url)
+				for (const e of nonFileErrors) sayerror(obj.errDiv, e.error)
+			}
 			// other unstructured errors; display as plain text
 			if (runStatus.body?.error) sayerror(obj.errDiv, runStatus.body.error)
 			if (runStatus.body?.message) sayerror(obj.errDiv, runStatus.body.message)

--- a/rust/index.js
+++ b/rust/index.js
@@ -115,8 +115,8 @@ function trackByPid(pid, name, maxElapsed = 300000) {
 	trackedPids.set(pid, { name, expires: Date.now() + maxElapsed })
 	if (!psKillInterval) psKillInterval = setInterval(killExpiredProcess, PSKILL_INTERVAL_MS)
 	// uncomment below to test
-	console.log([...trackedPids.entries()])
-	setTimeout(killExpiredProcess, 5) // uncomment for testing only
+	// console.log([...trackedPids.entries()])
+	// setTimeout(killExpiredProcess, 5) // uncomment for testing only
 }
 
 //

--- a/rust/index.js
+++ b/rust/index.js
@@ -115,8 +115,8 @@ function trackByPid(pid, name, maxElapsed = 300000) {
 	trackedPids.set(pid, { name, expires: Date.now() + maxElapsed })
 	if (!psKillInterval) psKillInterval = setInterval(killExpiredProcess, PSKILL_INTERVAL_MS)
 	// uncomment below to test
-	// console.log([...trackedPids.entries()])
-	// setTimeout(killExpiredProcess, 5) // uncomment for testing only
+	console.log([...trackedPids.entries()])
+	setTimeout(killExpiredProcess, 5) // uncomment for testing only
 }
 
 //
@@ -139,13 +139,5 @@ function killExpiredProcess() {
 		} catch (err) {
 			console.log(`unable to kill ${label}`, err)
 		}
-	}
-
-	// psKillInterval should not run when there are no tracked pids,
-	// and restarted in trackByPid() as needed
-	try {
-		if (!trackedPids.size && psKillInterval) clearInterval(psKillInterval)
-	} catch (e) {
-		console.log(e)
 	}
 }

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -74,7 +74,14 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 
 	try {
 		const rustStream = stream_rust('gdcmaf', JSON.stringify(arg), emitJson)
-		if (rustStream) rustStream.pipe(res, { end: false })
+		if (rustStream) {
+			rustStream.pipe(res, { end: false }).on('error', e => {
+				if (!e) return
+				console.log(e)
+			})
+		} else {
+			emitJson({ error: 'server error: undefined rustStream' })
+		}
 	} catch (e) {
 		console.log(e)
 	}


### PR DESCRIPTION
## Description

This branch removes the need for `exec('ps  | ...')` in `rust/index.js` to monitor expired rust processes. It uses spawned process.pid directly to simplify logic.

To test:
- when switching to this branch, run `npm ci` in pp dir; when switching back to master, run `npm run reset` in sjpp dir
- uncomment `setTimeout(killExpiredProcess, 5)` in `rust/index.js`, and set `maxElapsed=0` as argument to `trackByPid`
- try different downloads in http://localhost:3000/?gdcmaf=1

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x]  Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
