### PR TITLE
Remove nested childTerms

### DIFF
--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -181,6 +181,7 @@ export async function getChildTerms(term: RawGvTerm, vocabApi: VocabApi) {
 		}
 		t.values = values
 		t.parentTerm = structuredClone(term)
+		delete t.parentTerm.childTerms // remove any nested child terms
 		dtTermsInDs.push(t)
 	}
 	term.childTerms = dtTermsInDs


### PR DESCRIPTION
# Description

Remove `.childTerms[]` that may be nested within `.parentTerm{}` of a dtTerm.

All unit and integration tests pass.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
