### PR TITLE
Adding Rust formatting to CI

### DIFF
--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -139,7 +139,7 @@ jobs:
           cd rust
           rustup component add clippy
           echo "Running Clippy lints (warnings only, will not fail the build)..."
-          cargo clippy || echo "::warning::Clippy lints found issues. Please run 'cargo clippy' locally to fix them."
+          cargo clippy -- -D warnings || echo "::warning::Clippy lints found issues. Please run 'cargo clippy' locally to fix them."
 
       - name: 🔎 Rust unit tests
         if: contains(env.WS_TO_TEST, 'rust')

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -139,7 +139,7 @@ jobs:
           cd rust
           rustup component add clippy
           echo "Running Clippy lints (warnings only, will not fail the build)..."
-          cargo clippy -- -D warnings || echo "::warning::Clippy lints found issues. Please run 'cargo clippy' locally to fix them."
+          cargo clippy || echo "::warning::Clippy lints found issues. Please run 'cargo clippy' locally to fix them."
 
       - name: 🔎 Rust unit tests
         if: contains(env.WS_TO_TEST, 'rust')

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -124,6 +124,13 @@ jobs:
         with:
           override: true
 
+      - name: Format Rust code
+        if: contains(env.WS_TO_TEST, 'rust')
+        run: |
+          cd rust
+          rustup component add rustfmt
+          cargo fmt --all -- --check
+
       - name: 🔎 Rust unit tests
         if: contains(env.WS_TO_TEST, 'rust')
         run: |

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -132,6 +132,15 @@ jobs:
           echo "Checking Rust formatting (warnings only, will not fail the build)..."
           cargo fmt --all -- --check || echo "::warning::Rust formatting issues found. Please run 'cargo fmt' locally."
 
+      - name: Run Clippy (warnings only)
+        if: contains(env.WS_TO_TEST, 'rust')
+        continue-on-error: true  # This makes the step always pass
+        run: |
+          cd rust
+          rustup component add clippy
+          echo "Running Clippy lints (warnings only, will not fail the build)..."
+          cargo clippy -- -D warnings || echo "::warning::Clippy lints found issues. Please run 'cargo clippy' locally to fix them."
+
       - name: 🔎 Rust unit tests
         if: contains(env.WS_TO_TEST, 'rust')
         run: |

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -124,23 +124,6 @@ jobs:
         with:
           override: true
 
-      - name: Format Rust code
-        if: contains(env.WS_TO_TEST, 'rust')
-        continue-on-error: true  # This makes the step always pass
-        run: |
-          cd rust
-          echo "Checking Rust formatting (warnings only, will not fail the build)..."
-          cargo fmt --all -- --check || echo "::warning::Rust formatting issues found. Please run 'cargo fmt' locally."
-
-      - name: Run Clippy (warnings only)
-        if: contains(env.WS_TO_TEST, 'rust')
-        continue-on-error: true  # This makes the step always pass
-        run: |
-          cd rust
-          rustup component add clippy
-          echo "Running Clippy lints (warnings only, will not fail the build)..."
-          cargo clippy -- -D warnings || echo "::warning::Clippy lints found issues. Please run 'cargo clippy' locally to fix them."
-
       - name: 🔎 Rust unit tests
         if: contains(env.WS_TO_TEST, 'rust')
         run: |

--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -126,10 +126,11 @@ jobs:
 
       - name: Format Rust code
         if: contains(env.WS_TO_TEST, 'rust')
+        continue-on-error: true  # This makes the step always pass
         run: |
           cd rust
-          rustup component add rustfmt
-          cargo fmt --all -- --check
+          echo "Checking Rust formatting (warnings only, will not fail the build)..."
+          cargo fmt --all -- --check || echo "::warning::Rust formatting issues found. Please run 'cargo fmt' locally."
 
       - name: 🔎 Rust unit tests
         if: contains(env.WS_TO_TEST, 'rust')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Adding Rust formatting to CI

--- a/rust/src/readHDF5.rs
+++ b/rust/src/readHDF5.rs
@@ -109,7 +109,7 @@ fn query_gene(hdf5_filename: String, gene_name: String) -> Result<()> {
 ///
 /// # Error Handling
 /// Handles file access issues, missing datasets, and gene not found scenarios
-fn query_gene_dense(hdf5_filename: String, gene_name: String) -> Result<()> {
+fn query_gene_dense(hdf5_filename: String, gene_name: String                     ) -> Result<()> {
     let file = match File::open(hdf5_filename) {
         Ok(f) => f,
         Err(err) => {

--- a/rust/src/readHDF5.rs
+++ b/rust/src/readHDF5.rs
@@ -109,7 +109,7 @@ fn query_gene(hdf5_filename: String, gene_name: String) -> Result<()> {
 ///
 /// # Error Handling
 /// Handles file access issues, missing datasets, and gene not found scenarios
-fn query_gene_dense(hdf5_filename: String, gene_name: String                     ) -> Result<()> {
+fn query_gene_dense(hdf5_filename: String, gene_name: String) -> Result<()> {
     let file = match File::open(hdf5_filename) {
         Ok(f) => f,
         Err(err) => {

--- a/rust/src/readHDF5.rs
+++ b/rust/src/readHDF5.rs
@@ -109,7 +109,7 @@ fn query_gene(hdf5_filename: String, gene_name: String) -> Result<()> {
 ///
 /// # Error Handling
 /// Handles file access issues, missing datasets, and gene not found scenarios
-fn query_gene_dense(hdf5_filename: String, gene_name: String) -> Result<()> {
+fn query_gene_dense(hdf5_filename: String       , gene_name: String) -> Result<()> {
     let file = match File::open(hdf5_filename) {
         Ok(f) => f,
         Err(err) => {


### PR DESCRIPTION
## Description
Adding Rust formatting to CI. Will only display as warnings and won't fail the workflow.


## Checklist
[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
