### PR TITLE
fix: singlecell sample table allows showing "termid" as is

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -1457,10 +1457,16 @@ class singleCellPlot {
 
 		// add in optional sample columns
 		for (const c of s.sampleColumns || []) {
-			columns.push({
-				label: (await this.app.vocabApi.getterm(c.termid)).name,
-				width: '14vw'
-			})
+			let label = c.termid
+			try {
+				label = (await this.app.vocabApi.getterm(c.termid)).name
+			} catch (e) {
+				/* term not found by c.termid, in such case ignore and just show termid as column header
+				this is due to practical constrain that gdc needs to supply analysis.workflow_type as 'Library',
+				but this is not a term in gdc dictionary
+				*/
+			}
+			columns.push({ label, width: '14vw' })
 		}
 
 		// if samples are using experiments, add the hardcoded experiment column at the end

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- singlecell sample table allows showing "termid" as is


### PR DESCRIPTION
# Description
test at http://localhost:3000/example.gdc.scRNAseq.html
all works
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
