### PR TITLE
apply min sample size check to specific termdb routes

### DIFF
--- a/client/mass/test/barchart.integration.spec.js
+++ b/client/mass/test/barchart.integration.spec.js
@@ -1803,7 +1803,7 @@ tape('minimum sample size', test => {
 		barDiv = barchart.Inner.dom.barDiv
 		errDiv = barchart.Inner.app.Inner.components.plots['diaggrp'].Inner.dom.errdiv
 		testBarCount(0, 'with stricter filter')
-		test.true(errDiv.text().includes('required minimum sample size'), 'should display the expected error message')
+		test.true(errDiv.text().includes('has less than 10 samples'), 'should display the expected error message')
 		test.notEqual(errDiv.style('display'), 'none', 'should have a visible red error div')
 		await triggerClearedError(barchart)
 	}
@@ -1820,6 +1820,7 @@ tape('minimum sample size', test => {
 			filter: {
 				type: 'tvslst',
 				join: '',
+				in: true,
 				lst: [
 					{
 						type: 'tvs',

--- a/server/dataset/protected.test.ts
+++ b/server/dataset/protected.test.ts
@@ -4,15 +4,19 @@ import type { Mds3 } from '#types'
 // - in container-based CI, the installed @sjrch/proteinpaint-server/dataset has js files only
 import termdbTestInit from './termdb.test.js'
 
+const minSampleSize = 10
+
 // export a function to allow reuse of this dataset without causing conflicts
 // for the different use cases in runtime/tests
 export default function (): Mds3 {
 	// NOTE: may need to supply arguments to termdbTestInit if it requires it
 	const ds = termdbTestInit()
 	if (!ds.cohort) ds.cohort = { termdb: {} }
-	ds.cohort.termdb.hasMinSampleSize = sampleCount => {
-		//console.log(11, 'hasMinSampleSize()', sampleCount)
-		return sampleCount >= 10
+	ds.cohort.termdb.checkAccessToSampleData = (_, data) => {
+		return {
+			minSampleSize,
+			canAccess: data.sampleCount >= minSampleSize
+		}
 	}
 	return ds
 }

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -376,6 +376,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 				const cred = route[q.embedder] || route['*']
 				if (!cred) return
 				if (cred.protectedRoutes?.find(pattern => isMatch(path, pattern))) return cred
+				if (_protectedRoutes === '*') return cred
 				const protRoutes = _protectedRoutes || protectedRoutes.termdb
 				if (protRoutes.includes(q.for)) return cred
 			} else if (path.startsWith('/burden') && ds0.burden) {
@@ -431,7 +432,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 				authApi.mayAdjustFilter(req.query, ds)
 
 				// this flag may be used by downstream code that does not have access to req argument or ds object
-				__protected__.userCanAccessDs = authApi.userCanAccess(req, ds)
+				__protected__.userCanAccessDs = authApi.userCanAccess(req, ds, '*')
 			}
 		}
 		Object.freeze(__protected__)
@@ -648,8 +649,8 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 		return requiredCred.length ? requiredCred : undefined
 	}
 
-	authApi.userCanAccess = function (req, ds) {
-		const cred = getRequiredCred(req.query, req.path, protectedRoutes.samples)
+	authApi.userCanAccess = function (req, ds, _protectedRoutes) {
+		const cred = getRequiredCred(req.query, req.path, _protectedRoutes || protectedRoutes.samples)
 		if (!cred) return true
 		// !!! DEPRECATED: for 'basic' auth type, always require a login when runpp() is first called !!!
 		// this causes unnecessary additional logins when links are opened from a 'landing page'

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -55,9 +55,12 @@ export function handle_request_closure(genomes) {
 			if (q.getsamplelist) return res.send(await getSampleList(req, q, ds))
 
 			if (q.getsamples) return await trigger_getsamples(q, res, ds)
-			if (q.getcuminc) return await trigger_getincidence(q, res, ds)
-			if (q.getsurvival) return await trigger_getsurvival(q, res, ds)
-			if (q.getregression) return res.send(await get_regression(q, ds))
+			if (q.getcuminc) q.for = 'cuminc'
+			if (q.for == 'cuminc') return await trigger_getincidence(q, res, ds)
+			if (q.getsurvival) q.for = 'survival'
+			if (q.for == 'survival') return await trigger_getsurvival(q, res, ds)
+			if (q.getregression) q.for = 'regression'
+			if (q.for == 'regression') return res.send(await get_regression(q, ds))
 			if (q.validateSnps) return res.send(await snpValidate(q, tdb, ds, genome))
 			if (q.getvariantfilter) return res.send(ds?.queries?.snvindel?.variant_filter || {})
 			if (q.getLDdata) return await LDoverlay(q, ds, res)
@@ -66,7 +69,6 @@ export function handle_request_closure(genomes) {
 			if (q.for == 'scatter') return await trigger_getSampleScatter(req, q, res, ds)
 			if (q.getLowessCurve) return await trigger_getLowessCurve(req, q, res)
 
-			if (q.getCohortsData) return await trigger_getCohortsData(q, res, ds)
 			if (q.for == 'termTypes') return res.send(await ds.getTermTypes(q))
 			if (q.for == 'matrix') return await get_matrix(q, req, res, ds, genome)
 			if (q.for == 'numericDictTermCluster') return await get_numericDictTermCluster(q, req, res, ds, genome)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -1023,7 +1023,7 @@ function checkAccessToSampleData(data, ds, q) {
 	if (!ds.cohort.termdb.checkAccessToSampleData) return
 	// quick check
 	const access = ds.cohort.termdb.checkAccessToSampleData(q, { sampleCount: Object.keys(data.samples).length })
-	if (!access.hasAccess)
+	if (!access.canAccess)
 		throw {
 			message: `One or more terms has less than ${access.minSampleSize} samples with data.`,
 			code: 'ERR_MIN_SAMPLE_SIZE'
@@ -1038,7 +1038,7 @@ function checkAccessToSampleData(data, ds, q) {
 	}
 	const counts = [...sampleSizeByTermId.values()].map(v => v.size) // list of sample counts for each and every term
 	const access1 = ds.cohort.termdb.checkAccessToSampleData(q, { sampleCount: Math.min(...counts) })
-	if (!accessDetailed.hasAccess)
+	if (!access1.canAccess)
 		throw {
 			message: `One or more terms has less than ${access1.minSampleSize} samples with data.`,
 			code: 'ERR_MIN_SAMPLE_SIZE'

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -1113,7 +1113,7 @@ tape(`req.query.filter, __protected__`, async test => {
 				ignoredTermIds: [],
 				sessionid: 'xyz',
 				clientAuthResult: {},
-				userCanAccessDs: false
+				userCanAccess: false
 			},
 			'should set up req.query.__protected__'
 		)

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1384,10 +1384,12 @@ export type Termdb = {
 	 * in order to minimize the ease of extracting identifiable information from aggregate data
 	 * in server response
 	 *
-	 * sampleCount:   the number of samples with matching data from one or more queried terms
-	 * q          :   req.query as processed through app middleware (pre-parsed, may have req.body props, __protectec__, etc)
+	 * q            :   req.query as processed through app middleware (pre-parsed, may have req.body props, __protectec__, etc)
+	 * {
+	 *   sampleCount:   the number of samples with matching data from one or more queried terms
+	 * }
 	 */
-	hasMinSampleSize?: (sampleCount: number, q: any) => boolean
+	checkAccessToSampleData?: (q: any, data: { sampleCount: number }) => { minSampleSize: number; canAccess: boolean }
 	/** if true, backend is allowed to send sample names to client in charts */
 	displaySampleIds?: (clientAuthResult: any) => boolean
 	converSampleIds?: boolean

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1380,16 +1380,29 @@ export type Termdb = {
 	/** Terms */
 	termIds?: TermIds
 	/**
-	 * The required minimum number of samples with data as queried with getData() or other code,
+	 * Check for the required minimum number of samples with data as queried with getData() or other code,
 	 * in order to minimize the ease of extracting identifiable information from aggregate data
 	 * in server response
 	 *
 	 * q            :   req.query as processed through app middleware (pre-parsed, may have req.body props, __protectec__, etc)
-	 * {
+	 *
+	 * data{
 	 *   sampleCount:   the number of samples with matching data from one or more queried terms
 	 * }
+	 *
+	 * returns: {minSampleSize, canAccess}, see below
 	 */
-	checkAccessToSampleData?: (q: any, data: { sampleCount: number }) => { minSampleSize: number; canAccess: boolean }
+	checkAccessToSampleData?: (
+		q: any,
+		data: { sampleCount: number }
+	) => {
+		/** the required minimum sample size for the current user,
+		 * may be dependent on login status or other context
+		 * */
+		minSampleSize: number
+		/** whether downstreadm backend code can proceed */
+		canAccess: boolean
+	}
 	/** if true, backend is allowed to send sample names to client in charts */
 	displaySampleIds?: (clientAuthResult: any) => boolean
 	converSampleIds?: boolean


### PR DESCRIPTION
# Description

To test:
- pull the `sjpp/protected-fix` branch
- open http://localhost:3000/example.auth.html?dslabel=SJLife&route=termdb and follow the instructions to set up a fake-jwt
- create a filter with <10 samples, then open charts: should be an error when the user is not logged in, no error when logged in

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
