### PR TITLE
sort tooltip values for survival curves

### DIFF
--- a/client/dom/svgSeriesTips.js
+++ b/client/dom/svgSeriesTips.js
@@ -65,11 +65,10 @@ export function getSeriesTip(line, rect, _tip = null, plotType) {
 					const percentageA = parseFloat(a.match(/(\d+\.\d+)%/)[1])
 					const percentageB = parseFloat(b.match(/(\d+\.\d+)%/)[1])
 
-					// Sort in descending order (highest percentage first)
+					// Sort in ascending order (to see the lowest survival rate for the group first)
 					return percentageA - percentageB
 				})
 
-				// Render the tooltip with sorted seriesHtmls
 				tip
 					.show(event.clientX, event.clientY)
 					.d.html(`${opts.xTitleLabel}: ${xVal}<br>` + sortedSeriesHtmls.map(d => d).join(opts.separator))

--- a/client/dom/svgSeriesTips.js
+++ b/client/dom/svgSeriesTips.js
@@ -28,7 +28,7 @@ import { pointer } from 'd3-selection'
 	Returns
 	an API object (see the specs at the end of this function)
 */
-export function getSeriesTip(line, rect, _tip = null) {
+export function getSeriesTip(line, rect, _tip = null, plotType) {
 	const tip = _tip || new Menu({ padding: '5px' })
 	line.style('display', 'none')
 
@@ -58,9 +58,26 @@ export function getSeriesTip(line, rect, _tip = null) {
 		}
 
 		if (seriesHtmls.length) {
-			tip
-				.show(event.clientX, event.clientY)
-				.d.html(`${opts.xTitleLabel}: ${xVal}<br>` + seriesHtmls.map(d => d).join(opts.separator))
+			if (plotType === 'survival') {
+				// Sort the seriesHtmls array by percentage
+				const sortedSeriesHtmls = seriesHtmls.sort((a, b) => {
+					// Extract the percentage from each HTML string
+					const percentageA = parseFloat(a.match(/(\d+\.\d+)%/)[1])
+					const percentageB = parseFloat(b.match(/(\d+\.\d+)%/)[1])
+
+					// Sort in descending order (highest percentage first)
+					return percentageA - percentageB
+				})
+
+				// Render the tooltip with sorted seriesHtmls
+				tip
+					.show(event.clientX, event.clientY)
+					.d.html(`${opts.xTitleLabel}: ${xVal}<br>` + sortedSeriesHtmls.map(d => d).join(opts.separator))
+			} else {
+				tip
+					.show(event.clientX, event.clientY)
+					.d.html(`${opts.xTitleLabel}: ${xVal}<br>` + seriesHtmls.map(d => d).join(opts.separator))
+			}
 		} else {
 			tip.hide()
 		}

--- a/client/plots/survival.js
+++ b/client/plots/survival.js
@@ -711,7 +711,7 @@ function setRenderers(self) {
 		}
 
 		if (!svg.seriesTip) {
-			svg.seriesTip = getSeriesTip(line, plotRect, self.app?.tip)
+			svg.seriesTip = getSeriesTip(line, plotRect, self.app?.tip, 'survival')
 		}
 
 		return [mainG, seriesesG, axisG, xAxis, yAxis, xTitle, yTitle, atRiskG, plotRect]


### PR DESCRIPTION
## Description

when hovering over km curves, now values should sort from lowest survival rate for that time point and category to highest to make assessments easier when several categories are loaded. The 'survival' flag should not break cuminc. Please help me test. Thanks. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
