### PR TITLE
fix: Added tabix support back for all non-HDF5 datasets

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Added tabix support back for all non-HDF5 datasets

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -24,6 +24,7 @@ import { getData } from '#src/termdb.matrix.js'
 import { termType2label } from '#shared/terms.js'
 import { mayLog } from '#src/helpers.ts'
 import { formatElapsedTime } from '#shared/time.js'
+import { getResult as getResultGene } from '#src/gene.js'
 
 export const api: RouteApi = {
 	endpoint: 'termdb/cluster',
@@ -262,7 +263,7 @@ export async function validate_query_geneExpression(ds: any, genome: any) {
 		return
 	}
 	if (q.src == 'native') {
-		await validateNative(q as GeneExpressionQueryNative, ds)
+		await validateNative(q as GeneExpressionQueryNative, ds, genome)
 		return
 	}
 	throw 'unknown queries.geneExpression.src'
@@ -329,16 +330,16 @@ async function queryGeneExpression(hdf5_file, geneNames) {
 
 /**
  * Validate and prepare a gene expression query
- * This function handles HDF5 file formats
+ * This function handles both HDF5 and tabix file formats
+ * If HDF5 validation fails, it falls back to tabix handling
  *
  * @param q - The gene expression query
  * @param ds - Dataset information
+ * @param genome - Genome information
  */
-async function validateNative(q: GeneExpressionQueryNative, ds: any) {
+async function validateNative(q: GeneExpressionQueryNative, ds: any, genome: any) {
 	q.file = path.join(serverconfig.tpmasterdir, q.file)
-
 	q.samples = []
-
 	// Validate that the HDF5 file exists
 	await utils.file_is_readable(q.file)
 
@@ -354,93 +355,196 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any) {
 		}
 
 		console.log(`${ds.label}: HDF5 file validated. Format: ${vr.format}, Samples:`, vr.sampleNames.length)
+
+		// HDF5 validation successful, set up the getter function for HDF5
+		q.get = async (param: TermdbClusterRequestGeneExpression) => {
+			const limitSamples = await mayLimitSamples(param, q.samples, ds)
+			if (limitSamples?.size == 0) {
+				// Got 0 sample after filtering, must still return expected structure with no data
+				return { term2sample2value: new Map(), byTermId: {}, bySampleId: {} }
+			}
+
+			// Set up sample IDs and labels
+			const bySampleId = {}
+			const samples = q.samples || []
+			if (limitSamples) {
+				for (const sid of limitSamples) {
+					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
+				}
+			} else {
+				// Use all samples with exp data
+				for (const sid of samples) {
+					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
+				}
+			}
+
+			// Initialize data structure
+			const term2sample2value = new Map()
+			const byTermId = {}
+
+			// First, collect all gene names
+			const geneNames: string[] = []
+			for (const geneTerm of param.terms) {
+				if (geneTerm.gene) {
+					geneNames.push(geneTerm.gene)
+				}
+			}
+
+			if (geneNames.length === 0) {
+				console.log('No genes to query')
+				return { term2sample2value, byTermId }
+			}
+
+			const time1 = Date.now()
+			try {
+				// Query expression values for all genes at once
+				const geneData = JSON.parse(await queryGeneExpression(q.file, geneNames))
+
+				mayLog('Time taken to run gene query:', formatElapsedTime(Date.now() - time1))
+
+				// Check if we have a multi-gene response (genes field) or single gene response
+				const genesData = geneData.genes || { [geneNames[0]]: geneData }
+				// Process each gene's data
+				for (const geneTerm of param.terms) {
+					if (!geneTerm.gene) continue
+
+					// Get this gene's data from the batch response
+					const geneResult = genesData[geneTerm.gene]
+					if (!geneResult) {
+						console.warn(`No data found for gene ${geneTerm.gene} in the response`)
+						continue
+					}
+
+					// Extract just the samples data
+					const samplesData = geneResult.samples || {}
+
+					// Convert the gene data to the expected format
+					const s2v = {}
+
+					// Process sample data the same way as before
+					for (const [sampleName, value] of Object.entries(samplesData)) {
+						const sampleId = ds.cohort.termdb.q.sampleName2id(sampleName)
+						if (!sampleId) continue
+						if (limitSamples && !limitSamples.has(sampleId)) continue
+						s2v[sampleId] = value
+					}
+
+					if (Object.keys(s2v).length) {
+						term2sample2value.set(geneTerm.gene, s2v)
+					}
+				}
+			} catch (error) {
+				console.error(`Error processing batch gene query:`, error)
+			}
+			if (term2sample2value.size == 0) {
+				throw 'No data available for the input ' + param.terms?.map(g => g.gene).join(', ')
+			}
+
+			return { term2sample2value, byTermId, bySampleId }
+		}
 	} catch (error) {
-		throw `${ds.label}: Failed to validate HDF5 file: ${error}`
-	}
+		console.log(`${ds.label}: HDF5 validation failed, falling back to tabix handling: ${error}`)
 
-	q.get = async (param: TermdbClusterRequestGeneExpression) => {
-		const limitSamples = await mayLimitSamples(param, q.samples, ds)
-		if (limitSamples?.size == 0) {
-			// Got 0 sample after filtering, must still return expected structure with no data
-			return { term2sample2value: new Map(), byTermId: {}, bySampleId: {} }
-		}
+		// HDF5 validation failed, try tabix (.gz) file handling
+		q.samples = [] as number[]
+		await utils.validate_tabixfile(q.file)
+		q.nochr = await utils.tabix_is_nochr(q.file, null, genome)
 
-		// Set up sample IDs and labels
-		const bySampleId = {}
-		const samples = q.samples || []
-		if (limitSamples) {
-			for (const sid of limitSamples) {
-				bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
+		{
+			// Is a gene-by-sample matrix file
+			const lines = await utils.get_header_tabix(q.file)
+			if (!lines[0]) throw 'Header line missing from ' + q.file
+			const l = lines[0].split('\t')
+			if (l.slice(0, 4).join('\t') != '#chr\tstart\tstop\tgene') {
+				throw 'Header line has wrong content for columns 1-4'
 			}
-		} else {
-			// Use all samples with exp data
-			for (const sid of samples) {
-				bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
-			}
-		}
 
-		// Initialize data structure
-		const term2sample2value = new Map()
-		const byTermId = {}
-
-		// First, collect all gene names
-		const geneNames: string[] = []
-		for (const geneTerm of param.terms) {
-			if (geneTerm.gene) {
-				geneNames.push(geneTerm.gene)
+			for (let i = 4; i < l.length; i++) {
+				const id = ds.cohort.termdb.q.sampleName2id(l[i])
+				if (id == undefined) {
+					throw 'queries.geneExpression: unknown sample from header: ' + l[i]
+				}
+				q.samples.push(id)
 			}
 		}
 
-		if (geneNames.length === 0) {
-			console.log('No genes to query')
-			return { term2sample2value, byTermId }
-		}
+		// Print that the tabix file successfully initialized
+		console.log(`${ds.label}: Tabix file successfully initialized. Samples: ${q.samples.length}`)
 
-		const time1 = Date.now()
-		try {
-			// Query expression values for all genes at once
-			const geneData = JSON.parse(await queryGeneExpression(q.file, geneNames))
+		q.get = async (param: TermdbClusterRequestGeneExpression) => {
+			const limitSamples = await mayLimitSamples(param, q.samples, ds)
+			if (limitSamples?.size == 0) {
+				// Got 0 sample after filtering, must still return expected structure with no data
+				return { term2sample2value: new Map(), byTermId: {}, bySampleId: {} }
+			}
 
-			mayLog('Time taken to run gene query:', formatElapsedTime(Date.now() - time1))
+			// Has at least 1 sample passing filter and with exp data
+			const bySampleId = {}
+			const samples = q.samples || []
+			if (limitSamples) {
+				for (const sid of limitSamples) {
+					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
+				}
+			} else {
+				// Use all samples with exp data
+				for (const sid of samples) {
+					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
+				}
+			}
 
-			// Check if we have a multi-gene response (genes field) or single gene response
-			const genesData = geneData.genes || { [geneNames[0]]: geneData }
-			// Process each gene's data
+			// Only valid genes with data are added
+			const term2sample2value = new Map()
+			const byTermId = {}
+
 			for (const geneTerm of param.terms) {
 				if (!geneTerm.gene) continue
-
-				// Get this gene's data from the batch response
-				const geneResult = genesData[geneTerm.gene]
-				if (!geneResult) {
-					console.warn(`No data found for gene ${geneTerm.gene} in the response`)
-					continue
+				if (!geneTerm.chr || !Number.isInteger(geneTerm.start) || !Number.isInteger(geneTerm.stop)) {
+					const re = getResultGene(genome, { input: geneTerm.gene, deep: 1 })
+					if (!re.gmlst || re.gmlst.length == 0) {
+						console.warn('Unknown gene:' + geneTerm.gene)
+						continue
+					}
+					const i = re.gmlst.find(i => i.isdefault) || re.gmlst[0]
+					geneTerm.start = i.start
+					geneTerm.stop = i.stop
+					geneTerm.chr = i.chr
 				}
 
-				// Extract just the samples data
-				const samplesData = geneResult.samples || {}
+				if (!geneTerm.chr || !Number.isInteger(geneTerm.start) || !Number.isInteger(geneTerm.stop)) {
+					throw 'Missing chr/start/stop'
+				}
 
-				// Convert the gene data to the expected format
 				const s2v = {}
-
-				// Process sample data the same way as before
-				for (const [sampleName, value] of Object.entries(samplesData)) {
-					const sampleId = ds.cohort.termdb.q.sampleName2id(sampleName)
-					if (!sampleId) continue
-					if (limitSamples && !limitSamples.has(sampleId)) continue
-					s2v[sampleId] = value
-				}
+				await utils.get_lines_bigfile({
+					args: [
+						q.file,
+						(q.nochr ? geneTerm.chr.replace('chr', '') : geneTerm.chr) + ':' + geneTerm.start + '-' + geneTerm.stop
+					],
+					callback: line => {
+						const l = line.split('\t')
+						// Case-insensitive match
+						if (l[3].toLowerCase() != geneTerm.gene.toLowerCase()) return
+						for (let i = 4; i < l.length; i++) {
+							const sampleId = samples[i - 4]
+							if (limitSamples && !limitSamples.has(sampleId)) continue
+							if (!l[i]) continue // Blank string
+							const v = Number(l[i])
+							if (Number.isNaN(v)) throw 'Expression value not number'
+							s2v[sampleId] = v
+						}
+					}
+				})
 
 				if (Object.keys(s2v).length) {
-					term2sample2value.set(geneTerm.gene, s2v)
+					term2sample2value.set(geneTerm.gene, s2v) // Only add gene if it has data
 				}
 			}
-		} catch (error) {
-			console.error(`Error processing batch gene query:`, error)
-		}
-		if (term2sample2value.size == 0) {
-			throw 'No data available for the input ' + param.terms?.map(g => g.gene).join(', ')
-		}
 
-		return { term2sample2value, byTermId, bySampleId }
+			if (term2sample2value.size == 0) {
+				throw 'No data available for the input ' + param.terms?.map(g => g.gene).join(', ')
+			}
+
+			return { term2sample2value, byTermId, bySampleId }
+		}
 	}
 }


### PR DESCRIPTION
## Description
This fix adds support for tabix (.gz) support in the error handling. The logic is that we first try to validate the file as HDF5. If it fails then it falls back to the tabix handling. The error message from the attempted HDF5 validation will be shown in your server log. It will also report the successful tabix validation


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
