### PR TITLE
Supported showing a violin in the report

### DIFF
--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -146,11 +146,12 @@ export default function (): Mds3 {
 									name: 'Demographics',
 									plots: [
 										{
-											chartType: 'barchart',
-											settings: { barchart: { colorBars: true, showPercent: true } },
+											chartType: 'violin',
+											settings: { violin: { showStats: false } },
 
 											term: {
-												id: 'agedx'
+												id: 'agedx',
+												q: { mode: 'continuous' }
 											}
 										},
 										{


### PR DESCRIPTION
# Description

Supported showing a violin in the report. Showed age as violin in the termdbTest report. See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/983)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
