### PR TITLE
Fix for disabled terms arguments

### DIFF
--- a/client/dom/MultiTermWrapperEditUI.ts
+++ b/client/dom/MultiTermWrapperEditUI.ts
@@ -75,7 +75,7 @@ export class MultiTermWrapperEditUI {
 	async getNewPill(d, div) {
 		//Do not allow users to select the same term more than once
 		//Combine with specified disable_terms from the caller
-		const disable_terms = [...this.disable_terms, ...this.twList]
+		const disable_terms = [...this.disable_terms, ...this.twList.map(tw => tw.term)]
 		const _opts = {
 			abbrCutoff: 50,
 			debug: this.app.opts?.debug,

--- a/client/dom/MultiTermWrapperEditUI.ts
+++ b/client/dom/MultiTermWrapperEditUI.ts
@@ -1,4 +1,4 @@
-import type { TermWrapper } from '#types'
+import type { TermWrapper, Term } from '#types'
 import type { MassAppApi, MassState } from '#mass/types/mass'
 import { termsettingInit } from '#termsetting'
 import { select } from 'd3-selection'
@@ -17,7 +17,7 @@ export class MultiTermWrapperEditUI {
 	buttonLabel: string
 	callback: (terms: any) => void
 	customInputs?: object
-	disable_terms: string[]
+	disable_terms: Term[]
 	dom: MultiTermWrapperDom
 	headerText: string
 	maxNum: number
@@ -75,7 +75,7 @@ export class MultiTermWrapperEditUI {
 	async getNewPill(d, div) {
 		//Do not allow users to select the same term more than once
 		//Combine with specified disable_terms from the caller
-		const disable_terms = [...this.disable_terms, ...this.twList.map(tw => tw.term.id)]
+		const disable_terms = [...this.disable_terms, ...this.twList]
 		const _opts = {
 			abbrCutoff: 50,
 			debug: this.app.opts?.debug,

--- a/client/dom/types/MultiTermWrapperEditUI.ts
+++ b/client/dom/types/MultiTermWrapperEditUI.ts
@@ -1,5 +1,5 @@
 import type { Button, Elem, Div } from '../../types/d3'
-import type { TermWrapper } from '#types'
+import type { TermWrapper, Term } from '#types'
 import type { MassAppApi, MassState } from '#mass/types/mass'
 
 /** Elements created by the UI, save the holder */
@@ -41,5 +41,5 @@ export type MultiTermWrapperUIOpts = {
 	/** Term wrappers already in use on init */
 	twList?: TermWrapper[]
 	/** Specific terms to disable. Will be combined with the running twlist.  */
-	disable_terms?: string[]
+	disable_terms?: Term[]
 }

--- a/client/filter/filter.interactivity.js
+++ b/client/filter/filter.interactivity.js
@@ -233,7 +233,9 @@ export function setInteractivity(self) {
 			tree: {
 				disable_terms:
 					self.activeData && self.activeData.filter && self.activeData.filter.lst && d == 'and'
-						? self.activeData.filter.lst.filter(d => d.type === 'tvs' && d.tvs.term.type !== 'condition')
+						? self.activeData.filter.lst
+								.filter(d => d.type === 'tvs' && d.tvs.term.type !== 'condition')
+								.map(d => d.tvs.term)
 						: [],
 
 				click_term2select_tvs(tvs) {
@@ -334,13 +336,13 @@ export function setInteractivity(self) {
 			tree: {
 				disable_terms:
 					filter && filter.lst && filter.join == 'and'
-						? filter.lst.filter(d => d.type === 'tvs' && d.tvs.term.type !== 'condition').map(d => d.tvs.term.id)
+						? filter.lst.filter(d => d.type === 'tvs' && d.tvs.term.type !== 'condition').map(d => d.tvs.term)
 						: !self.activeData.item
 						? []
 						: self.activeData.item.type == 'tvs'
-						? [self.activeData.item.tvs.term.id]
+						? [self.activeData.item.tvs.term]
 						: self.activeData.item.lst
-						? self.activeData.item.lst.filter(f => f.type == 'tvs').map(f => f.tvs.term.id)
+						? self.activeData.item.lst.filter(f => f.type == 'tvs').map(f => f.tvs.term)
 						: [],
 
 				click_term2select_tvs:

--- a/client/filter/filter.interactivity.js
+++ b/client/filter/filter.interactivity.js
@@ -233,9 +233,7 @@ export function setInteractivity(self) {
 			tree: {
 				disable_terms:
 					self.activeData && self.activeData.filter && self.activeData.filter.lst && d == 'and'
-						? self.activeData.filter.lst
-								.filter(d => d.type === 'tvs' && d.tvs.term.type !== 'condition')
-								.map(d => d.tvs.term.id)
+						? self.activeData.filter.lst.filter(d => d.type === 'tvs' && d.tvs.term.type !== 'condition')
 						: [],
 
 				click_term2select_tvs(tvs) {

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -32,12 +32,12 @@ export class VolcanoInteractions {
 				.filter(g => allowedGroupNames.has(g.name))
 				.flatMap(g =>
 					g.filter.lst.flatMap(f => {
-						if (f.tvs?.term) return f.tvs.term.id || f.tvs.term.name
-						else return f.lst.map(l => l.tvs.term.id || l.tvs.term.name)
+						if (f.tvs?.term) return f.tvs.term
+						else return f.lst.map(l => l.tvs.term)
 					})
 				)
 		)
-		const disable_terms = grpTerms.size ? Array.from(grpTerms) : []
+		const disable_terms: any[] = grpTerms.size ? Array.from(grpTerms) : []
 
 		const ui = new MultiTermWrapperEditUI({
 			app: this.app,

--- a/client/termdb/test/tree.integration.spec.js
+++ b/client/termdb/test/tree.integration.spec.js
@@ -204,7 +204,7 @@ tape('click_term', test => {
 	runpp({
 		tree: {
 			click_term: modifier_callback,
-			disable_terms: termjson['agedx'],
+			disable_terms: [termjson['agedx']],
 			callbacks: {
 				'postRender.test': runTests
 			}
@@ -259,7 +259,7 @@ tape('click_term2select_tvs', test => {
 		},
 		tree: {
 			click_term2select_tvs: modifier_callback,
-			disable_terms: termjson['agedx']
+			disable_terms: [termjson['agedx']]
 		}
 	})
 

--- a/client/termdb/test/tree.integration.spec.js
+++ b/client/termdb/test/tree.integration.spec.js
@@ -1,5 +1,6 @@
 import tape from 'tape'
 import * as helpers from '../../test/front.helpers.js'
+import { termjson } from '../../test/testdata/termjson.js'
 
 /*
 Tests:
@@ -203,7 +204,7 @@ tape('click_term', test => {
 	runpp({
 		tree: {
 			click_term: modifier_callback,
-			disable_terms: ['agedx'],
+			disable_terms: termjson['agedx'],
 			callbacks: {
 				'postRender.test': runTests
 			}
@@ -258,7 +259,7 @@ tape('click_term2select_tvs', test => {
 		},
 		tree: {
 			click_term2select_tvs: modifier_callback,
-			disable_terms: ['agedx']
+			disable_terms: termjson['agedx']
 		}
 	})
 

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -3,7 +3,7 @@ import { select, selectAll } from 'd3-selection'
 import { getNormalRoot } from '#filter'
 import { isUsableTerm } from '#shared/termdb.usecase.js'
 import { termInfoInit } from './termInfo'
-import { TermTypeGroups } from '#shared/terms.js'
+import { TermTypeGroups, equals } from '#shared/terms.js'
 
 const childterm_indent = '25px'
 export const root_ID = 'root'
@@ -327,7 +327,7 @@ function setRenderers(self) {
 			return
 		}
 
-		const termIsDisabled = self.opts?.disable_terms?.some(t => t.id == term.id)
+		const termIsDisabled = self.opts?.disable_terms?.some(t => equals(t, term))
 		const uses = isUsableTerm(term, self.state.usecase, self.app.vocabApi.termdbConfig)
 
 		div.style('display', '')
@@ -349,7 +349,7 @@ function setRenderers(self) {
 	}
 
 	self.addTerm = async function (term) {
-		const termIsDisabled = self.opts?.disable_terms?.some(t => t.id == term.id)
+		const termIsDisabled = self.opts?.disable_terms?.some(t => equals(t, term))
 		const uses = isUsableTerm(term, self.state.usecase, self.app.vocabApi.termdbConfig)
 
 		const div = select(this)

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -327,7 +327,7 @@ function setRenderers(self) {
 			return
 		}
 
-		const termIsDisabled = self.opts.disable_terms?.includes(term.id)
+		const termIsDisabled = self.opts?.disable_terms?.some(t => t.id == term.id)
 		const uses = isUsableTerm(term, self.state.usecase, self.app.vocabApi.termdbConfig)
 
 		div.style('display', '')
@@ -349,7 +349,7 @@ function setRenderers(self) {
 	}
 
 	self.addTerm = async function (term) {
-		const termIsDisabled = self.opts.disable_terms?.includes(term.id)
+		const termIsDisabled = self.opts?.disable_terms?.some(t => t.id == term.id)
 		const uses = isUsableTerm(term, self.state.usecase, self.app.vocabApi.termdbConfig)
 
 		const div = select(this)

--- a/shared/types/src/termsetting.ts
+++ b/shared/types/src/termsetting.ts
@@ -84,8 +84,8 @@ type BaseTermSettingOpts = {
 	 * before the pill name is truncated. */
 	abbrCutoff?: number
 	activeCohort?: number
-	/** tw.term.ids */
-	disable_terms?: string[]
+	/** array of term objects to show in the tree but not clickable */
+	disable_terms?: Term[]
 	// This is not used anywhere.
 	// Ok to remove?
 	handler: Handler
@@ -165,7 +165,7 @@ export type TermSettingInstance = {
 	clickNoPillDiv?: any
 	dom: InstanceDom
 	doNotHideTipInMain?: boolean
-	disable_terms?: string[]
+	disable_terms?: Term[]
 	durations: { exit: number }
 	filter?: Filter
 	handler?: Handler


### PR DESCRIPTION
## Description
Closes issue #3003. 

Changes: 
All instances of `opts.disable_terms` for tree init() pass an array of term objs, not an array of term.ids. Types reflect this change as well. 

Test all changed instances:
1. [Tree integration tests](http://localhost:3000/testrun.html?dir=termdb&name=tree.integration)
2. MultiTermWrapperEditUI. Use the default test in the [DA spec file](http://localhost:3000/testrun.html?dir=plots/diffAnalysis&name=diffAnalysis) -> Click on Confounders btn -> add the first term -> add the second term but search for the first term. Should see the first term appear as disabled in the tree and search result. 
3. Filter. Use [termdb test](http://localhost:3000/?massnative=hg38-test,TermdbTest) -> Add first term to filter -> click add and try to add the same term. Should appear as disabled. 
4. Disabling the group terms in the volcano. Use the [all pharma](http://localhost:3000/?massnative=hg38,ALL-pharmacotyping) -> create two groups. I suggest something with a small number of sample such as small agedx ranges -> launch DA app -> Click on Confounders btn -> add the first term -> add the second term but search for the first term. Should see the first term appear as disabled in the tree and search result. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
