### PR TITLE
update type def to allow ds-supplied getter as alternative to term-based assay availability

### DIFF
--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -368,6 +368,7 @@ export async function getPlotConfig(opts, app) {
 		if (opts.shapeTW) await fillTermWrapper(opts.shapeTW, app.vocabApi)
 		if (opts.scaleDotTW) await fillTermWrapper(opts.scaleDotTW, app.vocabApi)
 	} catch (e) {
+		if (e.stack) console.log(e.stack)
 		throw `${e} [summary getPlotConfig()]`
 	}
 

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -243,15 +243,15 @@ function mayMakeGroups(tw: RawGvCustomGsTW) {
 	if (!dtTerms) throw 'dtTerms is missing'
 	let WTfilter, WTname, MUTfilter, MUTtvs, MUTname
 	for (const dtTerm of dtTerms) {
+		const classes = Object.keys(dtTerm.values)
 		// wildtype filter
-		const WT = 'WT'
+		const WT = classes.includes('WT') ? 'WT' : classes[0] // TODO: this is a quick fix, should generalize groups to be grp1 vs. grp2 instead of mut vs. wt
 		const WTvalue = { key: WT, label: dtTerm.values[WT].label, value: WT }
 		const WTtvs = { type: 'tvs', tvs: { term: dtTerm, values: [WTvalue] } }
 		WTfilter = getWrappedTvslst([WTtvs])
-		WTname = 'Wildtype'
+		WTname = dtTerm.values[WT].label
 		if (dtTerm.origin) WTname += ` (${dtTerm.origin})`
 		// mutated filter
-		const classes = Object.keys(dtTerm.values)
 		if (classes.length < 2) {
 			// fewer than 2 classes, try next dt term
 			continue
@@ -269,7 +269,7 @@ function mayMakeGroups(tw: RawGvCustomGsTW) {
 			// more than 2 classes
 			// mutant filter will filter for all non-wildtype classes
 			MUTtvs = { type: 'tvs', tvs: { term: dtTerm, values: [WTvalue], isnot: true } }
-			MUTname = dtTerm.name
+			MUTname = classes.includes('WT') ? dtTerm.name : `Other ${dtTerm.name}`
 		}
 		MUTfilter = getWrappedTvslst([MUTtvs])
 		break

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -431,6 +431,7 @@ export async function initGenomesDs(serverconfig) {
 			ds.noHandleOnClient = d.noHandleOnClient
 			ds.label = d.name
 			ds.genomename = genomename
+			ds.genomeObj = g // this makes genome obj readily accessible to functions that already accepts ds obj as argument, avoid retrofit to add in additional genome obj argument
 			g.datasets[ds.label] = ds
 
 			// populate possibly missing ds.init option values

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1491,7 +1491,7 @@ async function querySamplesSurvival(q, survivalTwLst, ds, samples, geneTwLst) {
 		filter.content.push(q.filter0)
 	}
 
-	if (geneTwLst) q.isoforms = mapGenes2isoforms(geneTwLst, q.genome)
+	if (geneTwLst) q.isoforms = mapGenes2isoforms(geneTwLst, ds.genomeObj)
 
 	addSsmIsoformRegion4filter(filter.content, q, 'survival')
 
@@ -1583,7 +1583,7 @@ async function querySamplesTwlstNotForGeneexpclustering(q, dictTwLst, ds, geneTw
 
 	if (geneTwLst) {
 		// temporarily create q.isoforms[] to filter for cases with ssm on these genes; will be deleted after query completes
-		q.isoforms = mapGenes2isoforms(geneTwLst, q.genome)
+		q.isoforms = mapGenes2isoforms(geneTwLst, ds.genomeObj)
 	}
 
 	if (q.isoforms || q.isoform || q.ssm_id_lst || q.rglst) {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -167,7 +167,7 @@ async function getSampleData(q, ds, onlyChildren = false) {
 				byTermId[tw.$id] = { bins: lstOfBins }
 			}
 			const args = {
-				genome: q.ds.genome,
+				genome: q.ds.genomename,
 				dslabel: q.ds.label,
 				dataType: tw.term.type,
 				terms: [tw.term],
@@ -689,7 +689,7 @@ async function findListOfBins(q, tw, ds) {
 			await new Promise(async (resolve, reject) => {
 				const _q = {
 					tw,
-					genome: ds.genome,
+					genome: ds.genomename,
 					dslabel: ds.label,
 					filter: q.filter,
 					filter0: q.filter0

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -32,8 +32,15 @@ q{}
 		each element is {id=str, term={}, q={}}
 ds{}
 	server-side dataset object
+
 genome{}
 	server-side genome object
+	XXX avoid using this argument!
+	some calling code (barchart) has bug of suppling genome name instead of obj 
+
+onlyChildren
+	true: the term annotates parent samples, the query will return annotations for the children of the samples that have the term
+	false: the term annotates child samples, the query will return annotations for the samples that have the term
 
 Returns:
 	- see ValidGetDataResponse type in shared/types/src/termdb.matrix.ts
@@ -44,7 +51,7 @@ Returns:
 
 export async function getData(q, ds, genome, onlyChildren = false) {
 	try {
-		validateArg(q, ds, genome)
+		validateArg(q, ds)
 		return await getSampleData(q, ds, onlyChildren)
 	} catch (e) {
 		if (e.stack) console.log(e.stack)
@@ -52,13 +59,12 @@ export async function getData(q, ds, genome, onlyChildren = false) {
 	}
 }
 
-function validateArg(q, ds, genome) {
+function validateArg(q, ds) {
 	if (!ds.cohort) throw 'cohort missing from ds'
 	if (!q.terms) throw `missing 'terms' parameter`
 
 	// needed by some helper functions
 	q.ds = ds
-	q.genome = genome
 
 	for (const tw of q.terms) {
 		// TODO clean up

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1495,41 +1495,51 @@ type MutationSet = {
 	fusion: string
 }
 
-type BaseDtEntry = {
+/** different methods to return samples with assay availability info */
+type DtAssayAvailability = DtAssayAvailabilityGetter | DtAssayAvailabilityTerm
+
+/** using ds-supplied getter */
+type DtAssayAvailabilityGetter = {
+	get: (q: any) => any
+}
+/** using dictionary term */
+type DtAssayAvailabilityTerm = {
+	/** id of this assay term for this dt */
 	term_id: string
-	yes: { value: string[] }
-	no: { value: string[] }
+	/** optional label */
 	label?: string
+	/** categories meaning the sample has this assay */
+	yes: { value: string[] }
+	/** categories meaning the sample doesn't have this assay */
+	no: { value: string[] }
 }
 
-type SNVByOrigin = {
-	[index: string]: BaseDtEntry
+type DtAssayAvailabilityByOrigin = {
+	byOrigin: {
+		/** each key is an origin value or category */
+		[index: string]: DtAssayAvailability
+	}
 }
 
-type DtEntrySNV = {
-	byOrigin: SNVByOrigin
+type Mds3AssayAvailability = {
+	/** object of key-value pairs. keys are dt values */
+	byDt: {
+		/** each index is a dt value */
+		[index: number]: DtAssayAvailabilityByOrigin | DtAssayAvailability
+	}
 }
 
-type ByDt = {
-	/** SNVs differentiate by sample origin. Non-SNV, no differentiation*/
-	[index: number]: DtEntrySNV | BaseDtEntry
-}
-
-type AssayValuesEntry = {
-	[index: string]: { label: string; color: string }
-}
-
-type AssaysEntry = {
-	id: string
-	name: string
-	type: string
-	values?: AssayValuesEntry
-}
-
-type AssayAvailability = {
-	byDt?: ByDt
+// mds legacy; delete when all are migrated to mds3
+type LegacyAssayAvailability = {
 	file?: string
-	assays?: AssaysEntry[]
+	assays?: {
+		id: string
+		name: string
+		type: string
+		values?: {
+			[index: string]: { label: string; color: string }
+		}
+	}[]
 }
 
 export type CumBurdenData = {
@@ -1887,7 +1897,7 @@ type ViewMode = {
 /*** types supporting Mds Dataset types ***/
 type BaseMds = {
 	genome?: string //Not declared in TermdbTest
-	assayAvailability?: AssayAvailability
+	assayAvailability?: Mds3AssayAvailability | LegacyAssayAvailability
 }
 
 export type Mds = BaseMds & {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1975,6 +1975,14 @@ export type isSupportedChartCallbacks = {
 }
 
 export type Mds3 = BaseMds & {
+	/** set in initGenomesDs.js during launch, should use .genomename instead of .genome */
+	genomename?: string // use this
+	genome?: string // avoid using it
+	/** server-side genome obj to which this ds belongs to is attached here in initGenomesDs.js during launch, 
+	so this obj can be conveniently available to server side functions without having to introduce extra param
+	TODO apply Genome type
+	*/
+	genomeObj?: any
 	label?: Title
 	isMds3: boolean
 	loadWithoutBlocking?: boolean


### PR DESCRIPTION
# Description
closes #2002 
do not plan to merge this into gdc release branch

introduces `ds.genomeObj` so server-side genome obj can be made readily accessible to any functions without having to pass around extra arg

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
