### PR TITLE
Removed Summary Plots button and renamed report to Disease Summary

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -191,6 +191,12 @@ function getChartTypeList(self, state) {
 			config: { chartType: 'report' }
 		},
 		{
+			label: 'Disease Summary',
+			chartType: 'diseaseSummary', //The real chart type is report but we use here the chartType used in isSupportedChartOverride to show this button instead	of report
+			clickTo: self.plotCreate, //when using prepPlot this error was raised: No plot with id='${this.id}' found. Did you set this.id before this.api = getComponentApi(this). TOD0: check with Edgar
+			config: { chartType: 'report', name: 'Disease Summary' }
+		},
+		{
 			label: 'Sample View',
 			clickTo: self.prepPlot,
 			chartType: 'sampleView',
@@ -199,12 +205,6 @@ function getChartTypeList(self, state) {
 			}
 		},
 
-		{
-			label: 'Summary Plots',
-			chartType: 'summary',
-			clickTo: self.showTree_select1term,
-			usecase: { target: 'summary', detail: 'term' }
-		},
 		{
 			label: self.getSamplescatterBtnLabel(state),
 			chartType: 'sampleScatter',

--- a/client/plots/report/view/reportView.ts
+++ b/client/plots/report/view/reportView.ts
@@ -32,7 +32,8 @@ export class ReportView {
 		}
 
 		if (this.dom.header) {
-			this.dom.header.html(this.report.config.name || 'Summary Report')
+			const name = this.report.config.name || 'Summary Report'
+			this.dom.header.html(name)
 		}
 		document.addEventListener('scroll', () => this?.dom?.tooltip?.hide())
 		select('.sjpp-output-sandbox-content').on('scroll', () => this.dom.tooltip.hide())

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -35,7 +35,7 @@ export default function (): Mds3 {
 		isSupportedChartOverride: {
 			runChart: () => true,
 			frequencyChart: () => true,
-			report: () => true
+			diseaseSummary: () => true
 		},
 		cohort: {
 			massNav: {


### PR DESCRIPTION
# Description

Removed Summary Plots button as agreed and renamed the Report button to Disease Summary for some datasets. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/927).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
