### PR TITLE
Allowed to download pdf or svgs in the barchart

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -12,6 +12,7 @@ import { getColors, mclass, plotColor } from '#shared/common.js'
 import { isNumericTerm } from '#shared/terms.js'
 import { roundValueAuto } from '#shared/roundValue.js'
 import { getCombinedTermFilter } from '#filter'
+import { DownloadMenu } from '#dom/downloadMenu'
 
 export class Barchart {
 	constructor(opts) {
@@ -349,6 +350,7 @@ export class Barchart {
 			const results = await this.app.vocabApi.getNestedChartSeriesData(reqOpts)
 			if (results.error) throw results
 			const data = results.data
+			this.charts = data.charts
 			this.sampleType = results.sampleType
 			this.bins = results.bins
 			if (results.chartid2dtterm) this.chartid2dtterm = results.chartid2dtterm
@@ -1110,7 +1112,23 @@ function setRenderers(self) {
 function setInteractivity(self) {
 	self.handlers = getHandlers(self)
 
-	self.download = function () {
+	self.getName2Svg = function () {
+		const name2svg = {}
+
+		for (const chart of this.charts) {
+			const name = chart.name
+			name2svg[name] = chart.svg
+		}
+		return name2svg
+	}
+
+	self.download = function (event) {
+		const name2svg = self.getName2Svg()
+		const dm = new DownloadMenu(name2svg, self.opts.holder.node())
+		dm.show(event.clientX, event.clientY)
+	}
+
+	self.download2 = function () {
 		if (!self.state) return
 		// has to be able to handle multichart view
 		const mainGs = []

--- a/client/plots/bars.renderer.js
+++ b/client/plots/bars.renderer.js
@@ -118,20 +118,19 @@ export default function barsRenderer(barsapp, holder) {
 		hm.cols = hm.cols.filter(colId => hm.colLabels.find(d => d.id == colId))
 		hm.rows = hm.rows?.filter(d => !hm.exclude.rows.includes(d)) || []
 		const nosvg = !svg
-		if (nosvg) init()
-
+		if (nosvg) init(_chart)
 		const unadjustedColw = hm.colw
 		currserieses = chart.visibleSerieses
 		currserieses.map(setIds)
 		chart.serieses.map(setIds)
 		setDimensions()
-
+		_chart.name = hm.handlers.chart.title(chart)
 		chartTitle
 			.style('width', hm.svgw + 100 + 'px')
 			//.style('font-weight', 600)
 			.style('font-size', '1.1em')
 			.style('margin-bottom', '24px')
-			.html(hm.handlers.chart.title(chart))
+			.html(_chart.name)
 
 		// only set this initially to prevent
 		// jerky svg resize on update
@@ -213,7 +212,7 @@ export default function barsRenderer(barsapp, holder) {
 		)
 	}
 
-	function init() {
+	function init(_chart) {
 		defaults = {
 			geneonrow: hm.geneonrow,
 			nicenames: {},
@@ -268,6 +267,7 @@ export default function barsRenderer(barsapp, holder) {
 				.on('mouseover.tphm2', hm.handlers.svg.mouseover)
 				.on('mouseout.tphm2', hm.handlers.svg.mouseout)
 				.on('click.tphm2', hm.handlers.svg.click)
+			_chart.svg = svg
 		}
 
 		mainG = svg.append('g').attr('class', 'sjpcb-bars-mainG').attr('data-testid', 'sjpcb-bars-mainG')


### PR DESCRIPTION
# Description

Allowed to download pdf or svgs in the barchart. This replaces the previous barchart download combining multiple svgs into one, as they appear overlapped and maybe for the user is better to have  each plot in an independent svg. Please check if you want this approach.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
