### PR TITLE
GDC gene exp clustering excludes sex chr genes and indicates on ui

### DIFF
--- a/client/plots/matrix/matrix.js
+++ b/client/plots/matrix/matrix.js
@@ -241,11 +241,9 @@ export class Matrix {
 			await this.adjustSvgDimensions(prevTranspose)
 			this.controlsRenderer.main()
 			if (this.data.removedHierClusterTerms) {
-				sayerror(
-					this.dom.errorDiv,
-					`Failed to get values for hierCluster ${this.data.removedHierClusterTerms.length > 1 ? 'terms' : 'term'}: ` +
-						this.data.removedHierClusterTerms.join(', ')
-				)
+				for (const r of this.data.removedHierClusterTerms) {
+					sayerror(this.dom.errorDiv, r.text + ': ' + r.lst.join(', '))
+				}
 			}
 		} catch (e) {
 			// a new token message error may have been triggered by the data request here,

--- a/shared/types/src/routes/termdb.cluster.ts
+++ b/shared/types/src/routes/termdb.cluster.ts
@@ -82,8 +82,13 @@ export type ValidResponse = {
 	byTermId: { [index: string]: any }
 	/**  */
 	bySampleId: { [index: string]: any }
-	/** list of term names that are excluded from analysis for lacking any numerical data */
-	removedHierClusterTerms?: string[]
+	/** list of term names that are excluded from analysis, one reason per set, for client display */
+	removedHierClusterTerms?: {
+		/** reason for skipping */
+		text: string
+		/** list of skipped item names */
+		lst: string[]
+	}[]
 }
 
 //response of just 1 gene, thus unable to do clustering


### PR DESCRIPTION
## Description

closes #3023 
test with [GDC HGG link](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22and%22,%22content%22:[{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.project.project_id%22,%22value%22:[%22TCGA-GBM%22]}}]}},%22plots%22:[{%22chartType%22:%22hierCluster%22,%22dataType%22:%22geneExpression%22,%22terms%22:[{%22gene%22:%22ATRX%22,%22type%22:%22geneExpression%22},{%22gene%22:%22AKT1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MYC%22,%22type%22:%22geneExpression%22},{%22gene%22:%22YAP1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CD109%22,%22type%22:%22geneExpression%22},{%22gene%22:%22BCL6%22,%22type%22:%22geneExpression%22},{%22gene%22:%22BRAF%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CDKN2A%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CD34%22,%22type%22:%22geneExpression%22},{%22gene%22:%22ALDH1A3%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CTNNB1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22CXCL14%22,%22type%22:%22geneExpression%22},{%22gene%22:%22E2F1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22EGFR%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PTEN%22,%22type%22:%22geneExpression%22},{%22gene%22:%22FAT1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22FGFR1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22FOXM1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22IDH1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22IDH2%22,%22type%22:%22geneExpression%22},{%22gene%22:%22HOXA10%22,%22type%22:%22geneExpression%22},{%22gene%22:%22HOXA13%22,%22type%22:%22geneExpression%22},{%22gene%22:%22HOXA9%22,%22type%22:%22geneExpression%22},{%22gene%22:%22LAT1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MAPK1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MAPK3%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MMP1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22MGMT%22,%22type%22:%22geneExpression%22},{%22gene%22:%22NOTCH3%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PIK3CA%22,%22type%22:%22geneExpression%22},{%22gene%22:%22PDGFRA%22,%22type%22:%22geneExpression%22},{%22gene%22:%22RB1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22},{%22gene%22:%22WWTR1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22ROS1%22,%22type%22:%22geneExpression%22}],%22termgroups%22:[{%22name%22:%22Variables%22,%22lst%22:[{%22id%22:%22case.diagnoses.age_at_diagnosis%22},{%22id%22:%22case.demographic.gender%22},{%22id%22:%22case.project.project_id%22},{%22id%22:%22case.tissue_source_site.name%22}]}]}]})

ATRX can be indicated at top

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
