### PR TITLE
Fixed brush shifting in the numeric filter

### DIFF
--- a/client/dom/violinRenderer.js
+++ b/client/dom/violinRenderer.js
@@ -28,6 +28,7 @@ export class violinRenderer {
 	render() {
 		this.svg.selectAll('*').remove()
 		this.violinG = this.svg.append('g').attr('transform', `translate(${this.shiftx}, ${this.height / 2 + this.shifty})`)
+		this.brushG = this.svg.append('g').attr('transform', `translate(${this.shiftx}, ${this.shifty})`)
 
 		this.scaleG = this.svg.append('g').attr('transform', `translate(${this.shiftx}, ${this.shifty})`)
 		this.scaleG.call(axisTop(this.axisScaleUI).tickValues(this.axisScaleUI.ticks()))

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -182,17 +182,9 @@ async function fillMenu(self, div, tvs) {
 		//}
 	}
 	// add brush_g for tvs brushes
-	self.num_obj.brush_g = self.num_obj.svg
-		.append('g')
-		.attr('transform', `translate(${self.num_obj.plot_size.xpad}, ${self.num_obj.plot_size.ypad})`)
-		.attr('class', 'brush_g')
+	self.num_obj.brush_g = self.vr.brushG.attr('class', 'brush_g')
 
-	const maxvalue = self.num_obj.density_data.maxvalue
-	const minvalue = self.num_obj.density_data.minvalue
-
-	self.num_obj.xscale = scaleLinear()
-		.domain([minvalue, maxvalue])
-		.range([self.num_obj.plot_size.xpad, self.num_obj.plot_size.width + self.num_obj.plot_size.xpad])
+	self.num_obj.xscale = self.vr.axisScale
 
 	self.num_obj.ranges = ranges
 	self.num_obj.brushes = []


### PR DESCRIPTION
# Description
When creating a numeric filter the brush was a bit shifted causing that some values could not be reached. Added brushG in the violinRenderer aligned with the violin. Used xScale from the violin. This fixes the brush shifting. Closes #3285
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
