### PR TITLE
Fixed report filter recovered from a session. Should use the current user filter.

### DIFF
--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -139,7 +139,8 @@ export async function getPlotConfig(opts, app) {
 
 	try {
 		const config = app.vocabApi?.termdbConfig?.plotConfigByCohort?.default?.report
-		config.filter = app.vocabApi?.termdbConfig?.authFilter
+		// the filter should always start with the authFilter, avoids issues with previous filters from previous sessions with different user access
+		opts.filter = app.vocabApi?.termdbConfig?.authFilter
 		copyMerge(plot, config, opts)
 		if (plot.filterTWs) for (const tw of plot.filterTWs) await fillTermWrapper(tw, app.vocabApi)
 


### PR DESCRIPTION
# Description

When creating a report, overwrite previous filters. Auth filter should always be the starting filter. This solves the issue of recovering a report from a session with different user access and loading an invalid filter.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
