### PR TITLE
gdc correlation plot fixes

### DIFF
--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -515,8 +515,9 @@ function handle_click(event, self, chart) {
 		.attr('class', 'sja_menuoption')
 		.html(d => d.label)
 		.on('click', async (event, d) => {
-			self.app.tip.hide()
+			event.target.textContent = 'Loading...'
 			await d.callback(self, tvslst)
+			self.app.tip.hide()
 		})
 	self.app.tip.show(event.clientX, event.clientY)
 }

--- a/client/plots/summarizeGeneexpSurvival.ts
+++ b/client/plots/summarizeGeneexpSurvival.ts
@@ -14,6 +14,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		const t = chartsInstance.app.vocabApi.termdbConfig.defaultTw4correlationPlot?.survival
 		if (!t) throw 'defaultTw4correlationPlot missing'
 		dictTw = structuredClone(t)
+		await fillTermWrapper(dictTw, chartsInstance.app.vocabApi)
 	}
 
 	// 2-col table to organize input ui

--- a/client/plots/summarizeGeneexpSurvival.ts
+++ b/client/plots/summarizeGeneexpSurvival.ts
@@ -52,7 +52,6 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		const pillDiv = td2.append('div')
 
 		const pill = await termsettingInit({
-			menuOptions: '{edit,replace}',
 			usecase: { target: 'survival', detail: 'term' }, // limit to survival terms
 			vocabApi: chartsInstance.app.vocabApi,
 			holder: pillDiv,

--- a/client/plots/summarizeMutationDiagnosis.ts
+++ b/client/plots/summarizeMutationDiagnosis.ts
@@ -20,6 +20,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		const t = chartsInstance.app.vocabApi.termdbConfig.defaultTw4correlationPlot?.disease
 		if (!t) throw 'defaultTw4correlationPlot missing'
 		dictTw = structuredClone(t)
+		await fillTermWrapper(dictTw, chartsInstance.app.vocabApi)
 	}
 
 	// 2-col table to organize input ui

--- a/client/plots/summarizeMutationSurvival.ts
+++ b/client/plots/summarizeMutationSurvival.ts
@@ -14,6 +14,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		const t = chartsInstance.app.vocabApi.termdbConfig.defaultTw4correlationPlot?.survival
 		if (!t) throw 'defaultTw4correlationPlot missing'
 		dictTw = structuredClone(t)
+		await fillTermWrapper(dictTw, chartsInstance.app.vocabApi)
 	}
 
 	// 2-col table to organize input ui

--- a/client/plots/summarizeMutationSurvival.ts
+++ b/client/plots/summarizeMutationSurvival.ts
@@ -55,7 +55,6 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		const pillDiv = td2.append('div')
 
 		const pill = await termsettingInit({
-			menuOptions: '{edit,replace}',
 			usecase: { target: 'survival', detail: 'term' }, // limit to survival terms
 			vocabApi: chartsInstance.app.vocabApi,
 			holder: pillDiv,

--- a/client/termsetting/termsetting.ts
+++ b/client/termsetting/termsetting.ts
@@ -653,12 +653,17 @@ function setInteractivity(self) {
 			}
 		}
 
-		if (self.q && !self.term.groupsetting?.disabled && minimatch('edit', self.opts.menuOptions)) {
+		if (
+			self.q &&
+			!self.term.groupsetting?.disabled &&
+			self.term.type != 'survival' &&
+			minimatch('edit', self.opts.menuOptions)
+		) {
 			// hide edit option for survival term because its showEditMenu() is disabled
 			options.push({
 				label: 'Edit',
 				callback: async div => {
-					if (self.term && isNumericTerm(self.term) && !self.term.bins && self.term.type != 'survival') {
+					if (self.term && isNumericTerm(self.term) && !self.term.bins) {
 						await self.vocabApi.setTermBins({ term: self.term, q: self.q })
 					}
 					self.handler!.showEditMenu(div)

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -768,28 +768,6 @@ tape('Numerical term: toggle menu - 2 options', async test => {
 	tip.hide()
 })
 
-tape('Survival term: toggle menu - 2 options', async test => {
-	test.timeoutAfter(3000)
-	test.plan(1)
-
-	const opts = await getOpts({
-		numericEditMenuVersion: ['continuous', 'discrete'],
-		tsData: {
-			term: termjson['os']
-		}
-	})
-
-	await opts.pill.main(opts.tsData)
-	await opts.pillMenuClick('Edit')
-	const tip = opts.pill.Inner.dom.tip
-	test.equal(
-		tip.d.node().querySelectorAll('.sj-toggle-button').length,
-		2,
-		'Should have 2 toggle buttons for survival edit menu'
-	)
-	tip.hide()
-})
-
 tape('Numerical term: toggle menu - 1 option', async test => {
 	test.timeoutAfter(3000)
 	test.plan(1)

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1592,7 +1592,7 @@ type Tw = {
 	/** short hand for using either id (dict term) or term{} */
 	id?: string
 	term?: object
-	q: unknown
+	q?: unknown
 	/** quick fix for generating URL links in mds3 tk sample table! adhoc design. may move to tw.term.baseURL and not specific to mds3 tk
 	 */
 	baseURL?: string


### PR DESCRIPTION
# Description

Additional fixes related to https://github.com/stjude/proteinpaint/issues/3552

- Display `Loading...` text in `List samples` button after clicking it in barchart
- Display time unit in x-axis label of survival plot when loading plot from exp-survival chart button
- Disable edit option for survival term. For gdc, also disable replace option.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
