### PR TITLE
gb menu button provides protein/genomic options and refactor via gbRe…

### DIFF
--- a/client/plots/test/genomeBrowser.spec.js
+++ b/client/plots/test/genomeBrowser.spec.js
@@ -66,7 +66,7 @@ const groupFilterAML = {
 			{
 				type: 'tvs',
 				tvs: {
-					term: { id: 'diaggrp', name: 'Diagnosis Group', type: 'categorical' },
+					term: { id: 'diaggrp_s', name: 'Diagnosis Group', type: 'categorical' },
 					values: [{ key: 'Acute myeloid leukemia', label: 'Acute myeloid leukemia' }]
 				}
 			}
@@ -83,13 +83,13 @@ const groupFilterALLmale = {
 			{
 				type: 'tvs',
 				tvs: {
-					term: { id: 'diaggrp', name: 'Diagnosis Group', type: 'categorical' },
+					term: { id: 'diaggrp_s', name: 'Diagnosis Group', type: 'categorical' },
 					values: [{ key: 'Acute lymphoblastic leukemia', label: 'Acute lymphoblastic leukemia' }]
 				}
 			},
 			{
 				type: 'tvs',
-				tvs: { term: { id: 'sex', name: 'Sex', type: 'categorical' }, values: [{ key: '1', label: 'Male' }] }
+				tvs: { term: { id: 'sex_s', name: 'Sex', type: 'categorical' }, values: [{ key: '1', label: 'Male' }] }
 			}
 		]
 	}
@@ -159,14 +159,14 @@ tape('Sjlife default, with global mass filter', test => {
 						{
 							type: 'tvs',
 							tvs: {
-								term: { id: 'diaggrp' },
+								term: { id: 'diaggrp_s' },
 								values: [{ key: 'Acute lymphoblastic leukemia', label: 'Acute lymphoblastic leukemia' }]
 							}
 						},
 						{
 							type: 'tvs',
 							tvs: {
-								term: { id: 'agedx', name: 'agedx', type: 'float' },
+								term: { id: 'agedx_s', name: 'agedx', type: 'float' },
 								ranges: [{ startunbounded: true, stop: 10, stopinclusive: true }]
 							}
 						}

--- a/client/plots/test/genomeBrowser.unit.spec.ts
+++ b/client/plots/test/genomeBrowser.unit.spec.ts
@@ -16,11 +16,11 @@ tape('\n', test => {
 	test.end()
 })
 
-const config = {
+const config: any = {
 	geneSearchResult: {}
 }
 
-const vocabApi = {
+const vocabApi: any = {
 	termdbConfig: {
 		queries: {
 			//gbRestrictMode

--- a/client/plots/test/genomeBrowser.unit.spec.ts
+++ b/client/plots/test/genomeBrowser.unit.spec.ts
@@ -1,0 +1,87 @@
+import tape from 'tape'
+import { computeBlockModeFlag } from '#plots/genomeBrowser.js'
+
+/* 
+Tests:
+
+computeBlockModeFlag()
+*/
+
+/**************
+ test sections
+***************/
+
+tape('\n', test => {
+	test.pass('-***- plots/genomebrowser -***-')
+	test.end()
+})
+
+const config = {
+	geneSearchResult: {}
+}
+
+const vocabApi = {
+	termdbConfig: {
+		queries: {
+			//gbRestrictMode
+		}
+	}
+}
+
+tape('computeBlockModeFlag()', test => {
+	console.log('priority 1: with override f(config,true)')
+
+	config.blockIsProteinMode = undefined
+	computeBlockModeFlag(config, true)
+	test.equal(config.blockIsProteinMode, true, 'override from undefined to true')
+
+	config.blockIsProteinMode = false
+	computeBlockModeFlag(config, true)
+	test.equal(config.blockIsProteinMode, true, 'override from false to true')
+
+	config.blockIsProteinMode = true
+	computeBlockModeFlag(config, false)
+	test.equal(config.blockIsProteinMode, false, 'override from true to false')
+
+	console.log('priority 2: no override and has default f(config)')
+
+	config.blockIsProteinMode = false
+	computeBlockModeFlag(config)
+	test.equal(config.blockIsProteinMode, false, 'remains false')
+
+	config.blockIsProteinMode = true
+	computeBlockModeFlag(config)
+	test.equal(config.blockIsProteinMode, true, 'remains true')
+
+	console.log('priority 3: no override and default, auto compute f(config, null, vocabApi)')
+	delete config.blockIsProteinMode // MUST delete flag before every of following test
+	computeBlockModeFlag(config, null, vocabApi)
+	test.equal(config.blockIsProteinMode, false, 'no gbRestrictMode, no geneSearchResult, auto set to false')
+
+	delete config.blockIsProteinMode
+	config.geneSearchResult.geneSymbol = 'xx'
+	computeBlockModeFlag(config, null, vocabApi)
+	test.equal(config.blockIsProteinMode, true, 'no gbRestrictMode, has gene symbol, auto set to true')
+
+	delete config.blockIsProteinMode
+	vocabApi.termdbConfig.queries.gbRestrictMode = 'protein'
+	computeBlockModeFlag(config, null, vocabApi)
+	test.equal(config.blockIsProteinMode, true, 'gbRestrictMode=protein, auto set to true')
+
+	delete config.blockIsProteinMode
+	vocabApi.termdbConfig.queries.gbRestrictMode = 'genomic'
+	computeBlockModeFlag(config, null, vocabApi)
+	test.equal(config.blockIsProteinMode, false, 'gbRestrictMode=genomic, auto set to false')
+
+	delete config.blockIsProteinMode
+	vocabApi.termdbConfig.queries.gbRestrictMode = 'invalid'
+	test.throws(
+		function () {
+			computeBlockModeFlag(config, null, vocabApi)
+		},
+		/unknown gbRestrictMode/,
+		'throws on unknown gbRestrictMode'
+	)
+
+	test.end()
+})

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -164,7 +164,7 @@ export default {
 	},
 	queries: {
 		// temporary fix for genomeBrowser app to show gene model
-		defaultBlock2GeneMode: true,
+		//defaultBlock2GeneMode: true,
 
 		snvindel: {
 			forTrack: true,

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -163,9 +163,6 @@ export default {
 		sunburst_twLst: [{ id: 'sex', q: {} }]
 	},
 	queries: {
-		// temporary fix for genomeBrowser app to show gene model
-		//defaultBlock2GeneMode: true,
-
 		snvindel: {
 			forTrack: true,
 			byrange: {

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -2,7 +2,6 @@ import serverconfig from '#src/serverconfig.js'
 import { authApi } from '#src/auth.js'
 import { get_ds_tdb } from '#src/termdb.js'
 import { mayCopyFromCookie } from '#src/utils.js'
-//import { mayComputeTermtypeByCohort } from '#src/termdb.server.init.ts'
 import { TermTypes } from '#shared/terms.js'
 import type { Mds3WithCohort } from '#types'
 
@@ -171,10 +170,10 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 	if (!q) return
 	// this ds supports genomic query methods
 	c.queries = {
-		defaultCoord: q.defaultCoord || genome.defaultcoord
+		defaultCoord: q.defaultCoord || genome.defaultcoord,
+		gbRestrictMode: q.gbRestrictMode
 	}
 	const q2 = c.queries
-	if (q.defaultBlock2GeneMode) q2.defaultBlock2GeneMode = q.defaultBlock2GeneMode
 	// copy from q{} to q2{}
 	if (q.snvindel) {
 		q2.snvindel = {
@@ -298,28 +297,13 @@ function getAllowedTermTypes(ds) {
 	for (const r of ds.cohort.termdb.termtypeByCohort) {
 		if (r.termType) typeSet.add(r.termType)
 	}
-
 	if (ds.cohort.termdb.allowedTermTypes) {
 		// optional predefined term types, append to set
 		for (const t of ds.cohort.termdb.allowedTermTypes) typeSet.add(t)
 	}
-
-	/*
-	mayComputeTermtypeByCohort(ds)
-	// ds.cohort.termdb.termtypeByCohort[] is set
-
-	// for now return list of term types irrespective of subcohorts
-
-	if (ds?.queries?.defaultBlock2GeneMode) {
-		// an mds3 dataset showing data in protein mode, add in "geneVariant"
-		// this disables gene from searchable for dataset e.g. sjlife
-		// same logic in trigger_findterm()
-		typeSet.add('geneVariant')
-	}
-	*/
+	// assess other data types and add corresponding term types
 	if (ds?.queries?.geneExpression) typeSet.add(TermTypes.GENE_EXPRESSION)
 	if (ds?.queries?.metaboliteIntensity) typeSet.add(TermTypes.METABOLITE_INTENSITY)
-
 	return [...typeSet]
 }
 

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -806,9 +806,8 @@ type SingleSampleGbtk = {
 }
 
 type Mds3Queries = {
-	defaultBlock2GeneMode?: true // TODO to be deleted
-	/** (gb=genomebrowser) affects gb chart button menu genesearchbox behavior, 
-	add some additional options after a gene is found, and mode of gb launched from the button menu
+	/** (gb=genomebrowser) controls gb chart button menu genesearchbox behavior, 
+	add some additional options after a gene is found, and mode of gb launched from the menu
 
 	- "protein":
 		genesearchbox only allow searching gene and not coord


### PR DESCRIPTION
…strictMode

## Description

closes #3074

at http://localhost:3000/?massnative=hg38-test,TermdbTest GenomeBrowser button menu shows new prompt with 2 buttons:
<img width="364" alt="image" src="https://github.com/user-attachments/assets/e151247e-364e-4efa-8dc2-9ba6e63ae78d" />

pnet/mbmeta will only allow searching gene and launch protein view;

ash can search either gene or coord: if searched a gene, user gets Protein/Genomic prompt

sjlife can only allow genomic view

corresponding sjpp changes https://github.com/stjude/sjpp/pull/741
with a new unit test against some tricky logic
all CI passed

last holdover will be addressed in https://github.com/stjude/proteinpaint/issues/3085


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
