### PR TITLE
Gdc init cache

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- simplify error handling by logging more non-sensitive information and moving non-blocking dataset initialization at the end of mds3 init

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -48,7 +48,7 @@ function init({ genomes }) {
 			if (!g) throw 'invalid genome name'
 			const ds = g.datasets[q.dslabel]
 			if (!ds) throw 'invalid dataset name'
-			if (ds.__gdc && !ds.__gdc.doneCaching)
+			if (!ds.__gdc?.doneCaching)
 				throw 'The server has not finished caching the case IDs: try again in about 2 minutes.'
 			if ([TermTypes.GENE_EXPRESSION, TermTypes.METABOLITE_INTENSITY, NUMERIC_DICTIONARY_TERM].includes(q.dataType)) {
 				if (!ds.queries?.[q.dataType] && q.dataType !== NUMERIC_DICTIONARY_TERM)

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -493,6 +493,7 @@ function mayRetryInit(g, ds, d, e) {
 	let currentRetry = 0
 	const interval = setInterval(async () => {
 		currentRetry++
+		ds.init.currentRetry = currentRetry
 		try {
 			console.log(`Retrying ${gdlabel} init(), attempt #${currentRetry} ...`)
 			if (ds.isMds3) await mds3_init.init(ds, g)

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -464,7 +464,7 @@ export async function initGenomesDs(serverconfig) {
 function mayRetryInit(g, ds, d, e) {
 	// if initial attempt fails, can stop or retry
 	const gdlabel = `${g.label}/${ds.label}`
-	console.log(`Init error with ${gdlabel}: ${e}`)
+	console.log(`Init error with ${gdlabel}: `, e)
 	console.trace(e)
 
 	if (!ds.init.recoverableError && !utils.nonFatalStatus.has(ds.init.status) && !utils.nonFatalStatus.has(e.status)) {
@@ -502,8 +502,7 @@ function mayRetryInit(g, ds, d, e) {
 			clearInterval(interval)
 			if (ds.init.status != 'nonblocking') ds.init.status = 'done'
 		} catch (e) {
-			console.log('init retry error:', gdlabel, e)
-			if (!ds.init.recoverableError && !utils.isRecoverableError(e)) {
+			if (ds.init.status != 'recoverableError' && !ds.init.recoverableError && !utils.isRecoverableError(e)) {
 				const msg = `Fatal error on ${gdlabel} retry, stopping retry`
 				console.log(msg)
 				clearInterval(interval) // cancel since retrying will not change the outcome

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -123,7 +123,9 @@ export async function init(ds, genome) {
 	}
 
 	if (ds.preInit) {
-		const response = await ds.preInit.getStatus(ds)
+		const response = await ds.preInit.getStatus(ds).catch(e => {
+			throw e
+		})
 		if (response?.status != 'OK') throw response
 	}
 
@@ -165,6 +167,7 @@ export async function init(ds, genome) {
 	await mayValidateAssayAvailability(ds)
 	await mayValidateViewModes(ds)
 	if (ds.cohort?.db?.refresh) throw `!!! ds.cohort.db.refresh has been deprecated !!!`
+	if (ds.initRemainingWithoutAwait) ds.initRemainingWithoutAwait()
 }
 
 export function client_copy(ds) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -167,6 +167,10 @@ export async function init(ds, genome) {
 	await mayValidateAssayAvailability(ds)
 	await mayValidateViewModes(ds)
 	if (ds.cohort?.db?.refresh) throw `!!! ds.cohort.db.refresh has been deprecated !!!`
+	// invoke non-blocking initialization steps at the end, after validation is complete,
+	// otherwise it will be difficult to coordinate the handling of errors from either
+	// validation or remaining steps that may include setInterval that can run at the
+	// same time as mayRetryInit() in initGenomesDs.js
 	if (ds.initRemainingWithoutAwait) ds.initRemainingWithoutAwait()
 }
 

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -26,6 +26,7 @@ variant2samples_getresult()
 export async function validate_variant2samples(ds) {
 	const vs = ds.variant2samples
 	if (!vs) return
+	// throw `!!! fake validate_variant2samples() failure !!!` // uncomment to test
 
 	if (ds.preInit?.getStatus) {
 		// should wait for dataset or API to be "healthy" before attempting to validate,

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1966,6 +1966,12 @@ export type Mds3 = BaseMds & {
 	isMds3: boolean
 	loadWithoutBlocking?: boolean
 	preInit?: PreInit
+	init?: {
+		/** number of milliseconds to wait before calling th preInit.getStatus() again */
+		retryDelay?: number
+		/** maximum number of times to call preInit.getStatus() before giving up */
+		retryMax?: number
+	}
 	initErrorCallback?: (a: any) => void
 	viewModes?: ViewMode[]
 	dsinfo?: KeyVal[]


### PR DESCRIPTION
# Description

Fixes:
- moved `initRemainingWithoutAwait()` after mds3 validation, to avoid having to coordinate error handling that comes from either mds3 queries validation and/or `cacheMappingOnNewRelease()` loop
- computed `cacheTimes.start` for pending  `ref` object, instead of `ds.__gdc` which will be replaced by the `ref.object` - this fixes missing `cacheTime.start` in `/healthcheck?dslabel=GDC`

To test:
- pull `sjpp/master` that has minor gdc dataset updates
- add `serverconfig.features."gdcCacheCheckWait": 5000, "runRemainingWithoutAwait": true`
- uncomment the fake failure at the beginning of `validate_variant2samples(ds)` in `mds3.variantsamples.js`: retries should be attempted from `mayRetryInit()` in `initGenomesDs.js`
- uncomment lines of code with either `status: 400` or `status: 500` in `initGdc.cache.js`: retries should continue from the `cacheMappingOnNewRelease()` interval as set in `initGdc.cache.js`
- check terminal logs and also http://localhost:3000/healthcheck?dslabel=GDC for more informative status, errors

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
