### PR TITLE
improve non-dictionary numeric tw type definitions

### DIFF
--- a/shared/types/src/terms/date.ts
+++ b/shared/types/src/terms/date.ts
@@ -1,5 +1,4 @@
-import type { BaseTW, NumericBaseTerm, NumericQ, PresetNumericBins } from '../index.ts'
-import type { TermSettingInstance } from '../termsetting.ts'
+import type { NumericBaseTerm, PresetNumericBins, NumTWTypes } from '../index.ts'
 
 /*
 --------EXPORTED--------
@@ -16,13 +15,4 @@ export type DateTerm = NumericBaseTerm & {
 	unit?: string
 }
 
-export type DateTW = BaseTW & {
-	type: 'NumTWCont'
-	q: NumericQ
-	term: DateTerm
-}
-
-export type DateTermSettingInstance = TermSettingInstance & {
-	q: NumericQ
-	term: DateTerm
-}
+export type DateTW = NumTWTypes & { term: DateTerm }

--- a/shared/types/src/terms/geneExpression.ts
+++ b/shared/types/src/terms/geneExpression.ts
@@ -1,5 +1,4 @@
-import type { BaseTW, PresetNumericBins, NumericBaseTerm, NumericQ } from '../index.ts'
-import type { TermSettingInstance } from '../termsetting.ts'
+import type { PresetNumericBins, NumericBaseTerm, NumTWTypes } from '../index.ts'
 
 /*
 --------EXPORTED--------
@@ -20,13 +19,4 @@ export type GeneExpressionTerm = NumericBaseTerm & {
 	stop?: number
 }
 
-export type GeneExpressionTW = BaseTW & {
-	q: NumericQ
-	term: GeneExpressionTerm
-	type: 'NumTWCont'
-}
-
-export type GeneExpressionTermSettingInstance = TermSettingInstance & {
-	q: NumericQ
-	term: GeneExpressionTerm
-}
+export type GeneExpressionTW = NumTWTypes & { term: GeneExpressionTerm }

--- a/shared/types/src/terms/metaboliteIntensity.ts
+++ b/shared/types/src/terms/metaboliteIntensity.ts
@@ -1,5 +1,4 @@
-import type { BaseTW, NumericBaseTerm, NumericQ, PresetNumericBins } from '../index.ts'
-import type { TermSettingInstance } from '../termsetting.ts'
+import type { NumericBaseTerm, PresetNumericBins, NumTWTypes } from '../index.ts'
 
 /*
 --------EXPORTED--------
@@ -7,12 +6,6 @@ MetaboliteIntensityTermWrapper
 MetaboliteIntensityTermSettingInstance
 
 */
-
-export type MetaboliteIntensityTW = BaseTW & {
-	type: 'NumTWCont'
-	q: NumericQ
-	term: MetaboliteIntensityTerm
-}
 
 export type MetaboliteIntensityTerm = NumericBaseTerm & {
 	name?: string
@@ -22,7 +15,4 @@ export type MetaboliteIntensityTerm = NumericBaseTerm & {
 	unit?: string
 }
 
-export type MetaboliteIntensityTermSettingInstance = TermSettingInstance & {
-	q: NumericQ
-	term: MetaboliteIntensityTerm
-}
+export type MetaboliteIntensityTW = NumTWTypes & { term: MetaboliteIntensityTerm }

--- a/shared/types/src/terms/ssGSEA.ts
+++ b/shared/types/src/terms/ssGSEA.ts
@@ -1,17 +1,10 @@
-import type { TermWrapper } from './tw.ts'
-import type { NumericBaseTerm, NumericQ, PresetNumericBins } from './numeric.ts'
-import type { TermSettingInstance } from '../termsetting.ts'
+import type { NumericBaseTerm, NumericQ, PresetNumericBins, NumTWTypes } from './numeric.ts'
 
 /*
 duplicated from geneExpression.ts
 */
 
 export type SsGSEAQ = NumericQ & { dt?: number }
-
-export type SsGSEATW = TermWrapper & {
-	q: SsGSEAQ
-	term: SsGSEATerm
-}
 
 export type SsGSEATerm = NumericBaseTerm & {
 	/** term.id: geneset db term id for native term, and cache file name for custom term */
@@ -24,7 +17,4 @@ export type SsGSEATerm = NumericBaseTerm & {
 	unit?: string
 }
 
-export type SsGSEATermSettingInstance = TermSettingInstance & {
-	q: SsGSEAQ
-	term: SsGSEATerm
-}
+export type SsGSEATW = NumTWTypes & { term: SsGSEATerm }


### PR DESCRIPTION
# Description

Improved numeric type definitions for date, metabolite intensity, ssGSEA, geneExpression.

Tested with all unit and integration tests,`npm run tsc` from client dir, `npm test` from shared/types dir, `npm run lint` from pp dir.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
