### PR TITLE
Enable option to hide tab content on double click

### DIFF
--- a/client/dom/toggleButtons.ts
+++ b/client/dom/toggleButtons.ts
@@ -201,9 +201,15 @@ function setRenderers(self) {
 			})
 			.on('click', async (event, tab) => {
 				for (const t of self.tabs) {
+					/** Hide tab content on double click if specified */
+					if (self.opts.hideOnDblClick && t.active == true && t === tab) {
+						t.active = false
+						continue
+					}
 					t.active = t === tab
 				}
 				const activeTabIndex = self.tabs.findIndex(t => t.active) //Fix for non-Rx implementations
+
 				/*
 				TODO: self.update() not required for non-RX components
 				Idea is to create super class, then state and stateless components

--- a/client/dom/types/toggleButtons.ts
+++ b/client/dom/types/toggleButtons.ts
@@ -3,6 +3,9 @@ import type { Elem } from 'types/d3'
 export type TabsOpts = {
 	/** optional: if not provided, create new under opts.holder */
 	contentHolder?: Elem
+	/** On double click, the tab content is hidden and there
+	 * is no active tab. Default: false. */
+	hideOnDblClick?: boolean
 	holder: any
 	/**  Optional: Gap between tabs. Must be = '[number]px'
 	 * Only applies to vertical position. Default = '' */

--- a/client/plots/genomeBrowser.controls.js
+++ b/client/plots/genomeBrowser.controls.js
@@ -216,7 +216,8 @@ class GbControls {
 		// has some tabs! initiate the tab ui, then at <div> of each tab, render contents
 		const toggles = new Tabs({
 			holder: this.opts.holder.append('div').style('border-bottom', 'solid 1px #ccc').style('padding-bottom', '20px'),
-			tabs
+			tabs,
+			hideOnDblClick: true
 		})
 		toggles.main()
 


### PR DESCRIPTION
# Description
Closes issue #3316. 

Changes: 
1. Added `.hideOnDblClick` to Tabs arguments. 
2. Included new argument to mass genome browser. 

Test: 
1. Use [this peddep example](http://localhost:3000/?mass=%7B%22dslabel%22:%22peddep%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:%7B%22chr%22:%22chr7%22,%22start%22:27058715,%22stop%22:27209115%7D%7D%5D%7D) and click on the active tab. Should see the tab color change and hide the content below. Clicking on the same tab or a new one activates the tab. 
2. To test tabs without this argument, choose any app card from [the homepage](http://localhost:3000/) and click on the active top tab or the example tabs. Should see the tab remain active with no change. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
