### PR TITLE
If term exists and is numeric set discrete mode and fill it

### DIFF
--- a/client/plots/sampleScatter.js
+++ b/client/plots/sampleScatter.js
@@ -240,8 +240,10 @@ class Scatter {
 			numericEditMenuVersion: ['discrete'],
 			processInput: async tw => {
 				//only discrete mode allowed so set discrete mode and fill term wrapper to add the bins
-				if (isNumericTerm(tw?.term)) tw.q = { mode: 'discrete' } //use discrete mode by default
-				await fillTermWrapper(tw, this.app.vocabApi)
+				if (isNumericTerm(tw?.term)) {
+					tw.q = { mode: 'discrete' } //use discrete mode by default
+					await fillTermWrapper(tw, this.app.vocabApi)
+				}
 			}
 		}
 		const shapeSizeOption = {


### PR DESCRIPTION
## Description

Thanks @karishma-gangwani. I needed to validate that the term exists and is numeric to fill it. Closes #3008 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
