### PR TITLE
Support sample listing for geneExpression term in gdc violin plot

### DIFF
--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -171,7 +171,8 @@ export function setInteractivity(self) {
 		}
 		const opts = {
 			terms: [term],
-			filter
+			filter,
+			filter0: self.state.termfilter.filter0
 		}
 		//getAnnotatedSampleData is used to retrieve sample id's and values (see matrix.js).
 		const data = await self.app.vocabApi.getAnnotatedSampleData(opts)

--- a/server/src/mds3.gdc.filter.js
+++ b/server/src/mds3.gdc.filter.js
@@ -25,13 +25,17 @@ export function filter2GDCfilter(f) {
 			// (see mayFilterByGeneVariant() in server/src/mds3.init.js)
 			continue
 		}
+		if (item.tvs.term.type == 'geneExpression') {
+			// geneExpression term filtering will be performed during post-processing (see mayFilterByExpression() in server/src/mds3.gdc.js)
+			continue
+		}
 
 		if (item.tvs.values) {
 			// categorical
 			const f = {
 				op: item.tvs.isnot ? '!=' : 'in',
 				content: {
-					field: mayChangeCase2Cases(item.tvs.term.id),
+					field: mayChangeCase2Cases(item.tvs.term),
 					value: item.tvs.values.map(i => i.key)
 				}
 			}
@@ -43,14 +47,14 @@ export function filter2GDCfilter(f) {
 				if (range.startunbounded) {
 					obj.content.push({
 						op: range.stopinclusive ? (item.tvs.isnot ? '>' : '<=') : item.tvs.isnot ? '>=' : '<',
-						content: { field: mayChangeCase2Cases(item.tvs.term.id), value: range.stop }
+						content: { field: mayChangeCase2Cases(item.tvs.term), value: range.stop }
 					})
 					continue
 				}
 				if (range.stopunbounded) {
 					obj.content.push({
 						op: range.startinclusive ? (item.tvs.isnot ? '<' : '>=') : item.tvs.isnot ? '<=' : '>',
-						content: { field: mayChangeCase2Cases(item.tvs.term.id), value: range.start }
+						content: { field: mayChangeCase2Cases(item.tvs.term), value: range.start }
 					})
 					continue
 				}
@@ -63,7 +67,7 @@ export function filter2GDCfilter(f) {
 								content: [
 									{
 										op: range.startinclusive ? '<' : '<=',
-										content: { field: mayChangeCase2Cases(item.tvs.term.id), value: range.start }
+										content: { field: mayChangeCase2Cases(item.tvs.term), value: range.start }
 									}
 								]
 							},
@@ -72,7 +76,7 @@ export function filter2GDCfilter(f) {
 								content: [
 									{
 										op: range.stopinclusive ? '>' : '>=',
-										content: { field: mayChangeCase2Cases(item.tvs.term.id), value: range.stop }
+										content: { field: mayChangeCase2Cases(item.tvs.term), value: range.stop }
 									}
 								]
 							}
@@ -84,11 +88,11 @@ export function filter2GDCfilter(f) {
 						content: [
 							{
 								op: range.startinclusive ? '>=' : '>',
-								content: { field: mayChangeCase2Cases(item.tvs.term.id), value: range.start }
+								content: { field: mayChangeCase2Cases(item.tvs.term), value: range.start }
 							},
 							{
 								op: range.stopinclusive ? '<=' : '<',
-								content: { field: mayChangeCase2Cases(item.tvs.term.id), value: range.stop }
+								content: { field: mayChangeCase2Cases(item.tvs.term), value: range.stop }
 							}
 						]
 					})
@@ -109,7 +113,8 @@ when a term id begins with "case"
 for the term to be used as a field in filter,
 it must be written as "cases"
 */
-function mayChangeCase2Cases(s) {
+function mayChangeCase2Cases(t) {
+	const s = t.id || t.name
 	const l = s.split('.')
 	if (l[0] == 'case') l[0] = 'cases'
 	return l.join('.')

--- a/shared/utils/src/terms.js
+++ b/shared/utils/src/terms.js
@@ -153,8 +153,6 @@ export function equals(t1, t2) {
 }
 
 export function getBin(lst, value) {
-	value = Math.round(value * 100) / 100 //to keep 2 decimal places
-
 	let bin = lst.findIndex(
 		b => (b.startunbounded && value < b.stop) || (b.startunbounded && b.stopinclusive && value == b.stop)
 	)


### PR DESCRIPTION
# Description

Related to https://github.com/stjude/proteinpaint/issues/3552

Fixes sample listing for geneExpression term in gdc violin plot. Can test with this [example](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22}},%22term2%22:{%22id%22:%22case.demographic.gender%22}}]}).

Sample listing is supported for both clicking on series label and for brushing data within a plot.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
