### PR TITLE
fix: pass fusion breakpoints as sample property for correct display i…

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -474,7 +474,7 @@ export async function samples2columnsRows(samples, tk) {
 								oneHtml.push(m.mname)
 							}
 						} else if (m.dt == dtsv || m.dt == dtfusionrna) {
-							const p = m.pairlst[0]
+							const p = sample._pairlst?.[0] || m.pairlst[0]
 							oneHtml.push(
 								`${p.a.name || ''} ${p.a.chr}:${p.a.pos} ${p.a.strand == '+' ? 'forward' : 'reverse'} > ${
 									p.b.name || ''

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -474,6 +474,7 @@ export async function samples2columnsRows(samples, tk) {
 								oneHtml.push(m.mname)
 							}
 						} else if (m.dt == dtsv || m.dt == dtfusionrna) {
+							// server-returned data has sample._pairlst and shouldn't use m.pairlst; client-side custom data only has m.pairlst
 							const p = sample._pairlst?.[0] || m.pairlst[0]
 							oneHtml.push(
 								`${p.a.name || ''} ${p.a.chr}:${p.a.pos} ${p.a.strand == '+' ? 'forward' : 'reverse'} > ${

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- pass fusion breakpoints as sample property for correct display in mds3 tk sample table

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2170,7 +2170,17 @@ export async function svfusionByRangeGetter_file(ds, genome) {
 						// for ds with sampleidmap, j.sample value should be integer
 						// XXX not guarding against file uses non-integer sample values in such case
 
-						sampleObj = { sample_id: j.sample }
+						sampleObj = {
+							sample_id: j.sample,
+							/* ssm_id of a fusion can only identify one breakend. 
+							position of the other breakend is missing from ssm_id
+							must attach pairlst at a sample so it's available to downstream
+							_pairlst is not required for skewer summary view, but required for sample table view
+							where sample._pairlst must be used instead of m.pairlst for displaying actual breakpoints in each sample
+							*/
+							_pairlst: pairlst
+						}
+
 						if (j.mattr) {
 							// mattr{} has sample-level attributes on this sv event, equivalent to FORMAT
 							if (formatFilter) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2177,6 +2177,11 @@ export async function svfusionByRangeGetter_file(ds, genome) {
 							must attach pairlst at a sample so it's available to downstream
 							_pairlst is not required for skewer summary view, but required for sample table view
 							where sample._pairlst must be used instead of m.pairlst for displaying actual breakpoints in each sample
+
+							known issue!
+							on clicking a fusion disk that covers multiple fusion m objects,
+							it still displays a single breakpoint for each m object, dispite samples from a m can have different breakpoints
+							this is due to practical design issue that sample-level breakpoint info is not known at the aggregated skewer view
 							*/
 							_pairlst: pairlst
 						}


### PR DESCRIPTION
…n mds3 tk sample table

# Description
closes #3356 
[test link](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22chr%22:%22chr1%22,%22start%22:164792437,%22stop%22:164792539}}]})
now the n=59 TCF3 disk will show varying chr19 TCF3 breakpoints across samples, rather than exactly the same chr19 breakpoints

all mds3 tests pass
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
