### PR TITLE
fix: dictionary ui new option backToSelectionText avoids duplicating …

### DIFF
--- a/client/filter/tvs.geneVariant.js
+++ b/client/filter/tvs.geneVariant.js
@@ -45,6 +45,7 @@ async function fillMenu(self, _div, tvs) {
 			tree: { usecase: { target: 'filter' } }
 		},
 		tree: {
+			backToSelectionText: 'Change alteration type',
 			click_term2select_tvs(tvs) {
 				tvs.term.geneVariantTerm = structuredClone(term) // track the parent geneVariant term
 				self.opts.callback(tvs)

--- a/client/termdb/app.js
+++ b/client/termdb/app.js
@@ -6,17 +6,23 @@ import { TermTypeSearchInit } from './TermTypeSearch'
 import { submenuInit } from './submenu'
 import { searchInit } from './search'
 import { select } from 'd3-selection'
-import { Menu } from '#dom/menu'
-import { sayerror } from '../dom/sayerror.ts'
+import { Menu, sayerror } from '#dom'
 import { dofetch3 } from '#common/dofetch'
 import { isUsableTerm } from '#shared/termdb.usecase.js'
 
 /*
 opts{}
-.state{}
-	required, will fill-in or override store.defaultState
-.app{} .tree{} etc
-see doc for full spec
+	state{}
+		required, will fill-in or override store.defaultState
+	app{}
+	tree{}
+		disable_terms[]
+		click_term2select_tvs()
+		click_term()
+		backToSelectionText:str
+	search{}
+	vocabApi
+	getCategoriesArguments{}
 */
 
 class TdbApp {

--- a/client/termdb/submenu.js
+++ b/client/termdb/submenu.js
@@ -43,7 +43,7 @@ function setRenderers(self) {
 			.append('div')
 			.style('margin', '10px')
 			.append('span')
-			.html('&laquo; Back to variable selection')
+			.html('&laquo; ' + (self.app.opts.tree?.backToSelectionText || 'Back to variable selection'))
 			.attr('class', 'sja_clbtext')
 			.on('click', () => self.app.dispatch({ type: 'submenu_set', submenu: {} }))
 

--- a/client/termdb/submenu.js
+++ b/client/termdb/submenu.js
@@ -45,6 +45,7 @@ function setRenderers(self) {
 			.append('span')
 			.html('&laquo; ' + (self.app.opts.tree?.backToSelectionText || 'Back to variable selection'))
 			.attr('class', 'sja_clbtext')
+			.attr('data-testid', 'sja_treesubmenu_backprompt')
 			.on('click', () => self.app.dispatch({ type: 'submenu_set', submenu: {} }))
 
 		self.dom.holder

--- a/client/termdb/test/submenu.integration.spec.js
+++ b/client/termdb/test/submenu.integration.spec.js
@@ -1,5 +1,4 @@
 import tape from 'tape'
-import * as d3s from 'd3-selection'
 import { termjson } from '../../test/testdata/termjson'
 import * as helpers from '../../test/front.helpers.js'
 
@@ -8,6 +7,7 @@ Tests:
 	no tree.click_term2select_tvs callback
 	with callback, but no submenu.term
 	with callback and submenu.term
+	with backToSelectionText
 
 Note:
 these tests are dependent on TermdbTest termdb data.
@@ -97,6 +97,32 @@ tape('with callback and submenu.term', function (test) {
 		test.equal(typeof app.Inner.components.submenu, 'object', 'should have a submenu')
 		test.equal(app.Inner.components.tree.Inner.dom.holder.style('display'), 'none', 'should have a hidden tree')
 		test.equal(app.Inner.components.submenu.Inner.dom.holder.style('display'), 'block', 'should have a visible submenu')
+		test.end()
+		if (test._ok) setTimeout(app.destroy, 1000)
+	}
+})
+
+tape('with backToSelectionText', function (test) {
+	runpp({
+		state: {
+			submenu: { type: 'tvs', term: termjson['sex'] }
+		},
+		tree: {
+			backToSelectionText: 'xyz',
+			click_term2select_tvs() {}
+		},
+		app: {
+			callbacks: {
+				postInit: runTests
+			}
+		}
+	})
+
+	function runTests(app) {
+		test.equal(
+			app.Inner.components.submenu.Inner.dom.holder.select('[data-testid="sja_treesubmenu_backprompt"]').html(),
+			'« xyz'
+		)
 		test.end()
 		if (test._ok) setTimeout(app.destroy, 1000)
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- dictionary ui new option backToSelectionText avoids duplicating Back handle with geneVariant tvs


### PR DESCRIPTION
…Back handle with geneVariant tvs

# Description
closes #3311 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
