### PR TITLE
Use custom mclass labels for geneVariant term

### DIFF
--- a/client/filter/tvs.geneVariant.js
+++ b/client/filter/tvs.geneVariant.js
@@ -1,7 +1,5 @@
-import { select } from 'd3-selection'
-import { mclass, dt2label } from '#shared/common.js'
-import { mayMakeVariantFilter } from '../termsetting/handlers/geneVariant'
-import { getNormalRoot, getWrappedTvslst } from './filter'
+import { dt2label } from '#shared/common.js'
+import { mayMakeVariantFilter } from '../tw/geneVariant'
 
 /*
 ********************** EXPORTED

--- a/client/plots/sampleScatter.renderer.js
+++ b/client/plots/sampleScatter.renderer.js
@@ -1328,13 +1328,15 @@ export function setRenderers(self) {
 				}
 				const hidden = tw.q.hiddenValues ? key in tw.q.hiddenValues : false
 
+				const label = category.mutation.label || mkey
+
 				G.append('g')
 					.append('text')
 					.attr('x', offsetX - step + 24)
 					.attr('y', offsetY + 4)
 					.attr('name', 'sjpp-scatter-legend-label')
 					.style('text-decoration', hidden ? 'line-through' : 'none')
-					.text(mkey.toUpperCase() + (key.includes(dtlabel) ? `, n=${category.sampleCount}` : ''))
+					.text(label.toUpperCase() + (key.includes(dtlabel) ? `, n=${category.sampleCount}` : ''))
 					.on('click', event =>
 						self.onLegendClick(chart, cname == 'shape' ? 'shapeTW' : 'colorTW', key, event, category)
 					)

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -124,6 +124,7 @@ export class GvBase extends TwBase {
 export async function mayMakeVariantFilter(tw: RawGvTW, vocabApi: VocabApi) {
 	if (tw.term.filter) return
 	if (!vocabApi.termdbConfig?.queries) throw 'termdbConfig.queries is missing'
+	const termdbmclass = vocabApi.termdbConfig.mclass // custom mclass labels from dataset
 	const dtTermsInDs: DtTerm[] = [] // dt terms in dataset
 	const categories = await vocabApi.getCategories(tw.term)
 	for (const _t of dtTerms) {
@@ -145,6 +146,11 @@ export async function mayMakeVariantFilter(tw: RawGvTW, vocabApi: VocabApi) {
 		}
 		// filter for only those mutation classes that are in the dataset
 		const values = Object.fromEntries(Object.entries(t.values).filter(([k, _v]) => Object.keys(classes).includes(k)))
+		// add custom mclass labels from dataset
+		for (const k of Object.keys(values)) {
+			const v: any = values[k]
+			if (termdbmclass && Object.keys(termdbmclass).includes(k)) v.label = termdbmclass[k].label
+		}
 		t.values = values
 		dtTermsInDs.push(t)
 	}

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2571,6 +2571,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		if (ds.queries.geneCnv) dts.push('geneCnv')
 
 		// retrieve mutation data for each dt
+		const termdbmclass = q.ds?.cohort?.termdb?.mclass // custom mclass labels from dataset
 		for (const dt of dts) {
 			const mlst =
 				dt == dtsnvindel
@@ -2611,7 +2612,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 						dt: m.dt,
 						chr: tw.term.chr,
 						class: m.class,
-						mname: m.mname
+						mname: m.mname,
+						label: termdbmclass?.[m.class]?.label || mclass[m.class].label
 					}
 					if (m.start) m2.start = m.start
 					if (m.stop) m2.stop = m.stop
@@ -2623,18 +2625,17 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					}
 
 					if (s.formatK2v) {
-						// sample has format values
-						if (tw.q.origin) {
-							// origin specified
-							if (!Object.keys(s.formatK2v).includes('origin')) throw 'format does not include origin'
-							if (s.formatK2v['origin'] != tw.q.origin) {
-								// mutation origin does not match specified origin
-								// skip sample
+						// flatten the format values
+						for (const k in s.formatK2v) {
+							if (k == 'origin' && !ds.assayAvailability?.byDt?.[dt]?.byOrigin) {
+								// possible that a dt can have origin
+								// annotations in data file, but not
+								// in ds.assayAvailability{}, because
+								// some data files use fake origin
+								// annotations for compatibility
+								// purposes (see mbmeta CNV data file)
 								continue
 							}
-						}
-						// flatten format values
-						for (const k in s.formatK2v) {
 							m2[k] = s.formatK2v[k]
 						}
 					}

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -216,6 +216,7 @@ function processGeneVariantSamples(map, bins, data, samplesMap, ds) {
 			const value1 = values[id1]
 			if (!value1) continue // skip samples without data for geneVariant term
 			for (const v1 of value1.values) {
+				const v1label = v1.label || mclass[v1.class].label
 				if (processedValues.some(p => p.value.dt == v1.dt && (v1.origin ? v1.origin == p.value.origin : true))) {
 					const sameDtOrigin = processedValues.filter(
 						p => p.value.dt == v1.dt && (v1.origin ? v1.origin == p.value.origin : true)
@@ -225,13 +226,12 @@ function processGeneVariantSamples(map, bins, data, samplesMap, ds) {
 						sameDtOrigin.item[`key1`] = {}
 						sameDtOrigin.item[`key1`][tmpKey] = 1
 					}
-					sameDtOrigin.item[`key1`][mclass[v1.class].label] = sameDtOrigin.item[`key1`][mclass[v1.class].label]
-						? sameDtOrigin.item[`key1`][mclass[v1.class].label] + 1
+					sameDtOrigin.item[`key1`][v1label] = sameDtOrigin.item[`key1`][v1label]
+						? sameDtOrigin.item[`key1`][v1label] + 1
 						: 1
 				} else {
 					const item = { sample: customSampleID }
-					item[`key1`] = mclass[v1.class].label
-					item[`val1`] = mclass[v1.class].label
+					item[`key1`] = item[`val1`] = v1label
 
 					const byOrigin = ds.assayAvailability?.byDt?.[v1.dt]?.byOrigin
 					if (byOrigin) {
@@ -264,6 +264,7 @@ function processGeneVariantSamples(map, bins, data, samplesMap, ds) {
 			const value1 = values[id1]
 			if (!value2) continue // skip samples without data for geneVariant term
 			for (const v2 of value2.values) {
+				const v2label = v2.label || mclass[v2.class].label
 				if (processedValues.some(p => p.value.dt == v2.dt && (v2.origin ? v2.origin == p.value.origin : true))) {
 					const sameDtOrigin = processedValues.filter(
 						p => p.value.dt == v2.dt && (v2.origin ? v2.origin == p.value.origin : true)
@@ -273,8 +274,8 @@ function processGeneVariantSamples(map, bins, data, samplesMap, ds) {
 						sameDtOrigin.item[`key2`] = {}
 						sameDtOrigin.item[`key2`][tmpKey] = 1
 					}
-					sameDtOrigin.item[`key2`][mclass[v2.class].label] = sameDtOrigin.item[`key2`][mclass[v2.class].label]
-						? sameDtOrigin.item[`key2`][mclass[v2.class].label] + 1
+					sameDtOrigin.item[`key2`][v2label] = sameDtOrigin.item[`key2`][v2label]
+						? sameDtOrigin.item[`key2`][v2label] + 1
 						: 1
 				} else {
 					const item = { sample: customSampleID }
@@ -289,8 +290,8 @@ function processGeneVariantSamples(map, bins, data, samplesMap, ds) {
 						item.key0 = item.val0 = dt2label[v2.dt]
 					}
 
-					item[`key2`] = mclass[v2.class].label
-					item[`val2`] = mclass[v2.class].label
+					item[`key2`] = v2label
+					item[`val2`] = v2label
 					processedValues.push({ value: v2, item })
 				}
 			}


### PR DESCRIPTION
## Description

For geneVariant term, a label property is now added to each mutation object on the server-side. This label will either be a custom label specified in `cohort.termdb.mclass` in dataset file, or the standard mclass label from `common.js`.

Barchart, scatter plot, and geneVariant groupsetting/tvs have been updated to use this new label property.

Can test by using [barchart](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22}}}]}) and [scatter plot](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:{%22term%22:%20{%22gene%22:%20%22TP53%22,%20%22type%22:%20%22geneVariant%22}}}]}) in mbmeta dataset, which specifies custom mclass labels. Can also test labels in geneVariant groupsetting by editing geneVariant term in barchart. Can also test labels in geneVariant tvs by adding geneVariant term to global filter.

Also fixed issue with fake origins being used from data file (see fake origin annotations in mbmeta CNV data file). Now, only origins from data file will be used if the dt has origins defined in `assayAvailability` in dataset. Can see this fix by comparing [scatter plot](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22Methylome%20TSNE%22,%22colorTW%22:{%22term%22:%20{%22gene%22:%20%22TP53%22,%20%22type%22:%20%22geneVariant%22}}}]}) in this branch and on master. Now there is no `Somatic CNV` section in the legend.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
