### PR TITLE
validate term.type as used for anno_* table name

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- validate term.type as used for anno_* table name, as additional protection sql injection beyond if-else/case branching against term.type's in request payload


### PR DESCRIPTION
## Description

Validate term.type as used for anno_* table name as additional protection sql injection beyond if-else/case branching against term.type's in request payload.

Tested with
- http://localhost:3000/testrun.html?name=*.unit
- http://localhost:3000/testrun.html?name=*.integration

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.
- [x] Tests: added and/or passed unit and integration tests, or N/A
- [x] Todos: commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
