### PR TITLE
Fix samplelst filter in the barchart when listing the samples

### DIFF
--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -983,6 +983,12 @@ export function getSamplelstTWFromIds(ids) {
 	return tw
 }
 
+export function getSamplelstFilter(ids) {
+	const tw = getSamplelstTWFromIds(ids)
+	const filter = getFilter(tw)
+	return filter
+}
+
 export function getFilter(samplelstTW) {
 	let i = 0
 	let noEdit = true

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -6,7 +6,7 @@ import { rgb } from 'd3-color'
 import { roundValueAuto } from '#shared/roundValue.js'
 import { isNumericTerm } from '#shared/terms.js'
 import { negateTermLabel } from './barchart'
-import { mclass } from '#shared/common.js'
+import { getSamplelstFilter } from '../mass/groups.js'
 
 export default function getHandlers(self) {
 	const tip = new Menu({ padding: '5px' })
@@ -603,7 +603,7 @@ async function listSamples(event, self, seriesId, dataId, chartId) {
 
 	function getTvs(termIndex, value) {
 		const term = termIndex == 0 ? self.config.term0 : termIndex == 1 ? self.config.term : self.config.term2
-		const tvs = {
+		let tvs = {
 			type: 'tvs',
 			tvs: {
 				term: term.term,
@@ -613,6 +613,11 @@ async function listSamples(event, self, seriesId, dataId, chartId) {
 		if (isNumericTerm(term.term)) {
 			const bins = self.bins[termIndex]
 			tvs.tvs.ranges = [bins.find(bin => bin.label == value)]
+		} else if (term.term.type == 'samplelst') {
+			const list = term.term.values?.[value]?.list || []
+			const ids = list.map(s => s.sampleId)
+			const tvslst = getSamplelstFilter(ids)
+			tvs = tvslst.lst[0] // tvslst only has the tvs for the samplelst term
 		} else if (term.term.type == 'geneVariant' && term.q.type == 'values') {
 			throw 'no longer supported in barchart'
 			/*** code below was used to list samples for geneVariant term with q.type='values', but now only geneVariant with groupsetting is used in barchart ***/

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -130,6 +130,7 @@ export async function barchart_data(q, ds, tdb) {
 				const q = map.get(i)?.q
 				const tw = map.get(i)
 				const term = tw?.term || null
+
 				const id = tw?.$id
 				if (id && data.refs.byTermId[id]?.bins) bins.push(data.refs.byTermId[id]?.bins)
 				else bins.push([])


### PR DESCRIPTION
# Description

When opening a barchart for a samplelst term, made from the groups tab, there was an issue with the list samples. It needed to filter by the category selected. This fixes the issue by passing the samplelst filter when listing samples. This bug was found  by @karishma-gangwani.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
