### PR TITLE
use a more reliable way to detect a protected route in client auth

### DIFF
--- a/client/common/auth.js
+++ b/client/common/auth.js
@@ -50,11 +50,14 @@ export function mayAddJwtToRequest(init, body, url) {
 	}
 	if (!dslabel || !jwtByDsRoute[dslabel]) return
 	const h = url.split('//')
-	// TODO: use a more reliable way to detect the url path without host or params, hash
-	const route = (h[1] || h[0])
-		.split('/')
-		.find(p => p != '')
-		.split('?')[0]
+	const postProtocolStr = h[1] || h[0] // handle a url such as '://something.abc'
+	const preQuestionMarkStr = postProtocolStr.split('?')[0]
+	const pathSegments = preQuestionMarkStr.split('/')
+	let route = pathSegments.find(p => p != '' && !p.includes(':') && !p.includes('.'))
+	// TODO: should not have to do this hardcoded mapping, ideally routes that are
+	//       protected together will share the same initial path segment
+	if (route.startsWith('profile') || route == 'filterTermValues') route = 'termdb'
+
 	const jwt = jwtByDsRoute[dslabel][route] || jwtByDsRoute[dslabel]['/**']
 	if (jwt) init.headers.authorization = 'Bearer ' + btoa(jwt)
 }


### PR DESCRIPTION
# Description

Fixes CORS-related issue where domain-based cookie is not automatically sent by the browser to the pp server instance at a different URL.

To test:
- run all unit and integration tests locally
- edit `sjpp/public/profile/index.html` to have these
```html
<head>
    <meta charset="utf-8">
    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
    <!-- should put these in head in dev, test pages to ensure it loads before html and runpp() call --->
    <script src="http://localhost:3000/bin/proteinpaint.js" charset="utf-8"></script>
    <script src="http://localhost:3000/static/js/login.js" charset="utf-8"></script>
</head>
<body> 
...
runproteinpaint({
    host: 'http://localhost:3000/',
```
- run `python3 -m http.server 8889` in the `sjpp/public dir`, in another terminal tab/window
- load http://localhost:8889/profile/?role=user: in this PR branch and the `Data Variable` chart, there should a `Site` root term. In master branch, this term will be missing for a user role.
- Also test other charts that may require term-level auth

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
