### PR TITLE
bug fix to reenable loading mds3 LD data

### DIFF
--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import * as termdbsql from './termdb.sql.js'
 import * as phewas from './termdb.phewas.js'
 import { get_incidence } from './termdb.cuminc.js'
@@ -16,6 +17,7 @@ import { searchSNP } from '../routes/snp.ts'
 import { get_samples_ancestry, get_samples } from './termdb.sql.js'
 import { TermTypeGroups } from '#shared/terms.js'
 import { trigger_getDefaultBins } from './termdb.getDefaultBins.js'
+import serverconfig from './serverconfig.js'
 /*
 ********************** EXPORTED
 handle_request_closure
@@ -417,8 +419,7 @@ async function LDoverlay(q, ds, res) {
 	const coord = (tk.nochr ? q.m.chr.replace('chr', '') : q.m.chr) + ':' + q.m.pos + '-' + (q.m.pos + 1)
 	const lst = []
 	await get_lines_bigfile({
-		args: [tk.file, coord],
-		dir: tk.dir,
+		args: [path.join(serverconfig.tpmasterdir, tk.file), coord],
 		callback: line => {
 			const l = line.split('\t')
 			const start = Number.parseInt(l[1])


### PR DESCRIPTION
## Description

tested to fix trouble at both snplocus variant clicking, and [block](http://localhost:3000/?mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22chr%22:%22chr10%22,%22start%22:61901683,%22stop%22:62096944}}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
