### PR TITLE
clarify the use of allowedTermTypes=[geneVariant], only compute termtypeByCohort once

### DIFF
--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -45,6 +45,7 @@ export default {
 		},
 
 		termdb: {
+			allowedTermTypes: ['geneVariant'],
 			displaySampleIds: true, // allow to display sample-level data
 
 			timeUnit: 'years',

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -2,7 +2,7 @@ import serverconfig from '#src/serverconfig.js'
 import { authApi } from '#src/auth.js'
 import { get_ds_tdb } from '#src/termdb.js'
 import { mayCopyFromCookie } from '#src/utils.js'
-import { mayComputeTermtypeByCohort } from '#src/termdb.server.init.ts'
+//import { mayComputeTermtypeByCohort } from '#src/termdb.server.init.ts'
 import { TermTypes } from '#shared/terms.js'
 import type { Mds3WithCohort } from '#types'
 
@@ -174,8 +174,8 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 		defaultCoord: q.defaultCoord || genome.defaultcoord
 	}
 	const q2 = c.queries
-	// copy from q{} to q2{}
 	if (q.defaultBlock2GeneMode) q2.defaultBlock2GeneMode = q.defaultBlock2GeneMode
+	// copy from q{} to q2{}
 	if (q.snvindel) {
 		q2.snvindel = {
 			allowSNPs: q.snvindel.allowSNPs,
@@ -292,15 +292,8 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 	}
 }
 
-// allowedTermTypes[] is an unique list of term types from this dataset
-// crucial for determining if a plot can function
-// e.g. survival plot can only work if allowedTermTypes.includes('survival')
+// allowedTermTypes[] is an unique list of term types from this dataset. allows plot to determine if term type specific feature is applicable for a ds
 function getAllowedTermTypes(ds) {
-	mayComputeTermtypeByCohort(ds)
-	// ds.cohort.termdb.termtypeByCohort[] is set
-
-	// for now return list of term types irrespective of subcohorts
-
 	const typeSet = new Set()
 	for (const r of ds.cohort.termdb.termtypeByCohort) {
 		if (r.termType) typeSet.add(r.termType)
@@ -311,12 +304,19 @@ function getAllowedTermTypes(ds) {
 		for (const t of ds.cohort.termdb.allowedTermTypes) typeSet.add(t)
 	}
 
+	/*
+	mayComputeTermtypeByCohort(ds)
+	// ds.cohort.termdb.termtypeByCohort[] is set
+
+	// for now return list of term types irrespective of subcohorts
+
 	if (ds?.queries?.defaultBlock2GeneMode) {
 		// an mds3 dataset showing data in protein mode, add in "geneVariant"
 		// this disables gene from searchable for dataset e.g. sjlife
 		// same logic in trigger_findterm()
 		typeSet.add('geneVariant')
 	}
+	*/
 	if (ds?.queries?.geneExpression) typeSet.add(TermTypes.GENE_EXPRESSION)
 	if (ds?.queries?.metaboliteIntensity) typeSet.add(TermTypes.METABOLITE_INTENSITY)
 

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -676,7 +676,7 @@ export function listTableColumns(cn, table) {
 	return rows.map(i => i.name)
 }
 
-export function mayComputeTermtypeByCohort(ds) {
+function mayComputeTermtypeByCohort(ds) {
 	if (ds.cohort.termdb.termtypeByCohort) {
 		if (!Array.isArray(ds.cohort.termdb.termtypeByCohort)) throw 'termtypeByCohort is not array'
 		// already set, by one of two methods:

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1269,12 +1269,12 @@ keep this setting here for reason of:
 		ssm?: UrlTemplateSsm | UrlTemplateSsm[]
 	}
 
-	/** ds-defined or dynamically created. the array has an extra "nested" property
+	termtypeByCohort?: any // FIXME see below
+	/** TODO not declared due to tsc err
+	ds-defined or dynamically created. the array has an extra "nested" property
 	only describes dictionary terms,
 	non-dict terms are dynamically generated in getAllowedTermTypes() of termdb.config.ts based on query types
-	*/
 	termtypeByCohort?: {
-		/** '' if ds doesn't use cohort */
 		cohort: string
 		termType: string
 		termCount: number
@@ -1285,6 +1285,8 @@ keep this setting here for reason of:
 			}
 		}
 	}
+	*/
+
 	/** ds defined add on to termtypeByCohort; note that this is not cohort-specific!
 	this is combined with termtypeByCohort in getAllowedTermTypes()
 	for now is used to support following types which lacks good way to auto generate them:


### PR DESCRIPTION
## Description

closes #3083 
clarifies that geneVariant term type must be defined via allowedTT[] for the time being
only compute termtypeByCohort once (didn't recall reason to do so prior)
tried to add typing for termtypeByCohort but failed


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
