### PR TITLE
fix: transitive exports in shared/utils/src/index.js should include f…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- transitive exports in shared/utils/src/index.js should include file extension

--- a/shared/utils/src/index.js
+++ b/shared/utils/src/index.js
@@ -10,7 +10,7 @@ export * from './filter.js'
 export * from './hash.js'
 export * from './helpers.js'
 export * from './joinUrl.js'
-export * from './mds.termdb.termvaluesetting' // deprecated?
+export * from './mds.termdb.termvaluesetting.js' // deprecated?
 export * from './mds3tk.js'
 export * from './roundValue.js'
 export * from './termdb.bins.js'


### PR DESCRIPTION
# Description

Tested in https://github.com/stjude/proteinpaint/actions/runs/16172458780.

This fix should fix the deployment in `pp-irt` since `joinUrl()` is from `proteinpaint-shared` as used in gdc dataset, and this PR branch fixes the missing file extension in `index.js`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
