### PR TITLE
Solved issues opening plots from the about tab

### DIFF
--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -334,7 +334,10 @@ export class MassAbout {
 				.style('margin', '5px')
 				.attr('class', 'sja_menuoption')
 				.html(item.title)
-				.on('click', () => {
+				.on('click', async () => {
+					//once the plots tab is set open a plot
+					await this.app.dispatch({ type: 'tab_set', activeTab: 1 })
+
 					this.app.dispatch({
 						type: 'plot_create',
 						id: getId(),


### PR DESCRIPTION
## Description

When opening plots from the about tab move first to the plots tab. Closes #3204 and #3203.
Thanks for pointing out these issues @creilly8, I was not in the track of them. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
