### PR TITLE
fix: mds3 tk cnvonly mode, leftlabel shows #CNVs but not variants

### DIFF
--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -14,6 +14,9 @@ Official - allow2selectSamples
 Official - hardcodeCnvOnly
 Incorrect dslabel
 Custom cnv only, no sample
+
+(todo) Custom fusion
+
 Custom ssm only, no sample
 Custom cnv and ssm, no sample
 Custom cnv and ssm, WITH sample
@@ -889,7 +892,7 @@ tape('Custom cnv only, no sample', test => {
 			test.ok(lab, '"Variants" leftlabel should be displayed')
 			test.equal(
 				lab.node().innerHTML,
-				`${custom_variants.length} variants`,
+				`${custom_variants.length} CNVs`,
 				`Variant leftlabel should print "${custom_variants.length} variants"`
 			)
 		}

--- a/client/mds3/test/skewer.unit.spec.ts
+++ b/client/mds3/test/skewer.unit.spec.ts
@@ -2,6 +2,7 @@ import tape from 'tape'
 import { whenVisible } from '../../test/test.helpers'
 import { showHoverTipOnDisk } from '../skewer.render.js'
 import { dataGood4sunburst } from '../clickVariant.js'
+import { getVariantLabelText } from '../leftlabel.variant.js'
 import { Menu } from '#dom'
 
 /*
@@ -9,6 +10,7 @@ Tests:
 
 showHoverTipOnDisk()
 dataGood4sunburst()
+getVariantLabelText
 */
 
 tape('\n', test => {
@@ -116,5 +118,78 @@ tape('dataGood4sunburst()', function (test) {
 		'should throw'
 	)
 	test.equal(dataGood4sunburst({ nodes: [{}, { name: 'x', cohortsize: 1 }] }), true, 'returns true on good data')
+	test.end()
+})
+
+tape('getVariantLabelText()', function (test) {
+	{
+		// nothing
+		const data = {},
+			tk = {},
+			block = {}
+		const re = getVariantLabelText(data, tk, block)
+		test.equal(re[0], 'No data', 'correct label')
+	}
+	{
+		// custom snv
+		const data = {},
+			tk = {
+				custom_variants: [{ dt: 1 }, { dt: 1 }],
+				skewer: {
+					viewModes: [{ inuse: true, type: 'skewer' }],
+					data: [{ x: 1, mlst: [1, 1] }]
+				}
+			},
+			block = { width: 10 }
+		const re = getVariantLabelText(data, tk, block)
+		test.equal(re[0], '2 variants', 'correct label')
+	}
+	{
+		// native snv
+		const data = {},
+			tk = {
+				skewer: {
+					rawmlst: [{ dt: 1 }, { dt: 1 }],
+					viewModes: [{ inuse: true, type: 'skewer' }],
+					data: [{ x: 1, mlst: [1, 1] }]
+				}
+			},
+			block = { width: 10 }
+		const re = getVariantLabelText(data, tk, block)
+		test.equal(re[0], '2 variants', 'correct label')
+	}
+	{
+		// custom cnv
+		const data = { cnv: [1, 1] },
+			tk = {
+				custom_variants: [{ dt: 4 }, { dt: 4 }]
+			},
+			block = { width: 10 }
+		const re = getVariantLabelText(data, tk, block)
+		test.equal(re[0], '2 CNVs', 'correct label')
+	}
+	{
+		// native cnv
+		const data = { cnv: [{ dt: 4 }, { dt: 4 }] },
+			tk = {},
+			block = { width: 10 }
+		const re = getVariantLabelText(data, tk, block)
+		test.equal(re[0], '2 CNVs', 'correct label')
+	}
+	{
+		// native snv and cnv
+		const data = { cnv: [{ dt: 4 }, { dt: 4 }] },
+			tk = {
+				skewer: {
+					rawmlst: [{ dt: 1 }, { dt: 1 }],
+					viewModes: [{ inuse: true, type: 'skewer' }],
+					data: [{ x: 1, mlst: [1, 1] }]
+				}
+			},
+			block = { width: 10 }
+		const re = getVariantLabelText(data, tk, block)
+		test.equal(re[0], '4 variants', 'correct label')
+	}
+
 	test.end()
 })

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- mds3 tk cnvonly mode, leftlabel shows #CNVs but not variants


### PR DESCRIPTION
# Description
closes #3332 
http://localhost:3000/?genome=hg38&block=1&position=chr11:108195437-108267444&mds3=ASH&cnvonly=1
all mds3 tests pass
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
