### PR TITLE
sjlife figure links fixes

### DIFF
--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -182,7 +182,7 @@ export class NumCustomBins extends NumericBase {
 
 		if (tw.q.mode == 'binary' && !tw.q.preferredBins) tw.q.preferredBins = 'median'
 
-		if (tw.q.preferredBins == 'median') {
+		if (tw.q.preferredBins == 'median' && !tw.q.lst?.length) {
 			const result = await opts.vocabApi.getPercentile(tw.term.id, [50])
 			if (!result.values) throw '.values[] missing from vocab.getPercentile()'
 			const median = roundValueAuto(result.values[0])

--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -18,7 +18,7 @@ import type {
 	RegularNumericBinConfig,
 	CustomNumericBinConfig
 } from '#types'
-import { TwBase, TwOpts } from './TwBase.ts'
+import { TwBase, type TwOpts } from './TwBase.ts'
 import { copyMerge } from '#rx'
 import { isNumeric } from '#shared/helpers.js'
 import { roundValueAuto } from '#shared/roundValue.js'

--- a/server/utils/regression.utils.R
+++ b/server/utils/regression.utils.R
@@ -24,7 +24,8 @@
 #######
 
 # prepare data table
-prepareDataTable <- function(dat, independent) {
+prepareDataTable <- function(tempdat, independent) {
+  dat <- tempdat[,colnames(tempdat) != "__sample"] # remove sample column
   for (r in 1:nrow(independent)) {
     variable <- independent[r,]
     id <- variable$id


### PR DESCRIPTION
## Description

The [sjlife figure 4 link](https://proteinpaint.stjude.org/survivorship/paper2024/figures/sf36-regression.html) uses default binary boundary value and not the one specified in session json file. This PR fixes this issue.

This PR also fixes the issue with the [sjlife figure 5 link](https://proteinpaint.stjude.org/survivorship/paper2024/figures/cardio-regression.html) that has been reported [here](https://github.com/stjude/proteinpaint/issues/2939).

Will send json session files through slack.

Closes https://github.com/stjude/proteinpaint/issues/2939


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
