### PR TITLE
Added save zoom icon to save the zoom state

### DIFF
--- a/client/dom/control.icons.js
+++ b/client/dom/control.icons.js
@@ -500,6 +500,15 @@ export const icons = {
 		</svg>`
 		return getHolder(elem, _opts).html(svg)
 	},
+	save: (elem, opts = {}) => {
+		const _opts = { color: 'black', width: 17, height: 17, transform: '' }
+		Object.assign(_opts, opts)
+		const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${_opts.width}" height="${_opts.height}" fill="${_opts.color}" class="bi bi-floppy" viewBox="0 0 18 18">
+			 	<path d="M11 2H9v3h2z"/>
+			  	<path d="M1.5 0h11.586a1.5 1.5 0 0 1 1.06.44l1.415 1.414A1.5 1.5 0 0 1 16 2.914V14.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13A1.5 1.5 0 0 1 1.5 0M1 1.5v13a.5.5 0 0 0 .5.5H2v-4.5A1.5 1.5 0 0 1 3.5 9h9a1.5 1.5 0 0 1 1.5 1.5V15h.5a.5.5 0 0 0 .5-.5V2.914a.5.5 0 0 0-.146-.353l-1.415-1.415A.5.5 0 0 0 13.086 1H13v4.5A1.5 1.5 0 0 1 11.5 7h-7A1.5 1.5 0 0 1 3 5.5V1H1.5a.5.5 0 0 0-.5.5m3 4a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5V1H4zM3 15h10v-4.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5z"/>
+			</svg>`
+		return getHolder(elem, _opts).html(svg)
+	},
 	burguer: (elem, opts = {}) => {
 		const _opts = { color: 'black', width: 20, height: 20, transform: '' }
 		Object.assign(_opts, opts)

--- a/client/plots/scatter/viewmodel/scatterZoom.ts
+++ b/client/plots/scatter/viewmodel/scatterZoom.ts
@@ -71,6 +71,7 @@ export class ScatterZoom {
 	}
 
 	saveZoom() {
+		if (!this.transform) return
 		this.scatter.config.transform = this.transform.toString()
 		this.scatter.app.dispatch({
 			type: 'plot_edit',

--- a/client/plots/scatter/viewmodel/scatterZoom.ts
+++ b/client/plots/scatter/viewmodel/scatterZoom.ts
@@ -20,12 +20,6 @@ export class ScatterZoom {
 			})
 			.on('end', async event => {
 				this.transform = event.transform
-				this.scatter.config.transform = event.transform.toString()
-				await this.scatter.app.dispatch({
-					type: 'plot_edit',
-					id: this.scatter.id,
-					config: this.scatter.config
-				})
 			})
 		this.zoom = 1
 	}
@@ -60,11 +54,29 @@ export class ScatterZoom {
 			handler: () => this.zoomOut(),
 			title: 'Zoom out. You can also zoom out pressing the Ctrl key and using the mouse wheel'
 		})
+		const saveZoomDiv = toolsDiv
+			.insert('div')
+			.style('display', display)
+			.style('margin', '15px 10px')
+			.attr('name', 'sjpp-zoom-save-btn') //For unit tests
+		icon_functions['save'](saveZoomDiv, {
+			handler: () => this.saveZoom(),
+			title: 'Save the zoom transformation in the state. Needed when creating a session to persist the zoom'
+		})
 		for (const chart of this.scatter.model.charts) {
 			chart.mainG.call(this.zoomD3)
 		}
 
 		if (this.scatter.config.scaleDotTW && this.zoom > 4) this.resetToIdentity()
+	}
+
+	saveZoom() {
+		this.scatter.config.transform = this.transform.toString()
+		this.scatter.app.dispatch({
+			type: 'plot_edit',
+			id: this.scatter.id,
+			config: this.scatter.config
+		})
 	}
 
 	handleZoom(transform) {


### PR DESCRIPTION
# Description

Do not save zoom state by default but allow to save it on a session created from the save session icon added to the zoom icons

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
