### PR TITLE
Show the exon stop position as rendered

### DIFF
--- a/client/src/block.js
+++ b/client/src/block.js
@@ -3326,7 +3326,7 @@ seekrange(chr,start,stop) {
 										':' +
 										(i.start + 1) +
 										'-' +
-										(i.stop + 1) +
+										i.stop +
 										' ' +
 										common.bplen(i.stop - i.start) +
 										'</span>'


### PR DESCRIPTION
# Description
Related to user inquiry about custom binding site data with the same issue. In master the exons stop at the zero based position but the tooltip adds a bp. These screenshots are from http://localhost:3000/?appcard=bedj&example=JSON%20BED, position: chr17:7573998-7574047. 

<img width="445" alt="Screenshot 2025-06-27 at 4 32 50 PM" src="https://github.com/user-attachments/assets/10b9244a-fb64-463f-862d-e631379abb2d" />



This PR corrects the tooltip to match the rendering, like so: 

<img width="483" alt="Screenshot 2025-06-27 at 4 32 13 PM" src="https://github.com/user-attachments/assets/e591e3e9-4e8a-4474-9aab-d6922a55cae1" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
