### PR TITLE
fix divide-by error by passing app argument to initByInput 

### DIFF
--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -1097,7 +1097,8 @@ export class MatrixControls {
 						{},
 						{
 							holder,
-							dispatch: app.dispatch,
+							app,
+							dispatch: action => app.dispatch(action),
 							id: parent.id,
 							debug: this.opts.debug,
 							parent
@@ -1146,6 +1147,7 @@ export class MatrixControls {
 						{},
 						{
 							holder,
+							app,
 							id: parent.id,
 							debug: self.opts.debug,
 							parent

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- fix divide-by error by passing app argument to initByInput in matrix.controls


### PR DESCRIPTION
# Description

… in matrix.controls

Tested with all unit and integration tests, plus adding/removing group-by term in matrix plot.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
