### PR TITLE
backend returns multiple CNV/fusion data sources for GDC disco plot

### DIFF
--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -32,7 +32,6 @@ mayInitSkewer
 mayInitCnv
 mayaddGetter_m2csq
 mayInit_variant2samples
-mayaddGetter_singleSampleMutation
 configPanel
 _load
 
@@ -145,7 +144,6 @@ export async function makeTk(tk, block) {
 
 	await mayInit_variant2samples(tk, block)
 	mayaddGetter_m2csq(tk, block)
-	mayaddGetter_singleSampleMutation(tk, block)
 
 	mayInitSkewer(tk) // tk.skewer{} may be added
 
@@ -557,19 +555,6 @@ function mayaddGetter_m2csq(tk, block) {
 		const headers = { 'Content-Type': 'application/json', Accept: 'application/json' }
 		if (tk.token) headers['X-Auth-Token'] = tk.token
 		return await dofetch3('mds3', { body, headers }, { serverData: tk.cache })
-	}
-}
-
-function mayaddGetter_singleSampleMutation(tk, block) {
-	if (!tk.mds.queries?.singleSampleMutation) return
-	tk.mds.queries.singleSampleMutation.get = async sample_id => {
-		const body = { genome: block.genome.name, dslabel: tk.mds.label, sample: sample_id }
-		const headers = { 'Content-Type': 'application/json', Accept: 'application/json' }
-		if (tk.token) headers['X-Auth-Token'] = tk.token
-		const data = await dofetch3('termdb/singleSampleMutation', { body, headers })
-		if (data.error) throw data.error
-		if (!Array.isArray(data.mlst)) throw 'data.mlst is not array'
-		return data.mlst
 	}
 }
 

--- a/shared/types/src/routes/termdb.singleSampleMutation.ts
+++ b/shared/types/src/routes/termdb.singleSampleMutation.ts
@@ -12,8 +12,24 @@ export type TermdbSingleSampleMutationRequest = {
 type ValidResponse = {
 	/** List of mutation data points from this sample TODO change to type of M elements */
 	mlst: object[]
-	/** */
+	/** total number of items for each dt, useful to indicate snvindel limited to 10k for a hypermutator */
 	dt2total?: { dt: number; total: number }[]
+	/** alternative data by dt
+	key: dt value
+	value: array of objects, each is a distinct set of data points for this dt
+		on ui, selecting an object will allow to show this data in disco plot
+		each is identified by either nameHtml or name
+	*/
+	alternativeDataByDt: {
+		[index: number]: {
+			/** hyperlink */
+			nameHtml?: string
+			/** name in text */
+			name?: string
+			/** required list of events from this data */
+			mlst: object[]
+		}[]
+	}
 }
 
 export type TermdbSingleSampleMutationResponse = ErrorResponse | ValidResponse

--- a/shared/types/src/routes/termdb.singleSampleMutation.ts
+++ b/shared/types/src/routes/termdb.singleSampleMutation.ts
@@ -20,7 +20,7 @@ type ValidResponse = {
 		on ui, selecting an object will allow to show this data in disco plot
 		each is identified by either nameHtml or name
 	*/
-	alternativeDataByDt: {
+	alternativeDataByDt?: {
 		[index: number]: {
 			/** hyperlink */
 			nameHtml?: string


### PR DESCRIPTION
…iles

# Description
implements part of #2794 
Backend and route type def changes completed.
All gdc disco plot works.
All mds3 tests pass.

Since only a new property "alternativeDataByDt" is introduced in route-returned data but no change to existing returned data, disco app is not affected and thus fine to merge this first. Victor can open new branch to implement ui support.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
