### PR TITLE
Used CategoryFiltersUI to replace the filters in the report, the runChart and the frequencyChart 

### DIFF
--- a/client/dom/categoryFiltersUI.ts
+++ b/client/dom/categoryFiltersUI.ts
@@ -1,9 +1,9 @@
-import { getCategoricalTermFilter } from '#shared/filter.js'
+import { getCategoricalTermFilter } from '#filter'
 
 /*
  *  component to display a group of select filters in a plot header
  */
-export class SelectFilters {
+export class CategoryFiltersUI {
 	holder: any
 	filterSelects: any[] = []
 	plot: any
@@ -72,7 +72,7 @@ export class SelectFilters {
 	}
 
 	getFilter() {
-		return getCategoricalTermFilter(this.plot.config.filterTWs, this.plot.settings, null)
+		return getCategoricalTermFilter(this.plot.config.filterTWs, this.plot.settings)
 	}
 
 	async replaceFilter() {

--- a/client/dom/categoryFiltersUI.ts
+++ b/client/dom/categoryFiltersUI.ts
@@ -43,12 +43,7 @@ export class CategoryFiltersUI {
 				filterValues = [filterValues] //ensure filterValues is an array
 			const filters: any = {}
 			for (const tw of this.config.filterTWs)
-				filters[tw.term.id] = getCategoricalTermFilter(
-					this.config.filterTWs,
-					this.plot.settings,
-					tw,
-					this.plot.state.termfilter.filter
-				)
+				filters[tw.term.id] = getCategoricalTermFilter(this.config.filterTWs, this.plot.settings, tw)
 			const data = await this.plot.app.vocabApi.filterTermValues({
 				terms: this.config.filterTWs,
 				filters,

--- a/client/dom/selectFilters.ts
+++ b/client/dom/selectFilters.ts
@@ -37,7 +37,10 @@ export class SelectFilters {
 		}
 		let index = 0
 		for (const tw of this.config.filterTWs) {
-			const filterValues = this.plot.settings[tw.term.id] || ''
+			let filterValues = this.plot.settings[tw.term.id] || ''
+			if (!Array.isArray(filterValues))
+				//User may have set a single value
+				filterValues = [filterValues] //ensure filterValues is an array
 			const filters: any = {}
 			for (const tw of this.config.filterTWs)
 				filters[tw.term.id] = getCategoricalTermFilter(
@@ -59,7 +62,7 @@ export class SelectFilters {
 				const option = select.append('option').attr('value', value.value).text(value.label)
 				option.property('disabled', value.disabled)
 				for (const filterValue of filterValues) {
-					if (value.value === filterValue) {
+					if (value.value == filterValue) {
 						option.attr('selected', 'selected')
 					}
 				}

--- a/client/dom/selectFilters.ts
+++ b/client/dom/selectFilters.ts
@@ -1,0 +1,83 @@
+import { getCategoricalTermFilter } from '#shared/filter.js'
+
+/*
+ *  component to display a group of select filters in a plot header
+ */
+export class SelectFilters {
+	holder: any
+	filterSelects: any[] = []
+	plot: any
+	config: any
+
+	constructor(holder: any, plot: any, config: any) {
+		holder.style('padding', '10px')
+		this.plot = plot
+		this.holder = holder
+		this.config = config
+		for (const tw of this.plot.config.filterTWs) {
+			this.holder.append('label').text(` ${tw.term.name}: `).style('vertical-align', 'top')
+			let timeoutId
+			const select = this.holder.append('select').property('multiple', true).attr('size', '5')
+
+			select.on('change', async () => {
+				clearTimeout(timeoutId)
+				timeoutId = setTimeout(() => {
+					const values = Array.from(select.node().selectedOptions).map((o: any) => o.value)
+					this.plot.settings[tw.term.id] = values
+					this.replaceFilter()
+				}, 1000)
+			})
+			this.filterSelects.push(select)
+		}
+	}
+
+	async fillFilters() {
+		if (!this.config.filterTWs) {
+			return
+		}
+		let index = 0
+		for (const tw of this.config.filterTWs) {
+			const filterValues = this.plot.settings[tw.term.id] || ''
+			const filters: any = {}
+			for (const tw of this.config.filterTWs)
+				filters[tw.term.id] = getCategoricalTermFilter(
+					this.config.filterTWs,
+					this.plot.settings,
+					tw,
+					this.plot.state.termfilter.filter
+				)
+			const data = await this.plot.app.vocabApi.filterTermValues({
+				terms: this.config.filterTWs,
+				filters,
+				showAll: false
+			})
+			const select = this.filterSelects[index]
+			select.selectAll('option').remove()
+
+			for (const value of data[tw.term.id]) {
+				if (value.label == '') continue //skip empty labels
+				const option = select.append('option').attr('value', value.value).text(value.label)
+				option.property('disabled', value.disabled)
+				for (const filterValue of filterValues) {
+					if (value.value === filterValue) {
+						option.attr('selected', 'selected')
+					}
+				}
+			}
+			index++
+		}
+	}
+
+	getFilter() {
+		return getCategoricalTermFilter(this.plot.config.filterTWs, this.plot.settings, null)
+	}
+
+	async replaceFilter() {
+		const filter = this.getFilter() //read by child plots
+		this.plot.app.dispatch({
+			type: 'plot_edit',
+			id: this.plot.id,
+			config: { filter, settings: { [this.plot.type]: this.plot.settings } } //update country and site in the report settings
+		})
+	}
+}

--- a/client/plots/frequencyChart/frequencyChart.ts
+++ b/client/plots/frequencyChart/frequencyChart.ts
@@ -7,7 +7,7 @@ import { plotColor } from '#shared/common.js'
 import { ScatterInteractivity } from '../scatter/viewmodel/scatterInteractivity.ts'
 import { Runchart } from '../runchart/runchart.ts'
 import { getColors } from '#shared/common.js'
-import { SelectFilters } from '#dom/selectFilters'
+import { CategoryFiltersUI } from '#dom/categoryFiltersUI'
 
 export class FrequencyChart extends Runchart {
 	type: string
@@ -28,7 +28,7 @@ export class FrequencyChart extends Runchart {
 		this.interactivity = new ScatterInteractivity(this)
 		if (!this.parentId)
 			//if you are in the report you dont show filters
-			this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
+			this.selectFilters = new CategoryFiltersUI(this.view.dom.headerDiv, this, this.config)
 	}
 
 	async main() {

--- a/client/plots/frequencyChart/frequencyChart.ts
+++ b/client/plots/frequencyChart/frequencyChart.ts
@@ -26,13 +26,15 @@ export class FrequencyChart extends Runchart {
 		this.model = new FrequencyChartModel(this)
 		this.vm = new RunchartViewModel(this)
 		this.interactivity = new ScatterInteractivity(this)
-		this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
+		if (!this.parentId)
+			//if you are in the report you dont show filters
+			this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
 	}
 
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings[this.type]
-		this.selectFilters.fillFilters()
+		if (!this.parentId) this.selectFilters.fillFilters()
 
 		await this.model.initData()
 		await this.model.processData()
@@ -68,7 +70,7 @@ export async function getPlotConfig(opts, app) {
 		await fillTermWrapper(plot.term, app.vocabApi)
 		if (plot.term0) await fillTermWrapper(plot.term0, app.vocabApi)
 		if (plot.scaleDotTW) await fillTermWrapper(plot.scaleDotTW, app.vocabApi)
-		if (plot.filterTWs) for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
+		for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
 
 		return plot
 	} catch (e) {

--- a/client/plots/frequencyChart/frequencyChart.ts
+++ b/client/plots/frequencyChart/frequencyChart.ts
@@ -7,6 +7,7 @@ import { plotColor } from '#shared/common.js'
 import { ScatterInteractivity } from '../scatter/viewmodel/scatterInteractivity.ts'
 import { Runchart } from '../runchart/runchart.ts'
 import { getColors } from '#shared/common.js'
+import { SelectFilters } from '#dom/selectFilters'
 
 export class FrequencyChart extends Runchart {
 	type: string
@@ -20,19 +21,19 @@ export class FrequencyChart extends Runchart {
 	async init(appState) {
 		const state: any = this.getState(appState)
 		this.config = structuredClone(state.config)
-		this.filterTWs = []
-		if (state.config.countryTW) this.filterTWs.push(state.config.countryTW)
-		if (state.config.siteTW) this.filterTWs.push(state.config.siteTW)
 
 		this.view = new FrequencyChartView(this)
 		this.model = new FrequencyChartModel(this)
 		this.vm = new RunchartViewModel(this)
 		this.interactivity = new ScatterInteractivity(this)
+		this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
 	}
 
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings[this.type]
+		this.selectFilters.fillFilters()
+
 		await this.model.initData()
 		await this.model.processData()
 		this.cat2Color = getColors(this.model.charts.length)
@@ -67,8 +68,8 @@ export async function getPlotConfig(opts, app) {
 		await fillTermWrapper(plot.term, app.vocabApi)
 		if (plot.term0) await fillTermWrapper(plot.term0, app.vocabApi)
 		if (plot.scaleDotTW) await fillTermWrapper(plot.scaleDotTW, app.vocabApi)
-		if (plot.countryTW) await fillTermWrapper(plot.countryTW, app.vocabApi)
-		if (plot.siteTW) await fillTermWrapper(plot.siteTW, app.vocabApi)
+		if (plot.filterTWs) for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
+
 		return plot
 	} catch (e) {
 		console.log(e)

--- a/client/plots/frequencyChart/frequencyChart.ts
+++ b/client/plots/frequencyChart/frequencyChart.ts
@@ -26,7 +26,7 @@ export class FrequencyChart extends Runchart {
 		this.model = new FrequencyChartModel(this)
 		this.vm = new RunchartViewModel(this)
 		this.interactivity = new ScatterInteractivity(this)
-		if (!this.parentId)
+		if (!this.parentId && this.config.filterTWs)
 			//if you are in the report you dont show filters
 			this.selectFilters = new CategoryFiltersUI(this.view.dom.headerDiv, this, this.config)
 	}
@@ -34,7 +34,7 @@ export class FrequencyChart extends Runchart {
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings[this.type]
-		if (!this.parentId) this.selectFilters.fillFilters()
+		if (!this.parentId && this.config.filterTWs) this.selectFilters.fillFilters()
 
 		await this.model.initData()
 		await this.model.processData()
@@ -70,7 +70,7 @@ export async function getPlotConfig(opts, app) {
 		await fillTermWrapper(plot.term, app.vocabApi)
 		if (plot.term0) await fillTermWrapper(plot.term0, app.vocabApi)
 		if (plot.scaleDotTW) await fillTermWrapper(plot.scaleDotTW, app.vocabApi)
-		for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
+		if (plot.filterTWs) for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
 
 		return plot
 	} catch (e) {

--- a/client/plots/frequencyChart/view/frequencyChartView.ts
+++ b/client/plots/frequencyChart/view/frequencyChartView.ts
@@ -14,7 +14,6 @@ export class FrequencyChartView extends RunchartView {
 	}
 
 	async getControlInputs() {
-		const filterInputs = await this.getFilterControlInputs()
 		const shapeOption = {
 			type: 'term',
 			configKey: 'shapeTW',
@@ -64,7 +63,6 @@ export class FrequencyChartView extends RunchartView {
 		}
 
 		const inputs: any = [
-			...filterInputs,
 			{
 				type: 'term',
 				configKey: 'term',

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -178,7 +178,8 @@ export class profilePlot {
 			filters,
 			// safe to pass because the backend code will still compare terms[] with the the dataset's hiddenTermIds,
 			// it only affects what will be included in the aggregation and does not disable user access authentication
-			filterByUserSites: this.settings.filterByUserSites
+			filterByUserSites: this.settings.filterByUserSites,
+			showAll: true
 		})
 		this.regions = this.filteredTermValues[this.config.regionTW.id]
 		this.countries = this.filteredTermValues[this.config.countryTW.id]

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -3,7 +3,7 @@ import { fillTermWrapper } from '#termsetting'
 import { ReportView } from './view/reportView'
 import { RxComponentInner } from '../../types/rx.d'
 import { controlsInit } from '../controls.js'
-import { SelectFilters } from '#dom/selectFilters'
+import { CategoryFiltersUI } from '#dom/categoryFiltersUI'
 
 export class Report extends RxComponentInner {
 	config: any
@@ -25,7 +25,7 @@ export class Report extends RxComponentInner {
 	async init(appState) {
 		this.config = appState.plots.find(p => p.id === this.id)
 		this.view = new ReportView(this)
-		this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
+		this.selectFilters = new CategoryFiltersUI(this.view.dom.headerDiv, this, this.config)
 		this.components = { plots: {} }
 		const state = this.getState(appState)
 		for (const section of state.config.sections) {

--- a/client/plots/report/view/reportView.ts
+++ b/client/plots/report/view/reportView.ts
@@ -36,25 +36,6 @@ export class ReportView {
 		}
 		document.addEventListener('scroll', () => this?.dom?.tooltip?.hide())
 		select('.sjpp-output-sandbox-content').on('scroll', () => this.dom.tooltip.hide())
-		this.dom.filterSelects = []
-		if (this.report.config.filterTWs) {
-			headerDiv.style('padding', '20px 0px 20px 0px')
-			for (const tw of this.report.config.filterTWs) {
-				this.dom.headerDiv.append('label').text(` ${tw.term.name}: `).style('vertical-align', 'top')
-				let timeoutId
-				const select = this.dom.headerDiv.append('select').property('multiple', true).attr('size', '5')
-
-				select.on('change', async () => {
-					clearTimeout(timeoutId)
-					timeoutId = setTimeout(() => {
-						const values = Array.from(select.node().selectedOptions).map((o: any) => o.value)
-						this.report.settings[tw.term.id] = values
-						this.report.replaceFilter()
-					}, 1000)
-				})
-				this.dom.filterSelects.push(select)
-			}
-		}
 	}
 
 	getControlInputs() {

--- a/client/plots/runchart/runchart.ts
+++ b/client/plots/runchart/runchart.ts
@@ -10,7 +10,7 @@ import { downloadSingleSVG } from '../../common/svg.download.js'
 import { select2Terms } from '#dom/select2Terms'
 import { Scatter } from '../scatter/scatter.js'
 import { getColors } from '#shared/common.js'
-import { SelectFilters } from '#dom/selectFilters'
+import { CategoryFiltersUI } from '#dom/categoryFiltersUI'
 
 export class Runchart extends Scatter {
 	type: string
@@ -32,7 +32,7 @@ export class Runchart extends Scatter {
 		this.model = new RunchartModel(this)
 		this.vm = new RunchartViewModel(this)
 		this.interactivity = new ScatterInteractivity(this)
-		if (!this.parentId) this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
+		if (!this.parentId) this.selectFilters = new CategoryFiltersUI(this.view.dom.headerDiv, this, this.config)
 	}
 
 	async main() {

--- a/client/plots/runchart/runchart.ts
+++ b/client/plots/runchart/runchart.ts
@@ -32,13 +32,14 @@ export class Runchart extends Scatter {
 		this.model = new RunchartModel(this)
 		this.vm = new RunchartViewModel(this)
 		this.interactivity = new ScatterInteractivity(this)
-		if (!this.parentId) this.selectFilters = new CategoryFiltersUI(this.view.dom.headerDiv, this, this.config)
+		if (!this.parentId && this.config.filterTWs)
+			this.selectFilters = new CategoryFiltersUI(this.view.dom.headerDiv, this, this.config)
 	}
 
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings[this.type]
-		if (!this.parentId) this.selectFilters.fillFilters()
+		if (!this.parentId && this.config.filterTWs) this.selectFilters.fillFilters()
 		await this.model.initData()
 		await this.model.processData()
 		this.cat2Color = getColors(this.model.charts.length)
@@ -96,7 +97,9 @@ export async function getPlotConfig(opts, app) {
 		await fillTermWrapper(plot.term2, app.vocabApi)
 		if (plot.term0) await fillTermWrapper(plot.term0, app.vocabApi)
 		if (plot.scaleDotTW) await fillTermWrapper(plot.scaleDotTW, app.vocabApi)
-		for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
+		if (plot.filterTWs)
+			//fill the filterTWs with the term data
+			for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
 
 		return plot
 	} catch (e) {

--- a/client/plots/runchart/runchart.ts
+++ b/client/plots/runchart/runchart.ts
@@ -32,13 +32,13 @@ export class Runchart extends Scatter {
 		this.model = new RunchartModel(this)
 		this.vm = new RunchartViewModel(this)
 		this.interactivity = new ScatterInteractivity(this)
-		this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
+		if (!this.parentId) this.selectFilters = new SelectFilters(this.view.dom.headerDiv, this, this.config)
 	}
 
 	async main() {
 		this.config = structuredClone(this.state.config)
 		this.settings = this.config.settings[this.type]
-		this.selectFilters.fillFilters()
+		if (!this.parentId) this.selectFilters.fillFilters()
 		await this.model.initData()
 		await this.model.processData()
 		this.cat2Color = getColors(this.model.charts.length)
@@ -96,7 +96,7 @@ export async function getPlotConfig(opts, app) {
 		await fillTermWrapper(plot.term2, app.vocabApi)
 		if (plot.term0) await fillTermWrapper(plot.term0, app.vocabApi)
 		if (plot.scaleDotTW) await fillTermWrapper(plot.scaleDotTW, app.vocabApi)
-		if (plot.filterTWs) for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
+		for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
 
 		return plot
 	} catch (e) {

--- a/client/plots/runchart/runchart.ts
+++ b/client/plots/runchart/runchart.ts
@@ -80,7 +80,8 @@ export async function getPlotConfig(opts, app) {
 			runChart: settings,
 			startColor: {}, //dict to store the start color of the gradient for each chart when using continuous color
 			stopColor: {} //dict to store the stop color of the gradient for each chart when using continuous color
-		}
+		},
+		filterTWs: opts.filterTWs || []
 	}
 	copyMerge(plot, defaultConfig, opts)
 

--- a/client/plots/runchart/view/runchartView.ts
+++ b/client/plots/runchart/view/runchartView.ts
@@ -2,7 +2,6 @@ import { fillTermWrapper } from '#termsetting'
 import type { Runchart } from '../runchart.js'
 import { ScatterView } from '../../scatter/view/scatterView.js'
 import { isNumericTerm } from '#shared/terms.js'
-import { getCategoricalTermFilter } from '#filter'
 
 export const minShapeSize = 0.2
 export const maxShapeSize = 6
@@ -14,54 +13,8 @@ export class RunchartView extends ScatterView {
 		this.runchart = runchart
 	}
 
-	async getFilterControlInputs() {
-		if (this.scatter.parentId) return [] // no filter inputs if this is a child plot
-		const terms = this.runchart.filterTWs
-		const filters = {}
-		for (const tw of terms) {
-			filters[tw.term.id] = getCategoricalTermFilter(terms, this.scatter.settings, tw)
-		}
-		//Dictionary with samples applying all the filters but not the one from the current term id
-		const filteredTermValues = await this.runchart.app.vocabApi.filterTermValues({
-			filter: this.scatter.state.termfilter.filter,
-			filters,
-			terms
-		})
-		const inputs: any[] = []
-		if (this.runchart.config.countryTW) {
-			// countries can show all the values
-			const countryValues = Object.values(this.runchart.config.countryTW.term.values)
-			const countries = countryValues.map((v: any) => ({
-				label: v.label,
-				value: v.value || v.label
-			}))
-			countries.sort((a, b) => a.label.localeCompare(b.label))
-			countries.unshift({ label: '', value: '' }) // add empty option
-			inputs.push({
-				label: 'Country',
-				type: 'dropdown',
-				chartType: this.runchart.type,
-				settingsKey: this.runchart.config.countryTW.term.id,
-				options: countries,
-				callback: value => this.runchart.setCountry(value)
-			})
-		}
-		if (this.runchart.config.siteTW) {
-			const sites = filteredTermValues[this.runchart.config.siteTW.term.id]
-			inputs.push({
-				label: 'Site',
-				type: 'dropdown',
-				chartType: this.runchart.type,
-				settingsKey: this.runchart.config.siteTW.term.id,
-				options: sites,
-				callback: value => this.runchart.setFilterValue(this.runchart.config.siteTW.term.id, value)
-			})
-		}
-		return inputs
-	}
-
 	async getControlInputs() {
-		const inputs: any[] = await this.getFilterControlInputs()
+		const inputs: any[] = []
 		const shapeOption = {
 			type: 'term',
 			configKey: 'shapeTW',

--- a/client/plots/scatter/view/scatterView.ts
+++ b/client/plots/scatter/view/scatterView.ts
@@ -25,9 +25,13 @@ export class ScatterView {
 			.insert('div')
 			.style('display', 'inline-block')
 			.attr('class', 'pp-termdb-plot-controls')
-		const mainDiv = this.opts.holder.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
+
+		const rightDiv = this.opts.holder.insert('div').style('display', 'inline-block').style('vertical-align', 'top')
+		const headerDiv = rightDiv.append('div')
+		const mainDiv = rightDiv.append('div')
 
 		this.dom = {
+			headerDiv,
 			mainDiv,
 			header: this.opts.header,
 			//holder,

--- a/server/routes/filterTermValues.ts
+++ b/server/routes/filterTermValues.ts
@@ -37,7 +37,7 @@ function init({ genomes }) {
 	}
 }
 
-function getList(samplesPerFilter, filtersData, tw) {
+function getList(samplesPerFilter, filtersData, tw, showAll) {
 	const values: any = Object.values(tw.term.values)
 	values.sort((v1: any, v2: any) => v1.label.localeCompare(v2.label))
 	const twSamples = samplesPerFilter[tw.term.id]
@@ -52,6 +52,7 @@ function getList(samplesPerFilter, filtersData, tw) {
 	for (const value of values) {
 		const label = value.label.replace(/["']/g, '') // remove quotes from the label if found, some datasets have quotes in the labels
 		const disabled = !sampleValues.includes(value.key || value.label) //if the value is not in the sample values, disable it
+		if (!showAll && disabled) continue //skip disabled values
 		filteredValues.push({ value: value.key || value.label, label, disabled })
 	}
 	filteredValues.unshift({ label: '', value: '' })


### PR DESCRIPTION
# Description

Created the CategoryFilters UI component to remove the duplicated code and/or hardcoded filters in the runChart, the frequencyChart and the report. Added choice showAll to show/hide categories not present disabled or hide them. In the report the missing categories are not shown now, resulting in less overcrowded filters. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
