### PR TITLE
Increase timeout for failing about integration test

### DIFF
--- a/client/mass/test/about.integration.spec.ts
+++ b/client/mass/test/about.integration.spec.ts
@@ -53,10 +53,11 @@ tape('"Active items" in about tab', function (test) {
 		const appInner = about.Inner.app.Inner
 
 		//Give app dispatch time to process
+		//Leave this timeout higher to pass on CI
 		setTimeout(() => {
 			test.equal(appInner.state.plots.length, 1, 'Should create a plot when the active item button is clicked.')
 			if (test['_ok']) about.Inner.app.destroy()
 			test.end()
-		}, 50)
+		}, 150)
 	}
 })


### PR DESCRIPTION
# Description

This test consistently fails on CI. Increasing the timeout ought to fix the problem. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
