### PR TITLE
Avoid possible text overlapping in legends

### DIFF
--- a/client/dom/maxLabelWidth.ts
+++ b/client/dom/maxLabelWidth.ts
@@ -14,6 +14,7 @@ import type { Svg, SvgG } from '../types/d3'
  *    - Box plot data: Uses item.boxplot.label
  *    - Violin plot data: Combines item.label with item.plotValueCount as "label, n=count"
  *    - Simple data: Uses item.label directly
+ * Be aware that if the svg is hidden this function will return 0 as getBBox will return 0
  *
  * Example Usage:
  *
@@ -45,6 +46,7 @@ export function getMaxLabelWidth(svg: Svg | SvgG, items: string[], size = 1): nu
 		const label = svg.append('text').text(item).style('font-size', `${size}em`)
 
 		// Update maximum width if current label is wider
+		//If the svg is hidden getBBox will return 0 !!!!
 		maxLabelLgth = Math.max(maxLabelLgth, label.node()!.getBBox().width)
 
 		// Clean up: remove temporary element

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -334,17 +334,19 @@ export class MassAbout {
 				.style('margin', '5px')
 				.attr('class', 'sja_menuoption')
 				.html(item.title)
-				.on('click', () => {
+				.on('click', async () => {
+					//Set the active tab to toggle to the plots tab and wait for the tab to be set, otherwise the plotDiv is hidden when rendering and
+					//may cause issues. A known issue is that calling betBBox on a hidden div would return 0 as width and getMaxLabelWidth would return 0. This affects
+					// the legend rendering in plots like the scatter resulting in overlapping texts
+					await this.app.dispatch({
+						type: 'tab_set',
+						activeTab: 1
+					})
 					//First create the plot
 					this.app.dispatch({
 						type: 'plot_create',
 						id: getId(),
 						config: structuredClone(item.plot)
-					})
-					//Then set the active tab to toggle to the plot
-					this.app.dispatch({
-						type: 'tab_set',
-						activeTab: 1
 					})
 				})
 		}

--- a/client/mass/about.ts
+++ b/client/mass/about.ts
@@ -335,14 +335,16 @@ export class MassAbout {
 				.attr('class', 'sja_menuoption')
 				.html(item.title)
 				.on('click', async () => {
-					//Set the active tab to toggle to the plots tab and wait for the tab to be set, otherwise the plotDiv is hidden when rendering and
-					//may cause issues. A known issue is that calling betBBox on a hidden div would return 0 as width and getMaxLabelWidth would return 0. This affects
-					// the legend rendering in plots like the scatter resulting in overlapping texts
+					/* First, set the active tab to toggle to the plots tab and wait for the tab to be set,
+					otherwise the plotDiv is hidden when rendering and
+					may cause issues. A known issue is that getMaxLabelWidth getBBox on a hidden div returns width=0
+					this affects the legend rendering in plots like the scatter resulting in overlapping texts
+					*/
 					await this.app.dispatch({
 						type: 'tab_set',
 						activeTab: 1
 					})
-					//First create the plot
+					// after switching tab so plot div is shown, dispatch to create the plot
 					this.app.dispatch({
 						type: 'plot_create',
 						id: getId(),

--- a/client/mass/test/about.unit.spec.ts
+++ b/client/mass/test/about.unit.spec.ts
@@ -204,22 +204,18 @@ tape('.initActiveItems()', test => {
 	const mockAbout = getAbout(opts)
 	mockAbout.initActiveItems()
 
-	const itemNode = mockAbout.subheader.select('[data-testid="sjpp-custom-about-activeItems"]').node()
+	// type any avoids tsc err: 'itemNode' is possibly 'null'
+	const itemNode: any = mockAbout.subheader.select('[data-testid="sjpp-custom-about-activeItems"]').node()
 
 	test.true(itemNode, 'Should render a node as activeItem')
 	test.equal(itemNode.firstChild.innerHTML, itemTitle, 'activeItem first child dom prints correct item title')
 
-	// this flag allows to detect if dispatch is called or not
-	let dispatchCalled = false
-	// mock a dispatch method to set flag to true; since this mock method is specific to this test, cannot mock it outside
-	mockAbout.app.dispatch = () => {
-		dispatchCalled = true
+	// mock dispatch method and finish test in callback
+	mockAbout.app.dispatch = async () => {
+		test.ok('Should dispatch on clicking activeItem')
+		if (test['_ok']) holder.remove() // must not use `if(test._ok)` to avoid tsc err
+		test.end()
 	}
 
 	itemNode.firstChild.click() // should call this.app.dispatch()
-
-	test.true(dispatchCalled, 'Should dispatch on clicking activeItem')
-
-	if (test['_ok']) holder.remove() // must not use `if(test._ok)` to avoid tsc err
-	test.end()
 })

--- a/client/mass/test/about.unit.spec.ts
+++ b/client/mass/test/about.unit.spec.ts
@@ -185,6 +185,8 @@ tape('.initCustomHtml()', test => {
 tape('.initActiveItems()', test => {
 	test.timeoutAfter(100)
 
+	const itemTitle = 'abc'
+
 	const holder = getHolder() as any
 	const opts = {
 		holder,
@@ -192,8 +194,7 @@ tape('.initActiveItems()', test => {
 			activeItems: {
 				items: [
 					{
-						title: 'abc'
-						// no need to supply plot because lack of app.dispatch()
+						title: itemTitle
 					}
 				]
 			}
@@ -203,10 +204,21 @@ tape('.initActiveItems()', test => {
 	const mockAbout = getAbout(opts)
 	mockAbout.initActiveItems()
 
-	test.true(
-		mockAbout.subheader.select('[data-testid="sjpp-custom-about-activeItems"]').node(),
-		'Should render activeItems'
-	)
+	const itemNode = mockAbout.subheader.select('[data-testid="sjpp-custom-about-activeItems"]').node()
+
+	test.true(itemNode, 'Should render a node as activeItem')
+	test.equal(itemNode.firstChild.innerHTML, itemTitle, 'activeItem first child dom prints correct item title')
+
+	// this flag allows to detect if dispatch is called or not
+	let dispatchCalled = false
+	// mock a dispatch method to set flag to true; since this mock method is specific to this test, cannot mock it outside
+	mockAbout.app.dispatch = () => {
+		dispatchCalled = true
+	}
+
+	itemNode.firstChild.click() // should call this.app.dispatch()
+
+	test.true(dispatchCalled, 'Should dispatch on clicking activeItem')
 
 	if (test['_ok']) holder.remove() // must not use `if(test._ok)` to avoid tsc err
 	test.end()


### PR DESCRIPTION
## Description

Avoided possible overlapping texts in legends caused by hidden svg when calculating getMaxLabelWidth by moving the tab_set dispatch up and waiting until is done. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/800)

closes https://github.com/stjude/proteinpaint/issues/3218

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
