### PR TITLE
clear the plot or summary error div on each component update

### DIFF
--- a/client/mass/plot.js
+++ b/client/mass/plot.js
@@ -28,6 +28,7 @@ class MassPlot {
 			throw `No plot with id='${this.id}' found. Did you set this.id before this.api = getComponentApi(this)?`
 		}
 		return {
+			termfilter: appState.termfilter,
 			config,
 			groups: appState.groups,
 			// quick fix to skip history tracking as needed
@@ -36,7 +37,7 @@ class MassPlot {
 	}
 
 	async main() {
-		this.dom.errdiv.style('display', 'none').style('background-color', 'rgba(255,100,100,0.2)')
+		this.dom.errdiv.style('display', 'none').style('background-color', 'rgba(255,100,100,0.2)').html('')
 		if (!this.components) await this.setComponents(this.opts)
 	}
 

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -366,8 +366,10 @@ export class Barchart {
 			}
 			this.chartsData = this.processData(this.currServerData)
 			this.render()
+			this.dom.barDiv.style('display', '')
 		} catch (e) {
 			this.toggleLoadingDiv('none')
+			this.dom.barDiv.style('display', 'none')
 			throw e
 		}
 	}

--- a/client/plots/summary.js
+++ b/client/plots/summary.js
@@ -56,6 +56,7 @@ class SummaryPlot {
 			throw `No plot with id='${this.id}' found. Did you set this.id before this.api = getComponentApi(this)?`
 		}
 		return {
+			termfilter: appState.termfilter,
 			config,
 			// quick fix to skip history tracking as needed
 			_scope_: appState._scope_
@@ -63,7 +64,7 @@ class SummaryPlot {
 	}
 
 	async main() {
-		this.dom.errdiv.style('display', 'none').style('background-color', 'rgba(255,100,100,0.2)')
+		this.dom.errdiv.style('display', 'none').style('background-color', 'rgba(255,100,100,0.2)').html('')
 		this.config = structuredClone(this.state.config)
 		if (!this.components.plots[this.config.childType]) {
 			await this.setComponent(this.config)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- clear the plot or summary error div on each component update


### PR DESCRIPTION
# Description

To test: 
- Create a global filter where the number of samples will fall below `ds.cohort.termdb.minSampleSizeForFilterCharts`, the error should still show up inside the chart sandbox and no chart should be rendered
- Edit the global filter to make the number of samples exceed `minSampleSizeForFilterCharts`, the error should disappear and the chart should render again. Previously, the error remained rendered even thought it wasn't applicable anymore. 
- also tested locally with all unit and integration tests

NOTE: Automated tests for protected test dataset will be added after this PR.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
