### PR TITLE
Support for gene set in geneVariant term

### DIFF
--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -16,6 +16,7 @@ Tests:
 	term0=defaultbins, term1=categorical
 	term1=geneVariant no group
 	term1=geneVariant with groups
+	term1=geneVariant gene set with groups
 	term1=categorical, term2=geneVariant
 	term1=geneExp, term2=geneVariant SKIPPED
 	term1=geneVariant, term2=geneExp
@@ -368,6 +369,50 @@ tape('term1=geneVariant with groups', function (test) {
 		const barDiv = barchart.Inner.dom.barDiv
 		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
 		test.true(numCharts == 1, 'Should have 1 chart from gene variant term')
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+})
+
+tape('term1=geneVariant gene set with groups', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'barchart',
+					term: {
+						term: {
+							genes: [
+								{
+									kind: 'gene',
+									gene: 'TP53',
+									type: 'geneVariant'
+								},
+								{
+									kind: 'gene',
+									gene: 'KRAS',
+									type: 'geneVariant'
+								}
+							],
+							type: 'geneVariant'
+						},
+						q: { type: 'predefined-groupset' }
+					}
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': testNumCharts
+			}
+		}
+	})
+
+	function testNumCharts(barchart) {
+		const barDiv = barchart.Inner.dom.barDiv
+		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
+		test.true(numCharts == 1, 'Should have 1 chart from gene variant gene set')
 		if (test._ok) barchart.Inner.app.destroy()
 		test.end()
 	}
@@ -2079,10 +2124,16 @@ const tp53dtTermFilter = {
 					name_noOrigin: 'SNV/indel',
 					origin: 'somatic',
 					parentTerm: {
-						kind: 'gene',
-						id: 'TP53',
-						gene: 'TP53',
 						name: 'TP53',
+						genes: [
+							{
+								kind: 'gene',
+								id: 'TP53',
+								gene: 'TP53',
+								name: 'TP53',
+								type: 'geneVariant'
+							}
+						],
 						type: 'geneVariant'
 					}
 				},

--- a/client/plots/matrix/test/matrix.integration.spec.js
+++ b/client/plots/matrix/test/matrix.integration.spec.js
@@ -1341,8 +1341,16 @@ tape('avoid race condition', function (test) {
 										{
 											$id: 3,
 											term: {
-												gene: 'BCR',
 												name: 'BCR',
+												genes: [
+													{
+														kind: 'gene',
+														id: 'BCR',
+														gene: 'BCR',
+														name: 'BCR',
+														type: 'geneVariant'
+													}
+												],
 												type: 'geneVariant',
 												isleaf: true,
 												groupsetting: { disabled: false }
@@ -2186,9 +2194,7 @@ tape(
 							{
 								name: '',
 								lst: [
-									{ term: { gene: 'TP53', name: 'TP53', type: 'geneVariant', isleaf: true } },
-									{ term: { gene: 'KRAS', name: 'KRAS', type: 'geneVariant', isleaf: true } },
-									{ term: { gene: 'AKT1', name: 'AKT1', type: 'geneVariant', isleaf: true } },
+									...getGenes(),
 									{ id: 'agedx', term: termjson['agedx'] },
 									{ id: 'diaggrp', term: termjson['diaggrp'] },
 									{ id: 'aaclassic_5', term: termjson['aaclassic_5'] }

--- a/client/plots/summarizeCnvGeneexp.ts
+++ b/client/plots/summarizeCnvGeneexp.ts
@@ -80,6 +80,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		geneSearchInst.init({
 			holder: searchDiv,
 			genomeObj: chartsInstance.app.opts.genome!,
+			app: chartsInstance.app, // required to supply "opts.app.vocabApi" for the search ui
 			callback: async term => {
 				waitDiv.text('LOADING ...')
 				try {

--- a/client/plots/summarizeMutationDiagnosis.ts
+++ b/client/plots/summarizeMutationDiagnosis.ts
@@ -38,6 +38,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		const geneSearchInst = new geneSearch() // FIXME allow searching chr17:7666658-7688275
 		geneSearchInst.init({
 			holder: searchDiv,
+			app: chartsInstance.app, // required to supply "opts.app.vocabApi" for the search ui
 			genomeObj: chartsInstance.app.opts.genome!,
 			callback: async term => {
 				waitDiv.text('LOADING ...')

--- a/client/plots/summarizeMutationSurvival.ts
+++ b/client/plots/summarizeMutationSurvival.ts
@@ -33,6 +33,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		geneSearchInst.init({
 			holder: searchDiv,
 			genomeObj: chartsInstance.app.opts.genome!,
+			app: chartsInstance.app, // required to supply "opts.app.vocabApi" for the search ui
 			callback: async term => {
 				waitDiv.text('LOADING ...')
 				launchPlot({

--- a/client/termdb/handlers/geneVariant.ts
+++ b/client/termdb/handlers/geneVariant.ts
@@ -1,6 +1,4 @@
-import { Menu, make_radios } from '#dom'
-import { addGeneSearchbox } from '../../dom/genesearch.ts'
-import { GeneSetEditUI } from '../../dom/GeneSetEdit/GeneSetEditUI'
+import { Menu, make_radios, addGeneSearchbox, GeneSetEditUI } from '#dom'
 
 export class SearchHandler {
 	opts: any

--- a/client/termdb/handlers/geneVariant.ts
+++ b/client/termdb/handlers/geneVariant.ts
@@ -35,36 +35,7 @@ export class SearchHandler {
 		})
 	}
 
-	searchGeneSet() {
-		this.dom.searchDiv.selectAll('*').remove()
-		this.dom.searchDiv.style('margin-top', '0px')
-		new GeneSetEditUI({
-			holder: this.dom.searchDiv,
-			genome: this.opts.genomeObj,
-			vocabApi: this.opts.app.vocabApi,
-			callback: result => {
-				const genes = result.geneList.map(v => {
-					const name = v.gene
-					const gene = {
-						kind: 'gene',
-						id: name,
-						gene: name,
-						name,
-						type: 'geneVariant'
-					}
-					return gene
-				})
-				const term = {
-					name: genes.map(gene => gene.name).join(', '),
-					genes,
-					type: 'geneVariant'
-				}
-				this.callback(term)
-			}
-		})
-	}
-
-	async selectGene(geneSearch) {
+	selectGene(geneSearch) {
 		if (geneSearch.geneSymbol) {
 			const name = geneSearch.geneSymbol
 			const term = {
@@ -103,5 +74,37 @@ export class SearchHandler {
 		} else {
 			throw 'no gene or position specified'
 		}
+	}
+
+	searchGeneSet() {
+		this.dom.searchDiv.selectAll('*').remove()
+		this.dom.searchDiv.style('margin-top', '0px')
+		new GeneSetEditUI({
+			holder: this.dom.searchDiv,
+			genome: this.opts.genomeObj,
+			vocabApi: this.opts.app.vocabApi,
+			callback: result => this.selectGeneSet(result)
+		})
+	}
+
+	selectGeneSet(result) {
+		const genes = result.geneList.map(v => {
+			if (!v.gene) throw 'gene name not found'
+			const name = v.gene
+			const gene = {
+				kind: 'gene',
+				id: name,
+				gene: name,
+				name,
+				type: 'geneVariant'
+			}
+			return gene
+		})
+		const term = {
+			name: genes.map(gene => gene.name).join(', '),
+			genes,
+			type: 'geneVariant'
+		}
+		this.callback(term)
 	}
 }

--- a/client/termdb/test/geneVariant.unit.spec.ts
+++ b/client/termdb/test/geneVariant.unit.spec.ts
@@ -12,7 +12,7 @@ tape('\n', function (test) {
 	test.end()
 })
 
-tape('selectGene()', async function (test) {
+tape('selectGene()', function (test) {
 	test.timeoutAfter(100)
 	test.plan(5)
 	let search, actualTerm, expectedTerm, message
@@ -25,12 +25,18 @@ tape('selectGene()', async function (test) {
 		geneSymbol: 'TP53',
 		fromWhat: 'TP53'
 	}
-	await handler.selectGene(search)
+	handler.selectGene(search)
 	expectedTerm = {
-		kind: 'gene',
-		id: 'TP53',
-		gene: 'TP53',
 		name: 'TP53',
+		genes: [
+			{
+				kind: 'gene',
+				id: 'TP53',
+				gene: 'TP53',
+				name: 'TP53',
+				type: 'geneVariant'
+			}
+		],
 		type: 'geneVariant'
 	}
 	test.deepEqual(actualTerm, expectedTerm, 'should return correct term when searching by gene symbol')
@@ -41,14 +47,19 @@ tape('selectGene()', async function (test) {
 		stop: 7687538,
 		fromWhat: 'Valid coordinate'
 	}
-	await handler.selectGene(search)
+	handler.selectGene(search)
 	expectedTerm = {
-		kind: 'coord',
-		id: 'chr17:7661779-7687538',
-		chr: 'chr17',
-		start: 7661778,
-		stop: 7687538,
 		name: 'chr17:7661779-7687538',
+		genes: [
+			{
+				kind: 'coord',
+				chr: 'chr17',
+				start: 7661778,
+				stop: 7687538,
+				name: 'chr17:7661779-7687538',
+				type: 'geneVariant'
+			}
+		],
 		type: 'geneVariant'
 	}
 	test.deepEqual(actualTerm, expectedTerm, 'should return correct term when searching by coordinate')
@@ -59,7 +70,7 @@ tape('selectGene()', async function (test) {
 		fromWhat: 'TP53'
 	}
 	message = 'should throw when no gene symbol and no chr'
-	await verifyError(search, message)
+	verifyError(search, message)
 
 	search = {
 		chr: 'chr17',
@@ -67,7 +78,7 @@ tape('selectGene()', async function (test) {
 		fromWhat: 'TP53'
 	}
 	message = 'should throw when no gene symbol and no start'
-	await verifyError(search, message)
+	verifyError(search, message)
 
 	search = {
 		chr: 'chr17',
@@ -75,14 +86,44 @@ tape('selectGene()', async function (test) {
 		fromWhat: 'TP53'
 	}
 	message = 'should throw when no gene symbol and no stop'
-	await verifyError(search, message)
+	verifyError(search, message)
 
-	async function verifyError(search, message) {
+	function verifyError(search, message) {
 		try {
-			await handler.selectGene(search)
+			handler.selectGene(search)
 			test.fail(message)
 		} catch (e: any) {
 			test.pass(`${message}: ${e.message || e}`)
 		}
 	}
+	test.end()
+})
+
+tape('selectGeneSet()', function (test) {
+	let actualTerm
+	handler.callback = term => (actualTerm = term)
+	const result = { geneList: [{ gene: 'CTNNB1' }, { gene: 'TP53' }] }
+	handler.selectGeneSet(result)
+	const expectedTerm = {
+		name: 'CTNNB1, TP53',
+		genes: [
+			{
+				kind: 'gene',
+				id: 'CTNNB1',
+				gene: 'CTNNB1',
+				name: 'CTNNB1',
+				type: 'geneVariant'
+			},
+			{
+				kind: 'gene',
+				id: 'TP53',
+				gene: 'TP53',
+				name: 'TP53',
+				type: 'geneVariant'
+			}
+		],
+		type: 'geneVariant'
+	}
+	test.deepEqual(actualTerm, expectedTerm, 'should return correct term when searching by gene set')
+	test.end()
 })

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -468,36 +468,41 @@ export async function getChildTerms(term: RawGvTerm, vocabApi: VocabApi, body: a
 		// any other properties
 		body.filter0 = filter0
 	}
-	const categories = await vocabApi.getCategories(term, filter, body)
-	for (const _t of dtTerms) {
-		const t: any = structuredClone(_t)
-		if (!Object.keys(vocabApi.termdbConfig.queries).includes(t.query)) continue // dt is not in dataset
-		const data = categories.lst.find(x => x.dt == t.dt)
-		if (!data) continue // gene does not have this dt
-		const byOrigin = vocabApi.termdbConfig.assayAvailability?.byDt[t.dt]?.byOrigin
-		let classes
-		if (byOrigin) {
-			// dt has origins in dataset
-			if (!t.origin) continue // dt term does not have origin, so skip
-			if (!Object.keys(byOrigin).includes(t.origin)) throw 'unexpected origin of dt term'
-			classes = data.classes.byOrigin[t.origin]
-		} else {
-			// dt does not have origins in dataset
-			if (t.origin) continue // dt term has origin, so skip
-			classes = data.classes
+	// get union of dt terms in data for all genes of term
+	// TODO: need to also get union of values within each dt term
+	for (const gene of term.genes) {
+		const categories = await vocabApi.getCategories(gene, filter, body)
+		for (const _t of dtTerms) {
+			if (dtTermsInDs.find(t => t.id == _t.id)) continue // dt term already found for another gene
+			const t: any = structuredClone(_t)
+			if (!Object.keys(vocabApi.termdbConfig.queries).includes(t.query)) continue // dt is not in dataset
+			const data = categories.lst.find(x => x.dt == t.dt)
+			if (!data) continue // gene does not have this dt
+			const byOrigin = vocabApi.termdbConfig.assayAvailability?.byDt[t.dt]?.byOrigin
+			let classes
+			if (byOrigin) {
+				// dt has origins in dataset
+				if (!t.origin) continue // dt term does not have origin, so skip
+				if (!Object.keys(byOrigin).includes(t.origin)) throw 'unexpected origin of dt term'
+				classes = data.classes.byOrigin[t.origin]
+			} else {
+				// dt does not have origins in dataset
+				if (t.origin) continue // dt term has origin, so skip
+				classes = data.classes
+			}
+			// filter for only those mutation classes that are in the dataset
+			const values = Object.fromEntries(Object.entries(t.values).filter(([k, _v]) => Object.keys(classes).includes(k)))
+			// add custom mclass labels from dataset
+			for (const k of Object.keys(values)) {
+				const v: any = values[k]
+				if (termdbmclass && Object.keys(termdbmclass).includes(k)) v.label = termdbmclass[k].label
+			}
+			t.values = values
+			t.parentTerm = structuredClone(term)
+			delete t.parentTerm.childTerms // remove any nested child terms
+			delete t.parentTerm.groupsetting // remove nested term groupsetting
+			dtTermsInDs.push(t)
 		}
-		// filter for only those mutation classes that are in the dataset
-		const values = Object.fromEntries(Object.entries(t.values).filter(([k, _v]) => Object.keys(classes).includes(k)))
-		// add custom mclass labels from dataset
-		for (const k of Object.keys(values)) {
-			const v: any = values[k]
-			if (termdbmclass && Object.keys(termdbmclass).includes(k)) v.label = termdbmclass[k].label
-		}
-		t.values = values
-		t.parentTerm = structuredClone(term)
-		delete t.parentTerm.childTerms // remove any nested child terms
-		delete t.parentTerm.groupsetting // remove nested term groupsetting
-		dtTermsInDs.push(t)
 	}
 	term.childTerms = dtTermsInDs
 }

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -1372,10 +1372,16 @@ const geneVariantQ = {
 }
 
 const genVariantTerm = {
-	kind: 'gene',
-	id: 'TP53',
-	gene: 'TP53',
 	name: 'TP53',
+	genes: [
+		{
+			kind: 'gene',
+			id: 'TP53',
+			gene: 'TP53',
+			name: 'TP53',
+			type: 'geneVariant'
+		}
+	],
 	type: 'geneVariant',
 	groupsetting: {
 		disabled: false,

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -69,7 +69,7 @@ export class GvBase extends TwBase {
 			if (!gene.id) gene.id = gene.name
 		}
 
-		tw.term.name = tw.term.genes.map(gene => gene.name).join(', ')
+		tw.term.id = tw.term.name = tw.term.genes.map(gene => gene.name).join(', ')
 
 		if (!Object.keys(tw.q).includes('type')) tw.q.type = 'values'
 

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -38,7 +38,12 @@ export class GvBase extends TwBase {
 			copyMerge(tw.q, opts.defaultQ)
 		}
 
-		if (!tw.term.genes?.length) throw 'tw.term.genes[] is empty'
+		if (!tw.term.genes?.length) {
+			// support legacy term structure that lacks term.genes[]
+			const gene = structuredClone(tw.term)
+			tw.term.genes = [gene]
+		}
+
 		for (const gene of tw.term.genes) {
 			if (!gene.kind) {
 				// support saved states that don't have term.kind, applied when rehydrating at runtime

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -38,29 +38,33 @@ export class GvBase extends TwBase {
 			copyMerge(tw.q, opts.defaultQ)
 		}
 
-		if (!tw.term.kind) {
-			// support saved states that don't have term.kind, applied when rehydrating at runtime
-			const term: any = tw.term
-			if (term.gene || (term.name && !term.chr)) term.kind = 'gene'
-			else if (term.chr) term.kind = 'coord'
-			else throw 'unable to assign geneVariant term.kind'
-		}
-
-		if (tw.term.kind == 'gene') {
-			if (!tw.term.gene) tw.term.gene = tw.term.name
-			if (!tw.term.name) tw.term.name = tw.term.gene
-			if (!tw.term.gene || !tw.term.name) throw 'missing gene/name'
-		} else if (tw.term.kind == 'coord') {
-			if (!tw.term.chr || !Number.isInteger(tw.term.start) || !Number.isInteger(tw.term.stop))
-				throw 'no position specified'
-			if (!tw.term.name) {
-				tw.term.name = `${tw.term.chr}:${tw.term.start + 1}-${tw.term.stop}`
+		if (!tw.term.genes?.length) throw 'tw.term.genes[] is empty'
+		for (const gene of tw.term.genes) {
+			if (!gene.kind) {
+				// support saved states that don't have term.kind, applied when rehydrating at runtime
+				const term: any = gene
+				if (term.gene || (term.name && !term.chr)) term.kind = 'gene'
+				else if (term.chr) term.kind = 'coord'
+				else throw 'unable to assign geneVariant term.kind'
 			}
-		} else {
-			throw 'cannot recognize tw.term.kind'
+
+			if (gene.kind == 'gene') {
+				if (!gene.gene) gene.gene = gene.name
+				if (!gene.name) gene.name = gene.gene
+				if (!gene.gene || !gene.name) throw 'missing gene/name'
+			} else if (gene.kind == 'coord') {
+				if (!gene.chr || !Number.isInteger(gene.start) || !Number.isInteger(gene.stop)) throw 'no position specified'
+				if (!gene.name) {
+					gene.name = `${gene.chr}:${gene.start + 1}-${gene.stop}`
+				}
+			} else {
+				throw 'cannot recognize gene.kind'
+			}
+
+			if (!gene.id) gene.id = gene.name
 		}
 
-		if (!tw.term.id) tw.term.id = tw.term.name
+		tw.term.name = tw.term.genes.map(gene => gene.name).join(', ')
 
 		if (!Object.keys(tw.q).includes('type')) tw.q.type = 'values'
 

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import type { GvCustomGsQ, RawGvTW, DtTerm, GvTW } from '#types'
+import type { GvTW } from '#types'
 import { vocabInit } from '#termdb/vocabulary'
 import { GvBase } from '../geneVariant'
 import { getPredefinedGroupsets } from '../../termsetting/handlers/geneVariant.ts'
@@ -70,7 +70,7 @@ tape('fill(): invalid tw', async test => {
 })
 
 tape('fill(): no q.type', async test => {
-	const tw: RawGvTW = {
+	const tw: any = {
 		term: {
 			kind: 'gene',
 			id: 'TP53',
@@ -94,7 +94,7 @@ tape('fill(): no q.type', async test => {
 })
 
 tape('fill(): q.type=values', async test => {
-	const tw: RawGvTW = {
+	const tw: any = {
 		term: {
 			kind: 'gene',
 			id: 'TP53',
@@ -111,12 +111,18 @@ tape('fill(): q.type=values', async test => {
 })
 
 tape('fill(): q.type=predefined-groupset', async test => {
-	const tw: RawGvTW = {
+	const tw: any = {
 		term: {
-			kind: 'gene',
-			id: 'TP53',
-			gene: 'TP53',
 			name: 'TP53',
+			genes: [
+				{
+					kind: 'gene',
+					id: 'TP53',
+					gene: 'TP53',
+					name: 'TP53',
+					type: 'geneVariant'
+				}
+			],
 			type: 'geneVariant'
 		},
 		isAtomic: true,
@@ -140,12 +146,18 @@ tape('fill(): q.type=predefined-groupset', async test => {
 })
 
 tape('fill(): q.type=custom-groupset', async test => {
-	const tw: RawGvTW = {
+	const tw: any = {
 		term: {
-			kind: 'gene',
-			id: 'TP53',
-			gene: 'TP53',
 			name: 'TP53',
+			genes: [
+				{
+					kind: 'gene',
+					id: 'TP53',
+					gene: 'TP53',
+					name: 'TP53',
+					type: 'geneVariant'
+				}
+			],
 			type: 'geneVariant'
 		},
 		isAtomic: true,
@@ -160,10 +172,17 @@ tape('fill(): q.type=custom-groupset', async test => {
 tape('getPredefinedGroupsets: fill groupsets', async test => {
 	const tw: any = {
 		term: {
-			type: 'geneVariant',
-			gene: 'TP53',
-			kind: 'gene',
 			name: 'TP53',
+			genes: [
+				{
+					kind: 'gene',
+					id: 'TP53',
+					gene: 'TP53',
+					name: 'TP53',
+					type: 'geneVariant'
+				}
+			],
+			type: 'geneVariant',
 			id: 'TP53',
 			groupsetting: { disabled: false }
 		},
@@ -218,7 +237,7 @@ tape('getPredefinedGroupsets: incorrect tw.q.type', async test => {
  variables
 ***********/
 
-const childTerms: DtTerm[] = [
+const childTerms = [
 	{
 		id: 'snvindel_somatic',
 		query: 'snvindel',
@@ -235,11 +254,18 @@ const childTerms: DtTerm[] = [
 		name_noOrigin: 'SNV/indel',
 		origin: 'somatic',
 		parentTerm: {
-			kind: 'gene',
-			id: 'TP53',
-			gene: 'TP53',
 			name: 'TP53',
-			type: 'geneVariant'
+			genes: [
+				{
+					kind: 'gene',
+					id: 'TP53',
+					gene: 'TP53',
+					name: 'TP53',
+					type: 'geneVariant'
+				}
+			],
+			type: 'geneVariant',
+			id: 'TP53'
 		}
 	},
 	{
@@ -258,11 +284,18 @@ const childTerms: DtTerm[] = [
 		name_noOrigin: 'SNV/indel',
 		origin: 'germline',
 		parentTerm: {
-			kind: 'gene',
-			id: 'TP53',
-			gene: 'TP53',
 			name: 'TP53',
-			type: 'geneVariant'
+			genes: [
+				{
+					kind: 'gene',
+					id: 'TP53',
+					gene: 'TP53',
+					name: 'TP53',
+					type: 'geneVariant'
+				}
+			],
+			type: 'geneVariant',
+			id: 'TP53'
 		}
 	},
 	{
@@ -279,11 +312,18 @@ const childTerms: DtTerm[] = [
 		},
 		name_noOrigin: 'CNV',
 		parentTerm: {
-			kind: 'gene',
-			id: 'TP53',
-			gene: 'TP53',
 			name: 'TP53',
-			type: 'geneVariant'
+			genes: [
+				{
+					kind: 'gene',
+					id: 'TP53',
+					gene: 'TP53',
+					name: 'TP53',
+					type: 'geneVariant'
+				}
+			],
+			type: 'geneVariant',
+			id: 'TP53'
 		}
 	},
 	{
@@ -300,16 +340,23 @@ const childTerms: DtTerm[] = [
 		},
 		name_noOrigin: 'Fusion RNA',
 		parentTerm: {
-			kind: 'gene',
-			id: 'TP53',
-			gene: 'TP53',
 			name: 'TP53',
-			type: 'geneVariant'
+			genes: [
+				{
+					kind: 'gene',
+					id: 'TP53',
+					gene: 'TP53',
+					name: 'TP53',
+					type: 'geneVariant'
+				}
+			],
+			type: 'geneVariant',
+			id: 'TP53'
 		}
 	}
 ]
 
-const customGsQ: GvCustomGsQ = {
+const customGsQ = {
 	isAtomic: true,
 	type: 'custom-groupset',
 	hiddenValues: {},
@@ -342,10 +389,16 @@ const customGsQ: GvCustomGsQ = {
 									name_noOrigin: 'SNV/indel',
 									origin: 'somatic',
 									parentTerm: {
-										kind: 'gene',
-										id: 'TP53',
-										gene: 'TP53',
 										name: 'TP53',
+										genes: [
+											{
+												kind: 'gene',
+												id: 'TP53',
+												gene: 'TP53',
+												name: 'TP53',
+												type: 'geneVariant'
+											}
+										],
 										type: 'geneVariant'
 									}
 								},
@@ -391,10 +444,16 @@ const customGsQ: GvCustomGsQ = {
 									name_noOrigin: 'SNV/indel',
 									origin: 'somatic',
 									parentTerm: {
-										kind: 'gene',
-										id: 'TP53',
-										gene: 'TP53',
 										name: 'TP53',
+										genes: [
+											{
+												kind: 'gene',
+												id: 'TP53',
+												gene: 'TP53',
+												name: 'TP53',
+												type: 'geneVariant'
+											}
+										],
 										type: 'geneVariant'
 									}
 								},

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2621,8 +2621,6 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		// validate tw
 		if (typeof tw.term != 'object') throw 'tw.term{} is not object'
 		if (tw.term.type != 'geneVariant') throw 'tw.term.type is not geneVariant'
-		if (!tw.term.gene && !(tw.term.chr && Number.isInteger(tw.term.start) && Number.isInteger(tw.term.stop)))
-			throw 'no gene or position specified'
 		if (tw.q.type == 'predefined-groupset' || tw.q.type == 'custom-groupset') {
 			if (tw.q.type == 'predefined-groupset' && !Number.isInteger(tw.q.predefined_groupset_idx))
 				throw 'predefined_groupset_idx is not an integer value'
@@ -2652,6 +2650,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		const termdbmclass = q.ds?.cohort?.termdb?.mclass // custom mclass labels from dataset
 		if (!tw.term.genes?.length) throw 'tw.term.genes[] is empty'
 		for (const gene of tw.term.genes) {
+			if (!gene.gene && !(gene.chr && Number.isInteger(gene.start) && Number.isInteger(gene.stop)))
+				throw 'no gene or position specified'
 			for (const dt of dts) {
 				let mlst = []
 				switch (dt) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2648,9 +2648,10 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 			dts.push(dtcnv)
 		}
 
-		// retrieve genomic data for each dt
+		// retrieve genomic data for each dt of each gene
 		const termdbmclass = q.ds?.cohort?.termdb?.mclass // custom mclass labels from dataset
-		for (const gene of tw.term.genes || []) {
+		if (!tw.term.genes?.length) throw 'tw.term.genes[] is empty'
+		for (const gene of tw.term.genes) {
 			for (const dt of dts) {
 				let mlst = []
 				switch (dt) {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -556,9 +556,16 @@ async function mayQueryMutatedSamples(q) {
 		// TODO: use fillTW() here
 		const tw = {
 			term: {
-				kind: 'gene',
-				gene: geneName,
 				name: geneName,
+				genes: [
+					{
+						kind: 'gene',
+						id: geneName,
+						gene: geneName,
+						name: geneName,
+						type: 'geneVariant'
+					}
+				],
 				type: 'geneVariant',
 				groupsetting: { disabled: false }
 			},

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -174,29 +174,7 @@ function getSampleArray(data, st) {
 
 function getSeriesKey(ot, d) {
 	const n = ot.name
-	if (ot.type == TermTypes.GENE_VARIANT) {
-		// TODO: may no longer need this code as geneVariant groupsetting is now performed on client-side
-		if (!d[n] || !d[n].values) return 'Wildtype' // TODO: should require definitive not-tested vs WT data
-		const tested = d[n].values.filter(v => v.class != 'Blank')
-
-		/*
-			TODO: ot.q may specify to
-			- filter out any value that has a certain dt or class (similar to the matrix)
-			- what classes to group together (groupsetting)
-
-			NOTE: handle this filtering/value processing per the q object within the getData() function?
-
-			!!! Very simplified series grouping below !!!
-		*/
-		// if a sample is mutated for any test, ignore that is may be wildtype and/or not tested for any other assay
-		if (tested.find(v => v.class != 'WT')) return `${n} Variant`
-		// so far, no variant was found. is the sample specifically marked as wildtype for any test?
-		if (tested.find(v => v.class == 'WT')) return `${n} Wildtype`
-		// not mutant or wildtype, was it marked not tested for any assay?
-		if (d[n].values.length > tested.length) return 'Not tested'
-		// TODO: more helpful message or throw
-		return 'Not sure'
-	} else if (ot.type == TermTypes.GENE_EXPRESSION) {
+	if (ot.type == TermTypes.GENE_EXPRESSION) {
 		return d[ot.name]?.key || 'Missing data'
 	} else if (d[ot.name]) {
 		return d[ot.name].key

--- a/shared/types/src/terms/geneVariant.ts
+++ b/shared/types/src/terms/geneVariant.ts
@@ -20,7 +20,7 @@ export type GvCustomGsQ = GvBaseQ & { type: 'custom-groupset'; customset: BaseGr
 export type GvQ = GvValuesQ | GvPredefinedGsQ | GvCustomGsQ
 
 // term types
-export type GvGene = {
+type Gene = {
 	kind: 'gene'
 	gene: string
 	// chr,start,stop should exist together as a separate type called
@@ -31,14 +31,19 @@ export type GvGene = {
 	stop?: number
 }
 
-export type GvCoord = {
+type Coord = {
 	kind: 'coord'
 	chr: string
 	start: number
 	stop: number
 }
 
-type GvBaseTerm = BaseTerm & { type: 'geneVariant' } & (GvGene | GvCoord)
+type GvGeneTerm = BaseTerm & (Gene | Coord)
+
+type GvBaseTerm = BaseTerm & {
+	type: 'geneVariant'
+	genes: GvGeneTerm[]
+}
 
 export type RawGvTerm = GvBaseTerm & {
 	groupsetting?: TermGroupSetting

--- a/shared/types/src/terms/geneVariant.ts
+++ b/shared/types/src/terms/geneVariant.ts
@@ -40,10 +40,13 @@ type Coord = {
 
 type GvGeneTerm = BaseTerm & (Gene | Coord)
 
-type GvBaseTerm = BaseTerm & {
-	type: 'geneVariant'
-	genes: GvGeneTerm[]
-}
+// including (Gene | Coord) for backwards compatibility
+// with older geneVariant term structure
+type GvBaseTerm = BaseTerm &
+	(Gene | Coord) & {
+		type: 'geneVariant'
+		genes: GvGeneTerm[]
+	}
 
 export type RawGvTerm = GvBaseTerm & {
 	groupsetting?: TermGroupSetting

--- a/shared/utils/src/common.js
+++ b/shared/utils/src/common.js
@@ -1240,8 +1240,6 @@ export const mutationClasses = Object.values(mclass)
 export const CNVClasses = Object.values(mclass)
 	.filter(m => m.dt == dtcnv)
 	.map(m => m.key)
-export const cnvGainClasses = [mclasscnvgain, mclasscnvAmp]
-export const cnvLossClasses = [mclasscnvloss, mclasscnvHomozygousDel]
 
 // dt terms used for filtering variants for geneVariant term
 const dtTerms_temp = [


### PR DESCRIPTION
# Description

Prototyping support for gene set in geneVariant term. The geneVariant termwrapper now has a `.genes[]` property that contains term objects for each gene in the gene set. The backend will query mutation data for all genes in the gene set and will assign a sample to a group if any genotype of the sample matches the group's genotype. For example, when comparing mutated group vs. wildtype group, if sample has mutation in geneA but not geneB it will be assigned to mutated group. If sample has no mutation in either group it will be assigned to wildtype group.

Can trigger gene set input using a url such as: [TP53, CTNNB1](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22,%22genes%22:[{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22},{%22gene%22:%22CTNNB1%22,%22type%22:%22geneVariant%22}]}}}]}) and [TP53, MYC](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22,%22genes%22:[{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22},{%22gene%22:%22MYC%22,%22type%22:%22geneVariant%22}]}}}]})

Can validate results by switching to master and overlaying these genes together in a barchart.

Setting this PR as a draft because geneVariant UI currently does not support gene set input.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
