### PR TITLE
Added a unit test for CnvColorProvider

### DIFF
--- a/client/plots/disco/cnv/test/CnvColorProvider.unit.spec.ts
+++ b/client/plots/disco/cnv/test/CnvColorProvider.unit.spec.ts
@@ -1,0 +1,117 @@
+import test from 'tape'
+import CnvColorProvider from '../CnvColorProvider'
+import { CnvRenderingType } from '#plots/disco/cnv/CnvRenderingType.ts'
+
+/*
+Tests:
+	CnvColorProvider.getColor returns the expected color
+	based on CNV value, rendering mode, and capping thresholds.
+*/
+
+// ───── Mock Settings ─────
+
+// Mock settings for heatmap mode
+// In this mode, capping values are taken from settings.Disco.cnvCapping
+const mockSettingsHeatmap = {
+	cnv: {
+		cappedLossColor: 'blue', // Color for values below the loss cap
+		lossColor: 'lightblue', // Color for loss values within -cap and 0
+		ampColor: 'lightred', // Color for gain values within 0 and +cap
+		cappedAmpColor: 'red' // Color for values above the gain cap
+	},
+	Disco: {
+		cnvRenderingType: CnvRenderingType.heatmap, // Rendering type is heatmap
+		cnvCapping: 2 // Capping threshold is 2
+	}
+} as any
+
+// Mock settings for non-heatmap mode
+// In this mode, capping values are passed as cnvMaxPercentileAbs
+const mockSettingsNonHeatmap = {
+	cnv: {
+		cappedLossColor: 'blue',
+		lossColor: 'lightblue',
+		ampColor: 'lightred',
+		cappedAmpColor: 'red'
+	},
+	Disco: {
+		cnvRenderingType: 'non-heatmap' // Use external cnvMaxPercentileAbs for thresholds
+	}
+} as any
+
+test('\n', function (t) {
+	t.pass('-***- client/plots/disco/cnv/CnvColorProvider.ts -***-')
+	t.end()
+})
+
+// ───── Unit Tests: Heatmap Mode ─────
+// Verifies behavior when rendering type is heatmap
+// Uses internal settings.Disco.cnvCapping as threshold
+
+test('CnvColorProvider.getColor - heatmap mode', t => {
+	// Test value below loss threshold (should return cappedLossColor)
+	t.equal(
+		CnvColorProvider.getColor(-3, mockSettingsHeatmap),
+		mockSettingsHeatmap.cnv.cappedLossColor,
+		`Capped loss should return cappedLossColor (${mockSettingsHeatmap.cnv.cappedLossColor})`
+	)
+
+	// Test value within negative range (should return lossColor)
+	t.equal(
+		CnvColorProvider.getColor(-1, mockSettingsHeatmap),
+		mockSettingsHeatmap.cnv.lossColor,
+		`In-range loss should return lossColor (${mockSettingsHeatmap.cnv.lossColor})`
+	)
+
+	// Test value within positive range (should return ampColor)
+	t.equal(
+		CnvColorProvider.getColor(1, mockSettingsHeatmap),
+		mockSettingsHeatmap.cnv.ampColor,
+		`In-range gain should return ampColor (${mockSettingsHeatmap.cnv.ampColor})`
+	)
+
+	// Test value above gain threshold (should return cappedAmpColor)
+	t.equal(
+		CnvColorProvider.getColor(3, mockSettingsHeatmap),
+		mockSettingsHeatmap.cnv.cappedAmpColor,
+		`Capped gain should return cappedAmpColor (${mockSettingsHeatmap.cnv.cappedAmpColor})`
+	)
+	t.end()
+})
+
+// ───── Unit Tests: Non-Heatmap Mode ─────
+// Verifies behavior when rendering type is not heatmap
+// Uses provided cnvMaxPercentileAbs value as threshold
+
+test('CnvColorProvider.getColor - non-heatmap mode with cnvMaxPercentileAbs', t => {
+	const cap = 1.5 // external capping threshold
+
+	// Test value below -cap (should return cappedLossColor)
+	t.equal(
+		CnvColorProvider.getColor(-2, mockSettingsNonHeatmap, cap),
+		mockSettingsNonHeatmap.cnv.cappedLossColor,
+		`Capped loss should return cappedLossColor (${mockSettingsNonHeatmap.cnv.cappedLossColor})`
+	)
+
+	// Test value between -cap and 0 (should return lossColor)
+	t.equal(
+		CnvColorProvider.getColor(-1, mockSettingsNonHeatmap, cap),
+		mockSettingsNonHeatmap.cnv.lossColor,
+		`In-range loss should return lossColor (${mockSettingsNonHeatmap.cnv.lossColor})`
+	)
+
+	// Test value between 0 and cap (should return ampColor)
+	t.equal(
+		CnvColorProvider.getColor(1, mockSettingsNonHeatmap, cap),
+		mockSettingsNonHeatmap.cnv.ampColor,
+		`In-range gain should return ampColor (${mockSettingsNonHeatmap.cnv.ampColor})`
+	)
+
+	// Test value above cap (should return cappedAmpColor)
+	t.equal(
+		CnvColorProvider.getColor(2, mockSettingsNonHeatmap, cap),
+		mockSettingsNonHeatmap.cnv.cappedAmpColor,
+		`Capped gain should return cappedAmpColor (${mockSettingsNonHeatmap.cnv.cappedAmpColor})`
+	)
+	t.end()
+})


### PR DESCRIPTION
# Description
Added unit tests for the CnvColorProvider class in client/plots/disco/cnv/CnvColorProvider.ts, verifying that the getColor method correctly maps CNV values to colors under both heatmap and non-heatmap modes using mock settings. It tests all four key categories: capped loss, in-range loss, in-range gain, and capped gain.

Link to test @ port 3000:
http://localhost:3000/testrun.html?dir=plots/disco/cnv&name=CnvColorProvider.unit

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR
