### PR TITLE
Used formatElapsedTime to handle formatting of time taken by top variably expressed genes output

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Used formatElapsedTime to handle formatting of time taken by top variably expressed genes code

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -6,6 +6,8 @@ import { get_samples } from '#src/termdb.sql.js'
 import { makeFilter } from '#src/mds3.gdc.js'
 import { cachedFetch } from '#src/utils.js'
 import { joinUrl } from '#shared/joinUrl.js'
+import { formatElapsedTime } from '#shared/time.js'
+import { mayLog } from '#src/helpers.ts'
 
 export const api: RouteApi = {
 	endpoint: 'termdb/topVariablyExpressedGenes',
@@ -37,7 +39,7 @@ function init({ genomes }) {
 				genes: await ds.queries.topVariablyExpressedGenes.getGenes(q)
 			}
 
-			if (serverconfig.debugmode) console.log('topVariablyExpressedGenes', Date.now() - t, 'ms')
+			mayLog('topVariablyExpressedGenes', formatElapsedTime(Date.now() - t))
 		} catch (e: any) {
 			result = { status: e.status || 400, error: e.message || e }
 		}


### PR DESCRIPTION
## Description
Minor update to use `maylog `and `formatElapsedTime `to format the time taken by top variable genes code.

## To Test
Go [here](http://localhost:3000/?massnative=hg38-test,TermdbTest). Click on 'Charts' then 'Gene Expression' then 'top variably expressed genes'. After submitting check server log to see that the time taken should be formatted.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
