### PR TITLE
Gsea improvements

### DIFF
--- a/client/plots/diffAnalysis/DifferentialAnalysis.ts
+++ b/client/plots/diffAnalysis/DifferentialAnalysis.ts
@@ -152,9 +152,7 @@ export function getPlotConfig(opts: DiffAnalysisOpts) {
 		childType: 'volcano',
 		termType: opts.termType,
 		highlightedData: opts.highlightedData || [],
-		settings: {
-			controls: { isOpen: false }
-		}
+		settings: {}
 	}
 
 	if (opts.termType == 'geneExpression') {

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -18,7 +18,7 @@ class gsea {
 		//Either allow a node to be passed or create a new div
 		const controlsDiv =
 			typeof opts.controls == 'object' ? opts.controls : holder || holder.append('div').style('display', 'inline-block')
-		const mainDiv = opts.holder.append('div').style('display', 'inline-block').style('margin-left', '50px')
+		const mainDiv = opts.holder.append('div').style('margin-left', '50px')
 		const holder = mainDiv.append('div').style('display', 'inline-block')
 		const detailsDiv = mainDiv
 			.append('div')
@@ -368,6 +368,13 @@ add:
 		]
 		let download = {}
 
+		const highlightGenesBtn = self.dom.detailsDiv
+			.append('button')
+			.style('margin-left', '10px')
+			.style('display', 'none')
+			.attr('aria-label', 'Highlight genes in the volcano plot')
+			.text('Highlight genes')
+
 		if (self.state.config.downloadFilename) download.fileName = self.state.config.downloadFilename
 		renderTable({
 			download,
@@ -379,6 +386,22 @@ add:
 			singleMode: true,
 			resize: true,
 			noButtonCallback: async index => {
+				if (self.config.chartType == 'differentialAnalysis') {
+					const genes = [...self.gsea_table_rows[index][5].value.split(',')]
+					if (!genes) return
+					highlightGenesBtn.style('display', '')
+					highlightGenesBtn.on('click', () => {
+						self.app.dispatch({
+							type: 'plot_edit',
+							id: self.id,
+							config: {
+								childType: 'volcano',
+								highlightedData: genes
+							}
+						})
+					})
+				}
+
 				//console.log("index:",self.gsea_table_rows[index][0].value)
 				const body = {
 					genome: self.config.gsea_params.genome,

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -357,10 +357,10 @@ add:
 		const d_gsea = self.dom.tableDiv.append('div')
 		// table columns showing analysis results for each gene set
 		self.gsea_table_cols = [
-			{ label: 'Geneset' },
+			{ label: 'Gene Set' },
 			//{ label: 'Enrichment Score' },
 			{ label: 'Normalized Enrichment Score', barplot: { axisWidth: 200 } },
-			{ label: 'Geneset Size' },
+			{ label: 'Gene Set Size' },
 			{ label: 'P value' },
 			//{ label: 'Sidak' },
 			{ label: 'FDR' },

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Features
+- GSEA opens to a dropdown menu for selection instead of loading the entire controls menu
+- Once a row is selected from the GSEA geneset table, a button to highlight the genes in the volcano plot appears.


### PR DESCRIPTION
## Description
Addresses some feature requests for the gsea.

Changes: 
1. Instead of displaying the controls menu on load, a simple dropdown requesting the pathway appears first. Once selected, the plot loads. 
2. Once the gene set is selected, a button for highlighting the genes appears to the right of the image, below the genes analyzed count table. 

Test with [DA spec file](http://localhost:3000/testrun.html?dir=plots/diffAnalysis&name=diffAnalysis). 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
