### PR TITLE
Use shorter, card file name instead of card label in breadcrumb URLs

### DIFF
--- a/client/appdrawer/adSandbox.js
+++ b/client/appdrawer/adSandbox.js
@@ -34,7 +34,9 @@ export async function openSandbox(element, pageArgs) {
 		.append('span')
 		.html(
 			element.type != 'nestedCard'
-				? `<a href="${sessionStorage.getItem('hostURL')}/?appcard=${element.name}">${element.name}</a>`
+				? `<a href="${sessionStorage.getItem('hostURL')}/?appcard=${element.sandboxJson || element.sandboxHtml}">${
+						element.name
+				  }</a>`
 				: element.name
 		)
 	sandboxDiv.body.style('overflow', 'hidden').style('background-color', 'white')
@@ -278,7 +280,9 @@ async function makeLeftsideTabMenu(card, contentHolder, examplesOnly, sandboxDiv
 		return {
 			active,
 			inTrail: active,
-			link: `${sessionStorage.getItem('hostURL')}/?appcard=${card.name}&example=${ppcalls.label}`,
+			link: `${sessionStorage.getItem('hostURL')}/?appcard=${card.sandboxJson || card.sandboxHtml}&example=${
+				ppcalls.label
+			}`,
 			label: ppcalls.label,
 			callback: async (event, tab) => {
 				const wait = tab_wait(tab.contentHolder)


### PR DESCRIPTION
## Description
The file name instead of the label is used to generate the URL on breadcrumb click. The label will still work, this is just shorter without any spaces. Test with any card breadcrumb in http://localhost:3000/, save the nested cards. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
