### PR TITLE
fix the gsea error

### DIFF
--- a/container/deps/Dockerfile
+++ b/container/deps/Dockerfile
@@ -60,7 +60,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 RUN python3 -m venv /opt/venv && \
     pip install --upgrade pip && \
-    pip install blitzgsea matplotlib nibabel numpy pre-commit && \
+    pip install blitzgsea==1.3.47 matplotlib nibabel numpy pre-commit && \
     ## clean up
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/downloaded_packages/ /tmp/*.rds


### PR DESCRIPTION
## Description
specify the version of blitzgsea python package(1.3.47) in `container/deps/Dockerfile`.
The image was built and tested; it works.
https://github.com/stjude/proteinpaint/issues/3143

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
