### PR TITLE
gdc cnv tool launcher will auto hide the <input> after search is done

### DIFF
--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -86,7 +86,10 @@ export async function init(arg, holder, genomes) {
 		tip,
 		row: geneInputDiv,
 		callback: launchView,
-		geneSymbol: arg.geneSymbol
+		geneSymbol: arg.geneSymbol,
+		triggerSearch: arg.geneSymbol && arg.geneSearch4GDCmds3?.hardcodeCnvOnly == true,
+		hideInputBeforeCallback: arg.geneSearch4GDCmds3?.hardcodeCnvOnly == true,
+		disableInput: arg.geneSearch4GDCmds3?.hardcodeCnvOnly == true
 	}
 	if (!arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
 		// not in cnv mode; is in lollipop mode to show coding ssm over gene coding exons, apply this flag
@@ -188,6 +191,7 @@ export async function init(arg, holder, genomes) {
 		if (!arg.geneSearch4GDCmds3.hardcodeCnvOnly) return await blockinit(pa) // does it need to return?
 		// launch genome browser view
 		const _ = await import('../src/block')
+		// TODO: pa argument needs an option to freeze the searchbox to demo geneSymbol, maybe .property('disable', true)
 		return new _.Block(pa)
 	}
 

--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -144,6 +144,7 @@ export async function init(arg, holder, genomes) {
 			pa.tklst = [tk]
 			if (arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
 				tk.hardcodeCnvOnly = 1
+				tk.disableSearchInput = searchOpt.disableInput
 				// also block is in genome browser mode
 				delete pa.gmmode
 				first_genetrack_tolist(pa.genome, pa.tklst)
@@ -191,7 +192,6 @@ export async function init(arg, holder, genomes) {
 		if (!arg.geneSearch4GDCmds3.hardcodeCnvOnly) return await blockinit(pa) // does it need to return?
 		// launch genome browser view
 		const _ = await import('../src/block')
-		// TODO: pa argument needs an option to freeze the searchbox to demo geneSymbol, maybe .property('disable', true)
 		return new _.Block(pa)
 	}
 

--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -88,8 +88,7 @@ export async function init(arg, holder, genomes) {
 		callback: launchView,
 		geneSymbol: arg.geneSymbol,
 		triggerSearch: arg.geneSymbol && arg.geneSearch4GDCmds3?.hardcodeCnvOnly == true,
-		hideInputBeforeCallback: arg.geneSearch4GDCmds3?.hardcodeCnvOnly == true,
-		disableInput: arg.geneSearch4GDCmds3?.hardcodeCnvOnly == true
+		hideInputBeforeCallback: arg.geneSearch4GDCmds3?.hardcodeCnvOnly == true
 	}
 	if (!arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
 		// not in cnv mode; is in lollipop mode to show coding ssm over gene coding exons, apply this flag
@@ -144,7 +143,6 @@ export async function init(arg, holder, genomes) {
 			pa.tklst = [tk]
 			if (arg.geneSearch4GDCmds3.hardcodeCnvOnly) {
 				tk.hardcodeCnvOnly = 1
-				tk.disableSearchInput = searchOpt.disableInput
 				// also block is in genome browser mode
 				delete pa.gmmode
 				first_genetrack_tolist(pa.genome, pa.tklst)

--- a/client/src/block.js
+++ b/client/src/block.js
@@ -938,6 +938,10 @@ export class Block {
 				'No tracks specified. If you don\'t expect to see this, delete the "block:true" from runproteinpaint() argument.'
 			)
 		}
+
+		if (this.tklst?.[0].hardcodeCnvOnly && this.tklst[0].disableSearchInput) {
+			this.coord.input.property('disabled', true).attr('title', 'This search input is disabled in demo mode.')
+		}
 	}
 	/****** end of constructor ***/
 

--- a/client/src/block.js
+++ b/client/src/block.js
@@ -938,10 +938,6 @@ export class Block {
 				'No tracks specified. If you don\'t expect to see this, delete the "block:true" from runproteinpaint() argument.'
 			)
 		}
-
-		if (this.tklst?.[0].hardcodeCnvOnly && this.tklst[0].disableSearchInput) {
-			this.coord.input.property('disabled', true).attr('title', 'This search input is disabled in demo mode.')
-		}
 	}
 	/****** end of constructor ***/
 


### PR DESCRIPTION
# Description

Manually tested in local GFF by choosing the demo mode. To test outside of GFF, force lines 90-92 to true in `lollipop.js` to simulate GFF demo mode.

Also tested to make sure that lollipop does not break with these changes. For example, genesearch does not get hidden/disabled.

DONE ~~Note the TODO to be able to freeze/disable the gene/coord input in genome browser during demo mode, otherwise the demo text about MYC may not match the displayed track if the user searches for a different gene/coord.~~

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
