### PR TITLE
Load gene sets issue

### DIFF
--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -1152,7 +1152,7 @@ export class MatrixControls {
 				holder,
 				genome: app.opts.genome,
 				geneList,
-				// Remove the Loads Gene Sets option from unclustered genes panel.
+				// Remove the GFF Loads Gene Sets option from unclustered genes panel.
 				customInputs: geneInputType == 'hierCluster' ? this.parent.opts.customInputs?.geneset : undefined,
 				/* running hier clustering and the editing group is the group used for clustering
 				pass this mode value to inform ui to support the optional button "top variably exp gene"

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -1152,7 +1152,8 @@ export class MatrixControls {
 				holder,
 				genome: app.opts.genome,
 				geneList,
-				customInputs: this.parent.opts.customInputs?.geneset,
+				// Remove the Loads Gene Sets option from unclustered genes panel.
+				customInputs: geneInputType == 'hierCluster' ? this.parent.opts.customInputs?.geneset : undefined,
 				/* running hier clustering and the editing group is the group used for clustering
 				pass this mode value to inform ui to support the optional button "top variably exp gene"
 				this is hardcoded for the purpose of gene expression and should be improved

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Remove the GFF "load gene sets" option from Gene set edit UI in unclustered genes panel. 


### PR DESCRIPTION
## Description
"load gene sets" cannot be used to add geneVaraint terms to hierCluster (will replace current hierCluster when giving > 3 genes and will throw "Error: A minimum of three genes is required for clustering. Please refresh this page to clear this error" when giving less than 3 genes). Keep "load gene sets" option only in the "Clustering" panel gene set Edit UI. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
