### PR TITLE
fix: on clicking a gene model from gene track, launch new protein vie…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- on clicking a gene model from gene track, launch new protein view in a sandbox instead of floating pane


### PR DESCRIPTION
…w in a sandbox instead of floating pane

# Description
closes https://gdc-ctds.atlassian.net/browse/SV-2614
test at http://localhost:3000/example.gdc.html
genome browser app from mass ui continues to work
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
