### PR TITLE
match protected routes against '*' or '/**' glob patterns 

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -361,7 +361,9 @@ export function setAuth(opts) {
 export function getRequiredAuth(dslabel, route) {
 	if (!dsAuth || !Array.isArray(dsAuth)) return
 	for (const a of dsAuth) {
-		if (a.dslabel == dslabel && a.route == route) return a
+		// wildcard route '*' is transformed by server auth.js into '/**' to support glob-pattern matching,
+		// since a single character '*' is interpreted by glob as a file, so need to also detect '/**' route
+		if (a.dslabel == dslabel && (a.route == route || a.route == '*' || a.route == '/**')) return a
 	}
 }
 


### PR DESCRIPTION
## Description

... to fix `getRequiredAuth()`, which is called in `mayGetAuthHeaders()` <- `getTermdbConfig()`.

Tested with http://localhost:3000/ash/login/, should load with no error. assuming serveronfig.dsCredentials.ASH is set up with expected secret to match `features.fakeTokens.ASH`.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
