### PR TITLE
GDC-GRIN2: Made timing report to just seconds

### DIFF
--- a/client/gdc/grin2.ts
+++ b/client/gdc/grin2.ts
@@ -2162,7 +2162,7 @@ async function getFilesAndShowTable(obj) {
 
 						// Rust Processing Time
 						if (response.timing.rustProcessingTime !== undefined) {
-							timingStatsGrid.append('div').style('color', '#6c757d').text('GDC API Data Query and Parsing:')
+							timingStatsGrid.append('div').style('color', '#6c757d').text('GDC API Data Query and Parsing (s):')
 							timingStatsGrid
 								.append('div')
 								.style('font-weight', 'bold')
@@ -2172,7 +2172,7 @@ async function getFilesAndShowTable(obj) {
 
 						// GRIN2 Processing Time
 						if (response.timing.grin2ProcessingTime !== undefined) {
-							timingStatsGrid.append('div').style('color', '#6c757d').text('GRIN2 Analysis:')
+							timingStatsGrid.append('div').style('color', '#6c757d').text('GRIN2 Analysis (s):')
 							timingStatsGrid
 								.append('div')
 								.style('font-weight', 'bold')
@@ -2182,7 +2182,7 @@ async function getFilesAndShowTable(obj) {
 
 						// Total Time
 						if (response.timing.totalTime !== undefined) {
-							timingStatsGrid.append('div').style('color', '#6c757d').text('Total Processing Time:')
+							timingStatsGrid.append('div').style('color', '#6c757d').text('Total Processing Time (s):')
 							timingStatsGrid
 								.append('div')
 								.style('font-weight', 'bold')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC-GRIN2: Made timing report to just seconds instead of hundredths of a second

--- a/server/routes/gdc.grin2.run.ts
+++ b/server/routes/gdc.grin2.run.ts
@@ -3,7 +3,6 @@ import { runGRIN2Payload } from '#types/checkers'
 import { stream_rust } from '@sjcrh/proteinpaint-rust'
 import serverconfig from '#src/serverconfig.js'
 import path from 'path'
-import { formatElapsedTime } from '@sjcrh/proteinpaint-shared/time.js'
 import { run_python } from '@sjcrh/proteinpaint-python'
 
 /**
@@ -223,7 +222,7 @@ function init({ genomes }) {
 
 			console.log('[GRIN2] Rust execution completed')
 			const downloadTime = Date.now() - downloadStartTime
-			const downloadTimeToPrint = formatElapsedTime(downloadTime)
+			const downloadTimeToPrint = Math.round(downloadTime / 1000)
 			console.log(`[GRIN2] Rust processing took ${downloadTimeToPrint}`)
 
 			// Parse the JSONL output
@@ -290,7 +289,7 @@ function init({ genomes }) {
 			console.log('[GRIN2] python execution completed')
 			console.log(`[GRIN2] Python stderr: ${pyResult.stderr}`)
 			const grin2AnalysisTime = Date.now() - grin2AnalysisStart
-			const grin2AnalysisTimeToPrint = formatElapsedTime(grin2AnalysisTime)
+			const grin2AnalysisTimeToPrint = Math.round(grin2AnalysisTime / 1000)
 			console.log(`[GRIN2] Python processing took ${grin2AnalysisTimeToPrint}`)
 
 			// Parse python result to get image or check for errors
@@ -302,7 +301,7 @@ function init({ genomes }) {
 				const pngImg = resultData.png[0]
 				const topGeneTable = resultData.topGeneTable || null
 				const analysisStats = parsedRustResult.summary || {}
-				const totalProcessTime = formatElapsedTime(downloadTime + grin2AnalysisTime)
+				const totalProcessTime = Math.round((downloadTime + grin2AnalysisTime) / 1000)
 				console.log('[GRIN2] Total GRIN2 processing time:', totalProcessTime)
 				return res.json({
 					pngImg,


### PR DESCRIPTION
# Description
GDC-GRIN2: Made timing report to just seconds instead of hundredths of a second. 
# To test 
Go [here](http://localhost:3000/?gdcgrin2=1&filter0={%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:%22myeloid%20leukemias%22}}) and make sure the timing report shows only seconds instead of going all the way down to hundredths of a second

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
