### PR TITLE
allow numeric sample name and perform input validation when loading mutation-per-sample files

### DIFF
--- a/shared/types/src/routes/termdb.singleSampleMutation.ts
+++ b/shared/types/src/routes/termdb.singleSampleMutation.ts
@@ -6,8 +6,8 @@ export type TermdbSingleSampleMutationRequest = {
 	genome: string
 	/** Dataset label */
 	dslabel: string
-	/** sample id */
-	sample: string
+	/** sample id, allow string or number; for native ds, sample name in number will be cast into string */
+	sample: string | number
 }
 type ValidResponse = {
 	/** List of mutation data points from this sample TODO change to type of M elements */


### PR DESCRIPTION
# Description

[tdbtest disco](http://localhost:3000/?genome=hg38-test&dslabel=TermdbTest&disco=1&sample=3416) now works (breaks `path.join()` in master)

also improved file validation

other gdc and non-gdc disco also works
launching disco from mds3 tk and matrix works
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
