### PR TITLE
Disco Issue.867.legend improvements

### DIFF
--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -603,8 +603,17 @@ function setCheckboxInput(opts) {
 
 /*
 	Use for array of allowed values
+
+	Use opts.style to control the checkboxes layout
+	style: {
+		colNum: number -> number of columns to display
+		gap: number -> gap between columns
+	}
 */
 function setMultiCheckbox(opts) {
+	const numCols = opts.style?.colNum || 2
+	const numRows = Math.ceil(opts.options.length / numCols)
+
 	const self = {
 		dom: {
 			row: opts.holder.style('display', 'table-row'),
@@ -616,8 +625,14 @@ function setMultiCheckbox(opts) {
 			inputTd: opts.holder
 				.append('td')
 				.attr('colspan', opts.colspan || '')
-				.style('padding', '5px')
 				.style('text-align', opts.align || '')
+				.style('padding', '5px')
+				.append('div')
+				.style('display', 'grid')
+				.style('grid-template-columns', `repeat(${numCols}, 1fr)`)
+				.style('grid-template-rows', `repeat(${numRows}, auto)`)
+				.style('grid-auto-flow', 'column')
+				.style('gap', `${opts.style.gap || 5}px`)
 		}
 	}
 

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -659,7 +659,7 @@ function setMultiCheckbox(opts) {
 						config: {
 							settings: {
 								[opts.chartType]: {
-									[opts.settingsKey]: checked
+									[opts.settingsKey]: opts.processInput?.(checked) || checked
 								}
 							}
 						}
@@ -674,7 +674,8 @@ function setMultiCheckbox(opts) {
 	const api = {
 		main(plot) {
 			const values = plot.settings[opts.chartType][opts.settingsKey]
-			self.dom.inputs.property('checked', d => values.includes(d.value))
+			const checkedValues = opts.processInput?.(values) || values
+			self.dom.inputs.property('checked', d => checkedValues.includes(d.value))
 			self.dom.labels.style('display', d => d.getDisplayStyle?.(plot) || '')
 			opts.holder.style('display', opts.getDisplayStyle?.(plot) || 'table-row')
 		}

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -46,18 +46,7 @@ export default class Disco {
 
 	async init() {
 		const state = this.app.getState()
-		const genomeChrs = Object.keys(this.app.opts.state.args.genome.majorchr)
-		let settings = state.plots.find(p => p.id === this.id).settings
-
-		if (!settings.Disco.selectedChromosomes || !settings.Disco.selectedChromosomes.length) {
-			await this.app.dispatch({
-				type: 'plot_edit',
-				id: this.id,
-				config: { settings: { Disco: { selectedChromosomes: genomeChrs } } }
-			})
-			const updatedState = this.app.getState()
-			settings = updatedState.plots.find(p => p.id === this.id).settings
-		}
+		const settings = state.plots.find(p => p.id === this.id).settings
 
 		this.stateViewModelMapper = new ViewModelMapper(settings, this.discoInteractions)
 		this.viewModel = this.stateViewModelMapper.map(state)
@@ -135,7 +124,7 @@ export default class Disco {
 			title: 'Select chromosomes to display',
 			type: 'multiCheckbox',
 			chartType: 'Disco',
-			settingsKey: 'selectedChromosomes',
+			settingsKey: 'hiddenChromosomes',
 			options: Object.keys(genomeChr).map(c => ({ label: c, value: c }))
 		}
 

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -120,15 +120,23 @@ export default class Disco {
 
 		const genomeChr = this.app.opts.state.args.genome.majorchr
 		const chromosomeConfigOption = {
-			label: 'Hidden chromosomes',
-			title: 'Hide chromosomes in the plot',
+			label: 'Chromosomes',
+			title: 'Chromosomes shown in the plot',
 			type: 'multiCheckbox',
 			chartType: 'Disco',
 			settingsKey: 'hiddenChromosomes',
 			style: {
 				colNum: 4
 			},
-			options: Object.keys(genomeChr).map(c => ({ label: c, value: c }))
+			options: Object.keys(genomeChr).map(c => ({ label: c, value: c })),
+			processInput: (values: string[] = []) => {
+				/** Show all chromosomes as checked by default but only
+				 * save to the state hidden (unchecked) chromosomes.
+				 * Allows for easier debugging, reduces user error when
+				 * embedding, and code clarity. */
+				const reverse = Object.keys(genomeChr).filter(c => !values.includes(c))
+				return reverse
+			}
 		}
 
 		configInputsOptions.push(chromosomeConfigOption)

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -46,7 +46,18 @@ export default class Disco {
 
 	async init() {
 		const state = this.app.getState()
-		const settings = state.plots.find(p => p.id === this.id).settings
+		const genomeChrs = Object.keys(this.app.opts.state.args.genome.majorchr)
+		let settings = state.plots.find(p => p.id === this.id).settings
+
+		if (!settings.Disco.selectedChromosomes || !settings.Disco.selectedChromosomes.length) {
+			await this.app.dispatch({
+				type: 'plot_edit',
+				id: this.id,
+				config: { settings: { Disco: { selectedChromosomes: genomeChrs } } }
+			})
+			const updatedState = this.app.getState()
+			settings = updatedState.plots.find(p => p.id === this.id).settings
+		}
 
 		this.stateViewModelMapper = new ViewModelMapper(settings, this.discoInteractions)
 		this.viewModel = this.stateViewModelMapper.map(state)
@@ -117,6 +128,18 @@ export default class Disco {
 			]
 			configInputsOptions.push(...cnvConfigInputOptions)
 		}
+
+		const genomeChr = this.app.opts.state.args.genome.majorchr
+		const chromosomeConfigOption = {
+			label: 'Chromosomes',
+			title: 'Select chromosomes to display',
+			type: 'multiCheckbox',
+			chartType: 'Disco',
+			settingsKey: 'selectedChromosomes',
+			options: Object.keys(genomeChr).map(c => ({ label: c, value: c }))
+		}
+
+		configInputsOptions.push(chromosomeConfigOption)
 
 		const dimensionOptions = [
 			{

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -120,11 +120,14 @@ export default class Disco {
 
 		const genomeChr = this.app.opts.state.args.genome.majorchr
 		const chromosomeConfigOption = {
-			label: 'Hide chromosomes',
+			label: 'Hidden chromosomes',
 			title: 'Hide chromosomes in the plot',
 			type: 'multiCheckbox',
 			chartType: 'Disco',
 			settingsKey: 'hiddenChromosomes',
+			style: {
+				colNum: 4
+			},
 			options: Object.keys(genomeChr).map(c => ({ label: c, value: c }))
 		}
 

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -257,11 +257,11 @@ export const discoInit = getCompInit(Disco)
 
 export const componentInit = discoInit
 
-export async function getPlotConfig(opts: any) {
+export async function getPlotConfig(opts: any, app: any) {
 	return {
 		chartType: 'Disco',
 		subfolder: 'disco',
 		extension: 'ts',
-		settings: discoDefaults(opts.overrides)
+		settings: discoDefaults(opts.overrides, app)
 	}
 }

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -120,8 +120,8 @@ export default class Disco {
 
 		const genomeChr = this.app.opts.state.args.genome.majorchr
 		const chromosomeConfigOption = {
-			label: 'Chromosomes',
-			title: 'Select chromosomes to display',
+			label: 'Hide chromosomes',
+			title: 'Hide chromosomes in the plot',
 			type: 'multiCheckbox',
 			chartType: 'Disco',
 			settingsKey: 'hiddenChromosomes',
@@ -262,6 +262,6 @@ export async function getPlotConfig(opts: any, app: any) {
 		chartType: 'Disco',
 		subfolder: 'disco',
 		extension: 'ts',
-		settings: discoDefaults(opts.overrides, app)
+		settings: discoDefaults(opts.settings, app)
 	}
 }

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -19,8 +19,8 @@ export default interface Settings {
 		/** auto, fixed, percentile. Used for the numeric inputs dropdown
 		 * for cnv color scales. */
 		cnvCutoffMode: string
-
-		selectedChromosomes?: string[]
+		/** Chromosomes not rendered */
+		hiddenChromosomes: string[]
 	}
 
 	rings: {

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -4,7 +4,7 @@ export default interface Settings {
 
 	downloadImgName: string // file name of downloaded svg
 
-    Disco: {
+	Disco: {
 		/** Global radius controlling ring size */
 		radius?: number
 		/** Opacity of the fusion arcs */
@@ -19,6 +19,8 @@ export default interface Settings {
 		/** auto, fixed, percentile. Used for the numeric inputs dropdown
 		 * for cnv color scales. */
 		cnvCutoffMode: string
+
+		selectedChromosomes?: string[]
 	}
 
 	rings: {

--- a/client/plots/disco/chromosome/Reference.ts
+++ b/client/plots/disco/chromosome/Reference.ts
@@ -62,8 +62,8 @@ export default class Reference {
 				startAngle: startAngle,
 				endAngle: endAngle,
 				angle: (startAngle + endAngle) / 2,
-				innerRadius: this.settings.chromosomeInnerRadius,
-				outerRadius: this.settings.chromosomeInnerRadius + this.settings.chromosomeWidth,
+				innerRadius: this.settings.rings.chromosomeInnerRadius,
+				outerRadius: this.settings.rings.chromosomeInnerRadius + this.settings.rings.chromosomeWidth,
 				color: '#AAA',
 				text: this.keysArray[i]
 			}

--- a/client/plots/disco/chromosome/Reference.ts
+++ b/client/plots/disco/chromosome/Reference.ts
@@ -1,4 +1,5 @@
 import type Chromosome from './Chromosome.ts'
+import type Settings from '../Settings.ts'
 
 export default class Reference {
 	chromosomes: Array<Chromosome> = []
@@ -12,10 +13,20 @@ export default class Reference {
 	private totalSizeArray: Array<number> = []
 	private chrSizesArray: Array<number> = []
 
-	private settings: any
+	private settings: Settings
 
-	constructor(settings: any, chromosomes: any, selectedChromosomes?: any) {
-		const chrSizes = selectedChromosomes || chromosomes
+	/**
+	 * Creates a Reference object that contains information about chromosomes.
+	 * @param settings State settings
+	 * @param chromosomes Chromosome order. This function formats into an obj with `chr` removed.
+	 * @param chromosomeOverride Obj of chromsome keys and sizes. Filtered to remove hidden chromosomes in settings.
+	 */
+	constructor(
+		settings: Settings,
+		chromosomes: string[] | { [chromosome: string]: number },
+		chromosomeOverride?: { [chromosome: string]: number }
+	) {
+		const chrSizes = chromosomeOverride || chromosomes
 
 		this.settings = settings
 

--- a/client/plots/disco/chromosome/Reference.ts
+++ b/client/plots/disco/chromosome/Reference.ts
@@ -14,8 +14,8 @@ export default class Reference {
 
 	private settings: any
 
-	constructor(settings: any, chromosomes: any, chromosomesOverride?: any) {
-		const chrSizes = chromosomesOverride || chromosomes
+	constructor(settings: any, chromosomes: any, selectedChromosomes?: any) {
+		const chrSizes = selectedChromosomes || chromosomes
 
 		this.settings = settings
 

--- a/client/plots/disco/chromosome/test/ReferenceTest.unit.spec.ts
+++ b/client/plots/disco/chromosome/test/ReferenceTest.unit.spec.ts
@@ -12,11 +12,13 @@ Tests:
 
 const overriders = {
 	padAngle: 0.01,
-	chromosomeInnerRadius: 90,
-	chromosomeWidth: 10
+	rings: {
+		chromosomeInnerRadius: 90,
+		chromosomeWidth: 10
+	}
 }
 const settings = discoDefaults(overriders)
-const chromosomesOrder = ['chr1', 'chr2']
+const chromosomesOrder = ['chr1', 'chr2', 'chr3']
 
 // Mock chromosome sizes (normally coming from genome data)
 const chromosomes = {
@@ -42,7 +44,6 @@ test('Reference class initializes correctly', t => {
 	// Check that totalSize matches the sum of the chromosome sizes
 	const expectedTotalSize = chromosomes.chr1 + chromosomes.chr2 + chromosomes.chr3
 	t.equal(reference.totalSize, expectedTotalSize, 'Total size should match sum of chromosome sizes')
-	t.equal(reference.totalSize, expectedTotalSize, 'Total size should match sum of chromosome sizes')
 
 	// Verify totalPadAngle is calculated correctly
 	const expectedPadAngle = 3 * overriders.padAngle
@@ -58,9 +59,12 @@ test('Reference class initializes correctly', t => {
 	// Validate the angles and radius properties on each Chromosome
 	reference.chromosomes.forEach((chr, i) => {
 		t.ok(chr.startAngle < chr.endAngle, `Chromosome ${i} startAngle should be less than endAngle`)
-		t.ok(chr.innerRadius === overriders.chromosomeInnerRadius, `Chromosome ${i} inner radius should match setting`)
 		t.ok(
-			chr.outerRadius === overriders.chromosomeInnerRadius + overriders.chromosomeWidth,
+			chr.innerRadius === overriders.rings.chromosomeInnerRadius,
+			`Chromosome ${i} inner radius should match setting`
+		)
+		t.ok(
+			chr.outerRadius === overriders.rings.chromosomeInnerRadius + overriders.rings.chromosomeWidth,
 			`Chromosome ${i} outer radius should match setting`
 		)
 	})

--- a/client/plots/disco/chromosome/test/ReferenceTest.unit.spec.ts
+++ b/client/plots/disco/chromosome/test/ReferenceTest.unit.spec.ts
@@ -16,6 +16,7 @@ const overriders = {
 	chromosomeWidth: 10
 }
 const settings = discoDefaults(overriders)
+const chromosomesOrder = ['chr1', 'chr2']
 
 // Mock chromosome sizes (normally coming from genome data)
 const chromosomes = {
@@ -32,7 +33,7 @@ test('\n', function (t) {
 
 // ───── Unit Tests ─────
 test('Reference class initializes correctly', t => {
-	const reference = new Reference(settings, chromosomes)
+	const reference = new Reference(settings, chromosomesOrder, chromosomes)
 
 	//Check that all chromosome keys are recorded in order
 	t.equal(reference.chromosomesOrder.length, 3, 'should imclude all chromosome keys')

--- a/client/plots/disco/cnv/test/CnvArcsMapperTest.unit.spec.ts
+++ b/client/plots/disco/cnv/test/CnvArcsMapperTest.unit.spec.ts
@@ -9,12 +9,13 @@ const overriders = { padAngle: 0.0 }
 const settings = discoDefaults(overriders)
 
 const sampleName = 'Sample'
+const chromosomesOrder = ['chr1', 'chr2']
 const chromosomes = {
 	chr1: 100,
 	chr2: 100
 }
 
-const reference = new Reference(settings, chromosomes)
+const reference = new Reference(settings, chromosomesOrder, chromosomes)
 
 const rawData = [
 	{

--- a/client/plots/disco/data/DataMapper.ts
+++ b/client/plots/disco/data/DataMapper.ts
@@ -77,17 +77,11 @@ export default class DataMapper {
 		return aPos - bPos
 	}
 
-	constructor(
-		settings: Settings,
-		reference: Reference,
-		sample: string,
-		prioritizedGenes: Array<string> = [],
-		excludedChromosomes: string[] = []
-	) {
+	constructor(settings: Settings, reference: Reference, sample: string, prioritizedGenes: Array<string> = []) {
 		this.settings = settings
 		this.reference = reference
 		this.sample = sample
-		this.excludedChromosomes = excludedChromosomes
+		this.excludedChromosomes = this.settings.Disco.hiddenChromosomes
 		this.lastInnerRadious = this.settings.rings.chromosomeInnerRadius
 
 		this.gainCapped = this.settings.Disco.cnvCapping

--- a/client/plots/disco/data/test/DataMapper.unit.spec.ts
+++ b/client/plots/disco/data/test/DataMapper.unit.spec.ts
@@ -19,9 +19,9 @@ const settings = discoDefaults({
 	},
 	rings: {}
 })
-
+const chromosomesOrder = ['chr1', 'chr2']
 const chromosomes = { chr1: 1000000, chr2: 100000 }
-const reference = new Reference(settings, chromosomes)
+const reference = new Reference(settings, chromosomesOrder, chromosomes)
 
 const dataMapper = new DataMapper(settings, reference, 'SampleA', [])
 
@@ -63,29 +63,33 @@ test('\n', function (t) {
 })
 
 test('DataMapper.map() skips fusion entries with unknown chromosomes', t => {
-        t.equal(result.fusionData.length, 1, 'Only valid fusion with known chromosomes should be included')
-        t.equal(result.fusionData[0].geneA, 'ALK', 'Valid fusion geneA should be ALK')
-        t.equal(result.fusionData[0].geneB, 'EML4', 'Valid fusion geneB should be EML4')
-		t.equal(result.invalidDataInfo?.count ?? 0, 2, 'Two invalid entries should be recorded')
-        t.end()
+	t.equal(result.fusionData.length, 1, 'Only valid fusion with known chromosomes should be included')
+	t.equal(result.fusionData[0].geneA, 'ALK', 'Valid fusion geneA should be ALK')
+	t.equal(result.fusionData[0].geneB, 'EML4', 'Valid fusion geneB should be EML4')
+	t.equal(result.invalidDataInfo?.count ?? 0, 2, 'Two invalid entries should be recorded')
+	t.end()
 })
 
 test('DataMapper.map() flags SNV positions outside chromosome size', t => {
-        const mapper = new DataMapper(settings, reference, 'SampleA', [])
-        const outOfRange = [
-                {
-                        dt: dtsnvindel,
-                        chr: 'chr1',
-						//Exaggerated position outsie chr1,adds entry to invalidDataInfo
-                        position: 9000000000, 
-                        gene: 'FAKE',
-                        class: 'M',
-                        mname: 'mname'
-                }
-        ]
-        const res = mapper.map(outOfRange)
-        t.equal(res.invalidDataInfo!.count, 1, 'One invalid entry should be recorded')
-		t.equal(res.invalidDataInfo!.entries[0].reason, `Position ${outOfRange[0].position} outside of chr1`, 'Reason should mention position outside chromosome')
-        t.equal(res.snvData.length, 0, 'Invalid SNV should be skipped')
-        t.end()
+	const mapper = new DataMapper(settings, reference, 'SampleA', [])
+	const outOfRange = [
+		{
+			dt: dtsnvindel,
+			chr: 'chr1',
+			//Exaggerated position outsie chr1,adds entry to invalidDataInfo
+			position: 9000000000,
+			gene: 'FAKE',
+			class: 'M',
+			mname: 'mname'
+		}
+	]
+	const res = mapper.map(outOfRange)
+	t.equal(res.invalidDataInfo!.count, 1, 'One invalid entry should be recorded')
+	t.equal(
+		res.invalidDataInfo!.entries[0].reason,
+		`Position ${outOfRange[0].position} outside of chr1`,
+		'Reason should mention position outside chromosome'
+	)
+	t.equal(res.snvData.length, 0, 'Invalid SNV should be skipped')
+	t.end()
 })

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -16,7 +16,8 @@ export default function discoDefaults(overrides: any = {}): Settings {
 			cnvPercentile: 90, // 90th percentile for removing outliers
 			cnvCutoffMode: 'percentile',
 			radius: 300,
-			fusionOpacity: 1
+			fusionOpacity: 1,
+			selectedChromosomes: []
 		},
 
 		rings: {

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -2,7 +2,13 @@ import type Settings from './Settings'
 import { copyMerge } from '#rx'
 import { CnvRenderingType } from '#plots/disco/cnv/CnvRenderingType.ts'
 
-export default function discoDefaults(overrides: any = {}): Settings {
+export default function discoDefaults(overrides: any = {}, app: any): Settings {
+	const hiddenChromosomes: string[] = []
+	//TODO: Change skipChrM into Set to accept multiple chromosomes
+	if (app.vocabApi?.termdbConfig?.queries?.singleSampleMutation?.discoPlot?.skipChrM) {
+		hiddenChromosomes.push('chrM')
+	}
+
 	const defaults = {
 		downloadImgName: 'disco.plot',
 
@@ -17,7 +23,7 @@ export default function discoDefaults(overrides: any = {}): Settings {
 			cnvCutoffMode: 'percentile',
 			radius: 300,
 			fusionOpacity: 1,
-			hiddenChromosomes: []
+			hiddenChromosomes
 		},
 
 		rings: {

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -2,10 +2,10 @@ import type Settings from './Settings'
 import { copyMerge } from '#rx'
 import { CnvRenderingType } from '#plots/disco/cnv/CnvRenderingType.ts'
 
-export default function discoDefaults(overrides: any = {}, app: any): Settings {
+export default function discoDefaults(overrides: any = {}, app?: any): Settings {
 	const hiddenChromosomes: string[] = []
 	//TODO: Change skipChrM into Set to accept multiple chromosomes
-	if (app.vocabApi?.termdbConfig?.queries?.singleSampleMutation?.discoPlot?.skipChrM) {
+	if (app?.vocabApi?.termdbConfig?.queries?.singleSampleMutation?.discoPlot?.skipChrM) {
 		hiddenChromosomes.push('chrM')
 	}
 

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -17,7 +17,7 @@ export default function discoDefaults(overrides: any = {}): Settings {
 			cnvCutoffMode: 'percentile',
 			radius: 300,
 			fusionOpacity: 1,
-			selectedChromosomes: []
+			hiddenChromosomes: []
 		},
 
 		rings: {

--- a/client/plots/disco/fusion/test/FusionMapperTest.unit.spec.ts
+++ b/client/plots/disco/fusion/test/FusionMapperTest.unit.spec.ts
@@ -9,12 +9,13 @@ const overriders = { padAngle: 0.0 }
 const settings = discoDefaults(overriders)
 
 const sampleName = 'Sample'
+const chromosomesOrder = ['chr1', 'chr2']
 const chromosomes = {
 	chr1: 100,
 	chr2: 100
 }
 
-const reference = new Reference(settings, chromosomes)
+const reference = new Reference(settings, chromosomesOrder, chromosomes)
 const fusionMapper = new FusionMapper(10, sampleName, reference)
 
 test('FusionMapper.map() should return an array of Fusion objects', t => {

--- a/client/plots/disco/launch.adhoc.ts
+++ b/client/plots/disco/launch.adhoc.ts
@@ -82,6 +82,7 @@ export type DiscoPlotArgs = {
 	cnvText?: string
 	cnvFile?: string
 	cnvUrl?: string
+	settings?: any
 }
 
 //... more datatypes can be added later
@@ -124,7 +125,8 @@ export async function launch(arg: DiscoPlotArgs, genomeObj: Genome, holder: Sele
 				{
 					chartType: 'Disco',
 					subfolder: 'disco',
-					extension: 'ts'
+					extension: 'ts',
+					settings: arg.settings || {} // use provided settings or empty object
 					/*
 					overrides: {
 						Disco: {

--- a/client/plots/disco/loh/test/LohArcMapper.unit.spec.ts
+++ b/client/plots/disco/loh/test/LohArcMapper.unit.spec.ts
@@ -24,6 +24,8 @@ const settings = discoDefaults(overriders)
 // Represents the label used to identify the sample (not a data type like `dt`).
 const sampleName = 'sample'
 
+const chromosomesOrder = ['chr1', 'chr2']
+
 // Defines chromosome lengths in base pairs.
 // Each chromosome is assigned 100 units; since a circle spans 0 to 2π,
 // this maps each chromosome to π radians.
@@ -34,7 +36,7 @@ const chromosomes = {
 
 // Initializes a genome reference object with chromosome definitions
 // and logic to convert base pair positions to angles.
-const reference = new Reference(settings, chromosomes)
+const reference = new Reference(settings, chromosomesOrder, chromosomes)
 
 test('LohArcMapper.map() should return an array of LohArc objects', function (t) {
 	const rawData = [

--- a/client/plots/disco/snv/test/NonExonicSnvArcsMapper.unit.spec.ts
+++ b/client/plots/disco/snv/test/NonExonicSnvArcsMapper.unit.spec.ts
@@ -16,12 +16,13 @@ const overriders = { padAngle: 0.0 }
 const settings = discoDefaults(overriders)
 
 const sampleName = 'Sample'
+const chromosomesOrder = ['chr1', 'chr2']
 const chromosomes = {
 	chr1: 1000,
 	chr2: 1000
 }
 
-const reference = new Reference(settings, chromosomes)
+const reference = new Reference(settings, chromosomesOrder, chromosomes)
 const nonExonicSnvArcsMapper = new NonExonicSnvArcsMapper(10, 10, sampleName, reference)
 
 // ───── Test Banner ─────

--- a/client/plots/disco/snv/test/SnvArcMapperTest.unit.spec.ts
+++ b/client/plots/disco/snv/test/SnvArcMapperTest.unit.spec.ts
@@ -10,12 +10,13 @@ const settings = discoDefaults(overriders)
 
 // TODO - Fix this test if chr is length 100
 const sampleName = 'Sample'
+const chromosomesOrder = ['chr1', 'chr2']
 const chromosomes = {
 	chr1: 100000,
 	chr2: 100000
 }
 
-const reference = new Reference(settings, chromosomes)
+const reference = new Reference(settings, chromosomesOrder, chromosomes)
 const snvArcsMapper = new SnvArcsMapper(10, 10, sampleName, reference)
 
 test('SnvArcsMapper.map() should return an array of SnvArc objects', t => {

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -36,7 +36,7 @@ export class ViewModelMapper {
 		// a mutable copy so ring dimensions can be adjusted at runtime
 		this.settings = JSON.parse(JSON.stringify(settings))
 		this.discoInteractions = discoInteractions
-    }
+	}
 
 	private applyRadius() {
 		const radius = this.settings.Disco.radius
@@ -56,10 +56,25 @@ export class ViewModelMapper {
 		this.settings.legend.fontSize *= scale
 	}
 
-    map(opts: any): ViewModel {
-		const chromosomesOverride = opts.args.chromosomes
+	map(opts: any): ViewModel {
+		let chromosomesOverride = opts.args.chromosomes
 
 		const chrSizes = opts.args.genome.majorchr
+		let excludedChromosomes: string[] = []
+
+		if (
+			!chromosomesOverride &&
+			Array.isArray(this.settings.Disco.selectedChromosomes) &&
+			this.settings.Disco.selectedChromosomes.length
+		) {
+			chromosomesOverride = {}
+			for (const chr of this.settings.Disco.selectedChromosomes) {
+				if (chrSizes[chr]) chromosomesOverride[chr] = chrSizes[chr]
+			}
+			excludedChromosomes = Object.keys(chrSizes).filter(c => !this.settings.Disco.selectedChromosomes!.includes(c))
+		} else if (chromosomesOverride) {
+			excludedChromosomes = Object.keys(chrSizes).filter(c => !(c in chromosomesOverride))
+		}
 
 		const sampleName = opts.args.sampleName
 
@@ -75,7 +90,7 @@ export class ViewModelMapper {
 
 		const reference = new Reference(this.settings, chrSizes, chromosomesOverride)
 
-		const dataMapper = new DataMapper(this.settings, reference, sampleName, prioritizedGenes)
+		const dataMapper = new DataMapper(this.settings, reference, sampleName, prioritizedGenes, excludedChromosomes)
 
 		return new ViewModelProvider(
 			this.settings,

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -62,7 +62,7 @@ export class ViewModelMapper {
 		/** Remove hidden chromosomes */
 		const chromosomeOverride = {}
 		for (const chr of Object.keys(chrSizes)) {
-			if (!this.settings.Disco.hiddenChromosomes!.includes(chr)) {
+			if (!this.settings.Disco.hiddenChromosomes.includes(chr)) {
 				chromosomeOverride[chr] = chrSizes[chr]
 			}
 		}

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -57,23 +57,23 @@ export class ViewModelMapper {
 	}
 
 	map(opts: any): ViewModel {
-		let chromosomesOverride = opts.args.chromosomes
+		let selectedChromosomes = opts.args.chromosomes
 
 		const chrSizes = opts.args.genome.majorchr
 		let excludedChromosomes: string[] = []
 
 		if (
-			!chromosomesOverride &&
+			!selectedChromosomes &&
 			Array.isArray(this.settings.Disco.selectedChromosomes) &&
 			this.settings.Disco.selectedChromosomes.length
 		) {
-			chromosomesOverride = {}
+			selectedChromosomes = {}
 			for (const chr of this.settings.Disco.selectedChromosomes) {
-				if (chrSizes[chr]) chromosomesOverride[chr] = chrSizes[chr]
+				if (chrSizes[chr]) selectedChromosomes[chr] = chrSizes[chr]
 			}
 			excludedChromosomes = Object.keys(chrSizes).filter(c => !this.settings.Disco.selectedChromosomes!.includes(c))
-		} else if (chromosomesOverride) {
-			excludedChromosomes = Object.keys(chrSizes).filter(c => !(c in chromosomesOverride))
+		} else if (selectedChromosomes) {
+			excludedChromosomes = Object.keys(chrSizes).filter(c => !(c in selectedChromosomes))
 		}
 
 		const sampleName = opts.args.sampleName
@@ -88,7 +88,7 @@ export class ViewModelMapper {
 
 		this.applyRadius()
 
-		const reference = new Reference(this.settings, chrSizes, chromosomesOverride)
+		const reference = new Reference(this.settings, chrSizes, selectedChromosomes)
 
 		const dataMapper = new DataMapper(this.settings, reference, sampleName, prioritizedGenes, excludedChromosomes)
 

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -62,6 +62,14 @@ export class ViewModelMapper {
 		const chrSizes = opts.args.genome.majorchr
 		let excludedChromosomes: string[] = []
 
+		// Determine which chromosomes should be visualized. When
+		// `selectedChromosomes` is not provided as an argument, fall back
+		// to `settings.Disco.selectedChromosomes` and construct a mapping
+		// of valid chromosomes. Any chromosomes omitted from that list are
+		// considered excluded. If `selectedChromosomes` is given, compute
+		// the excluded set by comparing it to the full list of reference
+		// chromosomes.
+
 		if (
 			!selectedChromosomes &&
 			Array.isArray(this.settings.Disco.selectedChromosomes) &&

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -60,10 +60,10 @@ export class ViewModelMapper {
 		const chrSizes = opts.args.genome.majorchr
 
 		/** Remove hidden chromosomes */
-		const chromosomeOverride = {}
+		const chromosomesOverride = {}
 		for (const chr of Object.keys(chrSizes)) {
 			if (!this.settings.Disco.hiddenChromosomes.includes(chr)) {
-				chromosomeOverride[chr] = chrSizes[chr]
+				chromosomesOverride[chr] = chrSizes[chr]
 			}
 		}
 
@@ -79,7 +79,7 @@ export class ViewModelMapper {
 
 		this.applyRadius()
 
-		const reference = new Reference(this.settings, chrSizes, chromosomeOverride)
+		const reference = new Reference(this.settings, chrSizes, chromosomesOverride)
 
 		const dataMapper = new DataMapper(this.settings, reference, sampleName, prioritizedGenes)
 

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -57,31 +57,14 @@ export class ViewModelMapper {
 	}
 
 	map(opts: any): ViewModel {
-		let selectedChromosomes = opts.args.chromosomes
-
 		const chrSizes = opts.args.genome.majorchr
-		let excludedChromosomes: string[] = []
 
-		// Determine which chromosomes should be visualized. When
-		// `selectedChromosomes` is not provided as an argument, fall back
-		// to `settings.Disco.selectedChromosomes` and construct a mapping
-		// of valid chromosomes. Any chromosomes omitted from that list are
-		// considered excluded. If `selectedChromosomes` is given, compute
-		// the excluded set by comparing it to the full list of reference
-		// chromosomes.
-
-		if (
-			!selectedChromosomes &&
-			Array.isArray(this.settings.Disco.selectedChromosomes) &&
-			this.settings.Disco.selectedChromosomes.length
-		) {
-			selectedChromosomes = {}
-			for (const chr of this.settings.Disco.selectedChromosomes) {
-				if (chrSizes[chr]) selectedChromosomes[chr] = chrSizes[chr]
+		/** Remove hidden chromosomes */
+		const chromosomeOverride = {}
+		for (const chr of Object.keys(chrSizes)) {
+			if (!this.settings.Disco.hiddenChromosomes!.includes(chr)) {
+				chromosomeOverride[chr] = chrSizes[chr]
 			}
-			excludedChromosomes = Object.keys(chrSizes).filter(c => !this.settings.Disco.selectedChromosomes!.includes(c))
-		} else if (selectedChromosomes) {
-			excludedChromosomes = Object.keys(chrSizes).filter(c => !(c in selectedChromosomes))
 		}
 
 		const sampleName = opts.args.sampleName
@@ -96,9 +79,9 @@ export class ViewModelMapper {
 
 		this.applyRadius()
 
-		const reference = new Reference(this.settings, chrSizes, selectedChromosomes)
+		const reference = new Reference(this.settings, chrSizes, chromosomeOverride)
 
-		const dataMapper = new DataMapper(this.settings, reference, sampleName, prioritizedGenes, excludedChromosomes)
+		const dataMapper = new DataMapper(this.settings, reference, sampleName, prioritizedGenes)
 
 		return new ViewModelProvider(
 			this.settings,


### PR DESCRIPTION
Addresses the first item under Phase 2-> Legend improvements -> "Show ui option to list chromosomes ..." in https://github.com/stjude/sjpp/issues/867. 

Changes: 
1. Add .hiddenChromosomes:[] to settings 
2. Allow user to select which chrs are not rendered in the disco plot. When selecting a chr that contains the only element in a ring, that ring will be removed.
3. Error UI no longer throws error when chrs are hidden
4. Default settings addresses possible `termdbConfig.queries.singleSampleMutation.discoPlot.skipChrM` flag.
5. Multi-checkbox control layout improved. Renders via flexbox for a cleaner appearance. 
6. Apply runpp() defined settings to disco launch func, thus applying to the state

Test :
1. [PNET example](http://localhost:3000/?genome=hg19&dslabel=PNET&disco=1&sample=SJBT032239_D1). Check the hidden chromosome controls. 
2. [GDC example](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-85-7710-01A). Should see chrM hidden by default. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
