### PR TITLE
fix: allow to customize font for many parts of block and mds3 tk

### DIFF
--- a/client/dom/axisstyle.js
+++ b/client/dom/axisstyle.js
@@ -1,14 +1,9 @@
-const font = 'Arial'
-
 export function axisstyle(p) {
 	if (!p || !p.axis) return
 	if (!p.color) {
 		p.color = '#545454'
 	}
-	p.axis
-		.selectAll('line')
-		.attr('stroke', p.color)
-		.attr('shape-rendering', 'crispEdges')
+	p.axis.selectAll('line').attr('stroke', p.color).attr('shape-rendering', 'crispEdges')
 	p.axis
 		.selectAll('path')
 		.attr('fill', 'none')
@@ -18,7 +13,6 @@ export function axisstyle(p) {
 	p.axis
 		.selectAll('text')
 		.style('cursor', 'default')
-		.attr('font-family', font)
 		.attr('font-size', p.fontsize ? p.fontsize + 'px' : '12px')
 		.attr('fill', p.color)
 }

--- a/client/dom/table2col.js
+++ b/client/dom/table2col.js
@@ -20,14 +20,14 @@ if need to insert html and other dynamic contents instead of plain text, do this
 
 arg{}
 	.holder
-	.margin todo
+	.margin
 */
 export function table2col(arg) {
 	const scrollDiv = arg.holder.append('div').style('max-width', '80vw')
 
 	const table = scrollDiv
 		.append('table')
-		.style('margin', '5px 8px')
+		.style('margin', arg.margin || '5px 8px')
 		.attr('class', 'sja_simpletable')
 		.attr('data-testid', 'sja_simpletable')
 	return {

--- a/client/mds3/leftlabel.js
+++ b/client/mds3/leftlabel.js
@@ -3,7 +3,6 @@ import { select } from 'd3-selection'
 // variant label is always made. sample label is optional and dynamically loads script when needed
 
 const labyspace = 5
-const font = 'Arial'
 
 /*
 make_leftlabels
@@ -111,7 +110,6 @@ export function makelabel(tk, block, y) {
 	const text = tk.leftlabels.g
 		.append('text')
 		.attr('font-size', block.labelfontsize)
-		.attr('font-family', font)
 		.attr('y', block.labelfontsize / 2 + y)
 		.attr('text-anchor', 'end')
 		.attr('dominant-baseline', 'central')

--- a/client/mds3/numericmode.js
+++ b/client/mds3/numericmode.js
@@ -182,7 +182,6 @@ function numeric_make(nm, tk, block) {
 			tk.glider
 				.append('text')
 				.text(tk.mnamegetter(m))
-				.attr('font-family', font)
 				.attr('font-size', m.radius * 2 - 2)
 				.each(function () {
 					m.labwidth = this.getBBox().width
@@ -378,7 +377,6 @@ function numeric_make(nm, tk, block) {
 			m.__svg_textlabel = this
 		})
 		.text(m => tk.mnamegetter(m))
-		.attr('font-family', font)
 		.attr('font-size', m => {
 			m._labfontsize = Math.max(12, m.radius * 1.2)
 			return m._labfontsize
@@ -667,7 +665,6 @@ function m_mouseover(m, nm, tk) {
 		tk.pica.g
 			.append('text')
 			.attr('font-size', fontsize)
-			.attr('font-family', font)
 			.text(w)
 			.each(function () {
 				textw = Math.max(textw, this.getBBox().width)
@@ -730,7 +727,6 @@ function m_mouseover(m, nm, tk) {
 			.text(w)
 			.attr('text-anchor', onleft ? 'end' : 'start')
 			.attr('font-size', fontsize)
-			.attr('font-family', font)
 			.attr('x', onleft ? linex1 - boxpad : boxx + boxpad)
 			.attr('y', y)
 			.attr('fill', color)

--- a/client/mds3/skewer.render.js
+++ b/client/mds3/skewer.render.js
@@ -27,7 +27,6 @@ const modeshow = 1
 const middlealignshift = 0.3
 const disclabelspacing = 1 // px spacing between disc and label
 const textlensf = 0.6 // to replace n.getBBox().width for detecting filling font size which breaks in chrome
-const font = 'Arial'
 
 /*
 sets tk.skewer.maxheight
@@ -181,7 +180,6 @@ export function skewer_make(tk, block) {
 		.filter(d => d.occurrence > 1)
 		.append('text')
 		.text(d => d.occurrence)
-		.attr('font-family', font)
 		.attr('class', 'sja_aa_discnum')
 		.attr('fill-opacity', d => (d.aa.showmode == modefold ? 0 : 1))
 		.attr('stroke-opacity', d => (d.aa.showmode == modefold ? 0 : 1))
@@ -224,7 +222,6 @@ export function skewer_make(tk, block) {
 		.attr('fill', d => tk.color4disc(d.mlst[0]))
 		.attr('x', d => d.radius + d.rimwidth + 1)
 		.attr('y', d => d._labfontsize * middlealignshift)
-		.attr('font-family', font)
 		.classed('sja_aa_disclabel', true)
 		.attr('fill-opacity', d => (d.aa.showmode == modefold ? 0 : 1))
 		.attr('transform', 'scale(1) rotate(0)')

--- a/client/src/block.js
+++ b/client/src/block.js
@@ -4,7 +4,7 @@ import { format as d3format } from 'd3-format'
 import { axisTop, axisLeft } from 'd3-axis'
 import { debounce } from 'debounce'
 import * as client from './client'
-import { Menu, newSandboxDiv, sayerror, appear, disappear } from '#dom'
+import { axisstyle, Menu, newSandboxDiv, sayerror, appear, disappear } from '#dom'
 import { dofetch3 } from '../common/dofetch'
 import * as common from '#shared/common.js'
 import * as coord from './coord'
@@ -343,7 +343,6 @@ export class Block {
 				.style('display', 'inline-block')
 				.style('font-size', '.7em')
 				.style('color', this.legend.legendcolor)
-				.style('font-family', client.font)
 				.on('click', () => {
 					if (shown) {
 						shown = false
@@ -443,7 +442,6 @@ export class Block {
 				// custom data, legacy ds
 				butrow
 					.append('div')
-					.style('font-family', client.font)
 					.attr('class', 'sja_opaque8 sjpp-plus-button')
 					.text('+')
 					.on('click', event => {
@@ -668,7 +666,6 @@ export class Block {
 			.attr('y', -this.rulerheight / 2)
 			.attr('dominant-baseline', 'central')
 			.attr('font-size', 13)
-			.attr('font-family', client.font)
 		if (this.hidegenecontrol) {
 			this.coord.name
 				.text('Zoom out')
@@ -1139,7 +1136,7 @@ export class Block {
 					.range([0, this.width])
 				const axis = axisTop().scale(scale).tickFormat(d3format('d'))
 				const __g = this.coord.axesg.append('g').attr('transform', 'translate(0,0)')
-				client.axisstyle({
+				axisstyle({
 					axis: __g.call(axis),
 					color: 'black',
 					showline: true
@@ -1188,7 +1185,7 @@ export class Block {
 				const scale = scaleLinear().domain(domain).range(range)
 				const axis = axisTop().scale(scale).tickFormat(tickformat)
 				const __g = this.coord.axesg.append('g').attr('transform', 'translate(0,0)')
-				client.axisstyle({
+				axisstyle({
 					axis: __g.call(axis),
 					color: 'black',
 					showline: true
@@ -1338,7 +1335,6 @@ export class Block {
 				.append('text')
 				.text(pos > 1000000 ? d3format('s')(pos) : d3format(',d')(pos))
 				.attr('font-size', this.rulerfontsize)
-				.attr('font-family', client.font)
 			maxticknumber = Math.floor(this.width / (t.node().getBBox().width + 60))
 			t.remove()
 		}
@@ -1353,7 +1349,7 @@ export class Block {
 		} else {
 			axis.tickFormat(d3format(',d'))
 		}
-		client.axisstyle({
+		axisstyle({
 			axis: rulerg.call(axis),
 			color: 'black',
 			showline: true,
@@ -2030,10 +2026,7 @@ reverseorient() {
 			this.error('unknown dsname ' + dsname)
 			return
 		}
-		const box = this.ctrl.dshandleholder
-			.append('div')
-			.attr('class', 'sjpp-dshandleholder')
-			.style('font-family', client.font)
+		const box = this.ctrl.dshandleholder.append('div').attr('class', 'sjpp-dshandleholder')
 		const says = box
 			.append('div')
 			.attr('class', 'sja_opaque8 sjpp-dslabel')
@@ -3197,7 +3190,6 @@ seekrange(chr,start,stop) {
 			.attr('y', y ? y : (tk.height_main - tk.toppad - tk.bottompad) / 2)
 			.attr('dominant-baseline', 'central')
 			.attr('font-size', '14px')
-			.attr('font-family', client.font)
 	}
 
 	block_setheight() {
@@ -3577,7 +3569,6 @@ seekrange(chr,start,stop) {
 			.append('text')
 			.text('CONFIG')
 			.attr('fill', '#555')
-			.attr('font-family', client.font)
 			.attr('font-size', this.labelfontsize)
 			.attr('y', this.labelfontsize)
 			.attr('class', 'sja_clbtext2')
@@ -3587,7 +3578,6 @@ seekrange(chr,start,stop) {
 		return tk.gleft
 			.append('text')
 			.attr('font-size', this.labelfontsize)
-			.attr('font-family', client.font)
 			.attr('y', this.labelfontsize / 2 + (y || 0))
 			.attr('text-anchor', 'end')
 			.attr('dominant-baseline', 'central')
@@ -4309,7 +4299,6 @@ seekrange(chr,start,stop) {
 			.attr('y', panel.height / 2)
 			.attr('dominant-baseline', 'central')
 			.attr('font-size', '14px')
-			.attr('font-family', client.font)
 	}
 
 	zoombutton_mouseover(fold, zoomout, button) {
@@ -4500,7 +4489,6 @@ seekrange(chr,start,stop) {
 					.append('text')
 					.text(pos > 1000000 ? d3format('s')(pos) : d3format(',d')(pos))
 					.attr('font-size', this.rulerfontsize)
-					.attr('font-family', client.font)
 					.each(function () {
 						w = this.getBBox().width
 					})
@@ -4515,7 +4503,7 @@ seekrange(chr,start,stop) {
 			} else {
 				axis.tickFormat(d3format(',d'))
 			}
-			client.axisstyle({
+			axisstyle({
 				axis: rulerg.call(axis),
 				color: 'black',
 				showline: true,

--- a/client/src/block.tk.menu.js
+++ b/client/src/block.tk.menu.js
@@ -390,9 +390,7 @@ function customtracktypeui(block, div) {
 	row
 		.append('span')
 		.style('padding-left', '10px')
-		.html(
-			'<a href=https://docs.google.com/document/d/1ZnPZKSSajWyNISSLELMozKxrZHQbdxQkkkQFnxw6zTs/edit?usp=sharing target=_blank>Track format</a>'
-		)
+		.html('<a href=https://github.com/stjude/proteinpaint/wiki/Tracks target=_blank>Track format</a>')
 	row.append('span').style('padding-left', '10px').html('<a href=https://jsonlint.com/ target=_blank>debug</a>')
 }
 
@@ -429,7 +427,7 @@ function newtk_bw(block, div) {
 		.append('div')
 		.style('margin', '20px')
 		.style('display', 'inline-block')
-		.html('&lt; go back')
+		.html('≪ Go back')
 		.attr('class', 'sja_menuoption')
 		.on('click', () => customtracktypeui(block, div))
 
@@ -658,7 +656,7 @@ function newtk_bedj(block, div) {
 	box
 		.append('p')
 		.html(
-			'<a href=https://drive.google.com/open?id=1GP81rer7YEb0RpIej2XXfx-k7SCAL1Od9At_oczf06A target=_blank>JSON-BED format</a>'
+			'<a href=https://github.com/stjude/proteinpaint/wiki/Tracks#Track-JSON-BED-track-format target=_blank>JSON-BED format</a>'
 		)
 }
 
@@ -716,7 +714,7 @@ function newtk_junction(block, div) {
 	box
 		.append('p')
 		.html(
-			'<a href=https://docs.google.com/document/d/1PFva3Mn-U4VPNW0vHHC-CSnYBeotRnqbhCMQPmyLQG4/edit?usp=sharing target=_blank>Junction track format</a>'
+			'<a href=https://github.com/stjude/proteinpaint/wiki/Tracks#Track-splice-junction target=_blank>Junction track format</a>'
 		)
 }
 
@@ -777,11 +775,7 @@ function newtk_vcf(block, div) {
 	p.append('button')
 		.text('Clear')
 		.on('click', () => (ta.node().value = nta.node().value = ''))
-	box
-		.append('p')
-		.html(
-			'<a href=https://drive.google.com/open?id=1dbuYeQR6cgkpzcPaIChRFtXwolJVheoTr9NEW_Mfthw target=_blank>VCF format</a>'
-		)
+	box.append('p').html('<a href=https://en.wikipedia.org/wiki/Variant_Call_Format target=_blank>VCF format</a>')
 	box.append('p').style('color', '#858585').style('font-size', '.8em').text('SNV/indel data only')
 }
 
@@ -911,7 +905,7 @@ function newtk_interaction(block, div) {
 		div2
 			.append('p')
 			.html(
-				'<a href=https://docs.google.com/document/d/1MQ0Z_AD5moDmaSx2tcn7DyVKGp49TS63pO0cceGL_Ns/edit#heading=h.kr6p4w2zhhwq target=_blank>BED file format</a>'
+				'<a href=https://github.com/stjude/proteinpaint/wiki/Tracks#track-json-bed-track-format target=_blank>BED file format</a>'
 			)
 		const urlinput = div2
 			.append('p')
@@ -945,7 +939,7 @@ function newtk_interaction(block, div) {
 		div3
 			.append('p')
 			.html(
-				'Enter interaction data as <a href=https://docs.google.com/document/d/1MQ0Z_AD5moDmaSx2tcn7DyVKGp49TS63pO0cceGL_Ns/edit#heading=h.kr6p4w2zhhwq target=_blank>tab-delimited text</a>.'
+				'Enter interaction data as <a href=https://github.com/stjude/proteinpaint/wiki/Tracks#Track-splice-junction target=_blank>tab-delimited text</a>.'
 			)
 		const textinput = div3
 			.append('textarea')

--- a/client/src/block.tk.usegm.js
+++ b/client/src/block.tk.usegm.js
@@ -1,4 +1,5 @@
 import * as client from './client'
+import { table2col } from '#dom'
 import { scaleLinear } from 'd3-scale'
 import { axisBottom } from 'd3-axis'
 import { format as d3format } from 'd3-format'
@@ -280,7 +281,6 @@ export function gmtkrender(tk, block) {
 				.attr('x', -12)
 				.attr('text-anchor', 'end')
 				.attr('dominant-baseline', 'central')
-				.attr('font-family', client.font)
 				.attr('fill', 'black')
 				.attr('font-size', block.labelfontsize)
 				.each(function () {
@@ -680,13 +680,13 @@ block:
 					tkg
 						.append('text')
 						.text(gm.cdseq[j]) // do not use j2 here
-						.attr('font-family', 'Courier')
 						.attr('font-size', rowh)
 						.attr('dominant-baseline', 'central')
 						.attr('text-anchor', 'middle')
 						.attr('fill', 'black')
 						.attr('x', x + pxstart + (j - cdsstart + 0.5) * block.exonsf)
 						.attr('y', 2 + rowh / 2)
+						.attr('font-family', 'Courier') // no override; customary to show nucleotide/aa in this font
 				}
 			}
 			if (cdsstart % 3 == 2) {
@@ -705,7 +705,6 @@ block:
 					tkg
 						.append('text')
 						.text(gm.aaseq[Math.floor(j2 / 3)])
-						.attr('font-family', 'Courier')
 						.attr('font-size', rowh)
 						.attr('font-weight', 'bold')
 						.attr('fill', 'black')
@@ -713,6 +712,7 @@ block:
 						.attr('text-anchor', 'middle')
 						.attr('x', x + pxstart + (j - cdsstart + 0.5) * block.exonsf) // do not use j2 here
 						.attr('y', h / 2)
+						.attr('font-family', 'Courier') // no override; customary to show nucleotide/aa in this font
 				}
 			}
 		}
@@ -755,11 +755,11 @@ block:
 					tkg
 						.append('text')
 						.text(nt)
-						.attr('font-family', 'Courier')
 						.attr('font-size', rowh)
 						.attr('dominant-baseline', 'central')
 						.attr('text-anchor', 'middle')
 						.attr('fill', 'black')
+						.attr('font-family', 'Courier') // no override; customary to show nucleotide/aa in this font
 						.attr(
 							'x',
 							x +
@@ -857,7 +857,7 @@ function moveisoform(gm, block, y0, height) {
 
 function coord2legend(tk, event, r, start, stop, gm, block, h) {
 	tk.tktip.clear()
-	const div = tk.tktip.d.append('div').style('font-family', 'Courier')
+	const table = table2col({ holder: tk.tktip.d, margin: '0px' })
 	const a = event.target.getBoundingClientRect()
 	const x = event.clientX - a.left
 
@@ -874,44 +874,31 @@ function coord2legend(tk, event, r, start, stop, gm, block, h) {
 	}
 
 	const p = coord.genomic2gm(pos, gm)
-	if (p.atexon) {
-		div.append('div').html('&nbsp;&nbsp;<span style="opacity:.5">exon:</span> ' + p.atexon)
-	}
-	if (p.atutr5) {
-		div.append('div').html('<span style="opacity:.5">5\' UTR:</span> ' + p.atutr5.off + ' bp')
-	} else if (p.atutr3) {
-		div.append('div').html('<span style="opacity:.5">3\' UTR:</span> ' + p.atutr3.off + ' bp')
-	} else if (p.aapos) {
-		div.append('div').html('&nbsp;&nbsp;&nbsp;&nbsp;<span style="opacity:.5">AA:</span> ' + p.aapos + ' aa')
-	}
-	if (p.rnapos) {
-		div.append('div').html('&nbsp;&nbsp;&nbsp;<span style="opacity:.5">RNA:</span> ' + p.rnapos + ' bp')
-	}
+	if (p.atexon) table.addRow('Exon', p.atexon)
+
+	if (p.atutr5) table.addRow("5' UTR", p.atutr5.off + ' bp')
+	else if (p.atutr3) table.addRow("3' UTR", p.atutr3.off + ' bp')
+	else if (p.aapos) table.addRow('AA', p.aapos + ' aa')
+
+	if (p.rnapos) table.addRow('RNA', p.rnapos + ' bp')
+	table.addRow(gm.chr, pos + 1)
 	if (p.aapos && gm.pdomains) {
+		table.table.style('margin-bottom', '5px')
 		for (const d of gm.pdomains) {
 			if (d.name + d.description in gm.domain_hidden) continue
 			if (d.start <= p.aapos && d.stop >= p.aapos) {
-				const row = div.append('div')
+				const row = tk.tktip.d.append('div')
 				row.append('span').style('background-color', d.color).html('&nbsp;&nbsp;')
-				row
-					.append('span')
-					.style('font-family', client.font)
-					.html('&nbsp;' + d.name)
+				row.append('span').html('&nbsp;' + d.name)
 				if (d.description) {
 					row
 						.append('span')
-						.style('font-family', client.font)
 						.style('font-size', '.7em')
 						.html('&nbsp;' + (d.description.length > 30 ? d.description.substring(0, 20) + ' ...' : d.description))
 				}
 			}
 		}
 	}
-	div
-		.append('div')
-		.style('margin-top', '5px')
-		.style('font-size', '.8em')
-		.text(gm.chr + ' ' + (pos + 1))
 	tk.tktip.show(event.clientX, gm.__tkg.node().getBoundingClientRect().top + h - 10)
 }
 
@@ -1177,7 +1164,6 @@ function customdomainmakeui(block, tk, proteinDomainUI) {
 				.style('display', 'inline-block')
 				.style('margin-right', '5px')
 				.style('padding', '1px 2px')
-				.style('font-family', 'Courier')
 				.html('&nbsp;')
 			row.append('div').style('display', 'inline-block').text(i.name)
 			row.on('click', () => {

--- a/client/src/client.js
+++ b/client/src/client.js
@@ -13,14 +13,10 @@ import { dofetch, dofetch2, dofetch3 } from '../common/dofetch'
 // support client code that import dofetch* from client.js
 // TODO: update affected code to import dofetch* directly from common/dofetch.js
 export { dofetch, dofetch2, dofetch3 }
-import { Menu } from '../dom/menu'
-export { Menu }
+import { Menu, make_table_2col, fillbar, axisstyle, sayerror } from '#dom'
+export { Menu, axisstyle, fillbar, make_table_2col, sayerror }
 import { first_genetrack_tolist } from '../common/1stGenetk'
 export { first_genetrack_tolist }
-import { make_table_2col } from '../dom/table2col'
-export { make_table_2col }
-import { fillbar } from '../dom/fillbar'
-export { fillbar }
 
 export const font = 'Arial'
 export const unspecified = 'Unspecified'
@@ -73,38 +69,6 @@ export function disappear(d, remove) {
 
 export const tip = new Menu({ padding: '' })
 tip.d.style('z-index', 1000)
-
-export function sayerror(holder, msg) {
-	const div = holder.append('div').attr('class', 'sja_errorbar')
-	// msg can contain injected XSS, so never do .html(msg)
-	div.append('div').text(msg)
-	div
-		.append('div')
-		.html('&#10005;')
-		.on('click', () => {
-			disappear(div, true)
-		})
-}
-
-export function axisstyle(p) {
-	if (!p || !p.axis) return
-	if (!p.color) {
-		p.color = '#545454'
-	}
-	p.axis.selectAll('line').attr('stroke', p.color).attr('shape-rendering', 'crispEdges')
-	p.axis
-		.selectAll('path')
-		.attr('fill', 'none')
-		.attr('stroke', p.showline ? p.color : 'none')
-		.attr('stroke-width', p.showline ? 1 : 0)
-		.attr('shape-rendering', 'crispEdges')
-	p.axis
-		.selectAll('text')
-		.style('cursor', 'default')
-		.attr('font-family', font)
-		.attr('font-size', p.fontsize ? p.fontsize + 'px' : '12px')
-		.attr('fill', p.color)
-}
 
 export function newpane(pm) {
 	/*

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1143,7 +1143,6 @@ sandbox header
 /*.sjpp_row_wrapper:nth-child(odd) {background: rgb(237, 237, 237)}*/
 
 .sjpp_table_header {
-    font-family: 'Arial';
     font-size: 1em;
     text-align: left;
     position: sticky;

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- allow to customize font for many parts of block and mds3 tk


### PR DESCRIPTION
# Description
FYI i started this fix mostly to prepare for updating font family for gdc view
try this in public/index.html
```
runproteinpaint({
  styles: `.sja_root_holder {
      font-family: cursive
  }
  .sja_menu_div {
      font-family: cursive
  }`
})
```

gets
<img width="604" alt="image" src="https://github.com/user-attachments/assets/7634eec4-ff96-498c-80cb-38fa50c7b092" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
