### PR TITLE
Fixing GDC correlation plot issues

### DIFF
--- a/client/filter/tvs.geneVariant.js
+++ b/client/filter/tvs.geneVariant.js
@@ -1,5 +1,3 @@
-import { getChildTerms } from '../termsetting/handlers/geneVariant'
-
 /*
 TVS handler for geneVariant term
 */
@@ -15,8 +13,6 @@ export const handler = {
 
 async function fillMenu(self, _div, tvs) {
 	const term = structuredClone(tvs.term)
-	// get child dt terms of the geneVariant term
-	await getChildTerms(term, self.opts.vocabApi)
 	if (!term.childTerms?.length) return
 	// generate a frontend vocab using dt terms from the variant filter
 	// and render a data dictionary of this vocab

--- a/client/filter/tvs.geneVariant.js
+++ b/client/filter/tvs.geneVariant.js
@@ -1,3 +1,5 @@
+import { getChildTerms } from '../termsetting/handlers/geneVariant'
+
 /*
 TVS handler for geneVariant term
 */
@@ -13,8 +15,10 @@ export const handler = {
 
 async function fillMenu(self, _div, tvs) {
 	const term = structuredClone(tvs.term)
-	if (!term.childTerms?.length) return
-	// generate a frontend vocab using dt terms from the variant filter
+	// get child dt terms
+	await getChildTerms(term, self.opts.vocabApi)
+	if (!term.childTerms?.length) throw 'term.childTerms[] is missing'
+	// generate a frontend vocab using the child dt terms
 	// and render a data dictionary of this vocab
 	const termdb = await import('../termdb/app')
 	termdb.appInit({

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -34,13 +34,6 @@ export function getHandler(self: GeneVariantTermSettingInstance) {
 
 		async showEditMenu(div: Element) {
 			await makeEditMenu(self, div)
-		},
-
-		async postMain() {
-			// need to regenerate child dt terms here to update
-			// the terms upon data updates (e.g., filter)
-			const body = self.opts.getBodyParams?.() || {}
-			await getChildTerms(self.term, self.vocabApi, body)
 		}
 	}
 }
@@ -278,8 +271,6 @@ function addNewGroup(filter, groups, name?: string) {
 
 export async function getPredefinedGroupsets(tw: RawGvPredefinedGsTW, vocabApi: VocabApi) {
 	if (tw.q.type != 'predefined-groupset') throw 'unexpected tw.q.type'
-	// get child dt terms of geneVariant term
-	await getChildTerms(tw.term, vocabApi)
 	if (!tw.term.childTerms?.length) throw 'tw.term.childTerms[] is missing'
 	// build predefined groupsets based on child dt terms
 	tw.term.groupsetting = {
@@ -490,6 +481,10 @@ export async function getChildTerms(term: RawGvTerm, vocabApi: VocabApi, body: a
 		body.filter0 = filter0
 	}
 	// passing term to getCategories() will get categories across all genes in gene set
+	// TODO: getCategories() can be time-consuming for gdc (especially for geneset
+	// input) and really only need categories to filter term.values for mutation
+	// classes that are present in the data. Consider a different approach
+	// for calling getCategories().
 	const categories = await vocabApi.getCategories(term, filter, body)
 	for (const _t of dtTerms) {
 		const t: any = structuredClone(_t)

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -1800,14 +1800,132 @@ const geneVariantTw = {
 					dt: 2
 				}
 			]
-		}
+		},
+		childTerms: [
+			{
+				id: 'snvindel_somatic',
+				query: 'snvindel',
+				name: 'SNV/indel (somatic)',
+				parent_id: null,
+				isleaf: true,
+				type: 'dtsnvindel',
+				dt: 1,
+				values: {
+					M: { label: 'MISSENSE' },
+					F: { label: 'FRAMESHIFT' },
+					WT: { label: 'Wildtype' }
+				},
+				name_noOrigin: 'SNV/indel',
+				origin: 'somatic',
+				parentTerm: {
+					name: 'TP53',
+					genes: [
+						{
+							kind: 'gene',
+							id: 'TP53',
+							gene: 'TP53',
+							name: 'TP53',
+							type: 'geneVariant'
+						}
+					],
+					type: 'geneVariant',
+					id: 'TP53'
+				}
+			},
+			{
+				id: 'snvindel_germline',
+				query: 'snvindel',
+				name: 'SNV/indel (germline)',
+				parent_id: null,
+				isleaf: true,
+				type: 'dtsnvindel',
+				dt: 1,
+				values: {
+					M: { label: 'MISSENSE' },
+					F: { label: 'FRAMESHIFT' },
+					WT: { label: 'Wildtype' }
+				},
+				name_noOrigin: 'SNV/indel',
+				origin: 'germline',
+				parentTerm: {
+					name: 'TP53',
+					genes: [
+						{
+							kind: 'gene',
+							id: 'TP53',
+							gene: 'TP53',
+							name: 'TP53',
+							type: 'geneVariant'
+						}
+					],
+					type: 'geneVariant',
+					id: 'TP53'
+				}
+			},
+			{
+				id: 'cnv',
+				query: 'cnv',
+				name: 'CNV',
+				parent_id: null,
+				isleaf: true,
+				type: 'dtcnv',
+				dt: 4,
+				values: {
+					CNV_amp: { label: 'Copy number gain' },
+					WT: { label: 'Wildtype' }
+				},
+				name_noOrigin: 'CNV',
+				parentTerm: {
+					name: 'TP53',
+					genes: [
+						{
+							kind: 'gene',
+							id: 'TP53',
+							gene: 'TP53',
+							name: 'TP53',
+							type: 'geneVariant'
+						}
+					],
+					type: 'geneVariant',
+					id: 'TP53'
+				}
+			},
+			{
+				id: 'fusion',
+				query: 'svfusion',
+				name: 'Fusion RNA',
+				parent_id: null,
+				isleaf: true,
+				type: 'dtfusion',
+				dt: 2,
+				values: {
+					Fuserna: { label: 'Fusion transcript' },
+					WT: { label: 'Wildtype' }
+				},
+				name_noOrigin: 'Fusion RNA',
+				parentTerm: {
+					name: 'TP53',
+					genes: [
+						{
+							kind: 'gene',
+							id: 'TP53',
+							gene: 'TP53',
+							name: 'TP53',
+							type: 'geneVariant'
+						}
+					],
+					type: 'geneVariant',
+					id: 'TP53'
+				}
+			}
+		]
 	},
+	isAtomic: true,
 	q: {
 		isAtomic: true,
 		type: 'predefined-groupset',
 		predefined_groupset_idx: 0,
 		hiddenValues: {}
 	},
-	isAtomic: true,
 	type: 'GvPredefinedGsTW'
 }

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -16,7 +16,7 @@ import type {
 import { TwBase, type TwOpts } from './TwBase.ts'
 import { copyMerge } from '#rx'
 import { set_hiddenvalues } from '#termsetting'
-import { getPredefinedGroupsets } from '../termsetting/handlers/geneVariant'
+import { getChildTerms, getPredefinedGroupsets } from '../termsetting/handlers/geneVariant'
 
 export class GvBase extends TwBase {
 	// type, isAtomic, $id are set in ancestor base classes
@@ -75,6 +75,9 @@ export class GvBase extends TwBase {
 
 		// fill term.groupsetting
 		if (!tw.term.groupsetting) tw.term.groupsetting = { disabled: false }
+
+		// fill term.childTerms
+		if (!tw.term.childTerms) await getChildTerms(tw.term, opts.vocabApi)
 
 		{
 			// apply optional ds-level configs for this specific term

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -2,7 +2,7 @@ import tape from 'tape'
 import type { GvTW } from '#types'
 import { vocabInit } from '#termdb/vocabulary'
 import { GvBase } from '../geneVariant'
-import { getPredefinedGroupsets } from '../../termsetting/handlers/geneVariant.ts'
+import { getChildTerms, getPredefinedGroupsets } from '../../termsetting/handlers/geneVariant.ts'
 
 /*************************
  reusable helper functions
@@ -194,6 +194,7 @@ tape('getPredefinedGroupsets: fill groupsets', async test => {
 		},
 		type: 'GvPredefinedGsTW'
 	}
+	await getChildTerms(tw.term, vocabApi)
 	await getPredefinedGroupsets(tw, vocabApi)
 	test.deepEqual(tw.term.childTerms, childTerms, 'should fill in term.childTerms')
 	test.equal(tw.term.groupsetting.lst.length, 4, 'should get 4 predefined groupsets')

--- a/server/routes/termdb.descrstats.ts
+++ b/server/routes/termdb.descrstats.ts
@@ -39,7 +39,12 @@ function init({ genomes }) {
 			const values: number[] = []
 			for (const key in data.samples) {
 				const sample = data.samples[key]
-				const value = sample[q.tw.$id].value
+				const v = sample[q.tw.$id]
+				if (!v && v !== 0) {
+					// skip undefined values
+					continue
+				}
+				const value = v.value
 				if (q.tw.q.hiddenValues?.[value]) {
 					// skip uncomputable values
 					continue

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1174,7 +1174,7 @@ function mayApplyBinning(samples, twLst) {
 			for (const s of samples) {
 				const v = s[tw.term.id]
 				if (Number.isFinite(v)) {
-					s[tw.term.id] = getBin(bins, v)
+					s[tw.term.id] = { key: getBin(bins, v), value: v }
 				}
 			}
 		} else if (tw.q.mode == 'continuous') {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -646,6 +646,7 @@ async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
 			} else if (v != undefined && v != null) {
 				if (typeof v == 'object') {
 					// v is {key,value}, should be for survival term
+					// now also for discrete numeric term to support {key: bin, value: value}
 					s2[$id] = v
 				} else {
 					// v is number/string, should be for non-survival term


### PR DESCRIPTION
# Description

Related to https://github.com/stjude/proteinpaint/issues/3552

This PR addresses some of the issues listed in the link above.

- Fixes the issue of selecting a continuous variable in correlation plot.
- Fixes the issue of sending multiple `/categories` requests for a geneVariant term. Now only a single `/categories` request is made. Also, genes from a geneset are now queried concurrently instead of in-sequence, which reduces computation time.



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
