### PR TITLE
improve the detection and handling of nonblocking steps in dataset initialization

### DIFF
--- a/server/src/mds3.init.nonblocking.js
+++ b/server/src/mds3.init.nonblocking.js
@@ -36,10 +36,16 @@ export async function mds3InitNonblocking(ds) {
 	const initNonblocking = ds.label == 'GDC' ? gdcInitCache : undefined
 	if (!initNonblocking) return
 
-	initNonblocking(ds)
+	return initNonblocking(ds)
 		.then(() => {
+			// uncomment below to test '--- failed dataset init ... ---' in startup log
+			// ds.init = {status: 'fatalError', fatalError: 'test ds.init.status == fatalError'}
+			// uncomment below to test '--- active retries ... ---' in startup log
+			// ds.init = {status: 'recoverableError', fatalError: 'test ds.init.status == recovarableError'}
+
 			if (ds.init.status == 'nonblocking') {
-				ds.init.status = ds.init.recoverableError ? 'recoverableError' : ds.init.fatalError ? 'fatalError' : 'done'
+				if (ds.init.recoverableError) ds.init.status = 'recoverableError'
+				if (ds.init.fatalError) ds.init.status = 'fatalError'
 			}
 		})
 		.catch(e => {


### PR DESCRIPTION
# Description
These are minor improvements, to make it easier to debug server validation or startup issues
- may await nonblocking ds init if there is only one dataset
- log any ds that's running nonblocking steps after validation in startup logs

To test:
- from the `sjpp/dir`, run `npx tsx ./server.ts` to simulate non-dev usage (unwatched, no automatic rebundling)
- in `mds3.init.js`, uncomment line 108: 
  - this should crash the server startup if there is only one dataset entry in serverconfig
  - with >1 dataset entries, the server should still startup
- undo previous edits, and uncomment line 42 or 44 of `server/src/mds3.init.nonblocking.js`:
  - same behavior as previous edits
- can also run ``npx tsx ./server.ts validate`: should fail validation if there is a fatal error (uncomment line 42 of `server/src/mds3.init.nonblocking.js`) regardless of number of dataset entries

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
