### PR TITLE
Supported dynamic report filters

### DIFF
--- a/client/plots/report/view/reportView.ts
+++ b/client/plots/report/view/reportView.ts
@@ -36,36 +36,20 @@ export class ReportView {
 		}
 		document.addEventListener('scroll', () => this?.dom?.tooltip?.hide())
 		select('.sjpp-output-sandbox-content').on('scroll', () => this.dom.tooltip.hide())
-
-		if (this.report.config.countryTW) {
+		this.dom.filterSelects = []
+		if (this.report.config.filterTWs) {
 			headerDiv.style('padding', '20px 0px 20px 0px')
-			this.dom.headerDiv.append('label').text('Country: ')
-			const select = this.dom.headerDiv.append('select')
-			select.append('option').attr('value', '').text('')
-			for (const value in this.report.config.countryTW.term.values) {
-				const country = this.report.config.countryTW.term.values[value].label
-				select.append('option').attr('value', country).text(country)
+			for (const tw of this.report.config.filterTWs) {
+				this.dom.headerDiv.append('label').text(` ${tw.term.name}: `)
+				const select = this.dom.headerDiv.append('select')
+				select.append('option').attr('value', '').text('')
 
-				if (this.report.config.settings.report[this.report.config.countryTW.term.id] === country) {
-					select.property('value', country)
-				}
+				select.on('change', async () => {
+					this.report.settings[tw.term.id] = select.node().value
+					this.report.replaceFilter()
+				})
+				this.dom.filterSelects.push(select)
 			}
-			select.on('change', async () => {
-				this.report.settings[this.report.config.siteTW.term.id] = '' // clear site if country is changed
-				this.report.settings[this.report.config.countryTW.term.id] = select.node().value
-				this.report.replaceFilter()
-			})
-			this.dom.countrySelect = select
-		}
-		if (this.report.config.siteTW) {
-			this.dom.headerDiv.append('label').text('Site: ')
-			const select = this.dom.headerDiv.append('select')
-
-			select.on('change', async () => {
-				this.report.settings[this.report.config.siteTW.term.id] = select.node().value
-				await this.report.replaceFilter()
-			})
-			this.dom.siteSelect = select
 		}
 	}
 


### PR DESCRIPTION
# Description

Report filters are now the list of terms specified in the dataset. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/917). Pending to make some plots like the matrix to react to the parent filter, like we have done for the barchart and the scatter.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
