### PR TITLE
support CORS-safe recovery of embedder session files

### DIFF
--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -49,9 +49,10 @@ export function parentCorsMessage(res, origin = '') {
 		}
 	}
 	window.addEventListener('message', messageListener, false)
-	setTimeout(() => window.removeEventListener('message', messageListener), 8000)
-	if (embedder.origin != window.location.origin) {
-		confirm(
+
+	const confirmedCorsWindow = JSON.parse(localStorage.getItem('confirmedCorsWindow') || `[]`)
+	if (embedder.origin != window.location.origin && !confirmedCorsWindow.includes(embedder.origin)) {
+		const ok = confirm(
 			`Another window will open to recover the saved session. When the next window opens,` +
 				`\n- You may need to allow popups.` +
 				`\n- You may have to refresh it.` +
@@ -62,7 +63,13 @@ export function parentCorsMessage(res, origin = '') {
 				Please close this browser tab. The recovered session should be visible in another browser tab.
 			</div>
 		`
+		if (ok) {
+			confirmedCorsWindow.push(embedder.origin)
+			localStorage.setItem('confirmedCorsWindow', JSON.stringify(confirmedCorsWindow))
+		}
 	}
+
+	setTimeout(() => window.removeEventListener('message', messageListener), 8000)
 	const child = window.open(embedder.href, '_blank')
 }
 

--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -35,8 +35,15 @@ export function parentCorsMessage(res, origin = '') {
 				// URL parameters.
 				setTimeout(() => {
 					try {
+						// If this page was launched from clicking a link outside of a web page (such as from an email),
+						// then there would be no browser history to go back to, this page should be automatically closed.
+						// If there is a page to go back to, assume that it's a page with a table or list of links
+						// for published figures and the user would prefer to go back to that page instead of seeing steps
+						// to manually go back or close the window.
+						// Either way, the recovered session will remain visible in another tab.
+						if (window.history.length > 1) window.history.back()
 						// Works when a shared URL is clicked from the session menu
-						window.close()
+						else window.close()
 					} catch (e) {
 						// the browser prevents the closing of an transitory tab that was opened
 						// by clicking on a bookmarked link or pasting that link directly on the browser
@@ -58,16 +65,18 @@ export function parentCorsMessage(res, origin = '') {
 				`\n- You may have to refresh it.` +
 				`\n- After the session is recovered, this browser window should automatically close.`
 		)
-		document.body.innerHTML = `
-			<div style='margin: 20px; padding: 20px; font-size: 24px'>
-				Please close this browser tab. The recovered session should be visible in another browser tab.
-			</div>
-		`
 		if (ok) {
 			confirmedCorsWindow.push(embedder.origin)
 			localStorage.setItem('confirmedCorsWindow', JSON.stringify(confirmedCorsWindow))
 		}
 	}
+
+	document.body.innerHTML = `
+		<div style='margin: 20px; padding: 20px; font-size: 24px'>
+			The recovered session should be visible in another browser tab.
+			You may go back in your browser history or close this browser tab.
+		</div>
+	`
 
 	setTimeout(() => window.removeEventListener('message', messageListener), 8000)
 	const child = window.open(embedder.href, '_blank')

--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -1,4 +1,4 @@
-export function corsMessage(res, origin = '') {
+export function parentCorsMessage(res, origin = '') {
 	const embedder = res.state?.embedder
 	const messageListener = event => {
 		if (event.origin !== embedder.origin) return
@@ -41,4 +41,54 @@ export function corsMessage(res, origin = '') {
 		`
 	}
 	const child = window.open(embedder.href, '_blank')
+}
+
+export function childCorsMessage(opts) {
+	if (!window.opener) return
+	const hostURL = sessionStorage.getItem('hostURL')
+	if (hostURL === window.location.origin) return
+
+	// if this is a child window or tab, refreshing it will need previously hydrated session state,
+	// in case the window.opener has already removed its message listener
+	opts.embeddedSessionState = JSON.parse(sessionStorage.getItem('embeddedSessionState') || `{}`)
+	const messageListener = event => {
+		if (event.origin != window.location.origin && event.origin !== hostURL) return
+		// !!! Potential race-condition
+		// - assumes that the message event from the window.opener will be received
+		//   before the storeInit() is triggered within the storeInit() call in mass/app.js
+		// - low-risk(?) since the postMessage() between browser tabs should be faster than
+		//   the dynamic code loading below and in mass/app
+		// !!!
+		if (event.data.state) {
+			window.removeEventListener('message', messageListener)
+			Object.assign(opts.embeddedSessionState, event.data.state)
+			// see the comment above for when this stored embeddedState may be used
+			sessionStorage.setItem('embeddedSessionState', JSON.stringify(opts.embeddedSessionState))
+		}
+	}
+	window.addEventListener('message', messageListener, false)
+	// limit the time to listen for the window.opener's message
+	setTimeout(() => window.removeEventListener('message', messageListener), 1000)
+	// the window.opener can be either
+	// - an embedder site when clicking on `Open Session`
+	// - a proteinpaint site when clicking on a shared URL link
+	// accessing window.opener.location.origin may emit a CORS-related error,
+	// so safer to send the message twice to cover both possibilities
+
+	let origin
+	try {
+		if (window.opener.origin) {
+			origin = window.opener.origin
+		} else {
+			origin = hostURL
+		}
+	} catch (e) {
+		origin = hostURL
+	}
+
+	try {
+		window.opener.postMessage('getActiveMassSession', origin)
+	} catch (e) {
+		console.log(e)
+	}
 }

--- a/client/mass/app.ts
+++ b/client/mass/app.ts
@@ -114,10 +114,15 @@ class MassApp extends AppBase implements RxAppInner {
 		try {
 			// TODO: may default later to having a debouncer ???
 			const debounceInterval = 'debounceInterval' in this.opts ? this.opts.debounceInterval : 0
-			if (this.opts.embeddedSessionState) {
+			// NOTE: Within the same browser tab, a refresh should load the embedder's intended page
+			// and not the recovered session, to avoid confusing default page load behavior. If a user
+			// wants to see the initial recovered state view in the embedder portal, they would have
+			// to click on a link again. May revisit this approach and reactivate the commented out code below.
+			const embeddedSessionState = this.opts.embeddedSessionState // || JSON.parse(sessionStorage.getItem('embeddedSessionState') || `null`)
+			if (embeddedSessionState) {
 				// may assume session state recovery for an embedder portal
 				// see the comment about potential race-condition in childCorsMessage embedder-helpers.js
-				Object.assign(this.opts.state, this.opts.embeddedSessionState)
+				Object.assign(this.opts.state, embeddedSessionState)
 			}
 			this.store = await storeInit({ app: this.api, state: this.opts.state, debounceInterval })
 			this.state = await this.store.copyState()

--- a/client/mass/app.ts
+++ b/client/mass/app.ts
@@ -116,7 +116,7 @@ class MassApp extends AppBase implements RxAppInner {
 			const debounceInterval = 'debounceInterval' in this.opts ? this.opts.debounceInterval : 0
 			if (this.opts.embeddedSessionState) {
 				// may assume session state recovery for an embedder portal
-				// see the comment about potential race-condition in launchmass() in src/app.js
+				// see the comment about potential race-condition in childCorsMessage embedder-helpers.js
 				Object.assign(this.opts.state, this.opts.embeddedSessionState)
 			}
 			this.store = await storeInit({ app: this.api, state: this.opts.state, debounceInterval })

--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -167,11 +167,11 @@ class MassSessionBtn {
 				} else if (window.location.origin == this.hostURL) {
 					window.open(`/?mass-session-id=${sessionName}&src=browser`)
 				} else {
-					if (state.embedder) corsMessage({ state })
+					if (state.embedder) parentCorsMessage({ state })
 					else {
 						const { protocol, host, search, origin, href } = window.location
 						const embedder = { protocol, host, search, origin, href }
-						corsMessage({ state: Object.assign({ embedder }, state) })
+						parentCorsMessage({ state: Object.assign({ embedder }, state) })
 					}
 				}
 				this.dom.tip.hide()
@@ -411,7 +411,7 @@ class MassSessionBtn {
 				//
 				a.on('click', event => {
 					event.preventDefault()
-					corsMessage({ state }, window.location.origin)
+					parentCorsMessage({ state }, window.location.origin)
 					return false
 				})
 			}

--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -2,7 +2,7 @@ import { getCompInit } from '#rx'
 import { Menu } from '#dom/menu'
 import { to_textfile } from '#dom/downloadTextfile'
 import { dofetch3 } from '#common/dofetch'
-import { corsMessage } from '#common/embedder-helpers'
+import { parentCorsMessage } from '#common/embedder-helpers'
 import { select } from 'd3-selection'
 import { importPlot } from '#plots/importPlot.js'
 
@@ -96,11 +96,11 @@ class MassSessionBtn {
 					} else if (window.location.origin == this.hostURL) {
 						window.open(`/?mass-session-id=${id}&src=browser`)
 					} else {
-						if (state.embedder) corsMessage({ state })
+						if (state.embedder) parentCorsMessage({ state })
 						else {
 							const { protocol, host, search, origin, href } = window.location
 							const embedder = { protocol, host, search, origin, href }
-							corsMessage({ state: Object.assign({ embedder }, state) })
+							parentCorsMessage({ state: Object.assign({ embedder }, state) })
 						}
 					}
 					this.dom.tip.hide()
@@ -119,7 +119,7 @@ class MassSessionBtn {
 						window.open(`/?mass-session-id=${id}&src=cred&dslabel=${this.dslabel}&route=${this.route}`)
 					} else {
 						// server-cached sessions should have an state.embedder object, no need to check
-						corsMessage(res)
+						parentCorsMessage(res)
 					}
 					this.dom.tip.hide()
 				}

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -193,7 +193,7 @@ upon error, throw err message as a string
 			const state = JSON.parse(d.text)
 
 			if (state.embedder && state.embedder.origin != window.location.origin) {
-				corsMessage({ state })
+				parentCorsMessage({ state })
 				return
 			}
 

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -6,7 +6,7 @@ import * as mdsjson from './app.mdsjson'
 import { getSavedToken } from '#common/dofetch'
 import urlmap from '#common/urlmap'
 import { first_genetrack_tolist } from '#common/1stGenetk'
-import { corsMessage } from '#common/embedder-helpers'
+import { parentCorsMessage, childCorsMessage } from '#common/embedder-helpers'
 import { sayerror } from '#dom'
 import { copyMerge } from '#rx'
 import { mayLaunchGdcPlotFromUrlparam } from '../gdc/launch.ts'
@@ -127,6 +127,8 @@ upon error, throw err message as a string
 			launchDate: arg.app.launchDate
 		}
 		if (!opts.genome) throw 'invalid genome'
+		childCorsMessage(opts)
+
 		const _ = await import('../mass/app')
 		const subapp = await _.appInit(opts)
 		return subapp
@@ -147,6 +149,8 @@ upon error, throw err message as a string
 		} else if (state?.vocab?.genome) {
 			opts.genome = arg.genomes[state.vocab.genome]
 		}
+		childCorsMessage(opts)
+
 		const _ = await import('../mass/app')
 		const subapp = await _.appInit(opts)
 		return subapp
@@ -164,9 +168,8 @@ upon error, throw err message as a string
 			if (d.error) throw d.error
 			if (!d.text) throw 'data.text missing'
 			const state = JSON.parse(d.text)
-
-			if (state.embedder && state.embedder.origin != window.location.origin) {
-				corsMessage({ state })
+			if (state.embedder?.origin != window.location.origin) {
+				parentCorsMessage({ state })
 				return
 			}
 

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -164,6 +164,12 @@ upon error, throw err message as a string
 			if (d.error) throw d.error
 			if (!d.text) throw 'data.text missing'
 			const state = JSON.parse(d.text)
+
+			if (state.embedder && state.embedder.origin != window.location.origin) {
+				corsMessage({ state })
+				return
+			}
+
 			opts = {
 				debug: arg.app.debugmode,
 				holder: arg.holder,
@@ -182,6 +188,12 @@ upon error, throw err message as a string
 			if (d.error) throw d.error
 			if (!d.text) throw 'data.text missing'
 			const state = JSON.parse(d.text)
+
+			if (state.embedder && state.embedder.origin != window.location.origin) {
+				corsMessage({ state })
+				return
+			}
+
 			opts = {
 				debug: arg.app.debugmode,
 				holder: arg.holder,

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -235,7 +235,7 @@ upon error, throw err message as a string
 		}
 		const embedder = res.state?.embedder
 		if (embedder && embedder.origin != window.location.origin) {
-			corsMessage(res)
+			parentCorsMessage(res)
 			return
 		}
 		const opts = {


### PR DESCRIPTION
# Description

This extends session recovery in embedder portals that do no allow `pp` to specify URL params, such as vizcom and ash.  Previously, only `mass-session-id` URLs had this support for vizcom, this branch extends that URL params with `mass-session-<file | url>`.  Support is also extended on child window, where `?mass=` and `?mass-native=` URL params could also be opened with the parent window's recovered session state. Previously, the child window must be opened with a `runproteinpaint({'mass':...}` argument.

To test:
- edit `/etc/hosts` in your dev machine to include `127.0.0.1 viz.localhost`
- the session file/state must have an embedder key-value like this:
```json
"embedder": {
 "protocol": "http:",
  "host": "viz.localhost:3000",
  "search": "",
  "origin": "http://viz.localhost:3000",
  "href": "http://viz.localhost:3000/?noheader=1&mass={\"genome\":\"hg38\",\"dslabel\":\"ASH\"}"
},
``` 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
