### PR TITLE
Show disclaimer in cox regression, if specified

### DIFF
--- a/client/plots/regression.results.js
+++ b/client/plots/regression.results.js
@@ -263,6 +263,7 @@ function setRenderers(self) {
 		self.mayshow_splinePlots(result)
 		self.mayshow_residuals(result)
 		self.mayshow_coefficients(result)
+		self.mayshow_coxDisclaimer()
 		self.mayshow_totalSnpEffect(result)
 		self.mayshow_type3(result)
 		self.mayshow_tests(result)
@@ -1190,6 +1191,21 @@ function setRenderers(self) {
 			else if (variables.length == 1) return variables[0]
 			else if (variables.length == 2) return variables.join(' and ')
 			else return `${variables.slice(0, -1).join(', ')}, and ${variables.slice(-1)}`
+		}
+	}
+
+	// show disclaimer message under the coefficient tables when
+	// regressionType == 'cox
+	self.mayshow_coxDisclaimer = () => {
+		const disclaimer = self.app.vocabApi.termdbConfig.regression?.settings?.coxDisclaimer
+		if (disclaimer && self.config.regressionType == 'cox') {
+			self.dom.oneSetResultDiv
+				.append('div')
+				.attr('data-testid', 'sjpp-regression-result-coxDisclaimer')
+				.style('margin', '20px 0px 20px 10px')
+				.style('font-size', '.8em')
+				.style('text-align', 'left')
+				.text(disclaimer)
 		}
 	}
 

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -1,8 +1,8 @@
-import type { Mds3, WSImage } from '#types'
+import type { Mds3 } from '#types'
 import serverconfig from '@sjcrh/proteinpaint-server/src/serverconfig.js'
 import * as path from 'path'
 import { existsSync, unlinkSync, symlinkSync, access, constants } from 'fs'
-import { WSISample } from '@sjcrh/proteinpaint-types/routes/wsisamples.js'
+// import { WSISample } from '@sjcrh/proteinpaint-types/routes/wsisamples.js'
 
 /*
 the "test mule" for the type of termdb dataset using server-side sqlite3 db
@@ -112,7 +112,12 @@ export default {
 					ignoreCnvValues: true
 				}
 			},
-			termid2totalsize2: {}
+			termid2totalsize2: {},
+			regression: {
+				settings: {
+					coxDisclaimer: 'This is a test disclaimer for the cox regression analysis.'
+				}
+			}
 		},
 		scatterplots: {
 			plots: [

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1026,6 +1026,9 @@ type SurvivalSettings = {
 }
 
 type RegressionSettings = {
+	/** Disclaimer message shown under the cofficient table when
+	 * regression type is cox. */
+	coxDisclaimer?: string
 	/** disable interactions */
 	disableInteractions?: boolean
 	/** hide type III statistics table in results */


### PR DESCRIPTION
## Description
Closes issue #3049. Test by running cox regression in [termdb test](http://localhost:3000/?massnative=hg38-test,TermdbTest) -> Should see the test message between the coefficients table and stats table. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
