### PR TITLE
Various DA fixes and improvements

### DIFF
--- a/client/dom/MultiTermWrapperEditUI.ts
+++ b/client/dom/MultiTermWrapperEditUI.ts
@@ -54,7 +54,7 @@ export class MultiTermWrapperEditUI {
 				.style('margin-left', '10px')
 		}
 		this.twList = opts.twList || []
-		//Used to determine if the use can submit or not
+		//Determines if the user can submit or not
 		//If >0, can submit to remove terms
 		//If == 0, user must select a term to submit
 		this.inputListLength = this.twList.length

--- a/client/dom/MultiTermWrapperEditUI.ts
+++ b/client/dom/MultiTermWrapperEditUI.ts
@@ -20,10 +20,12 @@ export class MultiTermWrapperEditUI {
 	disable_terms: Term[]
 	dom: MultiTermWrapperDom
 	headerText: string
+	inputListLength: number
 	maxNum: number
 	state?: MassState
 	twList: TermWrapper[]
 	update: any
+
 	constructor(opts: MultiTermWrapperUIOpts) {
 		this.app = opts.app
 		this.callback = opts.callback
@@ -52,6 +54,10 @@ export class MultiTermWrapperEditUI {
 				.style('margin-left', '10px')
 		}
 		this.twList = opts.twList || []
+		//Used to determine if the use can submit or not
+		//If >0, can submit to remove terms
+		//If == 0, user must select a term to submit
+		this.inputListLength = this.twList.length
 		this.buttonLabel = opts.buttonLabel || 'Submit'
 		this.maxNum = opts.maxNum || Infinity
 		this.headerText = opts.headerText || ''
@@ -154,8 +160,14 @@ function setRenderers(self) {
 		tws.each(self.renderTerm)
 		tws.enter().append('div').attr('class', 'sjpp-edit-ui-pill').each(self.addTerm)
 
-		self.dom.submitBtn.property('disabled', self.twList.length == 0)
-		self.dom.footer.text(`${self.twList.length} terms selected`)
+		//Disable submit if user did not remove terms from input list and did not select any terms
+		self.dom.submitBtn.property('disabled', self.twList.length === 0 && self.inputListLength == 0)
+		//Show message if terms are removed or if list is empty
+		self.dom.footer.text(
+			`${
+				self.twList.length === 0 && self.inputListLength > 0 ? `Terms removed` : `${self.twList.length} terms selected`
+			}`
+		)
 	}
 
 	self.addTerm = async function (d) {

--- a/client/dom/test/MultiTermWrapperEditUI.integration.spec.ts
+++ b/client/dom/test/MultiTermWrapperEditUI.integration.spec.ts
@@ -9,6 +9,7 @@ import { detectGte } from '../../test/test.helpers.js'
  * Tests
  * 	- Default Multi term edit UI
  *  - Render with terms
+ *	- All terms cleared
  */
 
 /*************************
@@ -111,6 +112,30 @@ tape('Render with terms and .maxNum', async test => {
 	test.equal(submitBtn?.disabled, false, 'Should enable submit button when terms are selected')
 
 	test.equal(ui.dom.footer.node()?.innerHTML, '3 terms selected', 'Should render footer with term count')
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('All terms cleared', async test => {
+	test.timeoutAfter(1000)
+
+	const holder = getHolder() as any
+	const testOpts = getTestOpts({
+		holder,
+		maxNum: 3,
+		twList: [{ term: termjson['agedx'] }, { term: termjson['os'] }, { term: termjson['Arrhythmias'] }]
+	})
+	const ui = new MultiTermWrapperEditUI(testOpts)
+	await ui.renderUI()
+
+	ui.twList = []
+	ui.update(ui)
+
+	const submitBtn = ui.dom.submitBtn.node()
+	test.equal(submitBtn?.disabled, false, 'Should enable submit button when all input terms are removed')
+
+	test.equal(ui.dom.footer.node()?.innerHTML, 'Terms removed', 'Should show user message when terms are removed')
 
 	if (test['_ok']) holder.remove()
 	test.end()

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -186,6 +186,7 @@ class gsea {
 
 async function renderPathwayDropdown(self) {
 	const pathwayOpts = [
+		{ label: '-', value: '-' },
 		{ label: 'BP: subset of GO', value: 'BP: subset of GO' },
 		{ label: 'MF: subset of GO', value: 'MF: subset of GO' },
 		{ label: 'CC: subset of GO', value: 'CC: subset of GO' },
@@ -213,11 +214,16 @@ async function renderPathwayDropdown(self) {
 		.style('margin-right', '10px')
 		.text('Select a gene set group:')
 
-	pathwayOpts.unshift({ label: '-', value: '-' })
 	const dropdown = self.dom.actionsDiv.append('select').on('change', event => {
+		if (!self.settings.pathway) {
+			//Remove placeholder from dropdown on first change
+			const placeholder = dropdown.select('option[value="-"]')
+			placeholder.remove()
+			pathwayOpts.shift()
+		}
+
 		const idx = event.target.selectedIndex
 		self.settings.pathway = pathwayOpts[idx].value
-		pathwayOpts.shift()
 		self.app.dispatch({
 			type: 'plot_edit',
 			id: self.id,

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -377,6 +377,11 @@ add:
 
 	if (self.state.config.downloadFilename) download.fileName = self.state.config.downloadFilename
 
+	//Table rerenders when main is called
+	//Fix to show which gene set is selected after rerender
+	const geneSetIdx = self.gsea_table_rows.findIndex(row => row[0].value == self.config.gsea_params.geneset_name)
+	const selectedRows = geneSetIdx > -1 ? [geneSetIdx] : []
+
 	renderTable({
 		download,
 		columns: self.gsea_table_cols,
@@ -387,6 +392,7 @@ add:
 		singleMode: true,
 		resize: true,
 		header: { allowSort: true },
+		selectedRows: selectedRows,
 		noButtonCallback: async index => {
 			const config = {
 				gsea_params: {

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -141,7 +141,7 @@ class gsea {
 		this.components.controls.on('downloadClick.gsea', () => {
 			if (!this.imageUrl) return alert('No image to download')
 			const dataUrl = this.imageUrl
-			const downloadImgName = this.state.config.downloadFilename + '_GSEA_IMG' || 'GSEA_IMG'
+			const downloadImgName = `${this.state.config.gsea_params.geneset_name || ''}_GSEA_IMG`
 			const a = document.createElement('a')
 			document.body.appendChild(a)
 

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -283,4 +283,4 @@ if (dim(read_counts)[1] * dim(read_counts)[2] < as.numeric(input$mds_cutoff)) { 
 #cat("Time for generating final dataframe: ", as.difftime(final_data_generation_time, unit = "secs")[3], " seconds\n")
 
 # Output results
-toJSON(final_output)
+toJSON(final_output, digits = NA) # Setting digits = NA makes toJSON() use the max precision. This from ?toJSON() documentation


### PR DESCRIPTION
## Description
Addresses issues discussed by the team and some comments in https://github.com/stjude/proteinpaint/pull/3054. 

Changes: 
1. Fix for values not appearing correctly in the volcano plot. 
2. Fix for the gsea dropdown and which gene set is selected is checked
3. Users may remove previously set confounders and click submit in the menu. 

Test: 
1. Volcano plot values -> please use `tOUunq74LiYPeiE` file sent via Slack [in ASH](http://localhost:3000/?massnative=hg38,ASH). This is the example shown in team meeting on Monday. 
2. GSEA dropdown and table -> use this [All pharma link](http://localhost:3000/?mass=%7B%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:2%7D,%22groups%22:%5B%7B%22name%22:%22Resistant%22,%22color%22:%22%23f09930%22,%22filter%22:%7B%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Molecular%20subtype%22%7D,%22values%22:%5B%7B%22key%22:%22High%20hyperdiploid%22%7D%5D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Asparaginase_normalizedLC50%22%7D,%22ranges%22:%5B%7B%22start%22:0.1,%22startinclusive%22:true,%22stopunbounded%22:true%7D%5D%7D%7D%5D%7D%7D,%7B%22name%22:%22Sensitive%22,%22color%22:%22%233453ed%22,%22filter%22:%7B%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Molecular%20subtype%22%7D,%22values%22:%5B%7B%22key%22:%22High%20hyperdiploid%22%7D%5D%7D%7D,%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Asparaginase_normalizedLC50%22%7D,%22ranges%22:%5B%7B%22stop%22:0.1,%22startunbounded%22:true%7D%5D%7D%7D%5D%7D%7D%5D%7D) and test with gsea
3. Confounders menu -> please use `open ALL-pharma DA.txt` in Slack messages

The remaining comment in https://github.com/stjude/proteinpaint/pull/3054 about the loading overlay will be addressed in a separate PR. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
