### PR TITLE
fix: cnv.get() returns {cnvs[], cnvMsg} to include server generated m…

### DIFF
--- a/client/mds3/cnv.js
+++ b/client/mds3/cnv.js
@@ -67,8 +67,11 @@ export function may_render_cnv(data, tk, block) {
 	tk.cnv?.g.selectAll('*').remove()
 	delete tk.cnv.cnvLst
 	delete tk.cnv.cnvInDensity
+	delete tk.cnv.cnvMsg
 
 	if (data.cnv) {
+		if (!Array.isArray(data.cnv.cnvs)) throw 'data.cnv.cnvs[] not array'
+		tk.cnv.cnvMsg = data.cnv.cnvMsg
 		// has moderate amounts of segments. show as lines
 		renderSegments(data, tk, block)
 		// tk.cnv.cnvLst created
@@ -76,6 +79,7 @@ export function may_render_cnv(data, tk, block) {
 	}
 	if (data.cnvDensity) {
 		tk.cnv.cnvInDensity = true
+		tk.cnv.cnvMsg = data.cnvDensity.cnvMsg
 		renderDensity(data, tk, block)
 		return
 	}
@@ -187,7 +191,7 @@ export function prepData(data, tk, block) {
 	const sample2cnv = new Map() // k: sample_id, v: [{chr/start/stop/value/x1/x2}]. only populated when cnv has sample, in order to show cnvs from the same sample grouped together rather than scattered
 	const cnvLst = [] // raw list of events passing filter, each has structure of {samples:[]} to be used in itemtable. is used for cnv rendering when there's no sample
 
-	for (const v of data.cnv) {
+	for (const v of data.cnv.cnvs) {
 		if (!v.chr) continue
 		if (!Number.isInteger(v.start) || !Number.isInteger(v.stop)) continue
 

--- a/client/mds3/leftlabel.variant.js
+++ b/client/mds3/leftlabel.variant.js
@@ -65,8 +65,8 @@ export function getVariantLabelText(data, tk, block) {
 			for (const m of tk.skewer.rawmlst) dtset.add(m.dt)
 		}
 		if (data.cnv) {
-			totalcount += data.cnv.length
-			for (const m of data.cnv) dtset.add(m.dt)
+			totalcount += data.cnv.cnvs.length
+			for (const m of data.cnv.cnvs) dtset.add(m.dt)
 		} else if (data.cnvDensity) {
 			totalcount += data.cnvDensity.segmentCount
 			dtset.add(dtcnv)
@@ -96,7 +96,7 @@ export function getVariantLabelText(data, tk, block) {
 
 	if (data.cnv) {
 		// always count cnv when present, so as not to trigger "xx of yy" at variant label
-		showcount += data.cnv.length
+		showcount += data.cnv.cnvs.length
 	} else if (data.cnvDensity) {
 		showcount += data.cnvDensity.segmentCount
 	}
@@ -128,7 +128,13 @@ export function getVariantLabelText(data, tk, block) {
 function menu_variants(tk, block) {
 	// in case only showing cnv density but no skewer, disable all options from this menu as they do not apply to cnv density
 	if ((!tk.skewer?.rawmlst || tk.skewer.rawmlst?.length == 0) && tk.cnv?.cnvInDensity) {
-		tk.menutip.d.append('div').style('margin', '10px').text('Viewing CNV density and cannot access segment details')
+		tk.menutip.d
+			.append('div')
+			.style('margin', '10px')
+			.text('Viewing CNV segment density, no information on individual segments.')
+		if (tk.cnv.cnvMsg) {
+			tk.menutip.d.append('div').style('margin', '10px').text(tk.cnv.cnvMsg)
+		}
 		return
 	}
 	const listDiv = tk.menutip.d

--- a/client/mds3/test/cnv.unit.spec.ts
+++ b/client/mds3/test/cnv.unit.spec.ts
@@ -56,20 +56,20 @@ tape('mayInitCnv()', test => {
 
 tape('prepData()', test => {
 	{
-		const [samples, cnvLst, absoluteMax] = prepData({ cnv: cnvNumeric }, mockTk, mockBlock)
+		const [samples, cnvLst, absoluteMax] = prepData({ cnv: { cnvs: cnvNumeric } }, mockTk, mockBlock)
 		test.deepEqual(cnvLst, cnvNumericProcessed, 'get expected processed cnv data')
 		test.equal(samples, undefined, 'no sample')
 		test.equal(absoluteMax, 1, 'absoluteMax=1')
 	}
 	{
-		const [samples, cnvLst, absoluteMax] = prepData({ cnv: cnvSample }, mockTk, mockBlock)
+		const [samples, cnvLst, absoluteMax] = prepData({ cnv: { cnvs: cnvSample } }, mockTk, mockBlock)
 		test.deepEqual(cnvLst, cnvSampleProcessed, 'get expected processed cnv data')
 		test.equal((samples as any[]).length, 1, 'returned 1 sample') // avoid tsc err
 
 		test.equal(absoluteMax, 1, 'absoluteMax=1')
 	}
 	{
-		const [samples, cnvLst, absoluteMax] = prepData({ cnv: cnvCategory }, mockTk, mockBlock)
+		const [samples, cnvLst, absoluteMax] = prepData({ cnv: { cnvs: cnvCategory } }, mockTk, mockBlock)
 		test.deepEqual(cnvLst, cnvCategoryProcessed, 'get expected processed cnv data')
 		test.equal(samples, undefined, 'no sample')
 		test.equal(absoluteMax, 0, 'absoluteMax=0')

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -853,7 +853,7 @@ tape('Custom data with samples and sample selection', test => {
 	}
 })
 
-tape.only('Custom cnv only, no sample', test => {
+tape('Custom cnv only, no sample', test => {
 	test.timeoutAfter(3000)
 	const holder = getHolder()
 

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -853,7 +853,7 @@ tape('Custom data with samples and sample selection', test => {
 	}
 })
 
-tape('Custom cnv only, no sample', test => {
+tape.only('Custom cnv only, no sample', test => {
 	test.timeoutAfter(3000)
 	const holder = getHolder()
 

--- a/client/mds3/test/skewer.unit.spec.ts
+++ b/client/mds3/test/skewer.unit.spec.ts
@@ -167,7 +167,7 @@ tape('getVariantLabelText()', function (test) {
 	}
 	{
 		// custom cnv
-		const data = { cnv: [1, 1] },
+		const data = { cnv: { cnvs: [1, 1] } },
 			tk = {
 				custom_variants: [{ dt: 4 }, { dt: 4 }]
 			},
@@ -177,7 +177,7 @@ tape('getVariantLabelText()', function (test) {
 	}
 	{
 		// native cnv
-		const data = { cnv: [{ dt: 4 }, { dt: 4 }] },
+		const data = { cnv: { cnvs: [{ dt: 4 }, { dt: 4 }] } },
 			tk = {},
 			block = { width: 10 }
 		const re = getVariantLabelText(data, tk, block)
@@ -185,7 +185,7 @@ tape('getVariantLabelText()', function (test) {
 	}
 	{
 		// native snv and cnv
-		const data = { cnv: [{ dt: 4 }, { dt: 4 }] },
+		const data = { cnv: { cnvs: [{ dt: 4 }, { dt: 4 }] } },
 			tk = {
 				skewer: {
 					rawmlst: [{ dt: 1 }, { dt: 1 }],

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -375,7 +375,7 @@ async function dataFromCustomVariants(tk, block) {
 		}
 	}
 
-	data.mclass2variantcount = summarize_mclass([...data.skewer, ...data.cnv])
+	data.mclass2variantcount = summarize_mclass([...data.skewer, ...data.cnv.cnvs])
 
 	if (data.cnv.cnvs.length == 0) delete data.cnv // important to delete to avoid triggering cnv logic
 

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -334,7 +334,9 @@ async function dataFromCustomVariants(tk, block) {
 	const data = {
 		// these holder will contain subset of tk.custom_variants[] that are in view range
 		skewer: [], // for non-cnv data
-		cnv: [] // for cnv segments
+		cnv: {
+			cnvs: [] // for cnv segments
+		}
 		// adds mclass2variantcount[] later
 	}
 
@@ -355,7 +357,7 @@ async function dataFromCustomVariants(tk, block) {
 		if (m.dt == dtcnv) {
 			if (m.chr != block.rglst[0].chr) continue
 			if (Math.max(m.start, bbstart) > Math.min(m.stop, bbstop)) continue
-			data.cnv.push(m)
+			data.cnv.cnvs.push(m)
 		} else if (m.dt == dtsnvindel || m.dt == dtsv || m.dt == dtfusionrna) {
 			if (m.chr != block.rglst[0].chr) continue // may not work for subpanel
 			if (m.pos <= bbstart || m.pos >= bbstop) continue
@@ -375,7 +377,7 @@ async function dataFromCustomVariants(tk, block) {
 
 	data.mclass2variantcount = summarize_mclass([...data.skewer, ...data.cnv])
 
-	if (data.cnv.length == 0) delete data.cnv // important to delete to avoid triggering cnv logic
+	if (data.cnv.cnvs.length == 0) delete data.cnv // important to delete to avoid triggering cnv logic
 
 	// count unique number of samples, if has such
 	const set = new Set()
@@ -387,8 +389,8 @@ async function dataFromCustomVariants(tk, block) {
 			}
 		}
 	}
-	if (data.cnv?.some(i => i.samples)) {
-		for (const m of data.cnv) {
+	if (data.cnv?.cnvs?.some(i => i.samples)) {
+		for (const m of data.cnv.cnvs) {
 			if (m.samples) {
 				for (const s of m.samples) set.add(s.sample_id)
 			}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- cnv.get() returns {cnvs[], cnvMsg} to include server generated msg on exceeding limit

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1460,12 +1460,13 @@ async function querySamplesWithCnv(q, dictTwLst, ds) {
 			}
 		]
 	}
-	const cnvs = await ds.queries.cnv.get(q2)
+	const re = await ds.queries.cnv.get(q2)
+	if (!Array.isArray(re?.cnvs)) throw 're.cnvs[] not array'
 
 	if (q.ssm_id_lst) {
 		// filter cnvs[] to get sample of this cnv seg!
 		const t = guessSsmid(q.ssm_id_lst)
-		for (const c of cnvs) {
+		for (const c of re.cnvs) {
 			if (c.start == t.l[1] && c.stop == t.l[2] && c.class == t.l[3] && c.samples?.[0]?.sample_id == t.l[5]) {
 				return [{}, [c.samples[0]]]
 			}
@@ -1473,11 +1474,11 @@ async function querySamplesWithCnv(q, dictTwLst, ds) {
 		throw 'cnv not found by queried segment'
 	}
 	// collect all samples
-	const samples = cnvs.map(c => c.samples[0])
+	const samples = re.cnvs.map(c => c.samples[0])
 	const byTermId = mayApplyBinning(samples, dictTwLst)
 
 	const id2samples = new Map()
-	for (const c of cnvs) {
+	for (const c of re.cnvs) {
 		combineSamplesById(c.samples, id2samples, c.ssm_id)
 	}
 

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2997,7 +2997,7 @@ async function getCnvByTw(ds, tw, genome, q) {
 	// tw.term.chr/start/stop are set
 	arg.rglst = [tw.term]
 	const re = await ds.queries.cnv.get(arg)
-	if (!Array.isArray(re.cnvs)) throw 're.cnvs not array'
+	if (!Array.isArray(re?.cnvs)) throw 're.cnvs not array'
 	return re.cnvs
 }
 async function getProbe2cnvByTw(ds, tw, genome, q) {

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -323,6 +323,7 @@ export async function load_driver(q, ds) {
 					// the required flag is missing. do not load
 				} else {
 					result.cnv = await ds.queries.cnv.get(q)
+					if (!Array.isArray(result.cnv?.cnvs)) throw 'result.cnv.cnvs[] not array'
 				}
 			}
 

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -94,7 +94,7 @@ function finalize_result(q, ds, result) {
 		}
 	}
 	if (result.cnv) {
-		for (const c of result.cnv) {
+		for (const c of result.cnv.cnvs) {
 			if (c.samples) {
 				for (const s of c.samples) {
 					sampleSet.add(s.sample_id)
@@ -107,7 +107,7 @@ function finalize_result(q, ds, result) {
 				}
 			}
 		}
-		if (result.cnv.length > ds.queries.cnv.densityViewCutoff) {
+		if (result.cnv.cnvs.length > ds.queries.cnv.densityViewCutoff) {
 			const q1 = {
 				rglst: structuredClone(q.rglst),
 				width: q.cnvDensity.width,
@@ -126,16 +126,17 @@ function finalize_result(q, ds, result) {
 			}
 			let bothMax = 0 // max for both gain and loss
 			for (const [i, r] of q.rglst.entries()) {
-				const [dgain, dloss] = getCnvDensity(result.cnv, r)
+				const [dgain, dloss] = getCnvDensity(result.cnv.cnvs, r)
 				bothMax = Math.max(bothMax, ...dgain, ...dloss)
 				q1.rglst[i].values = dgain
 				q2.rglst[i].values = dloss.map(i => i * -1)
 			}
 			result.cnvDensity = {
+				cnvMsg: result.cnv.cnvMsg,
 				gain: plotWiggle(q1, { fixminv: 0, fixmaxv: bothMax }),
 				loss: plotWiggle(q2, { fixminv: -bothMax, fixmaxv: 0 }),
 				max: bothMax,
-				segmentCount: result.cnv.length
+				segmentCount: result.cnv.cnvs.length
 			}
 			delete result.cnv
 		}
@@ -327,7 +328,7 @@ export async function load_driver(q, ds) {
 
 			filter_data(q, result)
 
-			result.mclass2variantcount = summarize_mclass([...result.skewer, ...(result.cnv || [])])
+			result.mclass2variantcount = summarize_mclass([...result.skewer, ...(result.cnv?.cnvs || [])])
 		}
 
 		// add queries for new data types

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -338,8 +338,9 @@ async function queryServerFileBySsmid(q, twLst, ds) {
 			if (!ds.queries.cnv) throw 'queries.cnv missing'
 			const [chr, start, stop, _class, value, sample] = _g.l
 			const param = Object.assign({}, q, { rglst: [{ chr, start, stop: start + 1 }] })
-			const mlst = await ds.queries.cnv.get(param)
-			for (const m of mlst) {
+			const cnv = await ds.queries.cnv.get(param)
+			if (!Array.isArray(cnv?.cnvs)) throw 'cnv.cnvs[] not array'
+			for (const m of cnv.cnvs) {
 				if (m.start != start || m.stop != stop) continue
 				if (m.class != _class) continue
 				if (Number.isFinite(value) && m.value != value) continue
@@ -437,8 +438,9 @@ async function queryServerFileByRglst(q, twLst, ds) {
 		}
 	}
 	if (ds.queries.cnv) {
-		const mlst = await ds.queries.cnv.get(q)
-		for (const m of mlst) {
+		const cnv = await ds.queries.cnv.get(q)
+		if (!Array.isArray(cnv?.cnvs)) throw 'cnv.cnvs[] not array'
+		for (const m of cnv.cnvs) {
 			combineSamplesById(m.samples, samples, m.ssm_id)
 		}
 	}

--- a/server/src/test/mds3.unit.spec.js
+++ b/server/src/test/mds3.unit.spec.js
@@ -28,13 +28,13 @@ tape('load_driver()', async function (test) {
 		// should return both skewer and cnv
 		const r = await load_driver(q, ds)
 		test.equal(r.skewer.length, 1, 'r.skewer.length=1')
-		test.equal(r.cnv.length, 1, 'r.cnv.length=1')
+		test.equal(r.cnv.cnvs.length, 1, 'r.cnv.length=1')
 	}
 	{
 		// q.hardcodeCnvOnly=1 and should only return cnv
 		const r = await load_driver(Object.assign({ hardcodeCnvOnly: 1 }, q), ds)
 		test.equal(r.skewer.length, 0, 'r.skewer.length=0 when hardcodeCnvOnly=1')
-		test.equal(r.cnv.length, 1, 'r.cnv.length=1')
+		test.equal(r.cnv.cnvs.length, 1, 'r.cnv.length=1')
 	}
 
 	// ds change!
@@ -49,7 +49,7 @@ tape('load_driver()', async function (test) {
 		// should only return cnv but not skewer
 		const r = await load_driver(Object.assign({ hardcodeCnvOnly: 1 }, q), ds)
 		test.equal(r.skewer.length, 0, 'r.skewer.length=0 when hardcodeCnvOnly=1')
-		test.equal(r.cnv.length, 1, 'r.cnv.length=1')
+		test.equal(r.cnv.cnvs.length, 1, 'r.cnv.length=1')
 	}
 
 	test.end()
@@ -111,7 +111,7 @@ const ds = {
 		},
 		cnv: {
 			get: () => {
-				return [{}]
+				return { cnvs: [{}] }
 			}
 		}
 	}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -549,8 +549,16 @@ configs for types of cnv data
 important: presence of filtering properties indiate the type of cnv quantification
 and will trigger rendering of ui controls
 */
-type CnvSegment = {
-	/** ds supplied ordynamically added getter */
+type CnvSegmentQuery = {
+	/** ds supplied or dynamically added getter
+	todo properly type input/output
+	returns:
+		{
+			cnvs:[]
+				{ chr, start, stop, value?, class, samples[], occurrence=1, ssm_id }
+			cnvMsg:string
+		}
+	*/
 	get?: (q: any) => any
 	/** either file or get is required. file is bgzipped with columns:
 	1. chr
@@ -633,7 +641,7 @@ type CnvSegment = {
 no longer used!!
 file content is a probe-by-sample matrix, values are signals
 for a given region, the median signal from probes in the region is used to make a gain/loss call for each sample
-this is alternative to CnvSegment
+this is alternative to CnvSegmentQuery
 
 type Probe2Cnv = {
                 file: string
@@ -901,7 +909,7 @@ type Mds3Queries = {
 	gbRestrictMode?: 'protein' | 'genomic'
 	snvindel?: SnvIndelQuery
 	svfusion?: SvFusion
-	cnv?: CnvSegment
+	cnv?: CnvSegmentQuery
 	trackLst?: TrackLst
 	ld?: LdQuery
 	defaultCoord?: string


### PR DESCRIPTION
…sg on exceeding limit

# Description
server generated optional message is displayed on handle menu:
<img width="585" alt="image" src="https://github.com/user-attachments/assets/b1f9ac56-cfdb-4a1c-92ba-0fe225c97ccc" />

all integration tests passed
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
