### PR TITLE
fix: avoid blank sunburst when samples are not annotated by sunburst …

### DIFF
--- a/client/mds3/clickVariant.js
+++ b/client/mds3/clickVariant.js
@@ -65,6 +65,13 @@ async function click2sunburst(d, tk, block, tippos) {
 		querytype: tk.mds.variant2samples.type_sunburst
 	})
 	tk.glider.style('cursor', 'auto')
+
+	if (!dataGood4sunburst(data)) {
+		await variant_details({ mlst: d.mlst, tk, block, tippos })
+		return
+	}
+
+	// when no samples from this group are annotated by sunburst terms, avoid showing a blank sunburst
 	const arg = {
 		nodes: data.nodes,
 		occurrence: d.occurrence,
@@ -158,6 +165,23 @@ async function click2sunburst(d, tk, block, tippos) {
 	}
 	const _ = await import('#src/sunburst')
 	_.default(arg)
+}
+
+export function dataGood4sunburst(data) {
+	// return true/false to show/not show sunburst; throws on data error
+	// data={nodes:[ {id:'root'}, {id:'root...cat1'}, ...]}
+	if (!Array.isArray(data.nodes)) throw 'nodes not array'
+	if (data.nodes.length == 0) throw 'nodes empty array'
+	// just {root} element means samples are not annotated by sunburst terms. return false to avoid showing a blank sunburst
+	if (data.nodes.length == 1) return false
+	// root node is not validated, do if needed
+	for (let i = 1; i < data.nodes.length; i++) {
+		const n = data.nodes[i]
+		if (!n.name) throw 'node name missing'
+		if (!Number.isInteger(n.cohortsize)) throw 'node cohortsize not integer'
+		// validate additional properties if needed
+	}
+	return true
 }
 
 /*

--- a/client/mds3/test/skewer.unit.spec.ts
+++ b/client/mds3/test/skewer.unit.spec.ts
@@ -1,10 +1,14 @@
 import tape from 'tape'
 import { whenVisible } from '../../test/test.helpers'
 import { showHoverTipOnDisk } from '../skewer.render.js'
+import { dataGood4sunburst } from '../clickVariant.js'
 import { Menu } from '#dom'
 
 /*
 Tests: 
+
+showHoverTipOnDisk()
+dataGood4sunburst()
 */
 
 tape('\n', test => {
@@ -74,5 +78,43 @@ tape('showHoverTipOnDisk()', async function (test) {
 	test.true(tk.hovertip.d.node()!.innerHTML.includes('2 alterations'), 'should show 2 alterations')
 
 	if (test['_ok']) tk.hovertip.d.remove()
+	test.end()
+})
+
+tape('dataGood4sunburst()', function (test) {
+	test.throws(
+		() => {
+			dataGood4sunburst({ nodes: 11 })
+		},
+		/nodes not array/,
+		'should throw'
+	)
+	test.throws(
+		() => {
+			dataGood4sunburst({ nodes: [] })
+		},
+		/nodes empty array/,
+		'should throw'
+	)
+	test.equal(
+		dataGood4sunburst({ nodes: [{}] }),
+		false,
+		'returns false when data.nodes.length==1 to disable sunburst rendering'
+	)
+	test.throws(
+		() => {
+			dataGood4sunburst({ nodes: [{}, {}] })
+		},
+		/node name missing/,
+		'should throw'
+	)
+	test.throws(
+		() => {
+			dataGood4sunburst({ nodes: [{}, { name: 'x' }] })
+		},
+		/node cohortsize not integer/,
+		'should throw'
+	)
+	test.equal(dataGood4sunburst({ nodes: [{}, { name: 'x', cohortsize: 1 }] }), true, 'returns true on good data')
 	test.end()
 })

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- avoid blank sunburst when samples are not annotated by sunburst terms; just show table view


### PR DESCRIPTION
…terms; just show table view

# Description

closes #3282 
<img width="245" alt="image" src="https://github.com/user-attachments/assets/167671d0-0d66-41a2-8d05-6d654d4e29b7" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
