### PR TITLE
fix: adhoc set gdc assay availability during caching, and support get…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- adhoc set gdc assay availability during caching, and support getting cases by filter in runtime

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -705,6 +705,7 @@ async function setAssayAvailability(ds, ref) {
 	}
 
 	ds.assayAvailability = {
+		useFilter0: true,
 		byDt: {
 			1: { yesSamples: ssmYes, noSamples: ssmNo },
 			4: { yesSamples: cnvYes, noSamples: cnvNo }

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -227,6 +227,7 @@ async function cacheMappingOnNewRelease(ds, version) {
 
 		await getCasesWithGeneExpression(ds, ref)
 		await getAnalysisTsv2loom4scrna(ds, ref)
+		await setAssayAvailability(ds, ref)
 	} catch (e) {
 		if (mayCancelStalePendingCache(ds, ref)) return // avoid resetting ds.__* variables that may affect newer data version caching
 		if (isRecoverableError(e)) {
@@ -651,4 +652,77 @@ async function getAnalysisTsv2loom4scrna(ds, ref) {
 		if (!hdf5) throw 'aliquot has tsv but missing hdf5'
 		ref.scrnaAnalysis2hdf5.set(tsv, hdf5)
 	}
+}
+
+async function setAssayAvailability(ds, ref) {
+	if (mayCancelStalePendingCache(ds, ref)) return
+	const json = {
+		filters: {},
+		size: 100000, // TODO set limit or not?
+		fields: [
+			'case_id', // only need to report case uuid to match with mayGetGeneVariantData which also uses case uuid
+			'available_variation_data'
+		].join(',')
+	}
+
+	const { host, headers } = ds.getHostHeaders()
+
+	const t0 = Date.now()
+
+	const response = await fetch(joinUrl(host.rest, 'case_ssms'), {
+		method: 'POST',
+		headers,
+		body: JSON.stringify(json),
+		signal: undefined
+	})
+
+	if (!response.ok) throw 'Failed to fetch. Status: ' + response.status
+
+	const re = await response.json()
+
+	if (!Number.isInteger(re.data?.pagination?.total)) throw 're.data.pagination.total is not int'
+	if (!Array.isArray(re.data?.hits)) throw 're.data.hits[] not array'
+
+	const ssmYes = new Set(),
+		ssmNo = new Set(),
+		cnvYes = new Set(),
+		cnvNo = new Set()
+
+	for (const h of re.data.hits) {
+		const caseid = h.case_id
+		if (!caseid) throw 'h.case_id missing'
+		if (!Array.isArray(h.available_variation_data)) throw 'h.available_variation_data[] not array'
+		if (h.available_variation_data.includes('ssm')) {
+			ssmYes.add(caseid)
+		} else {
+			ssmNo.add(caseid)
+		}
+		if (h.available_variation_data.includes('cnv')) {
+			cnvYes.add(caseid)
+		} else {
+			cnvNo.add(caseid)
+		}
+	}
+
+	ds.assayAvailability = {
+		byDt: {
+			1: { yesSamples: ssmYes, noSamples: ssmNo },
+			4: { yesSamples: cnvYes, noSamples: cnvNo }
+		}
+	}
+	console.log(
+		'GDC case_ssms:',
+		Date.now() - t0,
+		'ms,',
+		re.data.pagination.total,
+		'total records,',
+		ssmYes.size,
+		'ssmYes,',
+		ssmNo.size,
+		'ssmNo,',
+		cnvYes.size,
+		'cnvYes,',
+		cnvNo.size,
+		'cnvNo'
+	)
 }

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1620,7 +1620,7 @@ dictionary term ids starting with "case." must be trimmed before using as /cases
 
 case_filter variable names can still be "cases.xx"
 */
-async function querySamplesTwlstNotForGeneexpclustering_noGenomicFilter(q, dictTwLst, ds) {
+export async function querySamplesTwlstNotForGeneexpclustering_noGenomicFilter(q, dictTwLst, ds) {
 	const fieldset = new Set()
 	const updatedTwLst = [] // copy of dictTwLst by trimming "case."
 	const termIdMap = new Map() // map of new term id lacking "case." to original term id

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2812,9 +2812,10 @@ async function mayAddDataAvailability(sample2mlst, dtKey, ds, origin, q) {
 }
 
 async function filterSamples4assayAvailability(q, ds) {
-	if (ds.assayAvailability.set) {
+	if (ds.assayAvailability.useFilter0) {
 		/////////////////////////////
-		// quick dirty to detect this is gdc ds and use its method
+		// if true, instructs this ds will use both filter and filter0 to get it
+		// TODO solution below uses a hardcoded gdc function and is not generalized
 		if (q.filter0 || q.filter?.lst.length) {
 			/* only do this query when there is either filter0, or non-empty pp filter
 			gdc getter supports either filter or filter0 or both

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -3108,15 +3108,6 @@ async function mayValidateAssayAvailability(ds) {
 
 	// has this setting. at server launch it should query assay availability status for all samples and cache it
 
-	if (ds.assayAvailability.set) {
-		if (typeof ds.assayAvailability.set != 'function') throw 'ds.assayAvailability.set() is not function'
-		/* has optional setter. this is alterative to term-base definition
-		it will run as part of ds-specific async caching code
-		skip init and validation, with good faith they will be set properly
-		*/
-		return
-	}
-
 	if (ds.assayAvailability.byDt) {
 		for (const key in ds.assayAvailability.byDt) {
 			if (!dt2label[key]) throw 'unknown dt in assayAvailability.byDt: ' + key
@@ -3155,13 +3146,9 @@ async function getAssayAvailablility(ds, dt) {
 	// for assay availability from a db term
 	dt.yesSamples = new Set()
 	dt.noSamples = new Set()
-	const sql = `SELECT sample, value
-					FROM anno_categorical
-					WHERE term_id = '${dt.term_id}'`
-	const rows = ds.cohort.db.connection.prepare(sql).all()
-	for (const r of rows) {
-		if (dt.yes.value.includes(r.value)) dt.yesSamples.add(r.sample)
-		else if (dt.no.value.includes(r.value)) dt.noSamples.add(r.sample)
+	for (const [sample, value] of ds.cohort.termdb.q.getAllValues4term(dt.term_id)) {
+		if (dt.yes.value.includes(value)) dt.yesSamples.add(sample)
+		else if (dt.no.value.includes(value)) dt.noSamples.add(sample)
 		//else throw `value of term ${dt.term_id} is invalid`
 	}
 }

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1519,19 +1519,6 @@ type MutationSet = {
 }
 
 /** different methods to return samples with assay availability info */
-type DtAssayAvailability = DtAssayAvailabilityGetter | DtAssayAvailabilityTerm
-
-/** using ds-supplied getter */
-type DtAssayAvailabilityGetter = {
-	/** define q
-	returns:
-	{
-		yesSamples: Set() of sample ids
-		noSamples: Set() of sample ids
-	}
-	*/
-	get: (q: any) => any
-}
 /** using dictionary term */
 type DtAssayAvailabilityTerm = {
 	/** id of this assay term for this dt */
@@ -1542,20 +1529,26 @@ type DtAssayAvailabilityTerm = {
 	yes: { value: string[] }
 	/** categories meaning the sample doesn't have this assay */
 	no: { value: string[] }
+	/** dynamically generated cached sample lists on server launch, can also be ds-supplied. each is a Set of sample names*/
+	yesSamples?: Set<string>
+	noSamples?: Set<string>
 }
 
 type DtAssayAvailabilityByOrigin = {
 	byOrigin: {
 		/** each key is an origin value or category */
-		[index: string]: DtAssayAvailability
+		[index: string]: DtAssayAvailabilityTerm
 	}
 }
 
+/** assay availability can be set up as below, during server init it will query by assay dictionary terms to populate yes/no samples for each dt
+or as in gdc, it is entirely setup ad-hoc
+*/
 type Mds3AssayAvailability = {
 	/** object of key-value pairs. keys are dt values */
 	byDt: {
 		/** each index is a dt value */
-		[index: number]: DtAssayAvailabilityByOrigin | DtAssayAvailability
+		[index: number]: DtAssayAvailabilityByOrigin | DtAssayAvailabilityTerm
 	}
 }
 

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1529,9 +1529,11 @@ type DtAssayAvailabilityTerm = {
 	yes: { value: string[] }
 	/** categories meaning the sample doesn't have this assay */
 	no: { value: string[] }
-	/** dynamically generated cached sample lists on server launch, can also be ds-supplied. each is a Set of sample names*/
-	yesSamples?: Set<string>
-	noSamples?: Set<string>
+	/** dynamically generated cached sample lists on server launch, can also be ds-supplied.
+	each is a Set of sample integer id (non-gdc ds) or sample name (case uuid for gdc)
+	*/
+	yesSamples?: Set<string | number>
+	noSamples?: Set<string | number>
 }
 
 type DtAssayAvailabilityByOrigin = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1550,6 +1550,9 @@ type Mds3AssayAvailability = {
 		/** each index is a dt value */
 		[index: number]: DtAssayAvailabilityByOrigin | DtAssayAvailabilityTerm
 	}
+	/** if true, ds will use both filter and filter0 to filter samples (this is a temp quick fix)
+	 */
+	useFilter0?: true
 }
 
 // mds legacy; delete when all are migrated to mds3


### PR DESCRIPTION
…ting cases by filter in runtime

# Description

based on Edgar's prior `.set()` and caching implementation
- reverted prior change and deleted support for `byDt[].get()`, implementation was too slow
- simplified assayAvailability logic that is applied for all ds

please test with https://github.com/stjude/sjpp/pull/901

[idh1 in gliomas](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22nav%22:{%22header_mode%22:%22hidden%22},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22IDH1%22}}}]}) shows 1174 as ssm-not-tested, and needs 5 seconds for querying cases by filter0

[idh1 in all gdc](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22idh1%22}}}]}) shows 28340 ssm-not-tested and will not need the 5 seconds to query cases for lack of filter0

(SOLVED) caching assay availability is added to gdc.initCache.js but cachedFetch() doesn't work

in oncomatrix the 5-sec per gene case-by-filter query will still add up and are unecessary. address it in future pr
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
