### PR TITLE
supply a default clientAuthResult in the auth middleware

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -625,8 +625,8 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 			}
 		}
 		const id = getSessionId(req, cred, sessions)
-		const activeSession = sessions[req.query.dslabel]?.[id]
-		return { forbiddenRoutes, clientAuthResult: activeSession?.clientAuthResult }
+		const activeSession = id && sessions[req.query.dslabel]?.[id]
+		return { forbiddenRoutes, clientAuthResult: activeSession?.clientAuthResult || {} }
 	}
 
 	authApi.getRequiredCredForDsEmbedder = function (dslabel, embedder) {

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -343,14 +343,14 @@ tape(`auth methods`, async test => {
 	)
 	test.deepEqual(
 		authApi.getNonsensitiveInfo(req1),
-		{ forbiddenRoutes: ['burden'], clientAuthResult: undefined },
+		{ forbiddenRoutes: ['burden'], clientAuthResult: {} },
 		`should return the expected forbidden routes for a wildcard embedder with cred.type='forbidden'`
 	)
 
 	const req2 = { query: { embedder: 'notlocalhost', dslabel: 'ds100' }, get: () => 'localhost' }
 	test.deepEqual(
 		authApi.getNonsensitiveInfo(req2),
-		{ forbiddenRoutes: [], clientAuthResult: undefined },
+		{ forbiddenRoutes: [], clientAuthResult: {} },
 		`should return the expected forbidden routes for a non-wildcard embedder`
 	)
 	test.deepEqual(


### PR DESCRIPTION
# Description

This fixes the following issue as seen when the pp script src has a different domain from the embedder URL. In `master` branch there is no default `clientAuthResult` as set by the backend auth middleware, but this is not an issue in local dev since a domain-based cookie allows recovery of `clientAuthResult`. However, when the embedder URL is different from pp script src domain, CORS prevents the domain-based cookie from creating a non-empty default value for `clientAuthResult`.

To test:
- edit `sjpp/public/profile/index.html` to have these
```html
<head>
    <meta charset="utf-8">
    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
    <!-- should put these in head in dev, test pages to ensure it loads before html and runpp() call --->
    <script src="http://localhost:3000/bin/proteinpaint.js" charset="utf-8"></script>
    <script src="http://localhost:3000/static/js/login.js" charset="utf-8"></script>
</head>
<body> 
...
runproteinpaint({
    host: 'http://localhost:3000/',
```
- run `python3 -m http.server 8889` in the `sjpp/public dir`, in another terminal tab/window
- load http://localhost:8889/profile/?role=user: in this PR branch, there should be no error. In master, this error will show up: `✕Error: missing q.__protected__ clientAuthResult or ignoredTermIds`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
