### PR TITLE
Limit concurrent processes in geneVariant query

### DIFF
--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2735,12 +2735,12 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		// query genes concurrently to speed up geneset query
 		// limit to 50 genes at a time (otherwise gdc query can fail)
 		if (!tw.term.genes?.length) throw 'tw.term.genes[] is empty'
+		const termdbmclass = q.ds?.cohort?.termdb?.mclass // custom mclass labels from dataset
 		const chunkSize = 50
 		for (let i = 0; i < tw.term.genes.length; i += chunkSize) {
 			const genes = tw.term.genes.slice(i, i + chunkSize)
 			await Promise.all(genes.map(gene => getGeneMlst(gene)))
 		}
-		const termdbmclass = q.ds?.cohort?.termdb?.mclass // custom mclass labels from dataset
 		async function getGeneMlst(gene) {
 			if (!gene.gene && !(gene.chr && Number.isInteger(gene.start) && Number.isInteger(gene.stop)))
 				throw 'no gene or position specified'


### PR DESCRIPTION
# Description

Limiting geneVariant query to 50 concurrent processes (i.e., genes) at a time, otherwise the query can fail in GDC.

Can test with [gdc mass UI](http://localhost:3000/?noheader=1&gdccorrelation=1&filter0={%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.primary_site%22,%22value%22:[%22brain%22,%22breast%22]}}) and load barcharts of gene sets that are large in size (>50 genes).


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
