### PR TITLE
remove delete option for hierCluster term group

### DIFF
--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -1429,7 +1429,7 @@ function setTermActions(self) {
 
 				//if (self.moveInput.property('checked')) {}
 
-				if (sortColInput.property('checked') || self.moveInput.property('checked')) {
+				if (sortColInput.property('checked') || self.moveInput?.property('checked')) {
 					self.app.dispatch({
 						type: 'plot_nestedEdits',
 						id: self.opts.id,
@@ -1940,17 +1940,16 @@ function setTermGroupActions(self) {
 
 		self.dom.menubody.style('padding', 0).selectAll('*').remove()
 
-		const menuOptions = [
-			{ label: 'Edit', callback: self.showTermGroupEditMenu },
-			{ label: 'Add Rows', callback: self.showTermInsertMenu },
-			{ label: 'Sort', callback: self.showSortMenu },
-			{ label: 'Delete', callback: self.removeTermGroup }
-		]
-		if (self.chartType == 'hierCluster') {
-			// Do not show the 'Edit' and 'Sort' option in the term group menu for hierCluster term groups
-			// for hiercluster gene expression term group, the term group menu won't be shown after clicking the term group label.
-			menuOptions.splice(0, 1)
-			menuOptions.splice(1, 1)
+		const menuOptions = [{ label: 'Add Rows', callback: self.showTermInsertMenu }]
+		// try to maintain a familiar button order
+		if (self.chartType != 'hierCluster') {
+			menuOptions.push(
+				{ label: 'Edit', callback: self.showTermGroupEditMenu }
+				//{ label: 'Sort', callback: self.showSortMenu },
+			)
+		}
+		if (self.activeLabel.grp.type != 'hierCluster') {
+			menuOptions.push({ label: 'Delete', callback: self.removeTermGroup })
 		}
 
 		holder

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- remove delete option for hierCluster term group; remove sort option from term group menu


### PR DESCRIPTION
# Description

Remove sort option from term group menu. This addresses a known issue from the [last release notes (2.4.0 in March)](https://github.com/NCI-GDC/gdc-docs/blob/develop/docs/Data_Portal/Release_Notes/Data_Portal_Release_Notes.md#release-240).

Test:
- Click on the left side vertical `...` hier cluster term group label, there should not be any `Delete` option. Adding new gene is still allowed.
- also tested locally with unit and integration tests

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
