### PR TITLE
compare changed files against commit hash instead of master HEAD

### DIFF
--- a/.github/workflows/CI-spec-coverage.yml
+++ b/.github/workflows/CI-spec-coverage.yml
@@ -1,16 +1,9 @@
 name: Spec Coverage
 
 on:
-  push:
-    branches:
-      - master
-      - release-*
-      - fake-master
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - '.**ignore'
-      - 'docs/**'
+  pull_request_target:
+    types:
+      - closed
 
   workflow_dispatch:
     inputs:
@@ -166,10 +159,14 @@ jobs:
           fi
 
       - name: Commit updated coverage file
+        if: github.event.pull_request.merged
         run: |
           BRANCH=$(git rev-parse --abbrev-ref HEAD)
           STAGEDFILES=$(git diff --cached --name-only | sed 's| |\\ |g')
-          if [[ "$BRANCH" == "master" && "$STAGEDFILES" != "" ]]; then
+          
+          # this CI is intended to run on approving and closing a PR,
+          # should not automatically push to master since its protected
+          if [[ "$BRANCH" != "master" && "$STAGEDFILES" != "" ]]; then
             echo "$(git rev-parse --short HEAD)" > public/coverage/commitRef
             git add public/coverage/commitRef
 


### PR DESCRIPTION
## Description

Spec CI should run on closing a PR, to allow updating the `public/coverage/commitRef` in PR branch instead of the protected master branch.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
