### PR TITLE
new block callback onAddRemoveTk and replace onsetheight usage

### DIFF
--- a/client/src/block.js
+++ b/client/src/block.js
@@ -59,6 +59,7 @@ callbacks from constructor options
 - onCoordinateChange
 - onpanning
 - onsetheight
+- onAddRemoveTk
 
 **************** METHODS
 updateruler()
@@ -143,6 +144,10 @@ export class Block {
 		this.onloadalltk_always = arg.onloadalltk_always
 		this.onpanning = arg.onpanning
 		this.onsetheight = arg.onsetheight
+		if (arg.onAddRemoveTk) {
+			if (typeof arg.onAddRemoveTk != 'function') throw 'onAddRemoveTk() not function'
+			this.onAddRemoveTk = arg.onAddRemoveTk
+		}
 		this.onCoordinateChange = arg.onCoordinateChange // argument is the rglst[]
 
 		this.exonsf = 1 // # pixel per basepair
@@ -2328,6 +2333,7 @@ seekrange(chr,start,stop) {
 		if (oldt.tr_legend) {
 			disappear(oldt.tr_legend, true)
 		}
+		if (this.onAddRemoveTk) this.onAddRemoveTk(oldt) // lack of 2nd arg for removing
 	}
 
 	deletecustomdsbyname(dsname) {
@@ -3096,6 +3102,7 @@ seekrange(chr,start,stop) {
 			default:
 				this.error('tk_load: unknown tk type')
 		}
+		if (this.onAddRemoveTk) this.onAddRemoveTk(tk, true)
 	}
 
 	cloakOn() {


### PR DESCRIPTION
## Description

closes #3217 
tested with `sjlife` and `peddep` links from block section of url.html. both works and can be saved to state and recover

sorry for delay in committing the fix. i think my changes are simpler and i reverted your previous changes hope you don't mind

this should be tested in container first
[gb manual test](http://localhost:3000/testrun.html?dir=plots&name=genomeBrowser) is fixed and all passed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
