### PR TITLE
Issue.3414

### DIFF
--- a/client/plots/disco/viewmodel/test/ViewModel.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModel.unit.spec.ts
@@ -1,0 +1,77 @@
+import test from 'tape'
+import ViewModel from '../ViewModel'
+import { RingType } from '../../ring/RingType'
+import discoDefaults from '../../defaults'
+
+// ───── Mock Data Setup ─────
+
+// Use discoDefaults to avoid manually writing every settings field
+const settings = discoDefaults({
+	rings: {
+		labelLinesInnerRadius: 100,
+		labelsToLinesDistance: 20
+	},
+	legend: {
+		rowHeight: 30
+	}
+})
+
+// Mock ring structure, each with empty elements to test getElements
+const mockRings = {
+	chromosomesRing: { elements: [] },
+	labelsRing: { elementsToDisplay: [], collisions: [] },
+	nonExonicArcRing: { elements: [] },
+	snvArcRing: { elements: [] },
+	cnvArcRing: { elements: [] },
+	lohArcRing: { elements: [] }
+} as any
+
+// Mock Legend with 3 rows to verify legendHeight = rowHeight × count
+const mockLegend = {
+	legendCount: () => 3
+} as any
+
+// Empty list of Fusion ribbons
+const mockFusions = []
+
+// Mock DataHolder with sample SNV/CNV stats
+const mockDataHolder = {
+	snvData: [{}, {}, {}], // 3 SNV entries
+	filteredSnvData: [{}], // 1 filtered SNV entry
+	snvRingDataMap: new Map(), // unused in this test
+	cnvGainMaxValue: 5,
+	cnvLossMaxValue: -3,
+	cappedCnvMaxAbsValue: 4,
+	percentileNegative: -2,
+	percentilePositive: 2
+} as any
+
+// ───── Test 1: Constructor and field assignments ─────
+
+test('ViewModel initializes with expected values', t => {
+	const viewModel = new ViewModel(settings, mockRings, mockLegend, mockFusions, mockDataHolder, 'GeneSet123', 999)
+
+	t.equal(viewModel.snvDataLength, 3, 'SNV data length is correct')
+	t.equal(viewModel.filteredSnvDataLength, 1, 'Filtered SNV data length is correct')
+	t.equal(viewModel.cnvMaxValue, 5, 'CNV gain max value is correct')
+	t.equal(viewModel.cnvMinValue, -3, 'CNV loss max value is correct')
+	t.equal(viewModel.positivePercentile80, 2, 'Percentile positive is correct')
+	t.equal(viewModel.genesetName, 'GeneSet123', 'Gene set name is stored')
+
+	t.ok(viewModel.width > 0, 'Width is computed')
+	t.ok(viewModel.height > 0, 'Height is computed')
+	t.equal(viewModel.legendHeight, 90, 'Legend height = 3 rows × 30px each')
+
+	t.end()
+})
+
+// ───── Test 2: getElements returns correct arrays ─────
+
+test('ViewModel.getElements returns ring elements correctly', t => {
+	const viewModel = new ViewModel(settings, mockRings, mockLegend, mockFusions, mockDataHolder, 'AnotherGeneSet', 123)
+
+	t.deepEqual(viewModel.getElements(RingType.SNV), [], 'SNV ring returns empty array')
+	t.deepEqual(viewModel.getElements(RingType.LABEL), [], 'LABEL ring returns empty array')
+
+	t.end()
+})

--- a/client/plots/disco/viewmodel/test/ViewModel.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModel.unit.spec.ts
@@ -1,6 +1,5 @@
 import test from 'tape'
 import ViewModel from '../ViewModel'
-import { RingType } from '../../ring/RingType'
 import discoDefaults from '../../defaults'
 
 // ───── Mock Data Setup ─────
@@ -61,17 +60,6 @@ test('ViewModel initializes with expected values', t => {
 	t.ok(viewModel.width > 0, 'Width is computed')
 	t.ok(viewModel.height > 0, 'Height is computed')
 	t.equal(viewModel.legendHeight, 90, 'Legend height = 3 rows × 30px each')
-
-	t.end()
-})
-
-// ───── Test 2: getElements returns correct arrays ─────
-
-test('ViewModel.getElements returns ring elements correctly', t => {
-	const viewModel = new ViewModel(settings, mockRings, mockLegend, mockFusions, mockDataHolder, 'AnotherGeneSet', 123)
-
-	t.deepEqual(viewModel.getElements(RingType.SNV), [], 'SNV ring returns empty array')
-	t.deepEqual(viewModel.getElements(RingType.LABEL), [], 'LABEL ring returns empty array')
 
 	t.end()
 })

--- a/client/plots/disco/viewmodel/test/ViewModel.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModel.unit.spec.ts
@@ -2,6 +2,11 @@ import test from 'tape'
 import ViewModel from '../ViewModel'
 import discoDefaults from '../../defaults'
 
+/*
+Tests:
+	ViewModel initializes with expected values
+*/
+
 // ───── Mock Data Setup ─────
 
 // Use discoDefaults to avoid manually writing every settings field
@@ -45,21 +50,52 @@ const mockDataHolder = {
 	percentilePositive: 2
 } as any
 
+test('\n', function (t) {
+	t.pass('-***- plots/disco/viewmodel/ViewModel -***-')
+	t.end()
+})
+
 // ───── Test 1: Constructor and field assignments ─────
 
 test('ViewModel initializes with expected values', t => {
 	const viewModel = new ViewModel(settings, mockRings, mockLegend, mockFusions, mockDataHolder, 'GeneSet123', 999)
 
-	t.equal(viewModel.snvDataLength, 3, 'SNV data length is correct')
-	t.equal(viewModel.filteredSnvDataLength, 1, 'Filtered SNV data length is correct')
-	t.equal(viewModel.cnvMaxValue, 5, 'CNV gain max value is correct')
-	t.equal(viewModel.cnvMinValue, -3, 'CNV loss max value is correct')
-	t.equal(viewModel.positivePercentile80, 2, 'Percentile positive is correct')
+	t.equal(
+		viewModel.snvDataLength,
+		mockDataHolder.snvData.length,
+		`SNV data length should return ${mockDataHolder.snvData.length}`
+	)
+	t.equal(
+		viewModel.filteredSnvDataLength,
+		mockDataHolder.filteredSnvData.length,
+		`Filtered SNV data length should return ${mockDataHolder.filteredSnvData.length}`
+	)
+	t.equal(
+		viewModel.cnvMaxValue,
+		mockDataHolder.cnvGainMaxValue,
+		`CNV max gain value should return ${mockDataHolder.cnvGainMaxValue}`
+	)
+	t.equal(
+		viewModel.cnvMinValue,
+		mockDataHolder.cnvLossMaxValue,
+		`CNV min loss value should return ${mockDataHolder.cnvLossMaxValue}`
+	)
+	t.equal(
+		viewModel.positivePercentile80,
+		mockDataHolder.percentilePositive,
+		`Percentile positive should return ${mockDataHolder.percentilePositive}`
+	)
 	t.equal(viewModel.genesetName, 'GeneSet123', 'Gene set name is stored')
 
-	t.ok(viewModel.width > 0, 'Width is computed')
-	t.ok(viewModel.height > 0, 'Height is computed')
-	t.equal(viewModel.legendHeight, 90, 'Legend height = 3 rows × 30px each')
+	t.ok(viewModel.width > 0, 'Width is computed and greater than 0')
+	t.ok(viewModel.height > 0, 'Height is computed and greater than 0')
+	t.equal(
+		viewModel.legendHeight,
+		mockLegend.legendCount() * settings.legend.rowHeight,
+		`Legend height should return ${mockLegend.legendCount()} rows × ${settings.legend.rowHeight}px = ${
+			mockLegend.legendCount() * settings.legend.rowHeight
+		}`
+	)
 
 	t.end()
 })


### PR DESCRIPTION
# Description
Unit test for plots/disco/viewmodel/ViewModel.ts to verify that the constructor correctly computes width, height, and legendHeight, and accurately assigns values from the provided Settings, Rings, Legend, Fusions, and DataHolder objects.

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
