### PR TITLE
Radius and fusion opacity controls for disco plot with unit tests

### DIFF
--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -96,47 +96,48 @@ export default class Disco {
 			configInputsOptions.push(...filterMutationsGenesCheckbox)
 		}
 
-		const cnvConfigInputOptions = [
-			{
-				boxLabel: '',
-				label: 'CNV rendering type',
-				type: 'radio',
-				chartType: 'Disco',
-				settingsKey: 'cnvRenderingType',
-				title: 'CNV rendering type',
-				options: [
-					{ label: 'Heatmap', value: CnvRenderingType.heatmap },
-					{ label: 'Bar', value: CnvRenderingType.bar }
-				]
-			}
-		]
-
-		if (viewModel.cnvMaxValue !== 0 || viewModel.cnvMinValue !== 0) configInputsOptions.push(...cnvConfigInputOptions)
-
-			const dimensionOptions = [
+		if (viewModel.cnvMaxValue !== 0 || viewModel.cnvMinValue !== 0) {
+			const cnvConfigInputOptions = [
 				{
-					label: 'Radius',
-					title: 'Set the radius of the entire plot, between 300 and 1000 pixels.',
-					type: 'number',
+					boxLabel: '',
+					label: 'CNV rendering type',
+					type: 'radio',
 					chartType: 'Disco',
-					settingsKey: 'radius',
-					debounceInterval: 500,
-					step: 25,
-					min: 300,
-					max: 1000,
-				},
-				{
-					label: 'Fusion opacity',
-					title: 'Adjust opacity of fusion arcs, between 0 and 1',
-					type: 'number',
-					chartType: 'Disco',
-					settingsKey: 'fusionOpacity',
-					step: 0.01,
-					min: 0,
-					max: 1,
-					debounceInterval: 500
+					settingsKey: 'cnvRenderingType',
+					title: 'CNV rendering type',
+					options: [
+						{ label: 'Heatmap', value: CnvRenderingType.heatmap },
+						{ label: 'Bar', value: CnvRenderingType.bar }
+					]
 				}
 			]
+			configInputsOptions.push(...cnvConfigInputOptions)
+		}
+
+		const dimensionOptions = [
+			{
+				label: 'Radius',
+				title: 'Set the radius of the entire plot, between 300 and 1000 pixels.',
+				type: 'number',
+				chartType: 'Disco',
+				settingsKey: 'radius',
+				debounceInterval: 500,
+				step: 25,
+				min: 300,
+				max: 1000
+			},
+			{
+				label: 'Fusion opacity',
+				title: 'Adjust opacity of fusion arcs, between 0 and 1',
+				type: 'number',
+				chartType: 'Disco',
+				settingsKey: 'fusionOpacity',
+				step: 0.01,
+				min: 0,
+				max: 1,
+				debounceInterval: 500
+			}
+		]
 
 		configInputsOptions.push(...dimensionOptions)
 

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -113,6 +113,33 @@ export default class Disco {
 
 		if (viewModel.cnvMaxValue !== 0 || viewModel.cnvMinValue !== 0) configInputsOptions.push(...cnvConfigInputOptions)
 
+			const dimensionOptions = [
+				{
+					label: 'Radius',
+					title: 'Set the radius of the entire plot, between 300 and 1000 pixels.',
+					type: 'number',
+					chartType: 'Disco',
+					settingsKey: 'radius',
+					debounceInterval: 500,
+					step: 25,
+					min: 300,
+					max: 1000,
+				},
+				{
+					label: 'Fusion opacity',
+					title: 'Adjust opacity of fusion arcs',
+					type: 'number',
+					chartType: 'Disco',
+					settingsKey: 'fusionOpacity',
+					step: 0.01,
+					min: 0,
+					max: 1,
+					debounceInterval: 500
+				}
+			]
+
+		configInputsOptions.push(...dimensionOptions)
+
 		return configInputsOptions
 	}
 
@@ -144,8 +171,9 @@ export default class Disco {
 			const legendRenderer = new LegendRenderer(this.viewModel.cappedCnvMaxAbsValue, settings.label.fontSize)
 
 			const discoRenderer = new DiscoRenderer(
-				this.getRingRenderers(settings, this.viewModel, this.discoInteractions.geneClickListener),
-				legendRenderer
+				this.getRingRenderers(this.viewModel.settings, this.viewModel, this.discoInteractions.geneClickListener),
+				legendRenderer,
+				this.viewModel.settings.Disco.fusionOpacity ?? 1
 			)
 
 			discoRenderer.render(svgDiv, this.viewModel)
@@ -164,9 +192,14 @@ export default class Disco {
 		const chromosomesRenderer = new ChromosomesRenderer(
 			settings.padAngle,
 			settings.rings.chromosomeInnerRadius,
-			settings.rings.chromosomeInnerRadius + settings.rings.chromosomeWidth
+			settings.rings.chromosomeInnerRadius + settings.rings.chromosomeWidth,
+			settings.label.fontSize
 		)
-		const labelsRenderer = new LabelsRenderer(settings.label.animationDuration, geneClickListener)
+		const labelsRenderer = new LabelsRenderer(
+			settings.label.animationDuration,
+			settings.label.fontSize,
+			geneClickListener
+		)
 		const nonExonicSnvRenderer = new NonExonicSnvRenderer(geneClickListener)
 		const snvRenderer = new SnvRenderer(settings.rings.snvRingWidth, geneClickListener)
 		const cnvRenderer =

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -127,7 +127,7 @@ export default class Disco {
 				},
 				{
 					label: 'Fusion opacity',
-					title: 'Adjust opacity of fusion arcs',
+					title: 'Adjust opacity of fusion arcs, between 0 and 1',
 					type: 'number',
 					chartType: 'Disco',
 					settingsKey: 'fusionOpacity',

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -172,8 +172,7 @@ export default class Disco {
 
 			const discoRenderer = new DiscoRenderer(
 				this.getRingRenderers(this.viewModel.settings, this.viewModel, this.discoInteractions.geneClickListener),
-				legendRenderer,
-				this.viewModel.settings.Disco.fusionOpacity ?? 1
+				legendRenderer
 			)
 
 			discoRenderer.render(svgDiv, this.viewModel)

--- a/client/plots/disco/DiscoRenderer.ts
+++ b/client/plots/disco/DiscoRenderer.ts
@@ -9,10 +9,10 @@ export class DiscoRenderer {
 	private legendRenderer: LegendRenderer
 	private fusionRenderer: FusionRenderer
 
-	constructor(renders: Map<RingType, IRenderer>, legendRenderer: LegendRenderer) {
+	constructor(renders: Map<RingType, IRenderer>, legendRenderer: LegendRenderer, fusionOpacity: number) {
 		this.renders = renders
 		this.legendRenderer = legendRenderer
-		this.fusionRenderer = new FusionRenderer()
+		this.fusionRenderer = new FusionRenderer(fusionOpacity)
 	}
 
 	render(holder: any, viewModel: ViewModel) {
@@ -42,7 +42,7 @@ export class DiscoRenderer {
 			renderer.render(mainG, elements, collisions)
 		}
 
-		this.fusionRenderer.render(mainG, viewModel.fusions)
+		this.fusionRenderer.render(mainG, viewModel.fusions, viewModel.settings.Disco.fusionOpacity)
 
 		if (viewModel.settings.Disco.centerText) {
 			const chrRingBbox = mainG.select('[data-testid="sjpp_chromosomes_arc_group"]').node().getBBox()

--- a/client/plots/disco/DiscoRenderer.ts
+++ b/client/plots/disco/DiscoRenderer.ts
@@ -12,7 +12,7 @@ export class DiscoRenderer {
 	constructor(renders: Map<RingType, IRenderer>, legendRenderer: LegendRenderer, fusionOpacity: number) {
 		this.renders = renders
 		this.legendRenderer = legendRenderer
-		this.fusionRenderer = new FusionRenderer(fusionOpacity)
+		this.fusionRenderer = new FusionRenderer()
 	}
 
 	render(holder: any, viewModel: ViewModel) {

--- a/client/plots/disco/DiscoRenderer.ts
+++ b/client/plots/disco/DiscoRenderer.ts
@@ -9,7 +9,7 @@ export class DiscoRenderer {
 	private legendRenderer: LegendRenderer
 	private fusionRenderer: FusionRenderer
 
-	constructor(renders: Map<RingType, IRenderer>, legendRenderer: LegendRenderer, fusionOpacity: number) {
+	constructor(renders: Map<RingType, IRenderer>, legendRenderer: LegendRenderer) {
 		this.renders = renders
 		this.legendRenderer = legendRenderer
 		this.fusionRenderer = new FusionRenderer()

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -4,7 +4,11 @@ export default interface Settings {
 
 	downloadImgName: string // file name of downloaded svg
 
-	Disco: {
+    Disco: {
+		/** Global radius controlling ring size */
+		radius?: number
+		/** Opacity of the fusion arcs */
+		fusionOpacity?: number
 		centerText: string
 		cnvCapping: number
 		isOpen: boolean

--- a/client/plots/disco/chromosome/ChromosomesRenderer.ts
+++ b/client/plots/disco/chromosome/ChromosomesRenderer.ts
@@ -5,15 +5,22 @@ import MenuProvider from '#plots/disco/menu/MenuProvider.ts'
 import { bplen } from '#shared/common.js'
 
 export default class ChromosomesRenderer implements IRenderer {
-	private padAngle: number
-	private innerRadius: number
-	private outerRadius: number
+       private padAngle: number
+       private innerRadius: number
+       private outerRadius: number
+       private fontSize: number
 
-	constructor(padAngle: number, innerRadius: number, outerRadius: number) {
-		this.padAngle = padAngle
-		this.innerRadius = innerRadius
-		this.outerRadius = outerRadius
-	}
+       constructor(
+               padAngle: number,
+               innerRadius: number,
+               outerRadius: number,
+               fontSize: number
+       ) {
+               this.padAngle = padAngle
+               this.innerRadius = innerRadius
+               this.outerRadius = outerRadius
+               this.fontSize = fontSize
+       }
 
 	render(holder: any, elements: Array<Chromosome>) {
 		const pie = d3
@@ -78,13 +85,14 @@ export default class ChromosomesRenderer implements IRenderer {
 					d.data.angle > Math.PI ? 'rotate(180)' : ''
 				}`
 			})
-			.attr('dy', '0.35em')
-			.attr('text-anchor', 'middle')
-			.text((d: d3.PieArcDatum<Chromosome>) => d.data.text)
-			.style('fill', 'white')
-			.style('padding', '500px')
-			//prevents chromosome number from interfering with hover
-			.style('pointer-events', 'none')
-			.style('padding', '500px')
+                       .attr('dy', '0.35em')
+                       .attr('text-anchor', 'middle')
+                       .text((d: d3.PieArcDatum<Chromosome>) => d.data.text)
+                       .style('fill', 'white')
+                       .style('font-size', `${this.fontSize}px`)
+                       .style('padding', '500px')
+                       //prevents chromosome number from interfering with hover
+                       .style('pointer-events', 'none')
+                       .style('padding', '500px')
 	}
 }

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -2,7 +2,7 @@ import type Settings from './Settings'
 import { copyMerge } from '#rx'
 import { CnvRenderingType } from '#plots/disco/cnv/CnvRenderingType.ts'
 
-export default function discoDefaults(overrides = {}): Settings {
+export default function discoDefaults(overrides: any = {}): Settings {
 	const defaults = {
 		downloadImgName: 'disco.plot',
 
@@ -14,7 +14,9 @@ export default function discoDefaults(overrides = {}): Settings {
 			showPrioritizeGeneLabelsByGeneSets: false,
 			cnvRenderingType: CnvRenderingType.heatmap,
 			cnvPercentile: 90, // 90th percentile for removing outliers
-			cnvCutoffMode: 'percentile'
+			cnvCutoffMode: 'percentile',
+			radius: 300,
+			fusionOpacity: 1
 		},
 
 		rings: {
@@ -74,6 +76,10 @@ export default function discoDefaults(overrides = {}): Settings {
 		menu: {
 			padding: 5
 		}
+	}
+
+	if (overrides?.Disco?.radius > 1000 || overrides?.Disco?.radius < 300) {
+		console.log(`${overrides?.Disco?.radius} is greater or lower than the min and max for the radius`)
 	}
 
 	return copyMerge(defaults, overrides)

--- a/client/plots/disco/fusion/FusionRenderer.ts
+++ b/client/plots/disco/fusion/FusionRenderer.ts
@@ -7,7 +7,13 @@ import { table2col } from '#dom/table2col'
 
 // TODO extract constants from this file.
 export default class FusionRenderer {
-	render(holder: any, fusions: Array<Fusion>) {
+	private opacity: number
+
+	constructor(opacity = 1) {
+		this.opacity = opacity
+	}
+
+	render(holder: any, fusions: Array<Fusion>, opacityOverride?: number) {
 		let radius = 0
 		const fusionsWithTarget = fusions.filter(f => f.target)
 		if (fusionsWithTarget.length > 0) {
@@ -33,6 +39,7 @@ export default class FusionRenderer {
 					fusion.target.positionInChromosome.chromosome
 				)
 			})
+			.style('opacity', opacityOverride ?? this.opacity)
 			.on('mouseover', (mouseEvent: MouseEvent, fusion: Fusion) => {
 				const table = table2col({ holder: menu.d })
 				this.createTooltip(table, fusion)

--- a/client/plots/disco/fusion/FusionRenderer.ts
+++ b/client/plots/disco/fusion/FusionRenderer.ts
@@ -7,13 +7,7 @@ import { table2col } from '#dom/table2col'
 
 // TODO extract constants from this file.
 export default class FusionRenderer {
-	private opacity: number
-
-	constructor(opacity = 1) {
-		this.opacity = opacity
-	}
-
-	render(holder: any, fusions: Array<Fusion>, opacityOverride?: number) {
+	render(holder: any, fusions: Array<Fusion>, opacity = 1) {
 		let radius = 0
 		const fusionsWithTarget = fusions.filter(f => f.target)
 		if (fusionsWithTarget.length > 0) {
@@ -39,7 +33,7 @@ export default class FusionRenderer {
 					fusion.target.positionInChromosome.chromosome
 				)
 			})
-			.style('opacity', opacityOverride ?? this.opacity)
+			.style('opacity', opacity)
 			.on('mouseover', (mouseEvent: MouseEvent, fusion: Fusion) => {
 				const table = table2col({ holder: menu.d })
 				this.createTooltip(table, fusion)

--- a/client/plots/disco/label/LabelsRenderer.ts
+++ b/client/plots/disco/label/LabelsRenderer.ts
@@ -9,13 +9,19 @@ import { table2col } from '#dom/table2col'
 import type CnvTooltip from '#plots/disco/cnv/CnvTooltip.ts'
 
 export default class LabelsRenderer implements IRenderer {
-	private animationDuration: number
-	private geneClickListener: (gene: string, mnames: Array<string>) => void
+       private animationDuration: number
+       private fontSize: number
+       private geneClickListener: (gene: string, mnames: Array<string>) => void
 
-	constructor(animationDuration: number, geneClickListener: (gene: string, mnames: Array<string>) => void) {
-		this.animationDuration = animationDuration
-		this.geneClickListener = geneClickListener
-	}
+       constructor(
+               animationDuration: number,
+               fontSize: number,
+               geneClickListener: (gene: string, mnames: Array<string>) => void
+       ) {
+			this.animationDuration = animationDuration
+			this.fontSize = fontSize
+			this.geneClickListener = geneClickListener
+       }
 
 	render(holder: any, elements: Array<Label>, collisions?: Array<Label>) {
 		const labelsG = holder.append('g')
@@ -39,7 +45,7 @@ export default class LabelsRenderer implements IRenderer {
 					.attr('dy', '.35em')
 					.attr('transform', label.transform)
 					.style('text-anchor', label.textAnchor)
-					.style('font-size', '12px')
+					.style('font-size', `${this.fontSize}px`)
 					.style('fill', label.color)
 					.style('cursor', 'pointer')
 					.text(label.text)

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -47,30 +47,23 @@ export default class ViewModel {
 
 		let maxLabelSpace = 0
 		try {
-			const tempHolder = select('body')
-				.append('div')
-				.style('position', 'absolute')
-				.style('visibility', 'hidden')
+			const tempHolder = select('body').append('div').style('position', 'absolute').style('visibility', 'hidden')
 			const tempSvg = tempHolder.append('svg')
 			const labels = rings.labelsRing?.elementsToDisplay?.map(l => l.text) || []
-			maxLabelSpace = getMaxLabelWidth(
-				tempSvg as any,
-				labels,
-				this.settings.label.fontSize / 16
-			)
+			maxLabelSpace = getMaxLabelWidth(tempSvg as any, labels, this.settings.label.fontSize / 16)
 			tempHolder.remove()
-		} catch {
-			/* ignore measurement errors in non-browser environments */
+		} catch (e: any) {
+			console.error('Error calculating max label width:', e)
 		}
 
 		this.width =
-			2 *
+			1.2 *
 			(this.settings.horizontalPadding +
 				this.settings.rings.labelLinesInnerRadius +
 				this.settings.rings.labelsToLinesDistance +
 				maxLabelSpace)
 		this.height =
-			2.5 *
+			2 *
 			(this.settings.rings.labelLinesInnerRadius +
 				this.settings.rings.labelsToLinesDistance +
 				this.settings.verticalPadding +

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -44,15 +44,22 @@ export default class ViewModel {
 		this.genesetName = genesetName
 
 		this.width =
-			1.2 *
+		//length multiplier (2) must be great enough to allow canvas to expand beyond 
+		//the expansion of the discoplot. If not, some of the labels will render outside
+		//the canvas and result in cut labels.
+			2 *
 			(this.settings.horizontalPadding +
 				this.settings.rings.labelLinesInnerRadius +
 				this.settings.rings.labelsToLinesDistance)
 		this.height =
-			2 *
+		//heigth multiplier (2.5) must be great enough to allow canvas to expand beyond 
+		//the expansion of the discoplot. If not, some of the labels will render outside
+		//the canvas and result in cut labels.
+			2.5 *
 			(this.settings.rings.labelLinesInnerRadius +
 				this.settings.rings.labelsToLinesDistance +
-				this.settings.verticalPadding)
+				this.settings.verticalPadding +
+				this.settings.label.fontSize * 2)
 
 		this.legendHeight = this.calculateLegendHeight(legend)
 		this.snvDataLength = dataHolder.snvData.length

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -59,7 +59,7 @@ export default class ViewModel {
 				this.settings.label.fontSize / 16
 			)
 			tempHolder.remove()
-		} catch (e) {
+		} catch {
 			/* ignore measurement errors in non-browser environments */
 		}
 

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -45,16 +45,11 @@ export default class ViewModel {
 		this.fusions = fusions
 		this.genesetName = genesetName
 
-		let maxLabelSpace = 0
-		try {
-			const tempHolder = select('body').append('div').style('position', 'absolute').style('visibility', 'hidden')
-			const tempSvg = tempHolder.append('svg')
-			const labels = rings.labelsRing?.elementsToDisplay?.map(l => l.text) || []
-			maxLabelSpace = getMaxLabelWidth(tempSvg as any, labels, this.settings.label.fontSize / 16)
-			tempHolder.remove()
-		} catch (e: any) {
-			console.error('Error calculating max label width:', e)
-		}
+		const tempHolder = select('body').append('div').style('position', 'absolute').style('visibility', 'hidden')
+		const tempSvg = tempHolder.append('svg')
+		const labels = rings.labelsRing?.elementsToDisplay?.map(l => l.text) || []
+		const maxLabelSpace = getMaxLabelWidth(tempSvg as any, labels)
+		tempHolder.remove()
 
 		this.width =
 			1.2 *

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -5,6 +5,17 @@ import type Settings from '#plots/disco/Settings.ts'
 import ViewModelProvider from './ViewModelProvider.ts'
 import type { DiscoInteractions } from '../interactions/DiscoInteractions.ts'
 
+const DEFAULT_LABEL_RADIUS = 210
+const DEFAULT_CHROMOSOME_INNER_RADIUS = 190
+const DEFAULT_CHROMOSOME_WIDTH = 20
+const DEFAULT_NONEXONIC_RING_WIDTH = 20
+const DEFAULT_SNV_RING_WIDTH = 20
+const DEFAULT_LOH_RING_WIDTH = 20
+const DEFAULT_CNV_RING_WIDTH = 30
+const DEFAULT_LABELS_TO_LINES_DISTANCE = 30
+const DEFAULT_LABEL_FONT_SIZE = 12
+const DEFAULT_LEGEND_FONT_SIZE = 12
+
 export class ViewModelMapper {
 	static snvClassLayer = {
 		M: 'exonic',
@@ -32,11 +43,29 @@ export class ViewModelMapper {
 	private discoInteractions: DiscoInteractions
 
 	constructor(settings: Settings, discoInteractions: DiscoInteractions) {
-		this.settings = settings
+		// the settings object retrieved is frozen. created
+		// a mutable copy so ring dimensions can be adjusted at runtime
+		this.settings = JSON.parse(JSON.stringify(settings))
 		this.discoInteractions = discoInteractions
+    }
+
+	private applyRadius() {
+		const radius = this.settings.Disco.radius ?? DEFAULT_LABEL_RADIUS
+		const scale = radius / DEFAULT_LABEL_RADIUS
+
+		this.settings.rings.labelLinesInnerRadius = DEFAULT_LABEL_RADIUS * scale
+		this.settings.rings.labelsToLinesDistance = DEFAULT_LABELS_TO_LINES_DISTANCE * scale
+		this.settings.rings.chromosomeInnerRadius = DEFAULT_CHROMOSOME_INNER_RADIUS * scale
+		this.settings.rings.chromosomeWidth = DEFAULT_CHROMOSOME_WIDTH * scale
+		this.settings.rings.nonExonicRingWidth = DEFAULT_NONEXONIC_RING_WIDTH * scale
+		this.settings.rings.snvRingWidth = DEFAULT_SNV_RING_WIDTH * scale
+		this.settings.rings.lohRingWidth = DEFAULT_LOH_RING_WIDTH * scale
+		this.settings.rings.cnvRingWidth = DEFAULT_CNV_RING_WIDTH * scale
+		this.settings.label.fontSize = DEFAULT_LABEL_FONT_SIZE * scale
+		this.settings.legend.fontSize = DEFAULT_LEGEND_FONT_SIZE * scale
 	}
 
-	map(opts: any): ViewModel {
+    map(opts: any): ViewModel {
 		const chromosomesOverride = opts.args.chromosomes
 
 		const chrSizes = opts.args.genome.majorchr
@@ -50,6 +79,8 @@ export class ViewModelMapper {
 		const genesetName = genome?.geneset?.[0] ? genome.geneset[0].name : ''
 
 		const data: Array<any> = opts.args.data
+
+		this.applyRadius()
 
 		const reference = new Reference(this.settings, chrSizes, chromosomesOverride)
 

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -5,17 +5,6 @@ import type Settings from '#plots/disco/Settings.ts'
 import ViewModelProvider from './ViewModelProvider.ts'
 import type { DiscoInteractions } from '../interactions/DiscoInteractions.ts'
 
-const DEFAULT_LABEL_RADIUS = 210
-const DEFAULT_CHROMOSOME_INNER_RADIUS = 190
-const DEFAULT_CHROMOSOME_WIDTH = 20
-const DEFAULT_NONEXONIC_RING_WIDTH = 20
-const DEFAULT_SNV_RING_WIDTH = 20
-const DEFAULT_LOH_RING_WIDTH = 20
-const DEFAULT_CNV_RING_WIDTH = 30
-const DEFAULT_LABELS_TO_LINES_DISTANCE = 30
-const DEFAULT_LABEL_FONT_SIZE = 12
-const DEFAULT_LEGEND_FONT_SIZE = 12
-
 export class ViewModelMapper {
 	static snvClassLayer = {
 		M: 'exonic',
@@ -50,19 +39,21 @@ export class ViewModelMapper {
     }
 
 	private applyRadius() {
-		const radius = this.settings.Disco.radius ?? DEFAULT_LABEL_RADIUS
-		const scale = radius / DEFAULT_LABEL_RADIUS
+		const radius = this.settings.Disco.radius
+		if (!radius) return
 
-		this.settings.rings.labelLinesInnerRadius = DEFAULT_LABEL_RADIUS * scale
-		this.settings.rings.labelsToLinesDistance = DEFAULT_LABELS_TO_LINES_DISTANCE * scale
-		this.settings.rings.chromosomeInnerRadius = DEFAULT_CHROMOSOME_INNER_RADIUS * scale
-		this.settings.rings.chromosomeWidth = DEFAULT_CHROMOSOME_WIDTH * scale
-		this.settings.rings.nonExonicRingWidth = DEFAULT_NONEXONIC_RING_WIDTH * scale
-		this.settings.rings.snvRingWidth = DEFAULT_SNV_RING_WIDTH * scale
-		this.settings.rings.lohRingWidth = DEFAULT_LOH_RING_WIDTH * scale
-		this.settings.rings.cnvRingWidth = DEFAULT_CNV_RING_WIDTH * scale
-		this.settings.label.fontSize = DEFAULT_LABEL_FONT_SIZE * scale
-		this.settings.legend.fontSize = DEFAULT_LEGEND_FONT_SIZE * scale
+		const scale = radius / this.settings.rings.labelLinesInnerRadius
+
+		this.settings.rings.labelLinesInnerRadius *= scale
+		this.settings.rings.labelsToLinesDistance *= scale
+		this.settings.rings.chromosomeInnerRadius *= scale
+		this.settings.rings.chromosomeWidth *= scale
+		this.settings.rings.nonExonicRingWidth *= scale
+		this.settings.rings.snvRingWidth *= scale
+		this.settings.rings.lohRingWidth *= scale
+		this.settings.rings.cnvRingWidth *= scale
+		this.settings.label.fontSize *= scale
+		this.settings.legend.fontSize *= scale
 	}
 
     map(opts: any): ViewModel {

--- a/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
@@ -7,53 +7,92 @@ Tests:
 ViewModelMapper scales rings and dimensions using the radius setting
 */
 
-
-
 const settings = discoDefaults({ Disco: { radius: 500 } })
-const mapper = new ViewModelMapper(settings as any, {} as any)
+const mapper = new ViewModelMapper(structuredClone(settings as any), {} as any)
 
 const opts = {
-    args: {
-        chromosomes: undefined,
-        genome: { majorchr: { chr1: 1000 }, geneset: [] },
-        sampleName: 'Sample',
-        data: []
-    }
+	args: {
+		chromosomes: undefined,
+		genome: { majorchr: { chr1: 1000 }, geneset: [] },
+		sampleName: 'Sample',
+		data: []
+	}
 }
 
 const viewModel = mapper.map(opts)
 
 test('\n', function (t) {
-    t.pass('-***- plots/disco/viewmodel/ViewModelMapper -***-')
-    t.end()
+	t.pass('-***- plots/disco/viewmodel/ViewModelMapper -***-')
+	t.end()
 })
 
 test('ViewModelMapper.applyRadius adjusts settings and ViewModel dimensions', t => {
-    t.equal(
-        viewModel.settings.rings.labelLinesInnerRadius,
-        500,
-        'Label lines inner radius should match radius setting'
-    )
+	const vmSettings = viewModel.settings
+	const scale = settings.Disco.radius! / settings.rings.labelLinesInnerRadius
 
-    t.ok(
-        Math.abs(viewModel.settings.rings.chromosomeInnerRadius - 452) < 1,
-        'Chromosome inner radius scales with radius'
-    )
+	function timesScale(value: number) {
+		return value * scale
+	}
 
-    t.ok(
-        Math.abs(viewModel.settings.label.fontSize - 28.57) < 0.1,
-        'Font size should scale with radius setting'
-    )
+	t.equal(
+		vmSettings.rings.labelLinesInnerRadius,
+		timesScale(settings.rings.labelLinesInnerRadius),
+		'Should calculate labelLinesInnerRadius based on radius setting'
+	)
 
-    t.ok(
-        Math.abs(viewModel.width - 2142.86) < 1,
-        'Width should scale according to radius setting'
-    )
+	t.equal(
+		vmSettings.rings.labelsToLinesDistance,
+		timesScale(settings.rings.labelsToLinesDistance),
+		'Should calculate labelsToLinesDistance based on radius setting'
+	)
 
-    t.ok(
-        Math.abs(viewModel.height - 1746.43) < 1,
-        'Height should scale according to radius setting'
-    )
+	t.equal(
+		vmSettings.rings.chromosomeInnerRadius,
+		timesScale(settings.rings.chromosomeInnerRadius),
+		'Should calculate chromosomeInnerRadius based on radius setting'
+	)
 
-    t.end()
+	t.equal(
+		vmSettings.rings.chromosomeWidth,
+		timesScale(settings.rings.chromosomeWidth),
+		'Should calculate chromosomeWidth based on radius setting'
+	)
+
+	t.equal(
+		vmSettings.rings.nonExonicRingWidth,
+		timesScale(settings.rings.nonExonicRingWidth),
+		'Should calculate nonExonicRingWidth based on radius setting'
+	)
+
+	t.equal(
+		vmSettings.rings.snvRingWidth,
+		timesScale(settings.rings.snvRingWidth),
+		'Should calculate snvRingWidth based on radius setting'
+	)
+
+	t.equal(
+		vmSettings.rings.lohRingWidth,
+		timesScale(settings.rings.lohRingWidth),
+		'Should calculate lohRingWidth based on radius setting'
+	)
+
+	t.equal(
+		vmSettings.rings.cnvRingWidth,
+		timesScale(settings.rings.cnvRingWidth),
+		'Should calculate cnvRingWidth based on radius setting'
+	)
+
+	t.equal(
+		vmSettings.label.fontSize,
+		timesScale(settings.label.fontSize),
+		'Should calculate label font size based on radius setting'
+	)
+
+	t.equal(
+		vmSettings.legend.fontSize,
+		timesScale(settings.legend.fontSize),
+		'Should calculate legend font size based on radius setting'
+	)
+
+	t.end()
 })

--- a/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
@@ -1,0 +1,59 @@
+import test from 'tape'
+import { ViewModelMapper } from '../ViewModelMapper'
+import discoDefaults from '../../defaults'
+
+/*
+Tests:
+ViewModelMapper scales rings and dimensions using the radius setting
+*/
+
+
+
+const settings = discoDefaults({ Disco: { radius: 500 } })
+const mapper = new ViewModelMapper(settings as any, {} as any)
+
+const opts = {
+    args: {
+        chromosomes: undefined,
+        genome: { majorchr: { chr1: 1000 }, geneset: [] },
+        sampleName: 'Sample',
+        data: []
+    }
+}
+
+const viewModel = mapper.map(opts)
+
+test('\n', function (t) {
+    t.pass('-***- plots/disco/viewmodel/ViewModelMapper -***-')
+    t.end()
+})
+
+test('ViewModelMapper.applyRadius adjusts settings and ViewModel dimensions', t => {
+    t.equal(
+        viewModel.settings.rings.labelLinesInnerRadius,
+        500,
+        'Label lines inner radius should match radius setting'
+    )
+
+    t.ok(
+        Math.abs(viewModel.settings.rings.chromosomeInnerRadius - 452) < 1,
+        'Chromosome inner radius scales with radius'
+    )
+
+    t.ok(
+        Math.abs(viewModel.settings.label.fontSize - 28.57) < 0.1,
+        'Font size should scale with radius setting'
+    )
+
+    t.ok(
+        Math.abs(viewModel.width - 2142.86) < 1,
+        'Width should scale according to radius setting'
+    )
+
+    t.ok(
+        Math.abs(viewModel.height - 1746.43) < 1,
+        'Height should scale according to radius setting'
+    )
+
+    t.end()
+})


### PR DESCRIPTION
# Disco control improvements 
allow user to set plot radius
support adjustable opacity for fusion arcs

Unit test in:
http://localhost:3000/testrun.html?dir=plots/disco/viewmodel&name=ViewModelMapper.unit

Sv file for testing:
http://localhost:3000/?genome=hg19&dslabel=PNET&disco=1&sample=SJBT032239_D1

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
