### PR TITLE
server cache manager must allow validate step to exit immediately

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- server cache manager must allow validate step to exit immediately
+- create bam cache dir as needed

--- a/server/src/CacheManager.ts
+++ b/server/src/CacheManager.ts
@@ -42,6 +42,7 @@ type CacheOpts = {
 			  }
 	}
 	callbacks: Callbacks
+	mustExitPendingValidation?: boolean
 }
 
 // options to trigger a callback after
@@ -129,7 +130,7 @@ export class CacheManager {
 			}
 		}
 		if (this.callbacks.preStart) await this.callbacks.preStart(this)
-		await this.start()
+		if (!opts.mustExitPendingValidation) await this.start()
 	}
 
 	/** Check if the subdir exists. If not create. */

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -26,7 +26,11 @@ if (serverconfig.python) setPythonBinPath(serverconfig.python)
 
 export async function launch() {
 	try {
-		new CacheManager(Object.assign({ cachedir: serverconfig.cachedir }, serverconfig.features?.cacheMonitor || {}))
+		new CacheManager(
+			Object.assign({ cachedir: serverconfig.cachedir }, serverconfig.features?.cacheMonitor || {}, {
+				mustExitPendingValidation: serverconfig.features?.mustExitPendingValidation
+			})
+		)
 
 		const trackedDatasets = await initGenomesDs(serverconfig)
 		const doneLoading = processTrackedDs(trackedDatasets)

--- a/server/src/bam.js
+++ b/server/src/bam.js
@@ -3647,6 +3647,7 @@ const maxSize = bamCache.maxSize || 5e9
 const checkWait = bamCache.checkWait || 1 * 60 * 1000
 
 const cachedir_bam = serverconfig.cachedir_bam || path.join(serverconfig.cachedir, 'bam')
+if (!fs.existsSync(cachedir_bam)) fs.mkdirSync(cachedir_bam, { recursive: true })
 
 // a pending timeout reference from setTimeout that calls mayDeleteCacheFiles
 let cacheCheckTimeout,

--- a/server/src/initGdc.cache.js
+++ b/server/src/initGdc.cache.js
@@ -44,7 +44,7 @@ export async function initGdcCache(ds) {
 
 	// may do it because it could be disabled by feature toggle
 	// caching action is fine-tuned by the feature toggle on a pp instance; log out detailed status per setting
-	if (serverconfig.features.stopGdcCacheAliquot) {
+	if (serverconfig.features.stopGdcCacheAliquot || serverconfig.features.mustExitPendingValidation) {
 		// do not cache at all. this flag is auto-set for container validation. running stale cache check will cause the server process not to quit, and break validation, thus must skip this when flag is true
 		console.log('GDC: sample IDs are not cached! No periodic check will take place!')
 		if (!ds.__gdc) ds.__gdc = getCacheRef(ds) // though nothing is cached, must init the cache holder so not to break code that accesses this holder

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -228,6 +228,7 @@ if (process.argv.find(a => a == 'validate')) {
 	// async methods will still block the validation. Only other async methods are not blocked
 	// by each other while executing.
 	serverconfig.features.stopGdcCacheAliquot = true
+	serverconfig.features.mustExitPendingValidation = true
 }
 
 const publicDir = path.join(process.cwd(), './public')


### PR DESCRIPTION
# Description

Also, create bam cache dir as needed. Tested with: 
- run `npx tsx ./server.ts validate` from `sjpp` dir, this should exit immediately/not hang
- `npm run test:unit` from server dir

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
