### PR TITLE
use flag requiresHardcodeCnvOnlyFlag to prevent cnv seg from showing …

### DIFF
--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2584,6 +2584,13 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					? await getGenecnvByTerm(ds, tw.term, genome, q)
 					: []
 
+			if (!mlst) continue // cnv seg query now may return undefined
+
+			//////////////////////////////////////
+			// MUST NOT QUIT when mlst.length==0!
+			//////////////////////////////////////
+			// if ds has assayAvailability, on empty mlst, it should proceed to add wt status to all assayed samples
+
 			for (const m of mlst) {
 				/*
 				m={
@@ -2913,6 +2920,13 @@ async function getCnvByTw(ds, tw, genome, q) {
 	/* tw.term.type is "geneVariant"
 	tw.q{} carries optional cutoffs (max length and min value) to filter cnv segments
 	*/
+
+	if (ds.queries.cnv.requiresHardcodeCnvOnlyFlag && !q.hardcodeCnvOnly) {
+		// in gdc, the cnv segment datatype can only work for "cnv tool" but not any other case; this allow it to be disabled in oncomatrix and summary tool; these tools will use geneCnv instead
+		// later if ever cnv seg must be used for such in gdc, need a different solution
+		return
+	}
+
 	const arg = {
 		addFormatValues: true,
 		filter0: q.filter0, // hidden filter

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -180,7 +180,7 @@ async function get_ds(q, genome) {
 	return ds
 }
 
-async function load_driver(q, ds) {
+export async function load_driver(q, ds) {
 	// various bits of data to be appended as keys to result{}
 	// what other loaders can be if not in ds.queries?
 
@@ -189,13 +189,6 @@ async function load_driver(q, ds) {
 		const p = ds.queries.singleSampleGenomeQuantification[q.singleSampleGenomeQuantification.dataType]
 		if (!p) throw 'invalid dataType'
 		return await p.get(q.singleSampleGenomeQuantification.sample, q.devicePixelRatio)
-	}
-
-	if (q.NIdata) {
-		if (!ds.queries.NIdata) throw 'brainImaging not supported on this dataset'
-		const p = ds.queries.NIdata[q.NIdata.dataType]
-		if (!p) throw 'invalid dataType'
-		return await p.get(q.NIdata.sample, q.l, q.f, q.t)
 	}
 
 	if (q.singleSampleGbtk) {
@@ -252,19 +245,11 @@ async function load_driver(q, ds) {
 				if (d) result.skewer.push(...d)
 			}
 
-			if (ds.queries.geneCnv && !q.hardcodeCnvOnly) {
-				// just a test; can allow gene-level cnv to be indicated as leftlabel
-				// can disable this step if not to show it in skewer tk
-				// trouble is that it's using case id as event.samples[].sample_id
-				// compared to ssm where it is sample id for m.samples[].sample_id
-				const lst = await query_geneCnv(q, ds)
-				// this is not appended to result.skewer[]
-				result.geneCnv = lst
-			}
-
 			if (ds.queries.cnv) {
 				if (q.hiddenmclass?.has(dtcnv)) {
 					// cnv is hidden, do not load
+				} else if (ds.queries.cnv.requiresHardcodeCnvOnlyFlag && !q.hardcodeCnvOnly) {
+					// the required flag is missing. do not load
 				} else {
 					result.cnv = await ds.queries.cnv.get(q)
 				}
@@ -374,8 +359,6 @@ function filter_data(q, result) {
 		result.skewer = newskewer
 	}
 
-	if (result.genecnvAtsample) {
-	}
 	// other sample-level data types that need filtering
 }
 

--- a/server/src/test/mds3.unit.spec.js
+++ b/server/src/test/mds3.unit.spec.js
@@ -1,0 +1,67 @@
+import tape from 'tape'
+import { load_driver } from '../mds3.load.js'
+
+tape('\n', function (test) {
+	test.pass('-***- mds3.load specs -***-')
+	test.end()
+})
+
+tape('load_driver()', async function (test) {
+	// t.throws() cannot handle async function
+	try {
+		await load_driver({}, {})
+	} catch (e) {
+		test.equal(e, 'do not know what client wants', 'should throw')
+	}
+
+	const q = { forTrack: 1, skewer: 1, rglst: [{ chr: '1', start: 1, stop: 10 }] }
+
+	// ds without requiresHardcodeCnvOnlyFlag flag and allows cnv to coshow with skewer data
+	{
+		// should return both skewer and cnv
+		const r = await load_driver(q, ds)
+		test.equal(r.skewer.length, 1, 'r.skewer.length=1')
+		test.equal(r.cnv.length, 1, 'r.cnv.length=1')
+	}
+	{
+		// q.hardcodeCnvOnly=1 and should only return cnv
+		const r = await load_driver(Object.assign({ hardcodeCnvOnly: 1 }, q), ds)
+		test.equal(r.skewer.length, 0, 'r.skewer.length=0 when hardcodeCnvOnly=1')
+		test.equal(r.cnv.length, 1, 'r.cnv.length=1')
+	}
+
+	// ds change!
+	ds.queries.cnv.requiresHardcodeCnvOnlyFlag = true
+	{
+		// should only return skewer. cnv will not be returned
+		const r = await load_driver(q, ds)
+		test.equal(r.skewer.length, 1, 'r.skewer.length=1')
+		test.false(r.cnv, 'r.cnv is undefined when requiresHardcodeCnvOnlyFlag is set but q.hardcodeCnvOnly is not set')
+	}
+	{
+		// should only return cnv but not skewer
+		const r = await load_driver(Object.assign({ hardcodeCnvOnly: 1 }, q), ds)
+		test.equal(r.skewer.length, 0, 'r.skewer.length=0 when hardcodeCnvOnly=1')
+		test.equal(r.cnv.length, 1, 'r.cnv.length=1')
+	}
+
+	test.end()
+})
+
+///////// constants
+const ds = {
+	queries: {
+		snvindel: {
+			byrange: {
+				get: () => {
+					return [{ chr: '1', pos: 5 }]
+				}
+			}
+		},
+		cnv: {
+			get: () => {
+				return [{}]
+			}
+		}
+	}
+}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -600,9 +600,13 @@ type CnvSegment = {
 	cnvMaxCopynumber?: number
 	 */
 
-	/** if cnv is using qualitative categories. ui will show checkboxes for each category that's present
-	cnvCategories?:string[]
+	/** quick fix for gdc cnv tool:
+	if not set, mds3 tk & matrix will load cnv segments and show them together with ssm & fusion
+	if set: 
+		- for mds3 tk loading via mds3.load.js, only when tk.hardcodeCnvOnly=true, this will be loaded and shown
+		- for others using mayGetGeneVariantData(), this is always disabled, as request won't have this flag
 	*/
+	requiresHardcodeCnvOnlyFlag?: true
 }
 
 /*


### PR DESCRIPTION
…in mds3 tk

## Description

closes #3249 
tested to work with both sjpp master and https://github.com/stjude/sjpp/pull/782 (gdc cnvseg api query)

- gdc ds with the new cnv flag will prevent cnv seg from showing up in lollipop http://localhost:3000/?genome=hg38&gene=atm&mds3=GDC
- while ash without the flag allows cnvseg to show in lollipop http://localhost:3000/?genome=hg38&gene=bcr&mds3=ASH
- the mock gdc cnv seg can now show up in http://localhost:3000/?genome=hg38&block=1&position=chr11:108195437-108267444&mds3=GDC&cnvonly=1 (allows me to test it without gdc vpn)

integration tests passes in both sjpp branches
no tsc err
new unit test created for legacy mds3 code to cover newly added logic
safe to merge

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
