### PR TITLE
Supported report for termdb test to ilustrate usage

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -1212,6 +1212,8 @@ export async function getPlotConfig(opts, app) {
 		if (opts.term2) await fillTermWrapper(opts.term2, app.vocabApi)
 		if (opts.term0) await fillTermWrapper(opts.term0, app.vocabApi)
 	} catch (e) {
+		console.log('Error reading config: ' + JSON.stringify(opts))
+		console.error(e)
 		throw `${e} [barchart getPlotConfig()]`
 	}
 

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -99,6 +99,9 @@ export class Report extends RxComponentInner {
 	}
 
 	async fillSites() {
+		if (!this.config.countryTW || !this.config.siteTW) {
+			return
+		}
 		const site = this.settings[this.config.siteTW.term.id] || ''
 		this.filterTWs = [this.config.countryTW, this.config.siteTW]
 		const filters: any = {}

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -34,7 +34,8 @@ export default function (): Mds3 {
 		isMds3: true,
 		isSupportedChartOverride: {
 			runChart: () => true,
-			frequencyChart: () => true
+			frequencyChart: () => true,
+			report: () => true
 		},
 		cohort: {
 			massNav: {
@@ -137,6 +138,77 @@ export default function (): Mds3 {
 				regression: {
 					settings: {
 						coxDisclaimer: 'This is a test disclaimer for the cox regression analysis.'
+					}
+				},
+				plotConfigByCohort: {
+					default: {
+						report: {
+							sections: [
+								{
+									name: 'Demographics',
+									plots: [
+										{
+											chartType: 'barchart',
+											settings: { barchart: { colorBars: true } },
+
+											term: {
+												id: 'agedx'
+											}
+										},
+										{
+											chartType: 'barchart',
+											term: { id: 'sex' },
+											settings: { barchart: { colorBars: true } }
+										},
+										{
+											chartType: 'barchart',
+											term: { id: 'genetic_race' },
+											settings: { barchart: { colorBars: true } }
+										}
+									]
+								},
+								{
+									name: 'Diagnosis',
+									plots: [
+										{
+											chartType: 'barchart',
+											term: { id: 'diaggrp' },
+											settings: { barchart: { colorBars: true } }
+										}
+									]
+								},
+								{
+									name: 'Treatment',
+									plots: [
+										{
+											chartType: 'barchart',
+											term: { id: 'hrtavg' },
+											settings: { barchart: { colorBars: true } }
+										},
+										{
+											chartType: 'barchart',
+											term: { id: 'aaclassic_5' },
+											settings: { barchart: { colorBars: true } }
+										}
+									]
+								},
+								{
+									name: 'Survival',
+									plots: [
+										{
+											chartType: 'survival',
+											term: { id: 'efs' },
+											term2: { id: 'diaggrp' }
+										},
+										{
+											chartType: 'survival',
+											term: { id: 'os' },
+											term2: { id: 'diaggrp' }
+										}
+									]
+								}
+							]
+						}
 					}
 				}
 			},


### PR DESCRIPTION
# Description

Supported report for termdb test to ilustrate its usage. To test please open the termdb test portal and click on the report button. I also add a small fix validating if country and site terms are provided to filter by when filling sites. @gavrielm I am adding you as a reviewer in case you find the report useful for SJLife. Please let me know if there are any important plots missing.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
