### PR TITLE
Report fix

### DIFF
--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -25,6 +25,18 @@ export class Report extends RxComponentInner {
 		this.config = appState.plots.find(p => p.id === this.id)
 		this.view = new ReportView(this)
 		this.components = { plots: {} }
+		const state = this.getState(appState)
+		for (const section of state.config.sections) {
+			const sectionDiv = this.view.dom.plotsDiv.append('div')
+
+			sectionDiv.append('div').style('font-size', '1.2em').style('font-weight', 'bold').text(section.name) //header
+			const plotDiv = sectionDiv.append('div').style('margin', '20px')
+
+			for (const plot of section.plots) {
+				if (this.components.plots[plot.id]) continue
+				await this.setPlot(plot, plotDiv)
+			}
+		}
 	}
 
 	async replaceFilter() {
@@ -56,18 +68,7 @@ export class Report extends RxComponentInner {
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings.report
-		//Though the plots are read from the dataset and do not change in the future they may be added dynamically so we keep this loop here
-		for (const section of this.state.config.sections) {
-			const sectionDiv = this.view.dom.plotsDiv.append('div')
 
-			sectionDiv.append('div').style('font-size', '1.2em').style('font-weight', 'bold').text(section.name) //header
-			const plotDiv = sectionDiv.append('div').style('margin', '20px')
-
-			for (const plot of section.plots) {
-				if (this.components.plots[plot.id]) continue
-				await this.setPlot(plot, plotDiv)
-			}
-		}
 		this.fillSites()
 	}
 


### PR DESCRIPTION
# Description

I noticed that when changing the country/site the sections where being added again below. This PR fixes this issue by creating the report sections on init. The report config is meant to be read from the dataset so it wont change and can be rendered on init. If we later on happen to support adding plots on the fly to the report we can revisit this logic. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
