### PR TITLE
By default, use pubmed URL instead of doi for publication results

### DIFF
--- a/client/src/header/AppHeader.ts
+++ b/client/src/header/AppHeader.ts
@@ -284,7 +284,9 @@ export class AppHeader {
 						.data(this.publications)
 						.enter()
 						.append('p')
-						.html((d: any) => `<a href=${d.doi} target=_blank>${d.appHeaderTitle}, ${d.journal}, ${d.year}</a>`)
+						.html(
+							(d: any) => `<a href=${d.pmidURL || d.doi} target=_blank>${d.appHeaderTitle}, ${d.journal}, ${d.year}</a>`
+						)
 				})
 		}
 	}

--- a/client/src/header/omniSearch.js
+++ b/client/src/header/omniSearch.js
@@ -56,7 +56,9 @@ export async function searchItems(app, tip, help, publications, jwt) {
 		),
 		color: '#E6E6FA',
 		callback: d => {
-			window.open(d.doi, d.title)
+			const url = d.pmidURL || d.doi
+			if (!url || !d.title) throw `Missing url or title for search selection`
+			window.open(url, d.title)
 		}
 	})
 	return data


### PR DESCRIPTION
# Description
Changed the links to default to the pubmed link and use the doi link as a back up. 

Test: 
1. See the citation link in the [genome paint](http://localhost:3000/?appcard=genomepaint), [fusion editor](http://localhost:3000/?appcard=fusioneditor), [bam](http://localhost:3000/?appcard=bam), and others already use the pubmed link. 
2. Click on any link from the Publications button in the [homepage ](http://localhost:3000/). Should link out to pubmed. 
3. Search for any paper in the app header on the [homepage](http://localhost:3000/). Should also link out to pubmed. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
