### PR TITLE
Improved q types

### DIFF
--- a/client/termsetting/handlers/numeric.binary.ts
+++ b/client/termsetting/handlers/numeric.binary.ts
@@ -4,7 +4,7 @@ import { get_bin_label, get_bin_range_equation } from '#shared/termdb.bins.js'
 import { make_one_checkbox, violinRenderer } from '#dom'
 import { getPillNameDefault } from '../termsetting'
 import { convertViolinData } from '#filter/tvs.numeric'
-import type { PillData, RangeEntry } from '#types'
+import type { PillData, NumericBin } from '#types'
 
 /*
 ********************** EXPORTED
@@ -265,27 +265,26 @@ function processCustomBinInputs(self) {
 	const val = self.q.lst![0].stop // should not get value from dom.customBinBoundaryInput as value can be percentile
 	if (!val && val !== 0) throw 'val is undefined'
 
-	const bins = [
+	const bins: NumericBin[] = [
 		{
 			startunbounded: true,
 			stop: Number(val),
-			startinclusive,
+			startinclusive: false,
 			stopinclusive
 		},
 		{
 			start: Number(val),
 			startinclusive,
-			stopinclusive,
+			stopinclusive: false,
 			stopunbounded: true
 		}
 	]
 
-	// assign bin labels
-	bins.forEach((bin: RangeEntry, i: number) => {
+	for (const [i, bin] of bins.entries()) {
 		// may use user assigned labels if not empty string
 		const label = inputDivs[i].value
 		bin.label = label ? label : get_bin_label(bin, self.q)
-	})
+	}
 
 	return bins
 }

--- a/shared/types/src/terms/categorical.ts
+++ b/shared/types/src/terms/categorical.ts
@@ -7,7 +7,7 @@ import type {
 	BaseTW,
 	PredefinedGroupSettingQ,
 	CustomGroupSettingQ
-} from './term.ts'
+} from '../index.ts'
 import type { RawValuesQ, RawPredefinedGroupsetQ, RawCustomGroupsetQ, MinBaseQ } from './q.ts'
 import type { TermSettingInstance } from '../termsetting.ts'
 
@@ -89,8 +89,9 @@ export type CatTWCustomGS = BaseTW & {
 
 export type CatTWTypes = CatTWValues | CatTWPredefinedGS | CatTWCustomGS
 
+// TODO: should not need this once TermSettingInstance is replaced with simply using the class as the type
 export type CategoricalTermSettingInstance = TermSettingInstance & {
-	q: CategoricalQ
+	q: CategoricalQ & { mode: 'binary' | 'discrete' }
 	term: CategoricalTerm
 	category2samplecount: any
 	validateGroupsetting: () => { text: string; bgcolor?: string }

--- a/shared/types/src/terms/condition.ts
+++ b/shared/types/src/terms/condition.ts
@@ -5,15 +5,11 @@ import type { BaseTerm, MinBaseQ, TermValues, BaseTW } from '../index.ts'
  * @category TW
  */
 
-// TODO: should implement the expected property combinations as distinct types
-export type ConditionQ = MinBaseQ & {
+export type ConditionGradeQ = MinBaseQ & {
 	mode: 'discrete' | 'binary' | 'cuminc' | 'cox'
-	type?: 'values'
-	bar_by_children?: boolean // 'true' if term is not a leaf and has subconditions
-	bar_by_grade?: boolean /* 'true' for barchart. Always 'true' for cuminc and logistic/cox outcome (children terms are not allowed for those cases)
-	when 'true', 'value_by_*' flags are effective.*/
-	breaks?: number[] /*
-	Breaks grades into groups
+	bar_by_grade: true
+	/**
+		Breaks grades into groups
 		Array length=1, will break grades to 2 groups. 
 			E.g. [3] divides to [-1,0,1,2,], [3,4,5]
 			Allowed for both conditionModes "discrete/binary"
@@ -23,11 +19,21 @@ export type ConditionQ = MinBaseQ & {
 			Only allowed for conditionMode="discrete" but not "binary"
 	*/
 	timeScale: 'age' | 'time'
+	breaks?: number[]
 	value_by_max_grade?: boolean //'false' if bar_by_children is 'true'
 	value_by_most_recent?: boolean //'false' if bar_by_children is 'true'
 	value_by_computable_grade?: boolean //'true' if bar_by_children is 'true'
 	groups?: any // TODO: should use a defined type
 }
+
+export type ConditionChildrenQ = MinBaseQ & {
+	mode: 'discrete'
+	bar_by_children: true
+	groups?: any // TODO: should use a defined type
+}
+
+// TODO: should implement the expected property combinations as distinct types
+export type ConditionQ = ConditionGradeQ | ConditionChildrenQ
 
 export type ConditionTerm = BaseTerm & {
 	type: 'condition'

--- a/shared/types/src/terms/condition.ts
+++ b/shared/types/src/terms/condition.ts
@@ -7,6 +7,7 @@ import type { BaseTerm, MinBaseQ, TermValues, BaseTW } from '../index.ts'
 
 export type ConditionGradeQ = MinBaseQ & {
 	mode: 'discrete' | 'binary' | 'cuminc' | 'cox'
+	valueFor: 'grade'
 	bar_by_grade: true
 	/**
 		Breaks grades into groups
@@ -28,6 +29,7 @@ export type ConditionGradeQ = MinBaseQ & {
 
 export type ConditionChildrenQ = MinBaseQ & {
 	mode: 'discrete'
+	valueFor: 'children'
 	bar_by_children: true
 	groups?: any // TODO: should use a defined type
 }
@@ -61,3 +63,11 @@ export type ConditionTermSettingInstance = TermSettingInstance & {
 	refGrp: any
 }
 */
+
+export type RawConditionTW = ConditionTW & {
+	q: {
+		valueFor?: 'grade' | 'children'
+		bar_by_children?: true
+		bar_by_grade?: true
+	}
+}

--- a/shared/types/src/terms/condition.ts
+++ b/shared/types/src/terms/condition.ts
@@ -1,11 +1,12 @@
-import type { BaseTerm, BaseQ, TermValues, BaseTW } from './term.ts'
+import type { BaseTerm, MinBaseQ, TermValues, BaseTW } from '../index.ts'
 //import type { TermWrapper } from './tw.ts'
 
 /**
  * @category TW
  */
 
-export type ConditionQ = BaseQ & {
+// TODO: should implement the expected property combinations as distinct types
+export type ConditionQ = MinBaseQ & {
 	mode: 'discrete' | 'binary' | 'cuminc' | 'cox'
 	type?: 'values'
 	bar_by_children?: boolean // 'true' if term is not a leaf and has subconditions

--- a/shared/types/src/terms/numeric.ts
+++ b/shared/types/src/terms/numeric.ts
@@ -63,6 +63,7 @@ export type StartUnboundedBin = {
 	stopinclusive?: boolean
 	stopunbounded?: false
 	label?: string
+	range?: string // alternative bin label
 }
 
 export type StopUnboundedBin = {
@@ -72,6 +73,7 @@ export type StopUnboundedBin = {
 	startunbounded?: false
 	stopinclusive?: false // cannot include an infinite bound
 	label?: string
+	range?: string // alternative bin label
 }
 
 // TODO??? should separate a fully bounded bin by startinclusive, stopinclusive
@@ -84,9 +86,12 @@ export type FullyBoundedBin = {
 	stopinclusive?: boolean
 	stopunbounded?: false
 	label?: string
+	range?: string // alternative bin label
 }
 
 export type NumericBin = StartUnboundedBin | FullyBoundedBin | StopUnboundedBin
+
+export type RangeEntry = NumericBin | { value: number; label: string }
 
 export type RegularNumericBinConfig = MinBaseQ & {
 	type: 'regular-bin' // another concrete value being assigned, instead of `string`

--- a/shared/types/src/terms/q.ts
+++ b/shared/types/src/terms/q.ts
@@ -1,4 +1,5 @@
-import type { HiddenValues, GroupSettingQ, GroupEntry } from './term.ts'
+import type { CategoricalBaseQ } from './categorical.js'
+import type { Filter } from '../filter.js'
 
 // MinBaseQ is BaseQ without .mode and .type
 // MinBaseQ should eventually replace BaseQ because .mode and .type
@@ -35,4 +36,62 @@ export type RawCustomGroupsetQ = MinBaseQ & {
 	}
 	/** deprecated nested object, will be handled by reshapeLegacyTW() in TwRouter */
 	groupsetting?: { inuse?: boolean } & GroupSettingQ
+}
+
+export type HiddenValues = {
+	[index: string]: number
+}
+
+/*** types supporting termwrapper q ***/
+
+export type ValuesQ = CategoricalBaseQ & {
+	type: 'values'
+}
+
+export type PredefinedGroupSettingQ = CategoricalBaseQ & {
+	type: 'predefined-groupset'
+	predefined_groupset_idx: number
+}
+
+export type CustomGroupSettingQ = CategoricalBaseQ & {
+	type: 'custom-groupset'
+	customset: BaseGroupSet
+}
+
+export type FilterQ = MinBaseQ & {
+	type: 'filter'
+}
+
+export type GroupSettingQ = ValuesQ | FilterQ | PredefinedGroupSettingQ | CustomGroupSettingQ
+
+export type ValuesGroup = {
+	name: string
+	type: 'values' | string // can remove boolean fallback once problematic js files are converted to .ts and can declare `type: 'values' as const`
+	values: { key: number | string; label: string }[]
+	uncomputable?: boolean // if true, do not include this group in computations
+}
+
+export type FilterGroup = {
+	name: string
+	type: 'filter'
+	filter: Filter
+	color: string
+}
+
+export type GroupEntry = ValuesGroup | FilterGroup
+
+export type BaseGroupSet = {
+	groups: GroupEntry[]
+}
+
+type Groupset = {
+	name: string
+	is_grade?: boolean
+	is_subcondition?: boolean
+	dt?: number // dt of groupset, used by geneVariant term
+} & BaseGroupSet
+
+export type TermGroupSetting = {
+	disabled: boolean // true when term has <= 2 values, otherwise false
+	lst?: Groupset[] // array of predefined groupsets
 }

--- a/shared/types/src/terms/samplelst.ts
+++ b/shared/types/src/terms/samplelst.ts
@@ -1,4 +1,4 @@
-import type { BaseTerm, BaseQ } from './term.ts'
+import type { BaseTerm, MinBaseQ } from '../index.ts'
 import type { TermWrapper } from './tw.ts'
 import type { TermSettingInstance } from '../termsetting.ts'
 
@@ -21,7 +21,7 @@ export type SampleLstTermValues = {
 	}
 }
 
-export type SampleLstQ = BaseQ & {
+export type SampleLstQ = MinBaseQ & {
 	groups: SampleLstTermValues
 }
 

--- a/shared/types/src/terms/singleCellCellType.ts
+++ b/shared/types/src/terms/singleCellCellType.ts
@@ -1,4 +1,4 @@
-import type { BaseTerm, BaseTW, GroupSettingQ, TermGroupSetting, TermValues } from './term.ts'
+import type { BaseTerm, BaseTW, GroupSettingQ, TermGroupSetting, TermValues } from '../index.ts'
 import type { MinBaseQ } from './q.ts'
 
 type SingleCellCellTypeBaseQ = MinBaseQ & { mode: 'discrete' | 'binary' }

--- a/shared/types/src/terms/snp.ts
+++ b/shared/types/src/terms/snp.ts
@@ -1,11 +1,11 @@
-import type { BaseTW, BaseQ, BaseTerm, GroupSettingQ, TermGroupSetting } from './term.ts'
+import type { BaseTW, MinBaseQ, BaseTerm, GroupSettingQ, TermGroupSetting } from '../index.ts'
 import type { TermSettingInstance } from '../termsetting.ts'
 
 /*
 For term type 'snp'
 */
 
-export type SnpQ = BaseQ & GroupSettingQ
+export type SnpQ = MinBaseQ & GroupSettingQ
 
 export type SnpTerm = BaseTerm & {
 	chr: string

--- a/shared/types/src/terms/snps.ts
+++ b/shared/types/src/terms/snps.ts
@@ -1,4 +1,4 @@
-import type { BaseTW, BaseQ, BaseTerm } from './term.ts'
+import type { BaseTW, MinBaseQ, BaseTerm } from '../index.ts'
 import type { TermSettingInstance, InstanceDom, UseCase } from '../termsetting.ts'
 import type { VocabApi } from '../vocab.ts'
 import type { Tvs, Filter } from '../filter.ts'
@@ -19,7 +19,7 @@ type RestrictAncestry = {
 	tvs: Tvs
 }
 
-export type SnpsQ = BaseQ & {
+export type SnpsQ = MinBaseQ & {
 	// termType: 'snplocus' | 'snplst'
 	//for snplst and snplocus term types
 	AFcutoff: number

--- a/shared/types/src/terms/term.ts
+++ b/shared/types/src/terms/term.ts
@@ -44,42 +44,10 @@ export type BaseTerm = {
 // NumericTerm includes integer, float, date, geneExpression, metaboliteIntensity, and other non-dict terms
 export type Term = BaseTerm & (NumericTerm | CategoricalTerm | ConditionTerm | SampleLstTerm | SnpsTerm | GvTerm)
 
-/*** types supporting termwrapper ***/
-
-export type BaseTW = {
-	id?: string
-	$id?: string
-	isAtomic?: true
-	// plot-specific customizations that are applied to a tw copy
-	// todo: should rethink these
-	legend?: any
-	settings?: {
-		[key: string]: any
-	}
-	sortSamples?: any
-	minNumSamples?: number
-	valueFilter?: any
-}
-
 /*** types supporting Term types ***/
 
 export type Subconditions = {
 	[index: string | number]: {
 		label: string
 	}
-}
-
-/*** other types ***/
-
-export type RangeEntry = {
-	//Used binconfig.lst[] and in tvs.ranges[]
-	start?: number
-	startunbounded?: boolean
-	startinclusive?: boolean
-	stop?: number
-	stopunbounded?: boolean
-	stopinclusive?: boolean
-	label?: string //for binconfig.lst[]
-	value?: string //for tvs.ranges[]
-	range?: any //No idea what this is
 }

--- a/shared/types/src/terms/term.ts
+++ b/shared/types/src/terms/term.ts
@@ -1,5 +1,5 @@
 import type { Filter } from '../filter.js'
-import type { CategoricalTerm, CategoricalBaseQ } from './categorical.js'
+import type { CategoricalTerm } from './categorical.js'
 import type { ConditionTerm } from './condition.js'
 import type { NumericTerm } from './numeric.js'
 import type { GvTerm } from './geneVariant.js'
@@ -10,75 +10,6 @@ import type { SnpsTerm } from './snps.js'
  * @param id      term.id for dictionary terms, undefined for non-dictionary terms
  * @params $id    client-computed deterministic unique identifier, to distinguish tw with the same term but different q, that are in the same payload
  */
-
-/*** types supporting termwrapper q ***/
-
-export type HiddenValues = {
-	[index: string]: number
-}
-
-// TODO: replace BaseQ with MinBaseQ (see below)
-// keeping BaseQ for now to not break old code
-export type BaseQ = {
-	/**Automatically set by fillTermWrapper()
-	Applies to barchart, survival plot, and cuminc plot.
-	Contains categories of a term to be hidden in its chart. This should only apply to client-side rendering, and should not be part of “dataName” when requesting data from server. Server will always provide a summary for all categories. It’s up to the client to show/hide categories.
-	This allows the key visibility to be stored in state, while toggling visibility will not trigger data re-request.
-	Currently termsetting menu does not manage this attribute. It’s managed by barchart legend.
-	*/
-	hiddenValues?: HiddenValues
-	/**indicates this object should not be extended by a copy-merge tool */
-	isAtomic?: boolean
-	name?: string
-	mode?:
-		| 'discrete'
-		/** Binary is a special case of discrete. */
-		| 'binary'
-		| 'continuous'
-		/** Only for numeric terms in regression analysis. Requires q.knots */
-		| 'spline'
-		/** Only applies to condition term. Requires q.breaks[] to have one grade value.*/
-		| 'cuminc'
-		/** Only applies to condition term for cox regression outcome. Requires q.breaks[] to have one grade value, for event and q.timeScale.*/
-		| 'cox'
-
-	reuseId?: string
-	/** To define ways to divide up cohort based on a term, using methods specific to term types.*/
-	type?: /** Requires term.values{} to access categories for categorical term, and grade for condition term */
-	| 'values'
-		/** Applies to numeric terms */
-		| 'regular-bin'
-		/** Applies to numeric terms */
-		| 'custom-bin'
-		/** Applies to categorical, condition, geneVariant, and singleCellCellType terms */
-		| 'predefined-groupset'
-		/** Applies to categorical, condition, geneVariant, and singleCellCellType terms */
-		| 'custom-groupset'
-		/** Applies to samplelst terms */
-		| 'custom-samplelst'
-		/** Applies to geneVariant term */
-		| 'filter'
-}
-
-export type ValuesQ = CategoricalBaseQ & {
-	type: 'values'
-}
-
-export type PredefinedGroupSettingQ = CategoricalBaseQ & {
-	type: 'predefined-groupset'
-	predefined_groupset_idx: number
-}
-
-export type CustomGroupSettingQ = CategoricalBaseQ & {
-	type: 'custom-groupset'
-	customset: BaseGroupSet
-}
-
-export type FilterQ = BaseQ & {
-	type: 'filter'
-}
-
-export type GroupSettingQ = ValuesQ | FilterQ | PredefinedGroupSettingQ | CustomGroupSettingQ
 
 /*** types supporting termwrapper term ***/
 
@@ -110,39 +41,8 @@ export type BaseTerm = {
 	skipValuesBuild?: boolean
 }
 
+// NumericTerm includes integer, float, date, geneExpression, metaboliteIntensity, and other non-dict terms
 export type Term = BaseTerm & (NumericTerm | CategoricalTerm | ConditionTerm | SampleLstTerm | SnpsTerm | GvTerm)
-
-export type ValuesGroup = {
-	name: string
-	type: 'values' | string // can remove boolean fallback once problematic js files are converted to .ts and can declare `type: 'values' as const`
-	values: { key: number | string; label: string }[]
-	uncomputable?: boolean // if true, do not include this group in computations
-}
-
-export type FilterGroup = {
-	name: string
-	type: 'filter'
-	filter: Filter
-	color: string
-}
-
-export type GroupEntry = ValuesGroup | FilterGroup
-
-export type BaseGroupSet = {
-	groups: GroupEntry[]
-}
-
-type Groupset = {
-	name: string
-	is_grade?: boolean
-	is_subcondition?: boolean
-	dt?: number // dt of groupset, used by geneVariant term
-} & BaseGroupSet
-
-export type TermGroupSetting = {
-	disabled: boolean // true when term has <= 2 values, otherwise false
-	lst?: Groupset[] // array of predefined groupsets
-}
 
 /*** types supporting termwrapper ***/
 

--- a/shared/types/src/terms/tw.ts
+++ b/shared/types/src/terms/tw.ts
@@ -6,6 +6,21 @@ import type { CatTWTypes, CategoricalQ } from './categorical.ts'
 import type { NumTW, NumericQ } from './numeric.ts'
 import type { GvTW, GvQ } from './geneVariant.ts'
 
+export type BaseTW = {
+	id?: string
+	$id?: string
+	isAtomic?: true
+	// plot-specific customizations that are applied to a tw copy
+	// todo: should rethink these
+	legend?: any
+	settings?: {
+		[key: string]: any
+	}
+	sortSamples?: any
+	minNumSamples?: number
+	valueFilter?: any
+}
+
 export type TermWrapper = CatTWTypes | NumTW | GvTW | ConditionTW | SnpsTW | SnpTW
 
 export type Q = CategoricalQ | NumericQ | GvQ | ConditionQ | SnpsQ | SnpQ | SampleLstQ // | other q


### PR DESCRIPTION
# Description

Replace the looser `BaseQ` with stricter `MinBaseQ` and improve the condition q type definitions. These improvements are needed for the next step of improving termsetting/handlers.

Tested with all unit and integration tests, `npm run tsc` from `client` dir, and `npm test` from the `shared/types` dir.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
