### PR TITLE
Fix geneVariant legend in scatter plot

### DIFF
--- a/client/plots/scatter/viewmodel/scatterLegend.ts
+++ b/client/plots/scatter/viewmodel/scatterLegend.ts
@@ -323,7 +323,7 @@ export class ScatterLegend {
 
 		offsetX += step
 		const mutations: any = []
-		for (const [value] of map)
+		for (const value of map.values())
 			if (value.mutation)
 				//if no mutation is Ref
 				mutations.push(value.mutation)


### PR DESCRIPTION
# Description

Fixed map iterator in `renderGeneVariantLegend()` to now render geneVariant mutations in legend. Can test in scatter plot with geneVariant as color overlay ([example](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22Transcriptome%20UMAP%22,%22colorTW%22:{%22term%22:%20{%22gene%22:%20%22TP53%22,%20%22type%22:%20%22geneVariant%22}}}]})).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
