### PR TITLE
Show data point on top when hovering over p value table

### DIFF
--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -198,12 +198,23 @@ export class VolcanoPlotView {
 				const circle = circles.find((d: any) => d.__data__.gene_symbol == row[0].value) as any
 				if (!circle || circle.__data__.highlighted) return
 
+				/** Circles may render behind several other circles, making it hard
+				 * to see the highlight. Clone the circle to appear on top of the
+				 * elements, then destroy. */
+				let clone
 				tr.on('mouseover', () => {
-					selectAll(circles).attr('stroke-opacity', d => (d != circle.__data__ ? 0.075 : 0.5))
-					select(circle).attr('fill-opacity', 0.9)
+					if (circle.__data__.highlighted || clone) return
+					clone = this.volcanoDom.plot.node()?.appendChild(circle.cloneNode(true))
+					clone.setAttribute('fill-opacity', 0.9)
 				})
 				tr.on('mouseleave', () => {
-					select(circle).attr('fill-opacity', 0)
+					if (!clone) return
+					clone.remove()
+					clone = null
+				})
+				//All other circles appear dimmed on hover
+				this.volcanoDom.pValueTable.on('mouseover', () => {
+					selectAll(circles).attr('stroke-opacity', 0.075)
 				})
 				this.volcanoDom.pValueTable.on('mouseleave', () => {
 					selectAll(circles).attr('stroke-opacity', (d: any) =>


### PR DESCRIPTION
## Description
This is the solution proposed in https://github.com/stjude/proteinpaint/pull/3065 for the highlighted data points appearing behind other data points when hovering over the p value table. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
