### PR TITLE
Just HDF5 File Flag Removal

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Removing hdf5file flag now that ds have been migrated. Removed the tabix handling code also. Removed some extraneous unused variables noticed by the liner

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -223,7 +223,6 @@ export default function (): Mds3 {
 			},
 			geneExpression: {
 				src: 'native',
-				hdf5File: true,
 				file: 'files/hg38/TermdbTest/TermdbTest.fpkm.matrix.h5'
 			},
 			topVariablyExpressedGenes: {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -590,8 +590,6 @@ type RnaseqGeneCount = {
 	/** Name of the HDF5 file */
 	file: string
 	samplesFile?: string
-	/** Storage_type for storing data (HDF5) */
-	storage_type: 'HDF5'
 }
 
 /** the metabolite query */

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -587,11 +587,11 @@ type Probe2Cnv = {
 */
 
 type RnaseqGeneCount = {
-	/** Name of the HDF5 or text file */
+	/** Name of the HDF5 file */
 	file: string
 	samplesFile?: string
-	/** Storage_type for storing data (HDF5 or text). Will deprecate text files in the future */
-	storage_type: 'text' | 'HDF5'
+	/** Storage_type for storing data (HDF5) */
+	storage_type: 'HDF5'
 }
 
 /** the metabolite query */
@@ -623,8 +623,6 @@ export type GeneExpressionQueryNative = {
 	samples?: number[]
 	/** dynamically added flag during launch */
 	nochr?: boolean
-	/** if true, the file is in HDF5 format */
-	hdf5File?: boolean
 	/** dynamically added getter */
 	get?: (param: any) => void
 	/** This dictionary is used to store/cache the default bins calculated for a geneExpression term when initialized in the fillTermWrapper */
@@ -635,7 +633,7 @@ export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNa
 
 export type SingleCellGeneExpressionNative = {
 	src: 'native'
-	/** path to HDF5 files. for now only hdf5 is supported.
+	/** path to HDF5 files. for now only HDF5 is supported.
 	each is a gene-by-cell matrix for a sample, with ".h5" suffix. missing files are detected and handled */
 	folder: string
 	/** dynamically added getter */


### PR DESCRIPTION
## Description
Removal of flag related to hdf5 files from dataset files (only termdbtest is done here. Other ds are in sjpp pr). Removal of tabix handling code now that all datasets are on HDF5. Removed some unused variables noticed by the linter now that tabix code is removed. No `npx tsc `errors. All unit and integration tests pass. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
