### PR TITLE
table shows download button instead of icon

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -77,22 +77,6 @@ export function renderTable({
 
 	const uniqueInputName = inputName || getUniqueNameOrId('input')
 	const parentDiv = div.append('div').style('background-color', 'white').style('display', 'inline-block')
-	if (download) {
-		const downloadDiv = div
-			.append('div')
-			.style('display', 'inline-block')
-			.style('padding', '5px')
-			.style('vertical-align', 'top')
-
-		icons['download'](downloadDiv, {
-			width: 15,
-			height: 15,
-			title: 'Download table',
-			handler: () => {
-				downloadTable(rows, columns, download.fileName || 'table.tsv')
-			}
-		})
-	}
 
 	if (resize) {
 		if (rows.length > 15) parentDiv.style('height', maxHeight)
@@ -383,6 +367,17 @@ export function renderTable({
 
 		// call function to update buttons with .onChange(), so their text can reflect default checkbox selection
 		updateButtons()
+	}
+
+	if (download) {
+		div
+			.append('div')
+			.style('padding', '10px')
+			.append('button')
+			.text('Download')
+			.on('click', () => {
+				downloadTable(rows, columns, download.fileName || 'table.tsv')
+			})
 	}
 
 	function updateButtons() {

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -77,7 +77,19 @@ export function renderTable({
 
 	const uniqueInputName = inputName || getUniqueNameOrId('input')
 	const parentDiv = div.append('div').style('background-color', 'white').style('display', 'inline-block')
+	if (download) {
+		parentDiv
+			.append('div')
+			.append('button')
+			.style('float', 'right')
+			.style('margin', '10px 50px 10px 0')
 
+			.text('Download')
+
+			.on('click', () => {
+				downloadTable(rows, columns, download.fileName || 'table.tsv')
+			})
+	}
 	if (resize) {
 		if (rows.length > 15) parentDiv.style('height', maxHeight)
 		parentDiv.style('max-width', maxWidth)
@@ -367,17 +379,6 @@ export function renderTable({
 
 		// call function to update buttons with .onChange(), so their text can reflect default checkbox selection
 		updateButtons()
-	}
-
-	if (download) {
-		div
-			.append('div')
-			.style('padding', '10px')
-			.append('button')
-			.text('Download')
-			.on('click', () => {
-				downloadTable(rows, columns, download.fileName || 'table.tsv')
-			})
 	}
 
 	function updateButtons() {

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -70,7 +70,7 @@ export async function displaySampleTable(samples, args) {
 		return await make_singleSampleTable(samples[0], args)
 	}
 	const [columns, rows] = await samples2columnsRows(samples, args.tk)
-	const params = { rows, columns, div: args.div, resize: rows.length > 10, dataTestId: 'sjpp_mds3tk_sampletable' }
+	const params = { rows, columns, div: args.div, resize: rows.length > 10, dataTestId: 'sjpp_mds3tk_sampletable' , download: { fileName: 'Sample table' } }
 	//if (args.maxWidth) params.maxWidth = args.maxWidth
 	//if (args.maxHeight) params.maxHeight = args.maxHeight
 


### PR DESCRIPTION
# Description

Replaced download icon with button that seems to look better in the UI. Please check:

Lollipop
<img width="1733" alt="Screenshot 2025-05-22 at 5 38 27 PM" src="https://github.com/user-attachments/assets/df296547-ddcc-4215-a12f-e28dd8b5b6a0" />

Single cell Diff Expression: 

<img width="898" alt="Screenshot 2025-05-22 at 5 40 41 PM" src="https://github.com/user-attachments/assets/061b3ef5-89b0-4ad7-bfc2-463d72cf7897" />




## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
