### PR TITLE
cnv supports {get/file} and disuses byrange

### DIFF
--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -184,10 +184,7 @@ export default function (): Mds3 {
 				}
 			},
 			cnv: {
-				byrange: {
-					src: 'native',
-					file: 'files/hg38/TermdbTest/TermdbTest_CNV_gene.gz'
-				}
+				file: 'files/hg38/TermdbTest/TermdbTest_CNV_gene.gz'
 			},
 			/*
 			on the fly cnv calls from gene body probe signals are no longer used

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -277,7 +277,7 @@ async function load_driver(q, ds) {
 				if (q.hiddenmclass?.has(dtcnv)) {
 					// cnv is hidden, do not load
 				} else {
-					result.cnv = await query_cnv(q, ds)
+					result.cnv = await ds.queries.cnv.get(q)
 				}
 			}
 
@@ -329,13 +329,6 @@ async function query_svfusion(q, ds) {
 		return
 	}
 	throw 'insufficient query parameters for svfusion'
-}
-async function query_cnv(q, ds) {
-	if (q.rglst) {
-		if (!ds.queries.cnv.byrange) throw 'q.rglst provided but cnv.byrange missing'
-		return await ds.queries.cnv.byrange.get(q)
-	}
-	throw 'insufficient query parameters for cnv'
 }
 async function query_geneCnv(q, ds) {
 	if (q.gene) {

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -435,7 +435,7 @@ async function queryServerFileByRglst(q, twLst, ds) {
 		}
 	}
 	if (ds.queries.cnv) {
-		const mlst = await ds.queries.cnv.byrange.get(q)
+		const mlst = await ds.queries.cnv.get(q)
 		for (const m of mlst) {
 			combineSamplesById(m.samples, samples, m.ssm_id)
 		}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -522,33 +522,57 @@ type TrackLst = {
 	activeTracks: string[]
 }
 
-type CnvSegment = {
-	byrange: CnvSegmentByRange
-	/****** rendering parameters ****
-not used as query parameter to filter segments
-value range for color scaling. default to 5. cnv segment value>this will use solid color
+/** cnv segments are queried by coordinates, and can be filtered by segment length and/or value
+configs for types of cnv data
+- log(ratio)
+	{
+		cnvMaxLength:10000000
+		cnvGainCutoff:5
+		cnvLossCutoff:-5
+	}
+- copy number
+	{
+		cnvMaxLength:1000000
+		cnvMaxCopynumber:10
+		cnvMinCopynumber:1
+	}
+important: presence of filtering properties indiate the type of cnv quantification
+and will trigger rendering of ui controls
 */
+type CnvSegment = {
+	/** ds supplied ordynamically added getter */
+	get?: (q: any) => any
+	/** either file or get is required. file is bgzipped with columns:
+	1. chr
+	2. start, 0-based
+	3. stop
+	4. {"dt": 4, "mattr": {"origin": "somatic"}, "sample": "3332", "value": -1.0}
+	*/
+	file?: string
+
+	/****** rendering parameters ****
+	not used as query parameter to filter segments
+	value range for color scaling. default to 5. cnv segment value>this will use solid color
+	*/
 	absoluteValueRenderMax?: number
 	gainColor?: string
 	lossColor?: string
 
-	/*** filtering parameters ***
-default max length setting to restrict to focal events; if missing show all */
+	/** filter segments by max length to restrict to focal events; set to -1 to show all
+	allow to be missing, in such case will always show all */
 	cnvMaxLength?: number
 
-	/** TODO define value type, if logratio, or copy number */
-
-	/** following two cutoffs only apply to log ratio, cnv gain value is positive, cnv loss value is negative
-if cnv is gain, skip if value<this cutoff */
+	/** if cnv is quantified as log(ratio) or similar, must set these two properties
+	filter segments by following two cutoffs only apply to log ratio, cnv gain value is positive, cnv loss value is negative
+	*/
+	/** if value>0, skip if value<this cutoff, set to a large value e.g. 100 for not filtering */
 	cnvGainCutoff?: number
-	/** if cnv is loss, skip if value>this cutoff */
+	/** if value<0, skip if value>this cutoff, set to a large negative value e.g. -100 for not filtering */
 	cnvLossCutoff?: number
-}
-
-type CnvSegmentByRange = {
-	src: 'native' | 'gdcapi' | string
-	/** only for src=native */
-	file?: string
+	/** TODO if cnv is quantified as integer copy number, must set these properties; do not use for log(ratio)
+	 */
+	cnvMinCopynumber?: number
+	cnvMaxCopynumber?: number
 }
 
 /*


### PR DESCRIPTION
## Description

closes #3138 
supports ds-supplied cnv.get(); otherwise requires cnv.file, and no longer uses cnv.byrange since the segment data query always requires coord

test with https://github.com/stjude/sjpp/pull/764 and https://github.com/stjude/ppclingen/pull/11/files

no tsc err
all CI passed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
