### PR TITLE
Allow the app drawer to finish transition before loading the sandbox

### DIFF
--- a/client/appdrawer/card.js
+++ b/client/appdrawer/card.js
@@ -94,7 +94,7 @@ function setRenderers(self) {
 		)
 	}
 
-	self.makeRibbon = function(ribbon) {
+	self.makeRibbon = function (ribbon) {
 		//only relevant for 'card', not 'nestedCard'
 		const ribbonDiv = card
 			.append('div')
@@ -144,6 +144,11 @@ function setRenderers(self) {
 			value: false
 		})
 		slideDrawer(self)
-		await openSandbox(self.opts.element, self.opts)
+		/** Focused elements rendering concurrently with the drawer
+		 * animation cause the drawer scrolling to jerk. Wait till
+		 * the animation is complete, then open the sandbox. */
+		setTimeout(async () => {
+			await openSandbox(self.opts.element, self.opts)
+		}, self.state.duration + 5)
 	})
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Allow the app drawer to finish transition before loading the sandbox


### PR DESCRIPTION
## Description
Closes #2880. I tested this at different zoom levels. I don't see the jerky behavior any more. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
