### PR TITLE
Add Unit Test for `Reference` Class in Disco Plot Module: Issue.3412

### DIFF
--- a/client/plots/disco/chromosome/test/ReferenceTest.unit.spec.ts
+++ b/client/plots/disco/chromosome/test/ReferenceTest.unit.spec.ts
@@ -1,0 +1,53 @@
+import test from 'tape'
+import discoDefaults from '#plots/disco/defaults.ts'
+import Reference from '../Reference'
+
+// Mock settings object used to configure chromosome layout
+const overriders = {
+	padAngle: 0.01,
+	chromosomeInnerRadius: 90,
+	chromosomeWidth: 10
+}
+const settings = discoDefaults(overriders)
+
+// Mock chromosome sizes (normally coming from genome data)
+const chromosomes = {
+	chr1: 100,
+	chr2: 200,
+	chr3: 300
+}
+
+test('Reference class initializes correctly', t => {
+	const reference = new Reference(settings, chromosomes)
+
+	//Check that all chromosome keys are recorded in order
+	t.equal(reference.chromosomesOrder.length, 3, 'should imclude all chromosome keys')
+	t.deepEqual(reference.chromosomesOrder, ['chr1', 'chr2', 'chr3'], 'Chromosome order should match input keys')
+
+	// Check that totalSize matches the sum of the chromosome sizes
+	const expectedTotalSize = 100 + 200 + 300
+	t.equal(reference.totalSize, expectedTotalSize, 'Total size should match sum of chromosome sizes')
+
+	// Verify totalPadAngle is calculated correctly
+	const expectedPadAngle = 3 * overriders.padAngle
+	t.equal(reference.totalPadAngle, expectedPadAngle, 'Total pad angle should be padAngle times number of chromosomes')
+
+	// Check that totalChromosomesAngle is correctly derived
+	const expectedTotalChromosomeAngle = 2 * Math.PI - expectedPadAngle
+	t.equal(reference.totalChromosomesAngle, expectedTotalChromosomeAngle, 'Total chromosome angle should be correct')
+
+	// Ensure the correct number of Chromosome objects were created
+	t.equal(reference.chromosomes.length, 3, 'Should generate 3 Chromosome objects')
+
+	// Validate the angles and radius properties on each Chromosome
+	reference.chromosomes.forEach((chr, i) => {
+		t.ok(chr.startAngle < chr.endAngle, `Chromosome ${i} startAngle should be less than endAngle`)
+		t.ok(chr.innerRadius === overriders.chromosomeInnerRadius, `Chromosome ${i} inner radius should match setting`)
+		t.ok(
+			chr.outerRadius === overriders.chromosomeInnerRadius + overriders.chromosomeWidth,
+			`Chromosome ${i} outer radius should match setting`
+		)
+	})
+
+	t.end()
+})


### PR DESCRIPTION
# Description

closes #3412 

This test verifies that the `Reference` class correctly initializes and computes chromosome layout properties for the disco plot visualization. It checks that input chromosome sizes are accurately transformed into ordered arrays, total size is correctly calculated, and that angular values (`startAngle`, `endAngle`, `angle`) and radius settings (`innerRadius`, `outerRadius`) for each `Chromosome` object are properly derived from the provided settings. The test also ensures that the optional `chromosomesOverride` parameter is handled appropriately.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
