### PR TITLE
fix the stalemate when a gdc/mafBuild request closes 

### DIFF
--- a/rust/index.js
+++ b/rust/index.js
@@ -135,12 +135,18 @@ exports.stream_rust = function (binfile, input_data, emitJson) {
 
 	function endStream() {
 		try {
-			if (!childStream.writableEnded) childStream.destroy()
+			if (!childStream.writableEnded) {
+				console.log('trigger childStream.destroy() in endStream()')
+				childStream.destroy()
+			}
 		} catch (e) {
 			console.log('error triggering childStream.destroy()', e)
 		}
 		try {
-			if (!ps.killed) ps.kill()
+			if (!ps.killed) {
+				console.log('trigger ps.kill() in endStream()')
+				ps.kill()
+			}
 			if (trackedPids.has(ps.pid)) trackedPids.delete(ps.pid)
 		} catch (e) {
 			console.log('error triggering ps.kill()', e)

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -73,8 +73,9 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	res.flush() // header text should be sent as a separate chunk from the content that will be streamed next
 
 	try {
-		const { rustStream, endStream } = stream_rust('gdcmaf', JSON.stringify(arg), emitJson)
-		if (rustStream) {
+		const streams = stream_rust('gdcmaf', JSON.stringify(arg), emitJson)
+		if (streams) {
+			const { rustStream, endStream } = streams
 			// Important: rustStream.pipe(res, { end: false }) may cause a stalemate
 			// where the spawned rust process, stream transform, and res instance
 			// wait on each other to trigger a "stop", but does not happen automatically

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -80,11 +80,10 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 			// wait on each other to trigger a "stop", but does not happen automatically
 			// when a browser tab is refreshed during a file download
 			res.on('close', () => {
+				if (res.writableEnded) return
 				try {
-					if (!res.writableEnded) {
-						console.log('\n-- forced res.end() ---\n')
-						res.end()
-					}
+					console.log('\n-- forced res.end() ---\n')
+					res.end()
 				} catch (e) {
 					console.log('error with forced res.end()', e)
 				}

--- a/server/routes/gdc.mafBuild.ts
+++ b/server/routes/gdc.mafBuild.ts
@@ -96,10 +96,17 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 				}
 			})
 
-			rustStream.pipe(res, { end: false }).on('error', e => {
-				// this is not triggered when a request is disconnected
-				console.log('rustStream.pipe().on(error)', e)
-			})
+			rustStream
+				.pipe(res, { end: false })
+				.on('error', e => {
+					// this is not triggered when a request is disconnected
+					console.log('rustStream.pipe().on(error)', e)
+				})
+				.on('end', () => {
+					if (res.writableEnded) return
+					console.log('rustStream.on(end), trigger res.end()')
+					res.end()
+				})
 		} else {
 			emitJson({ error: 'server error: undefined rustStream' })
 		}


### PR DESCRIPTION
## Description

Fixes https://github.com/stjude/proteinpaint/issues/2988

This branch breaks the stalemate when a browser tab is closed or refreshed, and somehow the spawned rust process, stream transform, and response instance in the backend are not able to trigger stopping each other. 

This fix is not likely to be included in release 2.16, but it would be ready in case the Cohort MAF becomes unusable in GDC prod due to `killExpiredProcesses()` not being sufficient to prevent accumulation of idle processes that consume server resources, like network connections. 

To test:
- run `npm ci` in pp dir when switching to this branch, and `npm run reset` when switching back to master
- open http://localhost:3000/?gdcmaf=1, select a few samples and submit, but immediately refresh the browser tab
- there should not be any matches to `ps aux | grep gdcmaf` in the terminal. Previously idle `gdcmaf` would exist and require `killExpiredProcesses()` to kill it in 5 minutes.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
