### PR TITLE
Snplocus pill fix

### DIFF
--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -207,7 +207,7 @@ export class MassAbout {
 								const confirm = window.confirm(
 									`Changing the cohort will clear all ${joinByComma(
 										toBeCleared
-									)}. To save the session, click "Cancel" and then click the "Session" button.`
+									)}. To proceed, click "OK". To save the session, click "Cancel" and then click the "Session" button at the top of the page.`
 								)
 								if (!confirm) {
 									event.preventDefault()

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -1,6 +1,6 @@
 import { getInitFxn, copyMerge, deepEqual } from '#rx'
 import { Menu } from '#dom'
-import { select, BaseType } from 'd3-selection'
+import { select, type BaseType } from 'd3-selection'
 import { minimatch } from 'minimatch'
 import type {
 	CategoricalQ,

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -575,6 +575,7 @@ function setInteractivity(self) {
 						if (isNumericTerm(self.term) && !self.term.bins && self.term.type != 'survival') {
 							await self.vocabApi.setTermBins({ term: self.term, q: self.q })
 						}
+						if (!self.$id) self.$id = await get$id(self.vocabApi.getTwMinCopy({ term: self.term, q: self.q }))
 						self.handler!.showEditMenu(self.dom.tip.d)
 					} else {
 						throw 'termtype missing'


### PR DESCRIPTION
## Description

When snplocus pill is loaded into regression UI and global filter is added, the snplocus pill is duplicated. This PR fixes this issue by assigning a $id to snplocus term upon `clickNoPillDiv()`.

Can test by opening [regression UI](http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22linear%22,%22outcome%22:{%22id%22:%22LV_Ejection_Fraction_3D_s%22}}]}) -> add snplocus term -> add a global filter

Also updated the message reported when changing cohorts.

Will make a new release to surv2 after merging this PR.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
