### PR TITLE
fix the handling of prerelease version

### DIFF
--- a/.github/workflows/CD-create-release.yml
+++ b/.github/workflows/CD-create-release.yml
@@ -7,9 +7,7 @@ on:
         type: choice
         description: Release type
         options:
-          - patch
-          - minor
-          - major
+          - auto-detect
           - prepatch
           - preminor
           - premajor

--- a/build/ci-version-update.sh
+++ b/build/ci-version-update.sh
@@ -12,11 +12,20 @@
 set -euxo pipefail
 
 VERTYPE=prerelease # default
-NOTES=$(node ./build/changeLogGenerator.js -u)
-if [[ "$NOTES" == *"Features:"* ]]; then
-  VERTYPE=minor
-elif [[ "$NOTES" == *"Fixes:"* ]]; then
-  VERTYPE=patch
+if [[ "$1" == "pre"* ]]; then
+  # respect user-selected prerelease, prepatch, preminor, premajor
+  VERTYPE=$1
+else
+  # non pre* version type will be ignored, instead auto-detect 
+  # the version type based on unreleased changelog entries 
+  NOTES=$(node ./build/changeLogGenerator.js -u)
+  if [[ "$NOTES" == *"Features:"* ]]; then
+    VERTYPE=minor
+  elif [[ "$NOTES" == *"Fixes:"* ]]; then
+    VERTYPE=patch
+  # else # devops, docs changelog defaults to prerelease 
+  #   VERTYPE=prerelease
+  fi
 fi
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
# Description

This branch:
- removes user option to specify non-prerelease version type
- force auto-detection of version type for non-prerelease argument to version/bump script

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
