### PR TITLE
Sometimes when running tests termdbConfig is not defined in Vocab 

### DIFF
--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -140,7 +140,7 @@ export class Vocab {
 	}
 
 	getClientAuthResult() {
-		return this.state.termdbConfig.clientAuthResult
+		return this.state.termdbConfig?.clientAuthResult
 	}
 
 	async trackDsAction({ action, details }) {

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -216,7 +216,7 @@ class TdbTree {
 }
 
 export function isVisibleTerm(app, auth, term) {
-	const hiddenTermIds = app.vocabApi.termdbConfig.hiddenTermIds
+	const hiddenTermIds = app.vocabApi.termdbConfig?.hiddenTermIds
 	if (hiddenTermIds && hiddenTermIds.includes(term.id)) {
 		if (auth) {
 			let isAdmin = false


### PR DESCRIPTION
## Description

Fixes broken tests when reading termdbConfig not present

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
