### PR TITLE
Updates on the auth filter 

### DIFF
--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -175,7 +175,8 @@ export class profilePlot {
 		}
 		this.filteredTermValues = await this.app.vocabApi.filterTermValues({
 			terms: this.config.filterTWs,
-			filters
+			filters,
+			ignoreUserFilter: !this.settings.filterByUserSites
 		})
 		this.regions = this.filteredTermValues[this.config.regionTW.id]
 		this.countries = this.filteredTermValues[this.config.countryTW.id]

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -83,7 +83,7 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request): Promise<GRIN2Re
 	mayLog('[GRIN2] Getting samples from cohort filter...')
 
 	const samples = await get_samples(
-		request.filter,
+		request,
 		ds,
 		true // must set to true to return sample name to be able to access file. FIXME this can let names revealed to grin2 client, may need to apply access control
 	)

--- a/server/routes/termdb.descrstats.ts
+++ b/server/routes/termdb.descrstats.ts
@@ -30,7 +30,11 @@ function init({ genomes }) {
 			if (!tdb) throw 'invalid termdb object'
 
 			if (!q.tw.$id) q.tw.$id = '_' // current typing thinks tw$id is undefined. add this to avoid tsc err. delete this line when typing is fixed
-			const data = await getData({ filter: q.filter, filter0: q.filter0, terms: [q.tw] }, ds, genome)
+			const data = await getData(
+				{ filter: q.filter, filter0: q.filter0, terms: [q.tw], __protected__: q.__protected__ },
+				ds,
+				genome
+			)
 			if (data.error) throw data.error
 
 			const values: number[] = []

--- a/server/routes/termdb.topMutatedGenes.ts
+++ b/server/routes/termdb.topMutatedGenes.ts
@@ -97,7 +97,7 @@ export function validate_query_getTopMutatedGenes(ds: any) {
 	q.get = async (param: topMutatedGeneRequest) => {
 		let sampleStatement = ''
 		if (param.filter) {
-			const lst = await get_samples(param.filter, ds)
+			const lst = await get_samples(param, ds)
 			if (lst.length == 0) throw 'empty sample filter'
 			sampleStatement = `WHERE sample IN (${lst.map(i => i.id).join(',')})`
 		}

--- a/server/routes/termdb.topTermsByType.ts
+++ b/server/routes/termdb.topTermsByType.ts
@@ -58,7 +58,7 @@ function nativeValidateQuery(ds: any, type: string) {
 		const samples = [] as string[]
 		if (q.filter) {
 			// get all samples pasing pp filter, may contain those without exp data
-			const sidlst = await get_samples(q.filter, ds)
+			const sidlst = await get_samples(q, ds)
 			// [{id:int}]
 			// filter for those with exp data from q.samples[]
 			for (const i of sidlst) {

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -73,7 +73,7 @@ function nativeValidateQuery(ds: any) {
 		const samples = [] as string[]
 		if (q.filter) {
 			// get all samples pasing pp filter, may contain those without exp data
-			const sidlst = await get_samples(q.filter, ds)
+			const sidlst = await get_samples(q, ds)
 			// [{id:int}]
 			// filter for those with exp data from q.samples[]
 			for (const i of sidlst) {

--- a/server/src/bulk.mset.js
+++ b/server/src/bulk.mset.js
@@ -51,7 +51,7 @@ export async function mayGetGeneVariantData(tw, q) {
 		// requires that not only q.filter{} is present, but also filter.lst[] is a non-empty array
 		// as client may send filter with blank array of tvs and will break get_samples()
 		//!!! DO NOT USE FOR geneVariant filterCTE constructor
-		filterSamples = [...new Set((await get_samples(q.filter, ds)).map(i => i.id))]
+		filterSamples = [...new Set((await get_samples(q, ds)).map(i => i.id))]
 	}
 
 	for (const flagname in flagset) {

--- a/server/src/mds3.filter.js
+++ b/server/src/mds3.filter.js
@@ -28,7 +28,7 @@ export async function mayLimitSamples(param, allSamples, ds) {
 	}
 
 	// get_samples() return [{id:int}] with possibly duplicated items, deduplicate and return list of integer ids
-	const filterSamples = [...new Set((await get_samples(filter, ds)).map(i => i.id))]
+	const filterSamples = [...new Set((await get_samples({ filter }, ds)).map(i => i.id))]
 
 	// filterSamples is the list of samples retrieved from termdb that are matching filter
 	// as allSamples (from bcf etc) may be a subset of what's in termdb

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2885,7 +2885,7 @@ async function filterSamples4assayAvailability(q, ds) {
 		return null
 	}
 	// not gdc
-	return q.filter && q.filter.lst.length ? new Set((await get_samples(q.filter, ds)).map(i => i.id)) : null
+	return q.filter && q.filter.lst.length ? new Set((await get_samples(q, ds)).map(i => i.id)) : null
 }
 
 function addDataAvailability(sid, sample2mlst, dtKey, mclass, origin, sampleFilter) {

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -32,7 +32,7 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 	}
 	if (filter.lst.length == 1) {
 		// only one element at this level, disregard "join"
-		if (filter.lst[0].type == 'tvslst') throw 'only one element at a level: type should not be "tvslst"'
+		//if (filter.lst[0].type == 'tvslst') throw 'only one element at a level: type should not be "tvslst"'
 	} else {
 		// multiple elements at this level
 		if (filter.join != 'or' && filter.join != 'and')

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -140,7 +140,7 @@ async function trigger_getsamples(q, res, ds) {
 
 async function getSampleList(req, q, ds) {
 	const canDisplay = authApi.canDisplaySampleIds(req, ds)
-	const samples = await termdbsql.get_samples(q.filter, ds, canDisplay)
+	const samples = await termdbsql.get_samples(q, ds, canDisplay)
 	return samples
 }
 
@@ -326,7 +326,7 @@ async function get_AllSamplesByName(q, req, res, ds) {
 		q.ds = ds
 		const filteredSamples = ds.cohort.termdb.hasSampleAncestry
 			? await get_samples_ancestry(q.filter, q.ds, true)
-			: await get_samples(q.filter, q.ds, true)
+			: await get_samples(q, q.ds, true)
 		for (const sample of filteredSamples) {
 			const name = ds.sampleId2Name.get(sample.id)
 			const sample_type = ds.sampleId2Type.get(sample.id)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -372,7 +372,8 @@ export async function getSamplesPerFilter(q, ds) {
 	q.ds = ds
 	const samples = {}
 	for (const id in q.filters) {
-		const filter = filterJoin([q.filter, q.filters[id]])
+		let filter = q.filters[id]
+		if (!q.ignoreUserFilter && q.filter) filter = filterJoin([q.filter, q.filters[id]])
 		const result = (await get_samples({ filter, __protected__: q.__protected__ }, q.ds)).map(i => i.id)
 		samples[id] = Array.from(new Set(result))
 	}

--- a/server/src/termdb.phewas.js
+++ b/server/src/termdb.phewas.js
@@ -44,7 +44,7 @@ export async function trigger(q, res, ds) {
 	// optional filter on samples
 	let samplefilterset
 	if (q.filter) {
-		samplefilterset = new Set(await termdbsql.get_samples(q.filter, ds))
+		samplefilterset = new Set(await termdbsql.get_samples(q, ds))
 	}
 
 	const [sample2gt, genotype2sample] = await utils.loadfile_ssid(q.ssid, samplefilterset)
@@ -436,7 +436,7 @@ async function may_subcohortTermtype2samples(ds) {
 		const config = ds.cohort.termdb.phewas.precompute_subcohort2totalsamples[key]
 		if (config.termtype) {
 			for (const type in config.termtype) {
-				config.termtype[type].samples = await termdbsql.get_samples(config.termtype[type].filter, ds)
+				config.termtype[type].samples = await termdbsql.get_samples({ filter: config.termtype[type].filter }, ds)
 			}
 		}
 	}
@@ -858,7 +858,10 @@ only used for precomputing, not for on the fly
 
 	if (ds.cohort.termdb.phewas.samplefilter4termtype) {
 		if (ds.cohort.termdb.phewas.samplefilter4termtype.condition) {
-			const samples = await termdbsql.get_samples(ds.cohort.termdb.phewas.samplefilter4termtype.condition.filter, ds)
+			const samples = await termdbsql.get_samples(
+				{ filter: ds.cohort.termdb.phewas.samplefilter4termtype.condition.filter },
+				ds
+			)
 			if (ds.track && ds.track.vcf && ds.track.vcf.sample2arrayidx) {
 				// must also restrict to vcf samples
 				condition_samples = []

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -89,7 +89,12 @@ export async function trigger_getSampleScatter(req, q, res, ds, genome) {
 		if (q.divideByTW) terms.push(q.divideByTW)
 		if (q.scaleDotTW) terms.push(q.scaleDotTW)
 		if (q.coordTWs) for (const tw of q.coordTWs) terms.push(tw)
-		const data = await getData({ filter: q.filter, filter0: q.filter0, terms }, ds, genome, true)
+		const data = await getData(
+			{ filter: q.filter, filter0: q.filter0, terms, __protected__: q.__protected__ },
+			ds,
+			genome,
+			true
+		)
 		if (data.error) throw data.error
 		let result
 		if (q.coordTWs.length > 0) {

--- a/server/src/termdb.snp.js
+++ b/server/src/termdb.snp.js
@@ -107,7 +107,7 @@ async function summarizeSamplesFromCache(q, tdb, ds, genome) {
 	let sampleinfilter // list of true/false, same length of tk.samples, to tell if a sample is in use
 	if (q.filter) {
 		// using optional filter
-		const filterSet = new Set((await termdbsql.get_samples(q.filter, ds)).map(i => i.id))
+		const filterSet = new Set((await termdbsql.get_samples({ filter: q.filter }, ds)).map(i => i.id))
 		if (filterSet.size == 0) throw 'no samples from filter'
 		sampleinfilter = tk.samples.map(i => filterSet.has(i.name))
 	} else {

--- a/shared/types/src/routes/termdb.descrstats.ts
+++ b/shared/types/src/routes/termdb.descrstats.ts
@@ -17,6 +17,7 @@ export type DescrStatsRequest = {
 	filter?: Filter
 	/** optional gdc filter */
 	filter0?: any
+	__protected__?: any //reuse definition from termdb.matrix.ts!!!
 }
 
 interface entries {


### PR DESCRIPTION
# Description
This branch is on top of auth-filter-sites-3. Worked on it with @siosonel. Here I passed q to get_samples where needed. Added misc fixes on the auth handling and supported the auth filter for sjcares. Please see corresponding branch in [sjpp](https://github.com/stjude/sjpp/pull/952/files). I see some routes are broken when running the tests @siosonel. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
