### PR TITLE
allow automatic entries for hg38-test datasets inside containers

### DIFF
--- a/server/dataset/protected.test.ts
+++ b/server/dataset/protected.test.ts
@@ -1,5 +1,8 @@
 import type { Mds3 } from '#types'
-import termdbTestInit from './termdb.test.ts'
+// on using .js instead of .ts extension when importing termdb.test:
+// - in local dev, `tsx` will automatically find and use the correct file
+// - in container-based CI, the installed @sjrch/proteinpaint-server/dataset has js files only
+import termdbTestInit from './termdb.test.js'
 
 // export a function to allow reuse of this dataset without causing conflicts
 // for the different use cases in runtime/tests

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -161,7 +161,10 @@ if (serverconfig.debugmode && !serverconfig.binpath.includes('sjcrh/')) {
 	// since the serverconfig.binpath prefix may
 	// have been applied to locate optional routeSetter files
 	serverconfig.routeSetters = routeSetters
+}
 
+if (serverconfig.debugmode) {
+	// should be able to run this in local dev and test environments that use containers
 	const hg38test = serverconfig.genomes.find(g => g.name == 'hg38-test')
 	// this internal function must be trusted to only modify test-related serverconfig entries
 	if (hg38test?.datasets) mayUpdateTestDatasets(hg38test.datasets, serverconfig)


### PR DESCRIPTION
# Description

Passed CI in https://github.com/stjude/proteinpaint/actions/runs/16781544518/job/47521475656, including the `minimum sample size` that was failing previously.

Also tested locally using testrun.html in browser and command line (`npm run test:integration` from the client dir).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
