### PR TITLE
Resolve tech debt

### DIFF
--- a/client/dom/boxplot.js
+++ b/client/dom/boxplot.js
@@ -21,6 +21,8 @@ labpad:
 	int, horizontal space between label <text> and boxplot <g>
 labColor: 
 	str, label text color. Default is color arg
+rectFill:
+	str, fill color of the box. Default is white
 */
 export function drawBoxplot({ bp, g, color, scale, rowheight, labpad, labColor = color }) {
 	if (bp.label) {
@@ -70,7 +72,7 @@ export function drawBoxplot({ bp, g, color, scale, rowheight, labpad, labColor =
 			.attr('y2', rowheight)
 		bp.box = g
 			.append('rect')
-			.attr('fill', 'white')
+			.attr('fill', bp?.rectFill || 'white')
 			.attr('stroke', color)
 			.attr('shape-rendering', 'crispEdges')
 			.attr('x', p25)

--- a/client/dom/test/boxplot.unit.spec.ts
+++ b/client/dom/test/boxplot.unit.spec.ts
@@ -7,6 +7,7 @@ import { drawBoxplot } from '#dom'
     Default drawBoxplot()
     With plot label and label color
     With out values and radius
+	With filled in rect with black lines
 */
 
 /**************
@@ -48,6 +49,8 @@ function mockBoxplotData(opts) {
 	}
 	if (opts.labColor) _opts.labColor = opts.labColor
 	if (opts.radius) _opts.bp.radius = opts.radius
+	if (opts.color) _opts.color = opts.color
+	if (opts.bp) Object.assign(_opts.bp, opts.bp)
 	return _opts
 }
 
@@ -118,6 +121,28 @@ tape('With out values and radius', test => {
 		circle && circle.attr('r') == opts.radius,
 		`Should render circle for out value with a radius = ${opts.radius}`
 	)
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('With filled in rect with black lines', test => {
+	test.timeoutAfter(100)
+
+	const holder = getHolder()
+	const g = appendGHolder(holder)
+	const opts = {
+		g,
+		bp: {
+			rectFill: 'pink'
+		},
+		color: 'black'
+	}
+	const boxplotData = mockBoxplotData(opts)
+	drawBoxplot(boxplotData)
+
+	test.equal(holder.select('rect').attr('fill'), opts.bp.rectFill, `Should render rect with fill ${opts.bp.rectFill}`)
+	test.equal(holder.selectAll('line').attr('stroke'), opts.color, `Should render lines with stroke ${opts.color}`)
 
 	if (test['_ok']) holder.remove()
 	test.end()

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -5,8 +5,8 @@ import { RxComponentInner } from '../../types/rx.d'
 import { plotColor } from '#shared/common.js'
 import { Menu, getMaxLabelWidth } from '#dom'
 import type { Elem } from '../../types/d3'
-import type { BasePlotConfig, MassAppApi, MassState, PlotConfig } from '#mass/types/mass'
-import type { TdbBoxPlotOpts, BoxPlotSettings, BoxPlotDom } from './BoxPlotTypes'
+import type { MassAppApi, MassState } from '#mass/types/mass'
+import type { TdbBoxPlotOpts, BoxPlotSettings, BoxPlotDom, BoxPlotConfig, BoxPlotConfigOpts } from './BoxPlotTypes'
 import { Model } from './model/Model'
 import { ViewModel } from './viewModel/ViewModel'
 import { View } from './view/View'
@@ -75,7 +75,7 @@ class TdbBoxplot extends RxComponentInner {
 					{ label: 'Default', value: false },
 					{ label: 'Median values', value: true }
 				],
-				getDisplayStyle: (plot: PlotConfig) => (plot.term2 ? '' : 'none')
+				getDisplayStyle: (plot: BoxPlotConfig) => (plot.term2 ? '' : 'none')
 			},
 			{
 				label: 'Scale',
@@ -144,7 +144,7 @@ class TdbBoxplot extends RxComponentInner {
 				type: 'color',
 				chartType: 'boxplot',
 				settingsKey: 'color',
-				getDisplayStyle: (plot: PlotConfig) => (plot.term2 ? 'none' : '')
+				getDisplayStyle: (plot: BoxPlotConfig) => (plot.term2 ? 'none' : '')
 			},
 			{
 				label: 'Display mode',
@@ -175,7 +175,7 @@ class TdbBoxplot extends RxComponentInner {
 	}
 
 	getState(appState: MassState) {
-		const config = appState.plots.find((p: BasePlotConfig) => p.id === this.id)
+		const config = appState.plots.find((p: any) => p.id === this.id)
 		if (!config) {
 			throw `No plot with id='${this.id}' found. Did you set this.id before this.api = getComponentApi(this)?`
 		}
@@ -270,7 +270,7 @@ export function getDefaultBoxplotSettings(app, overrides = {}) {
 	return Object.assign(defaults, overrides)
 }
 
-export async function getPlotConfig(opts, app: MassAppApi) {
+export async function getPlotConfig(opts: BoxPlotConfigOpts, app: MassAppApi) {
 	if (!opts.term) throw 'opts.term{} missing [boxplot getPlotConfig()]'
 	try {
 		await fillTermWrapper(opts.term, app.vocabApi)

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -16,7 +16,7 @@ class TdbBoxplot extends RxComponentInner {
 	readonly type = 'boxplot'
 	components: { controls: any }
 	dom: BoxPlotDom
-	interactions: BoxPlotInteractions
+	interactions?: BoxPlotInteractions
 	private useDefaultSettings = true
 	constructor(opts: TdbBoxPlotOpts) {
 		super()
@@ -40,7 +40,6 @@ class TdbBoxplot extends RxComponentInner {
 			legend: div.append('div').attr('id', 'sjpp-boxplot-legend'),
 			tip: new Menu()
 		}
-		this.interactions = new BoxPlotInteractions(this.app, this.dom, this.id)
 		if (opts.header) this.dom.header = opts.header.html('Box plot')
 	}
 
@@ -168,10 +167,10 @@ class TdbBoxplot extends RxComponentInner {
 		})
 
 		this.components.controls.on('downloadClick.boxplot', () => {
-			this.interactions.download()
+			this.interactions!.download()
 		})
 		this.components.controls.on('helpClick.boxplot', () => {
-			this.interactions.help()
+			this.interactions!.help()
 		})
 	}
 
@@ -192,13 +191,12 @@ class TdbBoxplot extends RxComponentInner {
 
 	async init() {
 		this.dom.div.style('display', 'inline-block').style('margin', '10px')
+		this.interactions = new BoxPlotInteractions(this.app, this.dom, this.id)
 		try {
 			await this.setControls()
 		} catch (e: any) {
 			console.error(new Error(e.message || e))
 		}
-		//Not the best approach. Come up with a better way.
-		this.interactions.setVarAfterInit(this.app, this.id)
 	}
 
 	async main() {
@@ -206,11 +204,13 @@ class TdbBoxplot extends RxComponentInner {
 			const config = structuredClone(this.state.config)
 			if (config.childType != this.type && config.chartType != this.type) return
 
+			if (!this.interactions) throw 'Interactions not initialized [box plot main()]'
+
 			const settings = config.settings.boxplot
 			const model = new Model(config, this.state, this.app, settings)
 			const data = await model.getData()
 			if (!data?.plots?.length || data['error']) {
-				this.interactions.clearDom()
+				this.interactions!.clearDom()
 				this.dom.error.style('padding', '20px 20px 20px 60px').text('No visible box plot data to render')
 				return
 			}

--- a/client/plots/boxplot/BoxPlotTypes.ts
+++ b/client/plots/boxplot/BoxPlotTypes.ts
@@ -1,5 +1,6 @@
 import type { Menu } from '#dom'
-import type { BoxPlotEntry, BoxPlotData } from '#types'
+import type { PlotConfig } from '#mass/types/mass'
+import type { BoxPlotEntry, BoxPlotData, TermWrapper } from '#types'
 import type { Div, Elem, SvgG, SvgSvg, SvgText } from '../../types/d3'
 
 /** Opts sent from mass */
@@ -9,6 +10,15 @@ export type TdbBoxPlotOpts = {
 	header?: Elem
 	numericEditMenuVersion?: string[]
 }
+
+export type BoxPlotConfigOpts = {
+	term: TermWrapper
+	term2?: TermWrapper
+	term0?: TermWrapper
+	overrides?: any
+}
+
+export type BoxPlotConfig = PlotConfig
 
 /** User controlled settings. Some settings are calculated based on
  * the number of boxplots */

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -15,13 +15,6 @@ export class BoxPlotInteractions {
 		this.id = id
 	}
 
-	setVarAfterInit(app: MassAppApi, id: string) {
-		// app and id created after init
-		// Avoid ts from complaining, reset here
-		if (this.app == undefined) this.app = app
-		if (this.id == undefined) this.id = id
-	}
-
 	download() {
 		//May add more options in the future
 		const svg = this.dom.svg.node() as Node

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -1,5 +1,5 @@
-import type { BoxPlotDom, LegendItemEntry } from '../BoxPlotTypes'
-import type { MassAppApi, PlotConfig } from '#mass/types/mass'
+import type { BoxPlotDom, LegendItemEntry, BoxPlotConfig } from '../BoxPlotTypes'
+import type { MassAppApi } from '#mass/types/mass'
 import type { RenderedPlot } from '../view/RenderedPlot'
 import { to_svg } from '#src/client'
 import { ListSamples } from './ListSamples'
@@ -18,7 +18,7 @@ export class BoxPlotInteractions {
 	download() {
 		//May add more options in the future
 		const svg = this.dom.svg.node() as Node
-		const plotConfig = this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)
+		const plotConfig = this.app.getState().plots.find((p: BoxPlotConfig) => p.id === this.id)
 		to_svg(svg, `${plotConfig.term.term.name} box plot`, { apply_dom_styles: true })
 	}
 
@@ -42,7 +42,7 @@ export class BoxPlotInteractions {
 
 	/** Option to hide a plot from the box plot label menu. */
 	hidePlot(plot: RenderedPlot) {
-		const plotConfig = this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)
+		const plotConfig = this.app.getState().plots.find((p: BoxPlotConfig) => p.id === this.id)
 		//Don't try to modify a frozen object
 		const config = structuredClone(plotConfig)
 		const contTerm = config.term.q.mode == 'continuous' ? 'term2' : 'term'
@@ -57,7 +57,7 @@ export class BoxPlotInteractions {
 
 	/** Trigger when clicking on a hidden plot in the legend */
 	unhidePlot(item: LegendItemEntry) {
-		const plotConfig = this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)
+		const plotConfig = this.app.getState().plots.find((p: BoxPlotConfig) => p.id === this.id)
 		const config = structuredClone(plotConfig)
 		const contTerm = config.term.q.mode == 'continuous' ? 'term2' : 'term'
 		delete config[contTerm].q.hiddenValues[item.key]
@@ -80,7 +80,7 @@ export class BoxPlotInteractions {
 	/** Callback for color picker in plot(s) label menu */
 	updatePlotColor(plot: RenderedPlot, color: string) {
 		if (!plot.seriesId) return
-		const plotConfig = this.app.getState().plots.find((p: PlotConfig) => p.id === this.id)
+		const plotConfig = this.app.getState().plots.find((p: BoxPlotConfig) => p.id === this.id)
 		const config = structuredClone(plotConfig)
 		config.term2.term.values[plot.seriesId].color = color
 		this.app.dispatch({

--- a/client/plots/boxplot/model/Model.ts
+++ b/client/plots/boxplot/model/Model.ts
@@ -1,7 +1,7 @@
 import type { MassAppApi } from '#mass/types/mass'
-import type { BoxPlotSettings } from '../BoxPlotTypes'
+import type { BoxPlotSettings, BoxPlotConfig } from '../BoxPlotTypes'
 import type { BoxPlotResponse } from '#types'
-import type { PlotConfig, MassState } from '#mass/types/mass'
+import type { MassState } from '#mass/types/mass'
 import { isNumericTerm } from '#shared/terms.js'
 
 /**
@@ -9,11 +9,11 @@ import { isNumericTerm } from '#shared/terms.js'
  * Add more methods for formating the request opts and api requests.
  */
 export class Model {
-	config: PlotConfig
+	config: BoxPlotConfig
 	state: MassState
 	app: MassAppApi
 	settings: BoxPlotSettings
-	constructor(config: PlotConfig, state: MassState, app: MassAppApi, settings: BoxPlotSettings) {
+	constructor(config: BoxPlotConfig, state: MassState, app: MassAppApi, settings: BoxPlotSettings) {
 		this.config = config
 		this.state = state
 		this.app = app

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -124,6 +124,10 @@ export class View {
 			const transformStr = `translate(${plot.x}, ${plot.y})${settings.isVertical ? `, rotate(-90)` : ''}`
 			g.attr('transform', transformStr)
 
+			if (settings.isVertical) {
+				g.select('text').attr('transform', 'rotate(45)')
+			}
+
 			new BoxPlotToolTips(plot, g, this.dom.tip, settings.isVertical)
 			if (data.plots.length > 1) {
 				//Do not try to use the same tip for the menu as the tooltips.

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -125,6 +125,7 @@ export class View {
 			g.attr('transform', transformStr)
 
 			if (settings.isVertical) {
+				//Rotate the text slightly in veritcal orientation
 				g.select('text').attr('transform', 'rotate(45)')
 			}
 
@@ -142,10 +143,6 @@ export class View {
 					labelMenuTip,
 					settings.isVertical
 				)
-			}
-			if (settings.displayMode !== 'default') {
-				const fillColor = settings.displayMode == 'filled' ? plot.color : data.plotDim.backgroundColor
-				g.selectAll('g[id^="sjpp-boxplot-"] > rect').style('fill', fillColor!)
 			}
 		}
 	}

--- a/client/plots/boxplot/viewModel/LegendDataMapper.ts
+++ b/client/plots/boxplot/viewModel/LegendDataMapper.ts
@@ -1,10 +1,9 @@
-import type { FormattedPlotEntry, LegendData, LegendItemEntry } from '../BoxPlotTypes'
+import type { FormattedPlotEntry, LegendData, LegendItemEntry, BoxPlotConfig } from '../BoxPlotTypes'
 import type { BoxPlotResponse } from '#types'
-import type { PlotConfig } from '#mass/types/mass'
 
 export class LegendDataMapper {
 	legendData: LegendData = []
-	constructor(config: PlotConfig, data: BoxPlotResponse, plots: FormattedPlotEntry[]) {
+	constructor(config: BoxPlotConfig, data: BoxPlotResponse, plots: FormattedPlotEntry[]) {
 		const isTerm2 = config?.term2
 		if (config.term.q?.descrStats) {
 			this.legendData.push({

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -2,8 +2,7 @@ import { format } from 'd3-format'
 import { decimalPlacesUntilFirstNonZero } from '#shared/roundValue.js'
 import { rgb } from 'd3-color'
 import type { BoxPlotResponse } from '#types'
-import type { PlotConfig } from '#mass/types/mass'
-import type { BoxPlotSettings, PlotDimensions, ViewData } from '../BoxPlotTypes'
+import type { BoxPlotSettings, PlotDimensions, ViewData, BoxPlotConfig } from '../BoxPlotTypes'
 import { LegendDataMapper } from './LegendDataMapper'
 
 export class ViewModel {
@@ -27,7 +26,7 @@ export class ViewModel {
 	private totalRowSize: number
 	viewData: ViewData
 	constructor(
-		config: PlotConfig,
+		config: BoxPlotConfig,
 		data: BoxPlotResponse,
 		settings: BoxPlotSettings,
 		maxLabelLgth: number,

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -132,7 +132,8 @@ export class ViewModel {
 			/** Set rendering properties for the plot */
 
 			//Set the color for all plots
-			if (!plot.color) plot.color = config?.term2?.term?.values?.[plot.seriesId]?.color || settings.color
+			const color = config?.term2?.term?.values?.[plot.seriesId]?.color || settings.color
+			if (!plot.color) plot.color = color
 			//Brighten the colors in dark mode for better visibility
 			if (settings.displayMode == 'dark') plot.color = rgb(plot.color).brighter(0.75)
 			//Ignore if hidden after the color is set
@@ -145,6 +146,8 @@ export class ViewModel {
 				plot.boxplot.radius = this.outRadius
 			}
 			plot.labColor = settings.displayMode == 'dark' ? 'white' : 'black'
+			plot.boxplot.rectFill =
+				settings.displayMode == 'dark' ? 'black' : settings.displayMode == 'filled' ? color : 'white'
 			plot.x = settings.isVertical ? this.horizPad / 2 + this.incrPad : this.totalLabelSize
 			plot.y = this.topPad + (settings.isVertical ? settings.boxplotWidth + settings.labelPad : this.incrPad)
 			this.incrPad += this.totalRowSize

--- a/client/plots/controls.btns.js
+++ b/client/plots/controls.btns.js
@@ -96,6 +96,7 @@ function helpBtnInit(opts) {
 			'profileRadar',
 			'profileRadarFacility',
 			'boxplot',
+			'correlationVolcano',
 			'differentialAnalysis'
 		],
 		dom: {

--- a/client/plots/corrVolcano/CorrelationVolcano.ts
+++ b/client/plots/corrVolcano/CorrelationVolcano.ts
@@ -174,6 +174,9 @@ class CorrelationVolcano extends RxComponentInner {
 		this.components.controls.on('downloadClick.correlationVolcano', () => {
 			this.interactions!.download()
 		})
+		this.components.controls.on('helpClick.correlationVolcano', () => {
+			window.open('https://github.com/stjude/proteinpaint/wiki/Correlation-volcano', '_blank')
+		})
 	}
 
 	async init(appState: MassState) {

--- a/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
+++ b/client/plots/corrVolcano/CorrelationVolcanoTypes.ts
@@ -1,4 +1,4 @@
-import type { TermWrapper } from '#types'
+import type { TermWrapper, VariableItemEntry } from '#types'
 import type { Elem, SvgG, SvgSvg, SvgText } from '../../types/d3.js'
 import type { Menu } from '#dom'
 import type { BasePlotConfig } from '#mass/types/mass'
@@ -67,7 +67,7 @@ export type CorrVolcanoDom = {
 	yAxisLabel: SvgText
 }
 
-export type PlotDimensions = {
+export type CorrVolcanoPlotDimensions = {
 	/** Height and width of the svg */
 	svg: {
 		height: number
@@ -114,7 +114,7 @@ export type PlotDimensions = {
 }
 
 /** Attributes added to the response data */
-export type VariableItem = {
+export type VariableItem = VariableItemEntry & {
 	color: string
 	label: string
 	/** x coordinate */
@@ -123,10 +123,14 @@ export type VariableItem = {
 	y: number
 	/** radius of the circle */
 	radius: number
+	/** last x coordinate */
+	previousX: number
+	/** last y coordinate */
+	previousY: number
 }
 
 /** Dimensions of sample size circles */
-export type LegendData = {
+export type CorrVolcanoLegendData = {
 	absMin: number
 	absMax: number
 	skippedVariables: { label: string }[]
@@ -134,10 +138,10 @@ export type LegendData = {
 
 /** Formated response data passed from the view model
  * to the view for rendering */
-export type ViewData = {
+export type CorrVolcanoViewData = {
 	/** Dimensions of all the plot elements except the data points */
-	plotDim: PlotDimensions
+	plotDim: CorrVolcanoPlotDimensions
 	/** Rendering specifics for each data point */
 	variableItems: VariableItem[]
-	legendData: LegendData
+	legendData: CorrVolcanoLegendData
 }

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -1,4 +1,3 @@
-import type { TermWrapper } from '#types'
 import { to_svg } from '#src/client'
 import { termType2label } from '#shared/terms.js'
 import { appInit } from '#termdb/app'
@@ -15,15 +14,6 @@ export class CorrVolcanoInteractions {
 		this.id = id
 		//TODO: should be in the state somehow
 		this.variableTwLst = []
-	}
-
-	setVars(app: any, id: string, variableTwLst: TermWrapper[]) {
-		/** This is a hack
-		 * app and id are set after init and therefore not available
-		 * until plot init completes. Need to fix. */
-		this.app = app
-		this.id = id
-		this.variableTwLst = variableTwLst
 	}
 
 	download() {

--- a/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
+++ b/client/plots/corrVolcano/interactions/CorrVolcanoInteractions.ts
@@ -1,18 +1,19 @@
 import { to_svg } from '#src/client'
 import { termType2label } from '#shared/terms.js'
 import { appInit } from '#termdb/app'
+import type { MassAppApi } from '#mass/types/mass'
+import type { CorrVolcanoDom } from '../CorrelationVolcanoTypes'
+import type { TermWrapper } from '#types'
 
-//TODO - finish typing this file
 export class CorrVolcanoInteractions {
-	app: any
-	dom: any
+	app: MassAppApi
+	dom: CorrVolcanoDom
 	id: string
-	variableTwLst: any
-	constructor(app, dom, id) {
+	variableTwLst: TermWrapper[]
+	constructor(app: MassAppApi, dom: CorrVolcanoDom, id: string) {
 		this.app = app
 		this.dom = dom
 		this.id = id
-		//TODO: should be in the state somehow
 		this.variableTwLst = []
 	}
 
@@ -52,7 +53,8 @@ export class CorrVolcanoInteractions {
 	launchSampleScatter(item: any) {
 		const config = this.app.getState()
 		const plot = config.plots.find(p => p.id === this.id)
-		const term2 = this.variableTwLst.find((t: any) => t.$id === item.tw$id).term
+		const term2 = this.variableTwLst?.find((t: any) => t.$id === item.tw$id)?.term
+		if (!term2) throw `No term found for ${item.tw$id}`
 		const scatterConfig = {
 			chartType: 'sampleScatter',
 			name: `${plot.featureTw.term.name} ${termType2label(plot.featureTw.term.type)} v ${term2.name}`,

--- a/client/plots/corrVolcano/view/ItemToolTip.ts
+++ b/client/plots/corrVolcano/view/ItemToolTip.ts
@@ -2,10 +2,10 @@ import { table2col } from '#dom'
 import { roundValue } from '#shared/roundValue.js'
 import type { Menu } from '#dom'
 import type { SvgCircle } from '../../../types/d3'
-import type { CorrVolcanoSettings } from '../CorrelationVolcanoTypes'
+import type { CorrVolcanoSettings, VariableItem } from '../CorrelationVolcanoTypes'
 
 export class ItemToolTip {
-	constructor(item: any, circle: SvgCircle, tip: Menu, settings: CorrVolcanoSettings) {
+	constructor(item: VariableItem, circle: SvgCircle, tip: Menu, settings: CorrVolcanoSettings) {
 		circle.on('mouseover', () => {
 			tip.clear().showunder(circle.node())
 			const table = table2col({ holder: tip.d.append('table') })

--- a/client/plots/corrVolcano/view/View.ts
+++ b/client/plots/corrVolcano/view/View.ts
@@ -5,9 +5,9 @@ import { LegendCircleReference } from '#dom'
 import type {
 	CorrVolcanoDom,
 	CorrVolcanoSettings,
-	LegendData,
-	PlotDimensions,
-	ViewData
+	CorrVolcanoLegendData,
+	CorrVolcanoPlotDimensions,
+	CorrVolcanoViewData
 } from '../CorrelationVolcanoTypes'
 import type { CorrVolcanoInteractions } from '../interactions/CorrVolcanoInteractions'
 import { ItemToolTip } from './ItemToolTip'
@@ -20,10 +20,10 @@ import { ItemToolTip } from './ItemToolTip'
 export class View {
 	dom: CorrVolcanoDom
 	readonly duration = 500
-	viewData: ViewData
+	viewData: CorrVolcanoViewData
 	constructor(
 		dom: CorrVolcanoDom,
-		viewData: ViewData,
+		viewData: CorrVolcanoViewData,
 		interactions: CorrVolcanoInteractions,
 		settings: CorrVolcanoSettings,
 		defaultMaxRadius: number,
@@ -41,7 +41,7 @@ export class View {
 		this.renderLegend(viewData.legendData, settings, interactions, defaultMaxRadius, defaultMinRadius)
 	}
 
-	renderDom(plotDim: PlotDimensions) {
+	renderDom(plotDim: CorrVolcanoPlotDimensions) {
 		this.dom.svg.attr('width', plotDim.svg.width).attr('height', plotDim.svg.height)
 
 		this.dom.title
@@ -112,7 +112,7 @@ export class View {
 	}
 
 	renderLegend(
-		legendData: LegendData,
+		legendData: CorrVolcanoLegendData,
 		settings: CorrVolcanoSettings,
 		interactions: CorrVolcanoInteractions,
 		defaultMaxRadius: number,

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -1,7 +1,7 @@
 import type { TermWrapper } from '#types'
 import { scaleLinear } from 'd3-scale'
 import { termType2label } from '#shared/terms.js'
-import type { CorrelationVolcanoResponse, VariableItemEntry } from '#types'
+import type { CorrelationVolcanoResponse } from '#types'
 import type {
 	CorrVolcanoDom,
 	CorrVolcanoPlotConfig,

--- a/client/plots/corrVolcano/viewModel/ViewModel.ts
+++ b/client/plots/corrVolcano/viewModel/ViewModel.ts
@@ -1,12 +1,18 @@
 import type { TermWrapper } from '#types'
 import { scaleLinear } from 'd3-scale'
 import { termType2label } from '#shared/terms.js'
-import type { CorrelationVolcanoResponse } from '#types'
-import type { CorrVolcanoDom, CorrVolcanoPlotConfig, CorrVolcanoSettings, ViewData } from '../CorrelationVolcanoTypes'
+import type { CorrelationVolcanoResponse, VariableItemEntry } from '#types'
+import type {
+	CorrVolcanoDom,
+	CorrVolcanoPlotConfig,
+	CorrVolcanoSettings,
+	CorrVolcanoViewData,
+	CorrVolcanoPlotDimensions
+} from '../CorrelationVolcanoTypes'
 
 export class ViewModel {
 	variableTwLst: TermWrapper[]
-	viewData: ViewData
+	viewData: CorrVolcanoViewData
 	readonly bottomPad = 60
 	/** Only one side, left or right */
 	readonly horizPad = 70
@@ -20,7 +26,7 @@ export class ViewModel {
 	) {
 		this.variableTwLst = variableTwLst
 		const pValueKey = settings.isAdjustedPValue ? 'adjusted_pvalue' : 'original_pvalue'
-		const d = this.transformPValues(data, pValueKey)
+		const d = this.transformPValues(data, pValueKey) as any
 		const [absYMax, absYMin] = this.setMinMax(d, `transformed_${pValueKey}`)
 		const [absXMax, absXMin] = this.setMinMax(d, 'correlation')
 		const [absSampleMax, absSampleMin] = this.setMinMax(d, 'sampleSize')
@@ -118,10 +124,10 @@ export class ViewModel {
 	setVariablesData(
 		absSampleMax: number,
 		absSampleMin: number,
-		data: any,
+		data: CorrVolcanoViewData,
 		dom: CorrVolcanoDom,
 		key: string,
-		plotDim: any,
+		plotDim: CorrVolcanoPlotDimensions,
 		settings: CorrVolcanoSettings
 	) {
 		const radiusScale = scaleLinear()

--- a/shared/types/src/routes/correlationVolcano.ts
+++ b/shared/types/src/routes/correlationVolcano.ts
@@ -24,18 +24,20 @@ export type CorrelationVolcanoResponse = {
 		tw$id: string
 	}[]
 	/** each element is test result of one variable corresponding to variableTwLst */
-	variableItems: {
-		/** correlation coefficient, -1 to 1 */
-		correlation: number
-		/** pvalue */
-		original_pvalue: number
-		/** pvalue */
-		adjusted_pvalue: number
-		/** tw.$id, for client to match the item with variableTwLst */
-		tw$id: string
-		/** number of samples analyzed. samples not having complete data for all terms will be excluded, thus size may be lower than current cohort */
-		sampleSize: number
-	}[]
+	variableItems: VariableItemEntry[]
+}
+
+export type VariableItemEntry = {
+	/** correlation coefficient, -1 to 1 */
+	correlation: number
+	/** pvalue */
+	original_pvalue: number
+	/** pvalue */
+	adjusted_pvalue: number
+	/** tw.$id, for client to match the item with variableTwLst */
+	tw$id: string
+	/** number of samples analyzed. samples not having complete data for all terms will be excluded, thus size may be lower than current cohort */
+	sampleSize: number
 }
 
 export const CorrelationVolcanoPayload: RoutePayload = {


### PR DESCRIPTION
## Description
This resolves the tech issues for the box plot and correlation volcano discussed on Thursday and during team meeting this morning. The main change is the interactions for both plots no longer use a `setVar` method. The remaining changes are relatively minor, mostly typing. 

Test with the following examples. Should not see any change in functionality:
1. [TermdbTest box plot example](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22childType%22:%22boxplot%22,%22term%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22sex%22}}]})
2. [All pharma corr vol ex](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22correlationVolcano%22,%22featureTw%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22KRAS%22}}}]})

Note: The tech debt in the differential analysis app will be addressed at a later date. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
