### PR TITLE
fix numeric CNV legend items shift to left and cover CNV legend group…

### DIFF
--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -101,9 +101,9 @@ export default function svgLegend(opts) {
 		if (settings.linesep) {
 			currlinex = settings.padleft
 			currliney += settings.lineh
-		} else if (d.hasScale) {
+		} /* else if (d.hasScale) {
 			currlinex = leftdist - 2 * settings.padx + 2
-		} else if (d.hasScale || settings.hangleft) {
+		} */ else if (d.hasScale || settings.hangleft) {
 			currlinex = leftdist + 2 * settings.padx
 		} else {
 			currlinex += settings.padleft + grplabel.node().getBBox().width + 2 * settings.padx


### PR DESCRIPTION
… name

# Description
Fix the CNV legend issue shown in below: 
<img width="978" alt="image" src="https://github.com/user-attachments/assets/ff9c0073-545a-49d2-91d7-2aea38972c92" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
