### PR TITLE
Added function to combine svgs into a pdf. 

### DIFF
--- a/client/common/svg.download.js
+++ b/client/common/svg.download.js
@@ -1,5 +1,7 @@
 import { select } from 'd3-selection'
 import { to_svg } from '../src/client'
+import { jsPDF } from 'jspdf'
+import 'svg2pdf.js'
 
 export function downloadSingleSVG(svg, filename, parent) {
 	if (parent) {
@@ -111,4 +113,26 @@ export function downloadChart(mainGsel, svgName, styleParent = null) {
 	})
 
 	to_svg(svg, svgName, { apply_dom_styles: true })
+}
+
+export function downloadSVGsAsPdf(svgs, filename = 'charts.pdf') {
+	const doc = new jsPDF('p', 'pt', 'a4') // Portrait, points, A4 size
+	let item,
+		index = 0
+	for (const svg of svgs) {
+		if (!item)
+			item = doc.svg(svg, { x: 10, y: 30, width: 1000, height: 1000 }).then(() => {
+				doc.addPage()
+			})
+		else
+			item = item
+				.then(() => doc.svg(svg, { x: 10, y: 30, width: 1000, height: 1000 }))
+				.then(() => {
+					doc.addPage()
+				})
+	}
+	item.then(() => {
+		doc.deletePage(svgs.length + 1) // Remove the last empty page
+		doc.save(filename)
+	})
 }

--- a/client/common/svg.download.js
+++ b/client/common/svg.download.js
@@ -117,23 +117,29 @@ export function downloadChart(mainGsel, svgName, styleParent = null) {
 }
 
 export function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
-	const doc = new jsPDF('p', 'pt', 'a4') // Portrait, points, A4 size
+	const doc = new jsPDF('l', 'px', 'a4') // landscape, points, A4 size
+	doc.setFontSize(12)
+	const pageWidth = doc.internal.pageSize.getWidth() - 10
+	const pageHeight = doc.internal.pageSize.getHeight() - 10
+
 	let item
 	const entries = Object.entries(name2svg)
 	for (const [name, svg] of entries) {
-		if (!item) item = addSvgToPdf(doc, svg, name)
-		else item = item.then(() => addSvgToPdf(doc, svg, name))
+		if (!item) item = addSvgToPdf(svg, name)
+		else item = item.then(() => addSvgToPdf(svg, name))
 	}
 	item.then(() => {
 		doc.deletePage(entries.length + 1) // Remove the last empty page
 		doc.save(filename)
 	})
-}
 
-function addSvgToPdf(doc, svg, name) {
-	const item = doc.svg(svg, { x: 10, y: 40, width: 1000, height: 1000 }).then(() => {
-		doc.text(name, 10, 20)
-		doc.addPage()
-	})
-	return item
+	function addSvgToPdf(svg, name) {
+		const rect = svg.getBoundingClientRect()
+		svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
+		const item = doc.svg(svg, { x: 15, y: 30, width: pageWidth, height: pageHeight }).then(() => {
+			doc.text(name, 15, 20)
+			doc.addPage()
+		})
+		return item
+	}
 }

--- a/client/common/svg.download.js
+++ b/client/common/svg.download.js
@@ -1,8 +1,5 @@
 import { select } from 'd3-selection'
 import { to_svg } from '../src/client'
-import { jsPDF } from 'jspdf'
-import 'svg2pdf.js'
-import { add } from 'ol/coordinate'
 
 export function downloadSingleSVG(svg, filename, parent) {
 	if (parent) {
@@ -114,32 +111,4 @@ export function downloadChart(mainGsel, svgName, styleParent = null) {
 	})
 
 	to_svg(svg, svgName, { apply_dom_styles: true })
-}
-
-export function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
-	const doc = new jsPDF('l', 'px', 'a4') // landscape, points, A4 size
-	doc.setFontSize(12)
-	const pageWidth = doc.internal.pageSize.getWidth() - 10
-	const pageHeight = doc.internal.pageSize.getHeight() - 10
-
-	let item
-	const entries = Object.entries(name2svg)
-	for (const [name, svg] of entries) {
-		if (!item) item = addSvgToPdf(svg, name)
-		else item = item.then(() => addSvgToPdf(svg, name))
-	}
-	item.then(() => {
-		doc.deletePage(entries.length + 1) // Remove the last empty page
-		doc.save(filename)
-	})
-
-	function addSvgToPdf(svg, name) {
-		const rect = svg.getBoundingClientRect()
-		svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
-		const item = doc.svg(svg, { x: 15, y: 30, width: pageWidth, height: pageHeight }).then(() => {
-			doc.text(name, 15, 20)
-			doc.addPage()
-		})
-		return item
-	}
 }

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -12,7 +12,7 @@ export class DownloadMenu {
 		this.holder = holder
 	}
 
-	show() {
+	show(x, y) {
 		this.menu.clear()
 		const menuDiv = this.menu.d.append('div')
 		menuDiv
@@ -31,7 +31,7 @@ export class DownloadMenu {
 				downloadSVGsAsPdf(this.name2svg)
 				this.menu.hide()
 			})
-		this.menu.showunder(this.holder)
+		this.menu.show(x - 10, y - 10)
 	}
 }
 

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -1,0 +1,66 @@
+import { Menu } from '#dom/menu'
+import { downloadSingleSVG } from '../common/svg.download.js'
+
+export class DownloadMenu {
+	menu: Menu
+	name2svg: any
+	holder: any
+
+	constructor(name2svg, holder) {
+		this.menu = new Menu({ padding: '0px' })
+		this.name2svg = name2svg
+		this.holder = holder
+	}
+
+	show() {
+		this.menu.clear()
+		const menuDiv = this.menu.d.append('div')
+		menuDiv
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.text('SVG')
+			.on('click', () => {
+				for (const [name, svg] of Object.entries(this.name2svg)) downloadSingleSVG(svg, name, this.holder)
+			})
+		menuDiv
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.text('PDF')
+			.on('click', () => {
+				downloadSVGsAsPdf(this.name2svg)
+			})
+		this.menu.showunder(this.holder)
+	}
+}
+
+export async function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
+	const JSPDF = await import('jspdf')
+	const { jsPDF } = JSPDF
+	await import('svg2pdf.js')
+	const doc = new jsPDF('l', 'px', 'a4') // landscape, points, A4 size
+	doc.setFontSize(12)
+	const pageWidth = doc.internal.pageSize.getWidth() - 10
+	const pageHeight = doc.internal.pageSize.getHeight() - 10
+
+	let item
+	const entries: any[] = Object.entries(name2svg)
+	for (const [name, svgObj] of entries) {
+		const svg = svgObj.node()
+		if (!item) item = addSvgToPdf(svg, name)
+		else item = item.then(() => addSvgToPdf(svg, name))
+	}
+	item.then(() => {
+		doc.deletePage(entries.length + 1) // Remove the last empty page
+		doc.save(filename)
+	})
+
+	function addSvgToPdf(svg, name) {
+		const rect = svg.getBoundingClientRect()
+		svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
+		const item = doc.svg(svg, { x: 15, y: 30, width: pageWidth, height: pageHeight }).then(() => {
+			doc.text(name, 15, 20)
+			doc.addPage()
+		})
+		return item
+	}
+}

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -21,6 +21,7 @@ export class DownloadMenu {
 			.text('SVG')
 			.on('click', () => {
 				for (const [name, svg] of Object.entries(this.name2svg)) downloadSingleSVG(svg, name, this.holder)
+				this.menu.hide()
 			})
 		menuDiv
 			.append('div')
@@ -28,6 +29,7 @@ export class DownloadMenu {
 			.text('PDF')
 			.on('click', () => {
 				downloadSVGsAsPdf(this.name2svg)
+				this.menu.hide()
 			})
 		this.menu.showunder(this.holder)
 	}

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -64,8 +64,8 @@ export async function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
 	function addSvgToPdf(svg, name) {
 		const rect = svg.getBoundingClientRect()
 		svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
-		const width = Math.min(pageWidth, rect.width)
-		const height = Math.min(pageHeight, rect.height)
+		const width = Math.min(pageWidth, rect.width) - 20
+		const height = Math.min(pageHeight, rect.height) - 20
 		const item = doc.svg(svg, { x: 15, y: 30, width, height }).then(() => {
 			doc.text(name, 15, 20)
 			doc.addPage()

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -38,7 +38,12 @@ export class DownloadMenu {
 export async function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
 	const JSPDF = await import('jspdf')
 	const { jsPDF } = JSPDF
-	await import('svg2pdf.js')
+	/*
+	When imported, the svg2pdf.js module modifies or extends the jsPDF library (which we already imported).
+	The code inside svg2pdf.js adds a new method (.svg()) to the jsPDF object prototype, making that functionality available on all jsPDF instances.
+	Therefore, a simple import 'svg2pdf.js' without curly braces is all that is needed to apply its functionality. 
+	 */
+	await import('svg2pdf.js') // This import extends jsPDF with SVG functionality
 	const doc = new jsPDF('l', 'px', 'a4') // landscape, points, A4 size
 	doc.setFontSize(12)
 	const pageWidth = doc.internal.pageSize.getWidth() - 10
@@ -59,7 +64,9 @@ export async function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
 	function addSvgToPdf(svg, name) {
 		const rect = svg.getBoundingClientRect()
 		svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
-		const item = doc.svg(svg, { x: 15, y: 30, width: pageWidth, height: pageHeight }).then(() => {
+		const width = Math.min(pageWidth, rect.width)
+		const height = Math.min(pageHeight, rect.height)
+		const item = doc.svg(svg, { x: 15, y: 30, width, height }).then(() => {
 			doc.text(name, 15, 20)
 			doc.addPage()
 		})

--- a/client/package.json
+++ b/client/package.json
@@ -70,6 +70,7 @@
     "highlight.js": "~11.2.0",
     "html-webpack-plugin": "^5.5.0",
     "install": "^0.13.0",
+    "jspdf": "^3.0.1",
     "minimatch": "^10.0.1",
     "monocart-coverage-reports": "^2.12.1",
     "node-notifier": "^9.0.1",
@@ -85,6 +86,7 @@
     "read-cache": "^1.0.0",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.1",
+    "svg2pdf.js": "^2.5.0",
     "tape": "^5.2.2",
     "three": "^0.152.2",
     "webpack": "^5.90.3",
@@ -111,9 +113,5 @@
   ],
   "bugs": {
     "url": "https://github.com/stjude/pp-dist"
-  },
-  "dependencies": {
-    "jspdf": "^3.0.1",
-    "svg2pdf.js": "^2.5.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -111,5 +111,9 @@
   ],
   "bugs": {
     "url": "https://github.com/stjude/pp-dist"
+  },
+  "dependencies": {
+    "jspdf": "^3.0.1",
+    "svg2pdf.js": "^2.5.0"
   }
 }

--- a/client/plots/controls.btns.js
+++ b/client/plots/controls.btns.js
@@ -118,7 +118,7 @@ function helpBtnInit(opts) {
 
 function downloadBtnInit(opts) {
 	const downloadDiv = opts.holder.style('margin-left', '10px')
-	icon_functions['download'](downloadDiv, { handler: opts.callback, title: opts.title || 'Download plot image' })
+	icon_functions['download'](downloadDiv, { handler: opts.callback, title: opts.title })
 
 	const self = {
 		plotTypes: ['summary', 'boxplot', 'scatter', 'brainImaging'],

--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -43,7 +43,7 @@ class TdbPlotControls {
 					holder: this.dom.topbar,
 					callback: this.toggleVisibility,
 					isOpen: () => this.isOpen,
-					downloadHandler: holder => this.bus.emit('downloadClick', this.dom.topbar),
+					downloadHandler: () => this.bus.emit('downloadClick', this.dom.topbar),
 					infoHandler: isOpen =>
 						this.app.dispatch({
 							type: 'plot_edit',

--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -43,7 +43,7 @@ class TdbPlotControls {
 					holder: this.dom.topbar,
 					callback: this.toggleVisibility,
 					isOpen: () => this.isOpen,
-					downloadHandler: () => this.bus.emit('downloadClick', this.dom.topbar),
+					downloadHandler: event => this.bus.emit('downloadClick', event),
 					infoHandler: isOpen =>
 						this.app.dispatch({
 							type: 'plot_edit',

--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -43,7 +43,7 @@ class TdbPlotControls {
 					holder: this.dom.topbar,
 					callback: this.toggleVisibility,
 					isOpen: () => this.isOpen,
-					downloadHandler: () => this.bus.emit('downloadClick'),
+					downloadHandler: holder => this.bus.emit('downloadClick', this.dom.topbar),
 					infoHandler: isOpen =>
 						this.app.dispatch({
 							type: 'plot_edit',

--- a/client/plots/runchart/runchart.ts
+++ b/client/plots/runchart/runchart.ts
@@ -6,7 +6,6 @@ import { RunchartView } from './view/runchartView.js'
 import { plotColor } from '#shared/common.js'
 import { ScatterInteractivity } from '../scatter/viewmodel/scatterInteractivity.js'
 import { controlsInit } from '../controls.js'
-import { downloadSingleSVG } from '../../common/svg.download.js'
 import { select2Terms } from '#dom/select2Terms'
 import { Scatter } from '../scatter/scatter.js'
 import { getColors } from '#shared/common.js'
@@ -62,8 +61,8 @@ export class Runchart extends Scatter {
 			})
 		}
 		// TODO: handle multiple chart download when there is a divide by term
-		this.components.controls.on('downloadClick.scatter', () => {
-			downloadSingleSVG(this.view.dom.svg, 'scatter.svg', this.opts.holder.node())
+		this.components.controls.on('downloadClick.scatter', event => {
+			this.download(event)
 		})
 	}
 }

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -24,7 +24,6 @@ export class Scatter extends RxComponentInner {
 	vm!: any
 	interactivity!: ScatterInteractivity
 	components: any
-	canvas: any
 	settings: any
 	charts: any
 	opts: any
@@ -135,12 +134,12 @@ export class Scatter extends RxComponentInner {
 		// TODO: handle multiple chart download when there is a divide by term
 		this.components.controls.on('downloadClick.scatter', async () => {
 			if (this.model.is2DLarge || this.model.is3D) {
-				const url = this.canvas.toDataURL('image/png')
+				const url = this.vm.canvas.toDataURL('image/png')
 				downloadImage(url)
 			} else {
 				const name2svg = {}
 				for (const chart of this.model.charts) {
-					const name = `${this.config.name}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
+					const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
 					name2svg[name] = chart.svg.node()
 				}
 				downloadSVGsAsPdf(name2svg)

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -80,7 +80,6 @@ export class Scatter extends RxComponentInner {
 			if (this.charts) for (const chart of this.charts) chart.chartDiv.selectAll('*').remove()
 			this.view.dom.loadingDiv.style('display', 'block').html('Processing data...')
 		}
-
 		this.settings = structuredClone(this.config.settings.sampleScatter)
 		await this.model.initData()
 		if (this.model.is3D) this.vm = new ScatterViewModel3D(this)
@@ -132,7 +131,7 @@ export class Scatter extends RxComponentInner {
 			})
 		}
 		// TODO: handle multiple chart download when there is a divide by term
-		this.components.controls.on('downloadClick.scatter', async holder => {
+		this.components.controls.on('downloadClick.scatter', async event => {
 			if (this.model.is2DLarge || this.model.is3D) {
 				const url = this.vm.canvas.toDataURL('image/png')
 				downloadImage(url)
@@ -142,8 +141,8 @@ export class Scatter extends RxComponentInner {
 					const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
 					name2svg[name] = chart.svg
 				}
-				const menu = new DownloadMenu(name2svg, holder.node())
-				menu.show()
+				const menu = new DownloadMenu(name2svg, this.view.dom.controlsHolder.node())
+				menu.show(event.clientX, event.clientY)
 			}
 		})
 	}

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -132,19 +132,28 @@ export class Scatter extends RxComponentInner {
 		}
 		// TODO: handle multiple chart download when there is a divide by term
 		this.components.controls.on('downloadClick.scatter', async event => {
-			if (this.model.is2DLarge || this.model.is3D) {
-				const url = this.vm.canvas.toDataURL('image/png')
-				downloadImage(url)
-			} else {
-				const name2svg = {}
-				for (const chart of this.model.charts) {
-					const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
-					name2svg[name] = chart.svg
-				}
-				const menu = new DownloadMenu(name2svg, this.view.dom.controlsHolder.node())
-				menu.show(event.clientX, event.clientY)
-			}
+			this.download(event)
 		})
+	}
+
+	async download(event) {
+		if (this.model.is2DLarge || this.model.is3D) {
+			const url = this.vm.canvas.toDataURL('image/png')
+			downloadImage(url)
+		} else {
+			const name2svg = this.getName2Svg()
+			const menu = new DownloadMenu(name2svg, this.opts.holder.node())
+			menu.show(event.clientX, event.clientY)
+		}
+	}
+
+	getName2Svg() {
+		const name2svg = {}
+		for (const chart of this.model.charts) {
+			const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
+			name2svg[name] = chart.svg
+		}
+		return name2svg
 	}
 }
 

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -12,7 +12,7 @@ import { ScatterInteractivity, downloadImage } from './viewmodel/scatterInteract
 import { ScatterViewModel2DLarge } from './viewmodel/scatterViewModel2DLarge.js'
 import { ScatterViewModel3D } from './viewmodel/scatterViewModel3D.js'
 import { controlsInit } from '../controls'
-import { downloadSingleSVG } from '../../common/svg.download.js'
+import { downloadSVGsAsPdf } from '../../common/svg.download.js'
 import { select2Terms } from '#dom/select2Terms'
 import type { MassState } from '../../../client/mass/types/mass.js'
 import { getCombinedTermFilter } from '#filter'
@@ -133,11 +133,14 @@ export class Scatter extends RxComponentInner {
 			})
 		}
 		// TODO: handle multiple chart download when there is a divide by term
-		this.components.controls.on('downloadClick.scatter', () => {
+		this.components.controls.on('downloadClick.scatter', async () => {
 			if (this.model.is2DLarge || this.model.is3D) {
 				const url = this.canvas.toDataURL('image/png')
 				downloadImage(url)
-			} else for (const chart of this.charts) downloadSingleSVG(chart.svg, 'scatter.svg', this.opts.holder.node())
+			} else {
+				const svgs = this.model.charts.map(chart => chart.svg.node())
+				downloadSVGsAsPdf(svgs)
+			}
 		})
 	}
 }

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -138,8 +138,12 @@ export class Scatter extends RxComponentInner {
 				const url = this.canvas.toDataURL('image/png')
 				downloadImage(url)
 			} else {
-				const svgs = this.model.charts.map(chart => chart.svg.node())
-				downloadSVGsAsPdf(svgs)
+				const name2svg = {}
+				for (const chart of this.model.charts) {
+					const name = `${this.config.name}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
+					name2svg[name] = chart.svg.node()
+				}
+				downloadSVGsAsPdf(name2svg)
 			}
 		})
 	}

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -12,10 +12,10 @@ import { ScatterInteractivity, downloadImage } from './viewmodel/scatterInteract
 import { ScatterViewModel2DLarge } from './viewmodel/scatterViewModel2DLarge.js'
 import { ScatterViewModel3D } from './viewmodel/scatterViewModel3D.js'
 import { controlsInit } from '../controls'
-import { downloadSVGsAsPdf } from '../../common/svg.download.js'
 import { select2Terms } from '#dom/select2Terms'
 import type { MassState } from '../../../client/mass/types/mass.js'
 import { getCombinedTermFilter } from '#filter'
+import { DownloadMenu } from '#dom/downloadMenu'
 
 export class Scatter extends RxComponentInner {
 	config: any
@@ -132,7 +132,7 @@ export class Scatter extends RxComponentInner {
 			})
 		}
 		// TODO: handle multiple chart download when there is a divide by term
-		this.components.controls.on('downloadClick.scatter', async () => {
+		this.components.controls.on('downloadClick.scatter', async holder => {
 			if (this.model.is2DLarge || this.model.is3D) {
 				const url = this.vm.canvas.toDataURL('image/png')
 				downloadImage(url)
@@ -140,9 +140,10 @@ export class Scatter extends RxComponentInner {
 				const name2svg = {}
 				for (const chart of this.model.charts) {
 					const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
-					name2svg[name] = chart.svg.node()
+					name2svg[name] = chart.svg
 				}
-				downloadSVGsAsPdf(name2svg)
+				const menu = new DownloadMenu(name2svg, holder.node())
+				menu.show()
 			}
 		})
 	}

--- a/client/plots/scatter/scatterTypes.ts
+++ b/client/plots/scatter/scatterTypes.ts
@@ -50,7 +50,7 @@ export type DataRange = {
 }
 
 export type ScatterChart = {
-	svg: any
+	svg?: any
 	chartDiv?: any
 	mainG?: any
 	xAxis?: any

--- a/client/plots/scatter/scatterTypes.ts
+++ b/client/plots/scatter/scatterTypes.ts
@@ -50,6 +50,7 @@ export type DataRange = {
 }
 
 export type ScatterChart = {
+	svg: any
 	chartDiv?: any
 	mainG?: any
 	xAxis?: any

--- a/client/plots/scatter/viewmodel/scatterLegend.ts
+++ b/client/plots/scatter/viewmodel/scatterLegend.ts
@@ -299,7 +299,7 @@ export class ScatterLegend {
 		itemG
 			.append('text')
 			.attr('name', 'sjpp-scatter-legend-label')
-			.attr('font-size', '1.1em')
+			.attr('font-size', '14px')
 			.attr('x', x + 20)
 			.attr('y', y + 4)
 			.text(`${name}, n=${category.sampleCount}`)

--- a/client/plots/scatter/viewmodel/scatterLegend.ts
+++ b/client/plots/scatter/viewmodel/scatterLegend.ts
@@ -299,7 +299,6 @@ export class ScatterLegend {
 		itemG
 			.append('text')
 			.attr('name', 'sjpp-scatter-legend-label')
-			.attr('font-size', '14px')
 			.attr('x', x + 20)
 			.attr('y', y + 4)
 			.text(`${name}, n=${category.sampleCount}`)

--- a/client/plots/scatter/viewmodel/scatterLegend.ts
+++ b/client/plots/scatter/viewmodel/scatterLegend.ts
@@ -41,6 +41,7 @@ export class ScatterLegend {
 	getFontSize(legend) {
 		let fontSize = 0.9
 		const top = 20
+		//legend is a Map<string, ScatterLegendItem>
 		if (legend.size > top) {
 			fontSize = Math.min(0.9, top / legend.size)
 			if (fontSize < 0.7) fontSize = 0.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
         "highlight.js": "~11.2.0",
         "html-webpack-plugin": "^5.5.0",
         "install": "^0.13.0",
+        "jspdf": "^3.0.1",
         "minimatch": "^10.0.1",
         "monocart-coverage-reports": "^2.12.1",
         "node-notifier": "^9.0.1",
@@ -140,6 +141,7 @@
         "read-cache": "^1.0.0",
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.1",
+        "svg2pdf.js": "^2.5.0",
         "tape": "^5.2.2",
         "three": "^0.152.2",
         "webpack": "^5.90.3",
@@ -1930,7 +1932,6 @@
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3642,8 +3643,7 @@
       "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -3704,8 +3704,7 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -4537,7 +4536,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
-      "peer": true,
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -4843,7 +4841,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -5228,7 +5225,6 @@
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
-      "peer": true,
       "bin": {
         "btoa": "bin/btoa.js"
       },
@@ -5479,7 +5475,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@types/raf": "^3.4.0",
@@ -5974,7 +5969,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -6129,7 +6123,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "utrie": "^1.0.2"
       }
@@ -7085,7 +7078,6 @@
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -8557,8 +8549,7 @@
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -8721,6 +8712,13 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/font-family-papandreou": {
+      "version": "0.2.0-patch2",
+      "resolved": "https://registry.npmjs.org/font-family-papandreou/-/font-family-papandreou-0.2.0-patch2.tgz",
+      "integrity": "sha512-l/YiRdBSH/eWv6OF3sLGkwErL+n0MqCICi9mppTZBOCL5vixWGDqCYvRcuxB2h7RGCTzaTKOHT2caHvCXQPRlw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -9507,7 +9505,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
@@ -10729,7 +10726,6 @@
       "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.7",
         "atob": "^2.1.2",
@@ -12399,8 +12395,7 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -13001,7 +12996,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -13231,8 +13225,7 @@
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/regex": {
       "version": "5.1.1",
@@ -13530,7 +13523,6 @@
       "dev": true,
       "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.8.15"
       }
@@ -14251,6 +14243,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "specificity": "bin/specificity"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -14265,7 +14267,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.1.14"
       }
@@ -14570,9 +14571,34 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/svg2pdf.js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/svg2pdf.js/-/svg2pdf.js-2.5.0.tgz",
+      "integrity": "sha512-cFRquPkZJ6G2wVKR0Cc9Z+5Vh7ycvfBu306a/TZFNwymYgF9aURmRddDCN0siQ00+b6hqjs9tSObJudizV4IRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "font-family-papandreou": "^0.2.0-patch1",
+        "specificity": "^0.4.1",
+        "svgpath": "^2.3.0"
+      },
+      "peerDependencies": {
+        "jspdf": "^3.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/svgpath": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.6.0.tgz",
+      "integrity": "sha512-OIWR6bKzXvdXYyO4DK/UWa1VA1JeKq8E+0ug2DG98Y/vOmMpfZNj+TIG988HjfYSqtcy/hFOtZq/n/j5GSESNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/fontello/svg2ttf?sponsor=1"
       }
     },
     "node_modules/tapable": {
@@ -14899,7 +14925,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "utrie": "^1.0.2"
       }
@@ -15661,7 +15686,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }


### PR DESCRIPTION
# Description
Reopened PR adding libraries jsPDF and svg2pdf.js as discussed. This PR adds a function to combine svgs into a pdf. Used it in the scatter when dividing by. Later on may be used to combine other plots like in the report (or to support the download of the open plots in the portal). See corresponding PR in [sjpp](https://github.com/stjude/sjpp/pull/1008/files) updating package-lock.json. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
