### PR TITLE
Added summary report to charts that opens the report plots for a country

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -208,6 +208,11 @@ function getChartTypeList(self, state) {
 			clickTo: self.loadChartSpecificMenu
 		},
 		{
+			label: 'Summary Report',
+			chartType: 'summaryReport',
+			clickTo: self.loadChartSpecificMenu
+		},
+		{
 			label: 'Cumulative Incidence',
 			chartType: 'cuminc',
 			clickTo: self.showTree_select1term,

--- a/client/plots/summaryReport.js
+++ b/client/plots/summaryReport.js
@@ -1,0 +1,32 @@
+import { fillTermWrapper } from '#termsetting'
+
+export class SummaryReport {
+	type = 'summaryReport'
+}
+
+export async function makeChartBtnMenu(holder, chartsInstance) {
+	const countryTW = { id: 'ISOcode' }
+	await fillTermWrapper(countryTW, chartsInstance.app.vocabApi)
+
+	const menuDiv = holder
+		.append('div')
+		.style('overflow', 'auto')
+		.style('height', '400px')
+		.attr('class', 'sjpp_show_scrollbar')
+	menuDiv.append('div').style('padding', '5px').style('color', 'gray').text('Select country:')
+	for (const value in countryTW.term.values) {
+		const country = countryTW.term.values[value].label
+		menuDiv
+			.append('button')
+			.style('margin', '5px')
+			.style('padding', '10px 15px')
+			.style('border-radius', '20px')
+			.style('border-color', '#ededed')
+			.style('display', 'block')
+			.text(country)
+			.on('click', () => {
+				window.open('summary.html?country=' + country, '_blank')
+				chartsInstance.dom.tip.hide()
+			})
+	}
+}


### PR DESCRIPTION
## Description
Added summary report to charts that opens the report plots for a country. In order to test it please access the summary report from the sjcares portal. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/819)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
