### PR TITLE
Updated `DEanalysis.rs`, `edge.R`,  `topGeneByExpressionVariance.rs`, and Multiple Files related to the Volcano plot and its test data to use `gene_ids` and `gene_names` instead of `gene_symbols`

### DIFF
--- a/client/plots/diffAnalysis/interactions/DiffAnalysisInteractions.ts
+++ b/client/plots/diffAnalysis/interactions/DiffAnalysisInteractions.ts
@@ -11,7 +11,7 @@ export class DiffAnalysisInteractions {
 	}
 
 	getGseaParameters() {
-		const inputGenes = this.volcanoResponse.data.map(i => i.gene_symbol)
+		const inputGenes = this.volcanoResponse.data.map(i => i.gene_name)
 		const gsea_params = {
 			genes: inputGenes,
 			fold_change: this.volcanoResponse.data.map(i => i.fold_change),

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -147,7 +147,7 @@ export class VolcanoInteractions {
 	launchGeneSetEdit() {
 		const plotConfig = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
 		const holder = this.dom.actionsTip.d.append('div').style('padding', '5px') as any
-		const limitedGenesList = this.data.map(d => d.gene_symbol)
+		const limitedGenesList = this.data.map(d => d.gene_name)
 		new GeneSetEditUI({
 			holder,
 			genome: this.app.opts.genome,

--- a/client/plots/volcano/test/testData.js
+++ b/client/plots/volcano/test/testData.js
@@ -87,71 +87,71 @@ export const groups = [
 
 export const responseData = [
 	{
-		gene_name: 'ENSG00000187634.6',
-		gene_symbol: 'SAMD11',
+		gene_id: 'ENSG00000187634.6',
+		gene_name: 'SAMD11',
 		fold_change: 0.1128,
 		original_p_value: 0.3325,
 		adjusted_p_value: 0.1565
 	},
 	{
-		gene_name: 'ENSG00000188976.6',
-		gene_symbol: 'NOC2L',
+		gene_id: 'ENSG00000188976.6',
+		gene_name: 'NOC2L',
 		fold_change: 0.1569,
 		original_p_value: 0.7206,
 		adjusted_p_value: 0.3427
 	},
 	{
-		gene_name: 'ENSG00000187961.9',
-		gene_symbol: 'KLHL17',
+		gene_id: 'ENSG00000187961.9',
+		gene_name: 'KLHL17',
 		fold_change: -0.1281,
 		original_p_value: 0.2826,
 		adjusted_p_value: 0.1345
 	},
 	{
-		gene_name: 'ENSG00000187608.5',
-		gene_symbol: 'ISG15',
+		gene_id: 'ENSG00000187608.5',
+		gene_name: 'ISG15',
 		fold_change: 0.1667,
 		original_p_value: 0.2198,
 		adjusted_p_value: 0.1032
 	},
 	{
-		gene_name: 'ENSG00000188157.9',
-		gene_symbol: 'AGRN',
+		gene_id: 'ENSG00000188157.9',
+		gene_name: 'AGRN',
 		fold_change: 0.6196,
 		original_p_value: 1.483,
 		adjusted_p_value: 0.7022
 	},
 	{
-		gene_name: 'ENSG00000131591.13',
-		gene_symbol: 'C1orf159',
+		gene_id: 'ENSG00000131591.13',
+		gene_name: 'C1orf159',
 		fold_change: -0.0021,
 		original_p_value: 0.0049,
 		adjusted_p_value: 0.0021
 	},
 	{
-		gene_name: 'ENSG00000078808.12',
-		gene_symbol: 'SDF4',
+		gene_id: 'ENSG00000078808.12',
+		gene_name: 'SDF4',
 		fold_change: 0.4862,
 		original_p_value: 3.2334,
 		adjusted_p_value: 1.5562
 	},
 	{
-		gene_name: 'ENSG00000176022.3',
-		gene_symbol: 'B3GALT6',
+		gene_id: 'ENSG00000176022.3',
+		gene_name: 'B3GALT6',
 		fold_change: 0.0751,
 		original_p_value: 0.1906,
 		adjusted_p_value: 0.0888
 	},
 	{
-		gene_name: 'ENSG00000160087.16',
-		gene_symbol: 'UBE2J2',
+		gene_id: 'ENSG00000160087.16',
+		gene_name: 'UBE2J2',
 		fold_change: 0.0744,
 		original_p_value: 0.3546,
 		adjusted_p_value: 0.168
 	},
 	{
-		gene_name: 'ENSG00000162572.15',
-		gene_symbol: 'SCNN1D',
+		gene_id: 'ENSG00000162572.15',
+		gene_name: 'SCNN1D',
 		fold_change: 0.0993,
 		original_p_value: 0.1659,
 		adjusted_p_value: 0.0758

--- a/client/plots/volcano/view/DataPointMouseEvents.ts
+++ b/client/plots/volcano/view/DataPointMouseEvents.ts
@@ -38,8 +38,8 @@ export class DataPointMouseEvents {
 
 	mayAddGeneExpressionRows(d: DataPointEntry, table: any) {
 		if (this.termType !== 'geneExpression') return
+		this.addTooltipRow(table, 'Gene ID', d.gene_id)
 		this.addTooltipRow(table, 'Gene name', d.gene_name)
-		this.addTooltipRow(table, 'Gene symbol', d.gene_symbol)
 		this.addTooltipRow(table, 'log2(fold change)', roundValueAuto(d.fold_change))
 		this.addTooltipRow(table, 'Original p value', roundValueAuto(d.original_p_value))
 		this.addTooltipRow(table, 'Adjusted p value', roundValueAuto(d.adjusted_p_value))

--- a/client/plots/volcano/view/DataPointMouseEvents.ts
+++ b/client/plots/volcano/view/DataPointMouseEvents.ts
@@ -26,7 +26,7 @@ export class DataPointMouseEvents {
 			circle.attr('fill-opacity', 0)
 		})
 		circle.on('click', async () => {
-			await interactions.launchBoxPlot(d.gene_symbol)
+			await interactions.launchBoxPlot(d.gene_name)
 		})
 	}
 

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -195,7 +195,7 @@ export class VolcanoPlotView {
 				//Highlight the data point when hovering over the table row
 				//Previously highlighted data points are not affected
 				const circles = this.volcanoDom.plot.selectAll('circle').nodes()
-				const circle = circles.find((d: any) => d.__data__.gene_symbol == row[0].value) as any
+				const circle = circles.find((d: any) => d.__data__.gene_name == row[0].value) as any
 				if (!circle || circle.__data__.highlighted) return
 
 				/** Circles may render behind several other circles, making it hard

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -138,7 +138,7 @@ export class VolcanoViewModel {
 		const radius = Math.max(this.settings.width, this.settings.height) / 80
 		const dataCopy: any = structuredClone(this.response.data)
 		for (const d of dataCopy) {
-			d.highlighted = this.config.highlightedData.includes(d.gene_symbol)
+			d.highlighted = this.config.highlightedData.includes(d.gene_name)
 			const significant = this.isSignificant(d)
 			this.getGenesColor(d, significant, controlColor, caseColor)
 			if (significant) {
@@ -149,7 +149,7 @@ export class VolcanoViewModel {
 					{ value: roundValueAuto(d.adjusted_p_value) }
 				]
 				if (this.dataType == 'genes') {
-					row.splice(0, 0, { value: d.gene_symbol })
+					row.splice(0, 0, { value: d.gene_name })
 				}
 				this.pValueTable.rows.push(row)
 			} else {
@@ -175,7 +175,7 @@ export class VolcanoViewModel {
 
 	getGenesColor(d: DataPointEntry, significant: boolean, controlColor: string, caseColor: string) {
 		if (this.termType != 'geneExpression') return
-		if (!d.gene_symbol) throw `Missing gene_symbol in data: ${JSON.stringify(d)} [VolcanoViewModel getGenesColor()]`
+		if (!d.gene_name) throw `Missing gene_name in data: ${JSON.stringify(d)} [VolcanoViewModel getGenesColor()]`
 		if (significant) {
 			if (controlColor && caseColor) d.color = d.fold_change > 0 ? caseColor : controlColor
 			else d.color = this.settings.defaultSignColor

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -210,7 +210,7 @@ export class VolcanoViewModel {
 
 	setPTableColumns() {
 		if (this.termType == 'geneExpression') {
-			this.pValueTable.columns.splice(0, 0, { label: 'Gene Symbol', sortable: true })
+			this.pValueTable.columns.splice(0, 0, { label: 'Gene Name', sortable: true })
 		}
 	}
 

--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -10,6 +10,7 @@ import { mayLog } from '#src/helpers.ts'
 import serverconfig from '../src/serverconfig.js'
 import imagesize from 'image-size'
 import { get_header_txt } from '#src/utils.js'
+import { formatElapsedTime } from '@sjcrh/proteinpaint-shared/time.js'
 
 export const api: RouteApi = {
 	endpoint: 'DEanalysis',
@@ -277,7 +278,7 @@ values[] // using integer sample id
 		const result = JSON.parse(
 			await run_R(path.join(serverconfig.binpath, 'utils', 'edge.R'), JSON.stringify(expression_input))
 		)
-		mayLog('Time taken to run edgeR:', Date.now() - time1, 'ms')
+		mayLog('Time taken to run edgeR:', formatElapsedTime(Date.now() - time1))
 		param.method = 'edgeR'
 		const ql_imagePath: string = path.join(serverconfig.cachedir, result.edgeR_ql_image_name[0]) // Retrieve the edgeR quality image and send it to client side. Does not need to be an array, will address this later.
 		mayLog('ql_imagePath:', ql_imagePath)
@@ -305,7 +306,7 @@ values[] // using integer sample id
 	// Wilcoxon test will be used for DE analysis
 	const time1 = new Date().valueOf()
 	const result = JSON.parse(await run_rust('DEanalysis', JSON.stringify(expression_input)))
-	mayLog('Time taken to run rust DE pipeline:', Date.now() - time1, 'ms')
+	mayLog('Time taken to run rust DE pipeline:', formatElapsedTime(Date.now() - time1))
 	param.method = 'wilcoxon'
 	return { data: result, sample_size1: sample_size1, sample_size2: sample_size2, method: param.method } as DEResponse
 }

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -33,7 +33,7 @@ read_json_time <- system.time({
 read_counts_time <- system.time({
   if (input$storage_type == "HDF5") {
     geneIDs <- h5read(input$input_file, "gene_ids")
-    geneSymbols <- h5read(input$input_file, "gene_names")
+    geneNames <- h5read(input$input_file, "gene_names")
     samples <- h5read(input$input_file, "samples")
 
     # Find indices of case and control samples in the HDF5 file
@@ -60,7 +60,7 @@ read_counts_time <- system.time({
       })
     })
     geneIDs <- unlist(read_counts[1])
-    geneSymbols <- unlist(read_counts[2])
+    geneNames <- unlist(read_counts[2])
     read_counts <- select(read_counts, -geneID)
     read_counts <- select(read_counts, -geneSymbol)
   } else {
@@ -71,7 +71,7 @@ read_counts_time <- system.time({
 
 # Create conditions vector
 conditions <- c(rep("Diseased", length(cases)), rep("Control", length(controls)))
-gene_id_symbols <- paste0(geneIDs, "\t", geneSymbols)
+gene_id_symbols <- paste0(geneIDs, "\t", geneNames)
 
 # Create DGEList object
 dge_list_time <- system.time({
@@ -193,7 +193,7 @@ if (DE_method == "edgeR") {
   pvalues <- et$table$PValue
   genes_matrix <- str_split_fixed(unlist(et$genes), "\t", 2)
   geneids <- unlist(genes_matrix[, 1])
-  genesymbols <- unlist(genes_matrix[, 2])
+  geneNames <- unlist(genes_matrix[, 2])
   adjust_p_values <- p.adjust(pvalues, method = "fdr")
 } else if (DE_method == "limma") {
   # Do voom transformation and fit linear model
@@ -246,7 +246,7 @@ if (DE_method == "edgeR") {
         pvalues <- top_table$P.Value
         genes_matrix <- str_split_fixed(unlist(top_table$genes), "\t", 2)
         geneids <- unlist(genes_matrix[, 1])
-        genesymbols <- unlist(genes_matrix[, 2])
+        geneNames <- unlist(genes_matrix[, 2])
         adjust_p_values <- top_table$adj.P.Val
       })
     })
@@ -257,9 +257,9 @@ if (DE_method == "edgeR") {
 }
 
 final_data_generation_time <- system.time({
-  output <- data.frame(geneids, genesymbols, logfc, pvalues, adjust_p_values)
-  names(output)[1] <- "gene_name"
-  names(output)[2] <- "gene_symbol"
+  output <- data.frame(geneids, geneNames, logfc, pvalues, adjust_p_values)
+  names(output)[1] <- "gene_id"
+  names(output)[2] <- "gene_name"
   names(output)[3] <- "fold_change"
   names(output)[4] <- "original_p_value"
   names(output)[5] <- "adjusted_p_value"

--- a/server/utils/edge.R
+++ b/server/utils/edge.R
@@ -32,8 +32,8 @@ read_json_time <- system.time({
 # Read counts data
 read_counts_time <- system.time({
   if (input$storage_type == "HDF5") {
-    geneIDs <- h5read(input$input_file, "gene_names")
-    geneSymbols <- h5read(input$input_file, "gene_symbols")
+    geneIDs <- h5read(input$input_file, "gene_ids")
+    geneSymbols <- h5read(input$input_file, "gene_names")
     samples <- h5read(input$input_file, "samples")
 
     # Find indices of case and control samples in the HDF5 file

--- a/shared/types/src/routes/termdb.DE.ts
+++ b/shared/types/src/routes/termdb.DE.ts
@@ -70,8 +70,8 @@ export type DataEntry = {
 	adjusted_p_value: number
 	original_p_value: number
 	fold_change: number
+	gene_id: string
 	gene_name: string
-	gene_symbol: string
 }
 
 export type DEImage = {


### PR DESCRIPTION
## Description
Updated `DEanalysis.rs`, and `edge.R` to use gene_ids and gene_names. Removed gene_symbols support and used gene_names instead. Used `formateElapsedTime` for reporting the time taking for DE analysis in `termdb.DE.ts`

reminder to recompile rust after checking branch

## To Test
Go to [here](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22Resistant%22,%22color%22:%22%23f09930%22,%22filter%22:{%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Molecular%20subtype%22},%22values%22:[{%22key%22:%22ETV6-RUNX1%22},{%22key%22:%22ETV6-RUNX1-like%22}]}},{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22ranges%22:[{%22start%22:0.1,%22startinclusive%22:true,%22stopunbounded%22:true}]}}]}},{%22name%22:%22Sensitive%22,%22color%22:%22%233453ed%22,%22filter%22:{%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Molecular%20subtype%22},%22values%22:[{%22key%22:%22ETV6-RUNX1%22},{%22key%22:%22ETV6-RUNX1-like%22}]}},{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22ranges%22:[{%22stop%22:0.1,%22startunbounded%22:true}]}}]}}]}) and test that DA analysis works as expected for both edgeR, limma, and wilcoxon

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
