### PR TITLE
on creating custom term from 1 group, use a negateFilter helper

### DIFF
--- a/client/filter/filter.utils.js
+++ b/client/filter/filter.utils.js
@@ -186,3 +186,32 @@ export function filterJoin(lst) {
 	}
 	return f
 }
+
+/* make copy of input filter, return negated copy
+if tag=filterUiRoot is found, negate that;
+else, assume is tvslst of single tvs an negate at tvs level
+
+allow other tags for future use
+*/
+export function negateFilter(f0, tag = 'filterUiRoot') {
+	const f = structuredClone(f0)
+	const fui = getFilterItemByTag(f, tag)
+	if (fui) {
+		if (typeof fui.in != 'boolean') throw 'filterUiRoot f.in is not boolean'
+		fui.in = !fui.in
+		return f
+	}
+	// tag not found, try root
+
+	if (f.lst?.length == 1 && f.lst[0].type == 'tvs' && typeof f.lst[0].tvs == 'object') {
+		// is a tvslst containing a single tvs. negate at tvs level
+		f.lst[0].tvs.isnot = !f.lst[0].tvs.isnot
+		return f
+	}
+	if (f.lst?.length > 1 && typeof f.in == 'boolean') {
+		// is a tvslst with multiple tvs. maybe from a subfilter nested somewhere
+		f.in = !f.in
+		return f
+	}
+	throw 'cannot negate filter'
+}

--- a/client/filter/test/filter.unit.spec.js
+++ b/client/filter/test/filter.unit.spec.js
@@ -1,0 +1,64 @@
+import tape from 'tape'
+import { negateFilter } from '../filter'
+
+/**************
+ test sections
+**************
+
+negateFilter
+
+*/
+
+tape('\n', test => {
+	test.pass('-***- filter/unit -***-')
+	test.end()
+})
+
+tape('negateFilter', test => {
+	{
+		const f = { tag: 'filterUiRoot', in: true }
+		const f2 = negateFilter(f)
+		test.equal(f2.in, false, 'f.in toggled to false')
+		const f3 = negateFilter(f2)
+		test.equal(f3.in, true, 'f.in toggled to true')
+	}
+
+	{
+		const f = {
+			type: 'tvslst',
+			lst: [
+				{ tag: 'othertag', in: true },
+				{ tag: 'filterUiRoot', in: true }
+			]
+		}
+		const f2 = negateFilter(f)
+		test.equal(f2.lst[1].in, false, 'f.lst[1].in toggled to false')
+		const f3 = negateFilter(f, 'othertag')
+		test.equal(f3.lst[0].in, false, 'f.lst[0].in toggled to false (by custom tag)')
+	}
+
+	// tvslst with single tvs. this is from groups UI generating a custom term by a single group
+	{
+		const f = {
+			type: 'tvslst',
+			lst: [{ type: 'tvs', tvs: {} }]
+		}
+		const f2 = negateFilter(f)
+		test.equal(f2.lst[0].tvs.isnot, true, 'f.lst[0].tvs.isnot toggled to true')
+	}
+
+	// tvslst with multiple tvs.
+	{
+		const f = {
+			type: 'tvslst',
+			in: true,
+			lst: [{}, {}]
+		}
+		const f2 = negateFilter(f)
+		test.equal(f2.in, false, 'f.in toggled to false')
+	}
+
+	test.throws(() => negateFilter({}), /cannot negate filter/, 'throws')
+
+	test.end()
+})

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -122,8 +122,9 @@ class MassGroups {
 				// not using cohort
 				filtercopy.in = !filtercopy.in
 			}
-			console.log(filtercopy)
-			const samples = await this.app.vocabApi.getFilteredSampleList(filtercopy)
+			const filter = Object.assign({}, this.app.getState().termfilter.filter, filtercopy)
+			filter.lst[1].lst[0].tvs.isnot = true
+			const samples = await this.app.vocabApi.getFilteredSampleList(filter)
 			if (!samples.length) throw '0 samples for the other group'
 			console.log(`Not in ${groups[0].name} has ${samples.length} samples`)
 			const items = []

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -1,6 +1,6 @@
 import { copyMerge, getCompInit } from '#rx'
 import { Menu, addGeneSearchbox, GeneSetEditUI, renderTable, table2col } from '#dom'
-import { filterInit, getNormalRoot, filterPromptInit, getFilterItemByTag } from '#filter/filter'
+import { filterInit, getNormalRoot, filterPromptInit, getFilterItemByTag, negateFilter } from '#filter/filter'
 import { appInit } from '#termdb/app'
 import { get$id } from '#termsetting'
 import { getCurrentCohortChartTypes } from './charts'
@@ -113,20 +113,8 @@ class MassGroups {
 		if (groups.length == 1) {
 			/* request rest of samples not in this single group, to form group2
 			 */
-			const filtercopy = structuredClone(groups[0].filter)
-			if (this.app.vocabApi.termdbConfig.selectCohort) {
-				// using cohort. assumes..
-				if (!filtercopy.lst?.[1]) throw 'filtercopy.lst[1] missing when using cohort'
-				filtercopy.lst[1].in = !filtercopy.lst[1].in
-			} else {
-				// not using cohort
-				filtercopy.in = !filtercopy.in
-			}
-			const filter = Object.assign({}, this.app.getState().termfilter.filter, filtercopy)
-			filter.lst[1].lst[0].tvs.isnot = true
-			const samples = await this.app.vocabApi.getFilteredSampleList(filter)
+			const samples = await this.app.vocabApi.getFilteredSampleList(negateFilter(groups[0].filter))
 			if (!samples.length) throw '0 samples for the other group'
-			console.log(`Not in ${groups[0].name} has ${samples.length} samples`)
 			const items = []
 			for (const sample of samples) {
 				const item = { sampleId: sample.id }

--- a/client/mass/test/groups.unit.spec.ts
+++ b/client/mass/test/groups.unit.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { getFilter, getSampleFilter, getSamplelstTW, getSamplelstTWFromIds } from '../groups'
+import { getFilter, getSampleFilter, getSamplelstTW, getSamplelstTW2, getSamplelstTWFromIds } from '../groups'
 
 /**
  * Tests:
@@ -319,5 +319,25 @@ tape('groups getSamplelstTW()', test => {
 	]
 	result = getSamplelstTW(input)
 	test.deepEqual(result, mockSamplelstTW, 'getSamplelstTW should return the correct sample list for two groups.')
+	test.end()
+})
+
+tape('groups getSamplelstTW2()', test => {
+	test.timeoutAfter(100)
+
+	const input = [
+		{
+			color: 'blue',
+			items: mockGrp1Values,
+			name: mockGrp1Name
+		},
+		{
+			color: 'green',
+			items: mockGrp2Values,
+			name: mockGrp2Name
+		}
+	]
+	const result = getSamplelstTW2(input)
+	test.deepEqual(result, mockSamplelstTW, 'getSamplelstTW2 should return the correct sample list for two groups.')
 	test.end()
 })


### PR DESCRIPTION
## Description

closes #3119 

[tdbtest with single group](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22Test%20Group%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22diaggrp%22},%22values%22:[{%22key%22:%22Acute%20lymphoblastic%20leukemia%22}]}}]}}]}) 
[ash with single group](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22DUX4%20Committed%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Molecular_subgroup%22},%22values%22:[{%22key%22:%22DUX4-R%20Committed%22}]}}]}}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
