### PR TITLE
Profile module colors

### DIFF
--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -33,6 +33,7 @@ export class profilePlot {
 			config,
 			termfilter: appState.termfilter,
 			dslabel: appState.vocab.dslabel,
+			termdbConfig: appState.termdbConfig,
 			vocab: appState.vocab,
 			logged, //later change to read login info
 			site,

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -96,7 +96,8 @@ function make(q, req, res, ds: Mds3WithCohort, genome) {
 		sampleTypes: ds.cohort.termdb.sampleTypes,
 		hasSampleAncestry: ds.cohort.termdb.hasSampleAncestry,
 		defaultChartType: ds.cohort.defaultChartType,
-		invalidTokenErrorHandling: tdb.invalidTokenErrorHandling
+		invalidTokenErrorHandling: tdb.invalidTokenErrorHandling,
+		colorMap: tdb.colorMap
 	}
 	// optional attributes
 	// when missing, the attribute will not be present as "key:undefined"

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1346,6 +1346,10 @@ keep this setting here for reason of:
 		/** allow color or shape changes in the lollipop */
 		allowSkewerChanges: boolean
 	}
+	colorMap?: {
+		/** colors for a category multivalues */
+		[index: string]: { [index: string]: string }
+	}
 }
 
 type SampleType = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1346,6 +1346,26 @@ keep this setting here for reason of:
 		/** allow color or shape changes in the lollipop */
 		allowSkewerChanges: boolean
 	}
+	//* specify color map per module/group of terms. Used in the profile dataset.
+	/** For example "National Context" is a profile module, that groups some multivalue terms for wich the category colors are the ones shown below: 
+	 colorMap: {
+				['*']: {
+					['Not applicable for my role']: '#aaa',
+					['Not Available/Do Not Know']: '#aaa',
+					["I don't know"]: '#aaa',
+					['Almost Never']: '#595959',
+					['Infrequently']: '#747474',
+					['No']: '#aaa'
+				},
+				['National Context']: {
+					['Almost Always']: '#15557C',
+					['Frequently']: '#1E77BB',
+					['Sometimes']: '#2FA9F4',
+					['Yes']: '#1E77BB'
+				},
+	}
+	If the colors are the same for all the categories, use the wildcard '*' to define the color for all the modules.
+	**/
 	colorMap?: {
 		/** colors for a category multivalues */
 		[index: string]: { [index: string]: string }


### PR DESCRIPTION
## Description

Reading colors from the colorMap defined in the dataset. Each module has its colors per category for the categories from Sometimes to Almost Always, the negative categories always use shades of gray no matter the module. See corresponding PR in sjpp

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
