### PR TITLE
fix: backend always return 0-based start & stop for BED-based gene coord

### DIFF
--- a/client/src/block.js
+++ b/client/src/block.js
@@ -5088,7 +5088,7 @@ function makecoordinput(bb, butrow) {
 				bb.coord.inputtip.hide()
 				if (bb.rglst.length == 1) {
 					const r = bb.rglst[0]
-					input.value = r.chr + ':' + r.start + '-' + r.stop
+					input.value = r.chr + ':' + (r.start + 1) + '-' + (r.stop + 1)
 				}
 				input.blur()
 				return

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- backend always return 0-based start & stop for BED-based gene coord

--- a/server/src/gene.js
+++ b/server/src/gene.js
@@ -63,6 +63,11 @@ export function getResult(g, q) {
 		const tmp = g.genedb.getjsonbyname.all(symbol)
 		result.gmlst = tmp.map(i => {
 			const j = JSON.parse(i.genemodel)
+			/* gene coordinate is from bed files with start=0-based, and stop=not included for feature display
+			minus 1 from stop is a stop-gap for client to uniformly "plus 1" to both start & stop when displaying
+			e.g. hg38 sox1 bed=chr13:112067148-112071706, client shows=chr13:112067149-112071706
+			*/
+			j.stop--
 			if (i.isdefault) j.isdefault = true
 			return j
 		})


### PR DESCRIPTION
# Description

fixes https://gdc-ctds.atlassian.net/browse/SV-2422
test at http://localhost:3000/?genome=hg38&block=1&position=chr11:108195437-108267444
search chr1:1000-2000, gene coord box shows same
search sox1, box shows chr13:112067149-112071706

<img width="311" alt="image" src="https://github.com/user-attachments/assets/69b5df6b-1c2a-431e-84f6-7edeac0a4c1e" />

all CI passed

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
