### PR TITLE
Skip validation of BiocManager package

### DIFF
--- a/R/utils/validate.pkgs.R
+++ b/R/utils/validate.pkgs.R
@@ -17,6 +17,13 @@ allPkgs <- c(CRANpkgs, BIOCpkgs)
 # wrap in a function to export to other scripts
 validatePkgs <- function() {
   for (pkg in allPkgs) {
+    if (pkg == "BiocManager") {
+      # loading BiocManager requires internet connection to reference a remote yaml file (see https://cran.r-project.org/web/packages/BiocManager/vignettes/BiocManager.html#offline-config.yaml)
+      # should avoid internet requirement since this script runs upon server startup
+      # therefore will skip validation of this package, which is fine since it is
+      # only needed to install Bioconductor packages (which has already been performed by install.pkgs.R)
+      next
+    }
     suppressPackageStartupMessages(library(pkg, character.only = TRUE))
   }
 }

--- a/R/utils/validate.pkgs.R
+++ b/R/utils/validate.pkgs.R
@@ -20,8 +20,9 @@ validatePkgs <- function() {
     if (pkg == "BiocManager") {
       # loading BiocManager requires internet connection to reference a remote yaml file (see https://cran.r-project.org/web/packages/BiocManager/vignettes/BiocManager.html#offline-config.yaml)
       # should avoid internet requirement since this script runs upon server startup
-      # therefore will skip validation of this package, which is fine since it is
-      # only needed to install Bioconductor packages (which has already been performed by install.pkgs.R)
+      # therefore will skip validation of this package, which is ok since it is
+      # only needed to install Bioconductor packages (see "install.pkgs.R") and is
+      # not used in runtime
       next
     }
     suppressPackageStartupMessages(library(pkg, character.only = TRUE))


### PR DESCRIPTION
# Description

The `R/utils/validate.pkgs.R` script validates all R dependencies upon server startup (see `server/src/checkDependenciesAndVersions.js`) by ensuring that each dependency can load within an R process. One of these dependencies is the `BiocManager` package, which is used to install Bioconductor packages. When this package is loaded it requires internet access to reference a remote yaml file (see https://cran.r-project.org/web/packages/BiocManager/vignettes/BiocManager.html#offline-config.yaml) to verify the Bioconductor version. Since we do not want to require internet access upon server startup, this PR skips the validation of the `BiocManager` package. Skipping the validation of this package is fine since this package is only used to install R dependencies (see `R/utils/install.pkgs.R`) and not used in runtime.

To test:
- Turn off WIFI/ethernet
- In serverconfig.json, set  `features.skip_checkDependenciesAndVersions: false`
- git checkout master
- Restart `npm run dev`
- The following error should be emitted:
```
R process emitted standard error
R stderr: Warning messages:
1: In file(con, "r") :
  URL 'https://bioconductor.org/config.yaml': status was 'Couldn't resolve host name'
2: In file(con, "r") :
  URL 'http://bioconductor.org/config.yaml': status was 'Couldn't resolve host name'
```
- git checkout biocmanager-no-validation
- Restart `npm run dev`
- Server should startup normally

I also tested with docker container and the server in the container is now also able to start up without internet.

@siosonel this fix should also fix the startup issue we saw with the GDC container, so the changes made in this [sjpp PR](https://github.com/stjude/sjpp/pull/852) may no longer be needed. But we can keep them for now.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
