### PR TITLE
Added option to aggretate samples from the same month in runChart

### DIFF
--- a/client/plots/runChart.renderer.ts
+++ b/client/plots/runChart.renderer.ts
@@ -11,7 +11,7 @@ import { minShapeSize, maxShapeSize } from './runChart.js'
 import { shapes } from './runChart.js'
 import { roundValueAuto } from '#shared/roundValue.js'
 import { median as d3Median } from 'd3-array'
-import { getDateStrFromNumber } from '#shared/terms.js'
+import { getDateFromNumber } from '#shared/terms.js'
 
 export function setRenderers(self) {
 	self.render = function () {
@@ -46,8 +46,8 @@ export function setRenderers(self) {
 		const yMax = this.range.yMax
 		const extraSpaceX = (xMax - xMin) * 0.01 //extra space added to avoid clipping the particles on the X axis
 		const extraSpaceY = (yMax - yMin) * 0.01 //extra space added to avoid clipping the particles on the Y axis
-		const xMinDate = new Date(getDateStrFromNumber(xMin - extraSpaceX))
-		const xMaxDate = new Date(getDateStrFromNumber(this.range.xMax + extraSpaceX))
+		const xMinDate = new Date(getDateFromNumber(xMin - extraSpaceX))
+		const xMaxDate = new Date(getDateFromNumber(this.range.xMax + extraSpaceX))
 
 		chart.xAxisScale = d3Linear()
 			.domain([xMin - extraSpaceX, xMax + extraSpaceX])

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -15,7 +15,7 @@ import { addNewGroup } from '../mass/groups.js'
 import { setRenderersThree } from './sampleScatter.rendererThree.js'
 import { shapes } from './sampleScatter.js'
 import { roundValueAuto } from '#shared/roundValue.js'
-import { getDateStrFromNumber } from '#shared/terms.js'
+import { getDateFromNumber } from '#shared/terms.js'
 
 export function setRenderers(self) {
 	setRenderersThree(self)
@@ -57,8 +57,8 @@ export function setRenderers(self) {
 			.range([offsetX, self.settings.svgw + offsetX])
 
 		if (self.config.term && self.config.term.term.type == 'date') {
-			const xMinDate = new Date(getDateStrFromNumber(xMin - extraSpaceX))
-			const xMaxDate = new Date(getDateStrFromNumber(xMax + extraSpaceX))
+			const xMinDate = getDateFromNumber(xMin - extraSpaceX)
+			const xMaxDate = getDateFromNumber(xMax + extraSpaceX)
 
 			chart.xAxisScaleTime = scaleTime()
 				.domain([xMinDate, xMaxDate])
@@ -71,8 +71,8 @@ export function setRenderers(self) {
 			.domain([yMax + extraSpaceY, yMin - extraSpaceY])
 			.range([offsetY, self.settings.svgh + offsetY])
 		if (self.config.term2 && self.config.term2.term.type == 'date') {
-			const yMinDate = new Date(getDateStrFromNumber(yMin - extraSpaceY))
-			const yMaxDate = new Date(getDateStrFromNumber(yMax + extraSpaceY))
+			const yMinDate = new Date(getDateFromNumber(yMin - extraSpaceY))
+			const yMaxDate = new Date(getDateFromNumber(yMax + extraSpaceY))
 
 			chart.yAxisScaleTime = scaleTime()
 				.domain([yMinDate, yMaxDate])

--- a/shared/utils/src/terms.js
+++ b/shared/utils/src/terms.js
@@ -210,6 +210,13 @@ export function termType2label(type) {
 	return typeMap[type] || 'Unknown term type'
 }
 
+export function getDateFromNumber(value) {
+	const year = Math.floor(value)
+	const time = (value - year) * 365 * 24 * 60 * 60 * 1000 // convert to milliseconds
+	const january1st = new Date(year, 0, 0)
+	const date = new Date(january1st.getTime() + time)
+	return date
+}
 /*
 Value is a decimal year.
 A decimal year is a way of expressing a date or time period as a year with a decimal part, where the decimal portion 

--- a/shared/utils/src/terms.js
+++ b/shared/utils/src/terms.js
@@ -250,3 +250,12 @@ export function getNumberFromDateStr(str) {
 	const decimal = roundValueAuto(diffDays / 365)
 	return year + decimal
 }
+
+export function getNumberFromDate(date) {
+	const year = date.getFullYear()
+	const january1st = new Date(year, 0, 0)
+	const diffTime = date - january1st
+	const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
+	const decimal = roundValueAuto(diffDays / 365)
+	return year + decimal
+}

--- a/shared/utils/src/test/date.unit.spec.js
+++ b/shared/utils/src/test/date.unit.spec.js
@@ -1,6 +1,5 @@
 import tape from 'tape'
-import { roundValueAuto, roundValue2, decimalPlacesUntilFirstNonZero } from '../roundValue.js'
-import { getDateStrFromNumber, getNumberFromDateStr } from '../terms.js'
+import { getDateStrFromNumber, getNumberFromDateStr, getDateFromNumber, getNumberFromDate } from '../terms.js'
 /**
  * Tests
  * convert date to number
@@ -15,7 +14,25 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('conver date to number', function (test) {
+tape('convert date to number', function (test) {
+	//2023.5 is the first of July 2023.
+	const date = new Date(2023, 6, 1) // July 1, 2023
+	const num = getNumberFromDate(date)
+	test.equal(num, 2023.5, `The number for date ${date.toDateString()} should be 2023.5`)
+
+	test.end()
+})
+
+tape('convert number to date', function (test) {
+	const num = 2023.5
+	const date = getDateFromNumber(num)
+	const str = date.toDateString()
+	const expectedDateStr = new Date(2023, 6, 1).toDateString()
+	test.equal(expectedDateStr, str, `The date for number ${num} should be ${expectedDateStr} and  it is ${str}`)
+	test.end()
+})
+
+tape('convert date str to number', function (test) {
 	//2023.5 is the first of July 2023.
 	const str = '2023-07-01'
 	const num = getNumberFromDateStr(str)
@@ -23,7 +40,7 @@ tape('conver date to number', function (test) {
 
 	test.end()
 })
-tape('convert number to date', function (test) {
+tape('convert number to date str', function (test) {
 	const num = 2023.5
 	const str = getDateStrFromNumber(num)
 	test.equal(


### PR DESCRIPTION
## Description

Added option to aggretate samples from the same month in runChart, as suggested by the sjcares team. By default the samples are aggregated and if unchecked the raw data is shown


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
