### PR TITLE
geneVariant fixes

### DIFF
--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -111,7 +111,7 @@ export class InputTerm {
 			// do not allow condition term
 			arg.numericEditMenuVersion = ['continuous', 'discrete', 'spline']
 			// for geneVariant term, only allow groupsetting
-			arg.defaultQ4fillTW['geneVariant'] = { type: 'predefined-groupset' }
+			arg.defaultQ4fillTW['geneVariant'] = { type: 'custom-groupset' }
 			arg.geneVariantEditMenuOnlyGrp = true
 			return
 		}

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -255,6 +255,18 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 		.text('Apply')
 		.on('click', () => {
 			if (self.groupSettingInstance) self.groupSettingInstance.processDraggables()
+			let validGrpset = false
+			if (self.q.type == 'custom-groupset') {
+				// groupset is assigned
+				if (self.q.customset.groups.map((group: any) => group.filter?.active.lst).some(lst => lst.length)) {
+					// filters in groupset are non-empty
+					validGrpset = true
+				}
+			}
+			if (!validGrpset) {
+				// groupset is not valid, so clear it
+				clearGroupset(self)
+			}
 			self.runCallback()
 		})
 	applyRow
@@ -290,7 +302,7 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 	if (self.usecase?.detail == 'term0' || self.usecase?.detail == 'term2' || self.opts.geneVariantEditMenuOnlyGrp) {
 		// hide option for turning off groupsetting
 		optsDiv.style('display', 'none')
-		groupsDiv.style('margin', '10px 0px 0px 00px')
+		groupsDiv.style('margin-top', '10px')
 	}
 
 	const selected = radios.inputs.filter(d => d.checked)
@@ -298,7 +310,7 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 
 	// make radio buttons for grouping variants
 	async function makeGroupUI() {
-		if (self.q.type != 'predefined-groupset' && self.q.type != 'custom-groupset') self.q.type = 'filter'
+		if (self.q.type != 'custom-groupset') self.q.type = 'filter'
 		await makeGroupsetDraggables()
 		applyRow.select('#applySpan').style('display', 'inline')
 		/*groupsDiv.style('display', 'inline-block')

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -270,8 +270,8 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 		}
 	})
 
-	if (self.usecase?.detail == 'term0' || self.usecase?.detail == 'term2') {
-		// hide option for turning off groupsetting for term0/term2
+	if (self.usecase?.detail == 'term0' || self.usecase?.detail == 'term2' || self.opts.geneVariantEditMenuOnlyGrp) {
+		// hide option for turning off groupsetting
 		optsDiv.style('display', 'none')
 		groupsDiv.style('margin', '10px 0px 0px 00px')
 	}

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -236,7 +236,7 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 	*/
 	const div = _div.append('div').style('padding', '10px')
 	div.append('div').style('font-size', '1.2rem').text(self.term.name)
-	const optsDiv = div.append('div').style('margin-top', '10px')
+	const optsDiv = div.append('div').style('margin-top', '10px').style('margin-bottom', '1px')
 	const groupsDiv = div
 		.append('div')
 		.style('display', 'none')
@@ -246,6 +246,25 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 	const originDiv = groupsDiv.append('div').style('margin-top', '15px')
 	const groupsetDiv = groupsDiv.append('div').style('margin-top', '15px')*/
 	const draggablesDiv = div.append('div').style('display', 'none').style('margin-left', '15px')
+	// apply button
+	// must create it at beginning to allow toggling applySpan message
+	const applyRow = div.append('div').style('margin-top', '15px')
+	applyRow
+		.append('button')
+		.style('display', 'inline-block')
+		.text('Apply')
+		.on('click', () => {
+			if (self.groupSettingInstance) self.groupSettingInstance.processDraggables()
+			self.runCallback()
+		})
+	applyRow
+		.append('span')
+		.attr('id', 'applySpan')
+		.style('display', 'none')
+		.style('padding-left', '15px')
+		.style('opacity', 0.8)
+		.style('font-size', '.8em')
+		.text('Only tested variants are considered')
 
 	// radio buttons for whether or not to group variants
 	optsDiv.append('div').style('font-weight', 'bold').text('Group variants')
@@ -257,15 +276,13 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 			{ label: 'Assign variants to groups', value: 'group', checked: isGroupset }
 		],
 		callback: async v => {
-			const applySpan = div.select('#applySpan')
 			if (v == 'group') {
 				await makeGroupUI()
-				applySpan.style('display', 'inline')
 			} else {
 				clearGroupset(self)
 				groupsDiv.style('display', 'none')
 				draggablesDiv.style('display', 'none')
-				applySpan.style('display', 'none')
+				applyRow.select('#applySpan').style('display', 'none')
 			}
 		}
 	})
@@ -283,6 +300,7 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 	async function makeGroupUI() {
 		if (self.q.type != 'predefined-groupset' && self.q.type != 'custom-groupset') self.q.type = 'filter'
 		await makeGroupsetDraggables()
+		applyRow.select('#applySpan').style('display', 'inline')
 		/*groupsDiv.style('display', 'inline-block')
 		makeDtRadios()
 		makeOriginRadios()
@@ -453,25 +471,6 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 		})
 		await self.groupSettingInstance.main()
 	}
-
-	// Apply button
-	const applyRow = div.append('div').style('margin-top', '15px')
-	applyRow
-		.append('button')
-		.style('display', 'inline-block')
-		.text('Apply')
-		.on('click', () => {
-			if (self.groupSettingInstance) self.groupSettingInstance.processDraggables()
-			self.runCallback()
-		})
-	applyRow
-		.append('span')
-		.attr('id', 'applySpan')
-		.style('display', 'none')
-		.style('padding-left', '15px')
-		.style('opacity', 0.8)
-		.style('font-size', '.8em')
-		.text('Only tested variants are considered')
 
 	/*
 	const applyBtn = div


### PR DESCRIPTION
## Description

This PR fixes the following issues with geneVariant termsetting:
- Adding geneVariant term to regression analysis
- Clearing groupset when filters in groupset are empty (can test by applying groupsetting without any filters specified)
- Displaying hint message next to Apply button upon re-opening edit menu


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
