### PR TITLE
fix: bug fix for mds3 custom tk to work with bcf file with samples

### DIFF
--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -4,7 +4,6 @@ import { initLegend, updateLegend } from './legend'
 import { loadTk, rangequery_rglst } from './tk'
 import urlmap from '#common/urlmap'
 import { mclass, dtsnvindel, dtsv, dtfusionrna, dtcnv } from '#shared/common.js'
-import { vcfparsemeta } from '#shared/vcf.js'
 import { ssmIdFieldsSeparator } from '#shared/mds3tk.js'
 import { getFilterName } from './filterName'
 import { fillTermWrapper } from '#termsetting'
@@ -1014,10 +1013,9 @@ async function getbcfheader_customtk(tk, genome) {
 		arg.url = tk.bcf.url
 		if (tk.bcf.indexURL) arg.indexURL = tk.bcf.indexURL
 	}
-	// FIXME if vcf and bcf files can both be used?
-	const data = await dofetch3('vcfheader', { body: arg })
+	const data = await dofetch3('bcfheader', { body: arg })
 	if (data.error) throw data.error
-	const [info, format, samples, errs] = vcfparsemeta(data.metastr.split('\n'))
+	const [info, format, samples, errs] = data.header
 	if (errs) throw 'Error parsing VCF meta lines: ' + errs.join('; ')
 	tk.mds.bcf = {
 		info,

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -1104,6 +1104,43 @@ tape('Numeric mode custom dataset, with mode change', test => {
 	}
 })
 
+tape('Custom bcf with sample', test => {
+	test.timeoutAfter(3000)
+	const holder = getHolder()
+	runproteinpaint({
+		holder,
+		noheader: true,
+		genome: 'hg38-test',
+		gene: 'NM_000546',
+		tracks: [
+			{
+				type: 'mds3',
+				name: 'custom bcf',
+				bcf: { file: 'files/hg38/TermdbTest/TermdbTest.bcf.gz' },
+				callbackOnRender
+			}
+		]
+	})
+
+	async function callbackOnRender(tk, bb) {
+		await testVariantLeftLabel(test, tk, bb)
+
+		// todo click a skewer to show samples
+
+		tk.leftlabels.doms.samples.node().dispatchEvent(new Event('click'))
+		await whenVisible(tk.menutip.d, 10000)
+		const div = await detectOne({ elem: tk.menutip.dnode, selector: '.sja_mds3_slb_sampletablebtn' })
+		test.ok(div, '"List 5 sample" option found')
+		div.dispatchEvent(new Event('click'))
+		const table = await detectOne({ elem: tk.menutip.dnode, selector: '[data-testid="sjpp_mds3tk_sampletable"]' })
+		test.ok(table, 'sample table shown')
+		tk.menutip.d.remove()
+
+		if (test._ok) holder.remove()
+		test.end()
+	}
+})
+
 /*************************
  reusable helper functions
 **************************/

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- bug fix for mds3 custom tk to work with bcf file with samples


### PR DESCRIPTION
## Description

closes #3104 
[test link](http://localhost:3000/?genome=hg38-test&gene=p53&mds3bcffile=custom,files/hg38/TermdbTest/TermdbTest.bcf.gz); click Samples leftlabel will not break and can list 5 samples

all mds3 tests passed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
