### PR TITLE
allow ci-version-update to resume from an interrupted release

### DIFF
--- a/build/bump.js
+++ b/build/bump.js
@@ -42,8 +42,7 @@ const defaults = {
 	// -x
 	exclude: [], // list of workspace name patterns to exclude from processing,
 	// -c
-	refCommit: `v${rootPkg.version}^{commit}`
-	//
+	refCommit: `v${rootPkg.version}^{commit}` // the commit reference to use for git diff
 }
 const opts = JSON.parse(JSON.stringify(defaults))
 for (const k of process.argv.slice(3)) {

--- a/rust/downloadBinariesOrCompileSource.js
+++ b/rust/downloadBinariesOrCompileSource.js
@@ -11,8 +11,8 @@ const __dirname = import.meta.dirname
 
 // Read package.json
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'))
-const { version, pp_release_tag } = packageJson
-
+const { version } = packageJson
+const pp_release_tag = `v${version}`
 const targetDirectory = './target/release'
 
 function downloadBinary(url, outputPath) {


### PR DESCRIPTION
# Description

The PR enables `ci-version-update.sh` to safely resume from an interrupted release, without creating duplicate version bump, commits, tags. In `master`,  this ci will exist with an error if any of the previous release steps were already completed.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
