### PR TITLE
Rm displaySubheader from the nav state

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -48,7 +48,7 @@ class TdbNav {
 		this.type = 'nav'
 		this.instanceNum = instanceNum++
 		this.tabs = [] // array of tab objects corresponding to what's shown on header, based on ds customization. hidden tabs are not in this array. filled in initUI()
-		this.activeTab = 0 // array index for .tabs[]
+		this.activeTab = 0 // array index for .tabs[]; -1 for no active tabs and all closed
 		this.activeCohort = 0 // -1 = unselected, 0,1,2... = selected
 		this.samplecounts = {} // tracks sample count by .activeCohort value and stringified filter json
 		this.searching = false

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -24,8 +24,7 @@ const navHeaderModes = new Set([
 const defaultState = {
 	nav: {
 		header_mode: 'with_tabs',
-		activeTab: 0,
-		displaySubheader: true
+		activeTab: 0
 	},
 	// will be ignored if there is no dataset termdb.selectCohort
 	// or value will be set to match a filter node that has been tagged
@@ -239,7 +238,6 @@ TdbStore.prototype.actions = {
 	},
 	tab_set(action) {
 		this.state.nav.activeTab = action.activeTab
-		this.state.nav.displaySubheader = action.displaySubheader
 	},
 	cohort_set(action) {
 		this.state.activeCohort = action.activeCohort

--- a/client/mass/store.js
+++ b/client/mass/store.js
@@ -24,7 +24,7 @@ const navHeaderModes = new Set([
 const defaultState = {
 	nav: {
 		header_mode: 'with_tabs',
-		activeTab: 0
+		activeTab: 0 // -1 for no active tab and all closed
 	},
 	// will be ignored if there is no dataset termdb.selectCohort
 	// or value will be set to match a filter node that has been tagged


### PR DESCRIPTION
## Description
Closes issue #2887. 

Test with:
1. [inactive tab example](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22groups%22:[{%22name%22:%22Test%20Group%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22diaggrp%22},%22values%22:[{%22key%22:%22Acute%20lymphoblastic%20leukemia%22}]}}]}}]})
2. [No active tab defined example](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22Auditory%20System%22}}]})
3. [Active tab defined example](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22Auditory%20System%22}}]})


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
