### PR TITLE
Misc fixes for the profile auth and the templates

### DIFF
--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -176,8 +176,7 @@ export class profilePlot {
 		}
 		this.filteredTermValues = await this.app.vocabApi.filterTermValues({
 			terms: this.config.filterTWs,
-			filters,
-			ignoredTermIds: this.settings.filterByUserSites ? [] : [this.config.facilityTW.term.id] //if filterByUserSites is true, do not ignore the facility term filter
+			filters
 		})
 		this.regions = this.filteredTermValues[this.config.regionTW.id]
 		this.countries = this.filteredTermValues[this.config.countryTW.id]

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -176,7 +176,8 @@ export class profilePlot {
 		}
 		this.filteredTermValues = await this.app.vocabApi.filterTermValues({
 			terms: this.config.filterTWs,
-			filters
+			filters,
+			ignoredTermIds: this.settings.filterByUserSites ? [] : [this.config.facilityTW.term.id] //if filterByUserSites is true, do not ignore the facility term filter
 		})
 		this.regions = this.filteredTermValues[this.config.regionTW.id]
 		this.countries = this.filteredTermValues[this.config.countryTW.id]
@@ -210,7 +211,8 @@ export class profilePlot {
 				isAggregate,
 				sites: this.settings.sites,
 				userSites: this.state.sites,
-				facilityTW: this.config.facilityTW
+				facilityTW: this.config.facilityTW,
+				filterByUserSites: this.settings.filterByUserSites
 			})
 		else
 			this.data = await this.app.vocabApi.getProfileFormScores({
@@ -220,7 +222,8 @@ export class profilePlot {
 				isAggregate,
 				sites: this.settings.sites,
 				userSites: this.state.sites,
-				facilityTW: this.config.facilityTW
+				facilityTW: this.config.facilityTW,
+				filterByUserSites: this.settings.filterByUserSites
 			})
 		this.sites = this.data.sites
 		this.sites.sort((a, b) => {
@@ -240,6 +243,13 @@ export class profilePlot {
 		const chartType = this.type
 		this.dom.controlsDiv.selectAll('*').remove()
 		let inputs = []
+		const userSitesFilterInput = {
+			label: 'Use accessible sites only',
+			boxLabel: '',
+			type: 'checkbox',
+			chartType,
+			settingsKey: 'filterByUserSites'
+		}
 		if (this.state.sites?.length == 1 && !isRadarFacility) {
 			const dataInput = {
 				label: 'Data',
@@ -268,7 +278,7 @@ export class profilePlot {
 						chartType,
 						settingsKey: this.config.regionTW.term.id,
 						options: this.regions,
-						callback: value => this.setRegion(value)
+						callback: value => this.setFilterValue(this.config.regionTW.term.id, value)
 					},
 					{
 						label: 'Country',
@@ -350,6 +360,7 @@ export class profilePlot {
 					}
 				}
 				inputs.push(sitesInput)
+				if (this.state.user != 'admin') inputs.unshift(userSitesFilterInput) //add filter by user sites only for non-admin users
 			}
 			if (isRadarFacility) {
 				this.sampleData = await this.app.vocabApi.getProfileScores({
@@ -428,14 +439,6 @@ export class profilePlot {
 
 	getFilter() {
 		return getCategoricalTermFilter(this.config.filterTWs, this.settings, null, this.state.termfilter.filter)
-	}
-
-	setRegion(region) {
-		const config = this.config
-		this.settings[config.regionTW.term.id] = region
-		this.clearFiltersExcept([config.regionTW.term.id])
-		config.filter = this.getFilter()
-		this.app.dispatch({ type: 'plot_edit', id: this.id, config })
 	}
 
 	clearFiltersExcept(ids) {
@@ -633,7 +636,8 @@ export function clearLocalFilters(plot) {
 export function getDefaultProfilePlotSettings() {
 	return {
 		isAggregate: false,
-		showTable: true
+		showTable: true,
+		filterByUserSites: false //if true, the user sites filter is applied
 	}
 }
 

--- a/server/routes/filterTermValues.ts
+++ b/server/routes/filterTermValues.ts
@@ -62,6 +62,7 @@ function getList(samplesPerFilter, filtersData, tw) {
 async function getFilters(query, ds, genome, res) {
 	try {
 		//Dictionary with samples applying all the filters but not the one from the current term id
+		if (query.ignoredTermIds) query.__protected__.ignoredTermIds.push(...query.ignoredTermIds)
 		const samplesPerFilter = await getSamplesPerFilter(query, ds)
 		const filtersData = await getData(
 			{

--- a/server/routes/filterTermValues.ts
+++ b/server/routes/filterTermValues.ts
@@ -62,7 +62,6 @@ function getList(samplesPerFilter, filtersData, tw) {
 async function getFilters(query, ds, genome, res) {
 	try {
 		//Dictionary with samples applying all the filters but not the one from the current term id
-		if (query.ignoredTermIds) query.__protected__.ignoredTermIds.push(...query.ignoredTermIds)
 		const samplesPerFilter = await getSamplesPerFilter(query, ds)
 		const filtersData = await getData(
 			{

--- a/server/routes/profileScores.ts
+++ b/server/routes/profileScores.ts
@@ -37,7 +37,7 @@ function init({ genomes }) {
 }
 
 async function getScores(query, ds, genome) {
-	query.__protected__.ignoredTermIds.push(query.facilityTW.term.id)
+	if (!query.filterByUserSites) query.__protected__.ignoredTermIds.push(query.facilityTW.term.id)
 
 	const terms: any[] = [query.facilityTW]
 	for (const term of query.scoreTerms) {

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -121,7 +121,7 @@ export function setAppMiddlewares(app, doneLoading) {
           and as determined by a server route code that the dataset can use to compute per-user access restrictions/authorizations 
           when querying data
         */
-		const __protected__ = { ignoredTermIds: [] }
+		const __protected__ = { ignoredTermIds: [] } // when provided the filter on these terms will be ignored
 		if (req.query.dslabel) Object.assign(__protected__, authApi.getNonsensitiveInfo(req))
 		if (req.cookies?.sessionid) {
 			__protected__.sessionid = req.cookies.sessionid

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -677,7 +677,10 @@ async function maySetAuthRoutes(app, basepath = '', _serverconfig = null) {
 
 		// NOTE: as needed, the server route code must append to q.__protected__ignoredTermRestrictions[],
 		//  since it knows the req.query key names that correspond to terms
-		const termsToCheck = twArr.filter(tw => !q.__protected__.ignoredTermIds.includes(tw.term.id)).map(tw => tw.term)
+		const termsToCheck =
+			twArr === null
+				? null
+				: twArr.filter(tw => !q.__protected__.ignoredTermIds.includes(tw.term.id)).map(tw => tw.term)
 		const additionalFilter = ds.cohort.termdb.getAdditionalFilter(q.__protected__.clientAuthResult, termsToCheck)
 		if (!additionalFilter) {
 			// certain roles (from jwt payload) may have access to everything,

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -372,6 +372,7 @@ export async function getSamplesPerFilter(q, ds) {
 	const samples = {}
 	for (const id in q.filters) {
 		const filter = q.filters[id]
+		// We need to update the filter to contain the user filter when ignoredTermIds includes the site term id!!!
 		const result = (await get_samples(filter, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -359,7 +359,7 @@ async function mayGetSampleFilterSet4snplst(q, nonDictTerms) {
 		return
 	}
 	if (!q.filter) return // no filter, allow snplst/snplocus to return data for all samples
-	return new Set((await get_samples(q.filter, q.ds)).map(i => i.id))
+	return new Set((await get_samples(q, q.ds)).map(i => i.id))
 }
 
 export async function getSamplesPerFilterResponse(q, ds, res) {
@@ -372,8 +372,7 @@ export async function getSamplesPerFilter(q, ds) {
 	const samples = {}
 	for (const id in q.filters) {
 		const filter = q.filters[id]
-		// We need to update the filter to contain the user filter when ignoredTermIds includes the site term id!!!
-		const result = (await get_samples(filter, q.ds)).map(i => i.id)
+		const result = (await get_samples({ filter, __protected__: q.__protected__ }, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}
 	return samples

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -7,6 +7,7 @@ import { sampleLstSql } from './termdb.sql.samplelst.js'
 import { multivalueCTE } from './termdb.sql.multivalue.js'
 import { boxplot_getvalue } from './utils.js'
 import { DEFAULT_SAMPLE_TYPE, isNumericTerm, annoNumericTypes } from '#shared/terms.js'
+import { authApi } from '#src/auth.js'
 /*
 
 ********************** EXPORTED
@@ -43,13 +44,17 @@ get_label4key
 
 */
 //in the future we may need to pass the sample type when there are more types than root and not root
-export async function get_samples(qfilter, ds, canDisplay = false) {
+export async function get_samples(q, ds, canDisplay = false) {
+	console.log(q)
 	/*
 must have qfilter[]
-as the actual query is embedded in qfilter
+as the actual query is embedded in q.filter
 return an array of sample names passing through the filter
 */
-	const filter = await getFilterCTEs(qfilter, ds) // if qfilter is blank, it returns null
+
+	authApi.mayExtendqFilter(q, ds, null)
+
+	const filter = await getFilterCTEs(q.filter, ds) // if q.filter is blank, it returns null
 	const sql = filter
 		? `WITH ${filter.filters} SELECT sample as id, name FROM ${filter.CTEname} join sampleidmap on sample = sampleidmap.id`
 		: `SELECT id, name FROM sampleidmap`


### PR DESCRIPTION
# Description
This branch is on top of Edgar's branch. Here I added some misc fixes in the auth handling and fixed some bugs found in the profileFormScores route. I also added a choice to the profile filters to use either the user samples or all the samples when calculating the scores, as this is something they want.
The most important issue remaining to be fixed is to pass the new filter to get_samples in termdb.sql.js

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
