### PR TITLE
Fix mismatching colors in disco legend and plot

### DIFF
--- a/client/dom/ColorScale/ColorScale.ts
+++ b/client/dom/ColorScale/ColorScale.ts
@@ -93,6 +93,11 @@ export class ColorScale {
 			throw new Error('Data and color arrays for #dom/ColorScale must be the same length')
 		if (opts.labels && (!opts.labels.left || !opts.labels.right))
 			throw new Error('Missing a label for #dom/ColorScale.')
+		if (opts.showNumsAsIs && opts.ticks) {
+			console.warn(
+				'Using showNumsAsIs will ignore the ticks option in #dom/ColorScale. The domain values will be shown as provided.'
+			)
+		}
 	}
 
 	renderLabels(scaleSvg: SvgSvg, labels: { left: string; right: string }, position: string) {
@@ -123,6 +128,11 @@ export class ColorScale {
 		return barG
 	}
 
+	/** Returns an evenly spaced range for each number in the domain.
+	 * Allows the numbers to appear visually equidistant in the
+	 * scale despite the actual interval. Matches the equidistant
+	 * color gradient in the color bar.
+	 */
 	getRange() {
 		return this.tickValues.map((_, i) => {
 			return this.barwidth * (i / (this.tickValues.length - 1))
@@ -217,7 +227,12 @@ export class ColorScale {
 
 	getAxis() {
 		const axis = this.topTicks === true ? axisTop(this.dom.scale) : axisBottom(this.dom.scale)
-		axis.ticks(this.ticks).tickValues(this.tickValues).tickSize(this.tickSize)
+		/** Use tickValues to avoid d3 generated tick values and tickFormat to avoid
+		 * unhelpful rounding (e.g 0.00462 becomes 0.0) */
+		if (this.showNumsAsIs) axis.tickValues(this.tickValues).tickFormat((d: any) => d)
+		/** Otherwise use a suggested number of tick values -- which d3 may ignore. See d3 docs. */ else
+			axis.ticks(this.ticks)
+		axis.tickSize(this.tickSize)
 
 		return axis
 	}

--- a/client/dom/ColorScale/ColorScale.ts
+++ b/client/dom/ColorScale/ColorScale.ts
@@ -6,7 +6,7 @@ import type {
 	ColorScaleMenuOpts,
 	NumericInputs
 } from '../types/colorScale'
-import { scaleLinear, scaleDiverging } from 'd3-scale'
+import { scaleLinear } from 'd3-scale'
 import { axisBottom, axisTop } from 'd3-axis'
 import { font } from '../../src/client'
 import { axisstyle, niceNumLabels } from '#dom'
@@ -156,8 +156,7 @@ export class ColorScale {
 
 		const scaleAxis = div.append('g').attr('data-testid', 'sjpp-color-scale-axis')
 		if (this.topTicks === false) scaleAxis.attr('transform', `translate(0, ${this.barheight})`)
-		const scaleFn = this.domain.length > 2 ? scaleDiverging() : scaleLinear()
-		const scale = scaleFn.domain(this.tickValues).range(this.getRange())
+		const scale = scaleLinear().domain(this.tickValues).range(this.getRange())
 
 		return { scale, scaleAxis }
 	}
@@ -246,8 +245,7 @@ export class ColorScale {
 		this.dom.scaleAxis.selectAll('*').remove()
 
 		this.tickValues = this.showNumsAsIs ? this.domain : niceNumLabels(this.domain)
-		const scaleFn = this.domain.length > 2 ? scaleDiverging() : scaleLinear()
-		this.dom.scale = scaleFn.domain(this.tickValues).range(this.getRange())
+		this.dom.scale = scaleLinear().domain(this.tickValues).range(this.getRange())
 
 		this.dom.scaleAxis
 			.transition()

--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -208,9 +208,12 @@ export default function svgLegend(opts) {
 				id: colorGradientId,
 				position: `${bbox.width + 25},${yPos}`,
 				showNumsAsIs: d.showNumsAsIs || false,
-				ticks: 3,
 				tickSize: 2,
 				topTicks: true
+			}
+			if (!d.showNumsAsIs) {
+				//console.warn fires if both .showNumsAsIs and .ticks are set
+				opts.ticks = 3
 			}
 			if (d.labels) {
 				opts.labels = d.labels

--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -207,6 +207,7 @@ export default function svgLegend(opts) {
 				holder: g,
 				id: colorGradientId,
 				position: `${bbox.width + 25},${yPos}`,
+				showNumsAsIs: d.showNumsAsIs || false,
 				ticks: 3,
 				tickSize: 2,
 				topTicks: true

--- a/client/dom/test/colorScale.unit.spec.ts
+++ b/client/dom/test/colorScale.unit.spec.ts
@@ -10,6 +10,7 @@ ColorScale
 	- ColorScale.render() - default bottom
 	- ColorScale.render() - top
 	- With labels
+	- With .showNumsAsIs as true
 	- ColorScale.updateColors()
 	- markedValue - Show value in color bar and update
 	- ColorScale.updateAxis()
@@ -147,6 +148,28 @@ tape('With labels', test => {
 		childNodes[2].nodeName == 'text' && childNodes[2].innerHTML == opts.labels.right,
 		`Should render text element to the left with label text = ${opts.labels.right}`
 	)
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('With .showNumsAsIs as true', test => {
+	test.timeoutAfter(100)
+
+	const holder = getHolder() as any
+	const domain = [-1.42, 0, 0.00462, 0.5]
+	const opts = { holder, domain, colors: ['blue', 'white', 'purple', 'green'], showNumsAsIs: true }
+	const testColorScale = getColorScale(opts)
+
+	test.equal(
+		testColorScale.tickValues,
+		domain,
+		'Should not format (i.e. round) domain values when showNumsAsIs is true'
+	)
+
+	const ticks = holder.selectAll('text').nodes()
+	const tickValues = ticks.map(t => Number(t.__data__))
+	test.deepEqual(tickValues, domain, 'Should render ticks with original domain values when showNumsAsIs is true')
 
 	if (test['_ok']) holder.remove()
 	test.end()

--- a/client/dom/types/colorScale.ts
+++ b/client/dom/types/colorScale.ts
@@ -46,7 +46,10 @@ export type ColorScaleOpts = {
 	height?: number
 	/** If present, creates a menu on click to change the colors */
 	setColorsCallback?: (val: string, idx: number) => void
-	/** Do not format numbers. Show as is.  */
+	/** Avoids formating tick labels. Instead shows the domain values as is, without formating.
+	 * If using this option, *** round the domain values in caller. *** Normal d3 rounding
+	 * functions are disabled.
+	 * Do not use with .ticks(). If .ticks() is provided it will be ignored. Default is false.*/
 	showNumsAsIs: boolean
 	/** Optional. Suggested number of ticks to show. Cannot be zero. Default is 5.
 	 * NOTE: D3 considers this a ** suggested ** count. d3-axis will ultimateluy render the

--- a/client/dom/types/colorScale.ts
+++ b/client/dom/types/colorScale.ts
@@ -50,7 +50,7 @@ export type ColorScaleOpts = {
 	 * If using this option, *** round the domain values in caller. *** Normal d3 rounding
 	 * functions are disabled.
 	 * Do not use with .ticks(). If .ticks() is provided it will be ignored. Default is false.*/
-	showNumsAsIs: boolean
+	showNumsAsIs?: boolean
 	/** Optional. Suggested number of ticks to show. Cannot be zero. Default is 5.
 	 * NOTE: D3 considers this a ** suggested ** count. d3-axis will ultimateluy render the
 	 * ticks based on the available space of each label.

--- a/client/dom/types/colorScale.ts
+++ b/client/dom/types/colorScale.ts
@@ -1,6 +1,6 @@
 import type { SvgG, SvgLine, SvgSvg, SvgText } from '../../types/d3'
 import type { Selection } from 'd3-selection'
-import type { ScaleLinear } from 'd3-scale'
+// import type { ScaleDiverging, ScaleLinear } from 'd3-scale'
 
 export type ColorScaleOpts = {
 	/** Optional but recommended. The height of the color bar in px. Default is 14. */
@@ -46,6 +46,8 @@ export type ColorScaleOpts = {
 	height?: number
 	/** If present, creates a menu on click to change the colors */
 	setColorsCallback?: (val: string, idx: number) => void
+	/** Do not format numbers. Show as is.  */
+	showNumsAsIs: boolean
 	/** Optional. Suggested number of ticks to show. Cannot be zero. Default is 5.
 	 * NOTE: D3 considers this a ** suggested ** count. d3-axis will ultimateluy render the
 	 * ticks based on the available space of each label.
@@ -65,7 +67,7 @@ export type ColorScaleDom = {
 	/** color bar */
 	gradient: GradientElem
 	/** d3 scale */
-	scale: ScaleLinear<number, number, never>
+	scale: any
 	/** holder for the d3 scale */
 	scaleAxis: SvgG
 	/** Marked value label */

--- a/client/plots/disco/legend/LegendJSONMapper.ts
+++ b/client/plots/disco/legend/LegendJSONMapper.ts
@@ -3,6 +3,7 @@ import { CnvType } from '#plots/disco/cnv/CnvType.ts'
 import { FusionLegend } from '#plots/disco/fusion/FusionLegend.ts'
 import { CnvRenderingType } from '#plots/disco/cnv/CnvRenderingType.ts'
 import { scaleLinear } from 'd3-scale'
+import { roundValueAuto } from '@sjcrh/proteinpaint-shared/roundValue.js'
 
 export default class LegendJSONMapper {
 	private cappedCnvMaxAbsValue: number
@@ -129,15 +130,19 @@ export default class LegendJSONMapper {
 				dt: 4
 			}
 			if (gain.value > 0 && loss.value < 0) {
-				const maxValue = Math.max(Math.abs(loss.value), gain.value)
-				const domain = [-maxValue, 0, maxValue]
+				/** Do not use equidistant domain (like code below) here.
+				 * Colorscale will not match the colors in the disco or tooltips. */
+				// const maxValue = Math.max(Math.abs(loss.value), gain.value)
+				// const domain = [-maxValue, 0, maxValue]
+				const domain = [roundValueAuto(loss.value), 0, roundValueAuto(gain.value)]
 				cnvItems.push(
 					Object.assign(
 						{
 							key: CnvType.LossGain,
 							domain,
-							scale: scaleLinear([-1, 0, 1], [loss.color, 'white', gain.color]),
+							colors: [loss.color, 'white', gain.color],
 							labels: { left: 'Loss', right: 'Gain' },
+							showNumsAsIs: true,
 							numericInputs: {
 								cutoffMode: legend.cnvCutoffMode,
 								defaultPercentile: legend.cnvPercentile,


### PR DESCRIPTION
# Description
Closes issue #3095. 

Changes: 
1. Shows the real min and max in the disco color scale to match the colors in the plot and tooltip
2. Allows the caller for the color scale to specify whether the domain values should be shown as is or allow d3 to round and generate tick labels. See new comments in #dom/types/colorScale.ts

Test: 
I made changes to the color scale code itself. Please test everywhere the component is implemented.

1. [Disco example](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-85-7710-01A) from issue
2. [Matrix example](http://localhost:3000/?noheader=1&mass=%7B%22dslabel%22:%22pantallMds3%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:%5B%7B%22chartType%22:%22matrix%22,%22termgroups%22:%5B%7B%22lst%22:%5B%7B%22term%22:%7B%22gene%22:%22NOTCH1%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22MYB%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22LMO1%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22term%22:%7B%22gene%22:%22TAL1%22,%22type%22:%22geneVariant%22%7D%7D,%7B%22id%22:%22Gender%22%7D,%7B%22id%22:%22Age%22,%22q%22:%7B%22mode%22:%22continuous%22%7D%7D%5D%7D%5D%7D%5D%7D)
3. [Whole genome hic example](http://localhost:3000/?genome=hg19&hicfile=proteinpaint_demo/hg19/hic/hic_demo.hic&enzyme=MboI) 
4. [Hic track](http://localhost:3000/?appcard=Hi-C&example=Hi-C) 
5. [Regression example](http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22logistic%22,%22outcome%22:{%22id%22:%22LV_Ejection_Fraction_3D_s%22},%22independent%22:[{%22term%22:{%22type%22:%22snplocus%22,%22id%22:%22temp112233%22},%22interactions%22:[%22sex_s%22],%22q%22:{%22chr%22:%22chr17%22,%22start%22:7664218,%22stop%22:7671018,%22AFcutoff%22:5,%22alleleType%22:0,%22geneticModel%22:0,%22restrictAncestry%22:{%22name%22:%22European%20ancestry%22,%22tvs%22:{%22term%22:{%22id%22:%22genetic_race_s%22,%22type%22:%22categorical%22,%22name%22:%22Genetically%20defined%20race%22},%22values%22:[{%22key%22:%22European%20Ancestry%22,%22label%22:%22European%20Ancestry%22}]}},%22variant_filter%22:{%22type%22:%22tvslst%22,%22join%22:%22and%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22Bad%22,%22key%22:%22Bad%22}],%22term%22:{%22id%22:%22QC%22,%22name%22:%22Classification%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22,%22values%22:{%22Good%22:{%22label%22:%22Good%22,%22key%22:%22Good%22},%22Bad%22:{%22label%22:%22Bad%22,%22key%22:%22Bad%22}}}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22SJcontrol_CR%22,%22name%22:%22SJLIFE%20control%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR%22,%22name%22:%22Call%20rate,%20SJLIFE+CCSS%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_sjlife%22,%22name%22:%22SJLIFE%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22ranges%22:[{%22start%22:0.95,%22startinclusive%22:true,%22stopunbounded%22:true}],%22term%22:{%22id%22:%22CR_ccss%22,%22name%22:%22CCSS%20call%20rate%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22float%22}}},{%22type%22:%22tvs%22,%22tvs%22:{%22isnot%22:true,%22values%22:[{%22label%22:%22yes%22,%22key%22:%221%22}],%22term%22:{%22id%22:%22Polymer_region%22,%22name%22:%22Polymer%20region%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22categorical%22}}}]}}},{%22id%22:%22sex_s%22,%22refGrp%22:%222%22,%22interactions%22:[%22temp112233%22]}]}]})
6. [Single cell example](http://localhost:3000/example.gdc.scRNAseq.html) 
8. [Mds3 example](http://localhost:3000/?genome=hg38&gene=bcr&mds3=ASH)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
