### PR TITLE
bug fix not to erroneously use value=0 for categorical cnv

### DIFF
--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2503,11 +2503,12 @@ async function addCnvGetter(ds, genome) {
 								sampleObj.formatK2v = j.mattr
 							}
 						}
+
+						j.ssm_id = [r.chr, j.start, j.stop, j.class, j.value, j.sample].join(ssmIdFieldsSeparator)
+
 						delete j.sample
 						j.samples = [sampleObj]
 						j.occurrence = 1 // each cnv seg is hardcoded to only have 1 sample
-
-						j.ssm_id = [r.chr, j.start, j.stop, j.class, j.value, j.sample].join(ssmIdFieldsSeparator)
 					} else {
 						// cnv without sample
 						j.ssm_id = [r.chr, j.start, j.stop, j.class, j.value].join(ssmIdFieldsSeparator)

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -883,7 +883,7 @@ export function guessSsmid(ssmid) {
 		const [chr, _start, _stop, _class, _value] = l
 		const start = Number(_start),
 			stop = Number(_stop),
-			value = Number(_value)
+			value = _value == '' ? null : Number(_value)
 		if (Number.isNaN(start) || Number.isNaN(stop)) throw 'ssmid cnv start/stop not integer'
 		return { dt: dtcnv, l: [chr, start, stop, _class, value] }
 	}
@@ -906,7 +906,7 @@ export function guessSsmid(ssmid) {
 		const [chr, _start, _stop, _class, _value, sample] = l
 		const start = Number(_start),
 			stop = Number(_stop),
-			value = Number(_value)
+			value = _value == '' ? null : Number(_value) // if cnv not using value, must avoid `Number('')=0`
 		if (Number.isNaN(start) || Number.isNaN(stop)) throw 'ssmid cnv start/stop not integer'
 		return { dt: dtcnv, l: [chr, start, stop, _class, value, sample] }
 	}

--- a/server/src/test/mds3.unit.spec.js
+++ b/server/src/test/mds3.unit.spec.js
@@ -69,30 +69,31 @@ tape('guessSsmid()', async function (test) {
 		'should throw'
 	)
 	test.deepEqual(
-		guessSsmid('chr1__123__456__CNV_amp__1'), // cnv with value
+		guessSsmid('chr1__123__456__CNV_amp__1'),
 		{ dt: 4, l: ['chr1', 123, 456, 'CNV_amp', 1] },
-		'good cnv'
+		'cnv with value'
 	)
 	test.deepEqual(
-		guessSsmid('chr1__123__456__CNV_amp__'), // cnv with no value
-		{ dt: 4, l: ['chr1', 123, 456, 'CNV_amp', 0] },
-		'good cnv'
-	)
-	test.deepEqual(
-		guessSsmid('chr1__123__456__CNV_amp__1__sample1'), // cnv with value, with sample
+		guessSsmid('chr1__123__456__CNV_amp__1__sample1'),
 		{ dt: 4, l: ['chr1', 123, 456, 'CNV_amp', 1, 'sample1'] },
-		'good cnv'
+		'cnv with value, with sample'
 	)
 	test.deepEqual(
-		guessSsmid('chr1__123__456__CNV_amp____sample1'), // cnv with no value, with sample
-		{ dt: 4, l: ['chr1', 123, 456, 'CNV_amp', 0, 'sample1'] },
-		'good cnv'
+		guessSsmid('chr1__123__456__CNV_amp__'),
+		{ dt: 4, l: ['chr1', 123, 456, 'CNV_amp', null] },
+		'cnv with no value'
+	)
+	test.deepEqual(
+		guessSsmid('chr1__123__456__CNV_amp____sample1'),
+		{ dt: 4, l: ['chr1', 123, 456, 'CNV_amp', null, 'sample1'] },
+		'cnv with no value, with sample'
 	)
 
 	// svfusion
 	test.throws(() => guessSsmid('invalidDt__chr1__111__+__1__xx'), /ssmid dt not sv\/fusion/, 'should throw')
 	test.throws(() => guessSsmid('2__chr1__invaliPos__+__1__xx'), /ssmid svfusion position not integer/, 'should throw')
 	test.deepEqual(guessSsmid('2__chr1__123__+__1__xx'), { dt: 2, l: [2, 'chr1', 123, '+', 1, 'xx'] }, 'good fusion')
+	test.deepEqual(guessSsmid('5__chr1__123__+__1__xx'), { dt: 5, l: [5, 'chr1', 123, '+', 1, 'xx'] }, 'good sv')
 
 	test.end()
 })


### PR DESCRIPTION
## Description

test at http://localhost:3000/?genome=hg38&gene=mycn&mds3=MB_meta_analysis2

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
