### PR TITLE
Unit added to `term.name` for geneExpression term

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -506,13 +506,12 @@ function setRenderers(self) {
 				const lst = group.lst.filter(tw => tw.term.type != 'geneVariant')
 				const tws = await Promise.all(
 					geneList.map(async d => {
-						const term = {
-							gene: d.symbol || d.gene,
-							name: d.symbol || d.gene,
-							type: 'geneExpression'
-						}
+						const gene = d.symbol || d.gene
+						const unit = app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+						const name = `${gene} ${unit}`
+						const term = { gene, name, type: 'geneExpression' }
 						//if it was present use the previous term, genomic range terms require chr, start and stop fields, found in the original term
-						let tw = group.lst.find(tw => tw.term.name == d.symbol || tw.term.name == d.gene)
+						let tw = group.lst.find(tw => tw.term.name == name)
 						if (!tw) {
 							tw = { term, q: {} }
 						}

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -787,12 +787,10 @@ export function addHierClusterPlotMenuItem(chartType, div, text, tip, samplelstT
 
 					const tws = await Promise.all(
 						geneList.map(async d => {
-							const term = {
-								gene: d.symbol || d.gene,
-								name: d.symbol || d.gene,
-								type: 'geneExpression'
-							}
-
+							const gene = d.symbol || d.gene
+							const unit = app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+							const name = `${gene} ${unit}`
+							const term = { gene, name, type: 'geneExpression' }
 							let tw = group.lst.find(tw => tw.term.name == d.symbol || tw.term.name == d.gene)
 							if (!tw) {
 								tw = { term, q: {} }

--- a/client/mass/test/cuminc.integration.spec.js
+++ b/client/mass/test/cuminc.integration.spec.js
@@ -515,19 +515,19 @@ tape('term1 = Cardiovascular System, term0 = agedx, numeric custom bins', test =
 						id: 'agedx',
 						term: {
 							type: 'float',
-							// bins: {
-							// 	default: {
-							// 		type: 'regular-bin',
-							// 		bin_size: 5,
-							// 		startinclusive: true,
-							// 		first_bin: {
-							// 			startunbounded: true,
-							// 			stop: 5
-							// 		},
-							// 		label_offset: 1
-							// 	},
-							// 	label_offset: 1
-							// },
+							bins: {
+								default: {
+									type: 'regular-bin',
+									bin_size: 5,
+									startinclusive: true,
+									first_bin: {
+										startunbounded: true,
+										stop: 5
+									},
+									label_offset: 1
+								},
+								label_offset: 1
+							},
 							name: 'Age (years) at Cancer Diagnosis',
 							id: 'agedx'
 						},

--- a/client/plots/matrix/hierCluster.js
+++ b/client/plots/matrix/hierCluster.js
@@ -127,7 +127,7 @@ export class HierCluster extends Matrix {
 		for (const [i, column] of c.col.order.entries()) {
 			samples[column.name] = { sample: column.name }
 			for (const [j, row] of c.row.order.entries()) {
-				const tw = twlst.find(tw => tw.term.name === row.name || tw.term.id === row.name)
+				const tw = twlst.find(tw => tw.$id === row.name)
 				const value = c.matrix[j][i]
 				samples[column.name][tw.$id] = {
 					key: tw.term.name,
@@ -298,9 +298,9 @@ export class HierCluster extends Matrix {
 
 	*/
 	getClusterRowTermsAsParameter() {
-		const lst = [...this.hcTermGroup.lst.map(tw => tw.term)]
+		const lst = structuredClone(this.hcTermGroup.lst)
 		// this helps caching by having a more consistent URL string
-		lst.sort((a, b) => (a.name < b.name ? -1 : 1))
+		lst.sort((a, b) => (a.term.name < b.term.name ? -1 : 1))
 		return lst
 	}
 }

--- a/client/plots/matrix/matrix.cells.js
+++ b/client/plots/matrix/matrix.cells.js
@@ -332,13 +332,20 @@ export function setHierClusterCellProps(cell, tw, anno, value, s, t, self, width
 	cell.x = cell.totalIndex * dx + cell.grpIndex * s.colgspace
 	cell.y = height * i
 
-	const groupName = self.config.settings.hierCluster?.termGroupName
-		? self.config.settings.hierCluster?.termGroupName
-		: tw.term.type == 'geneExpression'
-		? 'Expression'
-		: tw.term.type == 'metaboliteIntensity'
-		? 'Intensity'
-		: 'Heatmap color scale'
+	const hierCluster = self.config.settings.hierCluster
+	let groupName
+	if (hierCluster?.termGroupName) {
+		groupName = hierCluster.termGroupName
+	} else if (tw.term.type == 'geneExpression') {
+		groupName = 'Gene Expression'
+		const unit = self.app.vocabApi.termdbConfig.queries?.geneExpression?.unit
+		if (hierCluster?.zScoreTransformation) groupName += ' (Z-score)'
+		else if (unit) groupName += ` (${unit})`
+	} else if (tw.term.type == 'metaboliteIntensity') {
+		groupName = 'Intensity'
+	} else {
+		groupName = 'Heatmap color scale'
+	}
 
 	return {
 		ref: t.ref,

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -1209,14 +1209,22 @@ export class MatrixControls {
 					const lst = group.lst.filter(tw => tw.term.type != targetTermType)
 					const tws = await Promise.all(
 						geneList.map(async d => {
-							const term = {
-								gene: d.symbol || d.gene,
-								name: d.symbol || d.gene,
-								type: targetTermType
+							let term
+							if (targetTermType == 'geneExpression') {
+								const gene = d.symbol || d.gene
+								const unit = app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+								const name = `${gene} ${unit}`
+								term = { gene, name, type: 'geneExpression' }
+							} else {
+								term = {
+									gene: d.symbol || d.gene,
+									name: d.symbol || d.gene,
+									type: 'geneVariant'
+								}
 							}
 							//if it was present use the previous term, genomic range terms require chr, start and stop fields, found in the original term
 							let tw = group.lst.find(
-								tw => (tw.term.name == d.symbol || tw.term.name == d.gene) && tw.term.type == targetTermType
+								tw => (tw.term.gene == d.symbol || tw.term.gene == d.gene) && tw.term.type == targetTermType
 							)
 							if (!tw) {
 								tw = { term }
@@ -1292,7 +1300,7 @@ export class MatrixControls {
 					type: g.type,
 					lst:
 						g.type == 'hierCluster'
-							? g.lst.map(tw => ({ name: tw.term.name }))
+							? g.lst.map(tw => ({ name: tw.term.gene || tw.term.name }))
 							: g.lst.filter(tw => tw.term.type == TermTypes.GENE_VARIANT).map(tw => ({ name: tw.term.name })),
 					mode:
 						g.type == 'hierCluster'

--- a/client/plots/matrix/matrix.dom.js
+++ b/client/plots/matrix/matrix.dom.js
@@ -14,7 +14,7 @@ export function setMatrixDom(opts) {
 	const errdiv = holder.append('div').attr('class', 'sja_errorbar').style('display', 'none')
 	const svg = holder
 		.append('svg')
-		.style('margin', '20px 10px')
+		.style('margin', '20px')
 		.style('overflow', 'visible')
 		.on('mousemove.label', this.svgMousemove)
 		.on('mouseup.label', this.svgMouseup)

--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -152,7 +152,7 @@ export function setInteractivity(self) {
 					{
 						const [c1, c2] = table.addRow()
 						c1.html('Gene')
-						c2.html(d.term.name)
+						c2.html(d.term.gene)
 					}
 					{
 						const colorSquare =

--- a/client/plots/matrix/matrix.layout.js
+++ b/client/plots/matrix/matrix.layout.js
@@ -231,7 +231,7 @@ export function setLabelsAndScales() {
 				}
 			}
 		}
-		t.label = t.tw.label || t.tw.term.name
+		t.label = t.tw.label || t.tw.term.gene || t.tw.term.name
 		if (t.label.length > s.rowlabelmaxchars) t.label = t.label.slice(0, s.rowlabelmaxchars - 1) + '…'
 		const termGroupName = this.config?.settings.hierCluster?.termGroupName
 		if (s.samplecount4gene && t.tw.term.type.startsWith('gene') && (!termGroupName || t.grp.name !== termGroupName)) {

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -193,7 +193,10 @@ export class TermTypeSearch {
 
 		function renderTerm(this: any, term) {
 			const div = select(this).style('border-radius', '5px')
-			div.insert('div').style('display', 'inline-block').html(term.name)
+			div
+				.insert('div')
+				.style('display', 'inline-block')
+				.html(term.gene || term.name)
 		}
 	}
 

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1068,9 +1068,9 @@ export class TermdbVocab extends Vocab {
 	// it's safer to separately treat term and q as persisted objects but not tw,
 	// since tw may have been constructed only as an argument for this function
 	// and not as a persisted object elsewhere
-	async setTermBins({ term, q }) {
+	async setTermBins({ $id, term, q }) {
 		//TODO use the PresetNumericBins type for presetBins
-		const presetBins = await this.getDefaultBins({ tw: { term, q } })
+		const presetBins = await this.getDefaultBins({ tw: { $id, term, q } })
 		if ('error' in presetBins) throw presetBins.error
 		// NOTE: if term is frozen, creating an unfrozen copy here will
 		// not propagate changes to the original term

--- a/client/termdb/handlers/geneExpression.ts
+++ b/client/termdb/handlers/geneExpression.ts
@@ -17,7 +17,9 @@ export class SearchHandler {
 	}
 
 	async selectGene(gene) {
+		const unit = this.app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+		const name = `${gene} ${unit}`
 		if (!gene) throw new Error('No gene selected')
-		this.callback({ gene, type: TermTypes.GENE_EXPRESSION, name: gene })
+		this.callback({ gene, name, type: TermTypes.GENE_EXPRESSION })
 	}
 }

--- a/client/termsetting/handlers/geneExpression.ts
+++ b/client/termsetting/handlers/geneExpression.ts
@@ -1,4 +1,4 @@
-import type { NumericQ, VocabApi, GeneExpressionTW, CustomNumericBinConfig } from '#types'
+import type { NumericQ, VocabApi, CustomNumericBinConfig } from '#types'
 import { copyMerge } from '#rx'
 import { fillQWithMedianBin } from '../../tw/numeric'
 
@@ -24,7 +24,7 @@ export async function getHandler(self) {
 	return await _.getHandler(self)
 }
 
-export async function fillTW(tw: GeneExpressionTW, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
+export async function fillTW(tw, vocabApi: VocabApi, defaultQ: NumericQ | null = null) {
 	if (typeof tw.term !== 'object') throw 'tw.term is not an object'
 	if (!tw.term.gene && !tw.term.name) throw 'no gene or name present'
 	if (!tw.term.gene) tw.term.gene = tw.term.name

--- a/client/termsetting/handlers/numeric.toggle.ts
+++ b/client/termsetting/handlers/numeric.toggle.ts
@@ -6,7 +6,6 @@ import type { VocabApi } from '#types'
 import { roundValueAuto } from '#shared/roundValue.js'
 import type {
 	NumericQ,
-	NumericTW,
 	DefaultMedianQ,
 	DefaultBinnedQ,
 	DefaultNumericQ,
@@ -135,7 +134,7 @@ export async function getHandler(self) {
 	}
 }
 
-export async function fillTW(tw: NumericTW, vocabApi: VocabApi, defaultQ?: DefaultNumericQ) {
+export async function fillTW(tw, vocabApi: VocabApi, defaultQ?: DefaultNumericQ) {
 	// when missing, defaults mode to discrete
 	//const dq = defaultQ as DefaultNumericQ
 	if (!tw.q.mode && !(defaultQ as DefaultNumericQ)?.mode) (tw.q as NumericQ).mode = 'discrete'

--- a/client/tw/geneExpression.ts
+++ b/client/tw/geneExpression.ts
@@ -10,7 +10,11 @@ export class GeneExpBase extends TwBase {
 		if (!tw.term.gene) tw.term.gene = tw.term.name
 		if (!tw.term.gene || typeof tw.term.gene != 'string') throw 'geneExpression tw.term.gene must be non-empty string'
 
-		if (!tw.term.name) tw.term.name = tw.term.gene // auto fill if .name is missing
+		if (!tw.term.name) {
+			const unit = opts.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+			const name = `${tw.term.gene} ${unit}`
+			tw.term.name = name
+		}
 
 		if (!tw.q?.mode) tw.q = { mode: 'continuous' } // supply default q if missing
 		if (opts.defaultQ) copyMerge(tw.q, opts.defaultQ) // override if default is given

--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -111,7 +111,6 @@ export class NumericBase extends TwBase {
 	}
 
 	getTitleText() {
-		if (this.term.type == 'geneExpression') return `${this.term.name} Expression`
 		return this.term.name
 	}
 }

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -298,7 +298,8 @@ export default function (): Mds3 {
 			},
 			geneExpression: {
 				src: 'native',
-				file: 'files/hg38/TermdbTest/rnaseq/TermdbTest.fpkm.matrix.h5'
+				file: 'files/hg38/TermdbTest/rnaseq/TermdbTest.fpkm.matrix.h5',
+				unit: 'FPKM'
 			},
 			topVariablyExpressedGenes: {
 				src: 'native'

--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -366,9 +366,9 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any) {
 
 		// First, collect all gene names
 		const geneNames: string[] = []
-		for (const geneTerm of param.terms) {
-			if (geneTerm.gene) {
-				geneNames.push(geneTerm.gene)
+		for (const tw of param.terms) {
+			if (tw.term.gene) {
+				geneNames.push(tw.term.gene)
 			}
 		}
 
@@ -387,13 +387,13 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any) {
 		// Check if we have a multi-gene response (genes field) or single gene response
 		const genesData = geneData.genes || { [geneNames[0]]: geneData }
 		// Process each gene's data
-		for (const geneTerm of param.terms) {
-			if (!geneTerm.gene) continue
+		for (const tw of param.terms) {
+			if (!tw.term.gene) continue
 
 			// Get this gene's data from the batch response
-			const geneResult = genesData[geneTerm.gene]
+			const geneResult = genesData[tw.term.gene]
 			if (!geneResult) {
-				console.warn(`No data found for gene ${geneTerm.gene} in the response`)
+				console.warn(`No data found for gene ${tw.term.gene} in the response`)
 				continue
 			}
 
@@ -412,11 +412,11 @@ async function validateNative(q: GeneExpressionQueryNative, ds: any) {
 			}
 
 			if (Object.keys(s2v).length) {
-				term2sample2value.set(geneTerm.gene, s2v)
+				term2sample2value.set(tw.$id, s2v)
 			}
 		}
 		if (term2sample2value.size == 0) {
-			throw 'No data available for the input ' + param.terms?.map(g => g.gene).join(', ')
+			throw 'No data available for the input ' + param.terms?.map(tw => tw.term.gene).join(', ')
 		}
 
 		return { term2sample2value, byTermId, bySampleId }

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -235,6 +235,10 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome) {
 		}
 	}
 
+	if (q.geneExpression) {
+		q2.geneExpression = { unit: q.geneExpression.unit }
+	}
+
 	if (q.NIdata && serverconfig.features.showBrainImaging) {
 		q2.NIdata = {}
 		for (const k in q.NIdata) {

--- a/server/src/termdb.getDefaultBins.js
+++ b/server/src/termdb.getDefaultBins.js
@@ -20,7 +20,7 @@ export async function trigger_getDefaultBins(q, ds, res) {
 			if (!ds.queries?.singleCell?.geneExpression) throw 'term type not supported by this dataset'
 			binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample]
 			if (!binsCache) binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample] = {}
-			else if (binsCache[tw.term.gene]) return res.send(binsCache[tw.term.gene])
+			else if (binsCache[tw.$id]) return res.send(binsCache[tw.$id])
 			const args = {
 				sample: tw.term.sample,
 				gene: tw.term.gene
@@ -38,15 +38,16 @@ export async function trigger_getDefaultBins(q, ds, res) {
 			//binsCache = ds.queries[tw.term.type][`${tw.term.type}2bins`]
 			//if (binsCache[tw.term.name]) return res.send(binsCache[tw.term.name])
 
+			if (!tw.$id) tw.$id = '_'
 			const args = {
 				genome: q.genome,
 				dslabel: q.dslabel,
 				filter: q.filter,
 				filter0: q.filter0,
-				terms: [tw.term]
+				terms: [tw]
 			}
 			const data = await ds.queries[tw.term.type].get(args)
-			const termData = data.term2sample2value.get(tw.term.name)
+			const termData = data.term2sample2value.get(tw.$id)
 			for (const sample in termData) {
 				const value = termData[sample]
 				if (value < min) min = value
@@ -55,7 +56,7 @@ export async function trigger_getDefaultBins(q, ds, res) {
 			}
 		}
 		const binconfig = initBinConfig(lst)
-		if (binsCache) binsCache[tw.term.name] = { default: binconfig, min, max }
+		if (binsCache) binsCache[tw.$id] = { default: binconfig, min, max }
 		res.send({ default: binconfig, min, max })
 	} catch (e) {
 		console.log(e)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -192,17 +192,14 @@ async function getSampleData(q, ds, onlyChildren = false) {
 				genome: q.ds.genomename,
 				dslabel: q.ds.label,
 				dataType: tw.term.type,
-				terms: [tw.term],
+				terms: [tw],
 				filter: q.filter,
 				filter0: q.filter0
 			}
 			const data = await q.ds.queries[tw.term.type].get(args)
-			const termkey = tw.term.type == TermTypes.SSGSEA ? tw.term.id : tw.term.name
-			for (const sampleId in data.term2sample2value.get(termkey)) {
-				if (!(sampleId in samples)) {
-					samples[sampleId] = { sample: sampleId }
-				}
-				const values = data.term2sample2value.get(termkey)
+			const values = data.term2sample2value.get(tw.$id)
+			for (const sampleId in values) {
+				if (!(sampleId in samples)) samples[sampleId] = { sample: sampleId }
 				const value = Number(values[sampleId])
 				let key = value
 				if (lstOfBins) {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -721,6 +721,8 @@ export type MetaboliteIntensityQuery = MetaboliteIntensityQueryNative
 export type GeneExpressionQueryGdc = {
 	src: 'gdcapi'
 	geneExpression2bins?: { [index: string]: any }
+	/** gene expression unit (e.g. 'FPKM') */
+	unit?: string
 }
 
 export type GeneExpressionQueryNative = {
@@ -736,6 +738,8 @@ export type GeneExpressionQueryNative = {
 	get?: (param: any) => void
 	/** This dictionary is used to store/cache the default bins calculated for a geneExpression term when initialized in the fillTermWrapper */
 	geneExpression2bins?: { [index: string]: any }
+	/** gene expression unit (e.g. 'FPKM') */
+	unit?: string
 }
 
 export type GeneExpressionQuery = GeneExpressionQueryGdc | GeneExpressionQueryNative

--- a/shared/types/src/routes/termdb.cluster.ts
+++ b/shared/types/src/routes/termdb.cluster.ts
@@ -2,7 +2,7 @@ import type { RoutePayload } from './routeApi.js'
 import type { ErrorResponse } from './errorResponse.ts'
 import type { Filter } from '../filter.ts'
 import type { Term } from '../terms/term.ts'
-import type { GeneExpressionTerm } from '../terms/geneExpression.ts'
+import type { GeneExpressionTW } from '../terms/geneExpression.ts'
 import type { MetaboliteIntensityTerm } from '../terms/metaboliteIntensity.ts'
 import type { NumericDictTerm } from '../terms/numeric.ts'
 
@@ -34,7 +34,7 @@ export type TermdbClusterRequestGeneExpression = TermdbClusterRequestBase & {
 	/** Data type */
 	dataType: 'geneExpression'
 	/** List of terms */
-	terms: GeneExpressionTerm[]
+	terms: GeneExpressionTW[]
 	/** perform z-score transformation on values */
 	zScoreTransformation?: string
 }

--- a/shared/types/src/routes/termdb.cluster.ts
+++ b/shared/types/src/routes/termdb.cluster.ts
@@ -3,8 +3,8 @@ import type { ErrorResponse } from './errorResponse.ts'
 import type { Filter } from '../filter.ts'
 import type { Term } from '../terms/term.ts'
 import type { GeneExpressionTW } from '../terms/geneExpression.ts'
-import type { MetaboliteIntensityTerm } from '../terms/metaboliteIntensity.ts'
-import type { NumericDictTerm } from '../terms/numeric.ts'
+import type { MetaboliteIntensityTW } from '../terms/metaboliteIntensity.ts'
+import type { NumericTW } from '../terms/numeric.ts'
 
 export type Gene = {
 	/** gene symbol, required */
@@ -43,7 +43,7 @@ export type TermdbClusterRequestMetabolite = TermdbClusterRequestBase & {
 	/** Data type */
 	dataType: 'metaboliteIntensity'
 	/** List of terms */
-	terms: MetaboliteIntensityTerm[]
+	terms: MetaboliteIntensityTW[]
 	/** perform z-score transformation on values */
 	zScoreTransformation?: string
 }
@@ -52,7 +52,7 @@ export type TermdbClusterRequestNumericDictTerm = TermdbClusterRequestBase & {
 	/** Data type */
 	dataType: 'numericDictTerm'
 	/** List of terms */
-	terms: NumericDictTerm[]
+	terms: NumericTW[]
 	/** perform z-score transformation on values */
 	zScoreTransformation?: string
 }

--- a/shared/types/src/terms/geneExpression.ts
+++ b/shared/types/src/terms/geneExpression.ts
@@ -1,28 +1,18 @@
-import type { TermWrapper } from './updated-types.ts'
-import type { NumericTerm, NumericQ } from './numeric.ts'
+import type { BaseTW, PresetNumericBins, NumericBaseTerm, NumericQ } from '../index.ts'
 import type { TermSettingInstance } from '../termsetting.ts'
 
 /*
 --------EXPORTED--------
-GeneExpressionQ
+GeneExpressionTerm
 GeneExpressionTermWrapper
 GeneExpressionTermSettingInstance
-
 */
 
-export type GeneExpressionQ = NumericQ & {
-	dt?: number
-	preferredBins?: string
-}
-
-export type GeneExpressionTW = TermWrapper & {
-	q: GeneExpressionQ
-	term: GeneExpressionTerm
-	type: 'NumTWRegularBin' | 'NumTWCustomBin' | 'NumTWCont' | 'NumTWSpline'
-}
-
-export type GeneExpressionTerm = NumericTerm & {
+export type GeneExpressionTerm = NumericBaseTerm & {
 	gene: string
+	name: string
+	type: 'geneExpression'
+	bins?: PresetNumericBins
 	// temporarily allowing chr/start/stop to support
 	// legacy fpkm files
 	chr?: string
@@ -30,7 +20,13 @@ export type GeneExpressionTerm = NumericTerm & {
 	stop?: number
 }
 
+export type GeneExpressionTW = BaseTW & {
+	q: NumericQ
+	term: GeneExpressionTerm
+	type: string
+}
+
 export type GeneExpressionTermSettingInstance = TermSettingInstance & {
-	q: GeneExpressionQ
+	q: NumericQ
 	term: GeneExpressionTerm
 }

--- a/shared/types/src/terms/numeric.ts
+++ b/shared/types/src/terms/numeric.ts
@@ -1,4 +1,4 @@
-import type { MinBaseQ, BaseTW, TermValues, BaseTerm } from '../index.ts'
+import type { MinBaseQ, BaseTW, TermValues, BaseTerm, GeneExpressionTerm } from '../index.ts'
 
 export type RawRegularBin = Partial<RegularNumericBinConfig> & { preferredBins?: string }
 
@@ -30,31 +30,20 @@ export type RawNumTWSpline = BaseTW & {
 
 export type RawNumTW = RawNumTWCustomBin | RawNumTWRegularBin | RawNumTWCont | RawNumTWSpline
 
-export type NumericTerm = BaseTerm & {
-	id?: string
-	// these concrete term.type values make it clear that only these are numeric,
-	// "categorical", "condition", and other term.types are not included in this union
-	type: 'integer' | 'float' | 'geneExpression' | 'metaboliteIntensity' | 'date' | 'ssGSEA'
-	bins: PresetNumericBins
-	values?: TermValues
-	unit?: string
+export type NumericBaseTerm = BaseTerm & {
 	/** tailored color scale for this term, so that when the term is used for color gradient in scatter, this set of colors will be used by default */
 	continuousColorScale?: { minColor: string; maxColor: string }
-	/*densityNotAvailable?: boolean //Not used?
-	logScale?: string | number
-	max?: number
-	min?: number
-	skip0forPercentile?: boolean
-	valueConversion?: ValueConversion*/
+	unit?: string
 }
 
-export type NumericDictTerm = BaseTerm & {
+export type NumericDictTerm = NumericBaseTerm & {
 	id?: string
 	type: 'integer' | 'float' | 'date'
 	bins: PresetNumericBins
 	values?: TermValues
-	unit?: string
 }
+
+export type NumericTerm = NumericDictTerm | GeneExpressionTerm
 
 export type StartUnboundedBin = {
 	// where possible, assign a concrete value (true) when it is known in advance,
@@ -157,7 +146,7 @@ export type BinaryNumericQ = MinBaseQ & {
 }
 
 export type ContinuousNumericQ = MinBaseQ & {
-	mode: 'continuous'
+	mode?: 'continuous'
 	// TODO: do not use a boolean, convert to a `transform: 'zscore' | ...` option
 	convert2ZScore?: boolean
 	//scale?: string

--- a/shared/types/src/terms/singleCellGeneExpression.ts
+++ b/shared/types/src/terms/singleCellGeneExpression.ts
@@ -1,7 +1,6 @@
 import type { TermWrapper } from './tw.ts'
-import type { GeneExpressionQ } from './geneExpression.ts'
 import type { TermSettingInstance } from '../termsetting.ts'
-import type { NumericTerm } from './numeric.ts'
+import type { NumericTerm, NumericQ } from './numeric.ts'
 
 /*
 --------EXPORTED--------
@@ -12,7 +11,7 @@ GeneExpressionTermSettingInstance
 */
 
 export type SingleCellGeneExpressionTW = TermWrapper & {
-	q: GeneExpressionQ
+	q: NumericQ
 	term: SingleCellGeneExpressionTerm
 }
 
@@ -22,6 +21,6 @@ export type SingleCellGeneExpressionTerm = NumericTerm & {
 }
 
 export type SingleCellGeneExpressionTermSettingInstance = TermSettingInstance & {
-	q: GeneExpressionQ
+	q: NumericQ
 	term: SingleCellGeneExpressionTerm
 }


### PR DESCRIPTION
# Description

A unit is now added to `term.name` for geneExpression term. The unit is derived from the dataset file. In this PR, the unit `FPKM` is added to the TermdbTest dataset file (see `queries.geneExpression.unit` in `server/dataset/termdb.test.ts`). When a unit is provided, `term.name` will be `<gene_name> <unit>`. When a unit is not provided `term.name` will be `<gene_name> Gene Expression`.

Since `term.name` now is no longer equal to `gene_name`, the backend code needed to be updated to query for `tw.$id` instead of `tw.term.name`.

Please test geneExpression term in different plot types and with different datasets.

All unit and integration tests pass.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
