### PR TITLE
Modified hclust.R, edge.R and corr.R to set digits=NA, na = 'string'

### DIFF
--- a/server/utils/corr.R
+++ b/server/utils/corr.R
@@ -2,7 +2,7 @@
 
 # Load required packages
 suppressWarnings({
-    library(jsonlite)
+  library(jsonlite)
 })
 
 # Read JSON input from stdin
@@ -19,12 +19,12 @@ coeffs <- c()
 pvalues <- c()
 sample_sizes <- c()
 for (i in 1:length(v1)) {
-    suppressWarnings({
-        cor <- cor.test(as.numeric(unlist(v1[i])), as.numeric(unlist(v2[i])), method = input$method)
-    })    
-    coeffs <- c(coeffs, cor$estimate)
-    pvalues <- c(pvalues, cor$p.value)
-    sample_sizes <- c(sample_sizes, length(as.numeric(unlist(v1[i]))))
+  suppressWarnings({
+    cor <- cor.test(as.numeric(unlist(v1[i])), as.numeric(unlist(v2[i])), method = input$method)
+  })    
+  coeffs <- c(coeffs, cor$estimate)
+  pvalues <- c(pvalues, cor$p.value)
+  sample_sizes <- c(sample_sizes, length(as.numeric(unlist(v1[i]))))
 }
 
 # Adjusting for multiple testing correction
@@ -35,4 +35,4 @@ names(output)[2] <- "correlation"
 names(output)[3] <- "original_p_value"
 names(output)[4] <- "adjusted_p_value"
 names(output)[5] <- "sample_size"
-toJSON(output)
+toJSON(output, digits = NA, na = "string") # Setting digits = NA makes toJSON() use the max precision. na='string' causes any "not a number" to be reported as string. This from ?toJSON() documentation

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -283,4 +283,4 @@ if (dim(read_counts)[1] * dim(read_counts)[2] < as.numeric(input$mds_cutoff)) { 
 #cat("Time for generating final dataframe: ", as.difftime(final_data_generation_time, unit = "secs")[3], " seconds\n")
 
 # Output results
-toJSON(final_output, digits = NA) # Setting digits = NA makes toJSON() use the max precision. This from ?toJSON() documentation
+toJSON(final_output, digits = NA, na = "string") # Setting digits = NA makes toJSON() use the max precision. na='string' causes any "not a number" to be reported as string. This from ?toJSON() documentation

--- a/server/utils/hclust.R
+++ b/server/utils/hclust.R
@@ -17,7 +17,7 @@
 # To plot the heatmap uncomment line `library(ggplot2) and lines after "Visualization" comment
 
 suppressWarnings({
-    suppressPackageStartupMessages(library(jsonlite))
+  suppressPackageStartupMessages(library(jsonlite))
 })
 #library(flashClust)
 #library(ggplot2) # Uncomment this line to plot heatmap in R
@@ -93,8 +93,7 @@ colnames(sorted_col_names_df2) <- c("name")
 output_df$ColOrder <- sorted_col_names_df2
 
 
-
-toJSON(output_df)
+toJSON(output_df, digits = NA, na = "string") # Setting digits = NA makes toJSON() use the max precision. na='string' causes any "not a number" to be reported as string. This from ?toJSON() documentation
 
 
 # Visualization of heatmap, uncomment code below to get ggplot2 image of heatmap


### PR DESCRIPTION
## Description

Modified hclust.R, edge.R and corr.R to set digits=NA, na = 'string'

na='string' causes any "not a number" to be reported as string. This is similar to whats already being used for `server/utils/cuminc.R`

Very minor change:
    Some lines were incorrectly indented. This is now automatically fixed by my text editor. Maybe should consider common indentation techniques for all text editors like we have for js/ts files.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
