### PR TITLE
Disco Tooltip improvements

### DIFF
--- a/client/plots/disco/chromosome/ChromosomesRenderer.ts
+++ b/client/plots/disco/chromosome/ChromosomesRenderer.ts
@@ -37,20 +37,29 @@ export default class ChromosomesRenderer implements IRenderer {
 			.attr('d', arc)
 			.attr('fill', 'black')
 			.on('mousemove', (event: MouseEvent, d: d3.PieArcDatum<Chromosome>) => {
+				// Get mouse pointer coordinates relative to the arcs group
 				const [x, y] = d3.pointer(event, arcs.node())
+				// Convert Cartesian coordinates to polar angle (in radians)
 				let angle = Math.atan2(y, x) + Math.PI / 2
+				// Normalize angle to be within [0, 2π]
 				if (angle < 0) angle += 2 * Math.PI
+				// Compute how far along this arc segment the angle falls (fraction between 0 and 1)
 				const frac = Math.max(0, Math.min(1, (angle - d.data.startAngle) / (d.data.endAngle - d.data.startAngle)))
+				// Interpolate position along chromosome based on angle
 				const pos = Math.round(d.data.start + frac * d.data.size)
+				// Update tooltip text with chromosome name and position (formatted with commas)
 				menu.d.text(`Chr ${d.data.text}: Position: ${pos.toLocaleString()}`)
+				// Display tooltip at cursor position
 				menu.show(event.x, event.y)
 			})
 			.on('mouseover', event => {
+				// When hovering over an arc, highlight it with an orange border
 				d3.select(event.currentTarget as SVGElement)
 					.attr('stroke', 'orange')
 					.attr('stroke-width', 1)
 			})
 			.on('mouseout', event => {
+				// Remove highlight and hide tooltip when mouse leaves the arc
 				d3.select(event.currentTarget as SVGElement)
 					.attr('stroke', null)
 					.attr('stroke-width', null)

--- a/client/plots/disco/chromosome/ChromosomesRenderer.ts
+++ b/client/plots/disco/chromosome/ChromosomesRenderer.ts
@@ -27,7 +27,7 @@ export default class ChromosomesRenderer implements IRenderer {
 
 		const arcs = holder.append('g').attr('data-testid', 'sjpp_chromosomes_arc_group')
 
-        const menu = MenuProvider.create()
+		const menu = MenuProvider.create()
 
 		arcs
 			.selectAll('path')
@@ -37,28 +37,20 @@ export default class ChromosomesRenderer implements IRenderer {
 			.attr('d', arc)
 			.attr('fill', 'black')
 			.on('mousemove', (event: MouseEvent, d: d3.PieArcDatum<Chromosome>) => {
-				
-					let [x, y] = d3.pointer(event, arcs.node())
-					let angle = Math.atan2(y, x)  + Math.PI / 2
-					if (angle < 0) angle += 2 * Math.PI
-					let frac = Math.max(0, Math.min(1, (angle - d.data.startAngle) / (d.data.endAngle - d.data.startAngle)))
-					let pos = Math.round(d.data.start + frac * d.data.size)
-					menu.d.text(`Chr ${d.data.text}: Position: ${pos.toLocaleString()}`)
-					menu.show(event.x, event.y)
-					console.log({
-						angle,
-						startAngle: d.startAngle,
-						endAngle: d.endAngle,
-						frac,
-						pos
-					})
+				const [x, y] = d3.pointer(event, arcs.node())
+				let angle = Math.atan2(y, x) + Math.PI / 2
+				if (angle < 0) angle += 2 * Math.PI
+				const frac = Math.max(0, Math.min(1, (angle - d.data.startAngle) / (d.data.endAngle - d.data.startAngle)))
+				const pos = Math.round(d.data.start + frac * d.data.size)
+				menu.d.text(`Chr ${d.data.text}: Position: ${pos.toLocaleString()}`)
+				menu.show(event.x, event.y)
 			})
-			.on('mouseover', (event) => {
+			.on('mouseover', event => {
 				d3.select(event.currentTarget as SVGElement)
 					.attr('stroke', 'orange')
 					.attr('stroke-width', 1)
 			})
-			.on('mouseout', (event) => {
+			.on('mouseout', event => {
 				d3.select(event.currentTarget as SVGElement)
 					.attr('stroke', null)
 					.attr('stroke-width', null)

--- a/client/plots/disco/chromosome/ChromosomesRenderer.ts
+++ b/client/plots/disco/chromosome/ChromosomesRenderer.ts
@@ -1,6 +1,7 @@
 import * as d3 from 'd3'
 import type IRenderer from '#plots/disco/IRenderer.ts'
 import type Chromosome from './Chromosome.ts'
+import MenuProvider from '#plots/disco/menu/MenuProvider.ts'
 
 export default class ChromosomesRenderer implements IRenderer {
 	private padAngle: number
@@ -26,7 +27,43 @@ export default class ChromosomesRenderer implements IRenderer {
 
 		const arcs = holder.append('g').attr('data-testid', 'sjpp_chromosomes_arc_group')
 
-		arcs.selectAll('path').data(arcData).enter().append('path').attr('d', arc).attr('fill', 'black')
+        const menu = MenuProvider.create()
+
+		arcs
+			.selectAll('path')
+			.data(arcData)
+			.enter()
+			.append('path')
+			.attr('d', arc)
+			.attr('fill', 'black')
+			.on('mousemove', (event: MouseEvent, d: d3.PieArcDatum<Chromosome>) => {
+				
+					let [x, y] = d3.pointer(event, arcs.node())
+					let angle = Math.atan2(y, x)  + Math.PI / 2
+					if (angle < 0) angle += 2 * Math.PI
+					let frac = Math.max(0, Math.min(1, (angle - d.data.startAngle) / (d.data.endAngle - d.data.startAngle)))
+					let pos = Math.round(d.data.start + frac * d.data.size)
+					menu.d.text(`Chr ${d.data.text}: Position: ${pos.toLocaleString()}`)
+					menu.show(event.x, event.y)
+					console.log({
+						angle,
+						startAngle: d.startAngle,
+						endAngle: d.endAngle,
+						frac,
+						pos
+					})
+			})
+			.on('mouseover', (event) => {
+				d3.select(event.currentTarget as SVGElement)
+					.attr('stroke', 'orange')
+					.attr('stroke-width', 1)
+			})
+			.on('mouseout', (event) => {
+				d3.select(event.currentTarget as SVGElement)
+					.attr('stroke', null)
+					.attr('stroke-width', null)
+				menu.hide()
+			})
 
 		arcs
 			.selectAll('text')
@@ -43,5 +80,7 @@ export default class ChromosomesRenderer implements IRenderer {
 			.attr('text-anchor', 'middle')
 			.text((d: d3.PieArcDatum<Chromosome>) => d.data.text)
 			.style('fill', 'white')
+			//prevents chromosome number from interfering with hover
+			.style('pointer-events', 'none')
 	}
 }

--- a/client/plots/disco/cnv/CnvBarRenderer.ts
+++ b/client/plots/disco/cnv/CnvBarRenderer.ts
@@ -9,11 +9,14 @@ export default class CnvBarRenderer implements IRenderer {
 	render(holder: any, elements: Array<CnvArc>) {
 		const arcGenerator = d3.arc<CnvArc>()
 
+		// Create a group for the arcs (actual CNV bars)
 		const arcs = holder.append('g')
-		const hoverOverlay = holder.append('g')
+		// Create a group for overlays used to highlight hovered bars
+		const hoverOverlay = holder
+			.append('g')
 			.attr('class', 'hover-overlay')
 			// prevent highlighht from blocking thin CNVs
-			.style('pointer-events', 'none') 
+			.style('pointer-events', 'none')
 
 		const menu = MenuProvider.create()
 
@@ -22,42 +25,54 @@ export default class CnvBarRenderer implements IRenderer {
 			.data(elements)
 			.enter()
 			.append('path')
+			// Generate arc path for each CNV
 			.attr('d', (d: CnvArc) => arcGenerator(d))
+			// Fill with the CNV's specified color
 			.attr('fill', (d: CnvArc) => d.color)
+			// Start of highlight + tooltip behavior
 			.on('mouseover', (mouseEvent: MouseEvent, arc: CnvArc) => {
-				hoverOverlay.selectAll('*').remove() 
-
-				hoverOverlay.append('path')
+				// Remove any existing overlay (e.g., from previous hover)
+				hoverOverlay.selectAll('*').remove()
+				// Add a highlighted black stroke on top of the hovered arc
+				hoverOverlay
+					.append('path')
 					.datum(arc)
 					.attr('d', arcGenerator(arc))
 					.attr('fill', 'none')
 					.attr('stroke', 'black')
 					.attr('stroke-width', 1)
 
+				// Prepare the CNV data for tooltip display
 				const cnv: any = structuredClone(arc)
 				cnv.dt = dtcnv
 				cnv.samples = [{ sample_id: arc.sampleName }]
 				cnv.gene = cnv.text
 
+				// Create a two-column table in the tooltip
 				const table = table2col({ holder: menu.d })
+				// Add: Copy number change row
 				{
 					const [c1, c2] = table.addRow()
 					c1.text('Copy number change')
 					c2.html(`<span style="background:${cnv.color}">&nbsp;&nbsp;</span> ${cnv.value}`)
 				}
+				// Add: Position row
 				{
 					const [c1, c2] = table.addRow()
 					c1.text('Position')
 					c2.text(cnv.chr + ':' + cnv.start + '-' + cnv.stop)
 				}
+				// Add: Unit value row
 				{
 					const [c1, c2] = table.addRow()
 					c1.text('Unit')
 					c2.text(cnv.value)
 				}
 
+				// Show tooltip near the cursor
 				menu.show(mouseEvent.x, mouseEvent.y)
 			})
+			// Remove highlight and tooltip when mouse leaves
 			.on('mouseout', () => {
 				hoverOverlay.selectAll('*').remove()
 				menu.clear()

--- a/client/plots/disco/cnv/CnvBarRenderer.ts
+++ b/client/plots/disco/cnv/CnvBarRenderer.ts
@@ -10,6 +10,10 @@ export default class CnvBarRenderer implements IRenderer {
 		const arcGenerator = d3.arc<CnvArc>()
 
 		const arcs = holder.append('g')
+		const hoverOverlay = holder.append('g')
+			.attr('class', 'hover-overlay')
+			// prevent highlighht from blocking thin CNVs
+			.style('pointer-events', 'none') 
 
 		const menu = MenuProvider.create()
 
@@ -21,6 +25,15 @@ export default class CnvBarRenderer implements IRenderer {
 			.attr('d', (d: CnvArc) => arcGenerator(d))
 			.attr('fill', (d: CnvArc) => d.color)
 			.on('mouseover', (mouseEvent: MouseEvent, arc: CnvArc) => {
+				hoverOverlay.selectAll('*').remove() 
+
+				hoverOverlay.append('path')
+					.datum(arc)
+					.attr('d', arcGenerator(arc))
+					.attr('fill', 'none')
+					.attr('stroke', 'black')
+					.attr('stroke-width', 1)
+
 				const cnv: any = structuredClone(arc)
 				cnv.dt = dtcnv
 				cnv.samples = [{ sample_id: arc.sampleName }]
@@ -46,6 +59,7 @@ export default class CnvBarRenderer implements IRenderer {
 				menu.show(mouseEvent.x, mouseEvent.y)
 			})
 			.on('mouseout', () => {
+				hoverOverlay.selectAll('*').remove()
 				menu.clear()
 				menu.hide()
 			})

--- a/client/plots/disco/cnv/CnvHeatmapRenderer.ts
+++ b/client/plots/disco/cnv/CnvHeatmapRenderer.ts
@@ -6,12 +6,12 @@ import { scaleLinear } from 'd3-scale'
 import { dtcnv } from '#shared/common.js'
 
 export class CnvHeatmapRenderer {
-	private positivePercentile80: number
-	private negativePercentile80: number
+	private positivePercentile: number
+	private negativePercentile: number
 
-	constructor(positivePercentile80 = 0, negativePercentile80 = 0) {
-		this.positivePercentile80 = positivePercentile80
-		this.negativePercentile80 = negativePercentile80
+	constructor(positivePercentile = 0, negativePercentile = 0) {
+		this.positivePercentile = positivePercentile
+		this.negativePercentile = negativePercentile
 	}
 
 	render(holder: any, elements: Array<CnvArc>) {
@@ -19,9 +19,7 @@ export class CnvHeatmapRenderer {
 
 		// Group for actual heatmap CNV arcs
 		const arcs = holder.append('g')
-		const hoverOverlay = holder.append('g')
-			.attr('class', 'hover-overlay')
-			.style('pointer-events', 'none')
+		const hoverOverlay = holder.append('g').attr('class', 'hover-overlay').style('pointer-events', 'none')
 
 		const menu = MenuProvider.create()
 
@@ -37,7 +35,8 @@ export class CnvHeatmapRenderer {
 
 			// Hover event: show highlight stroke and tooltip
 			.on('mouseover', (mouseEvent: MouseEvent, arc: CnvArc) => {
-				hoverOverlay.append('path')
+				hoverOverlay
+					.append('path')
 					.datum(arc)
 					.attr('d', arcGenerator(arc))
 					.attr('fill', 'none')
@@ -71,7 +70,7 @@ export class CnvHeatmapRenderer {
 				// Show tooltip near mouse
 				menu.show(mouseEvent.x, mouseEvent.y)
 			})
-			.on('mouseout', (event) => {
+			.on('mouseout', () => {
 				hoverOverlay.selectAll('*').remove()
 				menu.clear()
 				menu.hide()
@@ -80,9 +79,8 @@ export class CnvHeatmapRenderer {
 
 	// Computes fill color using linear scale between -P80, 0, and +P80
 	getColor(color: string, value: number) {
-		return scaleLinear(
-			[this.negativePercentile80, 0, this.positivePercentile80],
-			[color, 'white', color]
-		).clamp(true)(value)
+		return scaleLinear([this.negativePercentile, 0, this.positivePercentile], [color, 'white', color]).clamp(true)(
+			value
+		)
 	}
 }

--- a/client/plots/disco/cnv/CnvHeatmapRenderer.ts
+++ b/client/plots/disco/cnv/CnvHeatmapRenderer.ts
@@ -57,6 +57,7 @@ export class CnvHeatmapRenderer {
 				{
 					const [c1, c2] = table.addRow()
 					c1.text('Copy number change')
+					//Match the color shown in the tooltip to the heatmap
 					c2.html(
 						`<span style="background:${this.getColor(
 							cnv.color,
@@ -85,8 +86,10 @@ export class CnvHeatmapRenderer {
 
 	// Computes fill color using linear scale between -P80, 0, and +P80
 	getColor(color: string, value: number) {
+		//For cnv values, use a zero-centered symmetric scale rather than the absolute values
+		const maxValue = Math.max(this.positivePercentile, Math.abs(this.negativePercentile))
 		return scaleLinear(
-			[this.negativePercentile, 0, this.positivePercentile],
+			[-maxValue, 0, maxValue],
 			[color, 'white', color] // transitions to white in the middle
 		).clamp(true)(value)
 	}

--- a/client/plots/disco/cnv/CnvHeatmapRenderer.ts
+++ b/client/plots/disco/cnv/CnvHeatmapRenderer.ts
@@ -6,18 +6,22 @@ import { scaleLinear } from 'd3-scale'
 import { dtcnv } from '#shared/common.js'
 
 export class CnvHeatmapRenderer {
-	private positivePercentile: number
-	private negativePercentile: number
+	private positivePercentile80: number
+	private negativePercentile80: number
 
-	constructor(positivePercentile = 0, negativePercentile = 0) {
-		this.positivePercentile = positivePercentile
-		this.negativePercentile = negativePercentile
+	constructor(positivePercentile80 = 0, negativePercentile80 = 0) {
+		this.positivePercentile80 = positivePercentile80
+		this.negativePercentile80 = negativePercentile80
 	}
 
 	render(holder: any, elements: Array<CnvArc>) {
 		const arcGenerator = d3.arc<CnvArc>()
 
+		// Group for actual heatmap CNV arcs
 		const arcs = holder.append('g')
+		const hoverOverlay = holder.append('g')
+			.attr('class', 'hover-overlay')
+			.style('pointer-events', 'none')
 
 		const menu = MenuProvider.create()
 
@@ -26,19 +30,30 @@ export class CnvHeatmapRenderer {
 			.data(elements)
 			.enter()
 			.append('path')
+			// Generate arc shape for each CNV
 			.attr('d', (d: CnvArc) => arcGenerator(d))
+			// Fill using interpolated color based on CNV value and percentile range
 			.attr('fill', (d: CnvArc) => this.getColor(d.color, d.value))
+
+			// Hover event: show highlight stroke and tooltip
 			.on('mouseover', (mouseEvent: MouseEvent, arc: CnvArc) => {
+				hoverOverlay.append('path')
+					.datum(arc)
+					.attr('d', arcGenerator(arc))
+					.attr('fill', 'none')
+					.attr('stroke', 'black')
+					.attr('stroke-width', 1)
+
 				const table = table2col({ holder: menu.d })
 				const cnv: any = structuredClone(arc)
 				cnv.dt = dtcnv
 				cnv.samples = [{ sample_id: arc.sampleName }]
 				cnv.gene = cnv.text
 
+				// Row 1: Copy number change + colored square
 				{
 					const [c1, c2] = table.addRow()
 					c1.text('Copy number change')
-					//Match the color shown in the tooltip to the heatmap
 					c2.html(
 						`<span style="background:${this.getColor(
 							cnv.color,
@@ -46,23 +61,28 @@ export class CnvHeatmapRenderer {
 						)}; border:solid lightgrey 0.1px;">&nbsp;&nbsp;</span> ${cnv.value}`
 					)
 				}
+				// Row 2: Position
 				{
 					const [c1, c2] = table.addRow()
 					c1.text('Position')
 					c2.text(cnv.chr + ':' + cnv.start + '-' + cnv.stop)
 				}
 
+				// Show tooltip near mouse
 				menu.show(mouseEvent.x, mouseEvent.y)
 			})
-			.on('mouseout', () => {
+			.on('mouseout', (event) => {
+				hoverOverlay.selectAll('*').remove()
 				menu.clear()
 				menu.hide()
 			})
 	}
 
+	// Computes fill color using linear scale between -P80, 0, and +P80
 	getColor(color: string, value: number) {
-		//For cnv values, use a zero-centered symmetric scale rather than the absolute values
-		const maxValue = Math.max(this.positivePercentile, Math.abs(this.negativePercentile))
-		return scaleLinear([-maxValue, 0, maxValue], [color, 'white', color]).clamp(true)(value)
+		return scaleLinear(
+			[this.negativePercentile80, 0, this.positivePercentile80],
+			[color, 'white', color]
+		).clamp(true)(value)
 	}
 }


### PR DESCRIPTION
# Tooltip Improvements to Disco

- **Hovering over a CNV segment** highlights the segment to give a sense of the span of the region.
- **Hovering over a chromosome band** shows the estimated `chr:pos` in a tooltip.

### Example

[http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=HCM-BROD-0048-C71-01A](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=HCM-BROD-0048-C71-01A)


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
