### PR TITLE
Fix for gsea UI bug

### DIFF
--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -1,9 +1,9 @@
-import * as d3axis from 'd3-axis'
-import { axisstyle, Menu, renderTable, table2col } from '#dom'
+// import * as d3axis from 'd3-axis'
+import { Menu, renderTable, table2col } from '#dom'
 import { dofetch3 } from '#common/dofetch'
 import { controlsInit } from './controls'
 import { getCompInit, copyMerge } from '#rx'
-import { scaleLinear } from 'd3-scale'
+// import { scaleLinear } from 'd3-scale'
 import { roundValueAuto } from '#shared/roundValue.js'
 
 const tip = new Menu()
@@ -19,7 +19,8 @@ class gsea {
 		const controlsDiv =
 			typeof opts.controls == 'object'
 				? opts.controls
-				: opts.holder.style('display', 'inline-block') || opts.holder.append('div').style('display', 'inline-block')
+				: opts.holder || opts.holder.append('div').style('display', 'inline-block')
+		opts.holder.style('display', 'inline-block')
 		const actionsDiv = opts.holder
 			.append('div')
 			.attr('data-testid', 'sjpp-gsea-actions')
@@ -223,6 +224,7 @@ async function renderPathwayDropdown(self) {
 		}
 
 		const idx = event.target.selectedIndex
+		self.settings.pathway = pathwayOpts[idx].value
 		self.app.dispatch({
 			type: 'plot_edit',
 			id: self.id,
@@ -390,7 +392,6 @@ add:
 	//Table rerenders when main is called
 	//Fix to show which gene set is selected after rerender
 	const geneSetIdx = self.gsea_table_rows.findIndex(row => row[0].value == self.config.gsea_params.geneset_name)
-	console.log(geneSetIdx)
 	const selectedRows = geneSetIdx > -1 ? [geneSetIdx] : []
 
 	renderTable({
@@ -568,10 +569,10 @@ export function makeChartBtnMenu(holder, chartsInstance) {
 
 async function rungsea(body, dom) {
 	//Only show the loading div as the gsea is running
-	// dom.actionsDiv.style('display', 'none')
-	// dom.loadingDiv.style('display', 'block')
+	dom.actionsDiv.style('display', 'none')
+	dom.loadingDiv.style('display', 'block')
 	const data = await dofetch3('genesetEnrichment', { body })
-	// dom.loadingDiv.style('display', 'none')
-	// dom.actionsDiv.style('display', 'block')
+	dom.loadingDiv.style('display', 'none')
+	dom.actionsDiv.style('display', 'block')
 	return data
 }

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -19,7 +19,7 @@ class gsea {
 		const controlsDiv =
 			typeof opts.controls == 'object'
 				? opts.controls
-				: opts.holder || opts.holder.append('div').style('display', 'inline-block')
+				: opts.holder.style('display', 'inline-block') || opts.holder.append('div').style('display', 'inline-block')
 		const actionsDiv = opts.holder
 			.append('div')
 			.attr('data-testid', 'sjpp-gsea-actions')
@@ -223,11 +223,17 @@ async function renderPathwayDropdown(self) {
 		}
 
 		const idx = event.target.selectedIndex
-		self.settings.pathway = pathwayOpts[idx].value
 		self.app.dispatch({
 			type: 'plot_edit',
 			id: self.id,
 			config: {
+				//Need to clear the gsea_params completely
+				gsea_params: {
+					geneset_name: null,
+					pickle_file: null,
+					pathway: pathwayOpts[idx].value
+				},
+				highlightGenes: [],
 				settings: {
 					gsea: self.settings
 				}
@@ -354,32 +360,37 @@ add:
 	]
 	let download = {}
 
-	//Highlight genes button
-	self.dom.detailsDiv
-		.append('button')
-		.style('margin-left', '10px')
-		.style(
-			'display',
-			self.config.chartType == 'differentialAnalysis' && self.config.gsea_params.geneset_name == null ? 'none' : 'block'
-		)
-		.attr('aria-label', 'Highlight genes in the volcano plot')
-		.text('Highlight genes')
-		.on('click', () => {
-			self.app.dispatch({
-				type: 'plot_edit',
-				id: self.id,
-				config: {
-					childType: 'volcano',
-					highlightedData: self.config.highlightData
-				}
+	if (self.config.chartType == 'differentialAnalysis') {
+		//Highlight genes button
+		self.dom.detailsDiv
+			.append('button')
+			.style('margin-left', '10px')
+			.style(
+				'display',
+				self.config.chartType == 'differentialAnalysis' && self.config.gsea_params.geneset_name == null
+					? 'none'
+					: 'block'
+			)
+			.attr('aria-label', 'Highlight genes in the volcano plot')
+			.text('Highlight genes')
+			.on('click', () => {
+				self.app.dispatch({
+					type: 'plot_edit',
+					id: self.id,
+					config: {
+						childType: 'volcano',
+						highlightedData: self.config.highlightGenes
+					}
+				})
 			})
-		})
+	}
 
 	if (self.state.config.downloadFilename) download.fileName = self.state.config.downloadFilename
 
 	//Table rerenders when main is called
 	//Fix to show which gene set is selected after rerender
 	const geneSetIdx = self.gsea_table_rows.findIndex(row => row[0].value == self.config.gsea_params.geneset_name)
+	console.log(geneSetIdx)
 	const selectedRows = geneSetIdx > -1 ? [geneSetIdx] : []
 
 	renderTable({
@@ -403,7 +414,7 @@ add:
 			if (self.config.chartType == 'differentialAnalysis') {
 				//Saves the data to highlight in the volcano plot
 				const genes = [...self.gsea_table_rows[index][5].value.split(',')]
-				if (genes) config.highlightData = genes
+				if (genes) config.highlightGenes = genes
 			}
 			await self.app.dispatch({
 				type: 'plot_edit',
@@ -557,10 +568,10 @@ export function makeChartBtnMenu(holder, chartsInstance) {
 
 async function rungsea(body, dom) {
 	//Only show the loading div as the gsea is running
-	dom.actionsDiv.style('display', 'none')
-	dom.loadingDiv.style('display', 'block')
+	// dom.actionsDiv.style('display', 'none')
+	// dom.loadingDiv.style('display', 'block')
 	const data = await dofetch3('genesetEnrichment', { body })
-	dom.loadingDiv.style('display', 'none')
-	dom.actionsDiv.style('display', 'block')
+	// dom.loadingDiv.style('display', 'none')
+	// dom.actionsDiv.style('display', 'block')
 	return data
 }

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - gsea table renders with new genesets on dropdown change
+- Changing the gsea dropdown in GDC single cell loads the appropriate table

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- gsea table renders with new genesets on dropdown change


### PR DESCRIPTION
## Description
Fixes the noted issue with the dropdown not loading a new gsea table. Also fixed the issue of the highlight genes button appearing without the volcano in the single cell plot. 

Test: 
 - In both examples: open the gsea tab -> select a gene set group -> pick a gene set from the table -> change the gene set group. Should see the new table appear. 
1. [GDC link](http://localhost:3000/example.gdc.scRNAseq.html)
2. [DA spec](http://localhost:3000/testrun.html?dir=plots/diffAnalysis&name=diffAnalysis)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
