### PR TITLE
DA cutoffs

### DIFF
--- a/client/plots/diffAnalysis/DifferentialAnalysis.ts
+++ b/client/plots/diffAnalysis/DifferentialAnalysis.ts
@@ -156,8 +156,8 @@ export function getPlotConfig(opts: DiffAnalysisOpts) {
 	}
 
 	if (opts.termType == 'geneExpression') {
-		config.settings['volcano'] = getDefaultVolcanoSettings(opts.overrides)
-		config.settings['gsea'] = getDefaultGseaSettings(opts.overrides)
+		config.settings['volcano'] = getDefaultVolcanoSettings(opts.overrides || {})
+		config.settings['gsea'] = getDefaultGseaSettings(opts.overrides || {})
 	}
 
 	return copyMerge(config, opts)

--- a/client/plots/diffAnalysis/DifferentialAnalysis.ts
+++ b/client/plots/diffAnalysis/DifferentialAnalysis.ts
@@ -6,7 +6,7 @@ import { Menu } from '#dom'
 import { termType2label } from '#shared/terms.js'
 import type { DiffAnalysisDom, DiffAnalysisOpts, DiffAnalysisPlotConfig } from './DiffAnalysisTypes'
 import { DiffAnalysisView } from './view/DiffAnalysisView'
-import { getDefaultVolcanoSettings } from '../volcano/Volcano.ts'
+import { getDefaultVolcanoSettings, validateVolcanoSettings } from '../volcano/Volcano.ts'
 import { getDefaultGseaSettings } from '#plots/gsea.js'
 import { DiffAnalysisInteractions } from './interactions/DiffAnalysisInteractions.ts'
 
@@ -153,11 +153,13 @@ export function getPlotConfig(opts: DiffAnalysisOpts) {
 		termType: opts.termType,
 		highlightedData: opts.highlightedData || [],
 		settings: {}
-	}
+	} as any
 
 	if (opts.termType == 'geneExpression') {
-		config.settings['volcano'] = getDefaultVolcanoSettings(opts.overrides || {})
-		config.settings['gsea'] = getDefaultGseaSettings(opts.overrides || {})
+		config.settings.volcano = getDefaultVolcanoSettings(opts.overrides || {}, opts)
+		config.settings.gsea = getDefaultGseaSettings(opts.overrides || {})
+
+		validateVolcanoSettings(config, opts)
 	}
 
 	return copyMerge(config, opts)

--- a/client/plots/diffAnalysis/view/DiffAnalysisView.ts
+++ b/client/plots/diffAnalysis/view/DiffAnalysisView.ts
@@ -4,7 +4,6 @@ import type { RenderedTab } from '#dom'
 import type { DiffAnalysisDom, DiffAnalysisPlotConfig } from '../DiffAnalysisTypes'
 import type { DiffAnalysisInteractions } from '../interactions/DiffAnalysisInteractions'
 
-/** TODO: finish typing this file */
 export class DiffAnalysisView {
 	app: MassAppApi
 	config: DiffAnalysisPlotConfig

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -12,6 +12,9 @@ import { VolcanoInteractions } from './interactions/VolcanoInteractions'
 import { VolcanoPlotView } from './view/VolcanoPlotView'
 import { VolcanoControlInputs } from './VolcanoControlInputs'
 
+// The max sample cutoff for volcano rendering
+const maxSampleCutoff = 4000
+
 class Volcano extends RxComponentInner {
 	readonly type = 'volcano'
 	components: { controls: any }
@@ -19,7 +22,6 @@ class Volcano extends RxComponentInner {
 	interactions?: VolcanoInteractions
 	termType: string
 	diffAnalysisInteractions?: DiffAnalysisInteractions
-	geSampleNumCuttoff?: number
 	constructor(opts: VolcanoOpts) {
 		super()
 		this.components = {
@@ -172,9 +174,12 @@ export function getSampleNum(config: any) {
 export function validateVolcanoSettings(config: any, opts: any) {
 	if (!config.settings.volcano) return
 	const settings = config.settings.volcano
+	const sampleNum = getSampleNum(opts)
+	if (sampleNum > maxSampleCutoff) {
+		throw `Sample size ${sampleNum} exceeds max sample size of ${maxSampleCutoff}. Please reduce sample size.`
+	}
 
 	if (config.termType == 'geneExpression') {
-		const sampleNum = getSampleNum(opts)
 		const largeNum = sampleNum > settings.sampleNumCutoff
 
 		if (!opts.overrides && largeNum) {

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -160,7 +160,7 @@ export function getDefaultVolcanoSettings(overrides = {}, opts: any): VolcanoSet
 		pValueType: 'adjusted',
 		rankBy: 'abs(foldChange)',
 		//Only declare this value in one place
-		sampleNumCutoff: opts.termType == 'geneExpression' ? 3000 : 4000,
+		sampleNumCutoff: opts.termType == 'geneExpression' ? 3000 : maxSampleCutoff,
 		width: 400
 	}
 

--- a/client/plots/volcano/VolcanoControlInputs.ts
+++ b/client/plots/volcano/VolcanoControlInputs.ts
@@ -1,5 +1,6 @@
 import type { ControlInputEntry } from '#mass/types/mass'
 import type { VolcanoPlotConfig } from './VolcanoTypes'
+import { getSampleNum } from './Volcano'
 
 /** Handles settings the controls in the menu based on the app
  * termType.
@@ -23,10 +24,9 @@ export class VolcanoControlInputs {
 	termType: string
 	/** control inputs for controls init */
 	inputs: ControlInputEntry[]
-	readonly geSampleNumCuttoff = 3000
-	constructor(config: VolcanoPlotConfig, termType: string, sampleNum: number) {
+	constructor(config: VolcanoPlotConfig, termType: string) {
 		this.config = config
-		this.sampleNum = sampleNum
+		this.sampleNum = getSampleNum(config)
 		this.termType = termType
 		//Populated with the default controls for the volcano plot
 		this.inputs = [
@@ -183,7 +183,8 @@ export class VolcanoControlInputs {
 
 	getMethodOptions() {
 		if (this.termType !== 'geneExpression') return
-		if (this.sampleNum < this.geSampleNumCuttoff) {
+		const settings = this.config.settings.volcano
+		if (this.sampleNum < settings!.sampleNumCutoff) {
 			return [
 				{ label: 'edgeR', value: 'edgeR' },
 				{ label: 'Wilcoxon', value: 'wilcoxon' },

--- a/client/plots/volcano/VolcanoControlInputs.ts
+++ b/client/plots/volcano/VolcanoControlInputs.ts
@@ -18,12 +18,15 @@ import type { VolcanoPlotConfig } from './VolcanoTypes'
 
 export class VolcanoControlInputs {
 	config: VolcanoPlotConfig
+	sampleNum: number
 	/** term type used to determine which controls to show */
 	termType: string
 	/** control inputs for controls init */
 	inputs: ControlInputEntry[]
-	constructor(config, termType: string) {
+	readonly geSampleNumCuttoff = 3000
+	constructor(config: VolcanoPlotConfig, termType: string, sampleNum: number) {
 		this.config = config
+		this.sampleNum = sampleNum
 		this.termType = termType
 		//Populated with the default controls for the volcano plot
 		this.inputs = [
@@ -141,11 +144,7 @@ export class VolcanoControlInputs {
 				chartType: 'volcano',
 				settingsKey: 'method',
 				title: 'Toggle between analysis methods',
-				options: [
-					{ label: 'edgeR', value: 'edgeR' },
-					{ label: 'Wilcoxon', value: 'wilcoxon' },
-					{ label: 'Limma', value: 'limma' }
-				]
+				options: this.getMethodOptions()
 			},
 			{
 				label: 'Rank Genes by',
@@ -180,5 +179,16 @@ export class VolcanoControlInputs {
 		]
 
 		this.inputs.splice(0, 0, ...geInputs)
+	}
+
+	getMethodOptions() {
+		if (this.termType !== 'geneExpression') return
+		if (this.sampleNum < this.geSampleNumCuttoff) {
+			return [
+				{ label: 'edgeR', value: 'edgeR' },
+				{ label: 'Wilcoxon', value: 'wilcoxon' },
+				{ label: 'Limma', value: 'limma' }
+			]
+		} else return [{ label: 'Wilcoxon', value: 'wilcoxon' }]
 	}
 }

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -144,4 +144,8 @@ export type VolcanoViewData = {
 	pointData: DataPointEntry[]
 	pValueTableData: VolcanoPValueTableData
 	images: DEImage[]
+	/** special logic per termtype for userActions */
+	userActions: {
+		noShow: string[]
+	}
 }

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -116,7 +116,7 @@ export type VolcanoSettings = {
 	defaultSignColor: string
 	/** largest absolute fold change to be considered in the analysis */
 	foldChangeCutoff: number
-	method: 'wilcoxon' | 'edgeR'
+	method: 'wilcoxon' | 'edgeR' | 'limma'
 	/** Not enabling this feature for now */
 	// geneORA: 'upregulated' | 'downregulated' | 'both' | undefined
 	/** smallest number of reads required for a gene to be considered in the analysis */
@@ -129,6 +129,8 @@ export type VolcanoSettings = {
 	pValueType: 'original' | 'adjusted'
 	/** Toggle between ranking the genes by variance or abs(foldChange) */
 	rankBy: 'abs(foldChange)' | 'pValue'
+	/** Cutoff for running the analysis */
+	sampleNumCutoff: number
 	/** plot height */
 	height: number
 	/** plot width */

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -1,7 +1,6 @@
 import type { MassAppApi } from '#mass/types/mass'
-import { downloadTable, GeneSetEditUI, MultiTermWrapperEditUI, sayerror } from '#dom'
+import { downloadTable, GeneSetEditUI, MultiTermWrapperEditUI } from '#dom'
 import { to_svg } from '#src/client'
-import { isDictionaryType } from '#shared/terms.js'
 import type { VolcanoDom, VolcanoPlotConfig } from '../VolcanoTypes'
 
 export class VolcanoInteractions {
@@ -39,24 +38,12 @@ export class VolcanoInteractions {
 				)
 		)
 		const disable_terms: any[] = grpTerms.size ? Array.from(grpTerms) : []
-		const maxNum = 2
+		const maxNum = config.settings.volcano.method == 'edgeR' ? 1 : 2
 
 		const ui = new MultiTermWrapperEditUI({
 			app: this.app,
-			allowFilter: true,
 			callback: async (tws: any) => {
 				this.dom.actionsTip.hide()
-
-				// let categoryNum = 0
-				// for (const tw of tws) {
-				// 	if (!isDictionaryType(tw.term)) continue
-				// 	const x = await this.app.vocabApi.getCategories(tw.term, state.termfilter.filter)
-				// 	if (x.length) categoryNum += x.length
-				// }
-				// if ((categoryNum * this.getSampleNum(config) > 3000)) {
-				// 	sayerror(this.dom.error, 'Too many term categories. Please select fewer categories.')
-				// }
-
 				await this.app.dispatch({
 					type: 'plot_edit',
 					id: this.id,
@@ -102,10 +89,6 @@ export class VolcanoInteractions {
 		for (const opt of opts) {
 			this.dom.actionsTip.d.append('div').attr('class', 'sja_menuoption').text(opt.text).on('click', opt.callback)
 		}
-	}
-
-	getSampleNum(config: VolcanoPlotConfig) {
-		return config.samplelst.groups.reduce((sum: number, g: any) => sum + g.values.length, 0)
 	}
 
 	async highlightDataPoint(value: string) {

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -1,6 +1,7 @@
 import type { MassAppApi } from '#mass/types/mass'
-import { downloadTable, GeneSetEditUI, MultiTermWrapperEditUI } from '#dom'
+import { downloadTable, GeneSetEditUI, MultiTermWrapperEditUI, sayerror } from '#dom'
 import { to_svg } from '#src/client'
+import { isDictionaryType } from '#shared/terms.js'
 import type { VolcanoDom, VolcanoPlotConfig } from '../VolcanoTypes'
 
 export class VolcanoInteractions {
@@ -38,11 +39,24 @@ export class VolcanoInteractions {
 				)
 		)
 		const disable_terms: any[] = grpTerms.size ? Array.from(grpTerms) : []
+		const maxNum = 2
 
 		const ui = new MultiTermWrapperEditUI({
 			app: this.app,
-			callback: async tws => {
+			allowFilter: true,
+			callback: async (tws: any) => {
 				this.dom.actionsTip.hide()
+
+				// let categoryNum = 0
+				// for (const tw of tws) {
+				// 	if (!isDictionaryType(tw.term)) continue
+				// 	const x = await this.app.vocabApi.getCategories(tw.term, state.termfilter.filter)
+				// 	if (x.length) categoryNum += x.length
+				// }
+				// if ((categoryNum * this.getSampleNum(config) > 3000)) {
+				// 	sayerror(this.dom.error, 'Too many term categories. Please select fewer categories.')
+				// }
+
 				await this.app.dispatch({
 					type: 'plot_edit',
 					id: this.id,
@@ -51,7 +65,7 @@ export class VolcanoInteractions {
 			},
 			holder: this.dom.actionsTip.d as any,
 			headerText: 'Select confounders',
-			maxNum: 2,
+			maxNum,
 			state,
 			twList: config.confounderTws,
 			disable_terms
@@ -88,6 +102,10 @@ export class VolcanoInteractions {
 		for (const opt of opts) {
 			this.dom.actionsTip.d.append('div').attr('class', 'sja_menuoption').text(opt.text).on('click', opt.callback)
 		}
+	}
+
+	getSampleNum(config: VolcanoPlotConfig) {
+		return config.samplelst.groups.reduce((sum: number, g: any) => sum + g.values.length, 0)
 	}
 
 	async highlightDataPoint(value: string) {

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -82,6 +82,7 @@ export class VolcanoPlotView {
 	}
 
 	addActionButton(text: string, callback: any) {
+		if (this.viewData.userActions.noShow.includes(text)) return
 		const button = this.volcanoDom.actions
 			.append('button')
 			.attr('class', 'sja_menuoption')

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -9,6 +9,7 @@ import type {
 import type { DEResponse } from '#types'
 import { scaleLinear } from 'd3-scale'
 import { roundValueAuto } from '#shared/roundValue.js'
+import { getSampleNum } from '../Volcano'
 
 export class VolcanoViewModel {
 	config: VolcanoPlotConfig
@@ -70,7 +71,8 @@ export class VolcanoViewModel {
 			pointData,
 			statsData: this.setStatsData(),
 			pValueTableData: this.pValueTable,
-			images: response.images || []
+			images: response.images || [],
+			userActions: this.setUserActions()
 		}
 	}
 
@@ -210,5 +212,17 @@ export class VolcanoViewModel {
 		if (this.termType == 'geneExpression') {
 			this.pValueTable.columns.splice(0, 0, { label: 'Gene Symbol', sortable: true })
 		}
+	}
+
+	setUserActions() {
+		const userActions = {
+			noShow: [] as string[]
+		}
+		if (this.termType == 'geneExpression') {
+			if (this.settings.method == 'edgeR' && getSampleNum(this.config) > 100) {
+				userActions.noShow.push('Confounding factors')
+			}
+		}
+		return userActions
 	}
 }


### PR DESCRIPTION
## Description
Addresses issue #3029. 

Test: 
**Do not use saved sessions. The state in those sessions will override changes.**
1. [EdgeR example, no confounders menu](http://localhost:3000/?mass=%7B%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:2%7D,%22groups%22:%5B%7B%22name%22:%22Resistant%22,%22color%22:%22%23f09930%22,%22filter%22:%7B%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Molecular%20subtype%22%7D,%22values%22:%5B%7B%22key%22:%22High%20hyperdiploid%22%7D%5D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Asparaginase_normalizedLC50%22%7D,%22ranges%22:%5B%7B%22start%22:0.1,%22startinclusive%22:true,%22stopunbounded%22:true%7D%5D%7D%7D%5D%7D%7D,%7B%22name%22:%22Sensitive%22,%22color%22:%22%233453ed%22,%22filter%22:%7B%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Molecular%20subtype%22%7D,%22values%22:%5B%7B%22key%22:%22High%20hyperdiploid%22%7D%5D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Asparaginase_normalizedLC50%22%7D,%22ranges%22:%5B%7B%22stop%22:0.1,%22startunbounded%22:true%7D%5D%7D%7D%5D%7D%7D%5D%7D)
2. Edge R, 1 confounder selected. See `open ALL-pharma DA.txt` in Slack messages
3. Wilcoxon only, See `smaller M v F ASH.txt` in Slack message. 
4. max cutoff rejection. See `M v F ASH open DA.txt` in Slack messages. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
