### PR TITLE
Fix about tab behaviour

### DIFF
--- a/client/mass/app.js
+++ b/client/mass/app.js
@@ -133,8 +133,11 @@ class MassApp {
 
 	async main() {
 		await this.api.vocabApi.main()
-		//Do not show the plots if the active tab is the about tab
-		this.dom.plotDiv.style('display', this.state.nav?.activeTab == 0 ? 'none' : 'block')
+		//Do not show the plots if about tab is active (activeTab=0 and displaySubheader=true)
+		this.dom.plotDiv.style(
+			'display',
+			this.state.nav?.activeTab == 0 && this.state.nav?.displaySubheader ? 'none' : 'block'
+		)
 		const newPlots = {}
 		let sandbox
 		for (const plot of this.state.plots) {

--- a/client/mass/app.js
+++ b/client/mass/app.js
@@ -133,7 +133,8 @@ class MassApp {
 
 	async main() {
 		await this.api.vocabApi.main()
-
+		//Do not show the plots if the active tab is the about tab
+		this.dom.plotDiv.style('display', this.state.nav?.activeTab == 0 ? 'none' : 'block')
 		const newPlots = {}
 		let sandbox
 		for (const plot of this.state.plots) {

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -480,10 +480,6 @@ function setRenderers(self) {
 function setInteractivity(self) {
 	self.setTab = async (event, d) => {
 		if (d.colNum === self.activeTab && !self.searching) {
-			// The about tab should not be hidden  on double click with or without plots
-			if (self.activeTab == 0) return
-			// FIXME in such case self.activeTab may not keep original value; may set activeTab=-1 to indicate all tabs are inactive
-			//self.activeTab=-1
 			self.prevCohort = self.activeCohort
 			/** Fix to ensure the subheader is displayed/not displayed when
 			 * sharing or saving the session.

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -481,7 +481,7 @@ function setInteractivity(self) {
 	self.setTab = async (event, d) => {
 		if (d.colNum === self.activeTab && !self.searching) {
 			// The about tab should not be hidden  on double click with or without plots
-			//if (self.activeTab == 0) return
+			if (self.activeTab == 0) return
 			// FIXME in such case self.activeTab may not keep original value; may set activeTab=-1 to indicate all tabs are inactive
 			//self.activeTab=-1
 			self.prevCohort = self.activeCohort

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -480,8 +480,8 @@ function setRenderers(self) {
 function setInteractivity(self) {
 	self.setTab = async (event, d) => {
 		if (d.colNum === self.activeTab && !self.searching) {
-			if (self.state.plots.length == 0) return // zero plots. do not hide an already open tab, to avoid a confusing look for users
-			//clicking on an active tab. turn it to hidden
+			// The about tab should not be hidden  on double click with or without plots
+			//if (self.activeTab == 0) return
 			// FIXME in such case self.activeTab may not keep original value; may set activeTab=-1 to indicate all tabs are inactive
 			//self.activeTab=-1
 			self.prevCohort = self.activeCohort

--- a/client/plots/profileRadarFacility.js
+++ b/client/plots/profileRadarFacility.js
@@ -15,9 +15,9 @@ class profileRadarFacility extends profilePlot {
 
 	async init(appState) {
 		await super.init(appState)
-		const config = appState.plots.find(p => p.id === this.id)
+		const config = structuredClone(appState.plots.find(p => p.id === this.id))
 		this.plotConfig = config
-		this.twLst = [this.config.facilityTW]
+		this.twLst = [config.facilityTW]
 		this.terms = config.terms
 		for (const row of this.terms) {
 			this.rowCount++
@@ -328,7 +328,7 @@ export async function getPlotConfig(opts, app, _activeCohort) {
 		const activeCohort = _activeCohort === undefined ? app.getState().activeCohort : _activeCohort
 		const defaults = await getProfilePlotConfig(activeCohort, app, opts)
 		if (!defaults) throw 'default config not found in termdbConfig.plotConfigByCohort.profileRadarFacility'
-		let config = copyMerge(structuredClone(defaults), opts)
+		const config = copyMerge(structuredClone(defaults), opts)
 		const settings = getDefaultProfilePlotSettings()
 
 		config.settings = {


### PR DESCRIPTION
## Description
When the active tab is the about tab do not show/hide the tab and do not show the plots. Keep the about tab content.

Fixed bug in profileRadarFacility.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
