### PR TITLE
Moved Validate_query_rnaseqgenecount To Termdb.de.ts And Fixed Related Typing Errors

### DIFF
--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -9,6 +9,7 @@ import run_R from '../src/run_R.js'
 import { mayLog } from '#src/helpers.ts'
 import serverconfig from '../src/serverconfig.js'
 import imagesize from 'image-size'
+import { spawn } from 'child_process'
 
 export const api: RouteApi = {
 	endpoint: 'DEanalysis',
@@ -308,4 +309,97 @@ async function readFileAndDelete(file, key, response) {
 	fs.unlink(file, err => {
 		if (err) throw err
 	})
+}
+
+
+function getFirstLine(file) {
+	// TODO now requires "head" command on the system
+	return new Promise<string>((resolve, reject) => {
+		const out1: string[] = [],
+			  out2: string[] = []
+
+		const ps = spawn('head', ['-1', file])
+		ps.stdout.on('data', data => out1.push(data.toString()))
+		ps.stderr.on('data', data => out2.push(data.toString()))
+		ps.on('error', err => {
+			if (out2.length) reject(out2.join(''))
+		})
+		ps.on('close', code => {
+			if (code != 0) reject('head command exited with non-zero status and this error: ' + out2.join(''))
+			resolve(out1.join(''))
+		})
+	})
+}
+
+
+/**
+ * Validates and processes RNA-seq gene count query data.
+ * 
+ * This function prepares RNA-seq gene count matrices for differential expression (DE) analysis by:
+ * 1. Verifies the query object and file exist
+ * 2. Resolves the absolute file path using the server configuration
+ * 3. Extracts sample information based on file storage type:
+ *    - For text files: Reads first line of the matrix and extracts samples starting from 5th column
+ *    - For HDF5 files: Uses Rust DEanalysis module to extract sample information (see DEanalysis.rs 
+ *      at proteinpaint/rust/src for more details)
+ * 4. Creates a set of all available samples (q.allSampleSet)
+ * 5. Identifies any samples that can't be mapped to sample IDs in the cohort database
+ * 6. Logs the number of samples extracted from the gene count matrix
+ * 
+ * @param {Object} ds - Dataset object containing query information, cohort data, and label
+ * @param {Object} ds.queries - Contains the rnaseqGeneCount query configuration
+ * @param {Object} ds.queries.rnaseqGeneCount - Gene count query parameters
+ * @param {string} ds.queries.rnaseqGeneCount.file - Path to gene count file (relative to tpmasterdir)
+ * @param {string} ds.queries.rnaseqGeneCount.storage_type - Storage format ("text" or "HDF5") 
+ * @param {Object} ds.cohort - Dataset cohort information
+ * @param {string} ds.label - Dataset label for logging
+ * @param {Object} genome - Genome reference information (unused in current implementation)
+ * @throws {string} Throws error strings for missing file or unknown storage type
+ * @returns {Promise<void>} No return value, but updates the query object with sample information
+ */
+export async function validate_query_rnaseqGeneCount(ds, genome) {
+	const q = ds.queries.rnaseqGeneCount
+	if (!q) return
+	if (!q.file) throw 'unknown data type for rnaseqGeneCount'
+	// the gene count matrix tabular text file
+	q.file = path.join(serverconfig.tpmasterdir, q.file)
+	/*
+	first line of matrix must be sample header, samples start from 5th column for text based files
+	read the first line to get all samples, and save at q.allSampleSet
+	so that samples from analysis request will be screened against q.allSampleSet
+	also require that there's no duplicate samples in header line, so rust/r won't break
+	*/
+	{
+		let samples: string[] = []
+		if (ds.queries.rnaseqGeneCount.storage_type == 'text') {
+			samples = (await getFirstLine(q.file)).trim().split('\t').slice(4)
+		} else if (ds.queries.rnaseqGeneCount.storage_type == 'HDF5') {
+			const get_samples_from_hdf5 = {
+				input_file: q.file,
+				data_type: 'get_samples'
+			}
+			//console.log("get_samples_from_hdf5:",get_samples_from_hdf5)
+			//fs.writeFile('test.txt', JSON.stringify(get_samples_from_hdf5), function (err) {
+			//	// For catching input to rust pipeline, in case of an error
+			//	if (err) return console.log(err)
+			//})
+			const time1 = new Date().valueOf()
+			const result = await run_rust('DEanalysis', JSON.stringify(get_samples_from_hdf5))
+			const time2 = new Date().valueOf()
+			//console.log('Time taken to query gene expression:', time2 - time1, 'ms')
+			samples = result.split(',')
+		} else throw 'unknown storage type:' + ds.queries.rnaseqGeneCount.storage_type
+
+		q.allSampleSet = new Set(samples)
+		//if(q.allSampleSet.size < samples.length) throw 'rnaseqGeneCount.file header contains duplicate samples'
+		const unknownSamples: string[] = [];
+		for (const n of q.allSampleSet) {
+			if (!ds.cohort.termdb.q.sampleName2id(n)) unknownSamples.push(n)
+		}
+		//if (unknownSamples.length)
+		//	throw `${ds.label} rnaseqGeneCount: ${unknownSamples.length} out of ${
+		//		q.allSampleSet.size
+		//	} sample names are unknown: ${unknownSamples.join(',')}`
+		console.log(q.allSampleSet.size, `rnaseqGeneCount samples from ${ds.label}`)
+	}
 }


### PR DESCRIPTION
## Descriptions
Moved `validate_query_rnaseqGeneCount` function and additional helper function from `mds3.init.js` to `termdb.DE.ts`. Fixed related typing errors caused by moving from javascript to typescript. Updated documentation of `validate_query_rnaseqGeneCounts` in the style of JSDoc for easier understanding in the future.

## Closes
Closes #2970 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
