### PR TITLE
support ds defined snvindel.byisoform.get(), fix bug launching custom…

### DIFF
--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -92,12 +92,17 @@ type bcfMafFile = {
 	maffile: string
 }
 
+type SnvindelByIsoform = {
+	/** if true, served from gdc. no other parameters */
+	gdcapi?: true
+	/** getter function to retrieve data. dynamically added or ds-supplied */
+	get?: (f: any) => void
+}
+
 type SnvindelByRange = {
-	/** if true, served from gdc. no other parameters TODO change to src='gdc/native' */
-	gdcapi?: boolean
-
+	/** if true, served from gdc. no other parameters */
+	gdcapi?: true
 	//local ds can have following different setup
-
 	/** one single bcf file */
 	bcffile?: string
 	/** one bcf file per chr */
@@ -106,8 +111,8 @@ type SnvindelByRange = {
 	bcfMafFile?: bcfMafFile
 	/** allow to apply special configurations to certain INFO fields of the bcf file */
 	infoFields?: InfoFieldEntry[]
-	/** if true, bcf or chr2bcf uses string sample name in header. to be used during this migrating so the code can deal with old files with integer sample ids and new ones; TODO once all datasets are migrated, delete the flag */
-	tempflag_sampleNameInVcfHeader?: boolean
+	/** getter function to retrieve data. dynamically added or ds-supplied */
+	get?: (f: any) => void
 }
 
 type URLEntry = {
@@ -310,12 +315,10 @@ type SnvindelComputeGroup_info = {
 /** a data type under ds.queries{} */
 type SnvIndelQuery = {
 	forTrack?: boolean
-	/** allow to query data by either isoform or range
-	 * isoform query is only used for gdc api
-	 */
-	byisoform?: GdcApi
+	/** allow to query data by either isoform or range; either or both can be used; cannot be both missing */
+	byisoform?: SnvindelByIsoform
 	/** query data by range */
-	byrange: SnvindelByRange
+	byrange?: SnvindelByRange
 
 	infoUrl?: URLEntry[]
 	skewerRim?: SkewerRim

--- a/shared/utils/src/common.js
+++ b/shared/utils/src/common.js
@@ -229,6 +229,8 @@ export function mclasstester(s) {
 			return 'N'
 		case 'splice_site':
 			return 'L'
+		case 'splice_region':
+			return 'P'
 		case 'rna':
 			return mclassnoncoding
 		case 'frame_shift_del':
@@ -253,6 +255,8 @@ export function mclasstester(s) {
 			return mclassutr5
 		case "5'flank":
 			return mclassnoncoding
+		case 'silent':
+			return 'S'
 		case 'blank':
 			return 'Blank'
 		default:


### PR DESCRIPTION
… bcf tk

## Description

closes #3017 
fixed a bug that's breaking custom bcf card on prod, e.g. http://localhost:3000/?genome=hg38-test&gene=p53&mds3bcffile=custom,files/hg38/TermdbTest/TermdbTest.bcf.gz

test the new getter at http://localhost:3000/?genome=hg38&gene=kras&mds3=ncienclave

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
