### PR TITLE
Add cnv options for gene set edit UI

### DIFF
--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -8,7 +8,6 @@ import type { ClientCopyGenome } from '../../types/global'
 import type { GeneArgumentEntry } from '#types'
 import { GenesMenu } from './GenesMenu'
 import { addButton } from './addButton.ts'
-import { debounce } from 'debounce'
 import { dofetch3 } from '#common/dofetch'
 
 type API = {
@@ -237,76 +236,8 @@ export class GeneSetEditUI {
 		if (this.mode == TermTypes.GENE_EXPRESSION && this.vocabApi.termdbConfig?.queries?.topVariablyExpressedGenes) {
 			if (this.vocabApi.termdbConfig.queries.topVariablyExpressedGenes.arguments) {
 				for (const param of this.vocabApi.termdbConfig.queries.topVariablyExpressedGenes.arguments) {
-					if (param.type == 'radio') {
-						if (!param.options || param.options.length == 0) throw 'Radio button must have options'
-						for (const opt of param.options) {
-							if (opt.type == 'tree') {
-								opt.callback = async (holder: Elem) => {
-									const termdb = await import('../../termdb/app.js')
-									const treeDiv = holder.append('div')
-									await termdb.appInit({
-										holder: treeDiv,
-										state: {
-											dslabel: opt.value,
-											genome: this.genome.name,
-											nav: {
-												header_mode: 'search_only'
-											}
-										},
-										tree: {
-											click_term: (term: any) => {
-												holder
-													.append('div')
-													.classed('ts_pill sja_filter_tag_btn sja_tree_click_term termlabel', true)
-													.style('margin', '5px')
-													.text(`${term.id}`)
-												param.value = {
-													type: opt.value,
-													geneList: term._geneset.map((t: any) => t.symbol)
-												}
-												treeDiv.selectAll('*').remove()
-											}
-										}
-									})
-								}
-							}
-							if (opt.type == 'text') {
-								opt.callback = async (holder: Elem) => {
-									holder
-										.append('span')
-										.style('display', 'block')
-										.style('font-size', '0.8em')
-										.style('opacity', 0.75)
-										.text('Enter genes separated by spaces or commas')
-									holder
-										.append('textarea')
-										.style('display', 'block')
-										.on(
-											'keyup',
-											debounce(function (this: any) {
-												const geneList = this.value
-													.split(/[\s,]+/)
-													.map((t: string) => t.trim())
-													.filter((t: string) => t !== '')
-												param.value = {
-													type: opt.value,
-													geneList
-												}
-											}),
-											500
-										)
-								}
-							}
-							if (opt.type == 'boolean') {
-								opt.callback = () => {
-									param.value = {
-										type: opt.value,
-										geneList: null
-									}
-								}
-							}
-						}
-					}
+					if (param.type == 'radio' && (!param.options || param.options.length == 0))
+						throw 'Radio button must have options'
 					this.api.topVariablyExpressedGenesParams.push({ param })
 				}
 			}
@@ -317,6 +248,7 @@ export class GeneSetEditUI {
 		arr = this.removeDuplicates(arr)
 		return {
 			tip: this.tip2,
+			genome: this.genome,
 			params: arr,
 			addOptionalParams: ({ param, input }) => {
 				arr.push({ param, input })

--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -282,10 +282,8 @@ export class GeneSetEditUI {
 							filter: this.vocabApi.state.termfilter.filter,
 							filter0: this.vocabApi.state.termfilter.filter0
 						}
-						for (const { param, input } of this.api.topMutatedGenesParams) {
-							const id = input.attr('id')
-							args[id] = this.getInputValue({ param, input })
-						}
+
+						this.getInputs(this.api.topMutatedGenesParams, args)
 						const result = await dofetch3('termdb/topMutatedGenes', { method: 'GET', body: args })
 
 						this.geneList = []
@@ -304,6 +302,8 @@ export class GeneSetEditUI {
 					this.api.topVariablyExpressedGenesParams
 						.filter(p => p.param.type == 'radio' && p.param?.options)
 						.forEach(p => {
+							//Sets the default value of the radio button to the first option
+							//for top VE args, it will always be a string
 							if (typeof p.param.options![0].value === 'string') {
 								p.param.value = { type: p.param.options![0].value, value: null }
 							} else {
@@ -321,10 +321,8 @@ export class GeneSetEditUI {
 							if (this.vocabApi.state.termfilter.filter) args.filter = this.vocabApi.state.termfilter.filter // pp filter
 							if (this.vocabApi.state.termfilter.filter0) args.filter0 = this.vocabApi.state.termfilter.filter0 // gdc filter
 						}
-						for (const { param, input } of this.api.topVariablyExpressedGenesParams) {
-							const id = input.attr('id')
-							args[id] = this.getInputValue({ param, input })
-						}
+
+						this.getInputs(this.api.topVariablyExpressedGenesParams, args)
 						const result = await this.vocabApi.getTopVariablyExpressedGenes(args)
 
 						this.geneList = []
@@ -412,6 +410,19 @@ export class GeneSetEditUI {
 					.on('click', async (event: Event) => {
 						await menu.callback(event)
 					})
+		}
+	}
+
+	getInputs(arr, args) {
+		for (const { param, input } of arr) {
+			if (param.parentId) {
+				const parent = arr.find(i => i.param.id == param.parentId)
+				//Parents are always checkboxes/boolean
+				//Do not include submenu inputs in the request if not checked
+				if (!parent || !parent.input.node().checked) return
+			}
+			const id = input.attr('id')
+			args[id] = this.getInputValue({ param, input })
 		}
 	}
 

--- a/client/dom/GeneSetEdit/GenesMenu.ts
+++ b/client/dom/GeneSetEdit/GenesMenu.ts
@@ -31,7 +31,7 @@ export class GenesMenu {
 	params: { param: GeneArgumentEntry; input?: Elem }[]
 	callback: (f?: number) => void
 	addOptionalParams: ({ param, input }) => void
-	/** Collects nested param .options:[]. */
+	/** Collects nested param .options:[] for submenus. See 'boolean' type. */
 	readonly params2Add: { param: GeneArgumentEntry; input: Elem }[] = []
 
 	constructor(opts: GenesMenuArgs) {
@@ -83,8 +83,10 @@ export class GenesMenu {
 				const contentDiv = div.append('div').style('padding-left', '20px')
 				for (const option of param.options) {
 					const optionInput = this.addParameter(option, contentDiv.append('div'))
+					option.parentId = param.id
 					this.params2Add.push({ param: option, input: optionInput })
 				}
+
 				if (param.value) {
 					input.property('checked', param.value)
 					contentDiv.style('display', 'block')
@@ -124,6 +126,7 @@ export class GenesMenu {
 			if (!hasChecked) param.options[0].checked = true
 			input = div.append('div').attr('id', param.id)
 			input.append('p').style('font-size', '0.8em').style('opacity', 0.75).text(param.label)
+			this.addRadioValue(param)
 			this.addRadioCallbacks(param, this.genome)
 			makeRadiosWithContentDivs(param.options, input as any)
 		}
@@ -141,6 +144,17 @@ export class GenesMenu {
 				.html(param.label!)
 				.attr('for', param.id)
 			labelDiv.append('span').style('display', 'block').style('font-size', '0.75em').html(param.sublabel)
+		}
+	}
+
+	addRadioValue(param) {
+		if (param.value) return
+		const checked = param.options.find((d: any) => d.checked)
+		if (checked) {
+			param.value = {
+				type: checked.value,
+				geneList: null
+			}
 		}
 	}
 

--- a/client/dom/GeneSetEdit/GenesMenu.ts
+++ b/client/dom/GeneSetEdit/GenesMenu.ts
@@ -1,4 +1,4 @@
-import { Menu } from '../menu'
+import type { Menu } from '#dom'
 import type { Div, Elem } from '../../types/d3'
 import type { GeneArgumentEntry } from '#types'
 import { addButton } from './addButton.ts'

--- a/client/dom/GeneSetEdit/GenesMenu.ts
+++ b/client/dom/GeneSetEdit/GenesMenu.ts
@@ -119,6 +119,22 @@ export class GenesMenu {
 			input = div.append('div').attr('id', param.id)
 			input.append('p').style('font-size', '0.8em').style('opacity', 0.75).text(param.label)
 			makeRadiosWithContentDivs(param.options, input as any)
+		} else if (param.type == 'submenu') {
+			const checkboxDiv = div.append('div')
+			const submenuDiv = div.append('div').style('display', 'none')
+			input = make_one_checkbox({
+				holder: checkboxDiv,
+				id: param.id,
+				checked: param.checked,
+				labeltext: param.label,
+				callback: () => {
+					submenuDiv.style('display', checkboxDiv.select('input').property('checked') ? 'block' : 'none')
+				}
+			})
+			for (const option of param.sections) {
+				const optionInput = this.addParameter(option, submenuDiv)
+				this.params2Add.push({ param: option, input: optionInput })
+			}
 		}
 		return input
 	}

--- a/client/dom/GeneSetEdit/radioWithContent.ts
+++ b/client/dom/GeneSetEdit/radioWithContent.ts
@@ -1,5 +1,5 @@
 import { select as d3select } from 'd3-selection'
-import { Elem } from '../../types/d3'
+import type { Elem } from '../../types/d3'
 
 export function makeRadiosWithContentDivs(options: any, div: Elem) {
 	const divs = div

--- a/client/dom/GeneSetEdit/radioWithContent.ts
+++ b/client/dom/GeneSetEdit/radioWithContent.ts
@@ -31,8 +31,7 @@ export function makeRadiosWithContentDivs(options: any, div: Elem) {
 				.style('padding-left', '25px')
 				.style('display', 'block')
 
-			//If no content (i.e. callback), continue
-			if (d.callback) await d.callback(contentDiv)
+			await d.callback(contentDiv)
 			d3select(this).property('checked', true)
 			inputs.property('disabled', false)
 		})

--- a/client/dom/GeneSetEdit/radioWithContent.ts
+++ b/client/dom/GeneSetEdit/radioWithContent.ts
@@ -31,7 +31,8 @@ export function makeRadiosWithContentDivs(options: any, div: Elem) {
 				.style('padding-left', '25px')
 				.style('display', 'block')
 
-			await d.callback(contentDiv)
+			//If no content (i.e. callback), continue
+			if (d.callback) await d.callback(contentDiv)
 			d3select(this).property('checked', true)
 			inputs.property('disabled', false)
 		})

--- a/server/routes/termdb.topMutatedGenes.ts
+++ b/server/routes/termdb.topMutatedGenes.ts
@@ -63,16 +63,44 @@ export function validate_query_getTopMutatedGenes(ds: any, genome: any) {
 			Min absolute log(ratio) radio select
 		*/
 		if (ds.queries.cnv) {
-			// TODO should be radio btns
-			q.arguments.push({ id: 'cnv_1mb_01', label: 'CNV <1Mb abs(logratio)>0.1', type: 'boolean', value: false })
-			q.arguments.push({ id: 'cnv_1mb_02', label: 'CNV <1Mb abs(logratio)>0.2', type: 'boolean', value: false })
-			q.arguments.push({ id: 'cnv_1mb_03', label: 'CNV <1Mb abs(logratio)>0.3', type: 'boolean', value: false })
-			q.arguments.push({ id: 'cnv_2mb_01', label: 'CNV <2Mb abs(logratio)>0.1', type: 'boolean', value: false })
-			q.arguments.push({ id: 'cnv_2mb_02', label: 'CNV <2Mb abs(logratio)>0.2', type: 'boolean', value: false })
-			q.arguments.push({ id: 'cnv_2mb_03', label: 'CNV <2Mb abs(logratio)>0.3', type: 'boolean', value: false })
-			q.arguments.push({ id: 'cnv_4mb_01', label: 'CNV <4Mb abs(logratio)>0.1', type: 'boolean', value: true })
-			q.arguments.push({ id: 'cnv_4mb_02', label: 'CNV <4Mb abs(logratio)>0.2', type: 'boolean', value: false })
-			q.arguments.push({ id: 'cnv_4mb_03', label: 'CNV <4Mb abs(logratio)>0.3', type: 'boolean', value: false })
+			q.arguments.push({
+				id: 'cnv',
+				type: 'submenu',
+				label: 'CNV',
+				checked: false,
+				sections: [
+					{
+						id: 'cnv_mb',
+						label: 'Length',
+						type: 'radio',
+						options: [
+							{ id: 'cnv_1mb', label: '<1Mb', value: 1, checked: false },
+							{ id: 'cnv_2mb', label: '<2Mb', value: 2, checked: false },
+							{ id: 'cnv_4mb', label: '<4Mb', value: 4, checked: false }
+						]
+					},
+					{
+						id: 'cnv_logratio',
+						label: 'Absolute log ratio',
+						type: 'radio',
+						options: [
+							{ id: 'cnv_01', label: '>0.1', value: 0.1, checked: false },
+							{ id: 'cnv_02', label: '>0.2', value: 0.2, checked: false },
+							{ id: 'cnv_03', label: '>0.3', value: 0.3, checked: false }
+						]
+					}
+				]
+			})
+			// // TODO should be radio btns
+			// q.arguments.push({ id: 'cnv_1mb_01', label: 'CNV <1Mb abs(logratio)>0.1', type: 'boolean', value: false })
+			// q.arguments.push({ id: 'cnv_1mb_02', label: 'CNV <1Mb abs(logratio)>0.2', type: 'boolean', value: false })
+			// q.arguments.push({ id: 'cnv_1mb_03', label: 'CNV <1Mb abs(logratio)>0.3', type: 'boolean', value: false })
+			// q.arguments.push({ id: 'cnv_2mb_01', label: 'CNV <2Mb abs(logratio)>0.1', type: 'boolean', value: false })
+			// q.arguments.push({ id: 'cnv_2mb_02', label: 'CNV <2Mb abs(logratio)>0.2', type: 'boolean', value: false })
+			// q.arguments.push({ id: 'cnv_2mb_03', label: 'CNV <2Mb abs(logratio)>0.3', type: 'boolean', value: false })
+			// q.arguments.push({ id: 'cnv_4mb_01', label: 'CNV <4Mb abs(logratio)>0.1', type: 'boolean', value: true })
+			// q.arguments.push({ id: 'cnv_4mb_02', label: 'CNV <4Mb abs(logratio)>0.2', type: 'boolean', value: false })
+			// q.arguments.push({ id: 'cnv_4mb_03', label: 'CNV <4Mb abs(logratio)>0.3', type: 'boolean', value: false })
 		}
 	}
 	q.get = async (param: topMutatedGeneRequest) => {

--- a/server/routes/termdb.topMutatedGenes.ts
+++ b/server/routes/termdb.topMutatedGenes.ts
@@ -40,11 +40,10 @@ function init({ genomes }) {
 
 /** This is a hack
 The user is presented with two radio buttons to reference
-one data column. Eventually the db will not store the data
+one data column. Eventually the db will not store data
 this way. */
-
 function consolidateCNVparams(q) {
-	if (q.cnv_ms && q.cnv_logratio) {
+	if (q.cnv == 1 && q.cnv_ms && q.cnv_logratio) {
 		const key = q.cnv_ms.type + q.cnv_logratio.type.replace('cnv', '')
 		q[key] = 1
 	}
@@ -87,9 +86,8 @@ export function validate_query_getTopMutatedGenes(ds: any, genome: any) {
 						id: 'cnv_ms',
 						label: 'Max size',
 						type: 'radio',
-						value: { type: 'cnv_1mb', geneList: null }, //This is a quick fix
 						options: [
-							{ id: 'cnv_1mb', label: '<1Mb', value: 'cnv_1mb', checked: true },
+							{ id: 'cnv_1mb', label: '<1Mb', value: 'cnv_1mb' },
 							{ id: 'cnv_2mb', label: '<2Mb', value: 'cnv_2mb' },
 							{ id: 'cnv_4mb', label: '<4Mb', value: 'cnv_4mb' }
 						]
@@ -98,9 +96,8 @@ export function validate_query_getTopMutatedGenes(ds: any, genome: any) {
 						id: 'cnv_logratio',
 						label: 'Min absolute log(ratio)',
 						type: 'radio',
-						value: { type: 'cnv_01', geneList: null }, //This is a quick fix
 						options: [
-							{ id: 'cnv_01', label: '>0.1', value: 'cnv_01', checked: true },
+							{ id: 'cnv_01', label: '>0.1', value: 'cnv_01' },
 							{ id: 'cnv_02', label: '>0.2', value: 'cnv_02' },
 							{ id: 'cnv_03', label: '>0.3', value: 'cnv_03' }
 						]

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -421,9 +421,14 @@ export type GeneArgumentEntry = {
 	label: string
 	/** Optional: Creates subtext below the main label */
 	sublabel?: string
-	/** boolean and string creates a checkbox
-	 * number creates a text input
-	 */
+	/** 'boolean' has two options.
+	 * 	- If .options[] is provided, it creates a 'submenu', a checkbox
+	 * 		that expands to show additional inputs when checked. .options[]
+	 * 		in this case is GeneArgumentEntry[]
+	 *  - If !.options[] is provided, it creates a checkbox
+	 * 'string' creates a checked checkbox if a .value is provided
+	 * 'number' creates a text number input
+	 * 'radio' creates a radio buttons, see options[] */
 	type: 'boolean' | 'string' | 'number' | 'radio'
 	/** value of the input or checkbox
 	 * required if type is string. Otherwise, optional
@@ -441,6 +446,8 @@ export type GeneArgumentEntry = {
 		 * 'text': creates a text area input
 		 * 'tree': launches termdb app and the tree
 		 * 'boolean': No element is created
+		 *
+		 * boolean is the default type
 		 */
 		type: 'text' | 'tree' | 'boolean' | string
 		/** value used to construct the server argument

--- a/shared/types/src/routes/termdb.topMutatedGenes.ts
+++ b/shared/types/src/routes/termdb.topMutatedGenes.ts
@@ -18,15 +18,9 @@ export type topMutatedGeneRequest = {
 	snv_s?: number
 	sv?: number
 	fusion?: number
-	cnv_1mb_01?: number
-	cnv_1mb_02?: number
-	cnv_1mb_03?: number
-	cnv_2mb_01?: number
-	cnv_2mb_02?: number
-	cnv_2mb_03?: number
-	cnv_4mb_01?: number
-	cnv_4mb_02?: number
-	cnv_4mb_03?: number
+	cnv?: number
+	cnv_ms?: { type: string; geneLst: null }
+	cnv_logratio?: { type: string; geneLst: null }
 }
 
 export type MutatedGene = {


### PR DESCRIPTION
## Description
Adds options for to the gene set edit UI for cnv parameters in the top mutated genes UI. Test with [ASH link](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22id%22:%22Sex%22},{%22term%22:{%22gene%22:%22TAL1%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22KRAS%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22MYB%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22MYC%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22CDKN2A%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22NOTCH1%22,%22type%22:%22geneVariant%22}}]}]}]}). I put a note in about how the data structure would change eventually in the server routes. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
