### PR TITLE
apply tvslst negation to a single-entry tvs to correctly normalize

### DIFF
--- a/client/filter/test/filter.integration.spec.js
+++ b/client/filter/test/filter.integration.spec.js
@@ -1322,7 +1322,7 @@ tape('renderAs: htmlSelect', async test => {
 
 tape('getNormalRoot()', async test => {
 	test.timeoutAfter(3000)
-	test.plan(7)
+	test.plan(8)
 
 	{
 		// direct testing of getNormalRoot
@@ -1332,6 +1332,7 @@ tape('getNormalRoot()', async test => {
 		const D = { type: 'tvs', tvs: { term_D: true } }
 		const input = {
 			type: 'tvslst',
+			//in:true, // cannot set in=true here. output.lst[0].type becomes "tvslst". see if this is issue
 			join: 'and',
 			lst: [
 				{
@@ -1349,11 +1350,31 @@ tape('getNormalRoot()', async test => {
 		const output = getNormalRoot(input)
 		const expectedOutput = {
 			type: 'tvslst',
+			//in:true,
 			join: 'and',
 			lst: [A, B, C, D]
 		}
 		test.deepEqual(output, expectedOutput, 'should flatten (A && B) && (C && D) into A && B && C && D')
 		test.notEqual(output.lst[0], A, 'should not output original filter data')
+	}
+
+	{
+		// allow negating tvslst of single tvs (needed for single-group-based custom term...)
+		const A = { type: 'tvs', tvs: { term_A: true } }
+		const input = {
+			type: 'tvslst',
+			in: false,
+			join: 'and',
+			lst: [A]
+		}
+		const output = getNormalRoot(input)
+		const expectedOutput = {
+			type: 'tvslst',
+			in: false,
+			join: 'and',
+			lst: [A]
+		}
+		test.deepEqual(output, expectedOutput, 'should allow tvslst of single-tvs to be negated')
 	}
 
 	const hidden = {

--- a/client/filter/test/filter.integration.spec.js
+++ b/client/filter/test/filter.integration.spec.js
@@ -1363,16 +1363,23 @@ tape('getNormalRoot()', async test => {
 		const A = { type: 'tvs', tvs: { term_A: true } }
 		const input = {
 			type: 'tvslst',
-			in: false,
 			join: 'and',
-			lst: [A]
+			lst: [
+				{
+					type: 'tvslst',
+					in: false,
+					lst: [A]
+				}
+			]
 		}
-		const output = getNormalRoot(input)
+		const output = getNormalRoot(structuredClone(input))
+		const Acopy = structuredClone(A)
+		Acopy.tvs.isnot = true // negate the tvs based on input.lst[0].in === false
 		const expectedOutput = {
 			type: 'tvslst',
-			in: false,
-			join: 'and',
-			lst: [A]
+			in: true,
+			join: '',
+			lst: [Acopy] // since the nested tvslst with negation was removed, the 'hoisted' tvs must be negated
 		}
 		test.deepEqual(output, expectedOutput, 'should allow tvslst of single-tvs to be negated')
 	}


### PR DESCRIPTION
## Description

This branch handles a single-entry `tvslst` where filter.in === false, which is not created from the filter UI, but may be created internally by non-UI code, so need to support under the hood.

Tested locally with all unit and all integration test using testrun.html. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
