### PR TITLE
fix: Do not show gene menu submenu content on load if input is not ch…

### DIFF
--- a/client/dom/GeneSetEdit/GenesMenu.ts
+++ b/client/dom/GeneSetEdit/GenesMenu.ts
@@ -76,7 +76,7 @@ export class GenesMenu {
 			if (param?.options?.length) {
 				/* ** Submenu ** 
 				Use checkbox to expand div for additional options when checked. */
-				const holder = div.append('div').attr('data-testid', 'sjpp-submenu-checkbox')
+				const holder = div.append('div').attr('data-testid', 'sjpp-submenu-checkbox').style('padding', '2px')
 				const contentDiv = div.append('div').style('padding-left', '20px')
 				input = make_one_checkbox({
 					holder: holder,
@@ -95,7 +95,7 @@ export class GenesMenu {
 					option.parentId = param.id
 					this.params2Add.push({ param: option, input: optionInput })
 				}
-				contentDiv.style('display', param.value ? 'block' : 'none')
+				contentDiv.style('display', input.property('checked') ? 'block' : 'none')
 			} else {
 				input = div.append('input').style('padding', '2px').attr('type', 'checkbox').attr('id', param.id)
 				if (param.value) input.property('checked', param.value)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Do not show gene menu submenu content on load if input is not checked


### PR DESCRIPTION
…ecked

## Description
In master, the submenu content in the genes menu can appear on load even if the submenu isn't checked, like this: 
<img width="355" alt="Screenshot 2025-04-16 at 10 26 11 AM" src="https://github.com/user-attachments/assets/cb15674c-71a5-4438-abe8-5fffe1281fe8" />

This fix only shows the content when checked:
<img width="280" alt="Screenshot 2025-04-16 at 10 29 53 AM" src="https://github.com/user-attachments/assets/95d05fdf-cfb8-4eb2-8de6-804b56c51a95" />

Test: http://localhost:3000/?massnative=hg38-test,TermdbTest -> Click on `Gene Expression` btn -> Click on `Top variably expressed genes` -> Should see the submenu content hidden until `Filter Extreme Values` is checked. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
