### PR TITLE
Restored global min max on the scatter

### DIFF
--- a/client/plots/scatter/model/scatterModel.ts
+++ b/client/plots/scatter/model/scatterModel.ts
@@ -73,10 +73,11 @@ export class ScatterModel {
 		const data: ScatterResponse = await this.scatter.app.vocabApi.getScatterData(reqOpts)
 		this.is3D = this.scatter.config.term0?.q.mode == 'continuous'
 		if ('error' in data) throw data.error
+		this.range = data.range
 		this.charts = []
-		for (const [key, item] of Object.entries(data)) {
-			if (!Array.isArray(item.samples)) throw 'data.samples[] not array'
-			this.createChart(key, item)
+		for (const [key, chartData] of Object.entries(data.result)) {
+			if (!Array.isArray(chartData.samples)) throw 'data.samples[] not array'
+			this.createChart(key, chartData)
 		}
 		this.initRanges()
 	}
@@ -110,10 +111,10 @@ export class ScatterModel {
 		)
 		for (const chart of this.charts) {
 			chart.ranges = {
-				xMin,
-				xMax,
-				yMin,
-				yMax,
+				xMin: this.scatter.settings.useGlobalMinMax ? this.range.xMin : xMin,
+				xMax: this.scatter.settings.useGlobalMinMax ? this.range.xMax : xMax,
+				yMin: this.scatter.settings.useGlobalMinMax ? this.range.yMin : yMin,
+				yMax: this.scatter.settings.useGlobalMinMax ? this.range.yMax : yMax,
 				zMin,
 				zMax,
 				scaleMin,

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -270,7 +270,8 @@ export function getDefaultScatterSettings() {
 		colorContours: false,
 		contourBandwidth: 30,
 		contourThresholds: 10,
-		duration: 500
+		duration: 500,
+		useGlobalMinMax: true
 	}
 }
 

--- a/client/plots/scatter/scatterTypes.ts
+++ b/client/plots/scatter/scatterTypes.ts
@@ -14,7 +14,7 @@ export type ShapeLegendItem = {
 
 export type ScatterLegendItem = ColorLegendItem | ShapeLegendItem
 
-export type ScatterDataResponse = { [index: string]: ScatterDataResult }
+export type ScatterDataResponse = { range: DataRange; result: { [index: string]: ScatterDataResult } }
 
 export type ErrorResponse = { error: string }
 


### PR DESCRIPTION
# Description

To solve the issue #3248 I restored min max calculation on the server side as it needs to be done before filtering the samples. Also added useGlobalMinMax property so only the scatter applies global min max and not the runchart where we want to apply the filter. Please do not use a session to test it as I added a property that will not be present, recreate the plot as described in the issue instead. Thanks for bringing this up @karishma-gangwani and @congyu-lu.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
