### PR TITLE
Delete pickle files periodically

### DIFF
--- a/server/routes/genesetEnrichment.ts
+++ b/server/routes/genesetEnrichment.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import serverconfig from '#src/serverconfig.js'
 import { run_python } from '@sjcrh/proteinpaint-python'
 import { mayLog } from '#src/helpers.ts'
-import { Cache } from '#src/Cache.ts'
+import { DeleteCacheFiles } from '#src/DeleteCacheFiles.ts'
 
 export const api: RouteApi = {
 	endpoint: 'genesetEnrichment',
@@ -56,7 +56,7 @@ async function run_genesetEnrichment_analysis(
 ): Promise<GenesetEnrichmentResponse | string> {
 	if (!genomes[q.genome].termdbs) throw 'termdb database is not available for ' + q.genome
 
-	const cache = new Cache({
+	const cache = new DeleteCacheFiles({
 		cachedir: serverconfig.cachedir_gsea,
 		fileExtensions: ['.pkl'],
 		maxSize: 1e6

--- a/server/routes/genesetEnrichment.ts
+++ b/server/routes/genesetEnrichment.ts
@@ -58,7 +58,8 @@ async function run_genesetEnrichment_analysis(
 
 	const cache = new Cache({
 		cachedir: serverconfig.cachedir_gsea,
-		fileExtensions: ['.pkl']
+		fileExtensions: ['.pkl'],
+		maxSize: 1e6
 	})
 
 	//Using default wait time of 1 minute

--- a/server/routes/genesetEnrichment.ts
+++ b/server/routes/genesetEnrichment.ts
@@ -29,12 +29,12 @@ function init({ genomes }) {
 			// instead of trying to generalize the same function to do different things
 			const results = await run_genesetEnrichment_analysis(q, genomes)
 			if (!q.geneset_name) {
-				// req.query.geneset_name contains the geneset name which is defined only when a request for plotting the details of a particular geneset_name is made. During the initial computation this is not defined as this will be selected by the user from the client side. When this is not defined, it will send the table output. The python code saves the table in serverconfig.cachedir in a pickle file (gsea_result_{random_number}.pkl) which will later be retrieved by a subsequent server request asking to plot the details of that geneset.
+				// req.query.geneset_name contains the geneset name which is defined only when a request for plotting the details of a particular geneset_name is made. During the initial computation this is not defined as this will be selected by the user from the client side. When this is not defined, it will send the table output. The python code saves the table in serverconfig.cachedir_gsea in a pickle file (gsea_result_{random_number}.pkl) which will later be retrieved by a subsequent server request asking to plot the details of that geneset.
 				if (typeof results != 'object') throw 'gsea result is not object'
 				res.send(results satisfies GenesetEnrichmentResponse)
 				return
 			}
-			// req.query.geneset_name is present, this will cause the geneset image to be generated. The python code will retrieve gsea_result_{random_number}.pkl from serverconfig.cachedir to generate the image (gsea_plot_{random_num}.png). This prevents having to rerun the entire gsea computation again.
+			// req.query.geneset_name is present, this will cause the geneset image to be generated. The python code will retrieve gsea_result_{random_number}.pkl from serverconfig.cachedir_gsea to generate the image (gsea_plot_{random_num}.png). This prevents having to rerun the entire gsea computation again.
 			if (typeof results != 'string') throw 'gsea result is not string'
 			res.sendFile(results, (err: any) => {
 				fs.unlink(results, () => {})
@@ -60,7 +60,7 @@ async function run_genesetEnrichment_analysis(
 		fold_change: q.fold_change,
 		db: genomes[q.genome].termdbs.msigdb.cohort.db.connection.name, // For now msigdb has been added, but later databases other than msigdb may be used
 		geneset_group: q.geneSetGroup,
-		cachedir: serverconfig.cachedir,
+		cachedir: serverconfig.cachedir_gsea,
 		geneset_name: q.geneset_name,
 		pickle_file: q.pickle_file,
 		num_permutations: q.num_permutations,
@@ -98,6 +98,6 @@ async function run_genesetEnrichment_analysis(
 	}
 
 	if (data_found) return result as GenesetEnrichmentResponse
-	if (image_found) return path.join(serverconfig.cachedir, result.image_file)
+	if (image_found) return path.join(serverconfig.cachedir_gsea, result.image_file)
 	throw 'data or image not found in gsea output; this should not happen'
 }

--- a/server/routes/genesetEnrichment.ts
+++ b/server/routes/genesetEnrichment.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import serverconfig from '#src/serverconfig.js'
 import { run_python } from '@sjcrh/proteinpaint-python'
 import { mayLog } from '#src/helpers.ts'
+import { Cache } from '#src/Cache.ts'
 
 export const api: RouteApi = {
 	endpoint: 'genesetEnrichment',
@@ -54,6 +55,14 @@ async function run_genesetEnrichment_analysis(
 	genomes: any
 ): Promise<GenesetEnrichmentResponse | string> {
 	if (!genomes[q.genome].termdbs) throw 'termdb database is not available for ' + q.genome
+
+	const cache = new Cache({
+		cachedir: serverconfig.cachedir_gsea,
+		fileExtensions: ['.pkl']
+	})
+
+	//Using default wait time of 1 minute
+	await cache.mayResetCacheCheckTimeout(cache.checkWait)
 
 	const genesetenrichment_input = {
 		genes: q.genes,

--- a/server/src/Cache.ts
+++ b/server/src/Cache.ts
@@ -27,23 +27,23 @@ type CacheOpts = {
 
 export class Cache {
 	/** a pending timeout reference from setTimeout that calls mayDeleteCacheFiles */
-	private cacheCheckTimeout: NodeJS.Timeout | undefined | number
+	#cacheCheckTimeout: NodeJS.Timeout | undefined | number
 	cachedir: string
 	public checkWait: number
-	private fileExtensions: string[]
+	#fileExtensions: string[]
 	/** in milliseconds */
-	private maxAge: number
+	#maxAge: number
 	/** in bytes */
-	private maxSize: number
-	private nextCheckTime = 0
+	#maxSize: number
+	#nextCheckTime = 0
 
 	constructor(opts: CacheOpts = {}) {
-		this.cacheCheckTimeout = 0
+		this.#cacheCheckTimeout = 0
 		this.cachedir = opts.cachedir || serverconfig.cachedir
 		this.checkWait = opts.checkWait || 1 * 60 * 1000
-		this.fileExtensions = opts.fileExtensions || []
-		this.maxAge = opts.maxAge || 2 * 60 * 60 * 1000
-		this.maxSize = opts.maxSize || 5e9
+		this.#fileExtensions = opts.fileExtensions || []
+		this.#maxAge = opts.maxAge || 2 * 60 * 60 * 1000
+		this.#maxSize = opts.maxSize || 5e9
 	}
 
 	mayResetCacheCheckTimeout(wait = 0) {
@@ -51,22 +51,22 @@ export class Cache {
 		if (process.argv.includes('validate')) return
 
 		const checkTime = Date.now() + wait
-		if (this.cacheCheckTimeout) {
-			if (this.nextCheckTime && this.nextCheckTime <= checkTime + 5) return
+		if (this.#cacheCheckTimeout) {
+			if (this.#nextCheckTime && this.#nextCheckTime <= checkTime + 5) return
 			else {
-				clearTimeout(this.cacheCheckTimeout)
-				this.cacheCheckTimeout = undefined
+				clearTimeout(this.#cacheCheckTimeout)
+				this.#cacheCheckTimeout = undefined
 			}
 		}
-		this.nextCheckTime = checkTime
+		this.#nextCheckTime = checkTime
 		console.log(`will trigger mayDeleteCacheFiles() in ${wait} ms`)
-		this.cacheCheckTimeout = setTimeout(this.mayDeleteCacheFiles.bind(this), wait)
+		this.#cacheCheckTimeout = setTimeout(this.mayDeleteCacheFiles.bind(this), wait)
 	}
 
 	async mayDeleteCacheFiles() {
 		console.log(`checking for cached files to delete ...`)
 		try {
-			const minTime = Date.now() - this.maxAge
+			const minTime = Date.now() - this.#maxAge
 			const filenames = await fs.promises.readdir(this.cachedir)
 			const files: { path: any; time: any; size: any; deleted?: any }[] = [] // keep list of undeleted files. may need to rank them and delete old ones ranked by age
 			let totalSize = 0,
@@ -74,7 +74,7 @@ export class Cache {
 				totalCount = 0,
 				deletedCount = 0
 			for (const filename of filenames) {
-				if (this.fileExtensions.length && !this.fileExtensions.some(ext => filename.endsWith(ext))) continue
+				if (this.#fileExtensions.length && !this.#fileExtensions.some(ext => filename.endsWith(ext))) continue
 				totalCount++
 				const fp = path.join(this.cachedir, filename)
 				const s = await fs.promises.stat(fp)
@@ -94,7 +94,7 @@ export class Cache {
 				totalSize += s.size
 			}
 			files.sort((i, j) => j.time - i.time) // descending
-			if (totalSize >= this.maxSize) {
+			if (totalSize >= this.#maxSize) {
 				/*
                 storage use is still above limit, deleting files just older than cutoff is not enough
                 a lot of recent requests may have deposited lots of cache files
@@ -109,15 +109,15 @@ export class Cache {
 					deletedCount++
 					deletedSize += f.size
 					totalSize -= f.size
-					if (totalSize < this.maxSize) break
+					if (totalSize < this.#maxSize) break
 				}
 			}
 			console.log(
 				`deleted ${deletedCount} of ${totalCount} cached files (${deletedSize} bytes deleted, ${totalSize} remaining)`
 			)
 			// empty out the following tracking variables
-			this.cacheCheckTimeout = undefined
-			this.nextCheckTime = 0
+			this.#cacheCheckTimeout = undefined
+			this.#nextCheckTime = 0
 			const nextFile = totalSize && files.find(f => !f.deleted)
 			if (nextFile) {
 				// trigger another mayDeleteCachefile() call with setTimeout,
@@ -125,7 +125,7 @@ export class Cache {
 				// or much sooner if the max cache size is currently exceeded
 				const wait =
 					this.checkWait +
-					Math.round(totalSize >= this.maxSize ? 0 : Math.max(0, nextFile.time + this.maxAge - Date.now()))
+					Math.round(totalSize >= this.#maxSize ? 0 : Math.max(0, nextFile.time + this.#maxAge - Date.now()))
 				this.mayResetCacheCheckTimeout(wait)
 			}
 		} catch (e) {

--- a/server/src/Cache.ts
+++ b/server/src/Cache.ts
@@ -1,0 +1,135 @@
+import fs from 'fs'
+import path from 'path'
+import serverconfig from './serverconfig.js'
+
+type CacheOpts = {
+	/** Set a specific directory within the cache (e.g. bam, gsea, etc.) instead of
+	 * the default/root cachedir.*/
+	cachedir?: string
+	/** time to wait before triggering another call to mayDeleteCacheFiles(),
+	 * this is used to debounce/prevent multiple active calls to mayDeleteCacheFiles()
+	 * also assumed to be roughly equivalent to the minimum required time for a file read
+	 * to complete, otherwise deleting sooner than this may cause a file read error;
+	 * this last assumption only applies to file deletion when the maxSize is exceeded */
+	checkWait?: number
+	/** file extensions to target. Leave blank to delete everything in the dir */
+	fileExtensions?: string[]
+	/** the max age for the modified time, will delete files whose modified time
+	 * exceeds this "aged" access (in milliseconds) */
+	maxAge?: number
+	/** maximum allowed cache size in bytes */
+	maxSize?: number
+}
+
+/**
+ * This is a prototype cache class for managing files in the cachedir.
+ */
+
+export class Cache {
+	/** a pending timeout reference from setTimeout that calls mayDeleteCacheFiles */
+	private cacheCheckTimeout: NodeJS.Timeout | undefined | number
+	private cachedir: string
+	public checkWait: number
+	private fileExtensions: string[]
+	/** in milliseconds */
+	private maxAge: number
+	/** in bytes */
+	private maxSize: number
+	private nextCheckTime = 0
+
+	constructor(opts: CacheOpts = {}) {
+		this.cacheCheckTimeout = 0
+		this.cachedir = opts.cachedir || serverconfig.cachedir
+		this.checkWait = opts.checkWait || 1 * 60 * 1000
+		this.fileExtensions = opts.fileExtensions || []
+		this.maxAge = opts.maxAge || 2 * 60 * 60 * 1000
+		this.maxSize = opts.maxSize || 5e9
+	}
+
+	mayResetCacheCheckTimeout(wait = 0) {
+		// do not trigger the cache check when only validating the server
+		if (process.argv.includes('validate')) return
+
+		const checkTime = Date.now() + wait
+		if (this.cacheCheckTimeout) {
+			if (this.nextCheckTime && this.nextCheckTime <= checkTime + 5) return
+			else {
+				clearTimeout(this.cacheCheckTimeout)
+				this.cacheCheckTimeout = undefined
+			}
+		}
+		this.nextCheckTime = checkTime
+		console.log(`will trigger mayDeleteCacheFiles() in ${wait} ms`)
+		this.cacheCheckTimeout = setTimeout(this.mayDeleteCacheFiles, wait)
+	}
+
+	async mayDeleteCacheFiles() {
+		console.log(`checking for cached files to delete ...`)
+		try {
+			const minTime = Date.now() - this.maxAge
+			const filenames = await fs.promises.readdir(this.cachedir)
+			const files: { path: any; time: any; size: any; deleted?: any }[] = [] // keep list of undeleted files. may need to rank them and delete old ones ranked by age
+			let totalSize = 0,
+				deletedSize = 0,
+				totalCount = 0,
+				deletedCount = 0
+			for (const filename of filenames) {
+				if (this.fileExtensions.length && !this.fileExtensions.some(ext => filename.endsWith(ext))) continue
+				totalCount++
+				const fp = path.join(this.cachedir, filename)
+				const s = await fs.promises.stat(fp)
+				if (!s.isFile()) continue
+				const time = s.mtimeMs
+				if (time < minTime) {
+					await fs.promises.unlink(fp)
+					deletedCount++
+					deletedSize += s.size
+					continue
+				}
+				files.push({
+					path: fp,
+					time,
+					size: s.size
+				})
+				totalSize += s.size
+			}
+			files.sort((i, j) => j.time - i.time) // descending
+			if (totalSize >= this.maxSize) {
+				/*
+                storage use is still above limit, deleting files just older than cutoff is not enough
+                a lot of recent requests may have deposited lots of cache files
+                must delete more old files ranked by age
+                */
+				const minMtime = Date.now() - this.checkWait
+				for (const f of files) {
+					// do not delete files too soon that it may affect a current file read
+					if (f.time > minMtime) break
+					await fs.promises.unlink(f.path)
+					f.deleted = true
+					deletedCount++
+					deletedSize += f.size
+					totalSize -= f.size
+					if (totalSize < this.maxSize) break
+				}
+			}
+			console.log(
+				`deleted ${deletedCount} of ${totalCount} cached files (${deletedSize} bytes deleted, ${totalSize} remaining)`
+			)
+			// empty out the following tracking variables
+			this.cacheCheckTimeout = undefined
+			this.nextCheckTime = 0
+			const nextFile = totalSize && files.find(f => !f.deleted)
+			if (nextFile) {
+				// trigger another mayDeleteCachefile() call with setTimeout,
+				// using the oldest file mtime + checkWait as the wait time,
+				// or much sooner if the max cache size is currently exceeded
+				const wait =
+					this.checkWait +
+					Math.round(totalSize >= this.maxSize ? 0 : Math.max(0, nextFile.time + this.maxAge - Date.now()))
+				this.mayResetCacheCheckTimeout(wait)
+			}
+		} catch (e) {
+			console.error('Error in mayDeleteCacheFiles(): ' + e)
+		}
+	}
+}

--- a/server/src/Cache.ts
+++ b/server/src/Cache.ts
@@ -28,7 +28,7 @@ type CacheOpts = {
 export class Cache {
 	/** a pending timeout reference from setTimeout that calls mayDeleteCacheFiles */
 	private cacheCheckTimeout: NodeJS.Timeout | undefined | number
-	private cachedir: string
+	cachedir: string
 	public checkWait: number
 	private fileExtensions: string[]
 	/** in milliseconds */
@@ -60,7 +60,7 @@ export class Cache {
 		}
 		this.nextCheckTime = checkTime
 		console.log(`will trigger mayDeleteCacheFiles() in ${wait} ms`)
-		this.cacheCheckTimeout = setTimeout(this.mayDeleteCacheFiles, wait)
+		this.cacheCheckTimeout = setTimeout(this.mayDeleteCacheFiles.bind(this), wait)
 	}
 
 	async mayDeleteCacheFiles() {

--- a/server/src/DeleteCacheFiles.ts
+++ b/server/src/DeleteCacheFiles.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import serverconfig from './serverconfig.js'
 
-type CacheOpts = {
+type DeleteCacheFilesOpts = {
 	/** Set a specific directory within the cache (e.g. bam, gsea, etc.) instead of
 	 * the default/root cachedir.*/
 	cachedir?: string
@@ -25,7 +25,7 @@ type CacheOpts = {
  * This is a prototype cache class for managing files in the cachedir.
  */
 
-export class Cache {
+export class DeleteCacheFiles {
 	/** a pending timeout reference from setTimeout that calls mayDeleteCacheFiles */
 	#cacheCheckTimeout: NodeJS.Timeout | undefined | number
 	cachedir: string
@@ -37,7 +37,7 @@ export class Cache {
 	#maxSize: number
 	#nextCheckTime = 0
 
-	constructor(opts: CacheOpts = {}) {
+	constructor(opts: DeleteCacheFilesOpts = {}) {
 		this.validateOpts(opts)
 		this.#cacheCheckTimeout = 0
 		this.cachedir = opts.cachedir || serverconfig.cachedir
@@ -47,7 +47,7 @@ export class Cache {
 		this.#fileExtensions = new Set(opts.fileExtensions || [])
 	}
 
-	validateOpts(opts: CacheOpts) {
+	validateOpts(opts: DeleteCacheFilesOpts) {
 		if (opts.fileExtensions) {
 			for (const ext of opts.fileExtensions) {
 				if (ext[0] !== '.') throw `file extension ${ext} should start with a dot`

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -68,6 +68,9 @@ export async function initGenomesDs(serverconfig) {
 	serverconfig.cachedir_genome = await mayCreateSubdirInCache('genome')
 	serverconfig.cachedir_ssid = await mayCreateSubdirInCache('ssid')
 
+	//Attach to features object??
+	serverconfig.cachedir_gsea = await mayCreateSubdirInCache('gsea')
+
 	// NOTE: required or imported code files are only loaded once by Nodejs
 	// and variables are static so that changes to common key-values will affect all
 	// server-side code that import common.js


### PR DESCRIPTION
## Description
Closes issue #3114 and addresses the comment in https://github.com/stjude/proteinpaint/pull/3189. The .pkl files are now in a separate cache dir. I took the logic Edgar came up with in server/src/bam.js for deleting files from the cache and recreated it into a reusable class. This prototype class runs every time the gsea route is called and deletes files after a minute. 

Notes: 
1. As far as I know, there isn't an equivalent `serverconfig.features.gseaCache`. I assume that is a possibility for later. 
2. If this implementation works to our liking, I can replace the original code in bam.js with this reusable option at a later time. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
