### PR TITLE
Volcano improvements

### DIFF
--- a/client/dom/MultiTermWrapperEditUI.ts
+++ b/client/dom/MultiTermWrapperEditUI.ts
@@ -17,6 +17,7 @@ export class MultiTermWrapperEditUI {
 	buttonLabel: string
 	callback: (terms: any) => void
 	customInputs?: object
+	disable_terms: string[]
 	dom: MultiTermWrapperDom
 	headerText: string
 	maxNum: number
@@ -55,6 +56,7 @@ export class MultiTermWrapperEditUI {
 		this.maxNum = opts.maxNum || Infinity
 		this.headerText = opts.headerText || ''
 		this.customInputs = opts.customInputs || {}
+		this.disable_terms = opts.disable_terms || []
 		if (opts.state) this.state = opts.state
 
 		setRenderers(this)
@@ -71,11 +73,13 @@ export class MultiTermWrapperEditUI {
 	}
 
 	async getNewPill(d, div) {
+		//Do not allow users to select the same term more than once
+		//Combine with specified disable_terms from the caller
+		const disable_terms = [...this.disable_terms, ...this.twList.map(tw => tw.term.id)]
 		const _opts = {
 			abbrCutoff: 50,
 			debug: this.app.opts?.debug,
-			//Do not allow users to select the same term more than once
-			disable_terms: this.twList.map(tw => tw.term.id),
+			disable_terms,
 			genomeObj: this.app.opts.genome,
 			holder: div,
 			menuOptions: '!replace',

--- a/client/dom/types/MultiTermWrapperEditUI.ts
+++ b/client/dom/types/MultiTermWrapperEditUI.ts
@@ -2,6 +2,7 @@ import type { Button, Elem, Div } from '../../types/d3'
 import type { TermWrapper } from '#types'
 import type { MassAppApi, MassState } from '#mass/types/mass'
 
+/** Elements created by the UI, save the holder */
 export type MultiTermWrapperDom = {
 	/** Div containing optional bottom text, next to the
 	 * submit button */
@@ -15,6 +16,8 @@ export type MultiTermWrapperDom = {
 	submitBtn: Button
 }
 
+/** Multiple opts match the opts for termsettingInit()
+ * See opts for termsettingInit() for more info */
 export type MultiTermWrapperUIOpts = {
 	app: MassAppApi
 	/** Customizable label for the 'submit' button.
@@ -37,4 +40,6 @@ export type MultiTermWrapperUIOpts = {
 	headerText?: string
 	/** Term wrappers already in use on init */
 	twList?: TermWrapper[]
+	/** Specific terms to disable. Will be combined with the running twlist.  */
+	disable_terms?: string[]
 }

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -22,6 +22,18 @@ export class VolcanoInteractions {
 	async confoundersMenu() {
 		const state = this.app.getState()
 		const config = state.plots.find((p: VolcanoPlotConfig) => p.id === this.id)
+
+		/** Find terms used to create the groups and disable in the
+		 * termsetting UI. Prevents users from trying to control for
+		 * variables used to create the groups.*/
+		const allowedGroupNames = new Set([config.samplelst.groups[0].name, config.samplelst.groups[1].name])
+		const grpTerms: Set<string> = new Set(
+			(this.app?.vocabApi?.state.groups || [])
+				.filter(g => allowedGroupNames.has(g.name))
+				.flatMap(g => g.filter.lst.map(f => f.tvs.term.id))
+		)
+		const disable_terms = grpTerms.size ? Array.from(grpTerms) : []
+
 		const ui = new MultiTermWrapperEditUI({
 			app: this.app,
 			callback: async tws => {
@@ -36,7 +48,8 @@ export class VolcanoInteractions {
 			headerText: 'Select confounders',
 			maxNum: 2,
 			state,
-			twList: config.confounderTws
+			twList: config.confounderTws,
+			disable_terms
 		})
 		await ui.renderUI()
 	}

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -30,7 +30,12 @@ export class VolcanoInteractions {
 		const grpTerms: Set<string> = new Set(
 			(this.app?.vocabApi?.state.groups || [])
 				.filter(g => allowedGroupNames.has(g.name))
-				.flatMap(g => g.filter.lst.map(f => f.tvs.term.id))
+				.flatMap(g =>
+					g.filter.lst.flatMap(f => {
+						if (f.tvs?.term) return f.tvs.term.id || f.tvs.term.name
+						else return f.lst.map(l => l.tvs.term.id || l.tvs.term.name)
+					})
+				)
 		)
 		const disable_terms = grpTerms.size ? Array.from(grpTerms) : []
 

--- a/client/plots/volcano/test/testData.js
+++ b/client/plots/volcano/test/testData.js
@@ -1,0 +1,159 @@
+export const group1Values = [
+	{ sampleId: 70, sample: 'SJALL044294' },
+	{ sampleId: 100, sample: 'SJBALL047019' },
+	{ sampleId: 109, sample: 'SJBALL047029' },
+	{ sampleId: 139, sample: 'SJALL048686' },
+	{ sampleId: 142, sample: 'SJALL048691' },
+	{ sampleId: 163, sample: 'SJALL054521' },
+	{ sampleId: 268, sample: 'SJALL061718' },
+	{ sampleId: 402, sample: 'SJMLL023' },
+	{ sampleId: 407, sample: 'SJMLL024' },
+	{ sampleId: 462, sample: 'SJMLL003329' },
+	{ sampleId: 596, sample: 'SJMLL022031' },
+	{ sampleId: 597, sample: 'SJMLL009' },
+	{ sampleId: 623, sample: 'SJINF022043' },
+	{ sampleId: 624, sample: 'SJ0624' },
+	{ sampleId: 641, sample: 'SJ0641' },
+	{ sampleId: 705, sample: 'SJ0705' },
+	{ sampleId: 804, sample: 'SJALL061926' },
+	{ sampleId: 816, sample: 'SJBALL030059' },
+	{ sampleId: 834, sample: 'SJBALL030123' },
+	{ sampleId: 883, sample: 'SJBALL030313' },
+	{ sampleId: 918, sample: 'SJBALL030543' },
+	{ sampleId: 964, sample: 'SJBALL031077' },
+	{ sampleId: 1056, sample: 'SJBALL032307' },
+	{ sampleId: 1068, sample: 'SJ1068' },
+	{ sampleId: 1071, sample: 'SJ1071' }
+]
+
+export const group2Values = [
+	{ sampleId: 49, sample: 'SJMLL033' },
+	{ sampleId: 68, sample: 'SJALL046376' },
+	{ sampleId: 73, sample: 'SJALL044301' },
+	{ sampleId: 81, sample: 'SJBALL042261' },
+	{ sampleId: 104, sample: 'SJBALL047023' },
+	{ sampleId: 107, sample: 'SJALL047974' },
+	{ sampleId: 108, sample: 'SJBALL047028' },
+	{ sampleId: 123, sample: 'SJALL048082' },
+	{ sampleId: 133, sample: 'SJALL048672' },
+	{ sampleId: 152, sample: 'SJALL049671' },
+	{ sampleId: 159, sample: 'SJALL049937' },
+	{ sampleId: 172, sample: 'SJALL054536' },
+	{ sampleId: 180, sample: 'SJALL054545' },
+	{ sampleId: 198, sample: 'SJALL055898' },
+	{ sampleId: 199, sample: 'SJALL057945' },
+	{ sampleId: 202, sample: 'SJALL057948' },
+	{ sampleId: 214, sample: 'SJALL059329' },
+	{ sampleId: 217, sample: 'SJALL059332' },
+	{ sampleId: 222, sample: 'SJALL059521' },
+	{ sampleId: 224, sample: 'SJALL059535' },
+	{ sampleId: 225, sample: 'SJALL059523' },
+	{ sampleId: 305, sample: 'SJALL063022' },
+	{ sampleId: 331, sample: 'SJALL063998' },
+	{ sampleId: 333, sample: 'SJALL064402' },
+	{ sampleId: 334, sample: 'SJALL064403' },
+	{ sampleId: 358, sample: 'SJALL066227' },
+	{ sampleId: 367, sample: 'SJALL066763' },
+	{ sampleId: 369, sample: 'SJALL066760' },
+	{ sampleId: 509, sample: 'SJ0509' },
+	{ sampleId: 512, sample: 'SJMLL003304' },
+	{ sampleId: 531, sample: 'SJINF022' },
+	{ sampleId: 587, sample: 'SJ0587' },
+	{ sampleId: 693, sample: 'SJALL048337' },
+	{ sampleId: 738, sample: 'SJALL062148' },
+	{ sampleId: 752, sample: 'SJALL040130' },
+	{ sampleId: 796, sample: 'SJALL048406' },
+	{ sampleId: 823, sample: 'SJALL047541' },
+	{ sampleId: 852, sample: 'SJ0852' },
+	{ sampleId: 871, sample: 'SJBALL030301' },
+	{ sampleId: 915, sample: 'SJBALL030535' },
+	{ sampleId: 946, sample: 'SJBALL030887' },
+	{ sampleId: 993, sample: 'SJ0993' },
+	{ sampleId: 1010, sample: 'SJBALL031772' }
+]
+
+export const groups = [
+	{
+		name: 'Sensitive',
+		in: true,
+		values: group1Values
+	},
+	{
+		name: 'Resistant',
+		in: true,
+		values: group2Values
+	}
+]
+
+export const responseData = [
+	{
+		gene_name: 'ENSG00000187634.6',
+		gene_symbol: 'SAMD11',
+		fold_change: 0.1128,
+		original_p_value: 0.3325,
+		adjusted_p_value: 0.1565
+	},
+	{
+		gene_name: 'ENSG00000188976.6',
+		gene_symbol: 'NOC2L',
+		fold_change: 0.1569,
+		original_p_value: 0.7206,
+		adjusted_p_value: 0.3427
+	},
+	{
+		gene_name: 'ENSG00000187961.9',
+		gene_symbol: 'KLHL17',
+		fold_change: -0.1281,
+		original_p_value: 0.2826,
+		adjusted_p_value: 0.1345
+	},
+	{
+		gene_name: 'ENSG00000187608.5',
+		gene_symbol: 'ISG15',
+		fold_change: 0.1667,
+		original_p_value: 0.2198,
+		adjusted_p_value: 0.1032
+	},
+	{
+		gene_name: 'ENSG00000188157.9',
+		gene_symbol: 'AGRN',
+		fold_change: 0.6196,
+		original_p_value: 1.483,
+		adjusted_p_value: 0.7022
+	},
+	{
+		gene_name: 'ENSG00000131591.13',
+		gene_symbol: 'C1orf159',
+		fold_change: -0.0021,
+		original_p_value: 0.0049,
+		adjusted_p_value: 0.0021
+	},
+	{
+		gene_name: 'ENSG00000078808.12',
+		gene_symbol: 'SDF4',
+		fold_change: 0.4862,
+		original_p_value: 3.2334,
+		adjusted_p_value: 1.5562
+	},
+	{
+		gene_name: 'ENSG00000176022.3',
+		gene_symbol: 'B3GALT6',
+		fold_change: 0.0751,
+		original_p_value: 0.1906,
+		adjusted_p_value: 0.0888
+	},
+	{
+		gene_name: 'ENSG00000160087.16',
+		gene_symbol: 'UBE2J2',
+		fold_change: 0.0744,
+		original_p_value: 0.3546,
+		adjusted_p_value: 0.168
+	},
+	{
+		gene_name: 'ENSG00000162572.15',
+		gene_symbol: 'SCNN1D',
+		fold_change: 0.0993,
+		original_p_value: 0.1659,
+		adjusted_p_value: 0.0758
+	}
+]

--- a/client/plots/volcano/test/volcano.unit.spec.ts
+++ b/client/plots/volcano/test/volcano.unit.spec.ts
@@ -1,0 +1,189 @@
+import tape from 'tape'
+import * as testData from './testData'
+import { VolcanoViewModel } from '../viewModel/VolcanoViewModel'
+// import { scaleLinear } from 'd3-scale'
+
+/* Tests:
+    -init VolcanoViewModel
+    -setDataType
+    -setMinMaxValues
+    -setPlotDimensions
+    -setPointData
+    -setStatsData
+*/
+
+const mockSettings = {
+	defaultSignColor: 'red',
+	defaultNonSignColor: 'black',
+	defaultHighlightColor: '#ffa200',
+	foldChangeCutoff: 0,
+	height: 400,
+	method: 'edgeR',
+	minCount: 10,
+	minTotalCount: 15,
+	pValue: 0.05,
+	pValueType: 'adjusted',
+	rankBy: 'abs(foldChange)',
+	showImages: false,
+	showPValueTable: false,
+	width: 400
+}
+
+const mockConfig = {
+	confounderTws: [],
+	highlightedData: [],
+	settings: {
+		volcano: mockSettings
+	},
+	termType: 'geneExpression',
+	samplelst: {
+		groups: testData.groups
+	},
+	tw: {
+		q: {
+			groups: testData.groups
+		},
+		term: {
+			name: 'Sensitive vs Resistant',
+			type: 'samplelst',
+			values: {
+				Sensitive: {
+					color: '#1b9e77',
+					key: 'Sensitive',
+					label: 'Sensitive',
+					list: testData.group1Values
+				},
+				Resistant: {
+					color: '#d95f02',
+					key: 'Resistant',
+					label: 'Resistant',
+					list: testData.group2Values
+				}
+			}
+		}
+	}
+}
+
+const mockResponse = {
+	data: testData.responseData,
+	images: [],
+	method: 'edgeR',
+	sample_size1: 3,
+	sample_size2: 3
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.pass('-***- plots/volcano/Volcano -***-')
+	test.end()
+})
+
+tape('init VolcanoViewModel', function (test) {
+	test.timeoutAfter(100)
+
+	const viewModel = new VolcanoViewModel(mockConfig as any, mockResponse, mockSettings as any)
+	test.equal(viewModel.config, mockConfig, `Should properly set config`)
+	test.equal(viewModel.response, mockResponse, `Should properly set response`)
+	test.equal(viewModel.settings, mockSettings, `Should properly set settings`)
+	test.equal(viewModel.pValueCutoff, -Math.log10(mockSettings.pValue), `Should properly set pValueCutoff`)
+	test.equal(viewModel.termType, mockConfig.termType, 'Should properly set termType')
+	test.equal(viewModel.numSignificant, 1, 'Should properly set numSignificant')
+	test.equal(viewModel.numNonSignificant, 9, 'Should properly set numNonSignificant')
+
+	test.end()
+})
+
+tape('setDataType', function (test) {
+	test.timeoutAfter(100)
+
+	const viewModel = new VolcanoViewModel(mockConfig as any, mockResponse, mockSettings as any)
+
+	viewModel.setDataType()
+	test.equal(viewModel.dataType, 'genes', 'Should properly set dataType')
+
+	test.end()
+})
+
+tape('setMinMaxValues', function (test) {
+	test.timeoutAfter(100)
+
+	const viewModel = new VolcanoViewModel(mockConfig as any, mockResponse, mockSettings as any)
+
+	viewModel.setMinMaxValues()
+	test.equal(viewModel.minLogFoldChange, -0.1281, 'Should properly set minLogFoldChange')
+	test.equal(viewModel.maxLogFoldChange, 0.6196, 'Should properly set maxLogFoldChange')
+	test.equal(viewModel.minLogPValue, 0, 'Should properly set minLogPValue')
+	test.equal(viewModel.maxLogPValue, 1.5562, 'Should properly set maxLogPValue')
+
+	test.end()
+})
+
+tape('setPlotDimensions', function (test) {
+	test.timeoutAfter(100)
+
+	const viewModel = new VolcanoViewModel(mockConfig as any, mockResponse, mockSettings as any)
+
+	const plotDim = viewModel.setPlotDimensions()
+	test.deepEqual(plotDim.svg, { height: 560, width: 540 }, 'Should properly set svg')
+	test.deepEqual(plotDim.xAxisLabel, { x: 280, y: 500 }, 'Should properly set xAxisLabel')
+	// test.deepEqual(plotDim.xScale, { x: 90, y: 450, scale: scaleLinear()}, 'Should properly set xScale')
+	test.deepEqual(
+		plotDim.yAxisLabel,
+		{ text: '-log10(adjusted P value)', x: 23.333333333333332, y: 250 },
+		'Should properly set yAxisLabel'
+	)
+	// test.deepEqual(plotDim.yScale, { x: 70, y: 30, scale: scaleLinear() }, 'Should properly set yScale')
+	test.deepEqual(plotDim.plot, { height: 400, width: 400, x: 90, y: 30 }, 'Should properly set plot')
+	test.deepEqual(
+		plotDim.logFoldChangeLine,
+		{ x: 158.5301591547412, y1: 30, y2: 430 },
+		'Should properly set logFoldChangeLine'
+	)
+
+	test.end()
+})
+
+tape('setPointData', function (test) {
+	test.timeoutAfter(100)
+
+	const viewModel = new VolcanoViewModel(mockConfig as any, mockResponse, mockSettings as any)
+
+	const plotDim = viewModel.setPlotDimensions()
+	const pointData = viewModel.setPointData(plotDim)
+
+	test.equal(pointData.length, 10, 'Should properly set pointData length')
+	test.equal(
+		pointData.filter((d: any) => d.color === 'black').length,
+		9,
+		'Should properly set color for each data point'
+	)
+	test.equal(
+		pointData.filter((d: any) => d.highlighted === false).length,
+		10,
+		'Should properly set highlighted property for each data point'
+	)
+	test.equal(pointData.filter((d: any) => d.radius === 5).length, 10, 'Should properly set radius for each data point')
+
+	test.end()
+})
+
+tape('setStatsData', function (test) {
+	test.timeoutAfter(100)
+
+	const viewModel = new VolcanoViewModel(mockConfig as any, mockResponse, mockSettings as any)
+
+	const statsData = viewModel.setStatsData()
+	const expected = [
+		{ label: 'Percentage of significant genes', value: 10 },
+		{ label: 'Number of significant genes', value: 1 },
+		{ label: 'Number of total genes', value: 10 },
+		{ label: 'Sensitive sample size (control group)', value: 3 },
+		{ label: 'Resistant sample size (case group)', value: 3 }
+	]
+	test.deepEqual(statsData, expected, 'Should properly set statsData')
+
+	test.end()
+})


### PR DESCRIPTION
## Description

Changes: 
1. Disable terms used to create the groups in confounders menu. The multi tw edit UI was updated to accommodate this logic. 
2. New unit tests for the volcano

Test: 
1. [All pharm](http://localhost:3000/?massnative=hg38,ALL-pharmacotyping) -> create two groups -> open the confounders menu -> see terms used to create the group as disabled. Note there's a termsetting bug that on search the pills are still enabled. In the tree the pills are disabled. 
2. [New unit tests](http://localhost:3000/testrun.html?dir=plots/volcano&name=volcano.unit)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
