### PR TITLE
restore cachedir_* and cache_snpgt initialization,

### DIFF
--- a/server/src/CacheManager.ts
+++ b/server/src/CacheManager.ts
@@ -99,6 +99,7 @@ export class CacheManager {
 	// the reference to setInterval
 	intervalId!: any // Timeout
 	callbacks: Callbacks
+	hasActiveCheck = false
 
 	constructor(opts: CacheOpts = defaultOpts) {
 		this.interval = opts.interval || defaultOpts.interval
@@ -150,6 +151,8 @@ export class CacheManager {
 
 	async start() {
 		const checkCacheFiles = async () => {
+			if (this.hasActiveCheck) return // prevent two active checks from running at the same time
+			this.hasActiveCheck = true
 			const now = Date.now()
 			const results = {}
 			for (const [subdir, dirOpts] of this.subdirs.entries()) {
@@ -159,6 +162,7 @@ export class CacheManager {
 				}
 			}
 			if (this.callbacks.postCheck) this.callbacks.postCheck(results)
+			this.hasActiveCheck = false
 		}
 
 		// clear expired cache files initially when this instance is constructed,

--- a/server/src/massSession.js
+++ b/server/src/massSession.js
@@ -4,6 +4,9 @@ import * as utils from './utils'
 import serverconfig from './serverconfig'
 import { authApi } from './auth'
 
+const cachedir_massSession = serverconfig.cachedir_massSession || path.join(serverconfig.cachedir, 'massSession')
+if (!fs.existsSync(cachedir_massSession)) fs.mkdirSync(cachedir_massSession)
+
 export async function save(req, res) {
 	// POST
 	try {
@@ -23,7 +26,7 @@ export async function save(req, res) {
 
 		// req.body is some string data, save it to file named by the session id
 		const content = JSON.stringify(req.body)
-		const dir = filename ? getSessionPath(q, payload) : serverconfig.cachedir_massSession
+		const dir = filename ? getSessionPath(q, payload) : cachedir_massSession
 		const dirExists = await fs.promises
 			.access(dir)
 			.then(() => true)
@@ -48,7 +51,7 @@ export async function get(req, res) {
 		if (!id) throw 'session id missing'
 		const { route, dslabel, embedder } = req.query
 		const payload = req.query.route ? authApi.getPayloadFromHeaderAuth(req, req.query.route) : null //; console.log(14, payload)
-		const dir = req.query.route ? getSessionPath(req.query, payload) : serverconfig.cachedir_massSession
+		const dir = req.query.route ? getSessionPath(req.query, payload) : cachedir_massSession
 		const file = path.join(dir, id)
 		let sessionCreationDate
 		try {
@@ -89,7 +92,7 @@ export async function _delete(req, res) {
 		const { route, dslabel, embedder } = req.query
 		const payload = req.query.route ? authApi.getPayloadFromHeaderAuth(req, req.query.route) : null
 		if (!payload) throw 'missing credentials'
-		const dir = req.query.route ? getSessionPath(req.query, payload) : serverconfig.cachedir_massSession
+		const dir = req.query.route ? getSessionPath(req.query, payload) : cachedir_massSession
 		const errors = []
 		for (const id of ids) {
 			const file = path.join(dir, id)

--- a/server/src/mds2.load.vcf.js
+++ b/server/src/mds2.load.vcf.js
@@ -92,7 +92,7 @@ get ssid by one m from vcf
 		result.groups[k] = { size: aa.length }
 		lines.push(k + '\t' + aa.join(','))
 	}
-	await utils.write_file(path.join(serverconfig.cachedir_ssid, filename), lines.join('\n'))
+	await utils.write_file(path.join(utils.cachedir_ssid, filename), lines.join('\n'))
 }
 
 export async function handle_vcfbyrange(q, genome, ds, result) {

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -253,4 +253,13 @@ if (fs.existsSync('./package.json')) {
 	serverconfig.version = JSON.parse(pkg).version
 }
 
+if (!serverconfig.cache_snpgt) {
+	serverconfig.cache_snpgt = {
+		dir: path.join(serverconfig.cachedir, 'snpgt'),
+		fileNameRegexp: /[^\w]/, // client-provided cache file name matching with this are denied
+		sampleColumn: 6 // in cache file, sample column starts from 7th column
+	}
+	if (!fs.existsSync(serverconfig.cache_snpgt.dir)) fs.mkdirSync(serverconfig.cache_snpgt.dir, { recursive: true })
+}
+
 export default serverconfig

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -559,12 +559,15 @@ export const genotype_types = {
 	het: 'Heterozygous'
 }
 
+export const cachedir_ssid = serverconfig.cachedir_ssid || path.join(serverconfig.cachedir, 'ssid')
+if (!fs.existsSync(cachedir_ssid)) fs.mkdirSync(cachedir_ssid)
+
 export async function loadfile_ssid(id, samplefilterset) {
 	/*
 samplefilterset:
 	optional Set of samples to restrict to
 */
-	const text = await read_file(path.join(serverconfig.cachedir_ssid, id))
+	const text = await read_file(path.join(cachedir_ssid, id))
 	const sample2gt = new Map()
 	// k: sample, v: genotype str
 	const genotype2sample = new Map()


### PR DESCRIPTION
# Description

This PR restores
- `serverconfig.cache_snpgt`, but set in `src/serverconfig.js`
- `cachedir_gsea`, `cachedir_massSession`, `cachedir_ssid` in the relevant code files
- NOTE: `cachedir_bam` was already reimplemented in a previous PR  

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
