### PR TITLE
Added validation when processing custom bins

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -335,6 +335,7 @@ export class Barchart {
 		if (c.chartType != this.type && c.childType != this.type) return
 		try {
 			this.config = structuredClone(c)
+			console.log(this.config)
 			if (!this.currServerData) this.dom.barDiv.style('max-width', window.innerWidth + 'px')
 			this.prevConfig = this.config || {}
 			if (this.dom.header)

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -335,7 +335,6 @@ export class Barchart {
 		if (c.chartType != this.type && c.childType != this.type) return
 		try {
 			this.config = structuredClone(c)
-			console.log(this.config)
 			if (!this.currServerData) this.dom.barDiv.style('max-width', window.innerWidth + 'px')
 			this.prevConfig = this.config || {}
 			if (this.dom.header)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -469,7 +469,10 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, only
 			//if ('id' in tw.term) twBy$id[$id] = tw
 			return CTE
 		})
-	).catch(console.error)
+	).catch(err => {
+		console.error(err)
+		throw err
+	})
 
 	// for "samplelst" term, term.id is missing and must use term.name
 	values.push(...termWrappers.map(tw => tw.$id || tw.term.id || tw.term.name))

--- a/shared/utils/src/termdb.bins.js
+++ b/shared/utils/src/termdb.bins.js
@@ -53,6 +53,9 @@ export default function validate_bins(binconfig) {
 					throw 'a custom last bin must not set a bin.stop value'
 				}
 			} else {
+				if (bin.startunbounded || bin.stopunbounded) {
+					throw 'bin.startunbounded and bin.stopunbounded must not be set for non-first/non-last bins'
+				}
 				if (!isStrictNumeric(bin.start)) throw 'bin.start must be numeric for a non-first bin'
 				if (!isStrictNumeric(bin.stop)) throw 'bin.stop must be numeric for a non-last bin'
 			}


### PR DESCRIPTION
# Description
Added validation when processing custom bins, it should not set to true startunbounded or stopunbounded on intermediate bins.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
