### PR TITLE
consolidate gdc app launchers

### DIFF
--- a/client/gdc/bam.js
+++ b/client/gdc/bam.js
@@ -113,16 +113,11 @@ inputValue=str
 Returns:
 	a public API object with callback
 */
-export async function bamsliceui({
-	genomes,
+export async function bamsliceui(
+	{ filter0, hideTokenInput = false, callbacks = {}, stream2download = false, inputValue, debugmode = false },
 	holder,
-	filter0,
-	hideTokenInput = false,
-	callbacks = {},
-	stream2download = false,
-	inputValue,
-	debugmode = false
-}) {
+	genomes
+) {
 	if (callbacks.postRender && typeof callbacks.postRender != 'function') throw 'callbacks.postRender is not function'
 
 	// public api obj to be returned

--- a/client/gdc/grin2.ts
+++ b/client/gdc/grin2.ts
@@ -2287,7 +2287,7 @@ const datatypeOptions = [
  * @param config - Configuration object containing holder, filters, and callbacks
  * @returns Public API object with update method
  */
-export async function gdcGRIN2ui({ holder, filter0, callbacks, debugmode = false }) {
+export async function gdcGRIN2ui({ filter0, callbacks, debugmode = false }, holder) {
 	if (debugmode) {
 		// Debug logic
 	}

--- a/client/gdc/launch.ts
+++ b/client/gdc/launch.ts
@@ -1,0 +1,91 @@
+/* launch from runpp() call. GDC react wrappers in the GFF repo use this method, to launch apps in gdc portal
+on matching with a flag, imports corresponding plot script, and returns api object to runpp()
+when no flags are matched, returns undefined
+*/
+export async function mayLaunchGdcPlotFromRunpp(arg, app) {
+	if (arg.geneSearch4GDCmds3) {
+		/* can generalize by changing to geneSearch4tk:{tkobj}
+		so it's no longer hardcoded for one dataset of one track type
+		*/
+		const _ = await import('./lollipop.js')
+		return await _.init(arg, app.holder0, app.genomes)
+	}
+	if (arg.launchGdcMatrix) {
+		const _ = await import('./oncomatrix.js')
+		return await _.init(arg, app.holder0, app.genomes)
+	}
+	if (arg.launchGdcHierCluster) {
+		const _ = await import('./geneExpClustering.js')
+		return await _.init(arg, app.holder0, app.genomes)
+	}
+	if (arg.launchGdcMaf) {
+		const _ = await import('./maf.js')
+		return await _.gdcMAFui(arg, app.holder0)
+	}
+	if (arg.launchGdcGrin2) {
+		const _ = await import('./grin2.ts')
+		return await _.gdcGRIN2ui(arg, app.holder0)
+	}
+	if (arg.launchGdcScRNAseq) {
+		const _ = await import('./singlecell.ts')
+		return await _.init(arg, app.holder0, app.genomes)
+	}
+	if (arg.launchGdcCorrelation) {
+		const _ = await import('./correlation.ts')
+		return await _.init(arg, app.holder0, app.genomes)
+	}
+	if (arg.gdcbamslice) {
+		const _ = await import('./bam.js')
+		arg.gdcbamslice.filter0 = arg.filter0
+		return await _.bamsliceui(arg.gdcbamslice, app.holder0, app.genomes)
+	}
+}
+
+/* launch from url param; this is for local testing and not used in gdc portal
+returns true for a match
+*/
+export async function mayLaunchGdcPlotFromUrlparam(urlp, arg) {
+	if (urlp.has('gdcbamslice')) {
+		// for local testing, not used in gdc portal
+		const _ = await import('./bam.js')
+		_.bamsliceui(
+			{
+				debugmode: arg.debugmode,
+				stream2download: urlp.has('stream2download') // for testing only, launch the app in "download mode", will not visualize
+			} as any,
+			arg.holder,
+			arg.genomes
+		)
+		return true
+	}
+	if (urlp.has('gdcmaf')) {
+		// for local testing, not used in gdc portal
+		const _ = await import('./maf.js')
+		const p: any = {
+			debugmode: arg.debugmode
+		}
+		if (urlp.has('filter0')) p.filter0 = urlp.get('filter0')
+		_.gdcMAFui(p, arg.holder)
+		return true
+	}
+	if (urlp.has('gdcgrin2')) {
+		// for local testing, not used in gdc portal
+		const _ = await import('./grin2.ts')
+		const p: any = {
+			debugmode: arg.debugmode
+		}
+		if (urlp.has('filter0')) p.filter0 = urlp.get('filter0')
+		_.gdcGRIN2ui(p, arg.holder)
+		return true
+	}
+	if (urlp.has('gdccorrelation')) {
+		// for local testing, not used in gdc portal
+		const _ = await import('./correlation.ts')
+		const p: any = {
+			debugmode: arg.debugmode
+		}
+		if (urlp.has('filter0')) p.filter0 = urlp.get('filter0')
+		_.init(p, arg.holder, arg.genomes)
+		return true
+	}
+}

--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -7,11 +7,6 @@ import { select } from 'd3-selection'
 a UI to list open-access maf files from current cohort
 let user selects some, for the backend to generate an aggregated maf file and download to user
 
-filter0=str
-	optional, stringified json obj as the cohort filter from gdc ATF
-	simply pass to backend to include in api queries
-callbacks{ postRender() }
-
 obj {} TODO convert to class and declare properties
 
 */
@@ -170,7 +165,7 @@ const mafColumns = [
 	{ column: 'callers', selected: true }
 ]
 
-export async function gdcMAFui({ holder, filter0, callbacks, debugmode = false }) {
+export async function gdcMAFui({ filter0, callbacks, debugmode = false }, holder) {
 	try {
 		if (callbacks) {
 			/* due to src/app.js line 100

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -18,6 +18,7 @@ import * as parseurl from './app.parseurl'
 import { init_mdsjson } from './app.mdsjson'
 import urlmap from '#common/urlmap'
 import { Menu, renderSandboxFormDiv, sayerror } from '#dom'
+import { mayLaunchGdcPlotFromRunpp } from '../gdc/launch.ts'
 
 /*
 exports a function runproteinpaint(), referred to as "runpp"
@@ -602,31 +603,6 @@ async function parseEmbedThenUrl(arg, app) {
 		return await launchWsiViewer(arg, app)
 	}
 
-	if (arg.geneSearch4GDCmds3) {
-		/* can generalize by changing to geneSearch4tk:{tkobj}
-		so it's no longer hardcoded for one dataset of one track type
-		*/
-		return await launchGeneSearch4GDCmds3(arg, app)
-	}
-	if (arg.launchGdcMatrix) {
-		return await launchGdcMatrix(arg, app)
-	}
-	if (arg.launchGdcHierCluster) {
-		return await launchGdcHierCluster(arg, app)
-	}
-	if (arg.launchGdcMaf) {
-		return await launchGdcMaf(arg, app)
-	}
-	if (arg.launchGdcGrin2) {
-		return await launchGdcGrin2(arg, app)
-	}
-	if (arg.launchGdcScRNAseq) {
-		return await launchGdcScRNAseq(arg, app)
-	}
-	if (arg.launchGdcCorrelation) {
-		return await launchGdcCorrelation(arg, app)
-	}
-
 	if (arg.parseurl && location.search.length) {
 		/*
 		since jwt token is only passed from arg of runpp()
@@ -664,8 +640,9 @@ async function parseEmbedThenUrl(arg, app) {
 		launchmaftimeline(arg, app)
 	}
 
-	if (arg.gdcbamslice) {
-		return await launchgdcbamslice(arg, app)
+	{
+		const _ = await mayLaunchGdcPlotFromRunpp(arg, app)
+		if (_) return _
 	}
 
 	if (arg.mass) {
@@ -1226,68 +1203,6 @@ async function launchSelectGenomeWithTklst(arg, app) {
 	const _ = await import('./selectGenomeWithTklst')
 	await _.init(arg, app.holder0, app.genomes)
 }
-
-///////////////// gdc launchers ///////////////
-async function launchGeneSearch4GDCmds3(arg, app) {
-	const _ = await import('../gdc/lollipop.js')
-	return await _.init(arg, app.holder0, app.genomes)
-}
-async function launchGdcMatrix(arg, app) {
-	const _ = await import('../gdc/oncomatrix.js')
-	return await _.init(arg, app.holder0, app.genomes)
-}
-async function launchGdcHierCluster(arg, app) {
-	const _ = await import('../gdc/geneExpClustering.js')
-	return await _.init(arg, app.holder0, app.genomes)
-}
-async function launchGdcScRNAseq(arg, app) {
-	const _ = await import('../gdc/singlecell.ts')
-	return await _.init(arg, app.holder0, app.genomes)
-}
-async function launchGdcMaf(arg, app) {
-	const _ = await import('../gdc/maf.js')
-	return await _.gdcMAFui({
-		holder: app.holder0,
-		filter0: arg.filter0,
-		callbacks: arg.callbacks || {},
-		debugmode: arg.debugmode
-	})
-}
-async function launchGdcGrin2(arg, app) {
-	const _ = await import('../gdc/grin2.ts')
-	return await _.gdcGRIN2ui({
-		holder: app.holder0,
-		filter0: arg.filter0,
-		callbacks: arg.callbacks || {},
-		debugmode: arg.debugmode
-	})
-}
-async function launchGdcCorrelation(arg, app) {
-	const _ = await import('../gdc/correlation.ts')
-	const p = {
-		debugmode: arg.debugmode,
-		filter0: arg.filter0
-	}
-	if (arg.opts) p.opts = arg.opts
-	return await _.init(p, app.holder0, app.genomes)
-}
-function launchgdcbamslice(arg, app) {
-	return import('../gdc/bam.js').then(p => {
-		return p.bamsliceui({
-			genomes: app.genomes,
-			holder: app.holder0,
-			hideTokenInput: arg.gdcbamslice.hideTokenInput, // set to true in gdc react wrapper
-			callbacks: arg.gdcbamslice.callbacks || {}, // for testing
-			// react wrapper can supply this optional filter as bam ui is required to only search cases within a cohort user created in Analysis Tools Framework(ATF)
-			filter0: arg.filter0,
-			// react wrapper can set this to true and run it in "download mode", will not visualize file
-			stream2download: arg.gdcbamslice.stream2download,
-			// for testing
-			inputValue: arg.gdcbamslice.inputValue
-		})
-	})
-}
-///////////////// end of gdc launchers ///////////////
 
 function launchmavb(arg, app) {
 	if (arg.mavolcanoplot.uionly) {

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -7,8 +7,9 @@ import { getSavedToken } from '#common/dofetch'
 import urlmap from '#common/urlmap'
 import { first_genetrack_tolist } from '#common/1stGenetk'
 import { corsMessage } from '#common/embedder-helpers'
-import { sayerror } from '../dom/sayerror'
+import { sayerror } from '#dom'
 import { copyMerge } from '#rx'
+import { mayLaunchGdcPlotFromUrlparam } from '../gdc/launch.ts'
 /*
 ********************** EXPORTED
 parse()
@@ -88,51 +89,7 @@ upon error, throw err message as a string
 		return
 	}
 
-	if (urlp.has('gdcbamslice')) {
-		// for local testing, not used in gdc portal
-		const _ = await import('../gdc/bam.js')
-		_.bamsliceui({
-			genomes: arg.genomes,
-			holder: arg.holder,
-			debugmode: arg.debugmode,
-			stream2download: urlp.has('stream2download') // for testing only, launch the app in "download mode", will not visualize
-		})
-		return
-	}
-
-	if (urlp.has('gdcmaf')) {
-		// for local testing, not used in gdc portal
-		const _ = await import('../gdc/maf.js')
-		const p = {
-			holder: arg.holder,
-			debugmode: arg.debugmode
-		}
-		if (urlp.has('filter0')) p.filter0 = urlp.get('filter0')
-		_.gdcMAFui(p)
-		return
-	}
-
-	if (urlp.has('gdcgrin2')) {
-		// for local testing, not used in gdc portal
-		const _ = await import('../gdc/grin2.ts')
-		const p = {
-			holder: arg.holder,
-			debugmode: arg.debugmode
-		}
-		if (urlp.has('filter0')) p.filter0 = urlp.get('filter0')
-		_.gdcGRIN2ui(p)
-		return
-	}
-	if (urlp.has('gdccorrelation')) {
-		// for local testing, not used in gdc portal
-		const _ = await import('../gdc/correlation.ts')
-		const p = {
-			debugmode: arg.debugmode
-		}
-		if (urlp.has('filter0')) p.filter0 = urlp.get('filter0')
-		_.init(p, arg.holder, arg.genomes)
-		return
-	}
+	if (await mayLaunchGdcPlotFromUrlparam(urlp, arg)) return // gdc plot launched
 
 	if (urlp.has('termdb')) {
 		const value = urlp.get('termdb')


### PR DESCRIPTION
# Description
- moves gdc launching code out of general code and into /client/gdc/launch.ts
- standardizes calls to be `gdcapp(arg, holder, genomes)`
- no changes needed for GFF react wrappers. maf and bam manual tests pass

later please help testing these apps in GFF. thanks!
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
