### PR TITLE
Move cache subdirectory init code into a separate file

### DIFF
--- a/server/src/Cache.ts
+++ b/server/src/Cache.ts
@@ -16,14 +16,12 @@ export class Cache {
 		{ dir: 'massSession' },
 		/** DELETE THIS after process for deleting mass session files moved into production */
 		{ dir: 'massSessionTrash' },
-		/** In use? */
+		/** Used by snplst and snplocus terms */
 		{
 			dir: 'snpgt',
 			fileNameRegexp: /[^\w]/, // client-provided cache file name matching with this are denied
 			sampleColumn: 6 // in cache file, sample column starts from 7th column
-		},
-		/** TODO: description */
-		{ dir: 'ssid' }
+		}
 	]
 
 	async init() {

--- a/server/src/Cache.ts
+++ b/server/src/Cache.ts
@@ -1,0 +1,62 @@
+import serverconfig from './serverconfig.js'
+import fs from 'fs'
+import path from 'path'
+
+export class Cache {
+	readonly defaultCacheDirs = [
+		/** Temporarily stores sliced bam files */
+		{ dir: 'bam' },
+		/** In use? */
+		{ dir: 'genome' },
+		/** Temporarily stores pickle files for gsea */
+		{ dir: 'gsea' },
+		/** to ensure temp files saved in previous server session are accessible in current session
+		 * must use consistent dir name but not random dir name that changes from last server boot
+		 */
+		{ dir: 'massSession' },
+		/** DELETE THIS after process for deleting mass session files moved into production */
+		{ dir: 'massSessionTrash' },
+		/** In use? */
+		{
+			dir: 'snpgt',
+			fileNameRegexp: /[^\w]/, // client-provided cache file name matching with this are denied
+			sampleColumn: 6 // in cache file, sample column starts from 7th column
+		},
+		/** TODO: description */
+		{ dir: 'ssid' }
+	]
+
+	async init() {
+		// create sub directories under cachedir, and register path in serverconfig
+		for (const dir of this.defaultCacheDirs) {
+			if (Object.keys(dir).length > 1) {
+				serverconfig[`cachedir_${dir.dir}`] = {
+					dir: await this.mayCreateSubdirInCache(dir.dir),
+					fileNameRegexp: dir.fileNameRegexp || '',
+					sampleColumn: dir.sampleColumn || 0
+				}
+			}
+			serverconfig[`cachedir_${dir.dir}`] = await this.mayCreateSubdirInCache(dir.dir)
+		}
+	}
+
+	/** Check if the subdir exists. If not create. */
+	async mayCreateSubdirInCache(subdir: string) {
+		const dir = path.join(serverconfig.cachedir, subdir)
+		try {
+			await fs.promises.stat(dir)
+		} catch (e: any) {
+			if (e.code == 'ENOENT') {
+				try {
+					// If no information is returned, make dir
+					await fs.promises.mkdir(dir)
+				} catch (err) {
+					throw `cannot make sub cache ${subdir}: ${err}`
+				}
+			} else {
+				throw `error stating sub cache ${subdir}`
+			}
+		}
+		return dir
+	}
+}

--- a/server/src/Cache.ts
+++ b/server/src/Cache.ts
@@ -28,13 +28,15 @@ export class Cache {
 		// create sub directories under cachedir, and register path in serverconfig
 		for (const dir of this.defaultCacheDirs) {
 			if (Object.keys(dir).length > 1) {
-				serverconfig[`cachedir_${dir.dir}`] = {
+				//cache objs are defined as cache_<dir> in serverconfig
+				serverconfig[`cache_${dir.dir}`] = {
 					dir: await this.mayCreateSubdirInCache(dir.dir),
 					fileNameRegexp: dir.fileNameRegexp || '',
 					sampleColumn: dir.sampleColumn || 0
 				}
 			}
-			serverconfig[`cachedir_${dir.dir}`] = await this.mayCreateSubdirInCache(dir.dir)
+			// cache dirs are defined as cachedir_<dir> in serverconfig
+			else serverconfig[`cachedir_${dir.dir}`] = await this.mayCreateSubdirInCache(dir.dir)
 		}
 	}
 


### PR DESCRIPTION
## Description
This addresses the first step in issue #3247. The intent is to create a simple implementation of a Cache class to build on later. Once we are comfortable with this, I can move on to implementing the `setInterval()` file deletion for the gsea subdirectory with `serverconfig.cacheMonitor.gsea` and then continue on with the rest of the plan.  


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
