### PR TITLE
Run chart divide by renders plots in same svg and misc fixes.

### DIFF
--- a/client/plots/runChart.renderer.ts
+++ b/client/plots/runChart.renderer.ts
@@ -224,12 +224,10 @@ export function setRenderers(self) {
 				.attr('height', self.settings.svgh)
 			chart.mainG.attr('clip-path', `url(#${id})`)
 
-			chart.serie = chart.mainG.append('g').attr('class', 'sjpcb-runchart-series')
 			chart.regressionG = chart.mainG.append('g').attr('class', 'sjpcb-runchart-lowess')
 			chart.legendG = svg.append('g').attr('class', 'sjpcb-runchart-legend')
 		} else {
 			chart.mainG = svg.select('.sjpcb-runchart-mainG')
-			chart.serie = chart.mainG.select('.sjpcb-runchart-series')
 			chart.regressionG = chart.mainG.select('.sjpcb-runchart-lowess')
 			axisG = svg.select('.sjpcb-runchart-axis')
 			labelsG = svg.select('.sjpcb-runchart-labelsG')
@@ -289,8 +287,7 @@ export function setRenderers(self) {
 	}
 
 	function renderSerie(chart, duration) {
-		if (self.canvas) self.canvas.remove()
-		const g = chart.serie
+		const g = chart.mainG.append('g')
 
 		const samples = chart.samples
 

--- a/client/plots/runChart.ts
+++ b/client/plots/runChart.ts
@@ -443,18 +443,6 @@ class RunChart {
 			},
 
 			{
-				label: 'Show regression',
-				type: 'dropdown',
-				chartType: 'runChart',
-				settingsKey: 'regression',
-				options: [
-					{ label: 'None', value: 'None' },
-					//{ label: 'Loess', value: 'Loess' },
-					{ label: 'Lowess', value: 'Lowess' },
-					{ label: 'Polynomial', value: 'Polynomial' }
-				]
-			},
-			{
 				label: 'Opacity',
 				type: 'number',
 				chartType: 'runChart',
@@ -505,6 +493,19 @@ class RunChart {
 				title: `Use median instead of mean to aggregate the data`
 			})
 		}
+		if (!this.config.term0)
+			inputs.push({
+				label: 'Show regression',
+				type: 'dropdown',
+				chartType: 'runChart',
+				settingsKey: 'regression',
+				options: [
+					{ label: 'None', value: 'None' },
+					//{ label: 'Loess', value: 'Loess' },
+					{ label: 'Lowess', value: 'Lowess' },
+					{ label: 'Polynomial', value: 'Polynomial' }
+				]
+			})
 
 		this.components = {
 			controls: await controlsInit({


### PR DESCRIPTION
## Description

Run chart with divide by plots rendered in the same svg with different colors. Allows to divide X into ranges and calculate medians per range. See example[ plot](http://localhost:3000/sjcares/runchart.html)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
