### PR TITLE
modify existing lollipop launcher for GDC cnv tool

### DIFF
--- a/client/dom/genesearch.ts
+++ b/client/dom/genesearch.ts
@@ -5,9 +5,22 @@ import { invalidcoord, string2pos } from '#src/coord'
 import type { ClientCopyGenome } from '../types/global'
 
 /*
-*********************************** EXPORT
+exports:
+
 addGeneSearchbox()
 string2variant()
+
+typical usage:
+
+	const arg={
+		genome: <>,
+		row: <>,
+		callback: async ()=>{
+			doAction(result)
+		}
+	}
+	const result=addGeneSearchbox(arg)
+
 
 
 TODO
@@ -16,8 +29,7 @@ TODO
 -- dedup code with block.js
 -- dedup code with app header
 -- unify help message from gdc bam slicing ui and termsetting.snplst
-
-***********************************/
+*/
 
 type GeneSearchBoxArg = {
 	/** required. menu instance to show list of matching genes */

--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -3,19 +3,26 @@ import { Menu } from '#dom/menu'
 import { dofetch3 } from '#common/dofetch'
 import blockinit from '#src/block.init'
 
-/*
+/* designed to work for lollipop & cnv apps in GDC Analysis Tools Framework
 
 test with http://localhost:3000/example.gdc.html
-runpp({ geneSearch4GDCmds3:true })
 
-designed to work for ssm lollipop app in GDC Analysis Tools Framework
+to launch lollipop:
+	runpp({ geneSearch4GDCmds3:true })
+to launch cnv tool:
+	runpp({ geneSearch4GDCmds3:{hardcodeCnvOnly:1} })
+
 
 ********* parameters
 
 arg = {}
-	runpp() argument object
-	geneSearch4GDCmds3:{ postRender(), onloadalltk_always() }
-		optional callbacks for testing
+	// runpp() argument object
+	geneSearch4GDCmds3:{}
+		.postRender()
+		.onloadalltk_always() }
+			// optional callbacks for testing
+		.hardcodeCnvOnly:1
+			// if true, launches cnv tool (gene search box allows searching both gene/coord and yields coord)
 	.allow2selectSamples:{}
 		pass to mds3 tk object to enable sample selection
 	.geneSymbol:str
@@ -69,7 +76,11 @@ export async function init(arg, holder, genomes) {
 	const coordInput = addGeneSearchbox(searchOpt)
 
 	// must declare this variable first then call postRender(), other wise it can crash for accessing variable before initialization...
-	let selectedIsoform
+	// saves user-selected isoform from <input>; on cohort change, this value will be used so the lollipop of the same gene can be auto updated
+	let selectedIsoform // str
+	// saves user-selected region
+	let selectedRegion // {chr,start,stop}
+
 	if (typeof arg.geneSearch4GDCmds3.postRender == 'function') {
 		// supports testing
 		await arg.geneSearch4GDCmds3.postRender({ tip })
@@ -81,6 +92,7 @@ export async function init(arg, holder, genomes) {
 	}
 
 	async function launchView(triggeredByInput = true, isoform) {
+		console.log(triggeredByInput, isoform)
 		let gmmode = 'exon only'
 		if (isoform) {
 			selectedIsoform = isoform

--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -1,16 +1,21 @@
-import { addGeneSearchbox } from '../dom/genesearch.ts'
-import { Menu } from '#dom/menu'
+import { addGeneSearchbox, Menu } from '#dom'
+import { first_genetrack_tolist } from '../common/1stGenetk'
 import { dofetch3 } from '#common/dofetch'
 import blockinit from '#src/block.init'
 
 /* designed to work for lollipop & cnv apps in GDC Analysis Tools Framework
+https://github.com/NCI-GDC/gdc-frontend-framework/blob/develop/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx
 
 test with http://localhost:3000/example.gdc.html
 
 to launch lollipop:
 	runpp({ geneSearch4GDCmds3:true })
 to launch cnv tool:
-	runpp({ geneSearch4GDCmds3:{hardcodeCnvOnly:1} })
+	runpp({
+		geneSearch4GDCmds3:{
+			hardcodeCnvOnly:1
+		}
+	})
 
 
 ********* parameters
@@ -24,22 +29,25 @@ arg = {}
 		.hardcodeCnvOnly:1
 			// if true, launches cnv tool (gene search box allows searching both gene/coord and yields coord)
 	.allow2selectSamples:{}
-		pass to mds3 tk object to enable sample selection
+		// pass to mds3 tk object to enable sample selection
 	.geneSymbol:str
-		default gene to fill into search box
+		// default gene to fill into search box
+	.state{}
+		// for auto updating app on GFF cohort change
+	.tracks[]
+		// for future use, allows to add extra annotation tracks in addition to mds3
 holder
 genomes = { hg38 : {} }
 
 
 ********* returns
 
-{ update() }
+api object. required to work with react wrapper
 
-this may work with react wrapper?
-
-
-TODO make it a generic mechanism to type in gene and launch any tk
+TODO 
+make it a generic mechanism to type in gene and launch any tk
 the hardcoded "GDC mutations" phrase should be configurable as well...
+- unlikely given all the gdc specific logic
 */
 
 const gdcGenome = 'hg38'
@@ -49,6 +57,10 @@ const tip = new Menu({ padding: '' })
 export async function init(arg, holder, genomes) {
 	const genome = genomes[gdcGenome]
 	if (!genome) throw gdcGenome + ' missing'
+	if (arg.geneSearch4GDCmds3.onloadalltk_always && typeof arg.geneSearch4GDCmds3.onloadalltk_always != 'function')
+		throw 'arg.geneSearch4GDCmds3.onloadalltk_always not function'
+	if (arg.geneSearch4GDCmds3.postRender && typeof arg.geneSearch4GDCmds3.postRender != 'function')
+		throw 'arg.geneSearch4GDCmds3.postRender not function'
 
 	// assume that there will only be one main div within a given holder
 	holder.selectAll('.sja_lollipop_holder').remove()
@@ -59,7 +71,9 @@ export async function init(arg, holder, genomes) {
 	geneInputDiv
 		.append('div')
 		.text(
-			'To view GDC mutations on a gene, enter one of gene symbol (MYC), alias (c-Myc), GENCODE accession (ENSG00000136997, ENST00000621592), or RefSeq accession (NM_002467).'
+			arg.geneSearch4GDCmds3.hardcodeCnvOnly
+				? 'To view GDC CNV segments over a gene or region, enter genomic position (chr11:108195437-108267444), dbSNP accesion, or gene name (MYC).'
+				: 'To view GDC mutations on a gene, enter one of gene symbol (MYC), alias (c-Myc), GENCODE accession (ENSG00000136997, ENST00000621592), or RefSeq accession (NM_002467).'
 		)
 
 	// second row, display graph
@@ -69,66 +83,105 @@ export async function init(arg, holder, genomes) {
 		genome,
 		tip,
 		row: geneInputDiv,
-		searchOnly: 'gene',
 		callback: launchView,
 		geneSymbol: arg.geneSymbol
 	}
+	if (!arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
+		// not in cnv mode; is in lollipop mode to show coding ssm over gene coding exons, apply this flag
+		searchOpt.searchOnly = 'gene'
+	}
 	const coordInput = addGeneSearchbox(searchOpt)
 
-	// must declare this variable first then call postRender(), other wise it can crash for accessing variable before initialization...
-	// saves user-selected isoform from <input>; on cohort change, this value will be used so the lollipop of the same gene can be auto updated
-	let selectedIsoform // str
-	// saves user-selected region
-	let selectedRegion // {chr,start,stop}
+	/**********************
+	must declare this variable first then call postRender(), other wise it can crash for accessing variable before initialization...
+	saves user-selected isoform (string) or region ({chr/start/stop}) from <input>;
+	on cohort change, this value will be used so the lollipop of the same gene can be auto updated
+	**********************/
+	let userSelection
 
-	if (typeof arg.geneSearch4GDCmds3.postRender == 'function') {
-		// supports testing
-		await arg.geneSearch4GDCmds3.postRender({ tip })
-	}
+	await arg.geneSearch4GDCmds3.postRender?.({ tip }) // supports testing
 
 	if (arg.state) {
-		if (arg.state.isoform) launchView(false, arg.state.isoform)
+		// this is only present when the app auto updates from GFF cohort change
+		if (arg.state.userSelection) launchView(false, arg.state.userSelection)
 		delete arg.state
 	}
 
-	async function launchView(triggeredByInput = true, isoform) {
-		console.log(triggeredByInput, isoform)
-		let gmmode = 'exon only'
-		if (isoform) {
-			selectedIsoform = isoform
+	/**************
+	parameters:
+		triggeredByInput
+			if true, func is called on user selecting something from <input>
+			if false, is from api.update()
+		userSelection
+			when user selects from <input>, this is undefined
+			otherwise is from api.update()
+	***************/
+	async function launchView(triggeredByInput = true, userSelection) {
+		const pa = {
+			// param for instantiating block
+			genome,
+			holder: graphDiv,
+			gmmode: 'exon only',
+			nobox: 1,
+			hide_dsHandles: arg.hide_dsHandles,
+			onloadalltk_always: arg.geneSearch4GDCmds3.onloadalltk_always
+		}
+		if (arg.tracks) {
+			pa.tklst = arg.tracks
 		} else {
-			if (!coordInput.geneSymbol) {
-				if (triggeredByInput) throw 'geneSymbol missing'
-				// updates of arg.filter0 should still render
-				// return
+			// generate mds3 tk
+			const tk = { type: 'mds3', dslabel: gdcDslabel, allow2selectSamples: arg.allow2selectSamples }
+			pa.tklst = [tk]
+			if (arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
+				tk.hardcodeCnvOnly = 1
+				// also block is in genome browser mode
+				delete pa.gmmode
+				first_genetrack_tolist(pa.genome, pa.tklst)
 			}
+		}
 
-			// a bit inefficient but must retrieve all gene models to find out if any is coding or all are noncoding
-			const gmlst = (await dofetch3(`genelookup?deep=1&input=${coordInput.geneSymbol}&genome=${gdcGenome}`)).gmlst
-			if (!Array.isArray(gmlst) || gmlst.length == 0) throw 'gmlst is not non-empty array'
-			selectedIsoform = isoform || getSelectedIsoform(coordInput, gmlst)
-			if (gmlst.some(i => i.coding)) gmmode = 'protein'
+		if (userSelection) {
+			// recovering from gff cohort change
+			if (arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
+				if (typeof userSelection != 'object') throw 'userSelection not object when pa.block is true'
+				pa.chr = userSelection.chr
+				pa.start = userSelection.start
+				pa.stop = userSelection.stop
+				if (!pa.chr || !Number.isInteger(pa.start) || !Number.isInteger(pa.stop))
+					throw 'userSelection not {chr,start,stop}'
+			} else {
+				if (typeof userSelection != 'string') throw 'userSelection should be string when pa.block is not true'
+				pa.query = userSelection
+			}
+		} else {
+			// user selected gene/region from <input>
+			if (arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
+				if (!coordInput.chr || !Number.isInteger(coordInput.start) || !Number.isInteger(coordInput.stop)) {
+					if (triggeredByInput) throw 'coordInput.chr/start/stop missing' // ??
+				}
+				pa.chr = coordInput.chr
+				pa.start = coordInput.start
+				pa.stop = coordInput.stop
+			} else {
+				if (!coordInput.geneSymbol) {
+					if (triggeredByInput) throw 'coordInput.geneSymbol missing' // ??
+					// updates of arg.filter0 should still render
+				}
+				// a bit inefficient but must retrieve all gene models to find out if any is coding or all are noncoding
+				const gmlst = (await dofetch3(`genelookup?deep=1&input=${coordInput.geneSymbol}&genome=${gdcGenome}`)).gmlst
+				if (!Array.isArray(gmlst) || gmlst.length == 0) throw 'gmlst is not non-empty array'
+				pa.query = getSelectedIsoform(coordInput, gmlst)
+				if (gmlst.some(i => i.coding)) pa.gmmode = 'protein'
+			}
 		}
 
 		graphDiv.selectAll('*').remove()
 
-		const pa = {
-			query: selectedIsoform,
-			genome,
-			holder: graphDiv,
-			gmmode,
-			hide_dsHandles: arg.hide_dsHandles,
-			tklst: arg.tracks
-				? arg.tracks
-				: [{ type: 'mds3', dslabel: gdcDslabel, allow2selectSamples: arg.allow2selectSamples }]
-		}
-
-		if (typeof arg.geneSearch4GDCmds3.onloadalltk_always == 'function') {
-			// supports testing
-			pa.onloadalltk_always = arg.geneSearch4GDCmds3.onloadalltk_always
-		}
-
-		return await blockinit(pa)
+		// launch protein view
+		if (!arg.geneSearch4GDCmds3.hardcodeCnvOnly) return await blockinit(pa) // does it need to return?
+		// launch genome browser view
+		const _ = await import('../src/block')
+		return new _.Block(pa)
 	}
 
 	const api = {
@@ -136,7 +189,7 @@ export async function init(arg, holder, genomes) {
 			Object.assign(arg, _arg)
 			launchView(false)
 		},
-		getState: () => ({ isoform: selectedIsoform })
+		getState: () => ({ userSelection })
 	}
 	return api
 }

--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -183,7 +183,7 @@ tape('GDC - allow2selectSamples', test => {
 	testAllow2selectSamples('hg38', 'IDH1', 'GDC', test)
 })
 
-tape('geneSearch4GDCmds3', async test => {
+tape.only('geneSearch4GDCmds3', async test => {
 	// enter a gene name into search box, find the gene match in tooltip, select matched gene to launch block with gdc track
 	const holder = getHolder()
 	const gene = 'HOXA1'
@@ -211,7 +211,7 @@ tape('geneSearch4GDCmds3', async test => {
 
 		const blockDiv = await detectOne({ elem: blockHolder, selector: '.sja_Block_div' })
 		test.ok(blockDiv, 'A block is rendered')
-		if (test._ok) holder.remove()
+		//if (test._ok) holder.remove()
 		test.end()
 	}
 })

--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -22,6 +22,7 @@ GDC - KRAS SSM ID
 GDC - ssm by range
 GDC - allow2selectSamples
 geneSearch4GDCmds3
+geneSearch4GDCmds3 hardcodeCnvOnly
 GDC - gene hoxa1 - Disco button
 Clinvar - gene kras
 GDC - sample summaries table, create subtrack (tk.filterObj)
@@ -183,7 +184,7 @@ tape('GDC - allow2selectSamples', test => {
 	testAllow2selectSamples('hg38', 'IDH1', 'GDC', test)
 })
 
-tape.only('geneSearch4GDCmds3', async test => {
+tape('geneSearch4GDCmds3', async test => {
 	// enter a gene name into search box, find the gene match in tooltip, select matched gene to launch block with gdc track
 	const holder = getHolder()
 	const gene = 'HOXA1'
@@ -208,6 +209,34 @@ tape.only('geneSearch4GDCmds3', async test => {
 		const geneHitDivs = await detectGte({ elem: arg.tip.d.node(), selector: '.sja_menuoption', count: 1 })
 		test.equal(geneHitDivs[0].innerHTML, gene, 'Gene search found ' + gene)
 		geneHitDivs[0].dispatchEvent(new Event('click'))
+
+		const blockDiv = await detectOne({ elem: blockHolder, selector: '.sja_Block_div' })
+		test.ok(blockDiv, 'A block is rendered')
+		if (test._ok) holder.remove()
+		test.end()
+	}
+})
+
+tape.skip('geneSearch4GDCmds3 hardcodeCnvOnly', async test => {
+	// enter a gene name into search box, find the gene match in tooltip, select matched gene to launch block with gdc track
+	const holder = getHolder()
+	await runproteinpaint({
+		holder,
+		noheader: 1,
+		geneSearch4GDCmds3: { hardcodeCnvOnly: 1, postRender }
+	})
+	async function postRender(arg) {
+		// arg={tip}; convenient method to provide the tooltip used by gene search <input> (remove some hassle of finding this tooltip)_
+		const searchBox = await detectOne({ elem: holder, selector: '.sja_genesearchinput' })
+		test.ok(searchBox, 'Gene search box is made')
+
+		const blockHolder = await detectOne({ elem: holder, selector: '.sja_geneSearch4GDCmds3_blockdiv' })
+		test.ok(blockHolder, 'Block holder is made')
+
+		// enter gene name and trigger search
+		searchBox.value = 'chr11:108195437-108267444'
+		searchBox.dispatchEvent(new Event('Enter'))
+		// FIXME this cannot trigger sja_Block_div to be made, making the test fail
 
 		const blockDiv = await detectOne({ elem: blockHolder, selector: '.sja_Block_div' })
 		test.ok(blockDiv, 'A block is rendered')


### PR DESCRIPTION
## Description

closes #3259 

please test with https://github.com/stjude/sjpp/pull/782

see the lollipop and cnv tool entry ui side by side at http://localhost:3000/example.gdc.html
<img width="734" alt="image" src="https://github.com/user-attachments/assets/03d4c523-fad6-4552-9472-cc3158ed3769" />

added a manual test but doesn't work

allows to extend [ProteinPaint Wrapper](https://github.com/NCI-GDC/gdc-frontend-framework/blob/develop/packages/portal-proto/src/features/proteinpaint/ProteinPaintWrapper.tsx)

and need to verify it works with GFF and can relaunch on cohort change

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
