### PR TITLE
The profile filter needs to join to the global filter

### DIFF
--- a/client/filter/filter.utils.js
+++ b/client/filter/filter.utils.js
@@ -220,11 +220,11 @@ export function negateFilter(f0, tag = 'filterUiRoot') {
 	throw 'cannot negate filter'
 }
 
-export function getCombinedTermFilter(appState, reportFilter) {
-	if (!reportFilter) return appState.termfilter
-	let filter = reportFilter
-	if (appState.termfilter.filter) filter = filterJoin([appState.termfilter.filter, reportFilter])
-	return { filter, filter0: appState.termfilter.filter0 }
+export function getCombinedTermFilter(appState, filter) {
+	if (!filter) return appState.termfilter
+	let _filter = filter
+	if (appState.termfilter.filter) _filter = filterJoin([appState.termfilter.filter, filter])
+	return { filter: _filter, filter0: appState.termfilter.filter0 }
 }
 
 /*

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -4,7 +4,7 @@ import { fillTermWrapper, fillTwLst } from '#termsetting'
 import { select } from 'd3-selection'
 import { Menu } from '#dom/menu'
 import { icons as icon_functions } from '#dom/control.icons'
-import { getCategoricalTermFilter } from '#filter'
+import { getCategoricalTermFilter, getCombinedTermFilter } from '#filter'
 
 /*
 
@@ -440,7 +440,9 @@ export class profilePlot {
 	}
 
 	getFilter() {
-		return getCategoricalTermFilter(this.config.filterTWs, this.settings, null)
+		let filter = getCategoricalTermFilter(this.config.filterTWs, this.settings, null)
+		filter = getCombinedTermFilter(this.state, filter)
+		return filter.filter
 	}
 
 	clearFiltersExcept(ids) {


### PR DESCRIPTION
# Description

The profile filter needs to join to the global filter. When creating a global filter the plots where not changing. Fixed now.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
