### PR TITLE
Fix menu combined coverage CI

### DIFF
--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -119,10 +119,11 @@ tape('show() with args', async test => {
 	{
 		//left (x) position
 		const posNum = 50
+		const y = /*testMenu.offsetY +*/ window.scrollY // when running many other tests, the screen would scroll vertically
 		testMenu.show(posNum)
 		test.deepEqual(
 			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum + testMenu.offsetX}px`, top: '' },
+			{ left: `${posNum + testMenu.offsetX}px`, top: y ? `${y}px` : '' },
 			`Should show menu left, under header, shifted by .offsetX = ${testMenu.offsetX}px`
 		)
 	}
@@ -130,22 +131,24 @@ tape('show() with args', async test => {
 	{
 		//top (y) position
 		const posNum = 50
+		const y = posNum + testMenu.offsetY + window.scrollY // when running many other tests, the screen would scroll vertically
 		testMenu.show('', posNum)
 		test.deepEqual(
 			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: '20px', top: `${posNum + testMenu.offsetY}px` },
-			`Should show menu at the top, above header, shifted by .offsetY = ${testMenu.offsety}px`
+			{ left: '20px', top: `${y}px` },
+			`Should show menu at the top, above header, shifted by .offsetY + window.scrollY = ${y}px`
 		)
 	}
 
 	// left & top (x & y) position
 	{
 		const posNum = 100
+		const y = posNum + testMenu.offsetY + window.scrollY
 		testMenu.show(posNum, posNum)
 		test.deepEqual(
 			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum + testMenu.offsetX}px`, top: `${posNum + testMenu.offsetY}px` },
-			`Should show menu top left corner, over header, shifted by .offsetX = ${testMenu.offsetX}px & .offsetY = ${testMenu.offsetY}px`
+			{ left: `${posNum + testMenu.offsetX}px`, top: `${y}px` },
+			`Should show menu top left corner, over header, shifted by .offsetX = ${testMenu.offsetX}px & .offsetY = ${y}px`
 		)
 	}
 
@@ -155,7 +158,7 @@ tape('show() with args', async test => {
 		testMenu.show(posNum, posNum, false)
 		test.deepEqual(
 			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum}px`, top: `${posNum}px` },
+			{ left: `${posNum}px`, top: `${posNum + window.scrollY}px` },
 			`Should show menu top left corner without .offsetX or .offsetY added to left or top, respectively.`
 		)
 	}

--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -20,13 +20,19 @@ Tests:
  reusable helper functions
 **************************/
 
-function getHolder() {
-	return d3s
+function getHolder(styles = {}) {
+	const holder = d3s
 		.select('body')
 		.append('div')
 		.style('border', '1px solid #aaa')
 		.style('padding', '5px')
 		.style('margin', '5px')
+
+	for (const k of Object.keys(styles)) {
+		holder.style(k, styles[k])
+	}
+
+	return holder
 }
 
 const longText =
@@ -123,7 +129,7 @@ tape('show() with args', async test => {
 		testMenu.show(posNum)
 		test.deepEqual(
 			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum + testMenu.offsetX}px`, top: y ? `${y}px` : '' },
+			{ left: `${posNum + testMenu.offsetX}px`, top: '' },
 			`Should show menu left, under header, shifted by .offsetX = ${testMenu.offsetX}px`
 		)
 	}
@@ -195,8 +201,8 @@ tape.skip('onHide() callback', test => {
 
 tape('showunder()', test => {
 	test.timeoutAfter(500)
-
-	const holder = getHolder()
+	// set holder position as fixed relative to viewport, so it's not affected by vertical scroll as other test DOMs are added or removed
+	const holder = getHolder({ position: 'fixed' })
 	const btn = holder.append('button').text('Button')
 	const testMenu = getTestMenu()
 
@@ -213,7 +219,7 @@ tape('showunder()', test => {
 	const btnP = btn.node().getBoundingClientRect()
 	const menuP = testMenu.dnode.getBoundingClientRect()
 	test.equal(btnP.x, menuP.x, `Should show menu with the same style.left value as test element.`)
-	const correctYvalue = btnP.top + btnP.height + window.scrollY + 5
+	const correctYvalue = btnP.top + btnP.height + 5 // window.scrollY is not applicable with fixed holder position
 	test.equal(
 		Math.round(correctYvalue),
 		Math.round(menuP.y),
@@ -229,8 +235,8 @@ tape('showunder()', test => {
 
 tape('showunderoffset()', test => {
 	test.timeoutAfter(500)
-
-	const holder = getHolder()
+	// set holder position as fixed relative to viewport, so it's not affected by vertical scroll as other test DOMs are added or removed
+	const holder = getHolder({ position: 'fixed' })
 	const btn = holder.append('button').text('Button')
 	const testMenu = getTestMenu()
 
@@ -252,7 +258,7 @@ tape('showunderoffset()', test => {
 		Math.round(menuP.x),
 		`Should show menu with the style.left value as test element, offset by ${testMenu.offsetX}px.`
 	)
-	const correctYvalue = btnP.top + btnP.height + window.scrollY + 5
+	const correctYvalue = btnP.top + btnP.height + 5 // window.scrollY is not applicable with fixed holder position
 	test.equal(
 		Math.round(correctYvalue + testMenu.offsetY),
 		Math.round(menuP.y),

--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -120,8 +120,9 @@ tape('show() with args', async test => {
 		//left (x) position
 		const posNum = 50
 		testMenu.show(posNum)
-		test.ok(
-			testMenu.dnode.style.left == `${posNum + testMenu.offsetX}px` && testMenu.dnode.style.top == '',
+		test.deepEqual(
+			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
+			{ left: `${posNum + testMenu.offsetX}px`, top: '' },
 			`Should show menu left, under header, shifted by .offsetX = ${testMenu.offsetX}px`
 		)
 	}
@@ -130,8 +131,9 @@ tape('show() with args', async test => {
 		//top (y) position
 		const posNum = 50
 		testMenu.show('', posNum)
-		test.ok(
-			testMenu.dnode.style.left == '20px' && testMenu.dnode.style.top == `${posNum + testMenu.offsetY}px`,
+		test.deepEqual(
+			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
+			{ left: '20px', top: `${posNum + testMenu.offsetY}px` },
 			`Should show menu at the top, above header, shifted by .offsetY = ${testMenu.offsety}px`
 		)
 	}
@@ -140,9 +142,9 @@ tape('show() with args', async test => {
 	{
 		const posNum = 100
 		testMenu.show(posNum, posNum)
-		test.ok(
-			testMenu.dnode.style.left == `${posNum + testMenu.offsetX}px` &&
-				testMenu.dnode.style.top == `${posNum + testMenu.offsetY}px`,
+		test.deepEqual(
+			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
+			{ left: `${posNum + testMenu.offsetX}px`, top: `${posNum + testMenu.offsetY}px` },
 			`Should show menu top left corner, over header, shifted by .offsetX = ${testMenu.offsetX}px & .offsetY = ${testMenu.offsetY}px`
 		)
 	}
@@ -151,8 +153,9 @@ tape('show() with args', async test => {
 		const posNum = 100
 		//No shift (i.e. additional 20px)
 		testMenu.show(posNum, posNum, false)
-		test.ok(
-			testMenu.dnode.style.left == `${posNum}px` && testMenu.dnode.style.top == `${posNum}px`,
+		test.deepEqual(
+			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
+			{ left: `${posNum}px`, top: `${posNum}px` },
 			`Should show menu top left corner without .offsetX or .offsetY added to left or top, respectively.`
 		)
 	}
@@ -167,13 +170,12 @@ tape('show() with args', async test => {
 		const posNum = 200
 		testMenu.d.append('div').text(longText)
 		testMenu.show(posNum, posNum, false)
-		test.ok(
-			testMenu.dnode.style.left == `${posNum + window.scrollX}px` &&
-				testMenu.dnode.style.top == `${posNum + window.scrollY}px`,
+		test.deepEqual(
+			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
+			{ left: `${posNum + window.scrollX}px`, top: `${posNum + window.scrollY}px` },
 			`Should show menu position with window.scrollX = ${window.scrollX} & window.scrollY = ${window.scrollY}`
 		)
 	}
-
 	testMenu.destroy()
 	test.end()
 })

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -419,13 +419,6 @@ tape('Numerical term: range boundaries', async test => {
 
 	await opts.pill.main(opts.tsData)
 
-	// create enter event to use for inputs of bin edit menu
-	const enter_event = new KeyboardEvent('keyup', {
-		code: 'Enter',
-		key: 'Enter',
-		keyCode: 13
-	})
-
 	const pilldiv = opts.holder.node().querySelectorAll('.ts_pill')[0]
 	await opts.pillMenuClick('Edit')
 	await sleep(1000)
@@ -468,17 +461,9 @@ tape('Numerical term: fixed bins', async test => {
 		}
 	})
 	await opts.pill.main(opts.tsData)
-
-	// create enter event to use for inputs of bin edit menu
-	const enter_event = new KeyboardEvent('keyup', {
-		code: 'Enter',
-		key: 'Enter',
-		keyCode: 13
-	})
-
 	await opts.pillMenuClick('Edit')
 	const tip = opts.pill.Inner.dom.tip
-	await sleep(100)
+	await detectGte({ target: tip.d.node(), selector: '.binsize_g', count: 1 })
 	const lines = tip.d.select('.binsize_g').node().querySelectorAll('line')
 	test.equal(lines.length, 8, 'should have 8 lines')
 	// first line should be draggable
@@ -520,7 +505,7 @@ tape('Numerical term: fixed bins', async test => {
 
 	//trigger 'change' to update bins
 	first_bin_input.dispatchEvent(new Event('change'))
-
+	await sleep(10)
 	test.equal(
 		d3s.select(tip.d.selectAll('tr')._groups[0][1]).selectAll('input')._groups[0][0].value,
 		'7',
@@ -542,7 +527,7 @@ tape('Numerical term: fixed bins', async test => {
 
 	//trigger 'change' to update bins
 	last_bin_input.dispatchEvent(new Event('change'))
-
+	await sleep(50)
 	test.equal(
 		tip.d.node().querySelectorAll('tr')[2].querySelectorAll('div')[1].querySelectorAll('input')[0].value,
 		'20',


### PR DESCRIPTION
# Description

This PR fixes the failing combined coverage CI as related to dom/menu unit tests. The menu position has to account for scrollY in some tests, or to use `fixed` position in a few tests to avoid being affected by other tests/scroll changes. Also added sleep() to a few termsetting integration tests.

Tests:
- https://github.com/stjude/proteinpaint/actions/runs/16448230759
- also passed all local unit and integration tests

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
