### PR TITLE
Show stats table will show/hide the barchart stats

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -338,7 +338,7 @@ export class Barchart {
 
 			const reqOpts = this.getDataRequestOpts()
 			await this.getDescrStats()
-			await this.setControls()
+			await this.setControls() //needs to be called after getDescrStats() to set hasStats
 
 			const results = await this.app.vocabApi.getNestedChartSeriesData(reqOpts)
 			const data = results.data
@@ -379,6 +379,7 @@ export class Barchart {
 	}
 
 	async getDescrStats() {
+		this.hasStats = false
 		// get descriptive statistics for numerical terms
 		const terms = [this.config.term]
 		if (this.config.term2) terms.push(this.config.term2)

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -224,7 +224,7 @@ export class Barchart {
 					//getDisplayStyle: plot => (plot.settings.barchart.colorBars || plot.term2 ? 'none' : 'table-row')
 				}
 			]
-			if (state.config.term2)
+			if (this.hasStats)
 				inputs.push({
 					label: 'Show stats',
 					type: 'checkbox',
@@ -335,10 +335,11 @@ export class Barchart {
 				)
 
 			this.toggleLoadingDiv()
-			await this.setControls()
 
 			const reqOpts = this.getDataRequestOpts()
 			await this.getDescrStats()
+			await this.setControls()
+
 			const results = await this.app.vocabApi.getNestedChartSeriesData(reqOpts)
 			const data = results.data
 			this.sampleType = results.sampleType
@@ -382,11 +383,13 @@ export class Barchart {
 		const terms = [this.config.term]
 		if (this.config.term2) terms.push(this.config.term2)
 		if (this.config.term0) terms.push(this.config.term0)
+
 		for (const t of terms) {
 			if (isNumericTerm(t.term)) {
 				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter)
 				if (data.error) throw data.error
 				t.q.descrStats = data.values
+				this.hasStats = true
 			}
 		}
 	}
@@ -412,7 +415,8 @@ export class Barchart {
 			rowh: config.settings.common.barwidth,
 			colspace: config.settings.common.barspace,
 			rowspace: config.settings.common.barspace,
-			colorUsing: config.settings.barchart.colorUsing
+			colorUsing: config.settings.barchart.colorUsing,
+			showStats: config.settings.barchart.showStats
 		}
 
 		/* mayResetHidden() was added before to prevent showing empty chart due to automatic hiding uncomputable categories

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -226,10 +226,10 @@ export class Barchart {
 			]
 			if (state.config.term2)
 				inputs.push({
-					label: 'Show stats table',
+					label: 'Show stats',
 					type: 'checkbox',
 					chartType: 'barchart',
-					settingsKey: 'showStatsTable',
+					settingsKey: 'showStats',
 					boxLabel: 'Yes'
 				})
 			else
@@ -743,7 +743,7 @@ export class Barchart {
 		const headingStyle = 'color: #aaa; font-weight: 400'
 
 		// descriptive statistics
-		if (t1.q.descrStats) {
+		if (t1.q.descrStats && s.showStats) {
 			// term1 has descriptive stats
 			const items = t1.q.descrStats.map(stat => {
 				return {
@@ -756,7 +756,7 @@ export class Barchart {
 			const name = `<span style="${headingStyle}">${title}</span>`
 			legendGrps.push({ name, items })
 		}
-		if (t2?.q.descrStats) {
+		if (t2?.q.descrStats && s.showStats) {
 			// term2 has descriptive stats
 			const items = t2.q.descrStats.map(stat => {
 				return {
@@ -934,7 +934,7 @@ function setRenderers(self) {
 		)
 
 		div.select('.pp-sbar-div-chartLengends').selectAll('*').remove()
-		if (self.chartsData.tests && self.chartsData.tests[chart.chartId] && self.config.settings.barchart.showStatsTable) {
+		if (self.chartsData.tests && self.chartsData.tests[chart.chartId] && self.config.settings.barchart.showStats) {
 			//chart has pvalues
 			generatePvalueTable(chart, div)
 		}
@@ -967,7 +967,7 @@ function setRenderers(self) {
 			.style('margin', '10px 10px 10px 30px')
 			.style('display', 'none')
 
-		if (self.chartsData.tests && self.chartsData.tests[chart.chartId] && self.config.settings.barchart.showStatsTable) {
+		if (self.chartsData.tests && self.chartsData.tests[chart.chartId] && self.config.settings.barchart.showStats) {
 			//chart has pvalues
 			generatePvalueTable(chart, div)
 		}
@@ -1234,7 +1234,7 @@ export function getDefaultBarSettings(app) {
 		colorBars: false,
 		colorUsing: 'preassigned',
 		dedup: false,
-		showStatsTable: true,
+		showStats: true,
 		showPercent: false
 	}
 }


### PR DESCRIPTION
# Description
Show stats table renamed to showStats and will show/hide stats in the barchart. Will show/hide the table and the stats legend when applicable. No default behaviour was changed. Just added the possibility to hide the stats when showing the age on the report barchart. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/949).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
