### PR TITLE
handle term-level authorization

### DIFF
--- a/client/filter/filter.utils.js
+++ b/client/filter/filter.utils.js
@@ -247,19 +247,17 @@ export function getCategoricalTermFilter(filterTWs, values, excludedTw) {
 	// returning null to represent empty filter value since
 	// - tvslst filter bloats the payload and clutters the server log
 	// - undefined value would be left out during JSON-encoding of an object-as-data
-	return !lst.length
-		? null
-		: {
-				type: 'tvslst',
-				in: true,
-				join: lst.length > 1 ? 'and' : '',
-				lst
-		  }
+	return {
+		type: 'tvslst',
+		in: true,
+		join: lst.length > 1 ? 'and' : '',
+		lst
+	}
 }
 
 function processTW(tw, values, lst) {
 	const value = values[tw.term.id]
-	if (value !== undefined) {
+	if (value) {
 		if (Array.isArray(value)) {
 			const tvs = {
 				type: 'tvs',
@@ -268,8 +266,8 @@ function processTW(tw, values, lst) {
 					values: []
 				}
 			}
-			for (const item of value) tvs.tvs.values.push({ key: item })
-			lst.push(tvs)
+			for (const item of value) if (item) tvs.tvs.values.push({ key: item })
+			if (tvs.tvs.values.length) lst.push(tvs)
 		} else
 			lst.push({
 				type: 'tvs',

--- a/client/filter/test/filter.unit.spec.js
+++ b/client/filter/test/filter.unit.spec.js
@@ -74,11 +74,10 @@ tape('getCategoricalTermFilter()', t => {
 	]
 	const countryTW = filterTWs.find(tw => tw.term.id === 'Acountry')
 	const valuesCountry = { Acountry: 'Kenya' }
-	const emptyFilter = { type: 'tvslst', in: true, join: '', lst: [] }
 	const result1 = getCategoricalTermFilter(filterTWs, valuesCountry, countryTW)
 	t.deepEqual(
 		result1,
-		emptyFilter,
+		null,
 		'Should filter out samples according to all the filter values except for the tw provided, as only one filter is provided and is for the tw passed there is no filter added'
 	)
 

--- a/client/filter/test/filter.unit.spec.js
+++ b/client/filter/test/filter.unit.spec.js
@@ -77,7 +77,7 @@ tape('getCategoricalTermFilter()', t => {
 	const result1 = getCategoricalTermFilter(filterTWs, valuesCountry, countryTW)
 	t.deepEqual(
 		result1,
-		null,
+		{ type: 'tvslst', in: true, join: '', lst: [] },
 		'Should filter out samples according to all the filter values except for the tw provided, as only one filter is provided and is for the tw passed there is no filter added'
 	)
 

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -214,7 +214,7 @@ function getChartTypeList(self, state) {
 			clickTo: self.loadChartSpecificMenu
 		},
 		{
-			label: 'Frecuency Chart',
+			label: 'Frequency Chart',
 			chartType: 'frequencyChart',
 			clickTo: self.showTree_select1term,
 			usecase: { target: 'frequencyChart', detail: 'term' }

--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -512,6 +512,7 @@ class MassSessionBtn {
 // may need to edit state based on updated expectations,
 // such as new or deprecated plot settings keys/values
 async function preprocessState(state, app) {
+	delete state.termdbConfig
 	if (state.plots) {
 		const promises = []
 		for (const plot of state.plots) {

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -176,7 +176,9 @@ export class profilePlot {
 		this.filteredTermValues = await this.app.vocabApi.filterTermValues({
 			terms: this.config.filterTWs,
 			filters,
-			ignoreUserFilter: !this.settings.filterByUserSites
+			// safe to pass because the backend code will still compare terms[] with the the dataset's hiddenTermIds,
+			// it only affects what will be included in the aggregation and does not disable user access authentication
+			filterByUserSites: this.settings.filterByUserSites
 		})
 		this.regions = this.filteredTermValues[this.config.regionTW.id]
 		this.countries = this.filteredTermValues[this.config.countryTW.id]
@@ -636,7 +638,7 @@ export function getDefaultProfilePlotSettings() {
 	return {
 		isAggregate: false,
 		showTable: true,
-		filterByUserSites: false //if true, the user sites filter is applied
+		filterByUserSites: false //if true, the aggregation will be limited to the user sites only
 	}
 }
 

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -170,11 +170,11 @@ export class profilePlot {
 		const isRadarFacility = this.isRadarFacility
 		const filters = {}
 		for (const tw of this.config.filterTWs) {
-			const filter = getCategoricalTermFilter(this.config.filterTWs, this.settings, tw, this.state.termfilter.filter)
-			if (filter) filters[tw.term.id] = filter
+			filters[tw.term.id] = getCategoricalTermFilter(this.config.filterTWs, this.settings, tw)
 		}
 		this.filteredTermValues = await this.app.vocabApi.filterTermValues({
 			terms: this.config.filterTWs,
+			filter: this.state.termfilter.filter,
 			filters,
 			// safe to pass because the backend code will still compare terms[] with the the dataset's hiddenTermIds,
 			// it only affects what will be included in the aggregation and does not disable user access authentication
@@ -439,7 +439,7 @@ export class profilePlot {
 	}
 
 	getFilter() {
-		return getCategoricalTermFilter(this.config.filterTWs, this.settings, null, this.state.termfilter.filter)
+		return getCategoricalTermFilter(this.config.filterTWs, this.settings, null)
 	}
 
 	clearFiltersExcept(ids) {

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -175,7 +175,8 @@ export class profilePlot {
 		}
 		this.filteredTermValues = await this.app.vocabApi.filterTermValues({
 			terms: this.config.filterTWs,
-			filters
+			filters,
+			ignoreUserFilter: !this.settings.filterByUserSites
 		})
 		this.regions = this.filteredTermValues[this.config.regionTW.id]
 		this.countries = this.filteredTermValues[this.config.countryTW.id]

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -175,8 +175,7 @@ export class profilePlot {
 		}
 		this.filteredTermValues = await this.app.vocabApi.filterTermValues({
 			terms: this.config.filterTWs,
-			filters,
-			ignoredTermIds: this.settings.filterByUserSites ? [] : [this.config.facilityTW.term.id] //if filterByUserSites is true, do not ignore the facility term filter
+			filters
 		})
 		this.regions = this.filteredTermValues[this.config.regionTW.id]
 		this.countries = this.filteredTermValues[this.config.countryTW.id]

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -69,7 +69,7 @@ export class Report extends RxComponentInner {
 	}
 
 	getFilter() {
-		return getCategoricalTermFilter(this.config.filterTWs, this.settings, this.state.termdbConfig.authFilter)
+		return getCategoricalTermFilter(this.config.filterTWs, this.settings)
 	}
 
 	getState(appState: any) {
@@ -141,14 +141,10 @@ export class Report extends RxComponentInner {
 			const filterValues = this.settings[tw.term.id] || ''
 			const filters: any = {}
 			for (const tw of this.config.filterTWs)
-				filters[tw.term.id] = getCategoricalTermFilter(
-					this.config.filterTWs,
-					this.settings,
-					tw,
-					this.state.termfilter.filter
-				)
+				filters[tw.term.id] = getCategoricalTermFilter(this.config.filterTWs, this.settings, tw)
 			const data = await this.app.vocabApi.filterTermValues({
 				terms: this.config.filterTWs,
+				filter: this.state.termfilter.filter,
 				filters
 			})
 			const select = this.view.dom.filterSelects[index]

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -69,7 +69,7 @@ export class Report extends RxComponentInner {
 	}
 
 	getFilter() {
-		return getCategoricalTermFilter(this.config.filterTWs, this.settings, null)
+		return getCategoricalTermFilter(this.config.filterTWs, this.settings, this.state.termdbConfig.authFilter)
 	}
 
 	getState(appState: any) {
@@ -77,7 +77,6 @@ export class Report extends RxComponentInner {
 		if (!config) {
 			throw `No plot with id='${this.id}' found. Did you set this.id before this.api = getComponentApi(this)?`
 		}
-
 		return {
 			config,
 			plots: appState.plots.filter(p => p.parentId === this.id), //this property is needed to indicate that child plots need to be added to the appState plots
@@ -187,6 +186,7 @@ export async function getPlotConfig(opts, app) {
 
 	try {
 		const config = app.vocabApi?.termdbConfig?.plotConfigByCohort?.default?.report
+		config.filter = app.vocabApi?.termdbConfig?.authFilter
 		copyMerge(plot, config, opts)
 		if (plot.filterTWs) for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
 

--- a/client/plots/runchart/runchart.ts
+++ b/client/plots/runchart/runchart.ts
@@ -81,7 +81,7 @@ export class Runchart extends Scatter {
 	}
 
 	getFilter() {
-		return getCategoricalTermFilter(this.filterTWs, this.settings, null, this.state.termfilter.filter)
+		return getCategoricalTermFilter(this.filterTWs, this.settings)
 	}
 }
 

--- a/client/plots/runchart/test/runchart.integration.spec.js
+++ b/client/plots/runchart/test/runchart.integration.spec.js
@@ -384,18 +384,16 @@ tape('Test divide by date', function (test) {
 
 	async function runTests(scatter) {
 		scatter.on('postRender.test', null)
-		const samples = scatter.Inner.model.charts[0].data.samples
-		const scatterDiv = scatter.Inner.model.charts[0].chartDiv
+		const charts = scatter.Inner.model.charts
+		const scatterDiv = scatter.Inner.model.charts[0].chartDiv //The runchart plots all the series in the same scatterDiv
 		testPlot()
 		if (test._ok) scatter.Inner.app.destroy()
 		test.end()
 
 		function testPlot() {
 			const serieG = scatterDiv.select('.sjpcb-scatter-series')
-			const paths = serieG.selectAll('path')
-			const numSymbols = paths.size() - 7 // exclude the line paths for each time frame
-			const expected = scatter.Inner.model.charts[0].data.samples.length
-			test.equal(numSymbols, expected, `Should be ${expected}. Rendered ${numSymbols} symbols.`)
+			const paths = serieG.selectAll('path').nodes().length - serieG.selectAll('path[name="serie"]').nodes().length //counted the paths that are connecting the dots in each serie
+			test.equal(charts.length, paths, `Should be ${charts.length}. Rendered ${paths} series.`)
 		}
 	}
 })

--- a/client/plots/runchart/test/runchart.integration.spec.js
+++ b/client/plots/runchart/test/runchart.integration.spec.js
@@ -82,11 +82,8 @@ tape('Render TermdbTest runchart plot', function (test) {
 		function testPlot() {
 			const serieG = scatterDiv.select('.sjpcb-scatter-series')
 			const numSymbols = serieG.selectAll('path').size() - 1 // exclude the path connecting the dots
-			test.equal(
-				numSymbols,
-				scatter.Inner.model.charts[0].data.samples.length,
-				`Should be ${scatter.Inner.model.charts[0].data.samples.length}. Rendered ${numSymbols} symbols.`
-			)
+			const expected = scatter.Inner.model.charts[0].data.samples.length
+			test.equal(numSymbols, expected, `Should be ${expected}. Rendered ${numSymbols} symbols.`)
 		}
 
 		function testLegendTitle() {
@@ -397,11 +394,8 @@ tape('Test divide by date', function (test) {
 			const serieG = scatterDiv.select('.sjpcb-scatter-series')
 			const paths = serieG.selectAll('path')
 			const numSymbols = paths.size() - 7 // exclude the line paths for each time frame
-			test.equal(
-				numSymbols,
-				scatter.Inner.model.charts[0].data.samples.length,
-				`Should be ${scatter.Inner.model.charts[0].data.samples.length}. Rendered ${numSymbols} symbols.`
-			)
+			const expected = scatter.Inner.model.charts[0].data.samples.length
+			test.equal(numSymbols, expected, `Should be ${expected}. Rendered ${numSymbols} symbols.`)
 		}
 	}
 })

--- a/client/plots/runchart/view/runchartView.ts
+++ b/client/plots/runchart/view/runchartView.ts
@@ -19,12 +19,11 @@ export class RunchartView extends ScatterView {
 		const terms = this.runchart.filterTWs
 		const filters = {}
 		for (const tw of terms) {
-			const filter = getCategoricalTermFilter(terms, this.scatter.settings, tw, this.scatter.state.termfilter.filter)
-			if (filter) filters[tw.term.id] = filter
+			filters[tw.term.id] = getCategoricalTermFilter(terms, this.scatter.settings, tw)
 		}
-
 		//Dictionary with samples applying all the filters but not the one from the current term id
 		const filteredTermValues = await this.runchart.app.vocabApi.filterTermValues({
+			filter: this.scatter.state.termfilter.filter,
 			filters,
 			terms
 		})

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1338,6 +1338,7 @@ export class TermdbVocab extends Vocab {
 		}
 		if (body.filter) body.filter = getNormalRoot(body.filter)
 		if (body.terms) {
+			body.terms = structuredClone(body.terms)
 			for (const tw of body.terms) {
 				this.mayStripTwProps(tw)
 			}
@@ -1352,6 +1353,7 @@ export class TermdbVocab extends Vocab {
 			...args
 		}
 		if (body.filter) body.filter = getNormalRoot(body.filter)
+		body.facilityTW = structuredClone(body.facilityTW)
 		this.mayStripTwProps(body.facilityTW)
 		if (body.scoreTerms) {
 			// replace with a mutable copy
@@ -1370,7 +1372,6 @@ export class TermdbVocab extends Vocab {
 			dslabel: this.vocab.dslabel,
 			...args
 		}
-		console.log(1372, body)
 		if (body.filter) body.filter = getNormalRoot(body.filter)
 		if (body.terms) {
 			for (const t of body.terms) {

--- a/server/routes/filterTermValues.ts
+++ b/server/routes/filterTermValues.ts
@@ -62,6 +62,7 @@ function getList(samplesPerFilter, filtersData, tw) {
 async function getFilters(query, ds, genome, res) {
 	try {
 		//Dictionary with samples applying all the filters but not the one from the current term id
+		if (query.ignoredTermIds) query.__protected__.ignoredTermIds.push(...query.ignoredTermIds)
 		const samplesPerFilter = await getSamplesPerFilter(query, ds)
 		const filtersData = await getData(
 			{

--- a/server/routes/filterTermValues.ts
+++ b/server/routes/filterTermValues.ts
@@ -62,7 +62,6 @@ function getList(samplesPerFilter, filtersData, tw) {
 async function getFilters(query, ds, genome, res) {
 	try {
 		//Dictionary with samples applying all the filters but not the one from the current term id
-		if (query.ignoredTermIds) query.__protected__.ignoredTermIds.push(...query.ignoredTermIds)
 		const samplesPerFilter = await getSamplesPerFilter(query, ds)
 		const filtersData = await getData(
 			{

--- a/server/routes/filterTermValues.ts
+++ b/server/routes/filterTermValues.ts
@@ -65,7 +65,8 @@ async function getFilters(query, ds, genome, res) {
 		const samplesPerFilter = await getSamplesPerFilter(query, ds)
 		const filtersData = await getData(
 			{
-				terms: query.terms
+				terms: query.terms,
+				__protected__: query.__protected__
 			},
 			ds,
 			genome

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -83,7 +83,7 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request): Promise<GRIN2Re
 	mayLog('[GRIN2] Getting samples from cohort filter...')
 
 	const samples = await get_samples(
-		request.filter,
+		request,
 		ds,
 		true // must set to true to return sample name to be able to access file. FIXME this can let names revealed to grin2 client, may need to apply access control
 	)

--- a/server/routes/profileScores.ts
+++ b/server/routes/profileScores.ts
@@ -48,7 +48,8 @@ async function getScores(query, ds, genome) {
 	const data = await getData(
 		{
 			terms,
-			filter: query.site || !query.isAggregate ? undefined : query.filter //if site is specified, do not apply the filter that is for the aggregation
+			filter: query.site || !query.isAggregate ? undefined : query.filter, //if site is specified, do not apply the filter that is for the aggregation
+			__protected__: query.__protected__
 		},
 		ds,
 		genome

--- a/server/routes/profileScores.ts
+++ b/server/routes/profileScores.ts
@@ -37,7 +37,7 @@ function init({ genomes }) {
 }
 
 async function getScores(query, ds, genome) {
-	query.__protected__.ignoredTermIds.push(query.facilityTW.term.id)
+	if (!query.filterByUserSites) query.__protected__.ignoredTermIds.push(query.facilityTW.term.id)
 
 	const terms: any[] = [query.facilityTW]
 	for (const term of query.scoreTerms) {

--- a/server/routes/profileScores.ts
+++ b/server/routes/profileScores.ts
@@ -37,6 +37,8 @@ function init({ genomes }) {
 }
 
 async function getScores(query, ds, genome) {
+	query.__protected__.ignoredTermIds.push(query.facilityTW.term.id)
+
 	const terms: any[] = [query.facilityTW]
 	for (const term of query.scoreTerms) {
 		terms.push(term.score)

--- a/server/routes/termdb.categories.ts
+++ b/server/routes/termdb.categories.ts
@@ -52,7 +52,8 @@ async function trigger_getcategories(
 		filter0: q.filter0,
 		terms: [q.tw],
 		currentGeneNames: q.currentGeneNames, // optional, from mds3 mayAddGetCategoryArgs()
-		rglst: q.rglst // optional, from mds3 mayAddGetCategoryArgs()
+		rglst: q.rglst, // optional, from mds3 mayAddGetCategoryArgs()
+		__protected__: q.__protected__
 	}
 
 	const data = await getData(arg, ds, genome)

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -117,7 +117,6 @@ function make(q, req, res, ds: Mds3WithCohort, genome) {
 	if (tdb.regression) c.regression = tdb.regression
 	if (ds.assayAvailability) c.assayAvailability = ds.assayAvailability
 	if (ds.cohort.correlationVolcano) c.correlationVolcano = ds.cohort.correlationVolcano
-	c.requiredAuth = authApi.getRequiredCredForDsEmbedder(q.dslabel, q.embedder)
 	addRestrictAncestries(c, tdb)
 	addScatterplots(c, ds)
 	addMatrixplots(c, ds)
@@ -129,6 +128,9 @@ function make(q, req, res, ds: Mds3WithCohort, genome) {
 	const info: any = authApi.getNonsensitiveInfo(req) // type any to avoid tsc err
 	c.clientAuthResult = info?.clientAuthResult || {}
 	if (tdb.displaySampleIds) c.displaySampleIds = tdb.displaySampleIds(c.clientAuthResult)
+	// app.middleware.js would have used authApi.mayAdjustFilter() to create an auth-related filter,
+	// note this may be undefined if there is no ds.cohort.termdb.getAdditionalFilter
+	c.authFilter = req.query.filter
 
 	res.send({ termdbConfig: c })
 }

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -98,7 +98,8 @@ function make(q, req, res, ds: Mds3WithCohort, genome) {
 		defaultChartType: ds.cohort.defaultChartType,
 		invalidTokenErrorHandling: tdb.invalidTokenErrorHandling,
 		colorMap: tdb.colorMap,
-		defaultTw4correlationPlot: tdb.defaultTw4correlationPlot
+		defaultTw4correlationPlot: tdb.defaultTw4correlationPlot,
+		authFilter: req.query.filter
 	}
 	// optional attributes
 	// when missing, the attribute will not be present as "key:undefined"

--- a/server/routes/termdb.descrstats.ts
+++ b/server/routes/termdb.descrstats.ts
@@ -30,7 +30,11 @@ function init({ genomes }) {
 			if (!tdb) throw 'invalid termdb object'
 
 			if (!q.tw.$id) q.tw.$id = '_' // current typing thinks tw$id is undefined. add this to avoid tsc err. delete this line when typing is fixed
-			const data = await getData({ filter: q.filter, filter0: q.filter0, terms: [q.tw] }, ds, genome)
+			const data = await getData(
+				{ filter: q.filter, filter0: q.filter0, terms: [q.tw], __protected__: q.__protected__ },
+				ds,
+				genome
+			)
 			if (data.error) throw data.error
 
 			const values: number[] = []

--- a/server/routes/termdb.topMutatedGenes.ts
+++ b/server/routes/termdb.topMutatedGenes.ts
@@ -97,7 +97,7 @@ export function validate_query_getTopMutatedGenes(ds: any) {
 	q.get = async (param: topMutatedGeneRequest) => {
 		let sampleStatement = ''
 		if (param.filter) {
-			const lst = await get_samples(param.filter, ds)
+			const lst = await get_samples(param, ds)
 			if (lst.length == 0) throw 'empty sample filter'
 			sampleStatement = `WHERE sample IN (${lst.map(i => i.id).join(',')})`
 		}

--- a/server/routes/termdb.topTermsByType.ts
+++ b/server/routes/termdb.topTermsByType.ts
@@ -58,7 +58,7 @@ function nativeValidateQuery(ds: any, type: string) {
 		const samples = [] as string[]
 		if (q.filter) {
 			// get all samples pasing pp filter, may contain those without exp data
-			const sidlst = await get_samples(q.filter, ds)
+			const sidlst = await get_samples(q, ds)
 			// [{id:int}]
 			// filter for those with exp data from q.samples[]
 			for (const i of sidlst) {

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -73,7 +73,7 @@ function nativeValidateQuery(ds: any) {
 		const samples = [] as string[]
 		if (q.filter) {
 			// get all samples pasing pp filter, may contain those without exp data
-			const sidlst = await get_samples(q.filter, ds)
+			const sidlst = await get_samples(q, ds)
 			// [{id:int}]
 			// filter for those with exp data from q.samples[]
 			for (const i of sidlst) {

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -113,11 +113,12 @@ export function setAppMiddlewares(app, doneLoading) {
         by doing this, route code is worry-free and no need to pass "req{}" to gdc purpose-specific code doing the API calls
         these *protected* contents are not used in non-gdc code
         */
-		req.query.__protected__ = req.query.dslabel ? authApi.getNonsensitiveInfo(req) : {}
+		const __protected__ = { ignoredTermIds: [] }
+		if (req.query.dslabel) Object.assign(__protected__, authApi.getNonsensitiveInfo(req))
 		if (req.cookies?.sessionid) {
-			req.query.__protected__.sessionid = req.cookies.sessionid
+			__protected__.sessionid = req.cookies.sessionid
 		}
-		Object.freeze(req.query.__protected__)
+		req.query.__protected__ = Object.freeze(__protected__)
 		next()
 	})
 

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -113,7 +113,7 @@ export function setAppMiddlewares(app, doneLoading) {
         by doing this, route code is worry-free and no need to pass "req{}" to gdc purpose-specific code doing the API calls
         these *protected* contents are not used in non-gdc code
         */
-		req.query.__protected__ = {}
+		req.query.__protected__ = req.query.dslabel ? authApi.getNonsensitiveInfo(req) : {}
 		if (req.cookies?.sessionid) {
 			req.query.__protected__.sessionid = req.cookies.sessionid
 		}

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -125,7 +125,7 @@ export function setAppMiddlewares(app, genomes, doneLoading) {
 		const __protected__ = req.query.__protected__
 		if (req.query.dslabel) {
 			Object.assign(__protected__, authApi.getNonsensitiveInfo(req))
-			if (req.query.genome && req.query.label && req.query.label !== 'msigdb') {
+			if (req.query.genome && req.query.dslabel && req.query.dslabel !== 'msigdb') {
 				const genome = genomes[req.query.genome]
 				try {
 					if (!genome) throw 'invalid genome'

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -125,16 +125,21 @@ export function setAppMiddlewares(app, genomes, doneLoading) {
 		const __protected__ = req.query.__protected__
 		if (req.query.dslabel) {
 			Object.assign(__protected__, authApi.getNonsensitiveInfo(req))
-			if (req.query.genome) {
+			if (req.query.genome && req.query.label && req.query.label !== 'msigdb') {
 				const genome = genomes[req.query.genome]
-				if (!genome) throw 'invalid genome'
-				const ds = genome.datasets[req.query.dslabel]
-				if (!ds) throw 'invalid dslabel'
-				// by not supplying the 3rd argument (routeTwList) to authApi.mayAdjustFilter(),
-				// it will add the stricted additional filter by default for any downstream code from here;
-				// later, any server route or downstream code may call authApi.mayAdjustFilter() again to
-				// loosen the additional filter, to consider fewer tvs terms based on route-specific payloads or aggregation logic
-				if (ds.cohort?.termdb?.getAdditionalFilter) authApi.mayAdjustFilter(req.query, ds)
+				try {
+					if (!genome) throw 'invalid genome'
+					const ds = genome.datasets[req.query.dslabel]
+					if (!ds) throw 'invalid dslabel'
+					// by not supplying the 3rd argument (routeTwList) to authApi.mayAdjustFilter(),
+					// it will add the stricted additional filter by default for any downstream code from here;
+					// later, any server route or downstream code may call authApi.mayAdjustFilter() again to
+					// loosen the additional filter, to consider fewer tvs terms based on route-specific payloads or aggregation logic
+					if (ds.cohort?.termdb?.getAdditionalFilter) authApi.mayAdjustFilter(req.query, ds)
+				} catch (error) {
+					res.send({ error })
+					return
+				}
 			}
 		}
 		if (req.cookies?.sessionid) {

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -121,7 +121,7 @@ export function setAppMiddlewares(app, doneLoading) {
           and as determined by a server route code that the dataset can use to compute per-user access restrictions/authorizations 
           when querying data
         */
-		const __protected__ = { ignoredTermIds: [] }
+		const __protected__ = { ignoredTermIds: [] } // when provided the filter on these terms will be ignored
 		if (req.query.dslabel) Object.assign(__protected__, authApi.getNonsensitiveInfo(req))
 		if (req.cookies?.sessionid) {
 			__protected__.sessionid = req.cookies.sessionid

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,7 +41,7 @@ export async function launch() {
 		console.log('setting app middlewares ...')
 		const app = express()
 		app.disable('x-powered-by')
-		setAppMiddlewares(app, doneLoading)
+		setAppMiddlewares(app, genomes, doneLoading)
 
 		console.log('setting server routes ...')
 		const routeCallbacks = await setOptionalRoutes(app)

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -545,7 +545,10 @@ async function maySetAuthRoutes(app, basepath = '', _serverconfig = null) {
 	*/
 	authApi.getNonsensitiveInfo = function (req) {
 		if (!req.query.dslabel) throw 'req.query.dslabel missing'
-		if (!req.query.embedder) throw 'req.query.embedder missing'
+		if (!req.query.embedder) {
+			req.query.embedder = req.get('host')?.split(':')[0]
+			if (!req.query.embedder) throw 'req.query.embedder missing'
+		}
 
 		const forbiddenRoutes = []
 		const ds = creds[req.query.dslabel] || creds['*']

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -677,7 +677,10 @@ async function maySetAuthRoutes(app, basepath = '', _serverconfig = null) {
 
 		// NOTE: as needed, the server route code must append to q.__protected__ignoredTermRestrictions[],
 		//  since it knows the req.query key names that correspond to terms
-		const termsToCheck = twArr.filter(tw => !q.__protected__.ignoredTermIds.includes(tw.term.id)).map(tw => tw.term)
+		const termsToCheck =
+			twArr === null
+				? null
+				: twArr.filter(tw => !q.__protected__.ignoredTermIds.includes(tw.term.id)).map(tw => tw.term)
 		const additionalFilter = ds.cohort.termdb.getAdditionalFilter(q.__protected__.clientAuthResult, termsToCheck)
 		if (!additionalFilter) {
 			// certain roles (from jwt payload) may have access to everything,

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -666,10 +666,15 @@ async function maySetAuthRoutes(app, basepath = '', _serverconfig = null) {
 
 	// q: req.query
 	// ds: dataset object
-	// routeTwLst
+	// routeTwLst[]: optional array of route-specific termwrappers
+	//   - if undefined: the ds.getAdditionalFilter() should return it's strictest auth filter
+	//   - if an empty array: no terms should be considered protected by ds.getAdditionalFilter(), so no auth filter
+	//   - if an array with 1+ entries: these are the only terms to be matched against a dataset's hidden terms,
+	//     and the ds should construct an actual or undefined auth filter based on matched terms
 	authApi.mayAdjustFilter = function (q, ds, routeTwLst) {
 		if (!ds.cohort.termdb.getAdditionalFilter) return
 		if (!q.__protected__) throw `missing q.__protected__`
+		if (routeTwLst && !Array.isArray(routeTwLst)) throw `invalid routeTwLst`
 
 		// clientAuthResult{}: from authApi.getNonsensitiveInfo()
 		// ignoredTermIds[]: a list of protected term.ids to ignore,

--- a/server/src/bulk.mset.js
+++ b/server/src/bulk.mset.js
@@ -51,7 +51,7 @@ export async function mayGetGeneVariantData(tw, q) {
 		// requires that not only q.filter{} is present, but also filter.lst[] is a non-empty array
 		// as client may send filter with blank array of tvs and will break get_samples()
 		//!!! DO NOT USE FOR geneVariant filterCTE constructor
-		filterSamples = [...new Set((await get_samples(q.filter, ds)).map(i => i.id))]
+		filterSamples = [...new Set((await get_samples(q, ds)).map(i => i.id))]
 	}
 
 	for (const flagname in flagset) {

--- a/server/src/mds3.filter.js
+++ b/server/src/mds3.filter.js
@@ -28,7 +28,7 @@ export async function mayLimitSamples(param, allSamples, ds) {
 	}
 
 	// get_samples() return [{id:int}] with possibly duplicated items, deduplicate and return list of integer ids
-	const filterSamples = [...new Set((await get_samples(filter, ds)).map(i => i.id))]
+	const filterSamples = [...new Set((await get_samples({ filter }, ds)).map(i => i.id))]
 
 	// filterSamples is the list of samples retrieved from termdb that are matching filter
 	// as allSamples (from bcf etc) may be a subset of what's in termdb

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2885,7 +2885,7 @@ async function filterSamples4assayAvailability(q, ds) {
 		return null
 	}
 	// not gdc
-	return q.filter && q.filter.lst.length ? new Set((await get_samples(q.filter, ds)).map(i => i.id)) : null
+	return q.filter && q.filter.lst.length ? new Set((await get_samples(q, ds)).map(i => i.id)) : null
 }
 
 function addDataAvailability(sid, sample2mlst, dtKey, mclass, origin, sampleFilter) {

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -108,7 +108,11 @@ export async function barchart_data(q, ds, tdb) {
 		if (term) map.set(i, term)
 	}
 	const terms = [...map.values()]
-	const data = await getData({ filter: q.filter, filter0: q.filter0, terms }, q.ds, q.genome)
+	const data = await getData(
+		{ filter: q.filter, filter0: q.filter0, terms, __protected__: q.__protected__ },
+		q.ds,
+		q.genome
+	)
 	if (data.error) throw data.error
 	const samplesMap = new Map()
 	const bins = []

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -32,7 +32,7 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 	}
 	if (filter.lst.length == 1) {
 		// only one element at this level, disregard "join"
-		if (filter.lst[0].type == 'tvslst') throw 'only one element at a level: type should not be "tvslst"'
+		//if (filter.lst[0].type == 'tvslst') throw 'only one element at a level: type should not be "tvslst"'
 	} else {
 		// multiple elements at this level
 		if (filter.join != 'or' && filter.join != 'and')

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -25,7 +25,9 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 	if (filter.type != 'tvslst') throw 'filter.type is not "tvslst" but: ' + filter.type
 	if (!Array.isArray(filter.lst)) throw 'filter.lst must be an array'
 	if (filter.lst.length == 0) {
-		// an empty filter.lst[] is acceptable and equivalent to having a falsy (null, undefined) filter
+		// an empty filter.lst[] at the top level is acceptable and equivalent to having a falsy (null, undefined) filter;
+		// a nested filter always has a non-default CTEname value as 4th argument and must not have an empty lst[]
+		if (CTEname != 'f') console.warn('!!! nested filter.lst[] is zero length, see if is an error !!!')
 		return
 	}
 	if (filter.lst.length == 1) {

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -140,7 +140,7 @@ async function trigger_getsamples(q, res, ds) {
 
 async function getSampleList(req, q, ds) {
 	const canDisplay = authApi.canDisplaySampleIds(req, ds)
-	const samples = await termdbsql.get_samples(q.filter, ds, canDisplay)
+	const samples = await termdbsql.get_samples(q, ds, canDisplay)
 	return samples
 }
 
@@ -326,7 +326,7 @@ async function get_AllSamplesByName(q, req, res, ds) {
 		q.ds = ds
 		const filteredSamples = ds.cohort.termdb.hasSampleAncestry
 			? await get_samples_ancestry(q.filter, q.ds, true)
-			: await get_samples(q.filter, q.ds, true)
+			: await get_samples(q, q.ds, true)
 		for (const sample of filteredSamples) {
 			const name = ds.sampleId2Name.get(sample.id)
 			const sample_type = ds.sampleId2Type.get(sample.id)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -372,6 +372,7 @@ export async function getSamplesPerFilter(q, ds) {
 	const samples = {}
 	for (const id in q.filters) {
 		const filter = q.filters[id]
+		// We need to update the filter to contain the user filter when ignoredTermIds includes the site term id!!!
 		const result = (await get_samples(filter, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -15,6 +15,7 @@ import { get_bin_label, compute_bins } from '#shared/termdb.bins.js'
 import { trigger_getDefaultBins } from './termdb.getDefaultBins.js'
 import { getCategories } from '../routes/termdb.categories.ts'
 import { authApi } from '#src/auth.js'
+import { filterJoin } from '#shared/filter.js'
 
 /*
 
@@ -54,7 +55,7 @@ Returns:
 export async function getData(q, ds, genome, onlyChildren = false) {
 	try {
 		validateArg(q, ds)
-		authApi.mayExtendqFilter(q, ds, q.terms)
+		authApi.mayAdjustFilter(q, ds, q.terms)
 		const data = await getSampleData(q, ds, onlyChildren)
 		// get categories within same data request to avoid a separate
 		// getCategories() request, which can be time-consuming for
@@ -96,7 +97,7 @@ function validateArg(q, ds) {
 	}
 	if (ds.cohort?.termdb?.getRestrictedTermValues) {
 		if (!q.__protected__) throw `missing q.__protected__, must be set upstream of getData()`
-		// also validated in authApi.mayExtendqFilter()
+		// also validated in authApi.mayAdjustFilter()
 	}
 }
 
@@ -371,7 +372,7 @@ export async function getSamplesPerFilter(q, ds) {
 	q.ds = ds
 	const samples = {}
 	for (const id in q.filters) {
-		const filter = q.filters[id]
+		const filter = filterJoin([q.filter, q.filters[id]])
 		const result = (await get_samples({ filter, __protected__: q.__protected__ }, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -372,7 +372,7 @@ export async function getSamplesPerFilter(q, ds) {
 	q.ds = ds
 	const samples = {}
 	for (const id in q.filters) {
-		const filter = filterJoin([q.filter, q.filters[id]])
+		const filter = q.filters[id] ? filterJoin([q.filter, q.filters[id]]) : q.filter
 		const result = (await get_samples({ filter, __protected__: q.__protected__ }, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -372,8 +372,7 @@ export async function getSamplesPerFilter(q, ds) {
 	q.ds = ds
 	const samples = {}
 	for (const id in q.filters) {
-		let filter = q.filters[id]
-		if (!q.ignoreUserFilter && q.filter) filter = filterJoin([q.filter, q.filters[id]])
+		const filter = filterJoin([q.filter, q.filters[id]])
 		const result = (await get_samples({ filter, __protected__: q.__protected__ }, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -372,7 +372,8 @@ export async function getSamplesPerFilter(q, ds) {
 	q.ds = ds
 	const samples = {}
 	for (const id in q.filters) {
-		const filter = filterJoin([q.filter, q.filters[id]])
+		let filter = q.filters[id]
+		if (!q.ignoreUserFilter && q.filter) filter = filterJoin([q.filter, q.filters[id]])
 		const result = (await get_samples({ filter, __protected__: q.__protected__ }, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -359,7 +359,7 @@ async function mayGetSampleFilterSet4snplst(q, nonDictTerms) {
 		return
 	}
 	if (!q.filter) return // no filter, allow snplst/snplocus to return data for all samples
-	return new Set((await get_samples(q.filter, q.ds)).map(i => i.id))
+	return new Set((await get_samples(q, q.ds)).map(i => i.id))
 }
 
 export async function getSamplesPerFilterResponse(q, ds, res) {
@@ -372,8 +372,7 @@ export async function getSamplesPerFilter(q, ds) {
 	const samples = {}
 	for (const id in q.filters) {
 		const filter = q.filters[id]
-		// We need to update the filter to contain the user filter when ignoredTermIds includes the site term id!!!
-		const result = (await get_samples(filter, q.ds)).map(i => i.id)
+		const result = (await get_samples({ filter, __protected__: q.__protected__ }, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}
 	return samples

--- a/server/src/termdb.phewas.js
+++ b/server/src/termdb.phewas.js
@@ -44,7 +44,7 @@ export async function trigger(q, res, ds) {
 	// optional filter on samples
 	let samplefilterset
 	if (q.filter) {
-		samplefilterset = new Set(await termdbsql.get_samples(q.filter, ds))
+		samplefilterset = new Set(await termdbsql.get_samples(q, ds))
 	}
 
 	const [sample2gt, genotype2sample] = await utils.loadfile_ssid(q.ssid, samplefilterset)
@@ -436,7 +436,7 @@ async function may_subcohortTermtype2samples(ds) {
 		const config = ds.cohort.termdb.phewas.precompute_subcohort2totalsamples[key]
 		if (config.termtype) {
 			for (const type in config.termtype) {
-				config.termtype[type].samples = await termdbsql.get_samples(config.termtype[type].filter, ds)
+				config.termtype[type].samples = await termdbsql.get_samples({ filter: config.termtype[type].filter }, ds)
 			}
 		}
 	}
@@ -858,7 +858,10 @@ only used for precomputing, not for on the fly
 
 	if (ds.cohort.termdb.phewas.samplefilter4termtype) {
 		if (ds.cohort.termdb.phewas.samplefilter4termtype.condition) {
-			const samples = await termdbsql.get_samples(ds.cohort.termdb.phewas.samplefilter4termtype.condition.filter, ds)
+			const samples = await termdbsql.get_samples(
+				{ filter: ds.cohort.termdb.phewas.samplefilter4termtype.condition.filter },
+				ds
+			)
 			if (ds.track && ds.track.vcf && ds.track.vcf.sample2arrayidx) {
 				// must also restrict to vcf samples
 				condition_samples = []

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -89,7 +89,12 @@ export async function trigger_getSampleScatter(req, q, res, ds, genome) {
 		if (q.divideByTW) terms.push(q.divideByTW)
 		if (q.scaleDotTW) terms.push(q.scaleDotTW)
 		if (q.coordTWs) for (const tw of q.coordTWs) terms.push(tw)
-		const data = await getData({ filter: q.filter, filter0: q.filter0, terms }, ds, genome, true)
+		const data = await getData(
+			{ filter: q.filter, filter0: q.filter0, terms, __protected__: q.__protected__ },
+			ds,
+			genome,
+			true
+		)
 		if (data.error) throw data.error
 		let result
 		if (q.coordTWs.length > 0) {

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -615,9 +615,7 @@ export function filterTerms(req, ds, terms) {
 
 const defaultCommonCharts: isSupportedChartCallbacks = {
 	dictionary: () => true,
-	summary: () => true,
 	matrix: () => true,
-
 	/*
 	parent type: regression
 	child types: linear/logistic/cox

--- a/server/src/termdb.snp.js
+++ b/server/src/termdb.snp.js
@@ -107,7 +107,7 @@ async function summarizeSamplesFromCache(q, tdb, ds, genome) {
 	let sampleinfilter // list of true/false, same length of tk.samples, to tell if a sample is in use
 	if (q.filter) {
 		// using optional filter
-		const filterSet = new Set((await termdbsql.get_samples(q.filter, ds)).map(i => i.id))
+		const filterSet = new Set((await termdbsql.get_samples({ filter: q.filter }, ds)).map(i => i.id))
 		if (filterSet.size == 0) throw 'no samples from filter'
 		sampleinfilter = tk.samples.map(i => filterSet.has(i.name))
 	} else {

--- a/server/src/termdb.sql.categorical.js
+++ b/server/src/termdb.sql.categorical.js
@@ -1,22 +1,16 @@
 import { getUncomputableClause } from './termdb.sql'
 
 export const values = {
-	getCTE(tablename, term, ds, q, values, groupset, restrictedTermValues) {
+	getCTE(tablename, term, ds, q, values) {
 		values.push(term.id)
 		const uncomputable = getUncomputableClause(term, q)
 		values.push(...uncomputable.values)
 		// groupsetting not applied
-		let extraClause = ''
-		if (restrictedTermValues) {
-			// ok for restrictedTermValues to be an empty array, that would mean all values are hidden
-			extraClause = `AND value IN (${restrictedTermValues.map(v => '?').join(',')})`
-			values.push(...restrictedTermValues)
-		}
 		return {
 			sql: `${tablename} AS (
 				SELECT sample,value as key, value as value
 				FROM anno_categorical
-				WHERE term_id=? ${uncomputable.clause} ${extraClause}
+				WHERE term_id=? ${uncomputable.clause}
 			)`,
 			tablename
 		}
@@ -41,24 +35,20 @@ export const groupset = {
 		- a series of "SELECT name, value" statements that are joined by UNION ALL
 		- uncomputable values are not included in the CTE results, EXCEPT IF such values are in a group
 	*/
-	async getCTE(tablename, term, ds, q, values, groupset, restrictedTermValues) {
-		if (restrictedTermValues)
-			throw `TODO: comment this out and verify the handling of restrictedTermValues in groupset.getCTE() below`
+	async getCTE(tablename, term, ds, q, values, groupset) {
 		if (!groupset.groups) throw `.groups[] missing from a group-set, term.id='${term.id}'`
 
 		const categories = []
 		const filters = []
 		for (const g of groupset.groups) {
 			if (g.uncomputable) continue
-			// TODO: test and verify this logic
-			const allowedValues = !restrictedTermValues ? g.values : g.values.filter(v => restrictedTermValues.includes(v))
 			if (g.type == 'values') {
 				categories.push(`SELECT sample, ? as key, value
 					FROM anno_categorical a
 					WHERE term_id=?
-						AND value IN (${allowedValues.map(v => '?').join(',')})
+						AND value IN (${g.values.map(v => '?').join(',')})
 				`)
-				values.push(g.name, term.id, ...allowedValues.map(v => v.key.toString()))
+				values.push(g.name, term.id, ...g.values.map(v => v.key.toString()))
 			} else if (g.type == 'filter') {
 				// TODO: create filter sql for group.type == 'filter'
 				if ('activeCohort' in q.groupsetting && g.filter4activeCohort) {
@@ -69,15 +59,9 @@ export const groupset = {
 					filters.push(filter.filters)
 					values.push(...filter.values.slice(), g.name, g.name)
 
-					let extraClause = ''
-					if (restrictedTermValues) {
-						extraClause = `AND value in $(allowedValues.map(v => '?'))`
-						values.push(...allowedValues)
-					}
-
 					categories.push(
 						`SELECT sample, ? AS key, ? AS value
-						FROM ${filter.CTEname} ${extraClause}`
+						FROM ${filter.CTEname}`
 					)
 				} else {
 					throw `activeCohort error: cannot construct filter statement for group name='${g.name}', term.id=${term.id}`

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -433,17 +433,6 @@ export async function get_term_cte(q, values, index, filter, termWrapper = null)
 		termq = JSON.parse(decodeURIComponent(termq))
 	}
 
-	let restrictedTermValues
-	if (q.ds.cohort?.termdb?.getRestrictedTermValues) {
-		// NOTES:
-		// - getRestrictedTermValues is expected to throw if q.__protected__ is not set
-		//   CRITICAL TO SET THIS WHEN CALLING getData() in termdb.matrix or other upstream code
-		//
-		// TODO: pass restrictedTermValues to every getCTE() function call below
-		//
-		restrictedTermValues = q.ds.cohort?.termdb?.getRestrictedTermValues(q.__protected__.clientAuthResult, term)
-	}
-
 	const tablename = 'samplekey_' + index
 
 	/*
@@ -463,15 +452,7 @@ export async function get_term_cte(q, values, index, filter, termWrapper = null)
 	let CTE
 	if (term.type == 'categorical') {
 		const groupset = get_active_groupset(term, termq)
-		CTE = await categoricalSql[groupset ? 'groupset' : 'values'].getCTE(
-			tablename,
-			term,
-			q.ds,
-			termq,
-			values,
-			groupset,
-			restrictedTermValues
-		)
+		CTE = await categoricalSql[groupset ? 'groupset' : 'values'].getCTE(tablename, term, q.ds, termq, values, groupset)
 	} else if (isNumericTerm(term)) {
 		const mode = termq.mode == 'spline' ? 'cubicSpline' : termq.mode || 'discrete'
 		// the error is coming from this

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -45,14 +45,14 @@ get_label4key
 */
 //in the future we may need to pass the sample type when there are more types than root and not root
 export async function get_samples(q, ds, canDisplay = false) {
-	console.log(q)
 	/*
 must have qfilter[]
 as the actual query is embedded in q.filter
 return an array of sample names passing through the filter
 */
-
-	authApi.mayExtendqFilter(q, ds, null)
+	// NOTE: no need to call authApi.mayAdjustFilter() here since the app.middleware
+	// already created/adjusted q.filter; would only need to call here if
+	// q.__protected__.ignoreTermIds is modified or if routeTwLst can be supplied at this point
 
 	const filter = await getFilterCTEs(q.filter, ds) // if q.filter is blank, it returns null
 	const sql = filter

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -433,6 +433,17 @@ export async function get_term_cte(q, values, index, filter, termWrapper = null)
 		termq = JSON.parse(decodeURIComponent(termq))
 	}
 
+	let restrictedTermValues
+	if (q.ds.cohort?.termdb?.getRestrictedTermValues) {
+		// NOTES:
+		// - getRestrictedTermValues is expected to throw if q.__protected__ is not set
+		//   CRITICAL TO SET THIS WHEN CALLING getData() in termdb.matrix or other upstream code
+		//
+		// TODO: pass restrictedTermValues to every getCTE() function call below
+		//
+		restrictedTermValues = q.ds.cohort?.termdb?.getRestrictedTermValues(q.__protected__.clientAuthResult, term)
+	}
+
 	const tablename = 'samplekey_' + index
 
 	/*
@@ -452,7 +463,15 @@ export async function get_term_cte(q, values, index, filter, termWrapper = null)
 	let CTE
 	if (term.type == 'categorical') {
 		const groupset = get_active_groupset(term, termq)
-		CTE = await categoricalSql[groupset ? 'groupset' : 'values'].getCTE(tablename, term, q.ds, termq, values, groupset)
+		CTE = await categoricalSql[groupset ? 'groupset' : 'values'].getCTE(
+			tablename,
+			term,
+			q.ds,
+			termq,
+			values,
+			groupset,
+			restrictedTermValues
+		)
 	} else if (isNumericTerm(term)) {
 		const mode = termq.mode == 'spline' ? 'cubicSpline' : termq.mode || 'discrete'
 		// the error is coming from this

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -7,6 +7,7 @@ import { sampleLstSql } from './termdb.sql.samplelst.js'
 import { multivalueCTE } from './termdb.sql.multivalue.js'
 import { boxplot_getvalue } from './utils.js'
 import { DEFAULT_SAMPLE_TYPE, isNumericTerm, annoNumericTypes } from '#shared/terms.js'
+import { authApi } from '#src/auth.js'
 /*
 
 ********************** EXPORTED
@@ -43,13 +44,17 @@ get_label4key
 
 */
 //in the future we may need to pass the sample type when there are more types than root and not root
-export async function get_samples(qfilter, ds, canDisplay = false) {
+export async function get_samples(q, ds, canDisplay = false) {
+	console.log(q)
 	/*
 must have qfilter[]
-as the actual query is embedded in qfilter
+as the actual query is embedded in q.filter
 return an array of sample names passing through the filter
 */
-	const filter = await getFilterCTEs(qfilter, ds) // if qfilter is blank, it returns null
+
+	authApi.mayExtendqFilter(q, ds, null)
+
+	const filter = await getFilterCTEs(q.filter, ds) // if q.filter is blank, it returns null
 	const sql = filter
 		? `WITH ${filter.filters} SELECT sample as id, name FROM ${filter.CTEname} join sampleidmap on sample = sampleidmap.id`
 		: `SELECT id, name FROM sampleidmap`

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -144,6 +144,7 @@ tape(`initialization`, async test => {
 				'getNonsensitiveInfo',
 				'getPayloadFromHeaderAuth',
 				'getRequiredCredForDsEmbedder',
+				'mayExtendqFilter',
 				'maySetAuthRoutes',
 				'userCanAccess'
 			],

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -144,7 +144,7 @@ tape(`initialization`, async test => {
 				'getNonsensitiveInfo',
 				'getPayloadFromHeaderAuth',
 				'getRequiredCredForDsEmbedder',
-				'mayExtendqFilter',
+				'mayAdjustFilter',
 				'maySetAuthRoutes',
 				'userCanAccess'
 			],

--- a/server/src/test/termdb.access.unit.spec.js
+++ b/server/src/test/termdb.access.unit.spec.js
@@ -12,6 +12,7 @@ tape('filterTerms()', async function (test) {
 		//headers:{authorization:'Bearer mock-token'}, // is this needed?
 		query: {
 			// lacking dslabel/embedder somehow did not cause auth.getNonsensitiveInfo to throw
+			__protected__: {}
 		}
 	}
 
@@ -35,7 +36,11 @@ tape('filterTerms()', async function (test) {
 	}
 
 	{
-		const result = filterTerms({ query: { dslabel: 'TermdbTest', embedder: 'http://localhost' } }, ds, terms)
+		const result = filterTerms(
+			{ query: { dslabel: 'TermdbTest', embedder: 'http://localhost', __protected__: {} } },
+			ds,
+			terms
+		)
 		test.deepEqual(result, [terms[0]], '1 term left after filtering')
 	}
 

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1523,7 +1523,7 @@ keep this setting here for reason of:
 	}
 	//terms  are shown in the dictionary based on term and user role.
 	isTermVisible?: (clientAuthResult: any, ids: string) => boolean
-	getAdditionalFilter?: (clientAuthResult: any, term: any) => undefined | string[] | number[]
+	getAdditionalFilter?: (clientAuthResult: any, term: any) => Filter | undefined
 }
 
 type SampleType = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1543,7 +1543,9 @@ type PlotConfigByCohort = {
 
 /** modified version of termwrapper*/
 type Tw = {
-	id: string
+	/** short hand for using either id (dict term) or term{} */
+	id?: string
+	term?: object
 	q: unknown
 	/** quick fix for generating URL links in mds3 tk sample table! adhoc design. may move to tw.term.baseURL and not specific to mds3 tk
 	 */

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1363,7 +1363,7 @@ if missing, name is value of m[url.namekey], as used in url itself (e.g. snp rsi
 }
 
 /*** type of ds.cohort.termdb{} ***/
-type Termdb = {
+export type Termdb = {
 	/** Terms */
 	termIds?: TermIds
 	/** if true, backend is allowed to send sample names to client in charts */
@@ -1517,15 +1517,13 @@ keep this setting here for reason of:
 		/** colors for a category multivalues */
 		[index: string]: { [index: string]: string }
 	}
-	/** terms are shown in the dictionary based on term and user role.
-	 */
-	isTermVisible?: (clientAuthResult: any, id: string) => boolean
-	/** when ds supports chart types e.g. summarizeMutationDiagnosis, this setting is required to supply a dict term to populate the chart ui
-	 */
 	defaultTw4correlationPlot?: {
 		/** key is string as disease/survial etc, value is tw */
 		[index: string]: Tw
 	}
+	//terms  are shown in the dictionary based on term and user role.
+	isTermVisible?: (clientAuthResult: any, ids: string) => boolean
+	getAdditionalFilter?: (clientAuthResult: any, term: any) => undefined | string[] | number[]
 }
 
 type SampleType = {
@@ -1545,10 +1543,8 @@ type PlotConfigByCohort = {
 
 /** modified version of termwrapper*/
 type Tw = {
-	/** short hand for using either id (dict term) or term{} */
-	id?: string
-	term?: object
-	q: object
+	id: string
+	q: unknown
 	/** quick fix for generating URL links in mds3 tk sample table! adhoc design. may move to tw.term.baseURL and not specific to mds3 tk
 	 */
 	baseURL?: string

--- a/shared/types/src/routes/termdb.categories.ts
+++ b/shared/types/src/routes/termdb.categories.ts
@@ -14,6 +14,11 @@ export type CategoriesRequest = {
 	currentGeneNames?: string[]
 	/** optional property added by mds3 tk, to limit to cases mutated in this region */
 	rglst?: any
+	__protected__?: {
+		sessionId?: string
+		clientAuthResults?: any
+		ignoredTermIds?: any
+	}
 }
 
 interface Entries {

--- a/shared/types/src/routes/termdb.descrstats.ts
+++ b/shared/types/src/routes/termdb.descrstats.ts
@@ -17,6 +17,7 @@ export type DescrStatsRequest = {
 	filter?: Filter
 	/** optional gdc filter */
 	filter0?: any
+	__protected__?: any //reuse definition from termdb.matrix.ts!!!
 }
 
 interface entries {


### PR DESCRIPTION
# Description

Also pull and test with the  `sjpp/auth-filter-sites-3` branch.

This branch handles term-level authorization, a new level of access authentication after portal-wide `jwt` and dataset-level credentials by server route. In this way, server route access may be allowed, but access privilege may still be restricted based on the term(s) in the request payload as well as the roles that are specified in the `jwt`. 

Design:
-  `clietnAuthResults{}` and `ignoredTermIds:[]` are added to `req.query.__protected__` in `app.middleware.js`. Previously, only `sessionId` was added to this object. This means  only having to pass these auth-related properties only once, instead of through many server route handler code and nested functions. 
- `authApi.mayExtendqFilter()` is called at the beginning of`getData()`, once all  `terms[]` are known regardless of what they are called in the request payload, and thereby all queried terms are protected by default and may be screened by the optional `ds.cohort.termdb.getAdditionalFilter()`.  
- a server route code may push specific term.ids. to `ignoredTermIds[]`, so that a server route that aggregate data can bypass term checks.

To test:
- open http://localhost:3000/profile/ `-> Graphs`: should still see a fully rendered polar plot, but the `Data Dictionary` plot should not list `Sites` as a term
-  open http://localhost:3000/profile/?role=user: should now see `Sites` in the `Data Dictionary`, but clicking on it should only render 3 bars corresponding to what the user's jwt payload/site access level
- open http://localhost:3000/profile/?role=admin: should see all terms in the `Data Dictionary`, and more chart options

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
