### PR TITLE
Create elems for marked value even if the init value was < 0.001

### DIFF
--- a/client/dom/ColorScale/ColorScale.ts
+++ b/client/dom/ColorScale/ColorScale.ts
@@ -69,12 +69,12 @@ export class ColorScale {
 		if (this.topTicks === true) {
 			const { scale, scaleAxis } = this.makeAxis(barG, id)
 			this.makeColorBar(gradient)
-			this.dom = { gradient, scale, scaleAxis }
+			this.dom = { gradient, scale, scaleAxis, barG }
 		} else {
 			this.makeColorBar(gradient)
 			const { scale, scaleAxis } = this.makeAxis(barG, id)
-			this.dom = { gradient, scale, scaleAxis }
-			if (this.markedValue !== null) this.markedValueInColorBar(barG)
+			this.dom = { gradient, scale, scaleAxis, barG }
+			this.markedValueInColorBar()
 		}
 		this.render()
 
@@ -149,10 +149,10 @@ export class ColorScale {
 		return { scale, scaleAxis }
 	}
 
-	markedValueInColorBar(div: SvgG) {
-		if (!this.markedValue || this.topTicks == true) return
+	markedValueInColorBar() {
+		if (this.markedValue == null || this.topTicks === true) return
 
-		this.dom.line = div
+		this.dom.line = this.dom.barG
 			.append('line')
 			.classed('sjpp-color-scale-marked', true)
 			.attr('data-testid', 'sjpp-color-scale-marked-tick')
@@ -160,7 +160,7 @@ export class ColorScale {
 			.attr('y2', this.barheight + 1)
 			.attr('stroke', 'black')
 
-		this.dom.label = div
+		this.dom.label = this.dom.barG
 			.append('text')
 			.classed('sjpp-color-scale-marked', true)
 			.attr('data-testid', 'sjpp-color-scale-marked-label')
@@ -201,7 +201,7 @@ export class ColorScale {
 			}
 		if (opts.numericInputs) {
 			_opts.cutoffMode = opts.numericInputs.cutoffMode || 'auto'
-			if (opts.numericInputs?.defaultPercentile) _opts.percentile = opts.numericInputs?.defaultPercentile
+			if (opts.numericInputs.defaultPercentile) _opts.percentile = opts.numericInputs?.defaultPercentile
 			_opts.setNumbersCallback = async obj => {
 				if (!obj) return
 				await opts.numericInputs!.callback(obj)
@@ -244,13 +244,14 @@ export class ColorScale {
 	}
 
 	updateValueInColorBar() {
-		if (!this.markedValue || this.topTicks == true) return
-		if (!this.dom.line || !this.dom.label)
-			throw new Error('Missing dom elements to update value in color bar in #dom/ColorScale.')
-
+		if (this.markedValue == null || this.topTicks === true) return
+		if (!this.dom.line || !this.dom.label) {
+			/** Allow the line to be made if the init value was < 0.001 */
+			this.markedValueInColorBar()
+		}
 		const x = Math.min(this.barwidth, this.dom.scale(this.markedValue))
-		this.dom.line.attr('x1', x).attr('x2', x)
-		this.dom.label.attr('x', x).text(Math.floor(this.markedValue))
+		this.dom.line!.attr('x1', x).attr('x2', x)
+		this.dom.label!.attr('x', x).text(Math.floor(this.markedValue))
 
 		// /**Determine if the text should be white or black based on the
 		//  * background color.

--- a/client/dom/types/colorScale.ts
+++ b/client/dom/types/colorScale.ts
@@ -60,10 +60,17 @@ export type ColorScaleOpts = {
 }
 
 export type ColorScaleDom = {
+	/** Holder for the axis, and gradient */
+	barG: SvgG
+	/** color bar */
 	gradient: GradientElem
+	/** d3 scale */
 	scale: ScaleLinear<number, number, never>
+	/** holder for the d3 scale */
 	scaleAxis: SvgG
+	/** Marked value label */
 	label?: SvgText
+	/** vertical line shown to indicate a marked value */
 	line?: SvgLine
 }
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- Create elements for marked values in the color scale after init rather than throwing


### PR DESCRIPTION
## Description
Fixes the issue Jared pointed on in the #proteinpaint Slack channel. 

Test: 
In master:
1. Open the [hic example](http://localhost:3000/?block=1&genome=hg19&position=chr7:13749862-20841903&hictkfile=Test_HiC,MboI,proteinpaint_demo/hg19/hic/hic_demo.hic) with a mincuff of 0. 
2. Change the cutoff to 1. 
3. Should see the same error as Jared's screenshot. 

In feature branch: 
1. Repeat the steps above. 
2. Should not see the error and should see the new min cutoff displayed in the color bar. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
