### PR TITLE
Default disco numeric setting set to `percentile`

### DIFF
--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -14,7 +14,7 @@ export default function discoDefaults(overrides = {}): Settings {
 			showPrioritizeGeneLabelsByGeneSets: false,
 			cnvRenderingType: CnvRenderingType.heatmap,
 			cnvPercentile: 90, // 90th percentile for removing outliers
-			cnvCutoffMode: 'auto'
+			cnvCutoffMode: 'percentile'
 		},
 
 		rings: {


### PR DESCRIPTION
# Description

This addresses the fifth item under the Legend improvements section in the phase 2 of https://github.com/stjude/sjpp/issues/867. The default numeric input from the color scale is changed to `percentile`. Please test with http://localhost:3000/?genome=hg19&dslabel=PNET&disco=1&sample=SJBT032239_D1. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
