### PR TITLE
Used formatElapsedTime To Format The Times Taken For Clustering And Top Variable Genes In Termdbtest

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Used formatElapsedTime to format the times taken for clustering and top variable genes in termdbtest. Used mayLog for both

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -24,6 +24,7 @@ import { TermTypes, NUMERIC_DICTIONARY_TERM } from '#shared/terms.js'
 import { getData } from '#src/termdb.matrix.js'
 import { termType2label } from '#shared/terms.js'
 import { mayLog } from '#src/helpers.ts'
+import { formatElapsedTime } from '@sjcrh/proteinpaint-shared/time.js'
 
 export const api: RouteApi = {
 	endpoint: 'termdb/cluster',
@@ -128,7 +129,7 @@ async function getResult(q: TermdbClusterRequest, ds: any, genome) {
 	// have data for multiple genes, run clustering
 	const t = Date.now() // use "t=new Date()" will lead to tsc error
 	const clustering: Clustering = await doClustering(term2sample2value, q, Object.keys(bySampleId).length)
-	mayLog('clustering done:', Date.now() - t, 'ms')
+	mayLog('clustering done:', formatElapsedTime(Date.now() - t))
 	const result = { clustering, byTermId, bySampleId } as ValidResponse
 	if (removedHierClusterTerms.length) result.removedHierClusterTerms = removedHierClusterTerms
 	return result

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -6,6 +6,8 @@ import { get_samples } from '#src/termdb.sql.js'
 import { makeFilter } from '#src/mds3.gdc.js'
 import { cachedFetch } from '#src/utils.js'
 import { joinUrl } from '#shared/joinUrl.js'
+import { mayLog } from '#src/helpers.ts'
+import { formatElapsedTime } from '@sjcrh/proteinpaint-shared/time.js'
 
 export const api: RouteApi = {
 	endpoint: 'termdb/topVariablyExpressedGenes',
@@ -37,7 +39,7 @@ function init({ genomes }) {
 				genes: await ds.queries.topVariablyExpressedGenes.getGenes(q)
 			}
 
-			if (serverconfig.debugmode) console.log('topVariablyExpressedGenes', Date.now() - t, 'ms')
+			mayLog('topVariablyExpressedGenes', formatElapsedTime(Date.now() - t))
 		} catch (e: any) {
 			result = { status: e.status || 400, error: e.message || e }
 		}


### PR DESCRIPTION
## Description
Used `formatElapsedTime` to format the times taken for clustering and top variable genes in `termdbTest`. Used `mayLog `for both

## To Test
Go to [here](http://localhost:3000/?massnative=hg38-test,TermdbTest) and run top variable genes analysis and then submit those identified genes for clustering. Then check your server log. Both times should be properly formatted with `formatElapsedTime`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
