### PR TITLE
Add docker-compose.yml

### DIFF
--- a/container/compose/docker-compose.yml
+++ b/container/compose/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  pp0:
+    image: ghcr.io/stjude/ppfull:2.122.0-dca7a83a7
+    container_name: container0
+    platform: linux/amd64
+    ports:
+      - "3456:3000"
+    volumes:
+      - /path/to/local/data/tp/:/home/root/pp/tp/
+      - /path/to/local/proteinpaint/container/serverconfig.json:/home/root/pp/app/active/serverconfig.json
+      - /path/to/local/proteinpaint/container/dataset:/home/root/pp/app/active/dataset
+      - /path/to/local/proteinpaint/container/public:/home/root/pp/app/active/public
+    restart: unless-stopped
+    user: root
+    depends_on:
+      - redis
+      - tile-server
+    networks:
+      - pp_network
+
+  redis:
+    image: redis:alpine
+    container_name: redis_container0
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    restart: unless-stopped
+    networks:
+      - pp_network
+
+  tile-server:
+    image: ghcr.io/stjude/tiatoolbox:latest
+    container_name: tileserver_container0
+    ports:
+      - "5000:5000"
+    volumes:
+      - /Users/aacic/data/tp/:/home/root/tileserver/tp:ro
+    environment:
+      - PORT=5000
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+          cpus: '4'
+    restart: unless-stopped
+    networks:
+      - pp_network
+
+networks:
+  pp_network:


### PR DESCRIPTION
## Description

This PR adds a Docker-Compose config that runs the PP server, TileServer, and Redis instance. It's a minimal configuration for running WSIViewer. 

To test:

Replace` /path/to/local/` inside `proteinpaint/container/compose/docker-compose.yml` with the real local paths.

Add to `serverconfig.json.features` :
  ```
      "redis": {
         "online_check": false,
         "nodes": [
            {
               "url": "redis://redis_container0:6379"
            }
         ]
      },
      "tileserver": {
         "online_check": false,
         "mount": "/home/root/tileserver/tp",
         "nodes": [
            {
               "url": "http://tileserver_container0:5000"
            }
         ]
      }
```

run from sjpp:

```
node utils/getDataset.js gdc
cd proteinpaint/container/compose
docker compose up
```

Click on the WSI card and verify that the content is displayed.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
