### PR TITLE
Add error handling into single cell plot for DEgenes route

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -695,21 +695,31 @@ class singleCellPlot {
 		const columnName = this.state.termdbConfig.queries.singleCell.DEgenes.columnName
 		const sample =
 			this.state.config.experimentID || this.state.config.sample || this.samples?.[0]?.experiments[0]?.experimentID
-		const args = { genome: this.state.genome, dslabel: this.state.dslabel, categoryName, sample, columnName }
-		const result = await dofetch3('termdb/singlecellDEgenes', { body: args })
-		if (result.error) {
-			tableDiv.text(result.error)
-			return
-		}
-		if (!Array.isArray(result.genes)) {
-			tableDiv.text('.genes[] missing')
-			return
-		}
+
 		const DEContentDiv = this.dom.plotsDiv.append('div').style('width', '100%')
 
 		const tabsDiv = DEContentDiv.append('div')
 		const tableDiv = DEContentDiv.append('div')
 		const GSEADiv = DEContentDiv.append('div').style('display', 'none')
+
+		let result
+		try {
+			const args = { genome: this.state.genome, dslabel: this.state.dslabel, categoryName, sample, columnName }
+			result = await dofetch3('termdb/singlecellDEgenes', { body: args })
+			if (result.error) {
+				tableDiv.text(result.error)
+				return
+			}
+			if (!result.genes || !result?.genes?.length) {
+				tableDiv.text('No differentially expressed genes found.')
+				return
+			}
+		} catch (e) {
+			if (e.stack) console.error(e.stack)
+			else throw `Error fetching DE genes: ${e.message || e} [singleCellPlot.renderDETable()]`
+			return
+		}
+
 		const tabs = [
 			{
 				label: 'Differentially Expressed Genes',

--- a/server/routes/termdb.singlecellDEgenes.ts
+++ b/server/routes/termdb.singlecellDEgenes.ts
@@ -31,6 +31,12 @@ function init({ genomes }) {
 			if (!ds) throw 'invalid dataset name'
 			if (!ds.queries?.singleCell?.DEgenes) throw 'not supported on this dataset'
 			result = await ds.queries.singleCell.DEgenes.get(q)
+			if (!result || !result.genes || !result?.genes?.length) {
+				result = {
+					status: 404,
+					error: !result ? 'No data found.' : 'No differentially expressed genes found.'
+				}
+			}
 		} catch (e: any) {
 			if (e.stack) console.log(e.stack)
 			result = {


### PR DESCRIPTION
## Description
Closes #3173. Test by adding a throw statement in `server/routes/termdb.singlecellDEgenes.ts`, line 28, and use any GDC single cell example from http://localhost:3000/url.html. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
