### PR TITLE
Add font parameter to runproteinpaint

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -36,7 +36,6 @@ export class Menu {
 			.style('display', 'none')
 			.style('position', 'absolute')
 			.style('background-color', 'white')
-			.style('font-family', JSON.parse(sessionStorage.getItem('sjRunppArg')).styles['font-family'])
 			.on('mousedown.menu' + this.typename, event => {
 				/* 
 					When clicking on non-interactive elements within a menu, 

--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -36,7 +36,7 @@ export class Menu {
 			.style('display', 'none')
 			.style('position', 'absolute')
 			.style('background-color', 'white')
-			.style('font-family', 'Arial')
+			.style('font-family', JSON.parse(sessionStorage.getItem('sjRunppArg')).styles['font-family'])
 			.on('mousedown.menu' + this.typename, event => {
 				/* 
 					When clicking on non-interactive elements within a menu, 

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -22,14 +22,18 @@ import { Menu, renderSandboxFormDiv, sayerror } from '#dom'
 /*
 exports a function runproteinpaint(), referred to as "runpp"
 runpp arg:
-	- styles{}
-		supports following css styles that will be applied to this portal instance. settings are tracked in sessionStorage
+	- styles ''
+		supports overriding css styles, with or without using sjpp CSS tag or class names
 		advantage:
 		* offers more freedom at customization at runpp level
 		* is ds-independent and possible to make same ds appears different in multiple browser tabs
 		* entirely up to "portal" code and no need to track any such settings in pp repos
 
-		.font-family
+		runproteinpaint({
+			styles: `.sja_root_holder {
+				font-family: cursive
+			}`
+		})
 
 runpp is called for launching anything from pp
 returns a promise that resolve to something e.g. block
@@ -74,21 +78,13 @@ headtip.d.style('z-index', 5555)
 // headtip must get a crazy high z-index so it can stay on top of all, no matter if server config has base_zindex or not
 
 export function runproteinpaint(arg) {
-	if (arg.styles && typeof arg.styles != 'object') throw 'arg.styles{} not object'
-	// persist runpp(arg) settings to make them accessible by other scripts
-	sessionStorage.setItem(
-		'sjRunppArg',
-		JSON.stringify({
-			styles: Object.assign(
-				{
-					'font-family': 'Arial'
-					// declare other default styles
-				},
-				arg.styles || {} // apply optional override
-			)
-			// add additional non-style settings
-		})
-	)
+	if (arg.styles) {
+		// must load portal css overrides after imports of git-tracked css files
+		if (typeof arg.styles != 'string') throw 'arg.styles{} not string'
+		const styles = new CSSStyleSheet()
+		styles.replaceSync(arg.styles)
+		document.adoptedStyleSheets.push(styles)
+	}
 
 	/* the "app" object is the main Proteinpaint instance, unique for each runproteinpaint() call
 	NOTE: this app instance may be returned or not depending on the
@@ -134,7 +130,6 @@ export function runproteinpaint(arg) {
 		//must not use the method of ".datum({ clientVersion })", as d3 propagates bound data custom property to all descendents and are accidentally passed to event listeners
 		.attr('data-ppclientversion', `___current-proteinpaint-client-version___`)
 		.style('font-size', '1em')
-		.style('font-family', JSON.parse(sessionStorage.getItem('sjRunppArg')).styles['font-family'])
 		.style('color', 'black')
 
 	app.sandbox_header = arg.sandbox_header || undefined

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -107,13 +107,13 @@ export function runproteinpaint(arg) {
 		return
 	}
 	// parse embedding arguments
-
 	app.holder = d3select(arg.holder || document.body)
 		.append('div')
 		.attr('class', 'sja_root_holder')
 		//must not use the method of ".datum({ clientVersion })", as d3 propagates bound data custom property to all descendents and are accidentally passed to event listeners
 		.attr('data-ppclientversion', `___current-proteinpaint-client-version___`)
-		.style('font', '1em Arial, sans-serif')
+		.style('font-size', '1em')
+		.style('font-family', arg.fontFamily || 'Arial, sans-serif')
 		.style('color', 'black')
 
 	app.sandbox_header = arg.sandbox_header || undefined
@@ -184,6 +184,7 @@ export function runproteinpaint(arg) {
 			//       where is it certain html, body css resets will not conflict with portal styles;
 			//       will also need to remove the import of the unscoped.css file from style.css
 			if (data.targetPortal && data.targetPortal == 'gdc') await import('./style.gdc.css')
+
 			// genome data init
 			for (const genomename in app.genomes) {
 				const err = initgenome(app.genomes[genomename])

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1292,3 +1292,9 @@ sandbox header
       opacity: 0;
     }
   }
+
+
+  @font-face {
+    font-family: 'Tangerine, serif'; /*a name to be used later*/
+    src: url("https://fonts.googleapis.com/css?family=Tangerine")/* Replace with path to font in static/fonts */
+}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -62,14 +62,18 @@ by normalize.css are covered here
 
 
 .sja_root_holder {
+    all: initial;  /* block inheritance for all properties */
+    font-family: Arial, sans-serif;
     /*background-color: #fff;*/
 }
 
-.sja_root_holder,
 .sja_menu_div,
 .sja_pane {
-    all: initial;
-    /* block inheritance for all properties */
+    all: initial; /* block inheritance for all properties */
+}
+
+.sja_menu_div {
+  font-family: Arial;
 }
 
 .sja_root_holder table,
@@ -1291,9 +1295,3 @@ sandbox header
       opacity: 0;
     }
   }
-
-
-  @font-face {
-    font-family: 'Tangerine, serif'; /*a name to be used later*/
-    src: url("https://fonts.googleapis.com/css?family=Tangerine")/* Replace with path to font in static/fonts */
-}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -98,7 +98,6 @@ by normalize.css are covered here
     border-style: solid;
     border-radius: 3px;
     box-shadow: inset 0 0 0 99999px rgba(255, 255, 255, 0.3);
-    font-family: Arial;
     color: black;
     background-color: buttonface;
     border-color: buttonborder;

--- a/client/test/matchSpecs.js
+++ b/client/test/matchSpecs.js
@@ -2,6 +2,13 @@ import process from 'process'
 import { minimatch } from 'minimatch'
 
 window.process = process
+/* sessionStorage is required by all client code https://github.com/stjude/proteinpaint/pull/3411/files
+- set below for integration tests to run
+- minimum code duplication: keep it consistent with client/src/app.js
+- okay to not to declare actual styles e.g. ".styles['font-family']",
+  js ignores undefined css settings and won't break test, and minimizes code duplication
+*/
+sessionStorage.setItem('sjRunppArg', `{"styles":{}}`)
 
 const params = getParams()
 //const CURRSPECDIR = params.dir ? `./${params.dir}` : '.'

--- a/client/test/matchSpecs.js
+++ b/client/test/matchSpecs.js
@@ -2,13 +2,6 @@ import process from 'process'
 import { minimatch } from 'minimatch'
 
 window.process = process
-/* sessionStorage is required by all client code https://github.com/stjude/proteinpaint/pull/3411/files
-- set below for integration tests to run
-- minimum code duplication: keep it consistent with client/src/app.js
-- okay to not to declare actual styles e.g. ".styles['font-family']",
-  js ignores undefined css settings and won't break test, and minimizes code duplication
-*/
-sessionStorage.setItem('sjRunppArg', `{"styles":{}}`)
 
 const params = getParams()
 //const CURRSPECDIR = params.dir ? `./${params.dir}` : '.'


### PR DESCRIPTION
# Description
 
Added possibility to pass a fontFamily parameter to runproteinpaint, as at this point we dont have the dataset config. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/866). Added font defintion to style.css. The path to the real font will be updated once we have the font, using a google font for testing now.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
