### PR TITLE
Include 'NONE' in nmeth array by default.

### DIFF
--- a/client/src/block.tk.hicstraw.ts
+++ b/client/src/block.tk.hicstraw.ts
@@ -42,7 +42,7 @@ const minimumbinnum_frag = 200 // minimum bin number at frag resolution
 const labyspace = 5
 const insidedomaincolor = '102,102,102'
 const docurl_text =
-	'https://docs.google.com/document/d/1MQ0Z_AD5moDmaSx2tcn7DyVKGp49TS63pO0cceGL_Ns/edit#heading=h.kr6p4w2zhhwq'
+	'https://github.com/stjude/proteinpaint/wiki/Interaction-Tracks:-Hi%E2%80%90C-and-Arc#text-data-copy--paste'
 
 // let hicstraw // loaded on the fly, will result in bundle duplication
 


### PR DESCRIPTION
# Description

Addresses user issue reported via team email. 'NONE' is included in the normalization array. Test with [hic example](http://localhost:3000/?appcard=hic&example=Hi-C). Should see 'NONE' in the CONFIG dropdown which is missing in master. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
