### PR TITLE
add download icon to lollipop sample table

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -70,7 +70,7 @@ export async function displaySampleTable(samples, args) {
 		return await make_singleSampleTable(samples[0], args)
 	}
 	const [columns, rows] = await samples2columnsRows(samples, args.tk)
-	const params = { rows, columns, div: args.div, resize: rows.length > 10, dataTestId: 'sjpp_mds3tk_sampletable' }
+	const params = { rows, columns, div: args.div, resize: rows.length > 10, dataTestId: 'sjpp_mds3tk_sampletable' , download: { fileName: 'Sample table' } }
 	//if (args.maxWidth) params.maxWidth = args.maxWidth
 	//if (args.maxHeight) params.maxHeight = args.maxHeight
 


### PR DESCRIPTION
# Description
sample table in lollipop chart now shows download option. @airenzp and @creilly8 could you help test and crosscheck if there's other places in the codebase that need this param. @xzhou82 is the name of the downloaded file suitable? or do you want something different? 

@creilly8, this could be something to add to the newsletter. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
