### PR TITLE
Putting back `storage_type` in `dataset.ts` to fix broken ds

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - Removing hdf5file flag now that ds have been migrated. Removed the tabix handling code also. Removed some extraneous unused variables noticed by the liner
+- putting back storage_type in dataset.ts to fix broken ds

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -590,6 +590,8 @@ type RnaseqGeneCount = {
 	/** Name of the HDF5 file */
 	file: string
 	samplesFile?: string
+	/** Storage_type for storing data (HDF5) */
+	storage_type: 'HDF5'
 }
 
 /** the metabolite query */


### PR DESCRIPTION
## Description
Restoring `storage_type` to dataset.ts to fix the broken datasets.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
