### PR TITLE
quick fix to trigger rust unit test when server/test/tp files have c…

### DIFF
--- a/build/requiresTest.sh
+++ b/build/requiresTest.sh
@@ -21,13 +21,14 @@ fi
 
 CHANGEDFILES="$(git diff --name-only HEAD $SHATESTED)"
 
-IS_CODE_OR_CONFIG="f => !f.endsWith('.md') && !f.endsWith('.txt') && !f.endsWith('ignore') && f != 'LICENSE' && f != 'DESCRIPTION'"
+IS_CODE_OR_CONFIG="f => !f.endsWith('.md') && (!f.endsWith('.txt') || f.startsWith('server/test/tp')) && !f.endsWith('ignore') && f != 'LICENSE' && f != 'DESCRIPTION'"
 RELEVANTFILES=$(node -p "(\`$CHANGEDFILES\`).split('\n').filter($IS_CODE_OR_CONFIG).join('\n')")
 # patch is used only to satisfy the version type argument, can be any other allowed value  
 CHANGEDWS="$(./build/bump.js patch -c=$SHATESTED)"
 WS_TO_TEST=""
 for ws in $CHANGEDWS; do
-	if [[ "$RELEVANTFILES" == *"$ws/"* ]]; then
+	# QUICK FIX to detect rust ws as changed when test tp files have changed
+	if [[ "$RELEVANTFILES" == *"$ws/"* || ("$ws" == "rust" && "$RELEVANTFILES" == *"server/test/tp"*) ]]; then
 		WS_TO_TEST="$WS_TO_TEST $ws"
 	fi
 done

--- a/server/test/tp/files/hg38/TermdbTest/fake-test-file.txt
+++ b/server/test/tp/files/hg38/TermdbTest/fake-test-file.txt
@@ -1,0 +1,4 @@
+untrack/delete this file once a permanent fix for rust dep/unit test is merged to master
+
+see https://github.com/stjude/proteinpaint/pull/3542
+


### PR DESCRIPTION
…hanged

# Description

To test locally
- from the pp dir, run `/build/bump.js`, should show `shared/utils shared/types server client front container/server container/full`
- edit any file under `server/test/tp/files/hg38/TermdbTest`, and repeat about, `rust` should be included in the output

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
