### PR TITLE
Report section show/hide fix

### DIFF
--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -49,7 +49,7 @@ export class Report extends RxComponentInner {
 				const display = sectionDiv.style('display')
 				headerIcon.text(display === 'none' ? '▼' : '▲') //toggle the icon
 				//toggle the display of the plot
-				sectionDiv.style('display', display === 'none' ? 'block' : 'none')
+				sectionDiv.style('display', display === 'none' ? 'flex' : 'none')
 			})
 
 			for (const plot of section.plots) {


### PR DESCRIPTION
# Description
When showing/hiding the section toggle between flex or none, not block. Otherwise the plots are missaligned when viewing them again.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
