### PR TITLE
Delete files from massSessionTrash

### DIFF
--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -582,7 +582,7 @@ async function deleteSessionFiles() {
 	const files = await fs.promises.readdir(serverconfig.cachedir_massSession)
 	try {
 		files.forEach(async file => {
-			const [massSessionDuration, sessionDaysElapsed] = await getDateDifferences(
+			const [massSessionDuration, sessionCreationDate, sessionDaysElapsed] = await getDateDifferences(
 				serverconfig.cachedir_massSession,
 				file
 			)
@@ -609,7 +609,7 @@ async function deleteTrashSessionFiles() {
 	const files = await fs.promises.readdir(serverconfig.cachedir_massSessionTrash)
 	try {
 		files.forEach(async file => {
-			const [massSessionDuration, sessionDaysElapsed] = await getDateDifferences(
+			const [massSessionDuration, sessionCreationDate, sessionDaysElapsed] = await getDateDifferences(
 				serverconfig.cachedir_massSessionTrash,
 				file
 			)
@@ -639,5 +639,5 @@ async function getDateDifferences(cachedir, file) {
 	const massSessionDuration = serverconfig.features.massSessionDuration || 30
 	const sessionDaysElapsed = Math.round((today.getTime() - fileDate.getTime()) / (1000 * 3600 * 24))
 
-	return [massSessionDuration, sessionDaysElapsed]
+	return [massSessionDuration, sessionCreationDate, sessionDaysElapsed]
 }


### PR DESCRIPTION
## Description
Closes issue #3240. Deletes the files that have been accumulating in massSessionTrash. 

Test: 
(this is assuming you have mass session file in massSessionTrash older than 60 days or two times your `serverconfig.features.massSessionDuration`.)
- Before restarting your instance, get the value from `find ~/data/cache/massSessionTrash -type f | wc -l`
- Restart your instance
- Run the command above again. Should see a decrease in the number of files. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
