### PR TITLE
Modified DataMapper to prevent invalid fusions and added unit test fo…

### DIFF
--- a/client/plots/disco/data/DataMapper.ts
+++ b/client/plots/disco/data/DataMapper.ts
@@ -121,7 +121,7 @@ export default class DataMapper {
 					this.addData(dObject, dataArray)
 				}
 			} else if (dObject.dt == dtfusionrna || dObject.dt == dtsv) {
-				if (indexA != -1 || indexB != -1) {
+				if (indexA != -1 && indexB != -1) {
 					// show fusion event when at least one gene knonw
 					this.addData(dObject, dataArray)
 				}

--- a/client/plots/disco/data/DataMapper.ts
+++ b/client/plots/disco/data/DataMapper.ts
@@ -122,7 +122,7 @@ export default class DataMapper {
 				}
 			} else if (dObject.dt == dtfusionrna || dObject.dt == dtsv) {
 				if (indexA != -1 && indexB != -1) {
-					// show fusion event when at least one gene knonw
+					// show sv/fusion event with valid A/B breakpoints.
 					this.addData(dObject, dataArray)
 				}
 			} else if ([dtcnv, dtloh].includes(Number(dObject.dt))) {

--- a/client/plots/disco/data/test/DataMapper.unit.spec.ts
+++ b/client/plots/disco/data/test/DataMapper.unit.spec.ts
@@ -1,0 +1,70 @@
+import test from 'tape'
+import DataMapper from '#plots/disco/data/DataMapper.ts'
+import Reference from '#plots/disco/chromosome/Reference.ts'
+import discoDefaults from '#plots/disco/defaults.ts'
+import { dtsv } from '#shared/common.js'
+
+/*
+Test:
+    DataMapper.map() should skip fusion/SV entries with invalid chrA/chrB
+*/
+
+// ───── Setup ─────
+
+const settings = discoDefaults({
+	Disco: {
+		cnvCapping: 2,
+		prioritizeGeneLabelsByGeneSets: false,
+		cnvPercentile: 0.8
+	},
+	rings: {}
+})
+
+const chromosomes = { chr1: 1000, chr2: 1000 }
+const reference = new Reference(settings, chromosomes)
+
+const dataMapper = new DataMapper(settings, reference, 'SampleA', [])
+
+const fusionInput = [
+	{
+		dt: dtsv,
+		chrA: 'chrUnknown',
+		chrB: 'chr2',
+		geneA: 'FAKE1',
+		geneB: 'TP53',
+		posA: 123,
+		posB: 456
+	},
+	{
+		dt: dtsv,
+		chrA: 'chr1',
+		chrB: 'chrBogus',
+		geneA: 'FAKE2',
+		geneB: 'BRCA2',
+		posA: 789,
+		posB: 999
+	},
+	{
+		dt: dtsv,
+		chrA: 'chr1',
+		chrB: 'chr2',
+		geneA: 'ALK',
+		geneB: 'EML4',
+		posA: 11111,
+		posB: 22222
+	}
+]
+
+const result = dataMapper.map(fusionInput)
+
+test('\n', function (t) {
+	t.pass('-***- disco/data/DataMapper -***-')
+	t.end()
+})
+
+test('DataMapper.map() skips fusion entries with unknown chromosomes', t => {
+	t.equal(result.fusionData.length, 1, 'Only valid fusion with known chromosomes should be included')
+	t.equal(result.fusionData[0].geneA, 'ALK', 'Valid fusion geneA should be ALK')
+	t.equal(result.fusionData[0].geneB, 'EML4', 'Valid fusion geneB should be EML4')
+	t.end()
+})


### PR DESCRIPTION
…r DataMapper

# Description
This PR updates the fusion filtering logic in DataMapper.map() to ensure that only fusion events with both chrA and chrB present in the reference genome are included. A corresponding unit test has also been added to verify that fusion entries with invalid chromosome names are properly excluded.

test in:
http://localhost:3000/testrun.html?dir=plots/disco/data&name=DataMapper.unit

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
