### PR TITLE
Handled no verified token error

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -194,6 +194,8 @@ export const navInit = getCompInit(TdbNav)
 
 function setRenderers(self) {
 	self.initUI = appState => {
+		const verifiedToken = self.app.vocabApi.verifiedToken
+		if (!verifiedToken) throw new Error('No verified token found. Please check your authentication.')
 		const header = self.opts.holder.append('div').style('white-space', 'nowrap')
 		const massNav = appState.termdbConfig?.massNav || {}
 		let titleDiv = header

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -195,7 +195,9 @@ export const navInit = getCompInit(TdbNav)
 function setRenderers(self) {
 	self.initUI = appState => {
 		const verifiedToken = self.app.vocabApi.verifiedToken
-		if (!verifiedToken) throw new Error('Please check your authentication. The token provided is invalid')
+		const invalidTokenErrorHandling = appState.termdbConfig.invalidTokenErrorHandling
+		if (!verifiedToken && invalidTokenErrorHandling.affectedCharts.includes('*'))
+			throw new Error(appState.termdbConfig.invalidTokenErrorHandling.errorMessage)
 		const header = self.opts.holder.append('div').style('white-space', 'nowrap')
 		const massNav = appState.termdbConfig?.massNav || {}
 		let titleDiv = header

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -195,7 +195,7 @@ export const navInit = getCompInit(TdbNav)
 function setRenderers(self) {
 	self.initUI = appState => {
 		const verifiedToken = self.app.vocabApi.verifiedToken
-		if (!verifiedToken) throw new Error('No verified token found. Please check your authentication.')
+		if (!verifiedToken) throw new Error('Please check your authentication. The token provided is invalid')
 		const header = self.opts.holder.append('div').style('white-space', 'nowrap')
 		const massNav = appState.termdbConfig?.massNav || {}
 		let titleDiv = header

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -199,7 +199,7 @@ function setRenderers(self) {
 		//Show error message if login failed and all charts require login. If the dataset does not require login verifiedToken is true
 		//Currently only the profile and sjcares always require a token.
 		// Note that if the user did not login the public token was used. So only if the user did login and the token passed was invalid this error is shown
-		if (!verifiedToken && invalidTokenErrorHandling.affectedCharts.includes('*'))
+		if (!verifiedToken && invalidTokenErrorHandling?.affectedCharts?.includes('*'))
 			throw new Error(appState.termdbConfig.invalidTokenErrorHandling.errorMessage)
 		const header = self.opts.holder.append('div').style('white-space', 'nowrap')
 		const massNav = appState.termdbConfig?.massNav || {}

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -196,6 +196,9 @@ function setRenderers(self) {
 	self.initUI = appState => {
 		const verifiedToken = self.app.vocabApi.verifiedToken
 		const invalidTokenErrorHandling = appState.termdbConfig.invalidTokenErrorHandling
+		//Show error message if login failed and all charts require login. If the dataset does not require login verifiedToken is true
+		//Currently only the profile and sjcares always require a token.
+		// Note that if the user did not login the public token was used. So only if the user did login and the token passed was invalid this error is shown
 		if (!verifiedToken && invalidTokenErrorHandling.affectedCharts.includes('*'))
 			throw new Error(appState.termdbConfig.invalidTokenErrorHandling.errorMessage)
 		const header = self.opts.holder.append('div').style('white-space', 'nowrap')

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -13,7 +13,14 @@ export class TermdbVocab extends Vocab {
 		if (this.opts.getDatasetAccessToken) {
 			// mass app init may need clientAuthResult, so need to trigger
 			// login so termdb/config response would match the user log-in status
-			await this.maySetVerifiedToken(this.state.vocab.dslabel)
+
+			try {
+				// sets this.app.vocabApi.verifiedToken to false if the token was not valid. nav.js checks this value and throws an error
+				// when the token is not valid no error is thrown but a response with an error message is sent
+				await this.maySetVerifiedToken(this.state.vocab.dslabel)
+			} catch (e) {
+				console.log(e)
+			}
 		}
 
 		const headers = this.mayGetAuthHeaders('termdb')

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -96,7 +96,8 @@ function make(q, req, res, ds: Mds3WithCohort, genome) {
 		tracks: tdb.tracks,
 		sampleTypes: ds.cohort.termdb.sampleTypes,
 		hasSampleAncestry: ds.cohort.termdb.hasSampleAncestry,
-		defaultChartType: ds.cohort.defaultChartType
+		defaultChartType: ds.cohort.defaultChartType,
+		invalidTokenErrorHandling: tdb.invalidTokenErrorHandling
 	}
 	// optional attributes
 	// when missing, the attribute will not be present as "key:undefined"

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -396,6 +396,11 @@ async function maySetAuthRoutes(app, basepath = '', _serverconfig = null) {
 
 	app.post(basepath + '/jwt-status', async (req, res) => {
 		let code = 401 // assume unauthorized by default
+
+		// To simulate a failed JWT signature verification uncomment the following lines
+		// res.status(code)
+		// res.send({"error":{"name":"JsonWebTokenError","message":"invalid signature"}})
+		// return
 		const q = req.query
 		const cred = getRequiredCred(q, req.path)
 		try {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1209,6 +1209,13 @@ type Termdb = {
 	restrictAncestries?: RestrictAncestriesEntry[]
 	/** Cohort specific */
 	selectCohort?: SelectCohortEntry
+	/* When a dataset uses login this property allows to configure the login logic */
+	invalidTokenErrorHandling?: {
+		//Affected charts contains the list of charts that require a login, if * is present, all charts require a login
+		affectedCharts: string[]
+		//Error message that will be displayed in the UI when the login fails or the token is invalid
+		errorMessage: string
+	}
 
 	/** quick fix to convert category values from a term to lower cases for comparison (case insensitive comparison)
 for gdc, graphql and rest apis return case-mismatching strings for the same category e.g. "Breast/breast"


### PR DESCRIPTION
## Description

Worked on this with @siosonel . When a wrong token is provided the portal will raise an error before rendering the content if all the charts are affected, which is configured in the dataset through the property invalidTokenHandling. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/735) To test it uncomment lines 401-403 in auth.js. See profile case:

<img width="1410" alt="Screenshot 2025-04-02 at 1 46 56 PM" src="https://github.com/user-attachments/assets/9c4af1ad-25a2-4b7a-8fef-bc8915ffd166" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
