### PR TITLE
Support mclass colors and listing mutations for geneVariant term

### DIFF
--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -2,7 +2,7 @@ import { getPillNameDefault } from '../termsetting'
 import type { GeneVariantTermSettingInstance, RawGvTerm, VocabApi } from '#types'
 import type { PillData } from '../types'
 import { make_radios, renderTable } from '#dom'
-import { dtTerms, getColors, dtcnv } from '#shared/common.js'
+import { dtTerms, getColors, dtcnv, mclass } from '#shared/common.js'
 import { filterInit, filterPromptInit, getNormalRoot } from '#filter/filter'
 import { rgb } from 'd3-color'
 import { getWrappedTvslst } from '#filter/filter'
@@ -393,13 +393,8 @@ export async function getPredefinedGroupsets(term: RawGvTerm, vocabApi: VocabApi
 				}
 			])
 			const name = `${dtTerm.name_noOrigin} ${dtTerm.origin ? `${label} (${dtTerm.origin})` : label}`
-			groupset.groups.push({ name, type: 'filter', filter })
-		}
-		// set color scale based on number of groups
-		colorScale = getColors(groupset.groups.length)
-		// assign colors to each group
-		for (const group of groupset.groups) {
-			group.color = rgb(colorScale(group.name)).formatHex()
+			const color = mclass[key].color
+			groupset.groups.push({ name, type: 'filter', filter, color })
 		}
 		return groupset
 	}

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2792,10 +2792,11 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				// for example: if groups[0] is SNV=M and groups[1] is
 				// CNV=Loss and a sample has both SNV=M and CNV=Loss, then
 				// the sample will be assigned to groups[0]
-				const values = [] // mlst elements associated with group assignment
-				// e.g. if group is SNV=M and sample mlst consists of M and F, then the M element will be added to values[]
+				let values = [] // subset of mlst, consists of mutations tested
+				// for dts specified in the group filter
 				const group = groupset.groups.find(group => {
 					if (group.type != 'filter') throw 'unexpected group.type'
+					values = []
 					const filter = group.filter
 					const passLst = []
 					// test filter against mutations from each gene separately
@@ -2991,17 +2992,11 @@ export function filterByItem(filter, mlst, values) {
 			sampleHasGenotype = tvs.cnvWT ? !sampleHasCnv : sampleHasCnv
 		} else {
 			// categorical mutation data
-			for (const m of mlst_tested) m.intvs = tvs.values.some(v => v.key == m.class)
-			sampleHasGenotype = mlst_tested.some(m => m.intvs)
+			sampleHasGenotype = mlst_tested.some(m => tvs.values.some(v => v.key == m.class))
 		}
 		if (typeof sampleHasGenotype != 'boolean') throw 'unexpected non-boolean value'
-		if (tvs.isnot) {
-			pass = !sampleHasGenotype
-			if (values) values.push(...mlst_tested.filter(m => !m.intvs))
-		} else {
-			pass = sampleHasGenotype
-			if (values) values.push(...mlst_tested.filter(m => m.intvs))
-		}
+		pass = tvs.isnot ? !sampleHasGenotype : sampleHasGenotype
+		if (values) values.push(...mlst_tested)
 	} else {
 		// sample is not tested for the dt of the filter
 		// so sample does not pass the filter


### PR DESCRIPTION
# Description

Related to https://github.com/stjude/proteinpaint/issues/3552

Addresses the following issues with geneVariant term:
- Use mclass colors for cnv categories
- Support listing specific mutations when listing samples in barchart. For geneset, mutations from different genes are rendered in separate columns.
- Listing samples now works with gdc

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
