### PR TITLE
Supported report pdf, single svg download and survival download with menu options

### DIFF
--- a/client/common/svg.download.js
+++ b/client/common/svg.download.js
@@ -113,29 +113,31 @@ export function downloadChart(mainGsel, svgName, styleParent = null) {
 	to_svg(svg, svgName, { apply_dom_styles: true })
 }
 
-export function downloadAggregatedSVG(name2svg, svgName, parent) {
+export function downloadAggregatedSVG(name2svg, svgName) {
 	const x = 50
 	const svgParent = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 	const styles = []
-	if (parent) {
-		const svgStyles = window.getComputedStyle(parent)
-		for (const [prop, value] of Object.entries(svgStyles)) {
-			if (prop.startsWith('font')) styles.push({ prop, value })
-		}
-	}
+
 	let y = 20
-	for (const [name, svg] of Object.entries(name2svg)) {
-		for (const style of styles) {
-			svg.style(style.prop, style.value)
-		}
-		const bbox = svg.node().getBoundingClientRect()
+	for (const [name, chart] of Object.entries(name2svg)) {
+		const parent = chart.parent
+		const svg = chart.svg.clone(true)
 		const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
 		g.setAttribute('transform', `translate(${x}, ${y + 20})`)
-		const title = document.createElementNS('http://www.w3.org/2000/svg', 'text')
-		title.textContent = name
-		const svgNode = svg.node().cloneNode(true)
 
-		svgParent.appendChild(title)
+		if (parent) {
+			const svgStyles = window.getComputedStyle(parent)
+			for (const [prop, value] of Object.entries(svgStyles)) {
+				if (prop.startsWith('font')) g.style[prop] = value
+			}
+		}
+		const bbox = chart.svg.node().getBoundingClientRect()
+		const title = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+
+		title.textContent = name
+		const svgNode = svg.node()
+
+		g.appendChild(title)
 		g.appendChild(svgNode)
 		svgParent.appendChild(g)
 		y += bbox.height + 40

--- a/client/common/svg.download.js
+++ b/client/common/svg.download.js
@@ -123,7 +123,7 @@ export function downloadAggregatedSVG(name2svg, svgName) {
 		const parent = chart.parent
 		const svg = chart.svg.clone(true)
 		const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
-		g.setAttribute('transform', `translate(${x}, ${y + 20})`)
+		g.setAttribute('transform', `translate(${x}, ${y})`)
 
 		if (parent) {
 			const svgStyles = window.getComputedStyle(parent)
@@ -131,16 +131,17 @@ export function downloadAggregatedSVG(name2svg, svgName) {
 				if (prop.startsWith('font')) g.style[prop] = value
 			}
 		}
-		const bbox = chart.svg.node().getBoundingClientRect()
 		const title = document.createElementNS('http://www.w3.org/2000/svg', 'text')
-
 		title.textContent = name
-		const svgNode = svg.node()
-
 		g.appendChild(title)
+
+		const svgNode = svg.node()
+		const bbox = svgNode.getBoundingClientRect()
+		svgNode.setAttribute('transform', `translate(${x}, ${30})`)
+
 		g.appendChild(svgNode)
 		svgParent.appendChild(g)
-		y += bbox.height + 40
+		y += bbox.height + 70 //30 from the shift for the label, 40 to add space for new plot
 	}
 	svgParent.setAttribute('height', `${y + 20}`)
 

--- a/client/common/svg.download.js
+++ b/client/common/svg.download.js
@@ -112,3 +112,35 @@ export function downloadChart(mainGsel, svgName, styleParent = null) {
 
 	to_svg(svg, svgName, { apply_dom_styles: true })
 }
+
+export function downloadAggregatedSVG(name2svg, svgName, parent) {
+	const x = 50
+	const svgParent = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+	const styles = []
+	if (parent) {
+		const svgStyles = window.getComputedStyle(parent)
+		for (const [prop, value] of Object.entries(svgStyles)) {
+			if (prop.startsWith('font')) styles.push({ prop, value })
+		}
+	}
+	let y = 20
+	for (const [name, svg] of Object.entries(name2svg)) {
+		for (const style of styles) {
+			svg.style(style.prop, style.value)
+		}
+		const bbox = svg.node().getBoundingClientRect()
+		const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+		g.setAttribute('transform', `translate(${x}, ${y + 20})`)
+		const title = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+		title.textContent = name
+		const svgNode = svg.node().cloneNode(true)
+
+		svgParent.appendChild(title)
+		g.appendChild(svgNode)
+		svgParent.appendChild(g)
+		y += bbox.height + 40
+	}
+	svgParent.setAttribute('height', `${y + 20}`)
+
+	to_svg(svgParent, svgName, { apply_dom_styles: true })
+}

--- a/client/dom/categoryFiltersUI.ts
+++ b/client/dom/categoryFiltersUI.ts
@@ -10,27 +10,18 @@ export class CategoryFiltersUI {
 	config: any
 
 	constructor(holder: any, plot: any, config: any) {
-		holder
-			.style('padding', '10px')
-			.style('display', 'flex')
-			.style('flex-direction', 'row')
-			.style('flex-wrap', 'wrap')
-			.style('width', '100vw')
 		this.plot = plot
-		this.holder = holder
+		this.holder = holder.style('margin', '10px')
 		this.config = config
 		for (const tw of this.plot.config.filterTWs) {
-			const div = this.holder.append('div').style('padding', '10px')
-			const button = div
-				.append('button')
-				.style('vertical-align', 'top')
-				.on('click', () => {
-					const display = select.style('display')
-					const selectedOptions = Array.from(select.node().selectedOptions)
-					const selection = selectedOptions.map((o: any) => o.text).join(', ')
-					button.text(display === 'none' ? ` ${tw.term.name}: ${selection} ▲` : ` ${tw.term.name}: ${selection} ▼`)
-					select.style('display', display === 'none' ? 'block' : 'none')
-				})
+			const div = this.holder.append('div').style('padding', '10px').style('display', 'inline-block')
+			const button = div.append('button').on('click', () => {
+				const display = select.style('display')
+				const selectedOptions = Array.from(select.node().selectedOptions)
+				const selection = selectedOptions.map((o: any) => o.text).join(', ')
+				button.text(display === 'none' ? ` ${tw.term.name}: ${selection} ▲` : ` ${tw.term.name}: ${selection} ▼`)
+				select.style('display', display === 'none' ? 'block' : 'none')
+			})
 			const filterValues = config?.settings[this.plot.type][tw.term.id] || []
 			button.text(` ${tw.term.name}: ${filterValues.map((o: any) => tw.term.values[o].label || o).join(', ')} ▼`)
 

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -3,15 +3,14 @@ import { downloadSingleSVG, downloadAggregatedSVG } from '../common/svg.download
 
 export class DownloadMenu {
 	menu: Menu
-	name2svg: any
+	name2svg: { [name: string]: { svg: any; parent: any } }
 	holder: any
 	multipleSVGs: boolean
 	filename: string
 
-	constructor(name2svg, holder, filename = 'charts') {
+	constructor(name2svg, filename = 'charts') {
 		this.menu = new Menu({ padding: '0px' })
 		this.name2svg = name2svg
-		this.holder = holder
 		this.multipleSVGs = Object.keys(name2svg).length > 1
 		this.filename = filename.replace(/\s/g, '_')
 	}
@@ -24,7 +23,7 @@ export class DownloadMenu {
 			.attr('class', 'sja_menuoption sja_sharp_border')
 			.text('PDF')
 			.on('click', () => {
-				downloadSVGsAsPdf(this.name2svg, this.filename, this.holder)
+				downloadSVGsAsPdf(this.name2svg, this.filename)
 				this.menu.hide()
 			})
 		menuDiv
@@ -32,7 +31,7 @@ export class DownloadMenu {
 			.attr('class', 'sja_menuoption sja_sharp_border')
 			.text('SVG')
 			.on('click', () => {
-				downloadAggregatedSVG(this.name2svg, this.filename, this.holder)
+				downloadAggregatedSVG(this.name2svg, this.filename)
 				this.menu.hide()
 			})
 
@@ -42,15 +41,15 @@ export class DownloadMenu {
 				.attr('class', 'sja_menuoption sja_sharp_border')
 				.text('Multiple SVG')
 				.on('click', () => {
-					for (const [name, svg] of Object.entries(this.name2svg))
-						downloadSingleSVG(svg, name.replace(/\s/g, '_'), this.holder)
+					for (const [name, chart] of Object.entries(this.name2svg))
+						downloadSingleSVG(chart.svg.node(), name.replace(/\s/g, '_'), chart.parent)
 					this.menu.hide()
 				})
 		this.menu.show(x - 20, y - 10)
 	}
 }
 
-export async function downloadSVGsAsPdf(name2svg, filename, parent) {
+export async function downloadSVGsAsPdf(name2svg, filename) {
 	const JSPDF = await import('jspdf')
 	const { jsPDF } = JSPDF
 	/*
@@ -59,7 +58,7 @@ export async function downloadSVGsAsPdf(name2svg, filename, parent) {
 	Therefore, a simple import 'svg2pdf.js' without curly braces is all that is needed to apply its functionality. 
 	 */
 	await import('svg2pdf.js') // This import extends jsPDF with SVG functionality
-	const doc = new jsPDF('p', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
+	const doc = new jsPDF('portrait', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
 	doc.setFontSize(12)
 	const pageWidth = doc.internal.pageSize.getWidth() - 10
 	const pageHeight = doc.internal.pageSize.getHeight() - 10
@@ -68,22 +67,22 @@ export async function downloadSVGsAsPdf(name2svg, filename, parent) {
 	let y = 50
 	const x = 30
 	const ratio = 72 / 96 //convert pixels to pt
-	const styles: any[] = []
-	if (parent) {
-		const svgStyles = window.getComputedStyle(parent)
-		for (const [prop, value] of Object.entries(svgStyles)) {
-			if (prop.startsWith('font')) styles.push({ prop, value })
+
+	for (const [name, chart] of entries) {
+		const parent = chart.parent
+		const svg = chart.svg.node().cloneNode(true) //clone to avoid modifying the original
+		if (parent) {
+			const svgStyles = window.getComputedStyle(parent)
+			for (const [prop, value] of Object.entries(svgStyles)) {
+				if (prop.startsWith('font')) svg.style[prop] = value
+			}
 		}
-	}
-	for (const [name, svgObj] of entries) {
-		const svg = svgObj.node()
-		for (const style of styles) {
-			svg.style[style.prop] = style.value
-		}
+		parent.appendChild(svg) //Added otherwise does not print, will remove later
+
 		const rect = svg.getBoundingClientRect()
 		svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
-		const width = Math.min(pageWidth, rect.width * ratio) - 20
-		const height = Math.min(pageHeight, rect.height * ratio) - 20
+		const width = Math.min(pageWidth, rect.width * ratio) - 10
+		const height = Math.min(pageHeight, rect.height * ratio) - 10
 		if (y + height > pageHeight - 20) {
 			doc.addPage()
 			y = 50
@@ -91,6 +90,7 @@ export async function downloadSVGsAsPdf(name2svg, filename, parent) {
 		doc.text(name, x + 10, y - 20)
 		await doc.svg(svg, { x, y, width, height })
 		y = y + height + 50
+		parent.removeChild(svg)
 	}
 	doc.save(filename + '.pdf')
 }

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -65,7 +65,7 @@ export async function downloadSVGsAsPdf(name2svg, filename) {
 
 	const entries: any[] = Object.entries(name2svg)
 	let y = 50
-	const x = 30
+	const x = 20
 	const ratio = 72 / 96 //convert pixels to pt
 
 	for (const [name, chart] of entries) {
@@ -79,10 +79,11 @@ export async function downloadSVGsAsPdf(name2svg, filename) {
 		}
 		parent.appendChild(svg) //Added otherwise does not print, will remove later
 
-		const rect = svg.getBoundingClientRect()
-		svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
-		const width = Math.min(pageWidth, rect.width * ratio) - 10
-		const height = Math.min(pageHeight, rect.height * ratio) - 10
+		let width = svg.getAttribute('width')
+		let height = svg.getAttribute('height')
+		svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+		width = Math.min(pageWidth, width * ratio) - 30
+		height = Math.min(pageHeight, height * ratio) - 30
 		if (y + height > pageHeight - 20) {
 			doc.addPage()
 			y = 50

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -31,7 +31,7 @@ export class DownloadMenu {
 				downloadSVGsAsPdf(this.name2svg)
 				this.menu.hide()
 			})
-		this.menu.show(x - 10, y - 10)
+		this.menu.show(x - 20, y - 10)
 	}
 }
 
@@ -51,6 +51,7 @@ export async function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
 
 	const entries: any[] = Object.entries(name2svg)
 	let y = 50
+	const x = 30
 	const ratio = 72 / 96 //convert pixels to pt
 
 	for (const [name, svgObj] of entries) {
@@ -63,8 +64,8 @@ export async function downloadSVGsAsPdf(name2svg, filename = 'charts.pdf') {
 			doc.addPage()
 			y = 50
 		}
-		doc.text(name, 30, y - 20)
-		await doc.svg(svg, { x: 15, y, width, height })
+		doc.text(name, x + 10, y - 20)
+		await doc.svg(svg, { x, y, width, height })
 		y = y + height + 50
 	}
 	doc.save(filename)

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -1130,135 +1130,137 @@ function setInteractivity(self) {
 		dm.show(event.clientX, event.clientY)
 	}
 
-	/** Downloads all charts as a single svg image, now done from the downloadMenu
+	/** Downloads all charts as a single svg image, including the legend for each barchart, needs review as it
+	 * has some glitches. The legend rendering may be moved to the same svg and then it will be included in the download or a callback may be provided
+	 * to the downloadMenu to use this download when generating a single svg, once it works well
 	 */
-	self.download2 = function () {
-		if (!self.state) return
-		// has to be able to handle multichart view
-		const mainGs = []
-		const translate = { x: undefined, y: undefined }
-		const titles = []
-		let maxw = 0,
-			maxh = 0,
-			tboxh = 0
-		let prevY = 0,
-			numChartsPerRow = 0
+	// self.download = function () {
+	// 	if (!self.state) return
+	// 	// has to be able to handle multichart view
+	// 	const mainGs = []
+	// 	const translate = { x: undefined, y: undefined }
+	// 	const titles = []
+	// 	let maxw = 0,
+	// 		maxh = 0,
+	// 		tboxh = 0
+	// 	let prevY = 0,
+	// 		numChartsPerRow = 0
 
-		self.dom.barDiv.selectAll('.sjpcb-bars-mainG').each(function () {
-			mainGs.push(this)
-			const bbox = this.getBBox()
-			if (bbox.width > maxw) maxw = bbox.width
-			if (bbox.height > maxh) maxh = bbox.height
-			const divY = Math.round(this.parentNode.parentNode.getBoundingClientRect().y)
-			if (!numChartsPerRow) {
-				prevY = divY
-				numChartsPerRow++
-			} else if (Math.abs(divY - prevY) < 5) {
-				numChartsPerRow++
-			}
-			const xy = select(this)
-				.attr('transform')
-				.split('translate(')[1]
-				.split(')')[0]
-				.split(',')
-				.map(d => +d.trim())
-			if (translate.x === undefined || xy[0] > translate.x) translate.x = +xy[0]
-			if (translate.y === undefined || xy[1] > translate.y) translate.y = +xy[1]
+	// 	self.dom.barDiv.selectAll('.sjpcb-bars-mainG').each(function () {
+	// 		mainGs.push(this)
+	// 		const bbox = this.getBBox()
+	// 		if (bbox.width > maxw) maxw = bbox.width
+	// 		if (bbox.height > maxh) maxh = bbox.height
+	// 		const divY = Math.round(this.parentNode.parentNode.getBoundingClientRect().y)
+	// 		if (!numChartsPerRow) {
+	// 			prevY = divY
+	// 			numChartsPerRow++
+	// 		} else if (Math.abs(divY - prevY) < 5) {
+	// 			numChartsPerRow++
+	// 		}
+	// 		const xy = select(this)
+	// 			.attr('transform')
+	// 			.split('translate(')[1]
+	// 			.split(')')[0]
+	// 			.split(',')
+	// 			.map(d => +d.trim())
+	// 		if (translate.x === undefined || xy[0] > translate.x) translate.x = +xy[0]
+	// 		if (translate.y === undefined || xy[1] > translate.y) translate.y = +xy[1]
 
-			const title = this.parentNode.parentNode.firstChild
-			const tbox = title.getBoundingClientRect()
-			if (tbox.width > maxw) maxw = tbox.width
-			if (tbox.height > tboxh) tboxh = tbox.height
-			titles.push({ text: title.innerText, styles: window.getComputedStyle(title) })
-		})
+	// 		const title = this.parentNode.parentNode.firstChild
+	// 		const tbox = title.getBoundingClientRect()
+	// 		if (tbox.width > maxw) maxw = tbox.width
+	// 		if (tbox.height > tboxh) tboxh = tbox.height
+	// 		titles.push({ text: title.innerText, styles: window.getComputedStyle(title) })
+	// 	})
 
-		// add padding between charts
-		maxw += 30
-		maxh += 30
+	// 	// add padding between charts
+	// 	maxw += 30
+	// 	maxh += 30
 
-		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+	// 	const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-		const svgSel = select(svg)
-			.style('display', 'block')
-			.style('opacity', 1)
-			.attr('width', numChartsPerRow * maxw)
-			.attr('height', Math.floor(mainGs.length / numChartsPerRow) * maxh)
+	// 	const svgSel = select(svg)
+	// 		.style('display', 'block')
+	// 		.style('opacity', 1)
+	// 		.attr('width', numChartsPerRow * maxw)
+	// 		.attr('height', Math.floor(mainGs.length / numChartsPerRow) * maxh)
 
-		const svgStyles = window.getComputedStyle(document.querySelector('.pp-bars-svg'))
-		for (const prop of svgStyles) {
-			if (prop.startsWith('font')) svgSel.style(prop, svgStyles.getPropertyValue(prop))
-		}
+	// 	const svgStyles = window.getComputedStyle(document.querySelector('.pp-bars-svg'))
+	// 	for (const prop of svgStyles) {
+	// 		if (prop.startsWith('font')) svgSel.style(prop, svgStyles.getPropertyValue(prop))
+	// 	}
 
-		mainGs.forEach((g, i) => {
-			const mainG = g.cloneNode(true)
-			const colNum = i % numChartsPerRow
-			const rowNum = Math.floor(i / numChartsPerRow)
-			const corner = { x: colNum * maxw + translate.x, y: rowNum * maxh + translate.y }
-			const title = select(svg)
-				.append('text')
-				.attr('transform', 'translate(' + corner.x + ',' + corner.y + ')')
-				.text(titles[i].text)
-			for (const prop of titles[i].styles) {
-				if (prop.startsWith('font')) title.style(prop, titles[i].styles.getPropertyValue(prop))
-			}
+	// 	mainGs.forEach((g, i) => {
+	// 		const mainG = g.cloneNode(true)
+	// 		const colNum = i % numChartsPerRow
+	// 		const rowNum = Math.floor(i / numChartsPerRow)
+	// 		const corner = { x: colNum * maxw + translate.x, y: rowNum * maxh + translate.y }
+	// 		const title = select(svg)
+	// 			.append('text')
+	// 			.attr('transform', 'translate(' + corner.x + ',' + corner.y + ')')
+	// 			.text(titles[i].text)
+	// 		for (const prop of titles[i].styles) {
+	// 			if (prop.startsWith('font')) title.style(prop, titles[i].styles.getPropertyValue(prop))
+	// 		}
 
-			select(mainG).attr('transform', 'translate(' + corner.x + ',' + (corner.y + tboxh) + ')')
-			svg.appendChild(mainG)
-		})
+	// 		select(mainG).attr('transform', 'translate(' + corner.x + ',' + (corner.y + tboxh) + ')')
+	// 		svg.appendChild(mainG)
+	// 	})
 
-		// svg + legend must be attached to DOM in order for getBBox() to work within svgLegendRenderer
-		const hiddenDiv = select('body').append('div').style('opacity', 0)
-		hiddenDiv.node().appendChild(svg)
+	// 	// svg + legend must be attached to DOM in order for getBBox() to work within svgLegendRenderer
+	// 	const hiddenDiv = select('body').append('div').style('opacity', 0)
+	// 	hiddenDiv.node().appendChild(svg)
 
-		self.svgLegendRenderer = svgLegend({
-			holder: svgSel.append('g'),
-			rectFillFxn: d => d.color,
-			iconStroke: '#aaa'
-		})
+	// 	self.svgLegendRenderer = svgLegend({
+	// 		holder: svgSel.append('g'),
+	// 		rectFillFxn: d => d.color,
+	// 		iconStroke: '#aaa'
+	// 	})
 
-		const s = self.settings
-		const svg0 = self.dom.barDiv.select('svg').node().getBoundingClientRect()
-		let data = self.getLegendGrps()
-		data.forEach(d => {
-			d.name = d.name.replace(/<[^>]*>?/gm, '')
-			if (d.items) d.items = d.items.filter(c => !c.isHidden)
-		})
-		data = data.filter(d => d.items.length && !d.name.includes('tatistic'))
-		const fontsize = 14
-		self.svgLegendRenderer(data, {
-			settings: Object.assign(
-				{
-					ontop: false,
-					lineh: 25,
-					padx: 5,
-					padleft: 0, //150,
-					padright: 20,
-					padbtm: 30,
-					fontsize,
-					iconh: fontsize - 2,
-					iconw: fontsize - 2,
-					hangleft: 1,
-					linesep: false
-				},
-				{
-					svgw: self.visibleCharts.length * svg0.width,
-					svgh: svg0.height,
-					dimensions: {
-						xOffset: 50
-					},
-					padleft: 50
-				}
-			)
-		})
+	// 	const s = self.settings
+	// 	const svg0 = self.dom.barDiv.select('svg').node().getBoundingClientRect()
+	// 	let data = self.getLegendGrps()
+	// 	data.forEach(d => {
+	// 		d.name = d.name.replace(/<[^>]*>?/gm, '')
+	// 		if (d.items) d.items = d.items.filter(c => !c.isHidden)
+	// 	})
+	// 	data = data.filter(d => d.items.length && !d.name.includes('tatistic'))
+	// 	const fontsize = 14
+	// 	self.svgLegendRenderer(data, {
+	// 		settings: Object.assign(
+	// 			{
+	// 				ontop: false,
+	// 				lineh: 25,
+	// 				padx: 5,
+	// 				padleft: 0, //150,
+	// 				padright: 20,
+	// 				padbtm: 30,
+	// 				fontsize,
+	// 				iconh: fontsize - 2,
+	// 				iconw: fontsize - 2,
+	// 				hangleft: 1,
+	// 				linesep: false
+	// 			},
+	// 			{
+	// 				svgw: self.visibleCharts.length * svg0.width,
+	// 				svgh: svg0.height,
+	// 				dimensions: {
+	// 					xOffset: 50
+	// 				},
+	// 				padleft: 50
+	// 			}
+	// 		)
+	// 	})
 
-		const box = self.dom.legendDiv.node().getBoundingClientRect()
-		select(svg).attr('height', svg0.height + box.height + 30)
-		if (box.width > svg0.width) select(svg).attr('width', box.width)
-		hiddenDiv.remove()
+	// 	const box = self.dom.legendDiv.node().getBoundingClientRect()
+	// 	select(svg).attr('height', svg0.height + box.height + 30)
+	// 	if (box.width > svg0.width) select(svg).attr('width', box.width)
+	// 	hiddenDiv.remove()
 
-		const svg_name = self.config.term.term.name + ' barchart'
-		to_svg(svg, svg_name, { apply_dom_styles: true })
-	}
+	// 	const svg_name = self.config.term.term.name + ' barchart'
+	// 	to_svg(svg, svg_name, { apply_dom_styles: true })
+	// }
 }
 
 export function getDefaultBarSettings(app) {

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -1125,12 +1125,13 @@ function setInteractivity(self) {
 
 	self.download = function (event) {
 		const name2svg = self.getName2Svg()
-		const dm = new DownloadMenu(name2svg, self.opts.holder.node())
+		const node = self.dom.barDiv.select('.sjpcb-bars-mainG').node() //node to read the style
+
+		const dm = new DownloadMenu(name2svg, node, self.config.term.term.name)
 		dm.show(event.clientX, event.clientY)
 	}
 
-	/** TODO:  Move this function to the downloadMenu component and adapt it to create a single svg from the dictionary name2svg.
-	 * this function will be used from the download menu when the corresponding option is selected
+	/** Downloads all charts as a single svg image, now done from the downloadMenu
 	 */
 	self.download2 = function () {
 		if (!self.state) return

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -23,7 +23,7 @@ export class Barchart {
 	//freeze the api of this class. don't want embedder functions to modify it.
 	preApiFreeze(api) {
 		api.download = this.download
-		api.getName2Svg = () => this.getName2Svg()
+		api.getChartDict = () => this.getChartDict()
 	}
 
 	async init(appState) {
@@ -1113,21 +1113,20 @@ function setRenderers(self) {
 function setInteractivity(self) {
 	self.handlers = getHandlers(self)
 
-	self.getName2Svg = function () {
+	self.getChartDict = function () {
 		const name2svg = {}
+		const node = self.dom.barDiv.select('.sjpcb-bars-mainG').node() //node to read the style
 
 		for (const chart of self.charts) {
 			const name = `${this.config.term.term.name}  ${chart.name ? chart.name : ''}`
-			name2svg[name] = chart.svg
+			name2svg[name] = { svg: chart.svg, parent: node }
 		}
 		return name2svg
 	}
 
 	self.download = function (event) {
-		const name2svg = self.getName2Svg()
-		const node = self.dom.barDiv.select('.sjpcb-bars-mainG').node() //node to read the style
-
-		const dm = new DownloadMenu(name2svg, node, self.config.term.term.name)
+		const name2svg = self.getChartDict()
+		const dm = new DownloadMenu(name2svg, self.config.term.term.name)
 		dm.show(event.clientX, event.clientY)
 	}
 

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -23,6 +23,7 @@ export class Barchart {
 	//freeze the api of this class. don't want embedder functions to modify it.
 	preApiFreeze(api) {
 		api.download = this.download
+		api.getName2Svg = () => this.getName2Svg()
 	}
 
 	async init(appState) {
@@ -1129,7 +1130,7 @@ function setInteractivity(self) {
 	}
 
 	/** TODO:  Move this function to the downloadMenu component and adapt it to create a single svg from the dictionary name2svg.
-	 * this function will be used from the download menu when selection option to create a single svg from multiple svgs
+	 * this function will be used from the download menu when the corresponding option is selected
 	 */
 	self.download2 = function () {
 		if (!self.state) return

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -143,13 +143,22 @@ export class Report extends RxComponentInner {
 		for (const section of this.config.sections) {
 			for (const plotConfig of section.plots) {
 				const plot = this.components.plots[plotConfig.id]
-				console.log(plot)
-				if (plot?.getName2Svg) {
-					const name2svg = plot.getName2Svg()
+				if (plot?.getChartDict) {
+					const name2svg = plot.getChartDict()
 					const entries: any[] = Object.entries(name2svg)
 
-					for (const [name, svgObj] of entries) {
-						const svg = svgObj.node()
+					for (const [name, chart] of entries) {
+						const parent = chart.parent
+						const svg = chart.svg.node().cloneNode(true)
+						if (parent) {
+							const svgStyles = window.getComputedStyle(parent)
+							for (const [prop, value] of Object.entries(svgStyles)) {
+								if (prop.startsWith('font')) {
+									svg.style[prop] = value
+								}
+							}
+						}
+						chart.parent.appendChild(svg) //Added otherwise does not print, will remove later
 						const rect = svg.getBoundingClientRect()
 						svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
 						const width = Math.min(pageWidth, rect.width * ratio) - 20
@@ -169,6 +178,7 @@ export class Report extends RxComponentInner {
 						y += 20
 						await doc.svg(svg, { x, y, width, height })
 						y = y + height + 30
+						chart.parent.removeChild(svg)
 					}
 				}
 			}

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -159,10 +159,11 @@ export class Report extends RxComponentInner {
 							}
 						}
 						chart.parent.appendChild(svg) //Added otherwise does not print, will remove later
-						const rect = svg.getBoundingClientRect()
-						svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`)
-						const width = Math.min(pageWidth, rect.width * ratio) - 20
-						const height = Math.min(pageHeight, rect.height * ratio) - 20
+						let width = svg.getAttribute('width')
+						let height = svg.getAttribute('height')
+						svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+						width = Math.min(pageWidth, width * ratio) - 20
+						height = Math.min(pageHeight, height * ratio) - 20
 						if (y + height > pageHeight - 20) {
 							doc.addPage()
 							y = 40
@@ -177,7 +178,7 @@ export class Report extends RxComponentInner {
 						doc.text(name, x, y)
 						y += 20
 						await doc.svg(svg, { x, y, width, height })
-						y = y + height + 30
+						y = y + height + 40
 						chart.parent.removeChild(svg)
 					}
 				}

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -140,6 +140,7 @@ export class Report extends RxComponentInner {
 		doc.setFontSize(12)
 		doc.text(this.config.sections[0].name, x, y)
 		doc.setFontSize(10)
+		let lastSection
 		for (const section of this.config.sections) {
 			for (const plotConfig of section.plots) {
 				const plot = this.components.plots[plotConfig.id]
@@ -168,21 +169,24 @@ export class Report extends RxComponentInner {
 							doc.addPage()
 							y = 40
 						}
-						if (y == 40) {
+						if (y == 40 || section.name !== lastSection) {
 							//new page, add section
 							doc.setFontSize(12)
-							doc.text(section.name, x, 40)
+							doc.text(section.name, x, y)
 							doc.setFontSize(10)
 							y += 30
 						}
-						doc.text(name, x, y)
-						y += 20
+						if (name.trim()) {
+							doc.text(name, x, y)
+							y += 20
+						}
 						await doc.svg(svg, { x, y, width, height })
 						y = y + height + 40
 						chart.parent.removeChild(svg)
 					}
 				}
 			}
+			lastSection = section.name
 		}
 		if (y == 40) doc.deletePage(doc.internal.getNumberOfPages()) //delete last page if nothing added
 		doc.save('report.pdf')

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -130,7 +130,7 @@ export class Report extends RxComponentInner {
 		Therefore, a simple import 'svg2pdf.js' without curly braces is all that is needed to apply its functionality. 
 		*/
 		await import('svg2pdf.js') // This import extends jsPDF with SVG functionality
-		const doc = new jsPDF('p', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
+		const doc: any = new jsPDF('p', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
 		const pageWidth = doc.internal.pageSize.getWidth() - 10
 		const pageHeight = doc.internal.pageSize.getHeight() - 10
 		const ratio = 72 / 96 //convert pixels to pt

--- a/client/plots/report/view/reportView.ts
+++ b/client/plots/report/view/reportView.ts
@@ -1,5 +1,6 @@
-import { select } from 'd3-selection'
 import type { Report } from '../report.ts'
+import { icons as icon_functions } from '#dom/control.icons'
+import { CategoryFiltersUI } from '#dom/categoryFiltersUI'
 
 export class ReportView {
 	opts: any
@@ -19,7 +20,21 @@ export class ReportView {
 			.style('display', 'inline-block')
 			.style('vertical-align', 'top')
 			.style('padding', '20px')
-		const headerDiv = mainDiv.append('div')
+		const headerDiv = mainDiv.append('div').style('padding', '10px')
+		this.report.selectFilters = new CategoryFiltersUI(headerDiv, this.report, this.report.config)
+
+		const downloadDiv = headerDiv
+			.append('div')
+			.style('display', 'inline-block')
+			.style('padding-left', '10px')
+			.style('vertical-align', 'middle')
+		icon_functions['pdf'](downloadDiv, {
+			handler: () => this.report.downloadReport(),
+			title: 'Download the report',
+			width: 20,
+			height: 20
+		})
+
 		const plotsDiv = mainDiv.append('div')
 
 		this.dom = {
@@ -33,8 +48,6 @@ export class ReportView {
 		if (this.dom.header) {
 			this.dom.header.html(this.report.config.name || 'Summary Report')
 		}
-		document.addEventListener('scroll', () => this?.dom?.tooltip?.hide())
-		select('.sjpp-output-sandbox-content').on('scroll', () => this.dom.tooltip.hide())
 	}
 
 	getControlInputs() {

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -150,23 +150,23 @@ export class Scatter extends RxComponentInner {
 			const url = this.vm.canvas.toDataURL('image/png')
 			downloadImage(url)
 		} else {
-			const name2svg = this.getName2Svg()
-			const menu = new DownloadMenu(name2svg, this.opts.holder.node())
+			const name2svg = this.getChartDict()
+			const menu = new DownloadMenu(name2svg, 'scatter')
 			menu.show(event.clientX, event.clientY)
 		}
 	}
 
-	getName2Svg() {
+	getChartDict() {
 		const name2svg = {}
 		for (const chart of this.model.charts) {
 			const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
-			name2svg[name] = chart.svg
+			name2svg[name] = { svg: chart.svg, parent: chart.svg.node() }
 		}
 		return name2svg
 	}
 
 	preApiFreeze(api) {
-		api.getName2Svg = () => this.getName2Svg()
+		api.getChartDict = () => this.getChartDict()
 	}
 }
 

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -164,6 +164,10 @@ export class Scatter extends RxComponentInner {
 		}
 		return name2svg
 	}
+
+	preApiFreeze(api) {
+		api.getName2Svg = () => this.getName2Svg()
+	}
 }
 
 export async function getPlotConfig(opts, app) {

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -1046,15 +1046,15 @@ function setInteractivity(self) {
 		return name2svg
 	}
 
-	// The logic is moved to the downloadMenu
-	self.download2 = function () {
-		if (!self.state) return
-		downloadChart(
-			self.dom.chartsDiv.selectAll('.sjpp-survival-mainG'),
-			'Survival_Plot',
-			self.dom.chartsDiv.select('.pp-survival-chart').node()
-		)
-	}
+	// The logic is replaced by the downloadMenu SVG option
+	// self.download = function () {
+	// 	if (!self.state) return
+	// 	downloadChart(
+	// 		self.dom.chartsDiv.selectAll('.sjpp-survival-mainG'),
+	// 		'Survival_Plot',
+	// 		self.dom.chartsDiv.select('.pp-survival-chart').node()
+	// 	)
+	// }
 
 	self.mouseover = function () {}
 

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -55,7 +55,7 @@ class TdbSurvival extends PlotBase implements RxComponentInner {
 	hiddenRenderer: any
 	legendClick = (_, __, ___) => {}
 	download: () => void = () => {}
-	getName2Svg = () => this.getName2Svg()
+	getChartDict = () => this.getChartDict()
 	loadingWait = 0
 
 	colorScale: any
@@ -158,7 +158,7 @@ class TdbSurvival extends PlotBase implements RxComponentInner {
 
 	preApiFreeze(api) {
 		api.download = this.download
-		api.getName2Svg = () => this.getName2Svg()
+		api.getChartDict = () => this.getChartDict()
 	}
 
 	async setControls() {
@@ -1031,16 +1031,17 @@ function setRenderers(self) {
 
 function setInteractivity(self) {
 	self.download = function (event) {
-		const name2svg = self.getName2Svg()
-		const node = self.dom.chartsDiv.select('.sjpp-survival-mainG').node() //node to read the style
-		const menu = new DownloadMenu(name2svg, node, self.state.config.term.term.name)
+		const name2svg = self.getChartDict()
+		const menu = new DownloadMenu(name2svg, self.state.config.term.term.name)
 		menu.show(event.clientX, event.clientY)
 	}
 
-	self.getName2Svg = function () {
+	self.getChartDict = function () {
 		const name2svg = {}
+		const node = self.dom.chartsDiv.select('.sjpp-survival-mainG').node() //node to read the style
+
 		for (const chart of self.pj.tree.charts) {
-			name2svg[chart.chartId] = chart.svg
+			name2svg[chart.chartId] = { svg: chart.svg, parent: node }
 		}
 		return name2svg
 	}

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -55,6 +55,7 @@ class TdbSurvival extends PlotBase implements RxComponentInner {
 	hiddenRenderer: any
 	legendClick = (_, __, ___) => {}
 	download: () => void = () => {}
+	getName2Svg = () => this.getName2Svg()
 	loadingWait = 0
 
 	colorScale: any
@@ -558,7 +559,6 @@ export const componentInit = survivalInit
 function setRenderers(self) {
 	self.render = function () {
 		const data = self.pj.tree.charts || [{ chartId: 'No survival data' }]
-		console.log(data)
 		const chartDivs = self.dom.chartsDiv.selectAll('.pp-survival-chart').data(data, d => d.chartId)
 		chartDivs.exit().remove()
 		chartDivs.each(self.updateCharts)
@@ -730,7 +730,7 @@ function setRenderers(self) {
 		/* eslint-disable */
 		const [mainG, seriesesG, axisG, xAxis, yAxis, xTitle, yTitle, atRiskG, plotRect] = getSvgSubElems(svg)
 		/* eslint-enable */
-		const xOffset = chart.atRiskLabelWidth + s.svgPadding.left + 40 //adding 40 avoids clipping of the svg
+		const xOffset = chart.atRiskLabelWidth + s.svgPadding.left + 70 //adding 70 avoids clipping of the svg when downloading
 		mainG.attr('transform', 'translate(' + xOffset + ',' + s.svgPadding.top + ')')
 
 		const serieses = seriesesG
@@ -1032,7 +1032,8 @@ function setRenderers(self) {
 function setInteractivity(self) {
 	self.download = function (event) {
 		const name2svg = self.getName2Svg()
-		const menu = new DownloadMenu(name2svg, self.opts.holder.node())
+		const node = self.dom.chartsDiv.select('.sjpp-survival-mainG').node() //node to read the style
+		const menu = new DownloadMenu(name2svg, node, self.state.config.term.term.name)
 		menu.show(event.clientX, event.clientY)
 	}
 
@@ -1044,7 +1045,7 @@ function setInteractivity(self) {
 		return name2svg
 	}
 
-	// The logic in downloadChart will be moved to the downloadMenu option to save all charts in an svg
+	// The logic is moved to the downloadMenu
 	self.download2 = function () {
 		if (!self.state) return
 		downloadChart(

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Features
+- Generate report pdf
+- Allow different download options in the plots. Supported in the scatter, runchart, frequencyChart, barchart and survival plots.


### PR DESCRIPTION
# Description

In this PR I integrated the download menu into the survival plot, and also used flex to display multiple survival plots. I added the option to download a single svg with all the charts embedded. I applied the styles in the svg/pdf generated and I supported to generate a pdf for the report. I also added some misc fixes in the download methods supported. 
Some details need to be addressed, like the wrong char encoding for pdf barcharts showing numeric terms, or embedding the barchart legend int he svg, I plan to look into it in a next PR, as I would like to show the sjcares report today in our meeting.

Please check

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
