### PR TITLE
Just displays PMID urls as are

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -550,7 +550,8 @@ export function value2urlsOrText(v, tw) {
 				h.push(`<a href=https://doi.org/${i.slice(5)} target=_blank>${i}</a>`)
 			} else {
 				// must be pmid
-				h.push(`<a href=https://pubmed.ncbi.nlm.nih.gov/${i} target=_blank>${i}</a>`)
+				// h.push(`<a href=https://pubmed.ncbi.nlm.nih.gov/${i} target=_blank>${i}</a>`)
+				h.push(`<a href="${i}" target="_blank">${i}</a>`)
 			}
 		}
 		return h.join('<br>')


### PR DESCRIPTION
# Description
GATA2 now reports the PMIDs as full urls instead of just numbers. This quick fix allows PMIDs to correctly link like before
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
