### PR TITLE
Cancel a stale gdc cache fetch loop

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- cancel a stale gdc cache fetch loop to prevent race condition issues


### PR DESCRIPTION
# Description

This PR prevents concurrent caching of different versions that may share ds-level tracking variables and thus lead to hard-to-debug issues/race condition. In master, an active `fetchIdsFromGdcApi()` loop in `initGdc.cache.js` was not canceled (did not break) when a stale version is detected.

Test:
- comment out the `serverconfig.features.extApiCache` option 
- gdc should still finish caching after about two minutes: should not break usual caching
- Simulated test using preInit.test from `sjpp/ppgdc/dataset/gdc.hg38.ts`:
  - set `serverconfig.features."gdcCacheCheckWait": 5000`
  - set 
  - there should be an awaited initial caching after `call #3` in the server logs 
  - set `const totalCases = 8000` in line 291 of `initGdc.cache.js`, for quicker testing
  - skipped recache after `call #4`
  - recache after `call #5`
  - skipped recache after `call #6`
  - a delayed recache after `call #7` - this will be cancelled after `call #8` recache starts and after a version change is detected 
  - recache after `call #8`, should finish to completion
 
Example server logs
```sh
--- these datasets are running nonblocking initialization steps ---
hg38/GDC

Sat May 24 2025 13:35:20 GMT-0500 (Central Daylight Time) 
setting app middlewares ...
setting server routes ...
setting /coverage routes
may set auth routes ...
setting routes from app.unorg.js ...

Validation succeeded.

STANDBY AT PORT 3000

--- call #3 to preInit.test.mayEditResponse() ---
GDC open-access projects: 52
GDC: Start to cache sample IDs of 8000 cases...
GDC: Done caching sample IDs. Time: 16 s
	 31690 aliquot IDs to sample submitter id,
	 8000 case uuid to submitter id,
	 53671 different ids to case uuid,
	 3382 cases with gene expression data.
GDC: checking if cache is stale OR should recover from an error

--- call #4 to preInit.test.mayEditResponse() ---
GDC: skip recache of  0 undefined 0
GDC: checking if cache is stale OR should recover from an error

--- call #5 to preInit.test.mayEditResponse() ---
GDC: cache is stale. Re-caching... 1
GDC open-access projects: 52
GDC: Start to cache sample IDs of 8000 cases...
GDC: allow pending cache to finish ({"major":43,"minor":1,"release_date":"2025-05-07"})
GDC: allow pending cache to finish ({"major":43,"minor":1,"release_date":"2025-05-07"})
GDC: allow pending cache to finish ({"major":43,"minor":1,"release_date":"2025-05-07"})
GDC: allow pending cache to finish ({"major":43,"minor":1,"release_date":"2025-05-07"})
GDC: Done caching sample IDs. Time: 21 s
	 31690 aliquot IDs to sample submitter id,
	 8000 case uuid to submitter id,
	 53671 different ids to case uuid,
	 3382 cases with gene expression data.
GDC: checking if cache is stale OR should recover from an error

--- call #6 to preInit.test.mayEditResponse() ---
GDC: skip recache of  1 undefined 1
GDC: checking if cache is stale OR should recover from an error

--- call #7 to preInit.test.mayEditResponse() ---
checking for cached bam files to delete ...
deleted 0 of 0 cached bam files (0 bytes deleted, 0 remaining)
GDC: checking if cache is stale OR should recover from an error

--- call #8 to preInit.test.mayEditResponse() ---
GDC: cache is stale. Re-caching... 3
GDC open-access projects: 52
GDC: Start to cache sample IDs of 8000 cases...
... after call #7 delay ..., version.minor= 2
GDC: !!! cancel stale pending cache for  { major: 43, minor: 2, release_date: '2025-05-07' }
GDC: allow pending cache to finish ({"major":43,"minor":3,"release_date":"2025-05-07"})
GDC: allow pending cache to finish ({"major":43,"minor":3,"release_date":"2025-05-07"})
GDC: allow pending cache to finish ({"major":43,"minor":3,"release_date":"2025-05-07"})
GDC: Done caching sample IDs. Time: 16 s
	 31690 aliquot IDs to sample submitter id,
	 8000 case uuid to submitter id,
	 53671 different ids to case uuid,
	 3382 cases with gene expression data.
GDC: checking if cache is stale OR should recover from an error

--- call #9 to preInit.test.mayEditResponse() ---
GDC: skip recache of  3 undefined 3
GDC: checking if cache is stale OR should recover from an error

--- call #10 to preInit.test.mayEditResponse() ---
```
 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
