### PR TITLE
create a shared/utils emitInports to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ shared/types/**/*.js
 !shared/types/checkers/index.js
 shared/types/terms/*.js
 shared/types/routes/checkers/*
+shared/**/test/internals*.*
 
 **/public/bin/*
 public/tmp/*

--- a/shared/utils/emitImports.js
+++ b/shared/utils/emitImports.js
@@ -1,0 +1,14 @@
+/*
+	Usage:
+
+	# run from the shared/utils dir
+	tsx emitImports > test/internals-test.js 
+
+	- emit imports for running tests
+*/
+
+import * as glob from 'glob'
+
+const specs = glob.sync('./**/test/*.unit.spec.*', { cwd: import.meta.dirname })
+const imports = specs.map(f => `import '../${f}'`)
+console.log(imports.join('\n'))

--- a/shared/utils/package.json
+++ b/shared/utils/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "build": "esbuild src/*.ts --platform=node --outdir=src/ --format=esm && prettier --no-semi --use-tabs --write src/urljson.js src/joinUrl.js src/doc.js",
     "prepack": "npm run build",
-    "test": "ls src/test/*.spec* | xargs node"
+    "pretest": "mkdir -p test && node emitImports > test/internals-test.ts",
+    "test": "tsx test/internals-test.ts",
+    "test-x": "ls src/test/*.spec* | xargs -I % bash -c '{ tsx %; sleep 0.001; }'"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Description

Closes https://github.com/stjude/proteinpaint/issues/3055

Note that the `shared/utils` tests were being run with client tests, http://localhost:3000/testrun.html?dir=../shared/utils/src and also in github CI. This way, the ability to run shared code in either browser or nodejs was verified.

To test:
- `npm test` from the shared/utils dir
- compare with running `npm run test-x` that uses `xargs` with `sleep`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
