### PR TITLE
fix the simulated jwt logout by deleting applicable jwtByDsRoute entr…

### DIFF
--- a/public/static/js/login.js
+++ b/public/static/js/login.js
@@ -1,9 +1,22 @@
-async function logout(dslabel) {
-	const body = JSON.stringify({ dslabel, route: 'termdb' })
+async function logout(dslabel, route = 'termdb') {
+	const jwtByDsRoute = getJwtByDsRoute()
+	if (jwtByDsRoute[dslabel]?.[route]) {
+		delete jwtByDsRoute[dslabel][route]
+		localStorage.setItem('jwtByDsRoute', JSON.stringify(jwtByDsRoute))
+	}
+
+	const body = JSON.stringify({ dslabel, route })
 	await fetch(`/dslogout`, { method: 'POST', body })
 		.then(r => r.json())
 		.then(console.log)
 		.catch(console.error)
+
+	window.location.reload()
+}
+
+function getJwtByDsRoute() {
+	const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
+	return JSON.parse(jwtByDsRouteStr)
 }
 
 async function login(dataset) {

--- a/public/static/js/login.js
+++ b/public/static/js/login.js
@@ -1,11 +1,14 @@
 async function logout(dslabel, route = 'termdb') {
 	const jwtByDsRoute = getJwtByDsRoute()
 	if (jwtByDsRoute[dslabel]?.[route]) {
+		// Deleting this entry means there will be no dofetch() request header.Authorization
+		// that the backend may use to reestablish user sessions that have expired
 		delete jwtByDsRoute[dslabel][route]
 		localStorage.setItem('jwtByDsRoute', JSON.stringify(jwtByDsRoute))
 	}
 
 	const body = JSON.stringify({ dslabel, route })
+	// this will clear any active user session in the backend
 	await fetch(`/dslogout`, { method: 'POST', body })
 		.then(r => r.json())
 		.then(console.log)
@@ -15,6 +18,13 @@ async function logout(dslabel, route = 'termdb') {
 }
 
 function getJwtByDsRoute() {
+	// jwtByDsRoute is a nested object that's saved to localStorage,
+	// so that a user can stay logged-in when opening new tabs.
+	// jwtByDsRoute{}
+	// .<dslabel>
+	//   .<route>: // <'termdb' | 'burden' | '*' | '/**'>
+	//     value = jwt
+	//
 	const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
 	return JSON.parse(jwtByDsRouteStr)
 }
@@ -29,8 +39,15 @@ async function getJwt(dataset) {
 	const params = getParams()
 	if (!params.role) params.role = 'public'
 
+	// The fakeTokens allows simulating valid, signed jwt by dataset and role.
+	// It assumes there is only one protected route entry for serverconfig.features.fakeTokens[<dslabel>],
+	// and there can be 1 or more role:jwt key-values nested under it.
+	//
+	// NOTE: Verified fake tokens will be passed to `setTokenByDsRoute()` in `dofetch()`, to be
+	// saved in localStorage 'jwtByDsCredentials' and returned by getJwtByDsRoute() above.
+	//
 	let jwt = JSON.parse(sessionStorage.getItem('optionalFeatures') || '{}').fakeTokens?.[dataset]?.[params.role] //; console.log(params.role, jwt)
-	// !!! NOTE: to clear/refresh the stored fake jwt's, force this condition to true !!!
+	// !!! NOTE: to clear/refresh the stored fake jwt's, use the dslogout() function above or force the condition below to true !!!
 	// otherwise, should reuse saved fake tokens that have not changed in serverconfig.features
 	if (!jwt) {
 		await fetch(`/genomes`, {})
@@ -47,6 +64,7 @@ async function getJwt(dataset) {
 	return jwt
 }
 
+// URL search params can be used to trigger user roles or other behaviour
 function getParams() {
 	const params = {}
 	if (!window.location.search.length) return params


### PR DESCRIPTION
…y in localStorage

## Description

To test:
- pull the `sjpp/ash-login` branch
- copy and remove the signature segment (substring after the second dot) of `serverconfig.features.fakeTokens.ASH`) 
- wait for server to restart
- open http://localhost:3000/ash/login/ and paste the signature when prompted, the mass UI should show up
- click `Logout` button, an error should be displayed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
