### PR TITLE
Detect unchanged code files that are affected by changed spec files

### DIFF
--- a/augen/src/closestSpec.js
+++ b/augen/src/closestSpec.js
@@ -139,7 +139,7 @@ function setMatchedSpecsByFile(matchedByFile, specs, matched, workspace, changed
 		if (!isRelevant) continue
 		if (f.includes('.unit.spec.') || f.includes('.integration.spec.')) {
 			matchedByFile[f] = [f]
-			matched.push(f)
+			if (!matched.includes(f)) matched.push(f)
 			continue
 		}
 		matchedByFile[f] = [] // default no matched spec, may be replaced below
@@ -152,6 +152,11 @@ function setMatchedSpecsByFile(matchedByFile, specs, matched, workspace, changed
 			const truncatedFilename = fileNameSegments.join('.')
 			const unitName = `${truncatedFilename}.unit.spec.`
 			const integrationName = `${truncatedFilename}.integration.spec.`
+			// To simplify relevant spec detection, matched unit and integration specs are always
+			// run together if both are available. Running them separately will result in code files
+			// having two different spec coverage results to track, which contradicts the goal of
+			// trying to have one reference coverage run to guide writing effective tests for
+			// a given code file.
 			const matchedSpecs = specs.filter(s => {
 				if (!s.includes(unitName) && !s.includes(integrationName)) return false
 				const spath = s.slice(0, s.indexOf(`/test/`))

--- a/augen/src/evalSpecCovResults.js
+++ b/augen/src/evalSpecCovResults.js
@@ -42,6 +42,9 @@ export async function evalSpecCovResults({ workspace, jsonExtract }) {
 	const failedCoverage = new Map()
 	const getPct = v => (Object.hasOwn(v, 'pct') ? v.pct : 0)
 	for (const f of coveredFilenames) {
+		// TODO: coveredFilenames is Object.keys(relevantCoverage), not sure why this
+		// was being detected as undefined sometimes and giving an error?
+		// maybe the filename was being truncated as object key???
 		if (!relevantCoverage[f]) continue
 		const hasPrev = Object.hasOwn(previousCoverage, f) && previousCoverage[f] !== undefined
 		{

--- a/augen/src/evalSpecCovResults.js
+++ b/augen/src/evalSpecCovResults.js
@@ -42,7 +42,8 @@ export async function evalSpecCovResults({ workspace, jsonExtract }) {
 	const failedCoverage = new Map()
 	const getPct = v => (Object.hasOwn(v, 'pct') ? v.pct : 0)
 	for (const f of coveredFilenames) {
-		const hasPrev = Object.hasOwn(previousCoverage, f)
+		if (!relevantCoverage[f]) continue
+		const hasPrev = Object.hasOwn(previousCoverage, f) && previousCoverage[f] !== undefined
 		{
 			const prev = hasPrev ? getLowestPct(previousCoverage[f], 'target') : 0
 			const curr = getLowestPct(relevantCoverage[f])

--- a/augen/src/test/closestSpec.unit.spec.js
+++ b/augen/src/test/closestSpec.unit.spec.js
@@ -44,7 +44,10 @@ const relevantSubdirs = {
 tape('simple getClosestSpec()', test => {
 	const changedFiles = ['D0/rel0/aaa.js', 'D0/ignored/ccc.js']
 	const D0dirname = path.join(gitProjectRoot, 'D0')
-	const closestSpecs = getClosestSpec(D0dirname, relevantSubdirs.toy, { specs: specs.toy, changedFiles })
+	const closestSpecs = getClosestSpec(D0dirname, relevantSubdirs.toy, {
+		specs: specs.toy,
+		changedFiles
+	})
 	test.deepEqual(
 		closestSpecs,
 		{
@@ -56,6 +59,30 @@ tape('simple getClosestSpec()', test => {
 			numIntegration: 1
 		},
 		`should return the expected matched specs`
+	)
+	test.end()
+})
+
+tape('unchanged code files that are affected by changed spec files', test => {
+	const changedFiles = ['D0/rel0/test/aaa.unit.spec.js']
+	const D0dirname = path.join(gitProjectRoot, 'D0')
+	const closestSpecs = getClosestSpec(D0dirname, relevantSubdirs.toy, {
+		specs: specs.toy,
+		changedFiles,
+		codeFiles: ['rel0/aaa.js']
+	})
+	test.deepEqual(
+		closestSpecs,
+		{
+			matchedByFile: {
+				'rel0/test/aaa.unit.spec.js': ['rel0/test/aaa.unit.spec.js'],
+				'rel0/aaa.js': ['rel0/test/aaa.unit.spec.js', 'rel0/test/aaa.integration.spec.js']
+			},
+			matched: ['rel0/test/aaa.unit.spec.js', 'rel0/test/aaa.integration.spec.js'],
+			numUnit: 1,
+			numIntegration: 1
+		},
+		`should return the expected matched specs for unchanged but affected code file`
 	)
 	test.end()
 })


### PR DESCRIPTION
## Description

This branch improves the spec coverage CI to runs tests on unchanged code files if a changed spec file affects it. This fixes an issue where a changed spec coverage file is evaluated by itself if there are no other code changes, even though  it affects the testing of some other code files that have not changed. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
