### PR TITLE
Added unit to the time reported by correlation analysis

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Added unit to the time reported by correlation analysis. Made little helper function to format the time.

--- a/server/routes/correlationVolcano.ts
+++ b/server/routes/correlationVolcano.ts
@@ -6,6 +6,7 @@ import serverconfig from '../src/serverconfig.js'
 import { mayLog } from '#src/helpers.ts'
 import path from 'path'
 import { getStdDev } from '#shared/descriptive.stats.js'
+import { formatElapsedTime } from '#shared/time'
 
 // to avoid crashing r, an array must meet below; otherwise the variable is skipped
 const minArrayLength = 3 // minimum number of values
@@ -39,24 +40,6 @@ function init({ genomes }) {
 			res.send({ error: e?.message || e })
 			if (e instanceof Error && e.stack) console.error(e)
 		}
-	}
-}
-
-/**
- * Formats elapsed time in milliseconds to a human-readable string with appropriate units
- * @param ms - Elapsed time in milliseconds
- * @returns Formatted time string with appropriate unit
- */
-function formatElapsedTime(ms: number): string {
-	if (ms < 1000) {
-		return `${ms}ms`
-	} else if (ms < 60000) {
-		const seconds = (ms / 1000).toFixed(2)
-		return `${seconds}s`
-	} else {
-		const minutes = Math.floor(ms / 60000)
-		const seconds = ((ms % 60000) / 1000).toFixed(2)
-		return `${minutes}m ${seconds}s`
 	}
 }
 

--- a/server/routes/correlationVolcano.ts
+++ b/server/routes/correlationVolcano.ts
@@ -42,6 +42,24 @@ function init({ genomes }) {
 	}
 }
 
+/**
+ * Formats elapsed time in milliseconds to a human-readable string with appropriate units
+ * @param ms - Elapsed time in milliseconds
+ * @returns Formatted time string with appropriate unit
+ */
+function formatElapsedTime(ms: number): string {
+	if (ms < 1000) {
+		return `${ms}ms`
+	} else if (ms < 60000) {
+		const seconds = (ms / 1000).toFixed(2)
+		return `${seconds}s`
+	} else {
+		const minutes = Math.floor(ms / 60000)
+		const seconds = ((ms % 60000) / 1000).toFixed(2)
+		return `${minutes}m ${seconds}s`
+	}
+}
+
 async function compute(q: CorrelationVolcanoRequest, ds: any, genome: any) {
 	const terms = [q.featureTw, ...q.variableTwLst]
 	const data = await getData(
@@ -108,7 +126,11 @@ async function compute(q: CorrelationVolcanoRequest, ds: any, genome: any) {
 	const output = {
 		terms: JSON.parse(await run_R(path.join(serverconfig.binpath, 'utils', 'corr.R'), JSON.stringify(input)))
 	}
-	mayLog('Time taken to run correlation analysis:', Date.now() - time1)
+	// Format the elapsed time with appropriate units
+	const elapsedMs = Date.now() - time1
+	const formattedTime = formatElapsedTime(elapsedMs)
+
+	mayLog('Time taken to run correlation analysis:', formattedTime)
 	for (const t of output.terms) {
 		const t2 = {
 			tw$id: t.id,

--- a/server/routes/correlationVolcano.ts
+++ b/server/routes/correlationVolcano.ts
@@ -6,8 +6,7 @@ import serverconfig from '../src/serverconfig.js'
 import { mayLog } from '#src/helpers.ts'
 import path from 'path'
 import { getStdDev } from '#shared/descriptive.stats.js'
-import { formatElapsedTime } from '#shared/time'
-
+import { formatElapsedTime } from '#shared/time.js'
 // to avoid crashing r, an array must meet below; otherwise the variable is skipped
 const minArrayLength = 3 // minimum number of values
 const minSD = 0.05 // minimum standard deviation

--- a/shared/utils/src/test/time.unit.spec.ts
+++ b/shared/utils/src/test/time.unit.spec.ts
@@ -1,0 +1,47 @@
+import tape from 'tape'
+import { formatElapsedTime } from '../time'
+
+tape('\n', function (test) {
+	test.pass('-***- formatElapsedTime specs -***-')
+	test.end()
+})
+
+tape('formatElapsedTime - less than 1 second', t => {
+	t.equal(formatElapsedTime(0), '0ms', 'should format 0 milliseconds')
+	t.equal(formatElapsedTime(1), '1ms', 'should format 1 millisecond')
+	t.equal(formatElapsedTime(500), '500ms', 'should format 500 milliseconds')
+	t.equal(formatElapsedTime(999), '999ms', 'should format 999 milliseconds')
+	t.end()
+})
+
+tape('formatElapsedTime - between 1 second and 1 minute', t => {
+	t.equal(formatElapsedTime(1000), '1.00s', 'should format 1 second')
+	t.equal(formatElapsedTime(1500), '1.50s', 'should format 1.5 seconds')
+	t.equal(formatElapsedTime(10250), '10.25s', 'should format 10.25 seconds')
+	t.equal(formatElapsedTime(59999), '60.00s', 'should format 60 seconds')
+	t.end()
+})
+
+tape('formatElapsedTime - greater than or equal to 1 minute', t => {
+	t.equal(formatElapsedTime(60000), '1m 0.00s', 'should format 1 minute')
+	t.equal(formatElapsedTime(90000), '1m 30.00s', 'should format 1 minute 30 seconds')
+	t.equal(formatElapsedTime(120500), '2m 0.50s', 'should format 2 minutes 0.5 seconds')
+	t.equal(formatElapsedTime(3723000), '62m 3.00s', 'should format 62 minutes 3 seconds')
+	t.end()
+})
+
+tape('formatElapsedTime - edge cases', t => {
+	t.equal(formatElapsedTime(-1), '-1ms', 'should handle negative time')
+	t.equal(formatElapsedTime(NaN), 'Invalid time: NaN', 'should handle NaN')
+	t.end()
+})
+
+tape('formatElapsedTime - type handling', t => {
+	t.equal(formatElapsedTime('1000' as unknown as number), 'Invalid time: not a number', 'should reject string inputs')
+	t.equal(formatElapsedTime(null as unknown as number), 'Invalid time: not a number', 'should reject null')
+	t.equal(formatElapsedTime(undefined as unknown as number), 'Invalid time: not a number', 'should reject undefined')
+	t.equal(formatElapsedTime({} as unknown as number), 'Invalid time: not a number', 'should reject objects')
+	t.equal(formatElapsedTime(Infinity), 'Infinite time', 'should handle positive infinity')
+	t.equal(formatElapsedTime(-Infinity), '-Infinite time', 'should handle negative infinity')
+	t.end()
+})

--- a/shared/utils/src/time.ts
+++ b/shared/utils/src/time.ts
@@ -1,0 +1,36 @@
+/**
+ * Formats elapsed time in milliseconds to a human-readable string with appropriate units
+ * @param ms - Elapsed time in milliseconds
+ * @returns Formatted time string with appropriate unit
+ */
+export function formatElapsedTime(ms: number | unknown): string {
+	// Handle non-numeric inputs
+	if (typeof ms !== 'number') {
+		return 'Invalid time: not a number'
+	}
+
+	// Handle NaN
+	if (isNaN(ms)) {
+		return 'Invalid time: NaN'
+	}
+
+	// Handle infinite values
+	if (!isFinite(ms)) {
+		return ms > 0 ? 'Infinite time' : '-Infinite time'
+	}
+
+	// Handle negative times (use absolute value but preserve sign in output)
+	const absMs = Math.abs(ms)
+	const sign = ms < 0 ? '-' : ''
+
+	if (absMs < 1000) {
+		return `${sign}${absMs}ms`
+	} else if (absMs < 60000) {
+		const seconds = (absMs / 1000).toFixed(2)
+		return `${sign}${seconds}s`
+	} else {
+		const minutes = Math.floor(absMs / 60000)
+		const seconds = ((absMs % 60000) / 1000).toFixed(2)
+		return `${sign}${minutes}m ${seconds}s`
+	}
+}


### PR DESCRIPTION
## Description
Added unit to the time reported by correlation analysis. Made little helper function to format the time.

## To test
Go [here](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22correlationVolcano%22,%22featureTw%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22KRAS%22}}}]}) and ensure you see a time unit reported in your server log for the correlation analysis.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
