### PR TITLE
copy TermdbTest files in the hg38.test genome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/*
 
 server/app.js
 server/genome/*.js
+!server/genome/copyDataFilesFromRepo2Tp.js
 server/dataset/*.js
 server/test/*.bundle.js
 server/test/cache/*

--- a/server/genome/copyDataFilesFromRepo2Tp.js
+++ b/server/genome/copyDataFilesFromRepo2Tp.js
@@ -1,0 +1,57 @@
+import serverconfig from '@sjcrh/proteinpaint-server/src/serverconfig.js'
+import * as path from 'path'
+import fs from 'fs'
+import { spawnSync } from 'child_process'
+
+/*
+	copyDataFilesFromRepo2Tp()
+	- does not work when tp is not writable, such as when the tp dir is mounted as read-only onto a container
+	- must be called before genome and dataset init steps in initGenomeDs(), 
+	  such as by calling in the genome js file like in genome/hg38.test.ts
+*/
+export async function copyDataFilesFromRepo2Tp(testPath) {
+	// when running tests where the tp directory is not writable (such as from inside a container),
+	// the workflow script should copy the server/test/tp dir as serverconfig.tpmasterdir
+	// and not trigger the symlinks below
+	if (fs.existsSync('/home/root/pp')) {
+		console.warn('skipped TermdbTest copying, assumed the mounted host tp dir is not writable from within a container')
+		return
+	}
+
+	const targetDir = path.join(serverconfig.binpath, 'test/tp', testPath)
+	const datadir = path.join(serverconfig.tpmasterdir, testPath)
+
+	// no need to copy files or set the symlink when the target TermdbTest dir
+	// already equals the datadir under serverconfig.tpmasterdir
+	if (targetDir === datadir) return
+
+	try {
+		await fs.promises.access(serverconfig.tpmasterdir)
+	} catch {
+		// the tp dir is not readable and/or writable,
+		// may still be okay if the tp/files/hg38/TermdbTest already exists and is up-to-date
+		console.log(`!!! insufficient permissions to create or update TermdbTest directory or symlink !!!`)
+		return
+	}
+
+	try {
+		if (!fs.existsSync(datadir)) {
+			fs.symlinkSync(targetDir, datadir)
+		} else if (fs.statSync(datadir).isDirectory()) {
+			// support an option to have an actual TermdbTest dir locally instead of a symlink,
+			// to make it easier to switch between native or container dev/test process,
+			// since a local symlink will not work as a container mount
+			console.log(`copying TermdbTest files to tp dir ...`)
+			// do not delete, copy files from repo to tp
+			const ps = spawnSync(`rsync`, ['-av', `${targetDir}/`, datadir], { encoding: 'utf-8' })
+			if (ps.stderr) throw ps.stderr
+			//console.log(421, [ps.stdout, ps.stderr])
+		} else {
+			console.log('replacing the TermdbTest symlink ...')
+			fs.unlinkSync(datadir)
+			fs.symlinkSync(targetDir, datadir)
+		}
+	} catch (error) {
+		console.warn('Error while copying data files from Repo to Tp: ', error)
+	}
+}

--- a/server/genome/hg38.test.ts
+++ b/server/genome/hg38.test.ts
@@ -1,4 +1,18 @@
 import type { Genome } from '#types'
+import { copyDataFilesFromRepo2Tp } from './copyDataFilesFromRepo2Tp.js'
+
+/*
+The call to copyDataFilesFromRepo2Tp() was moved from dataset/termdb.test.js to here,
+since `TermdbTest/msigdb/db` needs to exist and be loaded as part of genome init,
+before the processing of dataset init in initGenomeDs().
+
+Upon loading this dataset script in the dev environment, if the tp dir is writable then: 
+- directories under tp/ are auto-created if missing
+- data files committed in the repo are copied over to tp/ locations for the dataset to work
+*/
+
+const msigdbSrcPath = 'files/hg38/TermdbTest/msigdb/db'
+await copyDataFilesFromRepo2Tp(msigdbSrcPath)
 
 const genome: Genome = {
 	species: 'human',
@@ -11,7 +25,9 @@ const genome: Genome = {
 		msigdb: {
 			label: 'MSigDB',
 			cohort: {
-				db: { file: 'files/hg38/TermdbTest/msigdb/db' }, // nest file under TermdbTest since the folder is auto symlinked
+				// NOTE: in the dev environment, sjpp/start.js is
+				// nest file under TermdbTest since the folder is auto symlinked
+				db: { file: msigdbSrcPath },
 				termdb: {
 					isGeneSetTermdb: true
 				}


### PR DESCRIPTION
# Description

... to ensure that msigdb exists prior to dataset init. Also. reorganize and add more comments to clarify when copying will work or not, as well as background info on using a directory versus a symlink.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
