### PR TITLE
Unskip ci specs

### DIFF
--- a/augen/src/closestSpec.js
+++ b/augen/src/closestSpec.js
@@ -5,6 +5,8 @@ import fs from 'fs'
 export const gitProjectRoot = path.join(import.meta.dirname, '../..') // execSync(`git rev-parse --show-toplevel`, { encoding: 'utf8' }).trim()
 export const publicSpecsDir = path.join(gitProjectRoot, 'public/coverage/specs')
 
+process.removeAllListeners('warning')
+
 const ignore = ['dist/**', 'node_modules/**']
 const codeFileExt = new Set(['.js', '.mjs', '.cjs', '.ts'])
 let commitRef

--- a/augen/src/test/ReqResCache.unit.spec.js
+++ b/augen/src/test/ReqResCache.unit.spec.js
@@ -4,7 +4,7 @@ import fs from 'fs'
 import path from 'path'
 
 tape('\n', function (test) {
-	test.pass('-***- #shared/ReqResCache specs -***-')
+	test.comment('-***- #shared/ReqResCache specs -***-')
 	test.end()
 })
 

--- a/augen/src/tester.ts
+++ b/augen/src/tester.ts
@@ -41,7 +41,7 @@ export function testApi(route, f, checkers) {
 	const { api } = route
 
 	tape('\n', function (test) {
-		test.pass(`-***- ${f} specs -***-`)
+		test.comment(`-***- ${f} specs -***-`)
 		test.end()
 	})
 

--- a/build/bump.js
+++ b/build/bump.js
@@ -11,6 +11,8 @@ const execSync = require('child_process').execSync
 const semver = require('semver')
 const cwd = process.cwd()
 
+process.removeAllListeners('warning')
+
 // ************
 // * ARGUMENTS
 // ************

--- a/client/appdrawer/test/_x_.cards.spec.js
+++ b/client/appdrawer/test/_x_.cards.spec.js
@@ -42,7 +42,7 @@ const eventCallbacks = {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- server/src/cards -***-')
+	test.comment('-***- server/src/cards -***-')
 	test.end()
 })
 

--- a/client/common/test/auth.unit.spec.js
+++ b/client/common/test/auth.unit.spec.js
@@ -11,7 +11,10 @@ const text2buf = new TextEncoder()
  test sections
 ***************/
 
-console.log(`-***- common/auth unit -***-`)
+tape('\n', test => {
+	test.comment(`-***- common/auth unit -***-`)
+	test.end()
+})
 
 tape('setDsAuthOk()', async test => {
 	// clear saved tokens by not having 3rd argument

--- a/client/common/test/dofetch.integration.spec.js
+++ b/client/common/test/dofetch.integration.spec.js
@@ -5,13 +5,14 @@ import { dofetch3 } from '../dofetch.js'
  reusable helper functions
 **************************/
 
-const text2buf = new TextEncoder()
-
 /**************
  test sections
 ***************/
 
-console.log(`-***- common/dofetch integration -***-`)
+tape('\n', test => {
+	test.comment(`-***- common/dofetch integration -***-`)
+	test.end()
+})
 
 tape('processFormData', async test => {
 	const res1 = await dofetch3('/genomes')

--- a/client/common/test/dofetch.unit.spec.js
+++ b/client/common/test/dofetch.unit.spec.js
@@ -11,7 +11,10 @@ const text2buf = new TextEncoder()
  test sections
 ***************/
 
-console.log(`-***- common/dofetch unit -***-`)
+tape('\n', test => {
+	test.comment(`-***- common/dofetch unit -***-`)
+	test.end()
+})
 
 tape('processFormData', async test => {
 	const form = new FormData()

--- a/client/common/test/uncollide.spec.js
+++ b/client/common/test/uncollide.spec.js
@@ -74,7 +74,7 @@ function sleep(ms) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- common/uncollide -***-')
+	test.comment('-***- common/uncollide -***-')
 	test.end()
 })
 

--- a/client/common/test/urlmap.unit.spec.js
+++ b/client/common/test/urlmap.unit.spec.js
@@ -10,7 +10,7 @@ import urlmap from '../urlmap'
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- common/urlmap -***-')
+	test.comment('-***- common/urlmap -***-')
 	test.end()
 })
 

--- a/client/dom/test/GeneSetEditUI.integration.spec.ts
+++ b/client/dom/test/GeneSetEditUI.integration.spec.ts
@@ -50,7 +50,7 @@ function getOpts(_opts, genome = 'hg38-test', dslabel = 'TermdbTest') {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- dom/GeneSetEdit/GeneSetEditUI -***-')
+	test.comment('-***- dom/GeneSetEdit/GeneSetEditUI -***-')
 	test.end()
 })
 

--- a/client/dom/test/GeneSetEditUI.unit.spec.ts
+++ b/client/dom/test/GeneSetEditUI.unit.spec.ts
@@ -15,7 +15,7 @@ function getHolder() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- dom/GeneSetEdit//GeneSetEditUI -***-')
+	test.comment('-***- dom/GeneSetEdit//GeneSetEditUI -***-')
 	test.end()
 })
 

--- a/client/dom/test/LegendCircleReference.unit.spec.ts
+++ b/client/dom/test/LegendCircleReference.unit.spec.ts
@@ -13,7 +13,7 @@ function getHolder() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- dom/LegendCircleReference -***-')
+	test.comment('-***- dom/LegendCircleReference -***-')
 	test.end()
 })
 

--- a/client/dom/test/MultiTermWrapperEditUI.integration.spec.ts
+++ b/client/dom/test/MultiTermWrapperEditUI.integration.spec.ts
@@ -58,7 +58,7 @@ function getTestOpts(_opts, genome = 'hg38-test', dslabel = 'TermdbTest') {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- dom/MultiTermEditUI -***-')
+	test.comment('-***- dom/MultiTermEditUI -***-')
 	test.end()
 })
 

--- a/client/dom/test/boxplot.unit.spec.ts
+++ b/client/dom/test/boxplot.unit.spec.ts
@@ -59,7 +59,7 @@ function mockBoxplotData(opts) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/boxplot -***-')
+	test.comment('-***- dom/boxplot -***-')
 	test.end()
 })
 

--- a/client/dom/test/colorScale.unit.spec.ts
+++ b/client/dom/test/colorScale.unit.spec.ts
@@ -50,7 +50,7 @@ function getColorScale(opts) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/ColorScale/ColorScale -***-')
+	test.comment('-***- dom/ColorScale/ColorScale -***-')
 	test.end()
 })
 
@@ -609,7 +609,7 @@ Color scale helper functions
 ****************************/
 
 tape('\n', test => {
-	test.pass('-***- dom/ColorScale/helpers -***-')
+	test.comment('-***- dom/ColorScale/helpers -***-')
 	test.end()
 })
 

--- a/client/dom/test/genesearch.integration.spec.ts
+++ b/client/dom/test/genesearch.integration.spec.ts
@@ -45,7 +45,7 @@ async function getSearchBox(holder, opts = {}) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/genesearch.integration -***-')
+	test.comment('-***- dom/genesearch.integration -***-')
 	test.end()
 })
 

--- a/client/dom/test/genesearch.unit.spec.ts
+++ b/client/dom/test/genesearch.unit.spec.ts
@@ -37,7 +37,7 @@ function getSearchBox(holder, opts = {}) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/genesearch.unit-***-')
+	test.comment('-***- dom/genesearch.unit-***-')
 	test.end()
 })
 

--- a/client/dom/test/maxLabelWidth.unit.spec.ts
+++ b/client/dom/test/maxLabelWidth.unit.spec.ts
@@ -135,7 +135,7 @@ async function loadTestFont() {
  * Test sections
  **************/
 tape('\n', function (test) {
-	test.pass('-***- utils/maxLabelWidth -***-')
+	test.comment('-***- utils/maxLabelWidth -***-')
 	test.end()
 })
 

--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -44,7 +44,7 @@ function getTestMenu() {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/menu -***-')
+	test.comment('-***- dom/menu -***-')
 	test.end()
 })
 

--- a/client/dom/test/numLabel.unit.spec.ts
+++ b/client/dom/test/numLabel.unit.spec.ts
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { niceNumLabels } from '../niceNumLabels'
 
 tape('\n', test => {
-	test.pass('-***- dom/niceNumberLabels -***-')
+	test.comment('-***- dom/niceNumberLabels -***-')
 	test.end()
 })
 

--- a/client/dom/test/numericrange.unit.spec.ts
+++ b/client/dom/test/numericrange.unit.spec.ts
@@ -57,7 +57,7 @@ function getHolder() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- numericRangeInput specs -***-')
+	test.comment('-***- numericRangeInput specs -***-')
 	test.end()
 })
 

--- a/client/dom/test/radiobutton.unit.spec.ts
+++ b/client/dom/test/radiobutton.unit.spec.ts
@@ -26,7 +26,7 @@ function getHolder() {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/radiobutton -***-')
+	test.comment('-***- dom/radiobutton -***-')
 	test.end()
 })
 

--- a/client/dom/test/sandbox.unit.spec.js
+++ b/client/dom/test/sandbox.unit.spec.js
@@ -36,7 +36,7 @@ function getSandboxOpts(sandbox) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/sandbox -***-')
+	test.comment('-***- dom/sandbox -***-')
 	test.end()
 })
 

--- a/client/dom/test/table.unit.spec.js
+++ b/client/dom/test/table.unit.spec.js
@@ -71,7 +71,7 @@ const testOpts = {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/table -***-')
+	test.comment('-***- dom/table -***-')
 	test.end()
 })
 

--- a/client/dom/test/toggleButtons.unit.spec.js
+++ b/client/dom/test/toggleButtons.unit.spec.js
@@ -47,7 +47,7 @@ const tabsData = [
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- dom/toggleButtons -***-')
+	test.comment('-***- dom/toggleButtons -***-')
 	test.end()
 })
 

--- a/client/dom/test/zoom.unit.spec.js
+++ b/client/dom/test/zoom.unit.spec.js
@@ -13,17 +13,14 @@ Tests:
 **************/
 
 tape('\n', test => {
-	test.pass('-***- dom/zoompan -***-')
+	test.comment('-***- dom/zoompan -***-')
 	test.end()
 })
 
 tape('renders the expected elements', test => {
 	test.timeoutAfter(100)
 	test.plan(3)
-	const holder = select(document.body)
-		.append('div')
-		.style('margin', '20px')
-		.style('padding', '20px')
+	const holder = select(document.body).append('div').style('margin', '20px').style('padding', '20px')
 	let currentCallback
 	const callback = value => currentCallback(value)
 	const zoomApi = zoom({ holder, callback, debug: true, showJumpBtns: true })
@@ -41,10 +38,7 @@ tape('renders the expected elements', test => {
 tape('value synchronization', test => {
 	test.timeoutAfter(100)
 	test.plan(10)
-	const holder = select(document.body)
-		.append('div')
-		.style('margin', '20px')
-		.style('padding', '20px')
+	const holder = select(document.body).append('div').style('margin', '20px').style('padding', '20px')
 	let currentCallback
 	const callback = value => currentCallback(value)
 	const zoomApi = zoom({ holder, callback, debug: true, showJumpBtns: true })

--- a/client/emitImports.mjs
+++ b/client/emitImports.mjs
@@ -11,6 +11,8 @@
 import fs from 'fs'
 import path from 'path'
 
+process.removeAllListeners('warning')
+
 const cwd = process.cwd()
 const __dirname = import.meta.dirname
 

--- a/client/filter/test/filter.integration.spec.js
+++ b/client/filter/test/filter.integration.spec.js
@@ -192,12 +192,12 @@ function gettvs(id, val = '', overrides = {}) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- filter/filter.integration -***-')
+	test.comment('-***- filter/filter.integration -***-')
 	test.end()
 })
 
 tape('\n', test => {
-	test.pass('-***- filterInit() tests-***-')
+	test.comment('-***- filterInit() tests-***-')
 	test.end()
 })
 
@@ -1714,7 +1714,7 @@ tape('filterJoin()', test => {
 })
 
 tape('\n', test => {
-	test.pass('-***- filterRxCompInit() tests-***-')
+	test.comment('-***- filterRxCompInit() tests-***-')
 	test.end()
 })
 
@@ -1794,7 +1794,7 @@ tape('Rx filter state inputs', async test => {
 })
 
 tape('\n', test => {
-	test.pass('-***- filterPromptInit() tests-***-')
+	test.comment('-***- filterPromptInit() tests-***-')
 	test.end()
 })
 

--- a/client/filter/test/filter.unit.spec.js
+++ b/client/filter/test/filter.unit.spec.js
@@ -10,7 +10,7 @@ negateFilter
 */
 
 tape('\n', test => {
-	test.pass('-***- filter/unit -***-')
+	test.comment('-***- filter/unit -***-')
 	test.end()
 })
 

--- a/client/filter/test/tvs.density.unit.spec.ts
+++ b/client/filter/test/tvs.density.unit.spec.ts
@@ -66,7 +66,7 @@ function createTestSelf(holder) {
 }
 
 tape('\n', test => {
-	test.pass('-***- filter/tvs.density -***-')
+	test.comment('-***- filter/tvs.density -***-')
 	test.end()
 })
 

--- a/client/filter/test/tvs.integration.spec.js
+++ b/client/filter/test/tvs.integration.spec.js
@@ -104,7 +104,7 @@ async function getVocabApi() {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- filter/tvs.integration -***-')
+	test.comment('-***- filter/tvs.integration -***-')
 	test.end()
 })
 

--- a/client/filter/test/tvs.unit.spec.js
+++ b/client/filter/test/tvs.unit.spec.js
@@ -208,7 +208,7 @@ function testTermNameGen(test, handler) {
 */
 
 tape('\n', async test => {
-	test.pass('-***- filter/tvs.unit -***-')
+	test.comment('-***- filter/tvs.unit -***-')
 	test.end()
 })
 

--- a/client/gdc/test/bam.spec.js
+++ b/client/gdc/test/bam.spec.js
@@ -67,7 +67,7 @@ const entities = [
 ]
 
 tape('\n', function (test) {
-	test.pass('-***- GDC BAM slicing UI -***-')
+	test.comment('-***- GDC BAM slicing UI -***-')
 	test.end()
 })
 

--- a/client/gdc/test/maf.spec.js
+++ b/client/gdc/test/maf.spec.js
@@ -29,7 +29,7 @@ const femaleCohort = {
 const maleCases = new Set()
 
 tape('\n', function (test) {
-	test.pass('-***- GDC cohort MAF UI -***-')
+	test.comment('-***- GDC cohort MAF UI -***-')
 	test.end()
 })
 

--- a/client/mass/test/about.integration.spec.ts
+++ b/client/mass/test/about.integration.spec.ts
@@ -24,7 +24,7 @@ const runpp = helpers.getRunPp('mass', {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- mass/About -***-')
+	test.comment('-***- mass/About -***-')
 	test.end()
 })
 

--- a/client/mass/test/about.unit.spec.ts
+++ b/client/mass/test/about.unit.spec.ts
@@ -72,7 +72,7 @@ const mockCohort = {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- mass/about -***-')
+	test.comment('-***- mass/about -***-')
 	test.end()
 })
 

--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -67,7 +67,7 @@ const runpp = helpers.getRunPp('mass', {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/barchart -***-')
+	test.comment('-***- plots/barchart -***-')
 	test.end()
 })
 

--- a/client/mass/test/cuminc.integration.spec.js
+++ b/client/mass/test/cuminc.integration.spec.js
@@ -44,7 +44,7 @@ const runpp = helpers.getRunPp('mass', {
  ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/cuminc -***-')
+	test.comment('-***- plots/cuminc -***-')
 	test.end()
 })
 

--- a/client/mass/test/dataDownload.integration.spec.js
+++ b/client/mass/test/dataDownload.integration.spec.js
@@ -32,7 +32,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- plots/dataDownload -***-')
+	test.comment('-***- plots/dataDownload -***-')
 	test.end()
 })
 

--- a/client/mass/test/groups.integration.spec.js
+++ b/client/mass/test/groups.integration.spec.js
@@ -40,7 +40,7 @@ async function addDemographicSexFilter(btn, groups) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- mass/groups -***-')
+	test.comment('-***- mass/groups -***-')
 	test.end()
 })
 

--- a/client/mass/test/groups.unit.spec.ts
+++ b/client/mass/test/groups.unit.spec.ts
@@ -114,7 +114,7 @@ function getFilterObj(opts) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- mass/groups -***-')
+	test.comment('-***- mass/groups -***-')
 	test.end()
 })
 

--- a/client/mass/test/nav.integration.spec.js
+++ b/client/mass/test/nav.integration.spec.js
@@ -13,7 +13,7 @@ tests:
 */
 
 tape('\n', function (test) {
-	test.pass('-***- mass/nav -***-')
+	test.comment('-***- mass/nav -***-')
 	test.end()
 })
 

--- a/client/mass/test/regression.integration.spec.js
+++ b/client/mass/test/regression.integration.spec.js
@@ -18,7 +18,7 @@ TODO:
 */
 
 tape('\n', test => {
-	test.pass('-***- plots/regression -***-')
+	test.comment('-***- plots/regression -***-')
 	test.end()
 })
 
@@ -141,7 +141,7 @@ tape('Linear: continuous outcome = "agedx", cat. independents = "sex" + "genetic
 		}
 
 		const elem = regDom.inputs.node()
-		await detectOne({selector: '.sjpp-vp-violinDiv', elem})
+		await detectOne({ selector: '.sjpp-vp-violinDiv', elem })
 		test.ok(elem.querySelector('.sjpp-vp-violinDiv'), `Should render violin plot for outcome variable`)
 
 		if (test._ok) regression.Inner.app.destroy()

--- a/client/mass/test/regression.spec.js
+++ b/client/mass/test/regression.spec.js
@@ -573,7 +573,7 @@ const testList = [
 ////////////////////////// tests start
 
 tape('\n', function (test) {
-	test.pass('-***- mass/regression -***-')
+	test.comment('-***- mass/regression -***-')
 	test.end()
 })
 

--- a/client/mass/test/sampleScatter.spec.js
+++ b/client/mass/test/sampleScatter.spec.js
@@ -131,7 +131,7 @@ const groupState = {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- mass/sampleScatter -***-')
+	test.comment('-***- mass/sampleScatter -***-')
 	test.end()
 })
 

--- a/client/mass/test/summary.integration.spec.js
+++ b/client/mass/test/summary.integration.spec.js
@@ -38,7 +38,7 @@ const tabLabels2Find = ['Barchart', 'Violin', 'Boxplot'] //hardcoded data in sum
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/summary -***-')
+	test.comment('-***- plots/summary -***-')
 	test.end()
 })
 

--- a/client/mass/test/survival.integration.spec.js
+++ b/client/mass/test/survival.integration.spec.js
@@ -36,7 +36,7 @@ const runpp = helpers.getRunPp('mass', {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/survival -***-')
+	test.comment('-***- plots/survival -***-')
 	test.end()
 })
 

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -45,7 +45,7 @@ const runpp = getRunPp('mass', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/violin -***-')
+	test.comment('-***- plots/violin -***-')
 	test.end()
 })
 const open_state = {

--- a/client/mds3/test/cnv.unit.spec.ts
+++ b/client/mds3/test/cnv.unit.spec.ts
@@ -10,7 +10,7 @@ mayInitCnv()
 */
 
 tape('\n', test => {
-	test.pass('-***- mds3/cnv unit-***-')
+	test.comment('-***- mds3/cnv unit-***-')
 	test.end()
 })
 

--- a/client/mds3/test/customDataUI.unit.spec.ts
+++ b/client/mds3/test/customDataUI.unit.spec.ts
@@ -55,7 +55,7 @@ const mockBlock = {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- mds3/customdata.inputui -***-')
+	test.comment('-***- mds3/customdata.inputui -***-')
 	test.end()
 })
 

--- a/client/mds3/test/filterName.unit.spec.js
+++ b/client/mds3/test/filterName.unit.spec.js
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { getFilterName } from '../filterName'
 
 tape('\n', test => {
-	test.pass('-***- mds3/getFilterName-***-')
+	test.comment('-***- mds3/getFilterName-***-')
 	test.end()
 })
 

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -40,7 +40,7 @@ this script exports following test methods to share with non-CI test using GDC/c
 */
 
 tape('\n', function (test) {
-	test.pass('-***- mds3 -***-')
+	test.comment('-***- mds3 -***-')
 	test.end()
 })
 

--- a/client/mds3/test/mds3.spec.js
+++ b/client/mds3/test/mds3.spec.js
@@ -38,7 +38,7 @@ GDC - sunburst
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- mds3 -***-')
+	test.comment('-***- mds3 -***-')
 	test.end()
 })
 

--- a/client/mds3/test/skewer.unit.spec.ts
+++ b/client/mds3/test/skewer.unit.spec.ts
@@ -14,7 +14,7 @@ getVariantLabelText()
 */
 
 tape('\n', test => {
-	test.pass('-***- skewer unit -***-')
+	test.comment('-***- skewer unit -***-')
 	test.end()
 })
 

--- a/client/plots/boxplot/test/boxplot.integration.spec.ts
+++ b/client/plots/boxplot/test/boxplot.integration.spec.ts
@@ -31,7 +31,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/boxplot -***-')
+	test.comment('-***- plots/boxplot -***-')
 	test.end()
 })
 

--- a/client/plots/boxplot/test/boxplot.unit.spec.ts
+++ b/client/plots/boxplot/test/boxplot.unit.spec.ts
@@ -108,7 +108,7 @@ function getViewModel() {
 }
 
 tape('\n', function (test) {
-	test.pass('-***- plots/boxplot/ViewModel -***-')
+	test.comment('-***- plots/boxplot/ViewModel -***-')
 	test.end()
 })
 

--- a/client/plots/corrVolcano/test/corrVolcano.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.spec.ts
@@ -33,7 +33,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/correlationVolcano -***-')
+	test.comment('-***- plots/correlationVolcano -***-')
 	test.end()
 })
 

--- a/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
+++ b/client/plots/corrVolcano/test/corrVolcano.unit.spec.ts
@@ -91,7 +91,7 @@ const mockConfig = {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/correlationVolcano -***-')
+	test.comment('-***- plots/correlationVolcano -***-')
 	test.end()
 })
 

--- a/client/plots/diffAnalysis/test/diffAnalysis.integration.spec.ts
+++ b/client/plots/diffAnalysis/test/diffAnalysis.integration.spec.ts
@@ -28,7 +28,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/DiffAnalysis/DifferentialAnalysis -***-')
+	test.comment('-***- plots/DiffAnalysis/DifferentialAnalysis -***-')
 	test.end()
 })
 

--- a/client/plots/frequencyChart/test/frequencyChart.integration.spec.js
+++ b/client/plots/frequencyChart/test/frequencyChart.integration.spec.js
@@ -51,7 +51,7 @@ function getHolder() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/frequencyChart -***-')
+	test.comment('-***- plots/frequencyChart -***-')
 	test.end()
 })
 

--- a/client/plots/matrix/test/hierCluster.integration.spec.js
+++ b/client/plots/matrix/test/hierCluster.integration.spec.js
@@ -76,7 +76,7 @@ async function getHierClusterApp(_opts = {}) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/hierCluster.js -***-')
+	test.comment('-***- plots/hierCluster.js -***-')
 	test.end()
 })
 

--- a/client/plots/matrix/test/matrix.integration.spec.js
+++ b/client/plots/matrix/test/matrix.integration.spec.js
@@ -35,7 +35,7 @@ function getGenes() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/matrix -***-')
+	test.comment('-***- plots/matrix -***-')
 	test.end()
 })
 

--- a/client/plots/matrix/test/matrix.sort.unit.spec.js
+++ b/client/plots/matrix/test/matrix.sort.unit.spec.js
@@ -201,7 +201,7 @@ function simpleMatrix(sampleNames, termOrder, rows) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/matrix.sort -***-')
+	test.comment('-***- plots/matrix.sort -***-')
 	test.end()
 })
 

--- a/client/plots/matrix/test/matrix.sorterUi.unit.spec.js
+++ b/client/plots/matrix/test/matrix.sorterUi.unit.spec.js
@@ -49,7 +49,7 @@ async function getControls(_opts = {}) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/matrix.sorterUi -***-')
+	test.comment('-***- plots/matrix.sorterUi -***-')
 	test.end()
 })
 

--- a/client/plots/matrix/test/oncomatrix.spec.js
+++ b/client/plots/matrix/test/oncomatrix.spec.js
@@ -27,7 +27,7 @@ top mutated genes from APOLLO-LUAD, CNV only
 
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/matrix.gdc (aka OncoMatrix) -***-')
+	test.comment('-***- plots/matrix.gdc (aka OncoMatrix) -***-')
 	test.end()
 })
 

--- a/client/plots/runchart/test/runchart.integration.spec.js
+++ b/client/plots/runchart/test/runchart.integration.spec.js
@@ -52,7 +52,7 @@ function getHolder() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/runchart -***-')
+	test.comment('-***- plots/runchart -***-')
 	test.end()
 })
 

--- a/client/plots/sc/test/sc.spec.ts
+++ b/client/plots/sc/test/sc.spec.ts
@@ -31,7 +31,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/sc/SC -***-')
+	test.comment('-***- plots/sc/SC -***-')
 	test.end()
 })
 

--- a/client/plots/scatter/test/scatter.integration.spec.js
+++ b/client/plots/scatter/test/scatter.integration.spec.js
@@ -142,7 +142,7 @@ function getHolder() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/sampleScatter -***-')
+	test.comment('-***- plots/sampleScatter -***-')
 	test.end()
 })
 

--- a/client/plots/test/barchart.unit.spec.ts
+++ b/client/plots/test/barchart.unit.spec.ts
@@ -40,7 +40,7 @@ Tests:
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- plots/barchart -***-')
+	test.comment('-***- plots/barchart -***-')
 	test.end()
 })
 

--- a/client/plots/test/expclust.gdc.spec.js
+++ b/client/plots/test/expclust.gdc.spec.js
@@ -12,7 +12,7 @@ gdc laucher with top variably expressed genes, for gliomas
 
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/hierCluster.gdc -***-')
+	test.comment('-***- plots/hierCluster.gdc -***-')
 	test.end()
 })
 

--- a/client/plots/test/facet.integration.spec.ts
+++ b/client/plots/test/facet.integration.spec.ts
@@ -25,7 +25,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- plots/facet -***-')
+	test.comment('-***- plots/facet -***-')
 	test.end()
 })
 

--- a/client/plots/test/genomeBrowser.spec.js
+++ b/client/plots/test/genomeBrowser.spec.js
@@ -23,7 +23,7 @@ Single group: info
 ********************************************/
 
 tape('\n', function (test) {
-	test.pass('-***- mass/genomeBrowser -***-')
+	test.comment('-***- mass/genomeBrowser -***-')
 	test.end()
 })
 

--- a/client/plots/test/genomeBrowser.unit.spec.ts
+++ b/client/plots/test/genomeBrowser.unit.spec.ts
@@ -12,7 +12,7 @@ computeBlockModeFlag()
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- plots/genomebrowser -***-')
+	test.comment('-***- plots/genomebrowser -***-')
 	test.end()
 })
 

--- a/client/plots/test/gsea.spec.ts
+++ b/client/plots/test/gsea.spec.ts
@@ -36,7 +36,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/gsea -***-')
+	test.comment('-***- plots/gsea -***-')
 	test.end()
 })
 

--- a/client/plots/test/profile.spec.js
+++ b/client/plots/test/profile.spec.js
@@ -22,7 +22,7 @@ function getHolder() {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- plots/profile -***-')
+	test.comment('-***- plots/profile -***-')
 	test.end()
 })
 

--- a/client/plots/test/sampleView.integration.spec.ts
+++ b/client/plots/test/sampleView.integration.spec.ts
@@ -28,7 +28,7 @@ const runpp = helpers.getRunPp('mass', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/sampleView -***-')
+	test.comment('-***- plots/sampleView -***-')
 	test.end()
 })
 

--- a/client/plots/test/summary.gdc.spec.ts
+++ b/client/plots/test/summary.gdc.spec.ts
@@ -23,7 +23,7 @@ boxplot - geneExpression/geneVariant
 ***********************/
 
 tape('\n', function (test) {
-	test.pass('-***- summary.gdc -***-')
+	test.comment('-***- summary.gdc -***-')
 	test.end()
 })
 

--- a/client/plots/volcano/test/volcano.unit.spec.ts
+++ b/client/plots/volcano/test/volcano.unit.spec.ts
@@ -78,7 +78,7 @@ const mockResponse = {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- plots/volcano/Volcano -***-')
+	test.comment('-***- plots/volcano/Volcano -***-')
 	test.end()
 })
 

--- a/client/plots/wsiviewer/test/wsiviewer.spec.ts
+++ b/client/plots/wsiviewer/test/wsiviewer.spec.ts
@@ -20,7 +20,7 @@ const runpp = helpers.getRunPp('mass', {
 })
 
 tape.skip('\n', function (test) {
-	test.pass('-***- plots/wsiviewer/wsiviewer -***-')
+	test.comment('-***- plots/wsiviewer/wsiviewer -***-')
 	test.end()
 })
 

--- a/client/rx/test/recover.unit.spec.js
+++ b/client/rx/test/recover.unit.spec.js
@@ -71,7 +71,7 @@ function sleep(ms) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- rx/recover -***-')
+	test.comment('-***- rx/recover -***-')
 	test.end()
 })
 

--- a/client/rx/test/rx-async.unit.spec.js
+++ b/client/rx/test/rx-async.unit.spec.js
@@ -74,7 +74,7 @@ const partInit = rx.getCompInit(TestPart)
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- rx.core -***-')
+	test.comment('-***- rx.core -***-')
 	test.end()
 })
 

--- a/client/rx/test/rx-core.unit.spec.js
+++ b/client/rx/test/rx-core.unit.spec.js
@@ -84,7 +84,7 @@ class TestPart {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- rx.core -***-')
+	test.comment('-***- rx.core -***-')
 	test.end()
 })
 

--- a/client/src/databrowser/test/databrowser.ui.integration.spec.js
+++ b/client/src/databrowser/test/databrowser.ui.integration.spec.js
@@ -14,7 +14,7 @@ function getHolder() {
 }
 
 tape('\n', function (test) {
-	test.pass('-***- databrowser UI -***-')
+	test.comment('-***- databrowser UI -***-')
 	test.end()
 })
 

--- a/client/src/databrowser/test/databrowser.unit.spec.js
+++ b/client/src/databrowser/test/databrowser.unit.spec.js
@@ -31,7 +31,7 @@ Tests
 *****************/
 
 tape('\n', function (test) {
-	test.pass('-***- dictionary, phenotree parsing -***-')
+	test.comment('-***- dictionary, phenotree parsing -***-')
 	test.end()
 })
 

--- a/client/src/header/test/AppHeader.integration.spec.ts
+++ b/client/src/header/test/AppHeader.integration.spec.ts
@@ -44,7 +44,7 @@ function getHeader(opts) {
 ***************/
 
 tape('\n', test => {
-	test.pass('-***- src/header/AppHeader -***-')
+	test.comment('-***- src/header/AppHeader -***-')
 	test.end()
 })
 

--- a/client/src/test/appUrl.unit.spec.ts
+++ b/client/src/test/appUrl.unit.spec.ts
@@ -9,7 +9,7 @@ mayGetTkobj: mds3
 */
 
 tape('\n', function (test) {
-	test.pass('-***- app.parseurl.js mayGetTkobj() -***-')
+	test.comment('-***- app.parseurl.js mayGetTkobj() -***-')
 	test.end()
 })
 

--- a/client/termdb/test/geneVariant.unit.spec.ts
+++ b/client/termdb/test/geneVariant.unit.spec.ts
@@ -8,7 +8,7 @@ const handler = new SearchHandler()
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- geneVariant search handler -***-')
+	test.comment('-***- geneVariant search handler -***-')
 	test.end()
 })
 

--- a/client/termdb/test/search.integration.spec.js
+++ b/client/termdb/test/search.integration.spec.js
@@ -26,7 +26,7 @@ const runpp = helpers.getRunPp('termdb', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- termdb/search -***-')
+	test.comment('-***- termdb/search -***-')
 	test.end()
 })
 

--- a/client/termdb/test/store.integration.spec.js
+++ b/client/termdb/test/store.integration.spec.js
@@ -26,7 +26,7 @@ const runpp = helpers.getRunPp('termdb', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- termdb/store -***-')
+	test.comment('-***- termdb/store -***-')
 	test.end()
 })
 

--- a/client/termdb/test/submenu.integration.spec.js
+++ b/client/termdb/test/submenu.integration.spec.js
@@ -27,7 +27,7 @@ const runpp = helpers.getRunPp('termdb', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- termdb/submenu -***-')
+	test.comment('-***- termdb/submenu -***-')
 	test.end()
 })
 

--- a/client/termdb/test/tree.integration.spec.js
+++ b/client/termdb/test/tree.integration.spec.js
@@ -44,7 +44,7 @@ const runppMsigdb = helpers.getRunPp('termdb', {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- termdb/tree -***-')
+	test.comment('-***- termdb/tree -***-')
 	test.end()
 })
 

--- a/client/termdb/test/vocabulary.integration.spec.js
+++ b/client/termdb/test/vocabulary.integration.spec.js
@@ -111,7 +111,7 @@ async function getTermdbVocabApi(opts = {}) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- termdb/vocabulary -***-')
+	test.comment('-***- termdb/vocabulary -***-')
 	test.end()
 })
 
@@ -246,7 +246,7 @@ tape('Missing .state', test => {
 
 /* TermdbVocab tests */
 tape('\n', function (test) {
-	test.pass('-***- TermdbVocab Tests -***-')
+	test.comment('-***- TermdbVocab Tests -***-')
 	test.end()
 })
 
@@ -1160,7 +1160,7 @@ tape('getCohortsData()', async test => {
 
 /* FrontendVocab tests */
 tape('\n', function (test) {
-	test.pass('-***- FrontendVocab Tests -***-')
+	test.comment('-***- FrontendVocab Tests -***-')
 	test.end()
 })
 

--- a/client/termdb/test/vocabulary.unit.spec.js
+++ b/client/termdb/test/vocabulary.unit.spec.js
@@ -51,13 +51,13 @@ const termdbVocabApi = await getTermdbVocabApi()
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- vocabulary -***-')
+	test.comment('-***- vocabulary -***-')
 	test.end()
 })
 
 /* vocabInit tests */
 tape('\n', function (test) {
-	test.pass('-***- vocabInit Tests (main vocab function)-***-')
+	test.comment('-***- vocabInit Tests (main vocab function)-***-')
 	test.end()
 })
 
@@ -192,7 +192,7 @@ tape('q_to_param()', async test => {
 
 /* FrontendVocab tests */
 tape('\n', function (test) {
-	test.pass('-***- FrontendVocab Tests -***-')
+	test.comment('-***- FrontendVocab Tests -***-')
 	test.end()
 })
 
@@ -483,7 +483,7 @@ tape('graphable()', async test => {
 
 /* TermdbVocab tests */
 tape('\n', function (test) {
-	test.pass('-***- TermdbVocab Tests -***-')
+	test.comment('-***- TermdbVocab Tests -***-')
 	test.end()
 })
 

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -478,7 +478,7 @@ tape('Numerical term: fixed bins', async test => {
 
 	await opts.pillMenuClick('Edit')
 	const tip = opts.pill.Inner.dom.tip
-
+	await sleep(50)
 	const lines = tip.d.select('.binsize_g').node().querySelectorAll('line')
 	test.equal(lines.length, 8, 'should have 8 lines')
 	// first line should be draggable

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -111,7 +111,7 @@ async function getOpts(_opts = {}, genome = 'hg38-test', dslabel = 'TermdbTest')
  **************/
 
 tape('\n', test => {
-	test.pass('-***- termsetting.integration -***-')
+	test.comment('-***- termsetting.integration -***-')
 	test.end()
 })
 

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -478,7 +478,7 @@ tape('Numerical term: fixed bins', async test => {
 
 	await opts.pillMenuClick('Edit')
 	const tip = opts.pill.Inner.dom.tip
-	await sleep(50)
+	await sleep(100)
 	const lines = tip.d.select('.binsize_g').node().querySelectorAll('line')
 	test.equal(lines.length, 8, 'should have 8 lines')
 	// first line should be draggable
@@ -535,7 +535,7 @@ tape('Numerical term: fixed bins', async test => {
 		.querySelectorAll('input')[1]
 	d3s.select(last_bin_custom_radio).property('checked', true)
 	last_bin_custom_radio.dispatchEvent(new Event('change'))
-
+	await sleep(50)
 	const last_bin_input = tip.d.node().querySelectorAll('tr')[2].querySelectorAll('div')[1].querySelectorAll('input')[0]
 
 	last_bin_input.value = 20
@@ -556,7 +556,7 @@ tape('Numerical term: fixed bins', async test => {
 		.find(b => b.innerHTML == 'Apply')
 	apply_btn.click()
 	await opts.pillMenuClick('Edit')
-
+	await sleep(50)
 	test.equal(
 		tip.d.node().querySelectorAll('tr')[0].querySelectorAll('input')[0].value,
 		'5',

--- a/client/termsetting/test/termsetting.unit.spec.js
+++ b/client/termsetting/test/termsetting.unit.spec.js
@@ -18,7 +18,7 @@ Tests:
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- termsetting.unit -***-')
+	test.comment('-***- termsetting.unit -***-')
 	test.end()
 })
 

--- a/client/test/matchSpecs.js
+++ b/client/test/matchSpecs.js
@@ -24,8 +24,10 @@ export function matchSpecs(filepath) {
 	//if (window.testHost) return true
 	if (!params.dir && !params.name) return false
 	// !!! quick-fix for client:coverage failing on mds3.integration, menu, other 'flaky' tests !!!
-	if (window.location.pathname == '/puppet.html' && (filepath.includes('mds3.') || filepath.includes('menu.')))
-		return false
+	// if (window.location.pathname == '/puppet.html' && (filepath.includes('mds3.') || filepath.includes('menu.'))) {
+	// 	console.log(`!!! skipping ${filepath} in matchSpecs() !!!`)
+	// 	return false
+	// }
 	if (exclude && filepath.includes(exclude)) return false
 	for (const pattern of patterns) {
 		if (pattern && minimatch(filepath, pattern)) {

--- a/client/tracks/hic/test/hic.app.integration.spec-manual.ts
+++ b/client/tracks/hic/test/hic.app.integration.spec-manual.ts
@@ -5,13 +5,13 @@ import { DataFetcher } from '../data/DataFetcher.ts'
 import { DetailDataFetcher } from '../data/DetailDataFetcher.ts'
 
 tape('\n', test => {
-	test.pass('-***- hic app integration tracks/hic -***-')
+	test.comment('-***- hic app integration tracks/hic -***-')
 	test.end()
 })
 
-/** Run this file manually. Takes too long to run on CI. 
- * Notes: 
- * - Not able to test DetailDataMapper .getYFragData() and .getXFragData() methods 
+/** Run this file manually. Takes too long to run on CI.
+ * Notes:
+ * - Not able to test DetailDataMapper .getYFragData() and .getXFragData() methods
  * until the reference files are available on CI.
  */
 

--- a/client/tracks/hic/test/hic.app.unit.spec.ts
+++ b/client/tracks/hic/test/hic.app.unit.spec.ts
@@ -132,7 +132,7 @@ const mockFragData = {
 }
 
 tape('\n', test => {
-	test.pass('-***- hic app unit tracks/hic -***-')
+	test.comment('-***- hic app unit tracks/hic -***-')
 	test.end()
 })
 /************* General data tests *************/

--- a/client/tracks/hic/test/hic.integration.spec-manual2.ts
+++ b/client/tracks/hic/test/hic.integration.spec-manual2.ts
@@ -29,7 +29,7 @@ async function getGenomes(genome: string) {
 }
 
 tape('\n', test => {
-	test.pass('-***- tracks/hic integration -***-')
+	test.comment('-***- tracks/hic integration -***-')
 	test.end()
 })
 

--- a/client/tracks/hic/test/hic.unit.spec.ts
+++ b/client/tracks/hic/test/hic.unit.spec.ts
@@ -32,7 +32,7 @@ type Template = {
 }
 
 tape('\n', test => {
-	test.pass('-***- tracks/hic unit-***-')
+	test.comment('-***- tracks/hic unit-***-')
 	test.end()
 })
 

--- a/client/tw/test/TwRouter.integration.spec.ts
+++ b/client/tw/test/TwRouter.integration.spec.ts
@@ -91,7 +91,7 @@ async function getTws() {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- tw/TwRouter.integration -***-')
+	test.comment('-***- tw/TwRouter.integration -***-')
 	test.end()
 })
 

--- a/client/tw/test/TwRouter.unit.spec.ts
+++ b/client/tw/test/TwRouter.unit.spec.ts
@@ -63,7 +63,7 @@ function getTermWithGS() {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- tw/TwRouter.unit -***-')
+	test.comment('-***- tw/TwRouter.unit -***-')
 	test.end()
 })
 

--- a/client/tw/test/categorical.unit.spec.ts
+++ b/client/tw/test/categorical.unit.spec.ts
@@ -62,7 +62,7 @@ function getTermWithGS() {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- tw/categorical.unit -***-')
+	test.comment('-***- tw/categorical.unit -***-')
 	test.end()
 })
 

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -22,7 +22,7 @@ async function getVocabApi() {
 const vocabApi: any = await getVocabApi()
 
 tape('\n', function (test) {
-	test.pass('-***- tw/geneVariant.integration -***-')
+	test.comment('-***- tw/geneVariant.integration -***-')
 	test.end()
 })
 

--- a/client/tw/test/numeric.xtw.unit.spec.ts
+++ b/client/tw/test/numeric.xtw.unit.spec.ts
@@ -15,7 +15,7 @@ const vocabApi = vocabInit({ state: { vocab: { genome: 'hg38-test', dslabel: 'Te
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- tw/numeric.xtw.unit -***-')
+	test.comment('-***- tw/numeric.xtw.unit -***-')
 	test.end()
 })
 

--- a/rust/test/indel.unit.spec.js
+++ b/rust/test/indel.unit.spec.js
@@ -68,7 +68,7 @@ const pphost = 'http://pp-int-test.stjude.org/' // show links using this host
  Test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- rust indel specs -***-')
+	test.comment('-***- rust indel specs -***-')
 	test.end()
 })
 

--- a/rust/test/readHDF5.unit.spec.js
+++ b/rust/test/readHDF5.unit.spec.js
@@ -35,7 +35,7 @@ if (!fs.existsSync(HDF5_FILE)) {
  * Test sections
  **************/
 tape('\n', function (test) {
-	test.pass('-***- readHDF5 specs -***-')
+	test.comment('-***- readHDF5 specs -***-')
 	test.end()
 })
 

--- a/rust/test/validateHDF5.unit.spec.js
+++ b/rust/test/validateHDF5.unit.spec.js
@@ -42,7 +42,7 @@ if (!filesExist.dense) {
  * Test sections
  **************/
 tape('\n', function (test) {
-	test.pass('-***- validateHDF5 specs -***-')
+	test.comment('-***- validateHDF5 specs -***-')
 	test.end()
 })
 

--- a/server/emitImports.js
+++ b/server/emitImports.js
@@ -11,6 +11,8 @@
 import fs from 'fs'
 import path from 'path'
 
+process.removeAllListeners('warning')
+
 const mode = process.argv[2]
 const cwd = process.cwd()
 const __dirname = import.meta.dirname

--- a/server/src/test/CacheManager.unit.spec.ts
+++ b/server/src/test/CacheManager.unit.spec.ts
@@ -17,7 +17,7 @@ import { CacheManager } from '#src/CacheManager.ts'
 ***************/
 
 tape('\n', async function (test) {
-	test.pass('-***- src/CacheManager -***-')
+	test.comment('-***- src/CacheManager -***-')
 	test.end()
 })
 

--- a/server/src/test/Rscripts.integration.spec.js
+++ b/server/src/test/Rscripts.integration.spec.js
@@ -16,7 +16,7 @@ try {
 }
 
 tape('\n', test => {
-	test.pass('-***- R scripts integration specs -***-')
+	test.comment('-***- R scripts integration specs -***-')
 	test.end()
 })
 

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -63,7 +63,7 @@ function sleep(ms) {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- server/auth specs -***-')
+	test.comment('-***- server/auth specs -***-')
 	test.end()
 })
 

--- a/server/src/test/bedj.parseBedTest.js
+++ b/server/src/test/bedj.parseBedTest.js
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { parseBedLine } from '../bedj.parseBed'
 
 // tape('\n', function (test) {
-// 	test.pass('-***- server/bedj.parseBed test -***-')
+// 	test.comment('-***- server/bedj.parseBed test -***-')
 // 	test.end()
 // })
 

--- a/server/src/test/mds3.gdc.filter.unit.spec.js
+++ b/server/src/test/mds3.gdc.filter.unit.spec.js
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { filter2GDCfilter } from '../mds3.gdc.filter.js'
 
 tape('\n', function (test) {
-	test.pass('-***- mds3.gdc.filter specs -***-')
+	test.comment('-***- mds3.gdc.filter specs -***-')
 	test.end()
 })
 

--- a/server/src/test/mds3.unit.spec.js
+++ b/server/src/test/mds3.unit.spec.js
@@ -9,7 +9,7 @@ guessSsmid()
 */
 
 tape('\n', function (test) {
-	test.pass('-***- mds3 unit tests -***-')
+	test.comment('-***- mds3 unit tests -***-')
 	test.end()
 })
 

--- a/server/src/test/routes.type.spec.ts
+++ b/server/src/test/routes.type.spec.ts
@@ -81,7 +81,7 @@ async function testApi(f) {
 		`../../routes/${f}`
 	)
 	tape('\n', function (test) {
-		test.pass(`-***- server/${f} specs -***-`)
+		test.comment(`-***- server/${f} specs -***-`)
 		test.end()
 	})
 

--- a/server/src/test/routes/readme.js
+++ b/server/src/test/routes/readme.js
@@ -2,6 +2,8 @@ import path from 'path'
 import fs from 'fs'
 import serverconfig from '../../serverconfig.js'
 
+process.removeAllListeners('warning')
+
 export default function setRoutes(app, basepath) {
 	const cwd = path.join(serverconfig.binpath, '..')
 

--- a/server/src/test/routes/specs.js
+++ b/server/src/test/routes/specs.js
@@ -4,6 +4,8 @@ import path from 'path'
 import { minimatch } from 'minimatch'
 import serverconfig from '../../serverconfig.js'
 
+process.removeAllListeners('warning')
+
 export default function setRoutes(app, basepath) {
 	app.get(basepath + '/specs', async (req, res) => {
 		try {

--- a/server/src/test/termdb.access.unit.spec.js
+++ b/server/src/test/termdb.access.unit.spec.js
@@ -3,7 +3,7 @@ import { filterTerms } from '../termdb.server.init.ts'
 import * as authApi from '../auth'
 
 tape('\n', function (test) {
-	test.pass('-***- termdb access control specs -***-')
+	test.comment('-***- termdb access control specs -***-')
 	test.end()
 })
 

--- a/server/src/test/termdb.filter.unit.spec.js
+++ b/server/src/test/termdb.filter.unit.spec.js
@@ -12,7 +12,7 @@ import { init } from './load.testds.js'
 import { server_init_db_queries } from '../termdb.server.init.ts'
 
 tape('\n', function (test) {
-	test.pass('-***- modules/termdb.filter specs -***-')
+	test.comment('-***- modules/termdb.filter specs -***-')
 	test.end()
 })
 

--- a/server/src/test/termdb.matrix.unit.spec.js
+++ b/server/src/test/termdb.matrix.unit.spec.js
@@ -12,7 +12,7 @@ divideTerms: assigns $id from term.name if id missing
 */
 
 tape('\n', function (test) {
-	test.pass('-***- modules/termdb.matrix specs -***-')
+	test.comment('-***- modules/termdb.matrix specs -***-')
 	test.end()
 })
 

--- a/server/src/test/utils.unit.spec.js
+++ b/server/src/test/utils.unit.spec.js
@@ -11,7 +11,7 @@ validateRglst
 */
 
 tape('\n', function (test) {
-	test.pass('-***- server/utils specs -***-')
+	test.comment('-***- server/utils specs -***-')
 	test.end()
 })
 

--- a/server/src/test/validator.spec.js
+++ b/server/src/test/validator.spec.js
@@ -11,7 +11,7 @@ function sleep(ms) {
 
 // tests
 tape('\n', test => {
-	test.pass('-***- server/src/validator -***-')
+	test.comment('-***- server/src/validator -***-')
 	test.end()
 })
 

--- a/server/utils/test/Rscripts.spec.js
+++ b/server/utils/test/Rscripts.spec.js
@@ -285,7 +285,7 @@ tape('wilcoxon.R', async function (test) {
 */
 
 tape('\n', function (test) {
-	test.pass('-***- R correlation specs -***-')
+	test.comment('-***- R correlation specs -***-')
 	test.end()
 })
 

--- a/shared/types/emitCheckers.ts
+++ b/shared/types/emitCheckers.ts
@@ -19,6 +19,8 @@ import fs from 'fs'
 import path from 'path'
 import { execSync } from 'child_process'
 
+process.removeAllListeners('warning')
+
 const __dirname = import.meta.dirname
 const routesDir = './src/routes'
 const cwd = path.join(__dirname, routesDir)

--- a/shared/utils/src/test/date.unit.spec.js
+++ b/shared/utils/src/test/date.unit.spec.js
@@ -10,7 +10,7 @@ import { getDateStrFromNumber, getNumberFromDateStr, getDateFromNumber, getNumbe
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- date convert specs -***-')
+	test.comment('-***- date convert specs -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/descriptive.stats.unit.spec.js
+++ b/shared/utils/src/test/descriptive.stats.unit.spec.js
@@ -13,7 +13,7 @@ import { getMean, getVariance, getStdDev, summaryStats } from '../descriptive.st
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- #shared/descriptive.stats -***-')
+	test.comment('-***- #shared/descriptive.stats -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/fetch-helpers.unit.spec.js
+++ b/shared/utils/src/test/fetch-helpers.unit.spec.js
@@ -42,7 +42,7 @@ function cleanup() {
 ***************/
 
 tape('\n', function (test) {
-	test.pass('-***- #shared/fetch-helpers -***-')
+	test.comment('-***- #shared/fetch-helpers -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/joinUrl.unit.spec.js
+++ b/shared/utils/src/test/joinUrl.unit.spec.js
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { joinUrl } from '../joinUrl.js'
 
 tape('\n', function (test) {
-	test.pass('-***- #shared/joinUrl -***-')
+	test.comment('-***- #shared/joinUrl -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/mds3tk.unit.spec.js
+++ b/shared/utils/src/test/mds3tk.unit.spec.js
@@ -11,7 +11,7 @@ summarize_mclass()
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- mds3tk -***-')
+	test.comment('-***- mds3tk -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/roundvalue.unit.spec.js
+++ b/shared/utils/src/test/roundvalue.unit.spec.js
@@ -12,7 +12,7 @@ import { roundValueAuto, roundValue2, decimalPlacesUntilFirstNonZero } from '../
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- round value specs -***-')
+	test.comment('-***- round value specs -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/termdb.bins.unit.spec.js
+++ b/shared/utils/src/test/termdb.bins.unit.spec.js
@@ -36,7 +36,7 @@ function tryBin(test, arg, testMssg, expectedErrMssg) {
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- termdb.bins specs -***-')
+	test.comment('-***- termdb.bins specs -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/termdb.initbinconfig.unit.spec.js
+++ b/shared/utils/src/test/termdb.initbinconfig.unit.spec.js
@@ -5,7 +5,7 @@ import initBinConfig from '../termdb.initbinconfig'
  Test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- termdb init bin config specs -***-')
+	test.comment('-***- termdb init bin config specs -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/termdb.usecase.unit.spec.js
+++ b/shared/utils/src/test/termdb.usecase.unit.spec.js
@@ -5,7 +5,7 @@ import { isUsableTerm } from '../termdb.usecase.js'
  test sections
 ***************/
 tape('\n', function (test) {
-	test.pass('-***- termdb.usecase specs -***-')
+	test.comment('-***- termdb.usecase specs -***-')
 	test.end()
 })
 

--- a/shared/utils/src/test/time.unit.spec.ts
+++ b/shared/utils/src/test/time.unit.spec.ts
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { formatElapsedTime } from '../time'
 
 tape('\n', function (test) {
-	test.pass('-***- formatElapsedTime specs -***-')
+	test.comment('-***- formatElapsedTime specs -***-')
 	test.end()
 })
 


### PR DESCRIPTION
# Description

This PR branch:
- ensures warnings are not emitted as content in generated dev/test/CI files, for example in `bump.js`,, `emitImports.js` and similar scripts. Such warnings may break CI.
-  reenables skipped spec files (`mds3`, `dofetch`, `termdb.submenu`) that were skipped by `matchSpecs()` when using `puppet.html`. 
- uses `test.comment()` instead of `test.pass()` to delineate spec file sessions in the tape logs.

tested with:
- http://localhost:3000/testrun.html?name=*.unit and http://localhost:3000/testrun.html?name=*.integration
- from the `client` dir, `npm run test:unit` and `npm run test:integration`
- Github[ integration test CI ](https://github.com/stjude/proteinpaint/actions/runs/16251916807)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
