### PR TITLE
fix: Disabled Rust linting on pre-commit for now until can find a better solution for clippy-driver

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- improve gdcmaf ui not to show empty table and disable interactivity while downloading
+- Disabled Rust linting on commit for now until can find a better solution for clippy-driver

--- a/rust/src/gdcmaf.rs
+++ b/rust/src/gdcmaf.rs
@@ -10,16 +10,16 @@
     echo '{"host": "https://api.gdc.cancer.gov/data/","columns": ["Hugo_Symbol", "Entrez_Gene_Id", "Center", "NCBI_Build", "Chromosome", "Start_Position"], "fileIdLst": ["8b31d6d1-56f7-4aa8-b026-c64bafd531e7", "b429fcc1-2b59-4b4c-a472-fb27758f6249"]}'|./target/release/gdcmaf
 */
 
+use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
-use serde_json::{Value};
 use futures::StreamExt;
-use std::io::{self,Read,Write};
+use serde_json::Value;
+use std::io::{self, Read, Write};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, BufReader};
 use tokio::time::timeout;
-use std::sync::{Arc, Mutex};
 
 // Struct to hold error information
 #[derive(serde::Serialize)]
@@ -28,14 +28,14 @@ struct ErrorEntry {
     error: String,
 }
 
-fn select_maf_col(d:String,columns:&Vec<String>,url:&str) -> Result<(Vec<u8>,i32), (String, String)> {
+fn select_maf_col(d: String, columns: &Vec<String>, url: &str) -> Result<(Vec<u8>, i32), (String, String)> {
     let mut maf_str: String = String::new();
     let mut header_indices: Vec<usize> = Vec::new();
     let lines = d.trim_end().split("\n");
     let mut mafrows = 0;
     for line in lines {
         if line.starts_with("#") {
-            continue
+            continue;
         } else if line.contains("Hugo_Symbol") {
             let header: Vec<String> = line.split("\t").map(|s| s.to_string()).collect();
             for col in columns {
@@ -48,7 +48,7 @@ fn select_maf_col(d:String,columns:&Vec<String>,url:&str) -> Result<(Vec<u8>,i32
                         return Err((url.to_string(), error_msg));
                     }
                 }
-            };
+            }
             if header_indices.is_empty() {
                 return Err((url.to_string(), "No matching columns found".to_string()));
             }
@@ -57,19 +57,17 @@ fn select_maf_col(d:String,columns:&Vec<String>,url:&str) -> Result<(Vec<u8>,i32
             let mut maf_out_lst: Vec<String> = Vec::new();
             for x in header_indices.iter() {
                 maf_out_lst.push(maf_cont_lst[*x].to_string());
-            };
+            }
             maf_str.push_str(maf_out_lst.join("\t").as_str());
             maf_str.push_str("\n");
             mafrows += 1;
         }
-    };
-    Ok((maf_str.as_bytes().to_vec(),mafrows))
+    }
+    Ok((maf_str.as_bytes().to_vec(), mafrows))
 }
 
-
-
 #[tokio::main]
-async fn main() -> Result<(),Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Accepting the piped input json from jodejs and assign to the variable
     // host: GDC host
     // url: urls to download single maf files
@@ -84,23 +82,21 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
     })
     .await;
     // Handle the result of the timeout operation
-    let  file_id_lst_js: Value = match result {
-        Ok(Ok(buffer)) => {
-            match serde_json::from_str(&buffer) {
-                Ok(js) => js,
-                Err(e) => {
-                    let stdin_error = ErrorEntry {
-                        url: String::new(),
-                        error: format!("JSON parsing error: {}", e),
-                    };
-                    writeln!(io::stderr(), "{}", serde_json::to_string(&stdin_error).unwrap()).unwrap();
-                    return Err(Box::new(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "JSON parsing error!",
-                    )) as Box<dyn std::error::Error>);
-                }
+    let file_id_lst_js: Value = match result {
+        Ok(Ok(buffer)) => match serde_json::from_str(&buffer) {
+            Ok(js) => js,
+            Err(e) => {
+                let stdin_error = ErrorEntry {
+                    url: String::new(),
+                    error: format!("JSON parsing error: {}", e),
+                };
+                writeln!(io::stderr(), "{}", serde_json::to_string(&stdin_error).unwrap()).unwrap();
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "JSON parsing error!",
+                )) as Box<dyn std::error::Error>);
             }
-        }
+        },
         Ok(Err(_e)) => {
             let stdin_error = ErrorEntry {
                 url: String::new(),
@@ -128,22 +124,30 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
     };
 
     // reading the input from PP
-    let host = file_id_lst_js.get("host").expect("Host was not provided").as_str().expect("Host is not a string");
+    let host = file_id_lst_js
+        .get("host")
+        .expect("Host was not provided")
+        .as_str()
+        .expect("Host is not a string");
     let mut url: Vec<String> = Vec::new();
-    let file_id_lst = file_id_lst_js.get("fileIdLst").expect("File ID list is missed!").as_array().expect("File ID list is not an array");
+    let file_id_lst = file_id_lst_js
+        .get("fileIdLst")
+        .expect("File ID list is missed!")
+        .as_array()
+        .expect("File ID list is not an array");
     for v in file_id_lst {
         //url.push(Path::new(&host).join(&v.as_str().unwrap()).display().to_string());
-        url.push(format!("{}/{}",host.trim_end_matches('/'), v.as_str().unwrap()));
-    };
+        url.push(format!("{}/{}", host.trim_end_matches('/'), v.as_str().unwrap()));
+    }
 
     // read columns as array from input json and convert data type from Vec<Value> to Vec<String>
-    let maf_col:Vec<String>;
+    let maf_col: Vec<String>;
     if let Some(maf_col_value) = file_id_lst_js.get("columns") {
         //convert Vec<Value> to Vec<String>
         if let Some(maf_col_array) = maf_col_value.as_array() {
             maf_col = maf_col_array
                 .iter()
-                .map(|v| v.to_string().replace("\"",""))
+                .map(|v| v.to_string().replace("\"", ""))
                 .collect::<Vec<String>>();
         } else {
             let column_error = ErrorEntry {
@@ -165,62 +169,58 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
         let column_error_js = serde_json::to_string(&column_error).unwrap();
         writeln!(io::stderr(), "{}", column_error_js).expect("Failed to output stderr!");
         return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Columns was not selected",
+            std::io::ErrorKind::InvalidInput,
+            "Columns was not selected",
         )) as Box<dyn std::error::Error>);
     };
-    
+
     //downloading maf files parallelly and merge them into single maf file
-    let download_futures = futures::stream::iter(
-        url.into_iter().map(|url|{
-            async move {
-                let client = reqwest::Client::builder()
-                    .timeout(Duration::from_secs(60)) // 60-second timeout per request
-                    .connect_timeout(Duration::from_secs(15))
-                    .build()
-                    .map_err(|_e| {
-                        let client_error = ErrorEntry{
-                            url: url.clone(),
-                            error: "Client build error".to_string(),
-                        };
-                        let client_error_js = serde_json::to_string(&client_error).unwrap();
-                        writeln!(io::stderr(), "{}", client_error_js).expect("Failed to build reqwest client!");
-                    });
-                match client.unwrap().get(&url).send().await {
-                    Ok(resp) if resp.status().is_success() => {
-                        match resp.bytes().await {
-                            Ok(content) => {
-                                let mut decoder = GzDecoder::new(&content[..]);
-                                let mut decompressed_content = Vec::new();
-                                match decoder.read_to_end(&mut decompressed_content) {
-                                    Ok(_) => {
-                                        let text = String::from_utf8_lossy(&decompressed_content).to_string();
-                                        return Ok((url.clone(),text))
-                                    }
-                                    Err(e) => {
-                                        let error_msg = format!("Failed to decompress downloaded maf file: {}", e);
-                                        Err((url.clone(), error_msg))
-                                    }
-                                }
+    let download_futures = futures::stream::iter(url.into_iter().map(|url| {
+        async move {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(60)) // 60-second timeout per request
+                .connect_timeout(Duration::from_secs(15))
+                .build()
+                .map_err(|_e| {
+                    let client_error = ErrorEntry {
+                        url: url.clone(),
+                        error: "Client build error".to_string(),
+                    };
+                    let client_error_js = serde_json::to_string(&client_error).unwrap();
+                    writeln!(io::stderr(), "{}", client_error_js).expect("Failed to build reqwest client!");
+                });
+            match client.unwrap().get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => match resp.bytes().await {
+                    Ok(content) => {
+                        let mut decoder = GzDecoder::new(&content[..]);
+                        let mut decompressed_content = Vec::new();
+                        match decoder.read_to_end(&mut decompressed_content) {
+                            Ok(_) => {
+                                let text = String::from_utf8_lossy(&decompressed_content).to_string();
+                                return Ok((url.clone(), text));
                             }
                             Err(e) => {
-                                let error_msg = format!("Failed to decompress downloaded maf file: {}", e);
+                                let error_msg = format!("Failed to decompress downloaded MAF file: {}", e);
                                 Err((url.clone(), error_msg))
                             }
                         }
                     }
-                    Ok(resp) => {
-                        let error_msg = format!("HTTP error: {}", resp.status());
-                        Err((url.clone(), error_msg))
-                    }
                     Err(e) => {
-                        let error_msg = format!("Server request failed: {}", e);
+                        let error_msg = format!("Failed to decompress downloaded MAF file: {}", e);
                         Err((url.clone(), error_msg))
                     }
+                },
+                Ok(resp) => {
+                    let error_msg = format!("HTTP error: {}", resp.status());
+                    Err((url.clone(), error_msg))
+                }
+                Err(e) => {
+                    let error_msg = format!("Server request failed: {}", e);
+                    Err((url.clone(), error_msg))
                 }
             }
-        })
-    );
+        }
+    }));
 
     // binary output
     let encoder = Arc::new(Mutex::new(GzEncoder::new(io::stdout(), Compression::default())));
@@ -228,57 +228,57 @@ async fn main() -> Result<(),Box<dyn std::error::Error>> {
     // Write the header
     {
         let mut encoder_guard = encoder.lock().unwrap(); // Lock the Mutex to get access to the inner GzEncoder
-        encoder_guard.write_all(&maf_col.join("\t").as_bytes().to_vec()).expect("Failed to write header");
+        encoder_guard
+            .write_all(&maf_col.join("\t").as_bytes().to_vec())
+            .expect("Failed to write header");
         encoder_guard.write_all(b"\n").expect("Failed to write newline");
     }
-    
-    download_futures.buffer_unordered(20).for_each( |result| {
-        let encoder = Arc::clone(&encoder); // Clone the Arc for each task
-        let maf_col_cp = maf_col.clone();
-        async move {
-            match result {
-                Ok((url, content)) => {
-                    match select_maf_col(content, &maf_col_cp, &url) {
-                        Ok((maf_bit,mafrows)) => {
+
+    download_futures
+        .buffer_unordered(20)
+        .for_each(|result| {
+            let encoder = Arc::clone(&encoder); // Clone the Arc for each task
+            let maf_col_cp = maf_col.clone();
+            async move {
+                match result {
+                    Ok((url, content)) => match select_maf_col(content, &maf_col_cp, &url) {
+                        Ok((maf_bit, mafrows)) => {
                             if mafrows > 0 {
                                 let mut encoder_guard = encoder.lock().unwrap();
                                 encoder_guard.write_all(&maf_bit).expect("Failed to write file");
                             } else {
                                 let error = ErrorEntry {
                                     url: url.clone(),
-                                    error: "Empty maf file".to_string(),
+                                    error: "Empty MAF file".to_string(),
                                 };
                                 let error_js = serde_json::to_string(&error).unwrap();
                                 writeln!(io::stderr(), "{}", error_js).expect("Failed to output stderr!");
                             }
                         }
-                        Err((url,error)) => {
-                            let error = ErrorEntry {
-                                url,
-                                error,
-                            };
+                        Err((url, error)) => {
+                            let error = ErrorEntry { url, error };
                             let error_js = serde_json::to_string(&error).unwrap();
                             writeln!(io::stderr(), "{}", error_js).expect("Failed to output stderr!");
                         }
+                    },
+                    Err((url, error)) => {
+                        let error = ErrorEntry { url, error };
+                        let error_js = serde_json::to_string(&error).unwrap();
+                        writeln!(io::stderr(), "{}", error_js).expect("Failed to output stderr!");
                     }
-                }
-                Err((url, error)) => {
-                    let error = ErrorEntry {
-                        url,
-                        error,
-                    };
-                    let error_js = serde_json::to_string(&error).unwrap();
-                    writeln!(io::stderr(), "{}", error_js).expect("Failed to output stderr!");
-                }
-            };
-        }
-    }).await;
-    
+                };
+            }
+        })
+        .await;
+
     // Finalize output
 
     // Replace the value inside the Mutex with a dummy value (e.g., None)
     let mut encoder_guard = encoder.lock().unwrap();
-    let encoder = std::mem::replace(&mut *encoder_guard, GzEncoder::new(io::stdout(), Compression::default()));
+    let encoder = std::mem::replace(
+        &mut *encoder_guard,
+        GzEncoder::new(io::stdout(), Compression::default()),
+    );
     // Finalize the encoder
     encoder.finish().expect("Maf file output error!");
 

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -61,15 +61,16 @@ if [[ "$RUST_FULL_PATHS" != "" ]]; then
   # Extract just the filenames without the path prefix
   RUST_FILES=$(echo "$RUST_FULL_PATHS" | xargs basename)
   # Lint each file
-  echo "Linting Rust files with clippy..."
-  for f in $RUST_FILES; do
-    echo "Linting $f..."
-    clippy-driver --edition 2024 -Cpanic=abort $f
+  # echo "Linting Rust files with clippy..."
+  # for f in $RUST_FILES; do
+    #echo "Linting $f..."
+	# cargo clippy 
+    # clippy-driver --edition 2024 -Cpanic=abort $f
     # Get the base filename without extension
-    BINARY_NAME=$(basename "$f" .rs)
-    echo "Deleting binary: $BINARY_NAME"
-		rm -f "$BINARY_NAME"
-  done
+    #BINARY_NAME=$(basename "$f" .rs)
+    #echo "Deleting binary: $BINARY_NAME"
+		#rm -f "$BINARY_NAME"
+  #done
 
   # Return to original directory
   cd ../..


### PR DESCRIPTION
## Description
`Clipppy-driver` appears to not have access to our Rust crates/dependencies. Disabling its linting on pre-commit for now until a better solution can be found


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [ ] Tests: added and/or passed unit and integration tests, or N/A
- [ ] Todos: commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
