### PR TITLE
Include genome in hicstraw req for security purposes

### DIFF
--- a/client/src/block.tk.hicstraw.ts
+++ b/client/src/block.tk.hicstraw.ts
@@ -195,7 +195,8 @@ function setResolution(tk: any, block: any) {
 					getdata: 1,
 					getBED: 1,
 					file: tk.hic.enzymefile,
-					rglst: [{ chr: r.chr, start: r.start, stop: r.stop }]
+					rglst: [{ chr: r.chr, start: r.start, stop: r.stop }],
+					genome: block.genome.name
 				}
 				tasks.push(
 					client.dofetch2('tkbedj', { method: 'POST', body: JSON.stringify(arg) }).then(data => {
@@ -330,7 +331,8 @@ function bedfile_load(tk: any, block: any) {
 		getBED: 1,
 		rglst: tk.regions.map(i => {
 			return { chr: i.chr, start: i.start, stop: i.stop }
-		})
+		}),
+		genome: block.genome.name
 	}
 	if (tk.bedfile) {
 		arg.file = tk.bedfile

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Include genome in hicstraw req for security purposes


### PR DESCRIPTION
# Description
Closes issue #3409. Hicstraw tracks are failing in production (see the [iRNDb_v2 portal](https://proteinpaint.stjude.org/iRNDb_v2/) and [two chromosome example)](https://proteinpaint.stjude.org/?appcard=hic). This fix adds the required genome to the server request. Test with local [two chromosome example)](http://localhost:3000/?appcard=hic&example=Two%20chromosome%20view). 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
