### PR TITLE
geneVariant term uses groupsetting as term1

### DIFF
--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -151,9 +151,8 @@ tape('term1=categorical (no values)', function (test) {
 		// testing if term.values{} and term.samplecounts[] get filled
 		const tw = barchart.Inner.config.term
 		test.ok(tw.term.values && typeof tw.term.values == 'object', 'term.values{} should be an object')
-		test.equal(Object.keys(tw.term.values).length, 7, 'term.values{} should have 7 values')
-		test.ok(Array.isArray(tw.term.samplecounts), 'term.samplecounts[] should be an array')
-		test.equal(tw.term.samplecounts.length, 7, 'term.samplecounts[] should have 7 sample counts')
+		test.ok(Array.isArray(tw.term.categories.lst), 'term.categories.lst[] should be an array')
+		test.equal(tw.term.categories.lst.length, 7, 'term.categories.lst[] should have 7 sample counts')
 	}
 
 	let barDiv

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -100,8 +100,8 @@ export class Barchart {
 					defaultQ4fillTW: { geneVariant: { type: 'custom-groupset' } },
 					getBodyParams: () => {
 						const tw = this.config['term']
-						if (!tw) return { skip_samplecounts: true }
-						if (tw.term.samplecounts) return { samplecounts: tw.term.samplecounts }
+						if (!tw) return { skip_categories: true }
+						if (tw.term.categories) return { categories: tw.term.categories }
 						return {}
 					}
 				},
@@ -130,8 +130,8 @@ export class Barchart {
 					},
 					getBodyParams: () => {
 						const tw = this.config['term2']
-						if (!tw) return { skip_samplecounts: true }
-						if (tw.term.samplecounts) return { samplecounts: tw.term.samplecounts }
+						if (!tw) return { skip_categories: true }
+						if (tw.term.categories) return { categories: tw.term.categories }
 						return {}
 					}
 				},
@@ -147,8 +147,8 @@ export class Barchart {
 					defaultQ4fillTW: term0_term2_defaultQ,
 					getBodyParams: () => {
 						const tw = this.config['term0']
-						if (!tw) return { skip_samplecounts: true }
-						if (tw.term.samplecounts) return { samplecounts: tw.term.samplecounts }
+						if (!tw) return { skip_categories: true }
+						if (tw.term.categories) return { categories: tw.term.categories }
 						return {}
 					}
 				},

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -97,6 +97,7 @@ export class Barchart {
 					label: renderTerm1Label,
 					vocabApi: this.app.vocabApi,
 					menuOptions: 'edit',
+					defaultQ4fillTW: { geneVariant: { type: 'custom-groupset' } },
 					getBodyParams: () => {
 						const tw = this.config['term']
 						if (!tw) return { skip_samplecounts: true }

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -356,7 +356,7 @@ function setRenderers(self) {
 export async function getPlotConfig(opts, app) {
 	if (!opts.term) throw 'summary getPlotConfig: opts.term{} missing'
 	try {
-		await fillTermWrapper(opts.term, app.vocabApi)
+		await fillTermWrapper(opts.term, app.vocabApi, { geneVariant: { type: 'custom-groupset' } })
 		// supply term0_term2_defaultQ if opts.term0/2.bins/q is undefined
 		// e.g. for scatterplot, opts.term2.q.mode='continuous' so will not
 		// want to override with q.mode from term0_term2_defaultQ

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -109,7 +109,7 @@ export class TermdbVocab extends Vocab {
 			}
 		}
 
-		this.mayFillInValues(opts, data.categories)
+		this.mayFillCategories(opts, data.categories)
 
 		return data
 	}
@@ -128,23 +128,17 @@ export class TermdbVocab extends Vocab {
 		t.samplecount[key].samplecount += total
 	}
 
-	// fill in term.values and term.samplecounts with
+	// fill in term.categories with
 	// categories computed from the data
-	mayFillInValues(opts, categories) {
+	mayFillCategories(opts, categories) {
 		if (!categories) return
 		if (!Array.isArray(categories)) throw 'categories is not array'
 		for (const [i, k] of ['term0', 'term', 'term2'].entries()) {
 			const tw = opts[k]
 			if (!tw) continue
-			const clst = categories[i]
-			if (!clst?.length) continue
-			const term = tw.term
-			term.values = {}
-			term.samplecounts = []
-			for (const c of clst) {
-				term.values[c.key] = { label: c.label }
-				term.samplecounts.push({ key: c.key, label: c.label, samplecount: c.samplecount })
-			}
+			const c = categories[i]
+			if (!Object.keys(c).length) continue
+			tw.term.categories = c
 		}
 	}
 
@@ -650,12 +644,12 @@ export class TermdbVocab extends Vocab {
 			return { lst: l2 }
 		}
 
-		if (_body.samplecounts) {
+		if (_body.categories) {
 			// grab directly from body and not server
-			return { lst: _body.samplecounts }
+			return _body.categories
 		}
 
-		if (_body.skip_samplecounts) {
+		if (_body.skip_categories) {
 			// do not query server
 			return { lst: [] }
 		}

--- a/client/termdb/test/vocabulary.unit.spec.js
+++ b/client/termdb/test/vocabulary.unit.spec.js
@@ -25,8 +25,8 @@ Tests:
 		graphable()
 	
 	TermdbVocab
-		mayFillInValues: single term
-		mayFillInValues: multiple terms
+		mayFillCategories: single term
+		mayFillCategories: multiple terms
  */
 
 const vocab = getExample()
@@ -487,7 +487,7 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('mayFillInValues: single term', test => {
+tape('mayFillCategories: single term', test => {
 	const term = Object.freeze({
 		values: {
 			v1: { label: 'value1' },
@@ -497,7 +497,7 @@ tape('mayFillInValues: single term', test => {
 	})
 	let categories = undefined
 	const opts = { term: { term: structuredClone(term) } }
-	termdbVocabApi.mayFillInValues(opts, categories)
+	termdbVocabApi.mayFillCategories(opts, categories)
 	test.deepEqual(opts.term.term, term, 'opts.term.term should not change when categories is undefined')
 
 	categories = [
@@ -509,7 +509,7 @@ tape('mayFillInValues: single term', test => {
 			{ key: 'v6', label: 'value6', samplecount: 15 }
 		]
 	]
-	termdbVocabApi.mayFillInValues(opts, categories)
+	termdbVocabApi.mayFillCategories(opts, categories)
 	test.deepEqual(opts.term.term, term, 'opts.term.term should not change when term is not in categories')
 
 	categories = [
@@ -521,36 +521,29 @@ tape('mayFillInValues: single term', test => {
 		],
 		[]
 	]
-	termdbVocabApi.mayFillInValues(opts, categories)
-	let expectedValues = {
-		v4: { label: 'value4' },
-		v5: { label: 'value5' },
-		v6: { label: 'value6' }
-	}
-	let expectedSampleCounts = [
+	termdbVocabApi.mayFillCategories(opts, categories)
+	let expectedCategories = [
 		{ key: 'v4', label: 'value4', samplecount: 5 },
 		{ key: 'v5', label: 'value5', samplecount: 10 },
 		{ key: 'v6', label: 'value6', samplecount: 15 }
 	]
-	test.deepEqual(opts.term.term.values, expectedValues, 'term.values should change when term is in categories')
 	test.deepEqual(
-		opts.term.term.samplecounts,
-		expectedSampleCounts,
-		'term.samplecounts should get filled change when term is in categories'
+		opts.term.term.categories,
+		expectedCategories,
+		'term.categories should get filled change when term is in categories'
 	)
 
 	opts.term.term.values = {}
-	termdbVocabApi.mayFillInValues(opts, categories)
-	test.deepEqual(opts.term.term.values, expectedValues, 'term.values should get filled when term is in categories')
+	termdbVocabApi.mayFillCategories(opts, categories)
 	test.deepEqual(
-		opts.term.term.samplecounts,
-		expectedSampleCounts,
-		'term.samplecounts should get filled change when term is in categories'
+		opts.term.term.categories,
+		expectedCategories,
+		'term.categories should get filled change when term is in categories'
 	)
 	test.end()
 })
 
-tape('mayFillInValues: multiple terms', test => {
+tape('mayFillCategories: multiple terms', test => {
 	const term = Object.freeze({
 		values: {
 			v1: { label: 'value1' },
@@ -578,24 +571,18 @@ tape('mayFillInValues: multiple terms', test => {
 		term: { term: structuredClone(term) },
 		term2: { term: structuredClone(term2) }
 	}
-	termdbVocabApi.mayFillInValues(opts, categories)
+	termdbVocabApi.mayFillCategories(opts, categories)
 	test.deepEqual(opts.term.term, term, 'opts.term.term should not change when term is not in categories')
 	test.notDeepEqual(opts.term2.term, term2, 'opts.term.term2 should change when term is in categories')
-	let expectedValues = {
-		v7: { label: 'value7' },
-		v8: { label: 'value8' },
-		v9: { label: 'value9' }
-	}
-	let expectedSampleCounts = [
+	let expectedCategories = [
 		{ key: 'v7', label: 'value7', samplecount: 5 },
 		{ key: 'v8', label: 'value8', samplecount: 10 },
 		{ key: 'v9', label: 'value9', samplecount: 15 }
 	]
-	test.deepEqual(opts.term2.term.values, expectedValues, 'term.values should change when term is in categories')
 	test.deepEqual(
-		opts.term2.term.samplecounts,
-		expectedSampleCounts,
-		'term.samplecounts should get filled change when term is in categories'
+		opts.term2.term.categories,
+		expectedCategories,
+		'term.categories should get filled change when term is in categories'
 	)
 	test.end()
 })

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -30,7 +30,8 @@ export function getHandler(self: GeneVariantTermSettingInstance) {
 		async postMain() {
 			// need to regenerate child dt terms here to update
 			// the terms upon data updates (e.g., filter)
-			await getChildTerms(self.term, self.vocabApi)
+			const body = self.opts.getBodyParams?.() || {}
+			await getChildTerms(self.term, self.vocabApi, body)
 		}
 	}
 }
@@ -143,11 +144,10 @@ function clearGroupset(self) {
 
 // function to get child dt terms
 // will use these terms to generate a frontend vocab
-export async function getChildTerms(term: RawGvTerm, vocabApi: VocabApi) {
+export async function getChildTerms(term: RawGvTerm, vocabApi: VocabApi, body: any = {}) {
 	if (!vocabApi.termdbConfig?.queries) throw 'termdbConfig.queries is missing'
 	const termdbmclass = vocabApi.termdbConfig.mclass // custom mclass labels from dataset
 	const dtTermsInDs: DtTerm[] = [] // dt terms in dataset
-	const body: any = {}
 	const filter = vocabApi.state?.termfilter?.filter
 	const filter0 = vocabApi.state?.termfilter?.filter0
 	if (filter0) {

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -102,7 +102,10 @@ async function makeEditMenu(self: GeneVariantTermSettingInstance, _div: any) {
 		}
 	})
 
-	if (self.usecase?.detail == 'term0' || self.usecase?.detail == 'term2' || self.opts.geneVariantEditMenuOnlyGrp) {
+	if (
+		(self.usecase?.detail && ['term', 'term0', 'term2'].includes(self.usecase.detail)) ||
+		self.opts.geneVariantEditMenuOnlyGrp
+	) {
 		// hide option for turning off groupsetting
 		optsDiv.style('display', 'none')
 		groupsDiv.style('margin-top', '10px')

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -57,7 +57,14 @@ async function trigger_getcategories(
 
 	const data = await getData(arg, ds, genome)
 	if (data.error) throw data.error
+	const [lst, orderedLabels] = getCategories(data, q, ds, $id)
+	res.send({
+		lst,
+		orderedLabels
+	} satisfies CategoriesResponse)
+}
 
+export function getCategories(data, q, ds, $id) {
 	const lst: any[] = []
 	if (q.tw.term.type == 'geneVariant' && q.tw.q.type != 'predefined-groupset' && q.tw.q.type != 'custom-groupset') {
 		// specialized data processing for geneVariant term when
@@ -74,6 +81,7 @@ async function trigger_getcategories(
 		const sampleCountedFor = new Set() // if the sample is counted
 		for (const sampleData of Object.values(samples)) {
 			const key = $id
+			if (!Object.keys(sampleData).includes(key)) continue
 			const values = sampleData[key].values
 			sampleCountedFor.clear()
 			/* values here is an array of result entires, one or more entries for each dt. e.g.
@@ -147,8 +155,5 @@ async function trigger_getcategories(
 	if (orderedLabels.length) {
 		lst.sort((a, b) => orderedLabels.indexOf(a.label) - orderedLabels.indexOf(b.label))
 	}
-	res.send({
-		lst,
-		orderedLabels
-	} satisfies CategoriesResponse)
+	return [lst, orderedLabels]
 }

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -72,7 +72,8 @@ export function getCategories(data, q, ds, $id) {
 		const samples = data.samples as { [sampleId: string]: any }
 		const dtClassMap = new Map()
 		if (ds.assayAvailability?.byDt) {
-			for (const [dtType, dtValue] of Object.entries(ds.assayAvailability.byDt)) {
+			for (const [dtType, _dtValue] of Object.entries(ds.assayAvailability.byDt)) {
+				const dtValue: any = _dtValue
 				if (dtValue.byOrigin) {
 					dtClassMap.set(parseInt(dtType), { byOrigin: { germline: {}, somatic: {} } })
 				}

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -124,7 +124,7 @@ export async function barchart_data(q, ds, tdb) {
 			// term1 or term2 is a geneVariant term that is not using groupsetting
 			// data will need to be handled using specialized logic
 			// data from geneVariant term using groupsetting can be handled using regular logic
-			processGeneVariantSamples(map, bins, data, samplesMap, ds, chartid2dtterm)
+			processGeneVariantSamples(map, bins, categories, data, samplesMap, ds, chartid2dtterm)
 		} else {
 			for (let i = 0; i <= 2; i++) {
 				const q = map.get(i)?.q
@@ -200,20 +200,25 @@ export async function barchart_data(q, ds, tdb) {
 
 //used by barchart_data
 //process gene variant data into samplesMap
-function processGeneVariantSamples(map, bins, data, samplesMap, ds, chartid2dtterm) {
+function processGeneVariantSamples(map, bins, categories, data, samplesMap, ds, chartid2dtterm) {
 	bins.push([])
+	categories.push([])
 	let customSampleID = 1
 	const tw1 = map.get(1)
 	const term1 = tw1?.term || null
 	const id1 = tw1?.$id ? tw1.$id : term1?.id && term1?.type != 'geneVariant' ? term1.id : term1?.name
 	if (id1 && data.refs.byTermId[id1]?.bins) bins.push(data.refs.byTermId[id1]?.bins)
 	else bins.push([])
+	if (id1 && data.refs.byTermId[id1]?.categories) categories.push(data.refs.byTermId[id1]?.categories)
+	else categories.push([])
 
 	const tw2 = map.get(2)
 	const term2 = tw2?.term || null
 	const id2 = tw2?.$id ? tw2.$id : term2?.id && term1?.type != 'geneVariant' ? term2.id : term2?.name
 	if (id2 && data.refs.byTermId[id2]?.bins) bins.push(data.refs.byTermId[id2]?.bins)
 	else bins.push([])
+	if (id2 && data.refs.byTermId[id2]?.categories) categories.push(data.refs.byTermId[id2]?.categories)
+	else categories.push([])
 
 	for (const [sampleId, values] of Object.entries(data.samples)) {
 		if (map.get(1)?.term?.type == 'geneVariant') {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -983,8 +983,7 @@ function applyGeneticModel(tw, effAle, a1, a2) {
 function mayGetCategories(data, q, ds) {
 	const twLst = []
 	for (const _tw of q.terms) {
-		const tw = structuredClone(_tw)
-		tw.q = {}
+		const tw = structuredClone({ q: {}, term: _tw.term, $id: _tw.$id })
 		let term = tw.term
 		if (!term.type) term = q.ds.cohort.termdb.q.termjsonByOneid(tw.term.id)
 		if (term.type == 'geneVariant' || (term.type == 'categorical' && !hasValues(term))) twLst.push(tw)


### PR DESCRIPTION
# Description

geneVariant term now uses groupsetting when used as term1. Sample listing support has also been updated.

Also, geneVariant term will now get categories within same data request for barchart. This prevents a separate `getCategories()` request (similar to categorical terms without `term.values{}`).

Can test with [mbmeta](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22}}}]}) and [gdc](http://localhost:3000/?mass=%7B%22dslabel%22:%22GDC%22,%22nav%22:%7B%22header_mode%22:%22hidden%22%7D,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneVariant%22,%22gene%22:%22MYC%22%7D%7D%7D%5D%7D).

**Note, I noticed some sporadic `fail to fetch` errors when testing with gdc example. I could not reproduce them, so may just be API issue. Let me know if you see the same.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
