### PR TITLE
Updated geneVariant predefined groupsetting to allow loading as term2/0

### DIFF
--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -16,7 +16,7 @@ const panel_border_color = '#D3D3D3'
 let i = 0 // track controls "instances" for assigning unambiguous unique input names
 // defaultQ for term0/term2
 export const term0_term2_defaultQ = {
-	[TermTypes.GENE_VARIANT]: { type: 'custom-groupset' },
+	[TermTypes.GENE_VARIANT]: { type: 'predefined-groupset' },
 	[TermTypes.GENE_EXPRESSION]: { mode: 'discrete' },
 	[TermTypes.METABOLITE_INTENSITY]: { mode: 'discrete' }
 }

--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -16,7 +16,7 @@ const panel_border_color = '#D3D3D3'
 let i = 0 // track controls "instances" for assigning unambiguous unique input names
 // defaultQ for term0/term2
 export const term0_term2_defaultQ = {
-	[TermTypes.GENE_VARIANT]: { type: 'predefined-groupset' },
+	[TermTypes.GENE_VARIANT]: { type: 'custom-groupset' },
 	[TermTypes.GENE_EXPRESSION]: { mode: 'discrete' },
 	[TermTypes.METABOLITE_INTENSITY]: { mode: 'discrete' }
 }

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -1,4 +1,4 @@
-import { dtsnvindel, dtcnv, dtfusionrna, geneVariantTermGroupsetting, dtTerms } from '#shared/common.js'
+import { geneVariantTermGroupsetting, dtTerms } from '#shared/common.js'
 import { getPillNameDefault, set_hiddenvalues } from '../termsetting'
 import type { GeneVariantQ, GeneVariantTW, GeneVariantTermSettingInstance, VocabApi, DtTerm } from '#types'
 import type { PillData } from '../types'

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -1,19 +1,10 @@
 import { dtsnvindel, dtcnv, dtfusionrna, geneVariantTermGroupsetting, dtTerms } from '#shared/common.js'
 import { getPillNameDefault, set_hiddenvalues } from '../termsetting'
-import type {
-	FilterGroup,
-	GeneVariantQ,
-	GeneVariantTW,
-	GeneVariantTermSettingInstance,
-	TermGroupSetting,
-	VocabApi,
-	DtTerm
-} from '#types'
+import type { GeneVariantQ, GeneVariantTW, GeneVariantTermSettingInstance, VocabApi, DtTerm } from '#types'
 import type { PillData } from '../types'
 import { make_radios } from '#dom'
 import { copyMerge } from '#rx'
 import { GroupSettingMethods } from './groupsetting.ts'
-import { getWrappedTvslst } from '#filter/filter'
 
 /* 
 instance attributes
@@ -494,7 +485,7 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 		})*/
 }
 
-// get dts specified in dataset
+/*// get dts specified in dataset
 function getDsDts(ds_queries) {
 	const ds_dts: number[] = []
 	for (const query of Object.keys(ds_queries)) {
@@ -512,7 +503,7 @@ function getGroupsetIdxs(dt) {
 	const groupset_idxs = dt == dtsnvindel ? [0, 1, 2] : dt == dtcnv ? [3] : dt == dtfusionrna ? [4] : []
 	if (!groupset_idxs.length) throw 'groupset_idxs is empty'
 	return groupset_idxs
-}
+}*/
 
 function clearGroupset(self) {
 	self.q.type = 'values'

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -143,31 +143,20 @@ export class GroupSettingMethods {
 			if (this.tsInstance.term.type == 'geneVariant') {
 				const q = this.tsInstance.q as GeneVariantBaseQ & PredefinedGroupSettingQ
 				const term = this.tsInstance.term as GeneVariantTerm
-				// @ts-expect-error, need to harmonize input data structure between dictionary and geneVariant terms
-				const dt = input.find(i => i.dt == q.dt)
-				const classes = dt.classes.byOrigin ? dt.classes.byOrigin[q.origin] : dt.classes
 				const groupset = term.groupsetting.lst[q.predefined_groupset_idx]
 				let computableGrpIdx = 0
 				for (const g of groupset.groups) {
-					const group = g as ValuesGroup
+					const group = g as any // TODO: improve typing
 					const grpIdx = group.uncomputable ? 0 : ++computableGrpIdx
 					this.data.groups.push({
 						currentIdx: grpIdx,
-						type: 'values',
+						type: 'filter',
 						name: grpIdx === 0 ? 'Excluded categories' : group.name
 					})
 					grpIdxes.delete(grpIdx)
-					for (const [key, samplecount] of Object.entries(classes)) {
-						if (group.values.some(v => v.key == key)) {
-							this.data.values.push({
-								key,
-								label: mclass[key].label,
-								group: grpIdx,
-								// @ts-expect-error, will resolve when input data structure is harmonized (see above)
-								samplecount
-							})
-						}
-					}
+					const filter = group.filter
+					if (!filter) throw 'filter missing'
+					this.data.filters.push(filter)
 				}
 			}
 		} else {

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -3,10 +3,8 @@ import { select, type Selection } from 'd3-selection'
 //import { disappear } from '#src/client'
 import { throwMsgWithFilePathAndFnName } from '#dom/sayerror'
 import { debounce } from 'debounce'
-import { mclass } from '#shared/common.js'
 import type {
 	TermSettingInstance,
-	ValuesGroup,
 	PredefinedGroupSettingQ,
 	CustomGroupSettingQ,
 	GroupSettingQ,

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- fixed error when geneVariant term is added as either overlay or divideBy term

--- a/shared/types/src/terms/term.ts
+++ b/shared/types/src/terms/term.ts
@@ -122,7 +122,7 @@ export type ValuesGroup = {
 export type FilterGroup = {
 	name: string
 	type: 'filter'
-	filter: Filter
+	filter: any
 	uncomputable?: boolean // if true, do not include this group in computations
 }
 

--- a/shared/types/src/terms/term.ts
+++ b/shared/types/src/terms/term.ts
@@ -136,6 +136,7 @@ type Groupset = {
 	name: string
 	is_grade?: boolean
 	is_subcondition?: boolean
+	id?: string // to identify groupset, used by geneVariant term
 } & BaseGroupSet
 
 export type EnabledTermGroupSetting = {


### PR DESCRIPTION
## Description

This PR fixes the issue of a plot breaking when a geneVariant term is added as either a term2 (overlay) or term0 (divideBy). The predefined groupsetting for geneVariant term (`geneVariantTermGroupsetting` in common.js) has been updated to compare mutated vs. wildtype for every dt (and origin). In `fillTW` of geneVariant handler, the default predefined groupset index used will be the index of the groupset corresponding to the first dt available in the dataset.

Can test by opening this [barchart](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22Biological%20Sex%22}}],%22nav%22:{%22activeTab%22:1}}) and adding a geneVariant term as an overlay term. Please test using other plot types as well.

In next PR, will improve typescript typing and will create unit tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
