### PR TITLE
Generalize mayMakeGroups() for geneVariant term

### DIFF
--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -235,11 +235,10 @@ export class GvCustomGS extends GvBase {
 	}
 }
 
-function mayMakeGroups(tw: RawGvCustomGsTW) {
+export function mayMakeGroups(tw: RawGvCustomGsTW) {
 	if (tw.q.type != 'custom-groupset' || tw.q.customset?.groups.length) return
 	// custom groupset, but customset.groups[] is empty
-	// fill with mutated group vs. wildtype group
-	// for the first applicable dt in dataset
+	// fill with 2 groups for the first applicable dt term
 	const dtTerms = tw.term.childTerms
 	if (!dtTerms) throw 'dtTerms is missing'
 	let grp1Class, grp1Name, grp1Value, grp1Tvs, grp1Filter

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -84,7 +84,6 @@ tape('fill() tw with defaultQ', async test => {
 	const defaultQ = { type: 'custom-groupset' }
 	const fullTw = await GvBase.fill(tw, { vocabApi, defaultQ })
 	test.equal(fullTw.type, 'GvCustomGsTW', 'should fill in tw.type=GvCustomGsTW')
-	console.log('fullTw:', fullTw)
 	test.deepEqual(fullTw.q, customGsQ, 'should fill in q with custom groupset')
 	test.deepEqual(fullTw.term.groupsetting, { disabled: false }, 'should fill in term.groupsetting')
 	test.deepEqual(fullTw.term.childTerms, childTerms, 'should fill in term.childTerms')
@@ -202,6 +201,48 @@ const customGsQ: GvCustomGsQ = {
 				filter: { type: 'tvslst', in: true, join: '', lst: [] }
 			},
 			{
+				name: 'Wildtype (somatic)',
+				type: 'filter',
+				uncomputable: false,
+				filter: {
+					type: 'tvslst',
+					in: true,
+					join: '',
+					lst: [
+						{
+							type: 'tvs',
+							tvs: {
+								term: {
+									id: 'snvindel_somatic',
+									query: 'snvindel',
+									name: 'SNV/indel (somatic)',
+									parent_id: null,
+									isleaf: true,
+									type: 'dtsnvindel',
+									dt: 1,
+									values: {
+										M: { label: 'MISSENSE' },
+										F: { label: 'FRAMESHIFT' },
+										WT: { label: 'Wildtype' }
+									},
+									name_noOrigin: 'SNV/indel',
+									origin: 'somatic',
+									parentTerm: {
+										kind: 'gene',
+										id: 'TP53',
+										gene: 'TP53',
+										name: 'TP53',
+										type: 'geneVariant',
+										groupsetting: { disabled: false }
+									}
+								},
+								values: [{ key: 'WT', label: 'Wildtype', value: 'WT' }]
+							}
+						}
+					]
+				}
+			},
+			{
 				name: 'SNV/indel (somatic)',
 				type: 'filter',
 				uncomputable: false,
@@ -239,48 +280,6 @@ const customGsQ: GvCustomGsQ = {
 								},
 								values: [{ key: 'WT', label: 'Wildtype', value: 'WT' }],
 								isnot: true
-							}
-						}
-					]
-				}
-			},
-			{
-				name: 'Wildtype (somatic)',
-				type: 'filter',
-				uncomputable: false,
-				filter: {
-					type: 'tvslst',
-					in: true,
-					join: '',
-					lst: [
-						{
-							type: 'tvs',
-							tvs: {
-								term: {
-									id: 'snvindel_somatic',
-									query: 'snvindel',
-									name: 'SNV/indel (somatic)',
-									parent_id: null,
-									isleaf: true,
-									type: 'dtsnvindel',
-									dt: 1,
-									values: {
-										M: { label: 'MISSENSE' },
-										F: { label: 'FRAMESHIFT' },
-										WT: { label: 'Wildtype' }
-									},
-									name_noOrigin: 'SNV/indel',
-									origin: 'somatic',
-									parentTerm: {
-										kind: 'gene',
-										id: 'TP53',
-										gene: 'TP53',
-										name: 'TP53',
-										type: 'geneVariant',
-										groupsetting: { disabled: false }
-									}
-								},
-								values: [{ key: 'WT', label: 'Wildtype', value: 'WT' }]
 							}
 						}
 					]

--- a/client/tw/test/geneVariant.unit.spec.ts
+++ b/client/tw/test/geneVariant.unit.spec.ts
@@ -1,0 +1,260 @@
+import test from 'tape'
+import { mayMakeGroups } from '../geneVariant.ts'
+
+test('\n', t => {
+	t.pass('-***- tw/geneVariant.unit -***-')
+	t.end()
+})
+
+test('mayMakeGroups: fills groups for >2 classes', t => {
+	const dtTerm = {
+		name: 'SNV/indel',
+		values: {
+			M: { label: 'MISSENSE' },
+			F: { label: 'FRAMESHIFT' },
+			D: { label: 'PROTEINDEL' },
+			WT: { label: 'Wildtype' }
+		}
+	}
+	const tw: any = {
+		q: { type: 'custom-groupset' },
+		term: { childTerms: [dtTerm] }
+	}
+	mayMakeGroups(tw)
+	t.equal(tw.q.customset.groups.length, 3, 'Should create 3 groups')
+	const grp1 = tw.q.customset.groups[1]
+	const grp2 = tw.q.customset.groups[2]
+	t.equal(grp1.name, 'Wildtype', 'Group 1 name should be Wildtype')
+	t.equal(grp2.name, 'SNV/indel', 'Group 2 name should be SNV/indel')
+	t.equal(grp1.filter.lst.length, 1, 'Group 1 filter.lst should have 1 item')
+	t.equal(grp2.filter.lst.length, 1, 'Group 2 filter.lst should have 1 item')
+	const grp1Item = grp1.filter.lst[0]
+	const grp2Item = grp2.filter.lst[0]
+	t.equal(grp1Item.type, 'tvs', 'Group 1 filter item should be a tvs')
+	t.equal(grp2Item.type, 'tvs', 'Group 2 filter item should be a tvs')
+	t.deepEqual(grp1Item.tvs.term, dtTerm, 'Group 1 tvs term should equal dtTerm')
+	t.deepEqual(grp2Item.tvs.term, dtTerm, 'Group 2 tvs term should equal dtTerm')
+	t.equal(grp1Item.tvs.values.length, 1, 'Group 1 tvs.values should have a single value')
+	t.equal(grp2Item.tvs.values.length, 1, 'Group 2 tvs.values should have a single value')
+	const grp1Value = grp1Item.tvs.values[0]
+	const grp2Value = grp2Item.tvs.values[0]
+	t.deepEqual(grp1Value, { key: 'WT', label: 'Wildtype', value: 'WT' }, 'Group 1 value should be a wildtype object')
+	t.deepEqual(grp2Value, { key: 'WT', label: 'Wildtype', value: 'WT' }, 'Group 2 value should be a wildtype object')
+	t.false(grp1Item.tvs.isnot, 'Group 1 tvs.isnot should be undefined')
+	t.true(grp2Item.tvs.isnot, 'Group 2 tvs.isnot should be true')
+	const grp0 = tw.q.customset.groups[0]
+	t.true(grp0.uncomputable, 'First group should be uncomputable')
+	t.end()
+})
+
+test('mayMakeGroups: fills groups for 2 classes', t => {
+	const dtTerm = {
+		name: 'SNV/indel',
+		values: {
+			M: { label: 'MISSENSE' },
+			WT: { label: 'Wildtype' }
+		}
+	}
+	const tw: any = {
+		q: { type: 'custom-groupset' },
+		term: { childTerms: [dtTerm] }
+	}
+	mayMakeGroups(tw)
+	t.equal(tw.q.customset.groups.length, 3, 'Should create 3 groups')
+	const grp1 = tw.q.customset.groups[1]
+	const grp2 = tw.q.customset.groups[2]
+	t.equal(grp1.name, 'Wildtype', 'Group 1 name should be Wildtype')
+	t.equal(grp2.name, 'MISSENSE', 'Group 2 name should be MISSENSE')
+	t.equal(grp1.filter.lst.length, 1, 'Group 1 filter.lst should have 1 item')
+	t.equal(grp2.filter.lst.length, 1, 'Group 2 filter.lst should have 1 item')
+	const grp1Item = grp1.filter.lst[0]
+	const grp2Item = grp2.filter.lst[0]
+	t.equal(grp1Item.type, 'tvs', 'Group 1 filter item should be a tvs')
+	t.equal(grp2Item.type, 'tvs', 'Group 2 filter item should be a tvs')
+	t.deepEqual(grp1Item.tvs.term, dtTerm, 'Group 1 tvs term should equal dtTerm')
+	t.deepEqual(grp2Item.tvs.term, dtTerm, 'Group 2 tvs term should equal dtTerm')
+	t.equal(grp1Item.tvs.values.length, 1, 'Group 1 tvs.values should have a single value')
+	t.equal(grp2Item.tvs.values.length, 1, 'Group 2 tvs.values should have a single value')
+	const grp1Value = grp1Item.tvs.values[0]
+	const grp2Value = grp2Item.tvs.values[0]
+	t.deepEqual(grp1Value, { key: 'WT', label: 'Wildtype', value: 'WT' }, 'Group 1 value should be a wildtype object')
+	t.deepEqual(grp2Value, { key: 'M', label: 'MISSENSE', value: 'M' }, 'Group 2 value should be a missense object')
+	t.false(grp1Item.tvs.isnot, 'Group 1 tvs.isnot should be undefined')
+	t.false(grp2Item.tvs.isnot, 'Group 2 tvs.isnot should be undefined')
+	const grp0 = tw.q.customset.groups[0]
+	t.true(grp0.uncomputable, 'First group should be uncomputable')
+	t.end()
+})
+
+test('mayMakeGroups: fills groups for >2 classes (WT absent)', t => {
+	const dtTerm = {
+		name: 'SNV/indel',
+		values: {
+			M: { label: 'MISSENSE' },
+			F: { label: 'FRAMESHIFT' },
+			D: { label: 'PROTEINDEL' }
+		}
+	}
+	const tw: any = {
+		q: { type: 'custom-groupset' },
+		term: { childTerms: [dtTerm] }
+	}
+	mayMakeGroups(tw)
+	t.equal(tw.q.customset.groups.length, 3, 'Should create 3 groups')
+	const grp1 = tw.q.customset.groups[1]
+	const grp2 = tw.q.customset.groups[2]
+	t.equal(grp1.name, 'MISSENSE', 'Group 1 name should be MISSENSE')
+	t.equal(grp2.name, 'Other SNV/indel', 'Group 2 name should be Other SNV/indel')
+	t.equal(grp1.filter.lst.length, 1, 'Group 1 filter.lst should have 1 item')
+	t.equal(grp2.filter.lst.length, 1, 'Group 2 filter.lst should have 1 item')
+	const grp1Item = grp1.filter.lst[0]
+	const grp2Item = grp2.filter.lst[0]
+	t.equal(grp1Item.type, 'tvs', 'Group 1 filter item should be a tvs')
+	t.equal(grp2Item.type, 'tvs', 'Group 2 filter item should be a tvs')
+	t.deepEqual(grp1Item.tvs.term, dtTerm, 'Group 1 tvs term should equal dtTerm')
+	t.deepEqual(grp2Item.tvs.term, dtTerm, 'Group 2 tvs term should equal dtTerm')
+	t.equal(grp1Item.tvs.values.length, 1, 'Group 1 tvs.values should have a single value')
+	t.equal(grp2Item.tvs.values.length, 1, 'Group 2 tvs.values should have a single value')
+	const grp1Value = grp1Item.tvs.values[0]
+	const grp2Value = grp2Item.tvs.values[0]
+	t.deepEqual(grp1Value, { key: 'M', label: 'MISSENSE', value: 'M' }, 'Group 1 value should be a missense object')
+	t.deepEqual(grp2Value, { key: 'M', label: 'MISSENSE', value: 'M' }, 'Group 2 value should be a missense object')
+	t.false(grp1Item.tvs.isnot, 'Group 1 tvs.isnot should be undefined')
+	t.true(grp2Item.tvs.isnot, 'Group 2 tvs.isnot should be true')
+	const grp0 = tw.q.customset.groups[0]
+	t.true(grp0.uncomputable, 'First group should be uncomputable')
+	t.end()
+})
+
+test('mayMakeGroups: fills groups for 2 classes (WT absent)', t => {
+	const dtTerm = {
+		name: 'SNV/indel',
+		values: {
+			M: { label: 'MISSENSE' },
+			F: { label: 'FRAMESHIFT' }
+		}
+	}
+	const tw: any = {
+		q: { type: 'custom-groupset' },
+		term: { childTerms: [dtTerm] }
+	}
+	mayMakeGroups(tw)
+	t.equal(tw.q.customset.groups.length, 3, 'Should create 3 groups')
+	const grp1 = tw.q.customset.groups[1]
+	const grp2 = tw.q.customset.groups[2]
+	t.equal(grp1.name, 'MISSENSE', 'Group 1 name should be MISSENSE')
+	t.equal(grp2.name, 'FRAMESHIFT', 'Group 2 name should be FRAMESHIFT')
+	t.equal(grp1.filter.lst.length, 1, 'Group 1 filter.lst should have 1 item')
+	t.equal(grp2.filter.lst.length, 1, 'Group 2 filter.lst should have 1 item')
+	const grp1Item = grp1.filter.lst[0]
+	const grp2Item = grp2.filter.lst[0]
+	t.equal(grp1Item.type, 'tvs', 'Group 1 filter item should be a tvs')
+	t.equal(grp2Item.type, 'tvs', 'Group 2 filter item should be a tvs')
+	t.deepEqual(grp1Item.tvs.term, dtTerm, 'Group 1 tvs term should equal dtTerm')
+	t.deepEqual(grp2Item.tvs.term, dtTerm, 'Group 2 tvs term should equal dtTerm')
+	t.equal(grp1Item.tvs.values.length, 1, 'Group 1 tvs.values should have a single value')
+	t.equal(grp2Item.tvs.values.length, 1, 'Group 2 tvs.values should have a single value')
+	const grp1Value = grp1Item.tvs.values[0]
+	const grp2Value = grp2Item.tvs.values[0]
+	t.deepEqual(grp1Value, { key: 'M', label: 'MISSENSE', value: 'M' }, 'Group 1 value should be a wildtype object')
+	t.deepEqual(grp2Value, { key: 'F', label: 'FRAMESHIFT', value: 'F' }, 'Group 2 value should be a missense object')
+	t.false(grp1Item.tvs.isnot, 'Group 1 tvs.isnot should be undefined')
+	t.false(grp2Item.tvs.isnot, 'Group 2 tvs.isnot should be undefined')
+	const grp0 = tw.q.customset.groups[0]
+	t.true(grp0.uncomputable, 'First group should be uncomputable')
+	t.end()
+})
+
+test('mayMakeGroups: fills groups with origins', t => {
+	const dtTerm = {
+		name: 'SNV/indel (somatic)',
+		values: {
+			M: { label: 'MISSENSE' },
+			F: { label: 'FRAMESHIFT' },
+			D: { label: 'PROTEINDEL' },
+			WT: { label: 'Wildtype' }
+		},
+		origin: 'somatic'
+	}
+	const tw: any = {
+		q: { type: 'custom-groupset' },
+		term: { childTerms: [dtTerm] }
+	}
+	mayMakeGroups(tw)
+	t.equal(tw.q.customset.groups.length, 3, 'Should create 3 groups')
+	const grp1 = tw.q.customset.groups[1]
+	const grp2 = tw.q.customset.groups[2]
+	t.equal(grp1.name, 'Wildtype (somatic)', 'Group 1 name should be Wildtype (somatic)')
+	t.equal(grp2.name, 'SNV/indel (somatic)', 'Group 2 name should be SNV/indel (somatic)')
+	t.equal(grp1.filter.lst.length, 1, 'Group 1 filter.lst should have 1 item')
+	t.equal(grp2.filter.lst.length, 1, 'Group 2 filter.lst should have 1 item')
+	const grp1Item = grp1.filter.lst[0]
+	const grp2Item = grp2.filter.lst[0]
+	t.equal(grp1Item.type, 'tvs', 'Group 1 filter item should be a tvs')
+	t.equal(grp2Item.type, 'tvs', 'Group 2 filter item should be a tvs')
+	t.deepEqual(grp1Item.tvs.term, dtTerm, 'Group 1 tvs term should equal dtTerm')
+	t.deepEqual(grp2Item.tvs.term, dtTerm, 'Group 2 tvs term should equal dtTerm')
+	t.end()
+})
+
+test('mayMakeGroups: skips dtTerms with < 2 classes', t => {
+	const dtTerm1 = {
+		name: 'SNV/indel',
+		values: {
+			WT: { label: 'Wildtype' }
+		}
+	}
+	const dtTerm2 = {
+		name: 'CNV',
+		values: {
+			CNV_amp: { label: 'Focal amplification' },
+			WT: { label: 'Wildtype' }
+		}
+	}
+	const tw: any = {
+		q: { type: 'custom-groupset' },
+		term: { childTerms: [dtTerm1, dtTerm2] }
+	}
+	mayMakeGroups(tw)
+	t.equal(tw.q.customset.groups.length, 3, 'Should create 3 groups')
+	const grp1 = tw.q.customset.groups[1]
+	const grp2 = tw.q.customset.groups[2]
+	t.equal(grp1.name, 'Wildtype', 'Group 1 name should be Wildtype')
+	t.equal(grp2.name, 'Focal amplification', 'Group 2 name should be Focal amplification')
+	t.equal(grp1.filter.lst.length, 1, 'Group 1 filter.lst should have 1 item')
+	t.equal(grp2.filter.lst.length, 1, 'Group 2 filter.lst should have 1 item')
+	const grp1Item = grp1.filter.lst[0]
+	const grp2Item = grp2.filter.lst[0]
+	t.equal(grp1Item.type, 'tvs', 'Group 1 filter item should be a tvs')
+	t.equal(grp2Item.type, 'tvs', 'Group 2 filter item should be a tvs')
+	t.deepEqual(grp1Item.tvs.term, dtTerm2, 'Group 1 tvs term should equal dtTerm2')
+	t.deepEqual(grp2Item.tvs.term, dtTerm2, 'Group 2 tvs term should equal dtTerm2')
+	t.end()
+})
+
+test('mayMakeGroups: does nothing if groups already present', t => {
+	const grp1 = { name: 'existing' }
+	const tw: any = {
+		q: { type: 'custom-groupset', customset: { groups: [grp1] } },
+		term: { childTerms: [] }
+	}
+	mayMakeGroups(tw)
+	t.equal(tw.q.customset.groups.length, 1, 'Number of groups should be 1')
+	t.deepEqual(tw.q.customset.groups[0], grp1, 'Group 1 should equal grp1')
+	t.end()
+})
+
+test('mayMakeGroups: throws if dtTerms missing', t => {
+	const tw: any = {
+		q: { type: 'custom-groupset' },
+		term: {}
+	}
+	t.throws(
+		() => {
+			mayMakeGroups(tw)
+		},
+		/dtTerms is missing/,
+		'Throws if dtTerms missing'
+	)
+	t.end()
+})

--- a/client/tw/test/geneVariant.unit.spec.ts
+++ b/client/tw/test/geneVariant.unit.spec.ts
@@ -1,6 +1,17 @@
 import test from 'tape'
 import { mayMakeGroups } from '../geneVariant.ts'
 
+/* Tests:
+	mayMakeGroups: fills groups for >2 classes
+	mayMakeGroups: fills groups for 2 classes
+	mayMakeGroups: fills groups for >2 classes (WT absent)
+	mayMakeGroups: fills groups for 2 classes (WT absent)
+	mayMakeGroups: fills groups with origins
+	mayMakeGroups: skips dtTerms with < 2 classes
+	mayMakeGroups: does nothing if groups already present
+	mayMakeGroups: throws if dtTerms missing
+*/
+
 test('\n', t => {
 	t.pass('-***- tw/geneVariant.unit -***-')
 	t.end()

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -16,6 +16,11 @@ Tests:
 	filterByTvsLst: nested tvslst
 */
 
+test('\n', t => {
+	t.pass('-***- mds3.init unit tests -***-')
+	t.end()
+})
+
 test('filterByItem: sample has mutation for dt', t => {
 	const filter = {
 		type: 'tvs',


### PR DESCRIPTION
# Description

Generalized `mayMakeGroups()` in `client/tw/geneVariant.ts` to create a group1 vs. group2 default groupset instead of a mutant vs. wildtype default groupset. Group 1 will be the wildtype class or the first available mutant class. Group 2 will be all other classes.

Added unit tests to now cover the `mayMakeGroups()` function.

Can test by running a survival plot overlaid with a geneVariant term ([mbmeta example](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22survival%22,%22term2%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22}},%22term%22:{%22id%22:%22Overall%20Survival%22}}]})). Can also test with barchart and overlay with geneVariant term ([gdc example](http://localhost:3000/?mass=%7B%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22header_mode%22:%22hidden%22%7D,%22termfilter%22:%7B%22filter0%22:%7B%22op%22:%22in%22,%22content%22:%7B%22field%22:%22cases.disease_type%22,%22value%22:%5B%22Gliomas%22%5D%7D%7D%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22%7D%7D,%22term2%22:%7B%22term%22:%7B%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22%7D%7D%7D%5D%7D)).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
