### PR TITLE
avoid showing lollipop button for non-geneVaraint terms

### DIFF
--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -744,15 +744,20 @@ function setTermActions(self) {
 			})
 
 		if (vartype == 'gene') {
-			self.dom.gbButton = labelEditDiv
-				.append('button')
-				.style('text-align', 'center')
-				.html('Lollipop')
-				.attr('data-testid', 'oncoMatrix_cell_lollipop_button')
-				.on('click', async () => {
-					await self.launchGB(t)
-					self.dom.tip.hide()
-				})
+			// is gene, may show extra button for quick data access
+			if (t.tw.term.type == 'geneVariant') {
+				// lollipop btn for plotting gene-level mut data
+				self.dom.gbButton = labelEditDiv
+					.append('button')
+					.style('text-align', 'center')
+					.html('Lollipop')
+					.attr('data-testid', 'oncoMatrix_cell_lollipop_button')
+					.on('click', async () => {
+						await self.launchGB(t)
+						self.dom.tip.hide()
+					})
+			}
+			// might add new btn to support other type, e.g. boxplot for geneexp
 		}
 
 		// Add gene summary button


### PR DESCRIPTION
## Description

[test link](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22hierCluster%22,%22dataType%22:%22geneExpression%22,%22terms%22:[{%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22},{%22gene%22:%22AKT1%22,%22type%22:%22geneExpression%22},{%22gene%22:%22KRAS%22,%22type%22:%22geneExpression%22},{%22gene%22:%22BCR%22,%22type%22:%22geneExpression%22}],%22termgroups%22:[{%22name%22:%22Variables%22,%22lst%22:[{%22id%22:%22diaggrp%22},{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22}}]}]}]})
while testing all-pharm gene clustering from Andrew's branch, noticed it shows Lollipop btn on clicking gene label. this is nonsensical since 1) row data is gene exp 2) all-pharm doesn't have snvindel

this fix avoids that

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
