### PR TITLE
Added controls option to save the zoom in the scatter

### DIFF
--- a/client/plots/eventCount/eventCount.ts
+++ b/client/plots/eventCount/eventCount.ts
@@ -109,8 +109,7 @@ export function getDefaultEventCountSettings() {
 		// up to the 95th percentile by default
 		colorScaleMinFixed: null, // User-defined minimum value for fixed mode
 		// Null indicates this hasn't been set yet
-		colorScaleMaxFixed: null // User-defined maximum value for fixed mode
-		// Null indicates this hasn't been set yet
-		//3D Plot settings,
+		colorScaleMaxFixed: null, // User-defined maximum value for fixed mode
+		saveZoomTransform: false
 	}
 }

--- a/client/plots/eventCount/view/eventCountView.ts
+++ b/client/plots/eventCount/view/eventCountView.ts
@@ -74,7 +74,7 @@ export class EventCountView extends RunchartView {
 				menuOptions: '!remove',
 				numericEditMenuVersion: ['continuous']
 			},
-			
+
 			{
 				type: 'term',
 				configKey: 'term0',
@@ -136,6 +136,15 @@ export class EventCountView extends RunchartView {
 				type: 'color',
 				chartType: 'eventCount',
 				settingsKey: 'defaultColor'
+			},
+			{
+				label: 'Save zoom transform',
+				boxLabel: '',
+				type: 'checkbox',
+				chartType: 'eventCount',
+				settingsKey: 'saveZoomTransform',
+				title: `Option to save the zoom transformation in the state. Needed if you want to save a session with the actual zoom and pan applied`,
+				processInput: value => this.saveZoomTransform(value)
 			}
 		]
 		if (this.eventCount.config.scaleDotTW)

--- a/client/plots/runchart/runchart.ts
+++ b/client/plots/runchart/runchart.ts
@@ -225,8 +225,7 @@ export function getDefaultRunChartSettings() {
 		// up to the 95th percentile by default
 		colorScaleMinFixed: null, // User-defined minimum value for fixed mode
 		// Null indicates this hasn't been set yet
-		colorScaleMaxFixed: null // User-defined maximum value for fixed mode
-		// Null indicates this hasn't been set yet
-		//3D Plot settings,
+		colorScaleMaxFixed: null, // User-defined maximum value for fixed mode
+		saveZoomTransform: false
 	}
 }

--- a/client/plots/runchart/view/runchartView.ts
+++ b/client/plots/runchart/view/runchartView.ts
@@ -195,6 +195,15 @@ export class RunchartView extends ScatterView {
 					type: 'color',
 					chartType: 'runChart',
 					settingsKey: 'defaultColor'
+				},
+				{
+					label: 'Save zoom transform',
+					boxLabel: '',
+					type: 'checkbox',
+					chartType: 'runChart',
+					settingsKey: 'saveZoomTransform',
+					title: `Option to save the zoom transformation in the state. Needed if you want to save a session with zoom and pan applied`,
+					processInput: value => this.saveZoomTransform(value)
 				}
 			]
 		)

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -29,6 +29,7 @@ export class Scatter extends RxComponentInner {
 	opts: any
 	state!: any
 	readonly type: string
+	transform: any
 
 	constructor() {
 		super()
@@ -272,7 +273,8 @@ export function getDefaultScatterSettings() {
 		contourBandwidth: 30,
 		contourThresholds: 10,
 		duration: 500,
-		useGlobalMinMax: true
+		useGlobalMinMax: true,
+		saveZoomTransform: false
 	}
 }
 

--- a/client/plots/scatter/view/scatterView.ts
+++ b/client/plots/scatter/view/scatterView.ts
@@ -3,7 +3,6 @@ import { Menu } from '#dom'
 import type { Scatter } from '../scatter.js'
 import { select } from 'd3-selection'
 import { isNumericTerm } from '#shared/terms.js'
-
 export const minShapeSize = 0.2
 export const maxShapeSize = 6
 export class ScatterView {
@@ -181,6 +180,15 @@ export class ScatterView {
 				settingsKey: 'showContour',
 				title:
 					"Shows the density of point clouds. If 'Color' is used in continous mode, it uses it to weight the points when calculating the density contours. If 'Z/Divide by' is added in continous mode, it used it instead."
+			},
+			{
+				label: 'Save zoom transform',
+				boxLabel: '',
+				type: 'checkbox',
+				chartType: 'sampleScatter',
+				settingsKey: 'saveZoomTransform',
+				title: `Option to save the zoom transformation in the state. Needed if you want to save a session with the actual zoom and pan applied`,
+				processInput: value => this.saveZoomTransform(value)
 			}
 		]
 		if (this.scatter.settings.showContour)
@@ -367,6 +375,11 @@ export class ScatterView {
 			inputs.push(showAxes)
 		}
 		return inputs
+	}
+
+	saveZoomTransform(value: any) {
+		if (value) this.scatter.vm.scatterZoom.saveZoomTransform()
+		return value
 	}
 }
 

--- a/client/plots/scatter/viewmodel/scatterViewModelBase.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModelBase.ts
@@ -137,7 +137,7 @@ export class ScatterViewModelBase {
 			chart.regressionG = chart.mainG.append('g').attr('class', 'sjpcb-scatter-lowess')
 			chart.legendG = svg.append('g').attr('class', 'sjpcb-scatter-legend')
 			if (this.scatter.state.config.transform && chart.mainG.attr('transform') != this.scatter.state.config.transform) {
-				chart.mainG.attr('transform', this.scatter.state.config.transform, chart.mainG.attr('transform'))
+				chart.mainG.attr('transform', this.scatter.state.config.transform)
 			}
 			chart.G.attr('clip-path', `url(#${id})`)
 		} else {


### PR DESCRIPTION
# Description

Removed save session icon and added controls option to save the zoom transformation. When used it allows to create sessions that have the zoom transformation 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
