### PR TITLE
Adding rust R utilities for DE analysis

### DIFF
--- a/rust/RustRUtilities/DESCRIPTION
+++ b/rust/RustRUtilities/DESCRIPTION
@@ -1,0 +1,12 @@
+Package: RustRUtilities
+Title: Rust R utilities
+Version: 0.0.0.9000
+Authors@R: 
+    person("Xin", "Zhou", , "xin.zhou@stjude.org", role = c("aut", "cre"))
+Description: This package provides compiled rust code to be invoked from R.
+License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
+    license
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.2
+Config/rextendr/version: 0.3.1

--- a/rust/RustRUtilities/compile.R
+++ b/rust/RustRUtilities/compile.R
@@ -1,0 +1,23 @@
+# Syntax: Rscript compile.R
+
+library(rextendr)
+library(gtools)
+rextendr::document() # Compiles Rust code
+#devtools::load_all(".") # Loads rust code as an R package
+
+time0 <- Sys.time()
+suppressWarnings({
+  suppressPackageStartupMessages(library(edgeR))
+  #suppressPackageStartupMessages(library("BiocParallel"))
+  #suppressPackageStartupMessages(library(glmGamPoi))
+})
+library(doParallel)
+library(parallel)
+library(foreach)
+devtools::load_all(".") # Loads rust code as an R package
+
+print ("Adding numbers 3 and 4 in rust")
+add(3,4)
+
+print ("Printing 'Hello world!' in rust")
+hello_world()

--- a/rust/RustRUtilities/src/rust/Cargo.toml
+++ b/rust/RustRUtilities/src/rust/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = 'RustRUtilities'
+version = '0.1.0'
+edition = '2021'
+
+[lib]
+crate-type = [ 'staticlib' ]
+name = 'RustRUtilities'
+
+[dependencies]
+hdf5 = { package = "hdf5-metno", version = "0.9.0" }
+extendr-api = '0.8.0'
+itertools="^0.10.0"
+r_mathlib="^0.2.0"
+nalgebra = {version = "0.32.2"}
+statrs = "^0.16.0"
+json = "^0.12.4"
+csv = "^1.2.2"
+serde_json="^1.0.88"
+serde = {version = "^1.0.147", features = ["derive"]}

--- a/rust/RustRUtilities/src/rust/src/lib.rs
+++ b/rust/RustRUtilities/src/rust/src/lib.rs
@@ -1,0 +1,43 @@
+use extendr_api::prelude::*;
+use std::time::Instant;
+
+/// Return string `"Hello world!"` to R.
+/// @export
+#[extendr]
+fn hello_world() -> &'static str {
+    "Hello world!"
+}
+
+/// @export
+#[extendr]
+fn add(x: f64, y: f64) -> f64 {
+    x + y
+}
+
+/// @export
+#[extendr]
+fn differential_gene_expression(
+    case_string: String,
+    control_string: String,
+    file_name: String,
+) -> Robj {
+    let now = Instant::now();
+    let case_list: Vec<&str> = case_string.split(",").collect();
+    let control_list: Vec<&str> = control_string.split(",").collect();
+    let a = 1;
+    let b = R!(r"
+                        x <- {{ a }}
+                        x + 1
+                    ")
+    .unwrap();
+    b
+}
+
+// Macro to generate exports.
+// This ensures exported functions are registered with R.
+// See corresponding C code in `entrypoint.c`.
+extendr_module! {
+    mod RustRUtilities;
+    fn hello_world;
+    fn add;
+}


### PR DESCRIPTION
## Description
This is a work in progress. Please do **NOT** merge. This will **NOT** work currently in PP docker.

Doing preprocessing for edgeR/limma in rust. Specifically porting data query, HDF5 query, filtering for genes and normalization to rust. Rust will be directly called from R using [rextendr](https://extendr.github.io/rextendr/articles/package.html) package which will compile the embedded rust code and also call rust functions at (R) runtime.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
