### PR TITLE
Unblock tw menu

### DIFF
--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -638,6 +638,8 @@ export class TermdbVocab extends Vocab {
 		}
 
 		if (term.category2samplecount) {
+			if (term.category2samplecount instanceof Promise) await term.category2samplecount
+
 			// grab directly from term and not the server
 			// { categoryKey: count }
 			const l2 = []

--- a/client/termsetting/handlers/categorical.ts
+++ b/client/termsetting/handlers/categorical.ts
@@ -98,13 +98,16 @@ export async function getHandler(self: CategoricalTermSettingInstance) {
 		async postMain() {
 			//for rendering groupsetting menu
 			const body = self.opts.getBodyParams?.() || {}
-			const data = await self.vocabApi.getCategories(self.term, self.filter!, body)
-			/** Original code created a separate array (self.category2samplecount) and pushed only the key and label.
-			 * The new self.category2samplecount was used to create the groupsetting menu items. That logic was removed
-			 * as groupsetting.ts handles formating the data. However category2samplecount = [] is still used
-			 * in other client side code. The data shape may differ until all the code is refactored.
-			 */
-			self.category2samplecount = data.lst
+			// track as promise, so that when pill code detects a promise,
+			// it can show `Loading...` message while awaiting to resolve
+			self.category2samplecount = self.vocabApi.getCategories(self.term, self.filter!, body).then(data => {
+				/** Original code created a separate array (self.category2samplecount) and pushed only the key and label.
+				 * The new self.category2samplecount was used to create the groupsetting menu items. That logic was removed
+				 * as groupsetting.ts handles formating the data. However category2samplecount = [] is still used
+				 * in other client side code. The data shape may differ until all the code is refactored.
+				 */
+				self.category2samplecount = data.lst // replace promise with actual response data
+			})
 		}
 	}
 }

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -64,7 +64,7 @@ type GrpEntryWithDom = GrpEntry & {
 	draggables: any
 }
 type GrpSetDom = {
-	menuWrapper: HTMLElement
+	menuWrapper: Selection<HTMLElement, any, any, any>
 	actionDiv: HTMLElement
 	grpsWrapper: HTMLElement
 	includedWrapper: HTMLElement
@@ -242,6 +242,12 @@ export class GroupSettingMethods {
 
 	async main() {
 		try {
+			if (this.tsInstance.category2samplecount instanceof Promise) {
+				this.dom.menuWrapper!.selectAll('*').remove()
+				this.dom.menuWrapper!.append('div').text('Loading...')
+				await this.tsInstance.category2samplecount
+			}
+
 			const input =
 				(this.tsInstance.q.type == 'custom-groupset' && this.tsInstance.q.customset) ||
 				this.tsInstance.category2samplecount ||

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -227,12 +227,7 @@ async function cacheMappingOnNewRelease(ds, version) {
 
 		await getCasesWithGeneExpression(ds, ref)
 		await getAnalysisTsv2loom4scrna(ds, ref)
-		if (ds.assayAvailability.byDt) {
-			for (const v of Object.values(ds.assayAvailability.byDt)) {
-				// assume that the initial response will be cached in-memory by the dataset js code
-				await v.get(totalCases)
-			}
-		}
+		if (ds.assayAvailability.set) await ds.assayAvailability.set(totalCases)
 	} catch (e) {
 		if (mayCancelStalePendingCache(ds, ref)) return // avoid resetting ds.__* variables that may affect newer data version caching
 		if (isRecoverableError(e)) {

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -227,6 +227,12 @@ async function cacheMappingOnNewRelease(ds, version) {
 
 		await getCasesWithGeneExpression(ds, ref)
 		await getAnalysisTsv2loom4scrna(ds, ref)
+		if (ds.assayAvailability.byDt) {
+			for (const v of Object.values(ds.assayAvailability.byDt)) {
+				// assume that the initial response will be cached in-memory by the dataset js code
+				await v.get(totalCases)
+			}
+		}
 	} catch (e) {
 		if (mayCancelStalePendingCache(ds, ref)) return // avoid resetting ds.__* variables that may affect newer data version caching
 		if (isRecoverableError(e)) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2816,16 +2816,19 @@ async function mayAddDataAvailability(sample2mlst, dtKey, ds, origin, q) {
 		const sampleFilter =
 			!dt.get && q.filter && q.filter.lst.length ? new Set((await get_samples(q.filter, ds)).map(i => i.id)) : null
 
-		for (const sid of dt.yesSamples) {
-			// sample has been assayed
-			// if sample does not have annotated mutation for dt
-			// then it will be annotated as wildtype
-			addDataAvailability(sid, sample2mlst, dtKey, 'WT', dt.origin, sampleFilter)
-		}
-		for (const sid of dt.noSamples) {
-			// sample has not been assayed
-			// annotate the sample as not tested
-			addDataAvailability(sid, sample2mlst, dtKey, 'Blank', dt.origin, sampleFilter)
+		// shorter loop than iterating over initial cache of yesSamples and noSamples for all cases
+		// console.log(2780, 'sample2mlst.size=', sample2mlst.size )
+		for (const sid of sample2mlst) {
+			if (dt.yesSamples.has(sid)) {
+				// sample has been assayed
+				// if sample does not have annotated mutation for dt
+				// then it will be annotated as wildtype
+				addDataAvailability(sid, sample2mlst, dtKey, 'WT', dt.origin, sampleFilter)
+			}
+			if (dt.noSamples.has(sid)) {
+				// sample has not been assayed, annotate the sample as not tested
+				addDataAvailability(sid, sample2mlst, dtKey, 'Blank', dt.origin, sampleFilter)
+			}
 		}
 	}
 }

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1553,6 +1553,7 @@ type DtAssayAvailabilityByOrigin = {
 
 type Mds3AssayAvailability = {
 	/** object of key-value pairs. keys are dt values */
+	set?: (size: number) => Promise<void>
 	byDt: {
 		/** each index is a dt value */
 		[index: number]: DtAssayAvailabilityByOrigin | DtAssayAvailability


### PR DESCRIPTION
# Description

NOTE: This branch is on top of the [assay-availability-branch](https://github.com/stjude/proteinpaint/pull/3492). Changes to server code do not need to be reviewed. DO NOT APPROVE and MERGE this,  until that other PR is approved and merged. Or, this branch can be rebased on master as needed.

This fixes the issue of a long delay before the menu is displayed after clicking on a matrix row label for a dictionary term.

To test:
- load [gdc dict matrix url](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22and%22,%22content%22:[{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:%22ductal%20and%20lobular%20neoplasms%22}}]}},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22id%22:%22case.primary_site%22},{%22id%22:%22case.demographic.gender%22},{%22id%22:%22case.project.name%22},{%22id%22:%22case.diagnoses.age_at_diagnosis%22}]}]}]}), click on a row label. The menu should be displayed right away, and a `Loading...` message should be shown after clicking the `Edit` button.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
