### PR TITLE
show empty matrix without rendering errors 

### DIFF
--- a/client/plots/matrix/matrix.js
+++ b/client/plots/matrix/matrix.js
@@ -210,8 +210,9 @@ export class Matrix {
 			this.setLayout()
 			if (this.setHierColorScale) this.setHierColorScale(this.hierClusterData.clustering)
 			this.serieses = this.getSerieses(this.data)
+			// TODO: may re-enable below if showing no-data message/suggestions is preferred over rendering empty matrix
 			// can now return early before rendering computed data
-			if (!this.sampleOrder?.length) return
+			// if (!this.sampleOrder?.length) return
 
 			// render the data
 			this.dom.loadingDiv.html('Rendering ...')

--- a/client/plots/matrix/matrix.layout.js
+++ b/client/plots/matrix/matrix.layout.js
@@ -529,7 +529,7 @@ export function setLayout() {
 	// zoomCenter relative to mainw
 	const zoomCenter = s.zoomCenterPct * mainw
 	const centerCellX = s.zoomIndex * dx + s.zoomGrpIndex * s.colgspace
-	const zoomedMainW = nx * dx + (this[`${col}Grps`].length - 1) * s.colgspace
+	const zoomedMainW = Math.max(0, nx * dx + (this[`${col}Grps`].length - 1) * s.colgspace)
 	const seriesXoffset =
 		s.zoomLevel <= 1 && mainw >= zoomedMainW ? 0 : Math.max(zoomCenter - centerCellX, mainw - zoomedMainW)
 


### PR DESCRIPTION
## Description

For now, render empty matrix and comment out a single-line to not show the matrix no-data-message if applicable and suggest only applicable fixes based on available dt data and current legend filter. This alternative, commented out fix prevents rendering an empty matrix for apollo-luad.

Fixes https://github.com/stjude/proteinpaint/issues/3052

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
