### PR TITLE
Profile fix

### DIFF
--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -227,6 +227,7 @@ export class profilePlot {
 				facilityTW: this.config.facilityTW,
 				filterByUserSites: this.settings.filterByUserSites
 			})
+		if ('error' in this.data) throw this.data.error
 		this.sites = this.data.sites
 		this.sites.sort((a, b) => {
 			return a.label.localeCompare(b.label)

--- a/server/routes/termdb.profileFormScores.ts
+++ b/server/routes/termdb.profileFormScores.ts
@@ -49,7 +49,7 @@ async function getScoresDict(query, ds) {
 		},
 		ds
 	)
-	const lst = Object.values(data.samples)
+	const lst: any[] = Object.values(data.samples)
 	let sites = lst.map((s: any) => {
 		return { label: data.refs.bySampleId[s.sample].label, value: s.sample }
 	})
@@ -59,6 +59,12 @@ async function getScoresDict(query, ds) {
 	})
 	if (query.userSites) {
 		sites = sites.filter(s => query.userSites.includes(s.label))
+		if (lst.length == 1 && !sites.length) {
+			const siteId: number = lst[0].sample
+			const site = data.refs.bySampleId[siteId].label
+			const hospital = query.facilityTW.term.values[site].label
+			throw `The access to the hospital ${hospital} is denied`
+		}
 	}
 
 	let sitesSelected: any[] = []

--- a/server/routes/termdb.profileScores.ts
+++ b/server/routes/termdb.profileScores.ts
@@ -55,7 +55,7 @@ async function getScores(query, ds) {
 		},
 		ds
 	)
-	const lst = Object.values(data.samples)
+	const lst: any[] = Object.values(data.samples)
 
 	let sites = lst.map((s: any) => {
 		return { label: data.refs.bySampleId[s.sample].label, value: s.sample }
@@ -64,6 +64,12 @@ async function getScores(query, ds) {
 	//If the user has sites keep only the sites that are visible to the user
 	if (query.userSites) {
 		sites = sites.filter(s => query.userSites.includes(s.label))
+		if (lst.length == 1 && !sites.length) {
+			const siteId: number = lst[0].sample
+			const site = data.refs.bySampleId[siteId].label
+			const hospital = query.facilityTW.term.values[site].label
+			throw `The access to the hospital ${hospital} is denied`
+		}
 	}
 
 	let sitesSelected: any[] = []


### PR DESCRIPTION
# Description
If the data is filtered down to a sample should be a user sample,  otherwise throw error. This fix avoids to load plots from another session filtered down to one sample that does not belong to the user.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
