### PR TITLE
Prototyping summary input plot

### DIFF
--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -44,7 +44,7 @@ export async function init(
 			termfilter: { filter0: arg.filter0 },
 			nav: { activeTab: 1, header_mode: 'only_buttons' },
 			plots: [
-				{ chartType: 'dictionary' } // default shows dictionary ui, can change
+				{ chartType: 'summaryInput' } // default shows summaryInput ui, can change
 				//{ chartType: 'barchart', term: {id: 'case.demographic.gender'} }, // uncomment for quicker testing
 			]
 		},

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -202,6 +202,14 @@ function getChartTypeList(self, state) {
 			}
 		},
 		{
+			label: 'Summary Input',
+			clickTo: self.prepPlot,
+			chartType: 'summaryInput',
+			config: {
+				chartType: 'summaryInput'
+			}
+		},
+		{
 			label: self.getBtnLabel_report(state),
 			chartType: 'report',
 			clickTo: self.plotCreate,

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -779,7 +779,7 @@ async function setTermInput(opts) {
 	const pill = await termsettingInit({
 		menuOptions: opts.menuOptions || '*',
 		numericEditMenuVersion: opts.numericEditMenuVersion || ['continuous', 'discrete'],
-		vocabApi: opts.vocabApi,
+		vocabApi: opts.vocabApi || opts.app.vocabApi,
 		vocab: opts.state?.vocab,
 		activeCohort: opts.state?.activeCohort,
 		holder: self.dom.inputTd.append('div'),

--- a/client/plots/controls.js
+++ b/client/plots/controls.js
@@ -26,7 +26,7 @@ class TdbPlotControls {
 		this.opts = opts
 		this.type = 'plotControls'
 		this.customEvents = ['downloadClick', 'infoClick', 'helpClick']
-		this.isOpen = false
+		this.isOpen = opts.isOpen || false
 		setInteractivity(this)
 		setRenderers(this)
 	}

--- a/client/plots/importPlot.js
+++ b/client/plots/importPlot.js
@@ -23,6 +23,9 @@ export async function importPlot(chartType, notFoundMessage = '') {
 		case 'summarizeMutationSurvival':
 			return await import(`./summarizeMutationSurvival.ts`)
 
+		case 'summaryInput':
+			return await import(`./summaryInput.ts`)
+
 		case 'summary':
 			return await import(`./summary.ts`)
 

--- a/client/plots/summaryInput.ts
+++ b/client/plots/summaryInput.ts
@@ -1,0 +1,129 @@
+import { PlotBase } from './PlotBase.ts'
+import { getCompInit, type ComponentApi, type RxComponentInner } from '#rx'
+import { controlsInit } from './controls'
+
+let instanceNum = 1
+
+class SummaryInputPlot extends PlotBase implements RxComponentInner {
+	static type = 'summaryInput'
+
+	// expected RxComponentInner props, some are already declared/set in PlotBase
+	type: string
+	parentId?: string
+	dom!: {
+		[index: string]: any
+	}
+	components: {
+		[name: string]: ComponentApi | { [name: string]: ComponentApi }
+	} = {}
+	// expected class-specific props
+	configTermKeys = ['term', 'term0', 'term2']
+	config: any
+
+	constructor(opts) {
+		super(opts)
+		this.type = SummaryInputPlot.type
+		this.dom = this.getDom()
+		this.app = opts.app
+		this.id = opts.id
+		this.instanceNum = instanceNum++
+	}
+
+	getDom() {
+		const opts = this.opts
+		const dom = {
+			header: opts.header,
+			holder: opts.holder,
+			controls: opts.holder.append('div') /*.style('margin', '10px 0px')*/,
+			submit: opts.holder.append('div').style('margin', '10px')
+		}
+		if (dom.header) dom.header.html('Summary Input')
+		return dom
+	}
+
+	async init() {
+		const inputs = [
+			{
+				type: 'term',
+				configKey: 'term',
+				label: 'Variable to summarize'
+			},
+			{
+				type: 'term',
+				configKey: 'term2',
+				label: 'Overlay variable'
+			},
+			{
+				type: 'term',
+				configKey: 'term0',
+				label: 'Divide by variable'
+			}
+		]
+
+		/*const x = await configUiInit({
+            app: this.app,
+            id: this.id,
+            holder: this.dom.controls,
+            isOpen: () => true,
+            tip: this.app.tip,
+            inputs
+        })*/
+
+		const x = await controlsInit({
+			app: this.app,
+			id: this.id,
+			holder: this.dom.controls.attr('class', 'pp-termdb-plot-controls').style('display', 'inline-block'),
+			isOpen: true,
+			inputs
+		})
+
+		const appState = this.app.getState()
+		x.update({ state: this.state, appState })
+
+		this.dom.submit
+			.append('button')
+			.property('disabled', false)
+			.style('border', 'none')
+			.style('border-radius', '20px')
+			.style('padding', '10px 15px')
+			.text('Submit')
+			.on('click', () => {})
+	}
+
+	async main() {
+		console.log('main()')
+
+		//this.config = await this.getMutableConfig()
+
+		//const holder = this.dom.holder
+		//holder.append('div').text('This is a test')
+		//const table = table2col({ holder: this.dom.typeSettingDiv, margin: '0px 0px 15px 0px' })
+		//const table = holder.append('table')
+		/*const termrow = table.append('tr')
+        const termLabelTd = termrow.append('td')
+        const termInputTd = termrow.append('td')*/
+
+		/*initByInput['term']({
+            holder: table.append('tr'),
+            label: 'Data variable',
+            app: this.app,
+            id: this.id,
+            instanceNum: this.instanceNum,
+            debug: this.opts.debug,
+            parent: this
+        })*/
+	}
+
+	render() {}
+}
+
+export const summaryInputInit = getCompInit(SummaryInputPlot)
+export const componentInit = summaryInputInit
+
+export function getPlotConfig(/*opts, app*/) {
+	const config = {
+		chartType: 'summaryInput',
+		settings: {}
+	}
+	return config
+}

--- a/server/src/gdc.buildDictionary.js
+++ b/server/src/gdc.buildDictionary.js
@@ -687,7 +687,8 @@ function makeTermdbQueries(ds, id2term) {
 	q.getSupportedChartTypes = () => {
 		const supportedChartTypes = {
 			'': [
-				'dictionary', // to be able to show dictionary chart button at mass ui in correlation plot http://localhost:3000/?gdccorrelation=1
+				// 8/18/2025 no longer shows "dictionary" & "survival" chart buttons, show summaryInput instead
+				'summaryInput',
 				'summarizeMutationDiagnosis',
 				'summarizeCnvGeneexp',
 				'summarizeMutationSurvival',
@@ -707,10 +708,6 @@ function makeTermdbQueries(ds, id2term) {
 				supportedChartTypes[r.cohort] = ['barchart', 'table', 'regression']
 				numericTypeCount[r.cohort] = 0
 			}
-			if (r.type == 'survival' && !supportedChartTypes[r.cohort].includes('survival'))
-				supportedChartTypes[r.cohort].push('survival')
-			if (r.type == 'condition' && !supportedChartTypes[r.cohort].includes('cuminc'))
-				supportedChartTypes[r.cohort].push('cuminc')
 			if (r.type == 'float' || r.type == 'integer') numericTypeCount[r.cohort] += r.samplecount
 		}
 		for (const cohort in numericTypeCount) {

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -623,6 +623,7 @@ export function filterTerms(req, ds, terms) {
 
 const defaultCommonCharts: isSupportedChartCallbacks = {
 	dictionary: () => true,
+	summaryInput: () => true,
 	matrix: () => true,
 	/*
 	parent type: regression


### PR DESCRIPTION
# Description

Prototyping a new plot type called `summaryInput`, which allows user to first input main term, overlay term, and divide by term and then submit to create summary plot. Can open summary input by clicking on the `Summary Input` chart button. This new chart button is currently enabled for all datasets, but can change this.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
