### PR TITLE
Show/hide tables in the volcano

### DIFF
--- a/client/plots/controls.btns.js
+++ b/client/plots/controls.btns.js
@@ -90,7 +90,14 @@ function helpBtnInit(opts) {
 	icon_functions['help'](infoDiv, { handler: opts.callback, title: 'Documentation' })
 
 	const self = {
-		plotTypes: ['profilePolar', 'profileBarchart', 'profileRadar', 'profileRadarFacility', 'boxplot'],
+		plotTypes: [
+			'profilePolar',
+			'profileBarchart',
+			'profileRadar',
+			'profileRadarFacility',
+			'boxplot',
+			'differentialAnalysis'
+		],
 		dom: {
 			btn: infoDiv
 		}

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -17,7 +17,7 @@ class Volcano extends RxComponentInner {
 	components: { controls: any }
 	dom: VolcanoDom
 	interactions?: VolcanoInteractions
-	termType: string //'geneExpresion', etc.
+	termType: string
 	diffAnalysisInteractions?: DiffAnalysisInteractions
 
 	constructor(opts: VolcanoOpts) {
@@ -81,10 +81,13 @@ class Volcano extends RxComponentInner {
 			inputs: controls.inputs
 		})
 
-		this.components.controls.on('downloadClick.differentialAnalysis', () => this.interactions!.download(this.termType))
-		this.components.controls.on('helpClick.differentialAnalysis', () =>
-			window.open('https://github.com/stjude/proteinpaint/wiki/Differential-analysis')
-		)
+		this.components.controls.on('downloadClick.volcano', () => this.interactions!.download(this.termType))
+		if (plotConfig.chartType == 'differentialAnalysis')
+			this.components.controls.on('helpClick.differentialAnalysis', () =>
+				//Opens the page for the differential analysis wiki
+				//Can't put in parent as DA does not have a controls component
+				window.open('https://github.com/stjude/proteinpaint/wiki/Differential-analysis')
+			)
 	}
 
 	async init() {

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -147,7 +147,6 @@ export function getDefaultVolcanoSettings(overrides = {}): VolcanoSettings {
 		pValueType: 'adjusted',
 		rankBy: 'abs(foldChange)',
 		showImages: false,
-		showPValueTable: false,
 		width: 400
 	}
 	return Object.assign(defaults, overrides)

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -155,9 +155,6 @@ export function getDefaultVolcanoSettings(overrides = {}): VolcanoSettings {
 		pValue: 0.05,
 		pValueType: 'adjusted',
 		rankBy: 'abs(foldChange)',
-		showImages: false,
-		showPValueTable: false,
-		showStats: true,
 		width: 400
 	}
 	return Object.assign(defaults, overrides)

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -102,7 +102,11 @@ class Volcano extends RxComponentInner {
 		try {
 			if (!this.interactions) throw 'Interactions not initialized [main() Volcano.ts]'
 
-			this.dom.wait.style('display', 'block')
+			//Only show Loading for data requests that take longer than 500ms
+			const showWait = setTimeout(() => {
+				this.dom.wait.style('display', 'block')
+			}, 500)
+
 			const settings = config.settings.volcano
 			/** Fetch data */
 			const model = new VolcanoModel(this.app, config, settings)
@@ -120,6 +124,8 @@ class Volcano extends RxComponentInner {
 			//Pass table data for downloading
 			this.interactions.pValueTableData = viewModel.viewData.pValueTableData
 			this.interactions.data = response.data
+
+			clearTimeout(showWait)
 			this.dom.wait.style('display', 'none')
 			/** Render formatted data */
 			new VolcanoPlotView(this.dom, settings, viewModel.viewData, this.interactions, config.termType)

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -147,6 +147,8 @@ export function getDefaultVolcanoSettings(overrides = {}): VolcanoSettings {
 		pValueType: 'adjusted',
 		rankBy: 'abs(foldChange)',
 		showImages: false,
+		showPValueTable: false,
+		showStats: true,
 		width: 400
 	}
 	return Object.assign(defaults, overrides)

--- a/client/plots/volcano/VolcanoControlInputs.ts
+++ b/client/plots/volcano/VolcanoControlInputs.ts
@@ -48,14 +48,6 @@ export class VolcanoControlInputs {
 					{ label: 'Original', value: 'original' }
 				]
 			},
-			{
-				label: 'Show P value table',
-				type: 'checkbox',
-				chartType: 'volcano',
-				settingsKey: 'showPValueTable',
-				title: 'Show table with both original and adjusted p values for all significant genes',
-				boxLabel: ''
-			},
 			//Preferably, keep all the display (e.g. colors, sizes, etc.) controls
 			//at the bottom of the list or at least together
 			{

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -85,12 +85,9 @@ export type VolcanoDom = {
 export type VolcanoPlotDom = {
 	/** Holder for action buttons above the images and plot */
 	actions: Div
-	/** Div for server generated images */
-	images: Div
 	/** Holder for data points, p value line, and fold change line */
 	plot: SvgG
 	pValueTable: Div
-	stats: Div
 	/** Holder for plot, axis labels, and title */
 	svg: SvgSvg
 	/** X axis */
@@ -131,12 +128,6 @@ export type VolcanoSettings = {
 	pValueType: 'original' | 'adjusted'
 	/** Toggle between ranking the genes by variance or abs(foldChange) */
 	rankBy: 'abs(foldChange)' | 'pValue'
-	/** If true, show server generated images. If false, hide div. Default is false. */
-	showImages: boolean
-	/** If true, show p value table to the right of the volcano plot. Default is false. */
-	showPValueTable: boolean
-	/** If true, show stats/summary table underneath the volcano plot. Default is true.*/
-	showStats: boolean
 	/** plot height */
 	height: number
 	/** plot width */

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -131,9 +131,11 @@ export type VolcanoSettings = {
 	pValueType: 'original' | 'adjusted'
 	/** Toggle between ranking the genes by variance or abs(foldChange) */
 	rankBy: 'abs(foldChange)' | 'pValue'
-	/** If true, show server generated images. If false, hide div. */
+	/** If true, show server generated images. If false, hide div. Default is false. */
 	showImages: boolean
+	/** If true, show p value table to the right of the volcano plot. Default is false. */
 	showPValueTable: boolean
+	/** If true, show stats/summary table underneath the volcano plot. Default is true.*/
 	showStats: boolean
 	/** plot height */
 	height: number

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -133,6 +133,8 @@ export type VolcanoSettings = {
 	rankBy: 'abs(foldChange)' | 'pValue'
 	/** If true, show server generated images. If false, hide div. */
 	showImages: boolean
+	showPValueTable: boolean
+	showStats: boolean
 	/** plot height */
 	height: number
 	/** plot width */

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -89,6 +89,8 @@ export type VolcanoPlotDom = {
 	images: Div
 	/** Holder for data points, p value line, and fold change line */
 	plot: SvgG
+	pValueTable: Div
+	stats: Div
 	/** Holder for plot, axis labels, and title */
 	svg: SvgSvg
 	/** X axis */
@@ -131,8 +133,6 @@ export type VolcanoSettings = {
 	rankBy: 'abs(foldChange)' | 'pValue'
 	/** If true, show server generated images. If false, hide div. */
 	showImages: boolean
-	/** Show a table of p values */
-	showPValueTable: boolean
 	/** plot height */
 	height: number
 	/** plot width */

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -169,12 +169,12 @@ export class VolcanoInteractions {
 		})
 	}
 
-	showImages() {
+	showDom(key) {
 		const plotConfig = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
 		this.app.dispatch({
 			type: 'plot_edit',
 			id: this.id,
-			config: { settings: { volcano: { showImages: !plotConfig.settings.volcano.showImages } } }
+			config: { settings: { volcano: { [key]: !plotConfig.settings.volcano[key] } } }
 		})
 	}
 }

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -168,13 +168,4 @@ export class VolcanoInteractions {
 			}
 		})
 	}
-
-	showDom(key) {
-		const plotConfig = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
-		this.app.dispatch({
-			type: 'plot_edit',
-			id: this.id,
-			config: { settings: { volcano: { [key]: !plotConfig.settings.volcano[key] } } }
-		})
-	}
 }

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -159,6 +159,9 @@ export class VolcanoPlotView {
 			.append('div')
 			//Show the stats table underneath the images if > 1 image or to the right if only 1 image
 			.style('display', this.viewData.images.length > 1 ? 'block' : 'inline-block')
+			//Top margin is roughly inline with image however the margins are set by server
+			//Likewise the image margins are undetectable.
+			//This is a roughly satistifes the different image margin scenarios.
 			.style('margin', `${this.viewData.images.length > 1 ? `0px 0px` : `40px 10px`} 0px 5px`)
 			.style('vertical-align', 'top')
 		const table = table2col({ holder: tableHolder })

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -42,7 +42,8 @@ export class VolcanoPlotView {
 			.style('display', settings.showImages ? 'block' : 'none')
 			.style('vertical-align', 'top')
 			.attr('id', 'sjpp-volcano-images')
-		const svg = this.dom.holder.append('svg').style('display', 'inline-block').attr('id', 'sjpp-volcano-svg')
+		const volcanoHolder = this.dom.holder.append('div').style('display', 'inline-block').style('vertical-align', 'top')
+		const svg = volcanoHolder.append('svg').style('display', 'block').attr('id', 'sjpp-volcano-svg')
 		this.volcanoDom = {
 			actions,
 			images,
@@ -51,7 +52,9 @@ export class VolcanoPlotView {
 			yAxis: svg.append('g').attr('id', 'sjpp-volcano-yAxis'),
 			xAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-xAxisLabel').attr('text-anchor', 'middle'),
 			yAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-yAxisLabel').attr('text-anchor', 'middle'),
-			plot: svg.append('g').attr('id', 'sjpp-volcano-plot')
+			plot: svg.append('g').attr('id', 'sjpp-volcano-plot'),
+			pValueTable: this.dom.holder.append('div').attr('id', 'sjpp-volcano-pValueTable'),
+			stats: volcanoHolder.append('div').attr('id', 'sjpp-volcano-stats')
 		}
 		this.termType = termType
 
@@ -76,6 +79,15 @@ export class VolcanoPlotView {
 					this.interactions.showImages()
 				})
 			}
+			this.addActionButton('Statistics', () => {
+				this.volcanoDom.stats.style('display', this.volcanoDom.stats.style('display') == 'none' ? '' : 'none')
+			})
+			this.addActionButton('P Value Table', () => {
+				this.volcanoDom.pValueTable.style(
+					'display',
+					this.volcanoDom.pValueTable.style('display') == 'none' ? 'inline-block' : 'none'
+				)
+			})
 		}
 	}
 
@@ -143,12 +155,7 @@ export class VolcanoPlotView {
 
 	renderStatsTable() {
 		const statsData = this.viewData.statsData
-		const holder = this.dom.holder
-			.append('div')
-			.attr('id', 'sjpp-volcano-stats')
-			.style('display', 'inline-block')
-			.style('vertical-align', 'top')
-			.style('margin-top', '20px')
+		const holder = this.volcanoDom.stats.style('display', 'none').style('vertical-align', 'top')
 		const table = table2col({ holder })
 		for (const d of statsData) {
 			const [td1, td2] = table.addRow()
@@ -158,11 +165,7 @@ export class VolcanoPlotView {
 	}
 
 	renderPValueTable() {
-		if (!this.settings.showPValueTable) {
-			this.dom.holder.selectAll('div[id="sjpp-volcano-pValueTable"]').remove()
-			return
-		}
-		const tableDiv = this.dom.holder.append('div').attr('id', 'sjpp-volcano-pValueTable')
+		const tableDiv = this.volcanoDom.pValueTable.style('display', 'none')
 		renderTable({
 			columns: this.viewData.pValueTableData.columns,
 			rows: this.viewData.pValueTableData.rows,

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -53,11 +53,16 @@ export class VolcanoPlotView {
 			xAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-xAxisLabel').attr('text-anchor', 'middle'),
 			yAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-yAxisLabel').attr('text-anchor', 'middle'),
 			plot: svg.append('g').attr('id', 'sjpp-volcano-plot'),
-			pValueTable: this.dom.holder.append('div').attr('id', 'sjpp-volcano-pValueTable'),
-			stats: volcanoHolder.append('div').attr('id', 'sjpp-volcano-stats')
+			pValueTable: this.dom.holder
+				.append('div')
+				.attr('id', 'sjpp-volcano-pValueTable')
+				.style('display', settings.showPValueTable ? 'inline-block' : 'none'),
+			stats: volcanoHolder
+				.append('div')
+				.attr('id', 'sjpp-volcano-stats')
+				.style('display', settings.showStats ? 'block' : 'none')
 		}
 		this.termType = termType
-
 		const plotDim = this.viewData.plotDim
 		this.renderUserActions()
 		this.renderPlot(plotDim)
@@ -76,17 +81,14 @@ export class VolcanoPlotView {
 			if (this.viewData.images.length) {
 				const btnLabel = `Image${this.viewData.images.length > 1 ? `s (${this.viewData.images.length})` : ''}`
 				this.addActionButton(btnLabel, () => {
-					this.interactions.showImages()
+					this.interactions.showDom('showImages')
 				})
 			}
 			this.addActionButton('Statistics', () => {
-				this.volcanoDom.stats.style('display', this.volcanoDom.stats.style('display') == 'none' ? '' : 'none')
+				this.interactions.showDom('showStats')
 			})
 			this.addActionButton('P Value Table', () => {
-				this.volcanoDom.pValueTable.style(
-					'display',
-					this.volcanoDom.pValueTable.style('display') == 'none' ? 'inline-block' : 'none'
-				)
+				this.interactions.showDom('showPValueTable')
 			})
 		}
 	}
@@ -155,8 +157,7 @@ export class VolcanoPlotView {
 
 	renderStatsTable() {
 		const statsData = this.viewData.statsData
-		const holder = this.volcanoDom.stats.style('display', 'none').style('vertical-align', 'top')
-		const table = table2col({ holder })
+		const table = table2col({ holder: this.volcanoDom.stats })
 		for (const d of statsData) {
 			const [td1, td2] = table.addRow()
 			td1.text(d.label)
@@ -165,11 +166,10 @@ export class VolcanoPlotView {
 	}
 
 	renderPValueTable() {
-		const tableDiv = this.volcanoDom.pValueTable.style('display', 'none')
 		renderTable({
 			columns: this.viewData.pValueTableData.columns,
 			rows: this.viewData.pValueTableData.rows,
-			div: tableDiv.append('div'),
+			div: this.volcanoDom.pValueTable.append('div'),
 			showLines: true,
 			maxHeight: '150vh',
 			resize: true,

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -72,9 +72,9 @@ export class VolcanoViewModel {
 		for (const d of this.response.data) {
 			this.minLogFoldChange = Math.min(this.minLogFoldChange, d.fold_change)
 			this.maxLogFoldChange = Math.max(this.maxLogFoldChange, d.fold_change)
-			if (d.adjusted_p_value != 0) {
-				this.minLogPValue = Math.min(this.minLogPValue, d.adjusted_p_value)
-				this.maxLogPValue = Math.max(this.maxLogPValue, d.adjusted_p_value)
+			if (d[`${this.settings.pValueType}_p_value`] != 0) {
+				this.minLogPValue = Math.min(this.minLogPValue, d[`${this.settings.pValueType}_p_value`])
+				this.maxLogPValue = Math.max(this.maxLogPValue, d[`${this.settings.pValueType}_p_value`])
 			}
 		}
 	}

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -35,9 +35,9 @@ export class VolcanoViewModel {
 		this.pValueCutoff = -Math.log10(settings.pValue)
 		this.pValueTable = {
 			columns: [
-				{ label: 'log2 Fold change', sortable: true },
-				{ label: 'Original p-value (linear scale)', sortable: true },
-				{ label: 'Adjusted p-value (linear scale)', sortable: true }
+				{ label: 'log2(Fold change)', barplot: {}, sortable: true },
+				{ label: 'Original p-value (linear)', sortable: true },
+				{ label: 'Adjusted p-value (linear)', sortable: true }
 			],
 			rows: []
 		}
@@ -48,11 +48,15 @@ export class VolcanoViewModel {
 		this.setMinMaxValues()
 
 		const plotDim = this.setPlotDimensions()
-		this.setPTableData()
+		this.setPTableColumns()
+		const pointData = this.setPointData(plotDim)
+		//Get all rows data for the pValueTable in setPointsData, then sort by fold change
+		const foldChangeIdx = this.pValueTable.columns.findIndex(c => c.label.includes('log2(Fold change)'))
+		this.pValueTable.rows.sort((a: any, b: any) => b[foldChangeIdx].value - a[foldChangeIdx].value)
 
 		this.viewData = {
 			plotDim,
-			pointData: this.setPointData(plotDim),
+			pointData,
 			statsData: this.setStatsData(),
 			pValueTableData: this.pValueTable,
 			images: response.images || []
@@ -131,7 +135,7 @@ export class VolcanoViewModel {
 					{ value: roundValueAuto(Math.pow(10, -d.adjusted_p_value)) }
 				]
 				if (this.dataType == 'genes') {
-					row.splice(0, 0, { value: d.gene_name }, { value: d.gene_symbol })
+					row.splice(0, 0, { value: d.gene_symbol })
 				}
 				this.pValueTable.rows.push(row)
 			} else {
@@ -190,16 +194,9 @@ export class VolcanoViewModel {
 		return tableRows
 	}
 
-	setPTableData() {
+	setPTableColumns() {
 		if (this.termType == 'geneExpression') {
-			this.pValueTable.columns.splice(
-				0,
-				0,
-				{ label: 'Gene Name', sortable: true },
-				{ label: 'Gene Symbol', sortable: true }
-			)
+			this.pValueTable.columns.splice(0, 0, { label: 'Gene Symbol', sortable: true })
 		}
-		const foldChangeIdx = this.pValueTable.columns.findIndex(c => c.label.includes('Fold change'))
-		this.pValueTable.rows.sort((a: any, b: any) => a[foldChangeIdx].value - b[foldChangeIdx].value).reverse()
 	}
 }

--- a/release.txt
+++ b/release.txt
@@ -1,3 +1,2 @@
-
-Features
--Added the Profile Likert plot
+Fixes:
+- Data points in the differential analysis volcano plot appear inbounds when original p value is selected


### PR DESCRIPTION
## Description
Addresses feature requests and closes issue #3014. 

Changes: 
1. The p value table appears to the right of the plot. The gene name is removed and the fold change is shown as a bar plot. By default it is hidden. To show the table, click the new button appearing above the plot. The checkbox in the controls is removed. 
2. The stats table appears below the plot. It too is shown/hidden from a new button above the plot. It was requested to be shown by default. 
3. The issue with the data points appearing outside the plot is fixed. 
4. The click handler for [the wiki ](https://github.com/stjude/proteinpaint/wiki/Differential-analysis)is fixed. We should start adding documentation, explanations about the calculations, references, etc. to the wiki. 

Test with either [the test file](http://localhost:3000/testrun.html?dir=plots/diffAnalysis&name=diffAnalysis) or any mass groups in [all pharma](http://localhost:3000/?massnative=hg38,ALL-pharmacotyping). 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
