### PR TITLE
Clustering geneset edit

### DIFF
--- a/client/plots/matrix/hierCluster.interactivity.js
+++ b/client/plots/matrix/hierCluster.interactivity.js
@@ -1,6 +1,7 @@
 import { renderTable } from '#dom'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
 import { select } from 'd3-selection'
+import { TermTypes } from '#shared/terms.js'
 
 // Given a clusterId, return all its children clusterIds
 export function getAllChildrenClusterIds(clickedClusterId, left) {
@@ -508,5 +509,8 @@ function updateClusteringControls(self, app, parent, table) {
 				.closest('tr')
 		)
 		colorSchemeControl.style('display', 'none')
+	}
+	if (parent.chartType == 'hierCluster' && parent.config.dataType == TermTypes.GENE_EXPRESSION) {
+		self.appendGeneInputs(self, app, parent, table, 'hierCluster')
 	}
 }

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -1132,7 +1132,9 @@ export class MatrixControls {
 		const controlPanelBtn =
 			geneInputType == 'hierCluster'
 				? this.btns.filter(d => d.label == 'Clustering')?.node()
-				: this.btns.filter(d => d.label == 'Genes')?.node()
+				: this.btns
+						.filter(d => d.label == (parent.config.chartType == 'hierCluster' ? 'Unclustered Genes' : 'Genes'))
+						?.node()
 		const tip = app.tip //new Menu({ padding: '5px' })
 		const tg = parent.config.termgroups
 

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -350,7 +350,7 @@ export class MatrixControls {
 			.append('button')
 			//.property('disabled', d => d.disabled)
 			.datum({
-				label: 'Genes',
+				label: this.parent.chartType == 'hierCluster' ? 'Unclustered Genes' : 'Genes',
 				getCount: () => this.parent.termOrder?.filter(t => t.tw.term.type == 'geneVariant').length || 0,
 				customInputs: this.appendGeneInputs,
 				rows: [

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- hierCluster: add geneset edit ui in Clustering btn menu for geneExpression hierCluster. the geneset edit ui in "Genes" btn menu is only applicable to non-clustering row groups and could not edit clustering row group.


### PR DESCRIPTION
## Description
Fix #3030 

Clustering btn menu: geneset edit ui: can only be used to edit genes in hierCluster
Genes btn menu: geneset edit ui is only applicable to non-clustering row groups and could not edit clustering row group.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
