### PR TITLE
GRIN2: Enabled CNV max segment length filter. 

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -580,11 +580,7 @@ class GRIN2 extends RxComponentInner {
 
 			Object.entries(result.processingSummary).forEach(([key, value]) => {
 				const displayKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())
-				const displayValue = Array.isArray(value)
-					? value.join(', ')
-					: typeof value === 'object' && value !== null
-					? JSON.stringify(value)
-					: String(value)
+				const displayValue = Array.isArray(value) ? value.join(', ') : String(value)
 				table.addRow(displayKey, displayValue)
 			})
 		}

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -304,12 +304,33 @@ function filterAndConvertSnvIndel(
 		return null
 	}
 
+	// TODO: implement alleleic total depth and alt allele count filters
+	// TODO: implement hypermutator threshold filter (maybe calculate number of mutations per sample?)
+
 	return [sampleName, entry.chr, entry.pos, entry.pos, 'mutation']
 }
 
 function filterAndConvertCnv(sampleName: string, entry: any, options: GRIN2Request['cnvOptions']): string[] | null {
 	// Must check that options are defined for typescript
-	if (!options || options.gainThreshold === undefined || options.lossThreshold === undefined) {
+	if (
+		!options ||
+		options.gainThreshold === undefined ||
+		options.lossThreshold === undefined ||
+		options.maxSegLength === undefined
+	) {
+		return null
+	}
+
+	if (!Number.isInteger(entry.start)) {
+		return null
+	}
+
+	if (!Number.isInteger(entry.stop)) {
+		return null
+	}
+
+	// Filter max segment length
+	if (options.maxSegLength > 0 && entry.stop - entry.start > options.maxSegLength) {
 		return null
 	}
 
@@ -320,13 +341,7 @@ function filterAndConvertCnv(sampleName: string, entry: any, options: GRIN2Reque
 	if (!isGain && !isLoss) return null
 	const lesionType = isGain ? 'gain' : 'loss'
 
-	if (!Number.isInteger(entry.start)) {
-		return null
-	}
-
-	if (!Number.isInteger(entry.stop)) {
-		return null
-	}
+	// TODO: implement hypermutator threshold filter (maybe calculate number of mutations per sample?)
 
 	return [sampleName, entry.chr, entry.start, entry.stop, lesionType]
 }


### PR DESCRIPTION
# Description
Enabled CNV max segment length filter. Added TODOs for allelic and hypermutator filters. Simplified processing summary code a little.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
