### PR TITLE
Enable feature flags in serverconfig for the method in DE volcano plot

### DIFF
--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -145,6 +145,8 @@ export const volcanoInit = getCompInit(Volcano)
 export const componentInit = volcanoInit
 
 export function getDefaultVolcanoSettings(overrides = {}, opts: any): VolcanoSettings {
+	const features = JSON.parse(sessionStorage.getItem('optionalFeatures') as string)
+	const method = features?.runDE_methods?.includes('Wilcoxon') ? 'wilcoxon' : 'edgeR'
 	const defaults: VolcanoSettings = {
 		defaultSignColor: 'red',
 		defaultNonSignColor: 'black',
@@ -153,7 +155,7 @@ export function getDefaultVolcanoSettings(overrides = {}, opts: any): VolcanoSet
 		/** Not enabling this feature for now */
 		// geneORA: undefined,
 		height: 400,
-		method: 'edgeR',
+		method,
 		minCount: 10,
 		minTotalCount: 15,
 		pValue: 0.05,

--- a/client/plots/volcano/VolcanoControlInputs.ts
+++ b/client/plots/volcano/VolcanoControlInputs.ts
@@ -184,6 +184,14 @@ export class VolcanoControlInputs {
 	getMethodOptions() {
 		if (this.termType !== 'geneExpression') return
 		const settings = this.config.settings.volcano
+		const features = JSON.parse(sessionStorage.getItem('optionalFeatures') as string)
+		if (features?.runDE_methods?.length) {
+			const opts: { label: string; value: string }[] = []
+			for (const m of features.runDE_methods) {
+				opts.push({ label: m, value: m.toLowerCase() })
+			}
+			return opts
+		}
 		if (this.sampleNum < settings!.sampleNumCutoff) {
 			return [
 				{ label: 'edgeR', value: 'edgeR' },


### PR DESCRIPTION
## Description
Add `"runDE_methods":["Wilcoxon"]` to `serverconfig.features`. This will cause wilcoxon to be the default DE method that we can use in production for now

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
