### PR TITLE
support of multiple cnv data types

### DIFF
--- a/client/filter/tvs.dtcnv.js
+++ b/client/filter/tvs.dtcnv.js
@@ -35,26 +35,26 @@ async function fillMenu_cont(self, div, tvs) {
 
 	let cnvGainCutoff
 	if (cnv.cnvGainCutoff) {
-		cnvGainCutoff = cnv.cnvGainCutoff
+		cnvGainCutoff = tvs.cnvGainCutoff || cnv.cnvGainCutoff
 		const cnvGainDiv = settingsDiv.append('div').style('margin-bottom', '5px')
 		cnvGainDiv.append('span').style('opacity', 0.7).text('Minimum CNV Gain (log2 ratio)') // TODO: verify that this will always be log2 ratio
 		cnvGainDiv
 			.append('input')
 			.attr('type', 'number')
-			.property('value', cnv.cnvGainCutoff)
+			.property('value', cnvGainCutoff)
 			.style('width', '100px')
 			.style('margin-left', '15px')
 			.on('change', event => {
 				const value = event.target.value
 				if (value === '' || !Number.isFinite(Number(value))) {
 					window.alert('Please enter a numeric value.')
-					event.target.value = cnv.cnvGainCutoff
+					event.target.value = cnvGainCutoff
 					return
 				}
 				const newValue = Number(value)
 				if (newValue < 0) {
 					window.alert('Value must be a positive value.')
-					event.target.value = cnv.cnvGainCutoff
+					event.target.value = cnvGainCutoff
 					return
 				}
 				cnvGainCutoff = newValue
@@ -63,26 +63,26 @@ async function fillMenu_cont(self, div, tvs) {
 
 	let cnvLossCutoff
 	if (cnv.cnvLossCutoff) {
-		cnvLossCutoff = cnv.cnvLossCutoff
+		cnvLossCutoff = tvs.cnvLossCutoff || cnv.cnvLossCutoff
 		const cnvLossDiv = settingsDiv.append('div').style('margin-bottom', '5px')
 		cnvLossDiv.append('span').style('opacity', 0.7).text('Maximum CNV Loss (log2 ratio)') // TODO: verify that this will always be log2 ratio
 		cnvLossDiv
 			.append('input')
 			.attr('type', 'number')
-			.property('value', cnv.cnvLossCutoff)
+			.property('value', cnvLossCutoff)
 			.style('width', '100px')
 			.style('margin-left', '15px')
 			.on('change', event => {
 				const value = event.target.value
 				if (value === '' || !Number.isFinite(Number(value))) {
 					window.alert('Please enter a numeric value.')
-					event.target.value = cnv.cnvLossCutoff
+					event.target.value = cnvLossCutoff
 					return
 				}
 				const newValue = Number(value)
 				if (newValue > 0) {
 					window.alert('Value must be a negative value.')
-					event.target.value = cnv.cnvLossCutoff
+					event.target.value = cnvLossCutoff
 					return
 				}
 				cnvLossCutoff = newValue
@@ -91,20 +91,20 @@ async function fillMenu_cont(self, div, tvs) {
 
 	let cnvMaxLength
 	if (cnv.cnvMaxLength) {
-		cnvMaxLength = cnv.cnvMaxLength
+		cnvMaxLength = tvs.cnvMaxLength || cnv.cnvMaxLength
 		const cnvLengthDiv = settingsDiv.append('div').style('margin-bottom', '5px')
 		cnvLengthDiv.append('span').style('opacity', 0.7).text('CNV Max Length')
 		cnvLengthDiv
 			.append('input')
 			.attr('type', 'number')
-			.property('value', cnv.cnvMaxLength)
+			.property('value', cnvMaxLength)
 			.style('width', '100px')
 			.style('margin-left', '15px')
 			.on('change', event => {
 				const value = event.target.value
 				if (value === '' || !Number.isFinite(Number(value))) {
 					window.alert('Please enter a numeric value.')
-					event.target.value = cnv.cnvMaxLength
+					event.target.value = cnvMaxLength
 					return
 				}
 				const newValue = Number(value)
@@ -121,7 +121,7 @@ async function fillMenu_cont(self, div, tvs) {
 			})
 	}
 
-	let cnvWT = false
+	let cnvWT = tvs.cnvWT || false
 	const wtDiv = settingsDiv.append('div').style('margin-bottom', '5px')
 	wtDiv.append('span').style('margin-right', '3px').style('opacity', 0.7).text('Wildtype')
 	const wtCheckbox = wtDiv

--- a/client/filter/tvs.dtcnv.js
+++ b/client/filter/tvs.dtcnv.js
@@ -1,7 +1,142 @@
 import { handler as catHandler } from './tvs.categorical.js'
 
-/*
-TODO: add support for continuous CNV data
-*/
-
 export const handler = Object.assign({}, catHandler, { type: 'dtcnv' })
+
+handler.fillMenu = contfillMenu // TODO: use fillMenu from catHandler if CNV data is categorical
+
+// fill menu for continuous CNV data
+async function contfillMenu(self, div, tvs) {
+	div.style('margin-top', '10px').style('margin-left', '10px')
+
+	const cnv = self.opts.vocabApi.parent_termdbConfig?.queries?.cnv
+
+	let cnvWT = false
+	const wtDiv = div.append('div').style('margin-bottom', '5px')
+	wtDiv.append('span').style('margin-right', '3px').style('opacity', 0.7).text('Wildtype')
+	const wtCheckbox = wtDiv
+		.append('input')
+		.attr('type', 'checkbox')
+		.property('checked', cnvWT)
+		.style('vertical-align', 'top')
+		.style('margin-right', '3px')
+		.on('change', () => {
+			cnvWT = wtCheckbox.property('checked')
+		})
+
+	let cnvGainCutoff
+	if (cnv.cnvGainCutoff) {
+		cnvGainCutoff = cnv.cnvGainCutoff
+		const cnvGainDiv = div.append('div').style('margin-bottom', '5px')
+		cnvGainDiv.append('span').style('opacity', 0.7).text('CNV Gain Cutoff')
+		cnvGainDiv
+			.append('input')
+			.attr('type', 'number')
+			.property('value', cnv.cnvGainCutoff)
+			.style('width', '100px')
+			.style('margin-left', '15px')
+			.on('change', event => {
+				const value = event.target.value
+				if (value === '' || !Number.isFinite(Number(value))) {
+					window.alert('Please enter a numeric value.')
+					event.target.value = defaultValue
+					return
+				}
+				const newValue = Number(value)
+				// no gain cutoff if value > 100
+				cnvGainCutoff = newValue <= 100 ? newValue : null
+			})
+	}
+
+	let cnvLossCutoff
+	if (cnv.cnvLossCutoff) {
+		cnvLossCutoff = cnv.cnvLossCutoff
+		const cnvLossDiv = div.append('div').style('margin-bottom', '5px')
+		cnvLossDiv.append('span').style('opacity', 0.7).text('CNV Loss Cutoff')
+		cnvLossDiv
+			.append('input')
+			.attr('type', 'number')
+			.property('value', cnv.cnvLossCutoff)
+			.style('width', '100px')
+			.style('margin-left', '15px')
+			.on('change', event => {
+				const value = event.target.value
+				if (value === '' || !Number.isFinite(Number(value))) {
+					window.alert('Please enter a numeric value.')
+					event.target.value = defaultValue
+					return
+				}
+				const newValue = Number(value)
+				// no loss cutoff if value < -100
+				cnvLossCutoff = newValue >= -100 ? newValue : null
+			})
+	}
+
+	let cnvMaxLength
+	if (cnv.cnvMaxLength) {
+		cnvMaxLength = cnv.cnvMaxLength
+		const cnvLengthDiv = div.append('div').style('margin-bottom', '5px')
+		cnvLengthDiv.append('span').style('opacity', 0.7).text('CNV Max Length')
+		cnvLengthDiv
+			.append('input')
+			.attr('type', 'number')
+			.property('value', cnv.cnvMaxLength)
+			.style('width', '100px')
+			.style('margin-left', '15px')
+			.on('change', event => {
+				const value = event.target.value
+				if (value === '' || !Number.isFinite(Number(value))) {
+					window.alert('Please enter a numeric value.')
+					event.target.value = defaultValue
+					return
+				}
+				const newValue = Number(value)
+				// no max length if value == -1
+				cnvMaxLength = newValue == -1 ? null : newValue
+			})
+	}
+
+	// Apply button
+	div
+		.append('div')
+		.attr('class', 'sja_filter_tag_btn sjpp_apply_btn')
+		.style('border-radius', '13px')
+		.style('margin-top', '10px')
+		.style('font-size', '.8em')
+		.text('APPLY')
+		.on('click', () => {
+			const new_tvs = structuredClone(tvs)
+			new_tvs.cnvWT = cnvWT
+			if (cnvGainCutoff) new_tvs.cnvGainCutoff = cnvGainCutoff
+			if (cnvLossCutoff) new_tvs.cnvLossCutoff = cnvLossCutoff
+			if (cnvMaxLength) new_tvs.cnvMaxLength = cnvMaxLength
+			console.log('new_tvs:', new_tvs)
+			self.dom.tip.hide()
+			self.opts.callback(new_tvs)
+		})
+
+	/* Possible wrapper for adding inputs
+    function addInput(div, defaultValue, newValue, callback) {
+        newValue = defaultValue
+        console.log('newValue:', newValue)
+        console.log('cnvLossCutoff:', cnvLossCutoff)
+        const newDiv = div.append('div')
+        newDiv.append('span').style('opacity', 0.7).text('CNV Loss Cutoff')
+        newDiv
+            .append('input')
+            .attr('type', 'number')
+            .property('value', defaultValue)
+            .style('width', '100px')
+            .style('margin-left', '15px')
+            .on('change', event => {
+                const inputValue = event.target.value
+                if (inputValue === '' || !Number.isFinite(Number(inputValue))) {
+                    window.alert('Please enter a numeric value.')
+                    event.target.value = defaultValue
+                    return
+                }
+                const value = Number(inputValue)
+                newValue = callback(value)
+                console.log('newValue:', newValue)
+            })
+    }*/
+}

--- a/client/filter/tvs.js
+++ b/client/filter/tvs.js
@@ -133,8 +133,7 @@ function setRenderers(self) {
 	// optional _holder, for example when called by filter.js
 	self.showMenu = _holder => {
 		const holder = _holder ? _holder : self.dom.tip
-		if (self.tvs.term.type !== 'geneVariant') {
-			// do not show the Exclude checkbox for geneVaraint term
+		if (self.tvs.term.type != 'geneVariant' && !(self.tvs.term.type == 'dtcnv' && self.tvs.cnvMode == 'continuous')) {
 			addExcludeCheckbox(holder, self.tvs, self)
 		}
 		self.handler.fillMenu(self, holder, self.tvs)

--- a/client/filter/tvs.js
+++ b/client/filter/tvs.js
@@ -65,7 +65,9 @@ class TVS {
 		if (!this.handlerByType[type]) {
 			try {
 				const _ = await import(`./tvs.${type}.js`)
-				this.handlerByType[type] = _.handler
+				const handler = _.handler
+				if (handler.setMethods) handler.setMethods(this)
+				this.handlerByType[type] = handler
 			} catch (e) {
 				throw `error with handler='./tvs.${type}.js': ${e}`
 			}
@@ -144,7 +146,8 @@ function setRenderers(self) {
 		const lstlen =
 			(self.tvs.values && self.tvs.values.length) ||
 			(self.tvs.ranges && self.tvs.ranges.length) ||
-			self.tvs.term.type == 'samplelst'
+			self.tvs.term.type == 'samplelst' ||
+			dtTerms.map(t => t.type).includes(self.tvs.term.type)
 
 		// update the main label
 		one_term_div.select('.term_name_btn').html(self.handler.term_name_gen)

--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -13,7 +13,11 @@ Tests:
 	term1=categorical
 	term1=categorical, term2=defaultbins
 	term0=defaultbins, term1=categorical
-	term1=geneVariant
+	term1=geneVariant no group
+	term1=geneVariant with groups
+	term1=categorical, term2=geneVariant
+	term1=geneExp, term2=geneVariant SKIPPED
+	term2=geneExp, term1=geneVariant
 	term1=geneExp
 	term1=numeric term2=geneExp with default bins
 	term1=geneExp, term2=categorical
@@ -256,14 +260,14 @@ tape('term0=defaultbins, term1=categorical', function (test) {
 	}
 })
 
-tape('term1=geneVariant', function (test) {
+tape('term1=geneVariant no group', function (test) {
 	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			plots: [
 				{
 					chartType: 'summary', // cannot use 'barchart', breaks
-					term: { term: { type: 'geneVariant', gene: 'TP53', name: 'TP53' } }
+					term: { term: { type: 'geneVariant', gene: 'TP53' } }
 				}
 			]
 		},
@@ -278,6 +282,118 @@ tape('term1=geneVariant', function (test) {
 		const barDiv = barchart.Inner.dom.barDiv
 		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
 		test.true(numCharts > 2, 'Should have more than 2 charts by TP53 as a gene variant term')
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+})
+
+tape('term1=geneVariant with groups', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary', // cannot use 'barchart', breaks
+					term: geneVariantTw
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': testNumCharts
+			}
+		}
+	})
+
+	function testNumCharts(barchart) {
+		const barDiv = barchart.Inner.dom.barDiv
+		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
+		test.true(numCharts == 1, 'Should have 1 chart from gene variant term')
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+})
+
+tape('term1=categorical, term2=geneVariant', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary', // cannot use 'barchart', breaks
+					term: { id: 'diaggrp' },
+					term2: geneVariantTw
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': testNumCharts
+			}
+		}
+	})
+
+	function testNumCharts(barchart) {
+		const barDiv = barchart.Inner.dom.barDiv
+		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
+		test.true(numCharts == 1, 'Should have 1 chart from gene variant term')
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+})
+
+// FIXME this test times out, seems like postRender is never called
+tape.skip('term1=geneExp, term2=geneVariant SKIPPED', function (test) {
+	test.timeoutAfter(10000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary', // cannot use 'barchart', breaks
+					term2: geneVariantTw,
+					term: { term: { type: 'geneExpression', gene: 'TP53' } }
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': testNumCharts
+			}
+		}
+	})
+
+	function testNumCharts(barchart) {
+		const barDiv = barchart.Inner.dom.barDiv
+		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
+		test.true(numCharts == 1, 'Should have 1 chart from gene variant term')
+		//if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+})
+
+tape('term2=geneExp, term1=geneVariant', function (test) {
+	test.timeoutAfter(10000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary', // cannot use 'barchart', breaks
+					term: geneVariantTw,
+					term2: { term: { type: 'geneExpression', gene: 'TP53' } }
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': testNumCharts
+			}
+		}
+	})
+
+	function testNumCharts(barchart) {
+		const barDiv = barchart.Inner.dom.barDiv
+		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
+		test.true(numCharts == 1, 'Should have 1 chart from gene variant term')
 		if (test._ok) barchart.Inner.app.destroy()
 		test.end()
 	}
@@ -1844,3 +1960,293 @@ tape.skip('customized bins', test => {
 		test.deepEqual(barchart.Inner.config.term.q, q1, 'should not be reverted when using a searched term')
 	}
 })
+
+// to make or update this config, on the browser build/modify the tw, apply to chart, at Session > Share > Open link, open the session file and locate the gV tw entry and copy it out here
+const geneVariantTw = {
+	term: {
+		type: 'geneVariant',
+		gene: 'TP53',
+		groupsetting: { disabled: false },
+		filter: {
+			opts: { joinWith: ['and', 'or'] },
+			terms: [
+				{
+					id: 'snvindel_somatic',
+					query: 'snvindel',
+					name: 'SNV/indel (somatic)',
+					parent_id: null,
+					isleaf: true,
+					type: 'dtsnvindel',
+					dt: 1,
+					values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+					name_noOrigin: 'SNV/indel',
+					origin: 'somatic'
+				},
+				{
+					id: 'snvindel_germline',
+					query: 'snvindel',
+					name: 'SNV/indel (germline)',
+					parent_id: null,
+					isleaf: true,
+					type: 'dtsnvindel',
+					dt: 1,
+					values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+					name_noOrigin: 'SNV/indel',
+					origin: 'germline'
+				},
+				{
+					id: 'cnv',
+					query: 'cnv',
+					name: 'CNV',
+					parent_id: null,
+					isleaf: true,
+					type: 'dtcnv',
+					dt: 4,
+					values: { CNV_amp: { label: 'Copy number gain' }, WT: { label: 'Wildtype' } },
+					name_noOrigin: 'CNV'
+				},
+				{
+					id: 'fusion',
+					query: 'svfusion',
+					name: 'Fusion RNA',
+					parent_id: null,
+					isleaf: true,
+					type: 'dtfusion',
+					dt: 2,
+					values: { Fuserna: { label: 'Fusion transcript' }, WT: { label: 'Wildtype' } },
+					name_noOrigin: 'Fusion RNA'
+				}
+			]
+		}
+	},
+	q: {
+		type: 'custom-groupset',
+		customset: {
+			groups: [
+				{
+					name: 'Excluded categories',
+					type: 'filter',
+					uncomputable: true,
+					filter: {
+						opts: { joinWith: ['and', 'or'] },
+						terms: [
+							{
+								id: 'snvindel_somatic',
+								query: 'snvindel',
+								name: 'SNV/indel (somatic)',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtsnvindel',
+								dt: 1,
+								values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'SNV/indel',
+								origin: 'somatic'
+							},
+							{
+								id: 'snvindel_germline',
+								query: 'snvindel',
+								name: 'SNV/indel (germline)',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtsnvindel',
+								dt: 1,
+								values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'SNV/indel',
+								origin: 'germline'
+							},
+							{
+								id: 'cnv',
+								query: 'cnv',
+								name: 'CNV',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtcnv',
+								dt: 4,
+								values: { CNV_amp: { label: 'Copy number gain' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'CNV'
+							},
+							{
+								id: 'fusion',
+								query: 'svfusion',
+								name: 'Fusion RNA',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtfusion',
+								dt: 2,
+								values: { Fuserna: { label: 'Fusion transcript' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'Fusion RNA'
+							}
+						],
+						group: 0,
+						active: { type: 'tvslst', in: true, join: '', lst: [] }
+					}
+				},
+				{
+					name: 'WTSnvindel',
+					type: 'filter',
+					uncomputable: false,
+					filter: {
+						opts: { joinWith: ['and', 'or'] },
+						terms: [
+							{
+								id: 'snvindel_somatic',
+								query: 'snvindel',
+								name: 'SNV/indel (somatic)',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtsnvindel',
+								dt: 1,
+								values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'SNV/indel',
+								origin: 'somatic'
+							},
+							{
+								id: 'snvindel_germline',
+								query: 'snvindel',
+								name: 'SNV/indel (germline)',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtsnvindel',
+								dt: 1,
+								values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'SNV/indel',
+								origin: 'germline'
+							},
+							{
+								id: 'cnv',
+								query: 'cnv',
+								name: 'CNV',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtcnv',
+								dt: 4,
+								values: { CNV_amp: { label: 'Copy number gain' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'CNV'
+							},
+							{
+								id: 'fusion',
+								query: 'svfusion',
+								name: 'Fusion RNA',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtfusion',
+								dt: 2,
+								values: { Fuserna: { label: 'Fusion transcript' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'Fusion RNA'
+							}
+						],
+						group: 1,
+						active: {
+							type: 'tvslst',
+							in: true,
+							join: '',
+							lst: [
+								{
+									type: 'tvs',
+									tvs: {
+										term: {
+											id: 'snvindel_somatic',
+											query: 'snvindel',
+											name: 'SNV/indel (somatic)',
+											parent_id: null,
+											isleaf: true,
+											type: 'dtsnvindel',
+											dt: 1,
+											values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+											name_noOrigin: 'SNV/indel',
+											origin: 'somatic'
+										},
+										values: [{ key: 'WT', label: 'Wildtype', value: 'WT', bar_width_frac: null }]
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					name: 'ANYSnvindel',
+					type: 'filter',
+					uncomputable: false,
+					filter: {
+						opts: { joinWith: ['and', 'or'] },
+						terms: [
+							{
+								id: 'snvindel_somatic',
+								query: 'snvindel',
+								name: 'SNV/indel (somatic)',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtsnvindel',
+								dt: 1,
+								values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'SNV/indel',
+								origin: 'somatic'
+							},
+							{
+								id: 'snvindel_germline',
+								query: 'snvindel',
+								name: 'SNV/indel (germline)',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtsnvindel',
+								dt: 1,
+								values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'SNV/indel',
+								origin: 'germline'
+							},
+							{
+								id: 'cnv',
+								query: 'cnv',
+								name: 'CNV',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtcnv',
+								dt: 4,
+								values: { CNV_amp: { label: 'Copy number gain' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'CNV'
+							},
+							{
+								id: 'fusion',
+								query: 'svfusion',
+								name: 'Fusion RNA',
+								parent_id: null,
+								isleaf: true,
+								type: 'dtfusion',
+								dt: 2,
+								values: { Fuserna: { label: 'Fusion transcript' }, WT: { label: 'Wildtype' } },
+								name_noOrigin: 'Fusion RNA'
+							}
+						],
+						group: 2,
+						active: {
+							type: 'tvslst',
+							in: true,
+							join: '',
+							lst: [
+								{
+									type: 'tvs',
+									tvs: {
+										term: {
+											id: 'snvindel_somatic',
+											query: 'snvindel',
+											name: 'SNV/indel (somatic)',
+											parent_id: null,
+											isleaf: true,
+											type: 'dtsnvindel',
+											dt: 1,
+											values: { M: { label: 'MISSENSE' }, F: { label: 'FRAMESHIFT' }, WT: { label: 'Wildtype' } },
+											name_noOrigin: 'SNV/indel',
+											origin: 'somatic'
+										},
+										values: [{ key: 'WT', label: 'Wildtype', value: 'WT', bar_width_frac: null }],
+										isnot: true
+									}
+								}
+							]
+						}
+					}
+				}
+			]
+		}
+	}
+}

--- a/client/termdb/vocabulary.js
+++ b/client/termdb/vocabulary.js
@@ -29,7 +29,9 @@ export function vocabInit(opts) {
 		return new TermdbVocab(opts)
 	} else if (vocab.terms) {
 		//const { FrontendVocab } = await import('./FrontendVocab')
-		return new FrontendVocab(opts)
+		const vocabApi = new FrontendVocab(opts)
+		if (vocab.parent_termdbConfig) vocabApi.parent_termdbConfig = vocab.parent_termdbConfig
+		return vocabApi
 	}
 }
 

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -102,8 +102,10 @@ export async function fillTW(tw: GeneVariantTW, vocabApi: VocabApi, defaultQ: Ge
 		}
 	}
 
-	// cnv cutoffs; if the attributes are missing from q{}, add
-	if ('cnvMaxLength' in tw.q) {
+	// do not fill default cnv cutoffs here
+	// will set custom cnv cutoffs when creating
+	// variant filters in groupsetting UI
+	/*if ('cnvMaxLength' in tw.q) {
 		// has cutoff
 		if (!Number.isInteger(tw.q.cnvMaxLength)) throw 'cnvMaxLength is not integer'
 		// cnvMaxLength value<=0 will not filter by length
@@ -124,7 +126,7 @@ export async function fillTW(tw: GeneVariantTW, vocabApi: VocabApi, defaultQ: Ge
 		// =0 for not filtering losses
 	} else {
 		tw.q.cnvLossCutoff = -0.2
-	}
+	}*/
 
 	set_hiddenvalues(tw.q, tw.term)
 }

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -263,8 +263,6 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 				applySpan.style('display', 'inline')
 			} else {
 				clearGroupset(self)
-				delete self.q.dt
-				delete self.q.origin
 				groupsDiv.style('display', 'none')
 				draggablesDiv.style('display', 'none')
 				applySpan.style('display', 'none')

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -577,7 +577,10 @@ function setRenderers(self: any) {
 			joinWith: filter.opts.joinWith,
 			emptyLabel: '+Variant Filter',
 			holder: filterBody,
-			vocab: { terms: filter.terms },
+			vocab: {
+				terms: filter.terms,
+				parent_termdbConfig: self.tsInstance.vocabApi.termdbConfig
+			},
 			callback: async f => {
 				// once the filter is updated from UI, it's only updated here
 				// user must press submit button to attach current filter to self.q{}

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2792,7 +2792,7 @@ function filterByItem(filter, mlst) {
 			tvs.cnvMode == 'continuous'
 				? // continuous cnv data
 				  mlst_tested.some(m => {
-						if (!m.value && m.value !== 0) return false
+						if (!m.value) return false // will also consider value=0 as not mutated
 						if (m.value > 0 && tvs.cnvGainCutoff && m.value < tvs.cnvGainCutoff) return false
 						if (m.value < 0 && tvs.cnvLossCutoff && m.value > tvs.cnvLossCutoff) return false
 						if (tvs.cnvMaxLength && m.stop - m.start > tvs.cnvMaxLength) return false

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2546,6 +2546,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 	2. this query hardcodes to load geneCnv for showing in gdc matrix, the other does not need it (gdc tk)
 	*/
 	ds.mayGetGeneVariantData = async (tw, q) => {
+		console.log('tw.q.customset:', tw.q.customset?.groups[1].filter.active.lst)
+
 		// validate tw
 		if (typeof tw.term != 'object') throw 'tw.term{} is not object'
 		if (tw.term.type != 'geneVariant') throw 'tw.term.type is not geneVariant'

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -524,6 +524,7 @@ type TrackLst = {
 
 /** cnv segments are queried by coordinates, and can be filtered by segment length and/or value
 configs for types of cnv data
+
 - log(ratio)
 	{
 		cnvMaxLength:10000000
@@ -536,6 +537,15 @@ configs for types of cnv data
 		cnvMaxCopynumber:10
 		cnvMinCopynumber:1
 	}
+- qualitative categories
+	{
+		cnvMaxLength?:? // abscent if ds doesn't allow filtering by max length (e.g. segments are actually gene bodies)
+		//cnvCategories:['CNV_amp', 'CNV_loss'] // "CNV_amplification" and "CNV_homozygous_deletion" are optional depending on ds
+	}
+	may not need to declare cnvCategories[];
+	cnv edit ui rendering can be entirely based on actual server-returned gene cnv data
+	e.g. if CNV_amplification is present from getCategories() or cnv data, show its checkbox, otherwise do not show checkbox
+
 important: presence of filtering properties indiate the type of cnv quantification
 and will trigger rendering of ui controls
 */
@@ -547,6 +557,7 @@ type CnvSegment = {
 	2. start, 0-based
 	3. stop
 	4. {"dt": 4, "mattr": {"origin": "somatic"}, "sample": "3332", "value": -1.0}
+	   "value" can be logratio (minus/positive number), copy number (non-negative integer), or qualitative call (gain/loss)
 	*/
 	file?: string
 
@@ -558,21 +569,32 @@ type CnvSegment = {
 	gainColor?: string
 	lossColor?: string
 
-	/** filter segments by max length to restrict to focal events; set to -1 to show all
+	/** filter segments by max length to restrict to focal events;
+	samples with all events filtered out should be treated as wildtype
+	set to -1 to show all as a convenient solution, thus no need for UI to show a checkbox for filterbylength or not
 	allow to be missing, in such case will always show all */
 	cnvMaxLength?: number
 
-	/** if cnv is quantified as log(ratio) or similar, must set these two properties
+	/// quick fix: following sets of properties are mutually exclusive. TODO may improve with "type" property
+
+	/** presence of these properties indicate cnv is quantified as log(ratio) or similar
 	filter segments by following two cutoffs only apply to log ratio, cnv gain value is positive, cnv loss value is negative
+	samples with all events filtered out should be treated as wildtype
 	*/
 	/** if value>0, skip if value<this cutoff, set to a large value e.g. 100 for not filtering */
 	cnvGainCutoff?: number
 	/** if value<0, skip if value>this cutoff, set to a large negative value e.g. -100 for not filtering */
 	cnvLossCutoff?: number
-	/** TODO if cnv is quantified as integer copy number, must set these properties; do not use for log(ratio)
-	 */
+
+	/** presence of these properties indicate cnv is quantified as integer copy number
+	* not in use yet *
 	cnvMinCopynumber?: number
 	cnvMaxCopynumber?: number
+	 */
+
+	/** if cnv is using qualitative categories. ui will show checkboxes for each category that's present
+	cnvCategories?:string[]
+	*/
 }
 
 /*

--- a/shared/types/src/terms/geneVariant.ts
+++ b/shared/types/src/terms/geneVariant.ts
@@ -2,13 +2,13 @@ import type { MinBaseQ, BaseTerm, TermGroupSetting, BaseTW, GroupSettingQ, Value
 import type { TermSettingInstance } from '../termsetting.ts'
 
 export type GeneVariantBaseQ = MinBaseQ & {
+	// cnv cutoffs may no longer be necessary, but keeping for now
+	// see fillTW() in termsetting/handlers/geneVariant.ts
 	cnvGainCutoff?: number
 	cnvMaxLength?: number
 	cnvMinAbsValue?: number
 	cnvLossCutoff?: number
 	exclude: string[]
-	dt?: number
-	origin?: string
 }
 
 export type GeneVariantQ = GeneVariantBaseQ & (ValuesQ | GroupSettingQ)


### PR DESCRIPTION
…v categories

## Description

closes #3152 

for ds using different kinds of cnv categories (gain/loss versus gain/loss/amp/del), i decided not to declare anything about that; cnv tvs ui can employ existing implementation to first `getCategories()` then show checkboxes for returned categories

all existing ds files should work; this temporarily avoids having to update ds files using cnv categories at the present

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
