### PR TITLE
Added choice to assign colors dynamically in the barchart. 

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -204,17 +204,6 @@ export class Barchart {
 					boxLabel: 'Yes',
 					getDisplayStyle: plot => (plot.term2 ? 'none' : 'table-row')
 				},
-				{
-					label: 'Color using',
-					title: 'Color bars using the colors preassigned or generated dynamically',
-					type: 'radio',
-					chartType: 'barchart',
-					settingsKey: 'colorUsing',
-					options: [
-						{ label: 'Preassigned', value: 'preassigned' },
-						{ label: 'Generated', value: 'generated' }
-					]
-				},
 
 				{
 					label: 'Deduplicate',
@@ -250,6 +239,18 @@ export class Barchart {
 					chartType: 'barchart',
 					settingsKey: 'showPercent',
 					boxLabel: 'Yes'
+				})
+			if (state.config.settings.barchart.colorBars)
+				inputs.splice(8, 0, {
+					label: 'Color using',
+					title: `Colors bars either using the colors preassigned or generates colors. If there are many categories and only few are present the generated colors will provide more contrast.`,
+					type: 'radio',
+					chartType: 'barchart',
+					settingsKey: 'colorUsing',
+					options: [
+						{ label: 'Preassigned', value: 'preassigned' },
+						{ label: 'Generated', value: 'generated' }
+					]
 				})
 			const multipleTestingCorrection = this.app.getState().termdbConfig.multipleTestingCorrection
 			if (multipleTestingCorrection) {

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -175,7 +175,7 @@ export default function (): Mds3 {
 										{
 											chartType: 'barchart',
 											term: { id: 'diaggrp' },
-											settings: { barchart: { colorBars: true, showPercent: true } }
+											settings: { barchart: { colorBars: true, showPercent: true, colorUsing: 'generated' } }
 										}
 									]
 								},


### PR DESCRIPTION
# Description
Added choice to assign colors dynamically in the barchart instead of using the term colors. This allows to use a better color scale counting only the present categories. Used this option in the reports to improve the color scale as requested. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/946).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
