### PR TITLE
Broken mds3 legend items will appear when skewer mode is `skewer`

### DIFF
--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -613,7 +613,7 @@ function update_mclass(tk) {
 						isChangeShape: true,
 						isVisible: () => {
 							if (c.k == dtcnv) return false // no changing shape for cnv
-							return !tk.skewer.viewModes.find(v => v.type === 'numeric').inuse
+							return !tk.skewer.viewModes.find(v => v.type === 'numeric')?.inuse
 								? tk.mds?.termdbConfig?.tracks?.allowSkewerChanges ?? true
 								: false
 						},

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -21,7 +21,9 @@ Custom cnv (category but not numeric value), WITH sample
 Custom variants, missing or invalid mclass
 Custom variants WITH samples (allows some to be without)
 Custom data with samples and sample selection
+skewerMode with improper setting and should not break
 Numeric mode custom dataset, with mode change
+Custom bcf with sample
 
 
 this script exports following test methods to share with non-CI test using GDC/clinvar
@@ -399,6 +401,9 @@ export async function testVariantLeftLabel(test, tk, bb) {
 			test.ok(expandedText, 'Should find some expanded skewers')
 		}
 	}
+
+	// TODO test that view mode change options are not shown
+
 	tk.menutip.hide()
 }
 
@@ -1077,6 +1082,41 @@ tape('Custom cnv (category but not numeric value), WITH sample', test => {
 			tk.menutip.d.remove()
 			holder.remove()
 		}
+		test.end()
+	}
+})
+
+tape('skewerMode with improper setting and should not break', test => {
+	const holder = getHolder()
+
+	const custom_variants = [
+		{ chr: 'chr17', pos: 7676228, mname: 'P75', class: 'M', dt: 1, lpv: 1, value2: 4 },
+		{ chr: 'chr17', pos: 7675208, mname: 'T73', class: 'M', dt: 1, lpv: 2, value2: 5 },
+		{ chr: 'chr17', pos: 7674922, mname: 'WTPinsP75', class: 'I', dt: 1, lpv: 3, value2: 6 },
+		{ chr: 'chr17', pos: 7674225, mname: 'data point', class: 'I', dt: 1 }
+	]
+
+	runproteinpaint({
+		holder,
+		noheader: true,
+		genome: 'hg38-test',
+		gene: 'NM_000546',
+		tracks: [
+			{
+				type: 'mds3',
+				// type=skewer is supplied instead of type=numeric
+				skewerModes: [{ type: 'skewer', byAttribute: 'lpv', label: '-log10(p-value)', inuse: true, axisheight: 100 }],
+				name: 'AA sites with numbers',
+				custom_variants,
+				axisSetting: { auto: 1 },
+				callbackOnRender
+			}
+		]
+	})
+
+	async function callbackOnRender(tk, bb) {
+		await testVariantLeftLabel(test, tk, bb)
+		if (test._ok) holder.remove()
 		test.end()
 	}
 })

--- a/front/public/cards/index.json
+++ b/front/public/cards/index.json
@@ -116,6 +116,7 @@
             "type": "card",
             "name": "Lollipop",
             "section": "tracks",
+            "ribbon": {"text": "updated", "expireDate": "2025-06-15"},
             "description": "Coding mutations and gene fusions",
             "image": "https://proteinpaint.stjude.org/ppdemo/images/lollipop-square.png",
             "sandboxJson": "lollipop",

--- a/front/public/cards/lollipop.json
+++ b/front/public/cards/lollipop.json
@@ -301,8 +301,8 @@
             }
         },
         {
-            "label": "Setting default view",
-            "message": "Adding <span style='font-family: Courier; opacity: 0.6;'>gmmode</span> to the block level sets the default view. Valid values are <span style='font-family: Courier; opacity: 0.6;'>protein, exon only, splicing RNA</span>, and <span style='font-family: Courier; opacity: 0.6;'>genomic</span> ",
+            "label": "Setting default display",
+            "message": "Adding <span style='font-family: Courier; opacity: 0.6;'>gmmode</span> to the block level sets the default display. Valid values are <span style='font-family: Courier; opacity: 0.6;'>protein, exon only, splicing RNA</span>, and <span style='font-family: Courier; opacity: 0.6;'>genomic</span> ",
             "runargs": {
                 "nobox": 1,
                 "noheader": 1,
@@ -310,6 +310,12 @@
                 "gene": "TP53",
                 "gmmode": "splicing RNA"
             },
+            "buttons": [
+                {
+                    "name": "Gene View Documentation",
+                    "link": "https://github.com/stjude/proteinpaint/wiki/Embedding#gene-view"
+                }
+            ],
             "testSpec": {
                 "expected": {
                     "rect": 1

--- a/front/public/cards/lollipop.json
+++ b/front/public/cards/lollipop.json
@@ -164,7 +164,7 @@
                             "label": "Serine",
                             "color": "#E74C3C",
                             "desc": "phosphorylated amino acid"
-                        }, 
+                        },
                         "F": {
                             "label": "Tyrosine",
                             "color": "#00A86B",
@@ -174,9 +174,11 @@
                 }
             },
             "testSpec": {
-                "expected": { "circle": 10 }
+                "expected": {
+                    "circle": 10
+                }
             },
-            "buttons":[
+            "buttons": [
                 {
                     "name": "Custom Data Documentation",
                     "link": "https://github.com/stjude/proteinpaint/wiki/Lollipop-%E2%80%90-mds3#tkskewermodes"
@@ -277,7 +279,7 @@
                             "label": "Serine",
                             "color": "#E74C3C",
                             "desc": "phosphorylated amino acid"
-                        }, 
+                        },
                         "F": {
                             "label": "Tyrosine",
                             "color": "#00A86B",
@@ -286,34 +288,54 @@
                     }
                 }
             },
-            "buttons":[
+            "buttons": [
                 {
-                    "name":"Data Point Shape Documentation",
+                    "name": "Data Point Shape Documentation",
                     "link": "https://github.com/stjude/proteinpaint/wiki/Lollipop-%E2%80%90-mds3#mshape"
                 }
             ],
             "testSpec": {
-                "expected": { "circle": 10 }
+                "expected": {
+                    "circle": 10
+                }
+            }
+        },
+        {
+            "label": "Setting default view",
+            "message": "Adding <span style='font-family: Courier; opacity: 0.6;'>gmmode</span> to the block level sets the default view. Valid values are <span style='font-family: Courier; opacity: 0.6;'>protein, exon only, splicing RNA</span>, and <span style='font-family: Courier; opacity: 0.6;'>genomic</span> ",
+            "runargs": {
+                "nobox": 1,
+                "noheader": 1,
+                "genome": "hg38",
+                "gene": "TP53",
+                "gmmode": "splicing RNA"
+            },
+            "testSpec": {
+                "expected": {
+                    "rect": 1
+                }
             }
         },
         {
             "label": "Official dataset",
             "urlparam": "?genome=hg19&gene=JAK2&dataset=Pediatric",
             "runargs": {
-                "gene":"jak2",
+                "gene": "jak2",
                 "nobox": 1,
                 "noheader": 1,
                 "genome": "hg19",
-                "dataset":"Pediatric"
+                "dataset": "Pediatric"
             },
-            "buttons":[
+            "buttons": [
                 {
-                    "name":"Build an Official Dataset",
+                    "name": "Build an Official Dataset",
                     "link": "https://docs.google.com/document/d/1iY7x9PzAzLKzdABam_Tfg8h-kQ0oh2UyyKC0cP-9YWA/edit"
                 }
             ],
             "testSpec": {
-                "expected": { "circle": 10 }
+                "expected": {
+                    "circle": 10
+                }
             }
         }
     ],
@@ -323,6 +345,6 @@
             "link": "https://docs.google.com/document/d/1D78jKVaQrWBhAjnfmCqj0Cirf6s-CdcbfPkuZQMT8Co/edit#heading=h.tyjcwt"
         }
     ],
-    "ribbonMessage": "Please see the newest Custom Variant example!",
+    "ribbonMessage": "Please see our newest example of setting the default protein view.",
     "citation_id": 1001
-} 
+}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- broken mds3 legend items will appear when skewer mode is `skewer`


### PR DESCRIPTION
# Description
Closes issue #3314. The issue with the legend is the only bug found correcting user code for this inquiry: https://groups.google.com/g/proteinpaint/c/nAxbOM0qcUE. Will respond to user with the correct code. 

Test: 
- New example: http://localhost:3000/?appcard=lollipop&example=Setting%20default%20view

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
