### PR TITLE
geneVariant edit UI table layout

### DIFF
--- a/client/dom/types/table.ts
+++ b/client/dom/types/table.ts
@@ -98,7 +98,7 @@ export type TableArgs = {
 	singleMode?: boolean
 	/** true to show no radio buttons. should only use when singleMode=true */
 	noRadioBtn?: boolean
-	/** Shows or hides line column. */
+	/** set to false to hide line numbers */
 	showLines?: boolean
 	/** When active makes the table rows to alternate bg colors */
 	striped?: boolean

--- a/client/filter/tvs.dt.js
+++ b/client/filter/tvs.dt.js
@@ -7,6 +7,6 @@ Base TVS handler for dt terms
 export const handler = Object.assign({}, _handler, { term_name_gen })
 
 function term_name_gen(d) {
-	const name = d.term.parentTerm ? `${d.term.parentTerm.name} ${d.term.name}` : d.term.name
+	const name = d.term.parentTerm && !d.excludeGeneName ? `${d.term.parentTerm.name} ${d.term.name}` : d.term.name
 	return name.length < 31 ? name : '<label title="' + name + '">' + name.substring(0, 28) + '...' + '</label>'
 }

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -555,7 +555,8 @@ async function updateUI(self) {
 			{ label: 'FILTER' }
 		],
 		rows: [],
-		striped: false // no alternating row bg color so delete button appears more visible
+		striped: false, // no alternating row bg color so delete button appears more visible
+		showLines: false
 	}
 	for (const g of groups) {
 		tableArg.rows.push([

--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -18,7 +18,7 @@ Tests:
 	term1=geneVariant with groups
 	term1=categorical, term2=geneVariant
 	term1=geneExp, term2=geneVariant SKIPPED
-	term2=geneExp, term1=geneVariant
+	term1=geneVariant, term2=geneExp
 	term1=geneExp
 	term1=numeric term2=geneExp with default bins
 	term1=geneExp, term2=categorical
@@ -353,7 +353,7 @@ tape('term1=geneVariant with groups', function (test) {
 			plots: [
 				{
 					chartType: 'barchart',
-					term: geneVariantTw
+					term: { term: { type: 'geneVariant', gene: 'TP53' }, q: { type: 'custom-groupset' } }
 				}
 			]
 		},
@@ -381,7 +381,7 @@ tape('term1=categorical, term2=geneVariant', function (test) {
 				{
 					chartType: 'barchart',
 					term: { id: 'diaggrp' },
-					term2: geneVariantTw
+					term2: { term: { type: 'geneVariant', gene: 'TP53' }, q: { type: 'custom-groupset' } }
 				}
 			]
 		},
@@ -408,7 +408,7 @@ tape('term1=geneExp, term2=geneVariant SKIPPED', function (test) {
 			plots: [
 				{
 					chartType: 'summary',
-					term2: geneVariantTw,
+					term2: { term: { type: 'geneVariant', gene: 'TP53' }, q: { type: 'custom-groupset' } },
 					// must set geneExp q.mode=discrete to show barchart, otherwise it will become violin and not trigger provied postRender for barchart
 					term: { term: { type: 'geneExpression', gene: 'TP53' }, q: { mode: 'discrete' } }
 				}
@@ -430,14 +430,14 @@ tape('term1=geneExp, term2=geneVariant SKIPPED', function (test) {
 	}
 })
 
-tape('term2=geneExp, term1=geneVariant', function (test) {
+tape('term1=geneVariant, term2=geneExp', function (test) {
 	test.timeoutAfter(10000)
 	runpp({
 		state: {
 			plots: [
 				{
 					chartType: 'barchart',
-					term: geneVariantTw,
+					term: { term: { type: 'geneVariant', gene: 'TP53' }, q: { type: 'custom-groupset' } },
 					term2: { term: { type: 'geneExpression', gene: 'TP53' } }
 				}
 			]
@@ -2055,313 +2055,6 @@ tape.skip('customized bins', test => {
 // to make or update following config, on the browser build/modify the tw or filter, apply to chart, at Session > Share > Open link, open the session file and locate the record and copy it here:
 // for geneVariant tw, search for string "geneVariant"
 // for filter, search for "termfilter"
-const geneVariantTw = {
-	term: {
-		kind: 'gene',
-		id: 'TP53',
-		gene: 'TP53',
-		name: 'TP53',
-		type: 'geneVariant',
-		groupsetting: { disabled: false },
-		childTerms: [
-			{
-				id: 'snvindel_somatic',
-				query: 'snvindel',
-				name: 'SNV/indel (somatic)',
-				parent_id: null,
-				isleaf: true,
-				type: 'dtsnvindel',
-				dt: 1,
-				values: {
-					M: { label: 'MISSENSE' },
-					F: { label: 'FRAMESHIFT' },
-					WT: { label: 'Wildtype' }
-				},
-				name_noOrigin: 'SNV/indel',
-				origin: 'somatic',
-				parentTerm: {
-					kind: 'gene',
-					id: 'TP53',
-					gene: 'TP53',
-					name: 'TP53',
-					type: 'geneVariant',
-					groupsetting: { disabled: false }
-				}
-			},
-			{
-				id: 'snvindel_germline',
-				query: 'snvindel',
-				name: 'SNV/indel (germline)',
-				parent_id: null,
-				isleaf: true,
-				type: 'dtsnvindel',
-				dt: 1,
-				values: {
-					M: { label: 'MISSENSE' },
-					F: { label: 'FRAMESHIFT' },
-					WT: { label: 'Wildtype' }
-				},
-				name_noOrigin: 'SNV/indel',
-				origin: 'germline',
-				parentTerm: {
-					kind: 'gene',
-					id: 'TP53',
-					gene: 'TP53',
-					name: 'TP53',
-					type: 'geneVariant',
-					groupsetting: { disabled: false }
-				}
-			},
-			{
-				id: 'cnv',
-				query: 'cnv',
-				name: 'CNV',
-				parent_id: null,
-				isleaf: true,
-				type: 'dtcnv',
-				dt: 4,
-				values: {
-					CNV_amp: { label: 'Copy number gain' },
-					WT: { label: 'Wildtype' }
-				},
-				name_noOrigin: 'CNV',
-				parentTerm: {
-					kind: 'gene',
-					id: 'TP53',
-					gene: 'TP53',
-					name: 'TP53',
-					type: 'geneVariant',
-					groupsetting: { disabled: false }
-				}
-			},
-			{
-				id: 'fusion',
-				query: 'svfusion',
-				name: 'Fusion RNA',
-				parent_id: null,
-				isleaf: true,
-				type: 'dtfusion',
-				dt: 2,
-				values: {
-					Fuserna: { label: 'Fusion transcript' },
-					WT: { label: 'Wildtype' }
-				},
-				name_noOrigin: 'Fusion RNA',
-				parentTerm: {
-					kind: 'gene',
-					id: 'TP53',
-					gene: 'TP53',
-					name: 'TP53',
-					type: 'geneVariant',
-					groupsetting: { disabled: false }
-				}
-			}
-		]
-	},
-	q: {
-		isAtomic: true,
-		type: 'custom-groupset',
-		hiddenValues: {},
-		customset: {
-			groups: [
-				{
-					name: 'Excluded categories',
-					type: 'filter',
-					uncomputable: true,
-					filter: { type: 'tvslst', in: true, join: '', lst: [] }
-				},
-				{
-					name: 'SNV/indel',
-					type: 'filter',
-					uncomputable: false,
-					filter: {
-						type: 'tvslst',
-						in: true,
-						join: 'or',
-						lst: [
-							{
-								type: 'tvs',
-								tvs: {
-									term: {
-										id: 'snvindel_somatic',
-										query: 'snvindel',
-										name: 'SNV/indel (somatic)',
-										parent_id: null,
-										isleaf: true,
-										type: 'dtsnvindel',
-										dt: 1,
-										values: {
-											M: { label: 'MISSENSE' },
-											F: { label: 'FRAMESHIFT' },
-											WT: { label: 'Wildtype' }
-										},
-										name_noOrigin: 'SNV/indel',
-										origin: 'somatic',
-										parentTerm: {
-											kind: 'gene',
-											id: 'TP53',
-											gene: 'TP53',
-											name: 'TP53',
-											type: 'geneVariant',
-											groupsetting: { disabled: false }
-										}
-									},
-									values: [
-										{
-											key: 'M',
-											label: 'MISSENSE',
-											value: 'M',
-											bar_width_frac: null
-										},
-										{
-											key: 'F',
-											label: 'FRAMESHIFT',
-											value: 'F',
-											bar_width_frac: null
-										}
-									]
-								}
-							},
-							{
-								type: 'tvs',
-								tvs: {
-									term: {
-										id: 'snvindel_germline',
-										query: 'snvindel',
-										name: 'SNV/indel (germline)',
-										parent_id: null,
-										isleaf: true,
-										type: 'dtsnvindel',
-										dt: 1,
-										values: {
-											M: { label: 'MISSENSE' },
-											F: { label: 'FRAMESHIFT' },
-											WT: { label: 'Wildtype' }
-										},
-										name_noOrigin: 'SNV/indel',
-										origin: 'germline',
-										parentTerm: {
-											kind: 'gene',
-											id: 'TP53',
-											gene: 'TP53',
-											name: 'TP53',
-											type: 'geneVariant',
-											groupsetting: { disabled: false }
-										}
-									},
-									values: [
-										{
-											key: 'M',
-											label: 'MISSENSE',
-											value: 'M',
-											bar_width_frac: null
-										},
-										{
-											key: 'F',
-											label: 'FRAMESHIFT',
-											value: 'F',
-											bar_width_frac: null
-										}
-									]
-								}
-							}
-						]
-					}
-				},
-				{
-					name: 'Wildtype',
-					type: 'filter',
-					uncomputable: false,
-					filter: {
-						type: 'tvslst',
-						in: true,
-						join: 'and',
-						lst: [
-							{
-								type: 'tvs',
-								tvs: {
-									term: {
-										id: 'snvindel_somatic',
-										query: 'snvindel',
-										name: 'SNV/indel (somatic)',
-										parent_id: null,
-										isleaf: true,
-										type: 'dtsnvindel',
-										dt: 1,
-										values: {
-											M: { label: 'MISSENSE' },
-											F: { label: 'FRAMESHIFT' },
-											WT: { label: 'Wildtype' }
-										},
-										name_noOrigin: 'SNV/indel',
-										origin: 'somatic',
-										parentTerm: {
-											kind: 'gene',
-											id: 'TP53',
-											gene: 'TP53',
-											name: 'TP53',
-											type: 'geneVariant',
-											groupsetting: { disabled: false }
-										}
-									},
-									values: [
-										{
-											key: 'WT',
-											label: 'Wildtype',
-											value: 'WT',
-											bar_width_frac: null
-										}
-									]
-								}
-							},
-							{
-								type: 'tvs',
-								tvs: {
-									term: {
-										id: 'snvindel_germline',
-										query: 'snvindel',
-										name: 'SNV/indel (germline)',
-										parent_id: null,
-										isleaf: true,
-										type: 'dtsnvindel',
-										dt: 1,
-										values: {
-											M: { label: 'MISSENSE' },
-											F: { label: 'FRAMESHIFT' },
-											WT: { label: 'Wildtype' }
-										},
-										name_noOrigin: 'SNV/indel',
-										origin: 'germline',
-										parentTerm: {
-											kind: 'gene',
-											id: 'TP53',
-											gene: 'TP53',
-											name: 'TP53',
-											type: 'geneVariant',
-											groupsetting: { disabled: false }
-										}
-									},
-									values: [
-										{
-											key: 'WT',
-											label: 'Wildtype',
-											value: 'WT',
-											bar_width_frac: null
-										}
-									]
-								}
-							}
-						]
-					}
-				}
-			]
-		}
-	},
-	isAtomic: true,
-	type: 'GvCustomGsTW',
-	bins: []
-}
-
 const tp53dtTermFilter = {
 	type: 'tvslst',
 	in: true,

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -646,6 +646,11 @@ export class Barchart {
 
 	getColor(t, label, bins) {
 		if (!t.term) return
+		if (t.q.type == 'custom-groupset') {
+			const groups = t.q.customset.groups
+			const group = groups.find(g => g.name == label)
+			if (group?.color) return group.color
+		}
 		if (t.term.values) {
 			for (const [key, v] of Object.entries(t.term.values)) {
 				if (!v.color) continue

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -445,6 +445,9 @@ export async function getPlotConfig(opts, app) {
 	}
 	//config.mayAdjustConfig(config)
 
+	// TODO: may do similar thing for custom term
+	if (config.term.term.type == 'geneVariant') config.settings.barchart.colorBars = true
+
 	// may apply term-specific changes to the default object
 	return copyMerge(config, opts)
 }

--- a/client/plots/survival.js
+++ b/client/plots/survival.js
@@ -332,11 +332,13 @@ class TdbSurvival {
 		const config = this.state.config
 		const t2values = copyMerge({}, config.term2?.term?.values || {}, config.term2?.values || {})
 		const values = (this.refs.bins[2] && [this.refs.bins[2]]) || Object.values(t2values)
+		const t2groups = config.term2?.q.customset?.groups
 		this.term2toColor = {}
 		this.colorScale = this.uniqueSeriesIds.size < 11 ? scaleOrdinal(schemeCategory10) : scaleOrdinal(schemeCategory20)
 		const legendItems = []
 		for (const chart of charts) {
 			for (const series of chart.serieses) {
+				let color
 				const v = values.find(
 					v =>
 						v.seriesId === series.seriesId ||
@@ -344,8 +346,13 @@ class TdbSurvival {
 						v.name === series.seriesId ||
 						v.label === series.seriesId
 				)
+				color = v?.color
+				if (!color && t2groups?.length) {
+					const group = t2groups.find(g => g.name == series.seriesId)
+					color = group?.color
+				}
 				const c = {
-					orig: v?.color || (series.seriesId == '' ? this.settings.defaultColor : this.colorScale(series.seriesId))
+					orig: color || (series.seriesId == '' ? this.settings.defaultColor : this.colorScale(series.seriesId))
 				}
 				c.rgb = rgb(c.orig)
 				c.adjusted = c.rgb.toString()

--- a/client/termsetting/handlers/categorical.ts
+++ b/client/termsetting/handlers/categorical.ts
@@ -124,7 +124,10 @@ export function setCategoryMethods(self: CategoricalTermSettingInstance) {
 		}
 		if (self.q.type == 'custom-groupset') {
 			if (!self.q.customset) return { text: 'q.customset is missing', bgcolor: 'red' }
-			const n = self.q.customset.groups.filter(group => !group.uncomputable).length
+			const n = self.q.customset.groups.filter(group => {
+				if (group.type != 'values') throw `group.type must be 'values'`
+				if (!group.uncomputable) return true
+			}).length
 			return { text: 'Divided into ' + n + ' groups' }
 		}
 		return { text: 'Unknown setting for groupsetting', bgcolor: 'red' }

--- a/client/termsetting/handlers/groupsetting.ts
+++ b/client/termsetting/handlers/groupsetting.ts
@@ -71,6 +71,8 @@ type GrpSetDom = {
 	excludedWrapper: HTMLElement
 }
 
+// TODO: can retire support for .type='filter' as this is now handled by
+// makeGroupUI() in client/termsetting/handlers/geneVariant.ts
 export class GroupSettingMethods {
 	tsInstance: TsInstance // termsetting instance
 	opts: Opts //options for groupsetting

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -2,7 +2,7 @@ import tape from 'tape'
 import type { GvCustomGsQ, RawGvTW, DtTerm } from '#types'
 import { vocabInit } from '#termdb/vocabulary'
 import { GvBase } from '../geneVariant'
-import { mayMakeGroups } from '../geneVariant.ts'
+import { mayMakeGroups } from '../../termsetting/handlers/geneVariant.ts'
 
 /*************************
  reusable helper functions

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -102,11 +102,11 @@ tape('mayMakeGroups: fills groups', async test => {
 		}
 	}
 	await mayMakeGroups(tw, vocabApi)
-	test.equal(tw.q.customset.groups.length, 3, 'Should create 3 groups')
-	const grp1 = tw.q.customset.groups[1]
-	const grp2 = tw.q.customset.groups[2]
-	test.equal(grp1.name, 'Wildtype (somatic)', 'Group 1 name should be Wildtype (somatic)')
-	test.equal(grp2.name, 'SNV/indel (somatic)', 'Group 2 name should be SNV/indel (somatic)')
+	test.equal(tw.q.customset.groups.length, 2, 'Should create 2 groups')
+	const grp1 = tw.q.customset.groups[0]
+	const grp2 = tw.q.customset.groups[1]
+	test.equal(grp1.name, 'SNV/indel Wildtype (somatic)', 'Group 1 should have correct name')
+	test.equal(grp2.name, 'SNV/indel Mutated (somatic)', 'Group 2 should have correct name')
 	test.equal(grp1.filter.lst.length, 1, 'Group 1 filter.lst should have 1 item')
 	test.equal(grp2.filter.lst.length, 1, 'Group 2 filter.lst should have 1 item')
 	const grp1Item = grp1.filter.lst[0]
@@ -121,8 +121,6 @@ tape('mayMakeGroups: fills groups', async test => {
 	test.deepEqual(grp2Value, { key: 'WT', label: 'Wildtype', value: 'WT' }, 'Group 2 value should be a wildtype object')
 	test.false(grp1Item.tvs.isnot, 'Group 1 tvs.isnot should be undefined')
 	test.true(grp2Item.tvs.isnot, 'Group 2 tvs.isnot should be true')
-	const grp0 = tw.q.customset.groups[0]
-	test.true(grp0.uncomputable, 'First group should be uncomputable')
 	test.end()
 })
 
@@ -266,57 +264,8 @@ const customGsQ: GvCustomGsQ = {
 	customset: {
 		groups: [
 			{
-				name: 'Excluded categories',
+				name: 'SNV/indel Wildtype (somatic)',
 				type: 'filter',
-				uncomputable: true,
-				filter: { type: 'tvslst', in: true, join: '', lst: [] }
-			},
-			{
-				name: 'Wildtype (somatic)',
-				type: 'filter',
-				uncomputable: false,
-				filter: {
-					type: 'tvslst',
-					in: true,
-					join: '',
-					lst: [
-						{
-							type: 'tvs',
-							tvs: {
-								term: {
-									id: 'snvindel_somatic',
-									query: 'snvindel',
-									name: 'SNV/indel (somatic)',
-									parent_id: null,
-									isleaf: true,
-									type: 'dtsnvindel',
-									dt: 1,
-									values: {
-										M: { label: 'MISSENSE' },
-										F: { label: 'FRAMESHIFT' },
-										WT: { label: 'Wildtype' }
-									},
-									name_noOrigin: 'SNV/indel',
-									origin: 'somatic',
-									parentTerm: {
-										kind: 'gene',
-										id: 'TP53',
-										gene: 'TP53',
-										name: 'TP53',
-										type: 'geneVariant',
-										groupsetting: { disabled: false }
-									}
-								},
-								values: [{ key: 'WT', label: 'Wildtype', value: 'WT' }]
-							}
-						}
-					]
-				}
-			},
-			{
-				name: 'SNV/indel (somatic)',
-				type: 'filter',
-				uncomputable: false,
 				filter: {
 					type: 'tvslst',
 					in: true,
@@ -350,11 +299,56 @@ const customGsQ: GvCustomGsQ = {
 									}
 								},
 								values: [{ key: 'WT', label: 'Wildtype', value: 'WT' }],
-								isnot: true
+								excludeGeneName: true
 							}
 						}
 					]
-				}
+				},
+				color: '#1b9e77'
+			},
+			{
+				name: 'SNV/indel Mutated (somatic)',
+				type: 'filter',
+				filter: {
+					type: 'tvslst',
+					in: true,
+					join: '',
+					lst: [
+						{
+							type: 'tvs',
+							tvs: {
+								term: {
+									id: 'snvindel_somatic',
+									query: 'snvindel',
+									name: 'SNV/indel (somatic)',
+									parent_id: null,
+									isleaf: true,
+									type: 'dtsnvindel',
+									dt: 1,
+									values: {
+										M: { label: 'MISSENSE' },
+										F: { label: 'FRAMESHIFT' },
+										WT: { label: 'Wildtype' }
+									},
+									name_noOrigin: 'SNV/indel',
+									origin: 'somatic',
+									parentTerm: {
+										kind: 'gene',
+										id: 'TP53',
+										gene: 'TP53',
+										name: 'TP53',
+										type: 'geneVariant',
+										groupsetting: { disabled: false }
+									}
+								},
+								values: [{ key: 'WT', label: 'Wildtype', value: 'WT' }],
+								isnot: true,
+								excludeGeneName: true
+							}
+						}
+					]
+				},
+				color: '#d95f02'
 			}
 		]
 	},

--- a/shared/types/src/filter.ts
+++ b/shared/types/src/filter.ts
@@ -57,6 +57,9 @@ type GeneVariantTvs = BaseTvs & {
 	values: { key: string; label: string; value: string }[]
 	/** boolean for including not tested classes (excluded by default) */
 	includeNotTested?: boolean
+	/** boolean for excluding gene name from pill name (included by default)
+	 * used by geneVariant edit ui to exclude unnecessary gene name */
+	excludeGeneName?: boolean
 }
 
 /*** types supporting Filter type ***/

--- a/shared/types/src/terms/term.ts
+++ b/shared/types/src/terms/term.ts
@@ -123,7 +123,7 @@ export type FilterGroup = {
 	name: string
 	type: 'filter'
 	filter: Filter
-	uncomputable: boolean
+	color: string
 }
 
 export type GroupEntry = ValuesGroup | FilterGroup


### PR DESCRIPTION
# Description

geneVariant groupsetting edit UI now uses a table layout, similar to layout used by the GROUPS tab. Bars in barchart will now follow color scheme specified in groupsetting. Default group names have also been updated.

Can test by opening [mbmeta geneVariant barchart](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22}}}]}) and [gdc geneVariant barchart](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22nav%22:{%22header_mode%22:%22hidden%22},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22IDH1%22}}}]}). Then open edit UI.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
