### PR TITLE
Split tvs.dtcnv.js

### DIFF
--- a/client/filter/test/tvs.integration.spec.js
+++ b/client/filter/test/tvs.integration.spec.js
@@ -1023,7 +1023,7 @@ tape('tvs: Gene Variant - CNV - continuous', async test => {
 						cnvGainCutoff: 0.5,
 						cnvLossCutoff: -0.5,
 						cnvMaxLength: 4000000,
-						cnvMode: 'continuous',
+						continuousCnv: true,
 						cnvWT: false
 					}
 				}

--- a/client/filter/test/tvs.unit.spec.js
+++ b/client/filter/test/tvs.unit.spec.js
@@ -317,8 +317,6 @@ tape('geneVariant tvs', async test => {
 			}
 			const { pill, filter, item, term } = await getPillFilterItem('dtcnv')
 			await testTvs(test, pill, filter, item, term)
-			const handler = pill.Inner.handler
-			test.equal(typeof handler.setMethods, 'function', 'should have a setMethods() method')
 		}
 	} catch (e) {
 		test.fail('test error: ' + e)

--- a/client/filter/test/tvs.unit.spec.js
+++ b/client/filter/test/tvs.unit.spec.js
@@ -66,7 +66,7 @@ async function getPillFilterItem(termType) {
 		const cnv = vocabApi.termdbConfig.queries.cnv
 		const cnvKeys = Object.keys(cnv)
 		if (termType == 'dtcnv' && (cnvKeys.includes('cnvGainCutoff') || cnvKeys.includes('cnvLossCutoff'))) {
-			item.tvs.cnvMode = 'continuous'
+			item.tvs.continuousCnv = true
 			if (cnv.cnvGainCutoff) item.tvs.cnvGainCutoff = cnv.cnvGainCutoff
 			if (cnv.cnvLossCutoff) item.tvs.cnvLossCutoff = cnv.cnvLossCutoff
 			if (cnv.cnvMaxLength) item.tvs.cnvMaxLength = cnv.cnvMaxLength

--- a/client/filter/tvs.dtcnv.categorical.js
+++ b/client/filter/tvs.dtcnv.categorical.js
@@ -1,0 +1,7 @@
+import { handler as _handler } from './tvs.dt.js'
+
+/*
+TVS handler for dtcnv term (categorical cnv data)
+*/
+
+export const handler = Object.assign({}, _handler, { type: 'dtcnv' })

--- a/client/filter/tvs.dtcnv.continuous.js
+++ b/client/filter/tvs.dtcnv.continuous.js
@@ -2,38 +2,12 @@ import { handler as _handler } from './tvs.dt.js'
 import { Menu } from '../dom/menu'
 
 /*
-TVS handler for dtcnv term
+TVS handler for dtcnv term (continuous cnv data)
 */
 
-// TODO: handler instance should NOT be shared if the mehtods (such as fillMenu()) depends on mode (continuous, categorical),
-// since dynamically changing instance methods would affect different terms that use this same handler instance
-export const handler = Object.assign({}, _handler, { type: 'dtcnv', setMethods })
+export const handler = Object.assign({}, _handler, { type: 'dtcnv', fillMenu, get_pill_label })
 
-function setMethods(self, tvs) {
-	// fill cnv menu based on whether cnv data is continuous or categorical
-	const termdbConfig = self.opts.vocabApi.termdbConfig || self.opts.vocabApi.parent_termdbConfig
-	const cnv = termdbConfig.queries?.cnv
-	if (!cnv) throw 'cnv query is missing'
-	const keys = Object.keys(cnv)
-	if (keys.includes('cnvGainCutoff') || keys.includes('cnvLossCutoff')) {
-		// dataset has continuous cnv data
-		// use continuous fill menu
-		// to fill menu with cnv cutoff settings
-		handler.fillMenu = fillMenu_cont
-		handler.get_pill_label = get_pill_label_cont
-		tvs.cnvMode = 'continuous'
-	} else {
-		// dataset has categorical cnv data
-		// keep using categorical fill menu
-		// to fill menu with mutation classes
-		tvs.cnvMode = 'categorical'
-		handler.fillMenu = _handler.fillMenu
-		handler.get_pill_label = _handler.get_pill_label
-	}
-}
-
-// fill menu for continuous CNV data
-async function fillMenu_cont(self, div, tvs) {
+async function fillMenu(self, div, tvs) {
 	div.style('margin', '10px')
 	const tip = new Menu({ padding: '5px' })
 
@@ -169,6 +143,7 @@ async function fillMenu_cont(self, div, tvs) {
 		.text('APPLY')
 		.on('click', () => {
 			const new_tvs = structuredClone(tvs)
+			new_tvs.continuousCnv = true
 			new_tvs.cnvWT = cnvWT
 			if (cnvGainCutoff) new_tvs.cnvGainCutoff = cnvGainCutoff
 			if (cnvLossCutoff) new_tvs.cnvLossCutoff = cnvLossCutoff
@@ -178,7 +153,6 @@ async function fillMenu_cont(self, div, tvs) {
 		})
 }
 
-// pill label for continuous CNV data
-function get_pill_label_cont(tvs) {
+function get_pill_label(tvs) {
 	return { txt: tvs.cnvWT ? 'Wildtype' : 'Altered' }
 }

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2852,7 +2852,7 @@ export function filterByItem(filter, mlst) {
 		tested = true
 		// determine if sample genotype matches filter genotype
 		let sampleHasGenotype
-		if (tvs.cnvMode == 'continuous') {
+		if (tvs.continuousCnv) {
 			// continuous cnv data
 			if (tvs.term.dt != dtcnv) throw 'unexpected dt value'
 			const sampleHasMutation = mlst_tested.some(m => {

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -140,7 +140,7 @@ test('filterByItem: continuous CNV', t => {
 		type: 'tvs',
 		tvs: {
 			term: { dt: 4 },
-			cnvMode: 'continuous',
+			continuousCnv: true,
 			cnvGainCutoff: 0.5,
 			cnvLossCutoff: -0.5,
 			cnvMaxLength: 100,


### PR DESCRIPTION
# Description

In this PR, `client/filter/tvs.dtcnv.js` has been split into 2 files: `client/filter/tvs.dtcnv.categorical.js` and `client/filter/tvs.dtcnv.continuous.js`. This split is done to be able to use different `fillMenu()` functions for different CNV data modes, without having to modify a shared `tvs.dtcnv.js` handler.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
