### PR TITLE
Event listeners for p value table

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -42,7 +42,8 @@ export function renderTable({
 	selectedRowStyle = {},
 	inputName = null,
 	dataTestId = null,
-	download = undefined
+	download = undefined,
+	hoverEffects
 }: TableArgs) {
 	validateInput()
 	let _selectedRowStyle = selectedRowStyle
@@ -350,6 +351,10 @@ export function renderTable({
 					column.fillCell(td, rowIdx)
 				}
 			}
+			//Table code may update when the caller code does not (e.g. sorting)
+			//Added event listeners in caller code will be lost when the rows update.
+			//Allows for hover effects to remain consistent when the rows are updated.
+			if (hoverEffects) hoverEffects(tr, row)
 		}
 	}
 

--- a/client/dom/types/table.ts
+++ b/client/dom/types/table.ts
@@ -1,3 +1,4 @@
+import type { Tr } from '../../types/d3'
 /** Types for #dom/table */
 
 export type TableCell = {
@@ -37,8 +38,7 @@ export type TableColumn = {
 	/** Used for sorting function
 	 * Do not use this field for html columns */
 	sortable?: boolean
-	/** assume all values from this column are numbers; this renders the column into a barplot
-    note that this cannot be used together with `sortable:true` */
+	/** assume all values from this column are numbers; this renders the column into a barplot */
 	barplot?: TableBarplot
 }
 
@@ -137,4 +137,14 @@ export type TableArgs = {
 		/** optionally, provide download file name, if missing a default one is used */
 		fileName?: string
 	}
+	/** Add row eventlisteners here
+	 * eg.. () => {
+	 * //logic for event listener with row data
+	 * tr.on('mouseover', function() { //something })
+	 * tr.on('mouseleave', function() { //something })
+	 * }
+	 * *** Do not *** use this for a click event!
+	 * use noButtonCallback instead
+	 */
+	hoverEffects?: (tr: Tr, row: TableRow) => void
 }

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -90,6 +90,18 @@ export class VolcanoInteractions {
 		}
 	}
 
+	async highlightDataPoint(value: string) {
+		const config = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
+		const highlightedData = config.highlightedData.includes(value)
+			? config.highlightedData.filter(d => d !== value)
+			: [...config.highlightedData, value]
+		await this.app.dispatch({
+			type: 'plot_edit',
+			id: this.id,
+			config: { highlightedData }
+		})
+	}
+
 	/** When clicking on a data point, launches the box plot in a separate sandbox
 	 * For geneExpression, value == gene symbol */
 	async launchBoxPlot(value: string) {

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -181,13 +181,23 @@ export class VolcanoPlotView {
 			maxHeight: '150vh',
 			resize: true,
 			header: { allowSort: true },
+			noRadioBtn: true,
+			noButtonCallback: (i: number) => {
+				//On click, persistently highlight the data point
+				if (this.termType != 'geneExpression') return
+				const gene = this.viewData.pValueTableData.rows[i][0].value as string
+				if (!gene) return
+				this.interactions.highlightDataPoint(gene)
+			},
 			hoverEffects: (tr, row) => {
 				if (this.termType != 'geneExpression') return
+				//Highlight the data point when hovering over the table row
+				//Previously highlighted data points are not affected
 				const circle = this.volcanoDom.plot
 					.selectAll('circle')
 					.nodes()
-					.find((d: any) => d.__data__.gene_symbol == row[0].value)
-				if (!circle) return
+					.find((d: any) => d.__data__.gene_symbol == row[0].value) as any
+				if (!circle || circle.__data__.highlighted) return
 				tr.on('mouseover', () => {
 					select(circle).attr('fill-opacity', 0.9)
 				})

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -50,7 +50,7 @@ export class VolcanoPlotView {
 			xAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-xAxisLabel').attr('text-anchor', 'middle'),
 			yAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-yAxisLabel').attr('text-anchor', 'middle'),
 			plot: svg.append('g').attr('id', 'sjpp-volcano-plot'),
-			pValueTable: this.dom.holder.append('div').attr('id', 'sjpp-volcano-pValueTable').style('display', 'none')
+			pValueTable: this.dom.holder.append('div').attr('id', 'sjpp-volcano-pValueTable').style('display', 'inline-block')
 		}
 		this.termType = termType
 		const plotDim = this.viewData.plotDim
@@ -176,11 +176,25 @@ export class VolcanoPlotView {
 		renderTable({
 			columns: this.viewData.pValueTableData.columns,
 			rows: this.viewData.pValueTableData.rows,
-			div: this.volcanoDom.pValueTable.append('div'),
+			div: this.volcanoDom.pValueTable,
 			showLines: true,
 			maxHeight: '150vh',
 			resize: true,
-			header: { allowSort: true }
+			header: { allowSort: true },
+			hoverEffects: (tr, row) => {
+				if (this.termType != 'geneExpression') return
+				const circle = this.volcanoDom.plot
+					.selectAll('circle')
+					.nodes()
+					.find((d: any) => d.__data__.gene_symbol == row[0].value)
+				if (!circle) return
+				tr.on('mouseover', () => {
+					select(circle).attr('fill-opacity', 0.9)
+				})
+				tr.on('mouseleave', () => {
+					select(circle).attr('fill-opacity', 0)
+				})
+			}
 		})
 	}
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- In the differential analysis volcano plot, hovering over any row in the p value table highlights the data point in the volcano plot. Clicking on the row adds a persistent highlight. 


### PR DESCRIPTION
## Description
Closes issue #3021. 

Hovering over the p value table highlights the gene in the volcano plot. Clicking on the row adds a persistent highlight. Test with [the spec file](http://localhost:3000/testrun.html?dir=plots/diffAnalysis&name=diffAnalysis). 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
