### PR TITLE
Updated some additional places in `DEanalysis.rs` to reflect change to using `gene_names` and `gene_ids` for HDF5 Files

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Updated to reflect change to using gene_names and gene_ids instead of gene_symbols for HDF5 files

--- a/rust/src/DEanalysis.rs
+++ b/rust/src/DEanalysis.rs
@@ -497,8 +497,8 @@ fn input_data_from_text(
 #[derive(Debug, Serialize, Deserialize)]
 struct AdjustedPValueIndexes {
     index: usize,
+    gene_id: String,
     gene_name: String,
-    gene_symbol: String,
     fold_change: f64,
     original_p_value: f64,
     adjusted_p_value: f64,
@@ -506,8 +506,8 @@ struct AdjustedPValueIndexes {
 
 struct PValueIndexes {
     index: usize,
+    gene_id: String,
     gene_name: String,
-    gene_symbol: String,
     fold_change: f64,
     p_value: f64,
 }
@@ -746,8 +746,8 @@ fn main() {
                                         {
                                             p_values.push(PValueIndexes {
                                                 index: i,
-                                                gene_name: filtered_genes[i].to_owned(),
-                                                gene_symbol: filtered_gene_names[i].to_owned(),
+                                                gene_id: filtered_genes[i].to_owned(),
+                                                gene_name: filtered_gene_names[i].to_owned(),
                                                 fold_change: (treated_mean.unwrap()
                                                     / control_mean.unwrap())
                                                 .log2(),
@@ -833,9 +833,9 @@ fn main() {
                                                     {
                                                         p_values_thread.push(PValueIndexes {
                                                             index: i,
-                                                            gene_name: filtered_genes_temp[i]
+                                                            gene_id: filtered_genes_temp[i]
                                                                 .to_owned(),
-                                                            gene_symbol: filtered_gene_names_temp
+                                                            gene_name: filtered_gene_names_temp
                                                                 [i]
                                                                 .to_owned(),
                                                             fold_change: (treated_mean.unwrap()
@@ -919,8 +919,8 @@ fn adjust_p_values(mut original_p_values: Vec<PValueIndexes>) -> String {
         adjusted_p_values.push(AdjustedPValueIndexes {
             index: original_p_values[i].index,
             fold_change: original_p_values[i].fold_change,
+            gene_id: original_p_values[i].gene_id.to_owned(),
             gene_name: original_p_values[i].gene_name.to_owned(),
-            gene_symbol: original_p_values[i].gene_symbol.to_owned(),
             original_p_value: original_p_values[i].p_value,
             adjusted_p_value: adjusted_p_val,
         });
@@ -951,8 +951,8 @@ fn adjust_p_values_bonferroni(original_p_values: Vec<PValueIndexes>) -> Vec<Adju
         }
         adjusted_p_values.push(AdjustedPValueIndexes {
             index: original_p_values[i].index,
+            gene_id: original_p_values[i].gene_id.to_owned(),
             gene_name: original_p_values[i].gene_name.to_owned(),
-            gene_symbol: original_p_values[i].gene_symbol.to_owned(),
             fold_change: original_p_values[i].fold_change,
             original_p_value: original_p_values[i].p_value,
             adjusted_p_value: adjusted_p_value,


### PR DESCRIPTION
## Description
Updated to reflect change to using `gene_names `and `gene_ids` instead of `gene_symbols` for HDF5 files. The only remaining `gene_symbol` references are for the text handling function.

## To test
Go to [All-pharma](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22Resistant%22,%22color%22:%22%23f09930%22,%22filter%22:{%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Molecular%20subtype%22},%22values%22:[{%22key%22:%22ETV6-RUNX1%22},{%22key%22:%22ETV6-RUNX1-like%22}]}},{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22ranges%22:[{%22start%22:0.1,%22startinclusive%22:true,%22stopunbounded%22:true}]}}]}},{%22name%22:%22Sensitive%22,%22color%22:%22%233453ed%22,%22filter%22:{%22tag%22:%22filterUiRoot%22,%22in%22:true,%22type%22:%22tvslst%22,%22join%22:%22and%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Molecular%20subtype%22},%22values%22:[{%22key%22:%22ETV6-RUNX1%22},{%22key%22:%22ETV6-RUNX1-like%22}]}},{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Asparaginase_normalizedLC50%22},%22ranges%22:[{%22stop%22:0.1,%22startunbounded%22:true}]}}]}}]}) and create a new variable and run DA analysis. Changed the method used for DA analysis to Wilcoxon and mouse over the plot. You should see `gene ID: some Ensembl ID` and `gene name: some gene name`. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
