### PR TITLE
Support divideBy term in violin and box plots

### DIFF
--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -217,7 +217,7 @@ async function fillMenu(self, div, tvs) {
 
 // convert violin data (vd) to old density data (dd)
 export function convertViolinData(vd) {
-	const p = vd.plots[0] || { plotValueCount: 0, biggestBin: 0 } // assuming only one plot
+	const p = vd.charts[''].plots[0] || { plotValueCount: 0, biggestBin: 0 } // assuming only one plot
 	const dd = {
 		minvalue: vd.min,
 		maxvalue: vd.max,

--- a/client/mass/test/violin.integration.spec.js
+++ b/client/mass/test/violin.integration.spec.js
@@ -22,6 +22,8 @@ term1=geneExp, term2=survival
 test samplelst term2
 term=agedx, term2=geneExp with regular bins
 term=agedx, term2=geneExp with custom bins
+term1=numeric, term0=categorical
+term1=numeric, term2=numeric, term0=categorical
 test uncomputable categories legend
 Load linear regression-violin UI
 test change in plot length and thickness for new custom group variable
@@ -1105,6 +1107,88 @@ tape('term=agedx, term2=geneExp with custom bins', function (test) {
 
 		if (test._ok) violin.Inner.app.destroy()
 		test.end()
+	}
+})
+
+tape('term1=numeric, term0=categorical', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary',
+					childType: 'violin',
+					term: {
+						id: 'agedx',
+						q: { mode: 'continuous' }
+					},
+					term0: {
+						id: 'sex',
+						isAtomic: true
+					}
+				}
+			]
+		},
+		violin: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+	async function runTests(violin) {
+		const violinDiv = violin.Inner.dom.violinDiv
+		await testViolin(violin, violinDiv)
+		if (test._ok) violin.Inner.app.destroy()
+		test.end()
+	}
+	async function testViolin(violin, violinDiv) {
+		const chartDivs = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-chartDiv' })
+		test.equal(chartDivs.length, 2, 'Should have 2 charts')
+		const violinPaths = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path' })
+		test.equal(violinPaths.length, 4, 'Should have 4 paths')
+	}
+})
+
+tape('term1=numeric, term2=numeric, term0=categorical', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary',
+					childType: 'violin',
+					term: {
+						id: 'agedx',
+						q: { mode: 'continuous' }
+					},
+					term2: {
+						id: 'aaclassic_5',
+						isAtomic: true
+					},
+					term0: {
+						id: 'sex',
+						isAtomic: true
+					}
+				}
+			]
+		},
+		violin: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+	async function runTests(violin) {
+		const violinDiv = violin.Inner.dom.violinDiv
+		await testViolin(violin, violinDiv)
+		if (test._ok) violin.Inner.app.destroy()
+		test.end()
+	}
+	async function testViolin(violin, violinDiv) {
+		const chartDivs = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-chartDiv' })
+		test.equal(chartDivs.length, 2, 'Should have 2 charts')
+		const violinPaths = await detectGte({ elem: violinDiv.node(), selector: '.sjpp-vp-path' })
+		test.equal(violinPaths.length, 6, 'Should have 6 paths')
 	}
 })
 

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -17,6 +17,7 @@ class TdbBoxplot extends RxComponentInner {
 	readonly type = 'boxplot'
 	components: { controls: any }
 	dom: BoxPlotDom
+	data: any
 	interactions?: BoxPlotInteractions
 	private useDefaultSettings = true
 	constructor(opts: TdbBoxPlotOpts) {
@@ -256,38 +257,17 @@ class TdbBoxplot extends RxComponentInner {
 				const chartLabels = chart.plots.filter(p => !p.isHidden).map(p => p.boxplot.label)
 				labels.push(...chartLabels)
 			}
-			const maxLabelLgth = getMaxLabelWidth(tempsvg, labels)
+			const maxLabelLgth = getMaxLabelWidth(tempsvg.append('g'), labels)
 			tempsvg.remove()
 
 			// plot charts
 			const legend: any = [] // legend items across charts
 			for (const key of Object.keys(data.charts)) {
 				const chart = data.charts[key]
-				// setup a dom{} object for the chart
-				const chartDiv = this.dom.charts
-					.append('div')
-					.attr('class', 'sjpp-boxplot-chartDiv')
-					.style('padding', Object.keys(data.charts).length > 1 ? '20px 20px 0px 0px' : '0px')
-				const chartTitle = chartDiv
-					.append('div')
-					.attr('class', 'pp-chart-title')
-					.style('display', config.term0 ? 'block' : 'none')
-					.style('text-align', 'center')
-					.style('font-size', '1.1em')
-					.style('margin-bottom', '20px')
-				const chartSvg = chartDiv.append('svg')
-				chart.svg = chartSvg
-				const chartDom = Object.assign({}, this.dom, {
-					svg: chartSvg,
-					chartTitle,
-					plotTitle: chartSvg.append('text'),
-					axis: chartSvg.append('g'),
-					boxplots: chartSvg.append('g')
-				})
-				// get view model of chart
 				chart.absMin = data.absMin
 				chart.absMax = data.absMax
 				chart.uncomputableValues = data.uncomputableValues
+				// get view model of chart
 				const viewModel = new ViewModel(config, chart, settings, maxLabelLgth, this.useDefaultSettings)
 				// collect legend items
 				for (const l of viewModel.viewData.legend) {
@@ -317,6 +297,28 @@ class TdbBoxplot extends RxComponentInner {
 					})
 				}
 				// render view of chart
+				// setup a dom{} object for the chart
+				const chartDiv = this.dom.charts
+					.append('div')
+					.attr('class', 'sjpp-boxplot-chartDiv')
+					.style('padding', Object.keys(data.charts).length > 1 ? '20px 20px 0px 0px' : '0px')
+				const chartSvg = chartDiv.append('svg')
+				chart.svg = chartSvg // for downloading svg
+				const chartTitle = chartDiv
+					.append('div')
+					.attr('class', 'pp-chart-title')
+					.style('display', config.term0 ? 'block' : 'none')
+					.style('text-align', 'center')
+					.style('font-size', '1.1em')
+					.style('margin-bottom', '20px')
+				const chartDom = Object.assign({}, this.dom, {
+					svg: chartSvg,
+					chartTitle,
+					plotTitle: chartSvg.append('text'),
+					axis: chartSvg.append('g'),
+					boxplots: chartSvg.append('g')
+				})
+				// render the view
 				new View(viewModel.viewData, settings, chartDom, this.app, this.interactions)
 			}
 			// render legend (applies to all charts)

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -6,7 +6,7 @@ import { plotColor } from '#shared/common.js'
 import { Menu, getMaxLabelWidth } from '#dom'
 import type { Elem } from '../../types/d3'
 import type { MassAppApi, MassState } from '#mass/types/mass'
-import type { TdbBoxPlotOpts, BoxPlotSettings, BoxPlotDom, BoxPlotConfig, BoxPlotConfigOpts } from './BoxPlotTypes'
+import type { TdbBoxPlotOpts, BoxPlotSettings, BoxPlotDom, BoxPlotConfigOpts } from './BoxPlotTypes'
 import { Model } from './model/Model'
 import { ViewModel } from './viewModel/ViewModel'
 import { View } from './view/View'
@@ -27,7 +27,7 @@ class TdbBoxplot extends RxComponentInner {
 		}
 		const holder = opts.holder.classed('sjpp-boxplot-main', true)
 		const controls = opts.controls ? holder : holder.append('div')
-		const div = holder.append('div').style('padding', '5px')
+		const div = holder.append('div')
 		const errorDiv = div.append('div').attr('class', 'sjpp-boxplot-error').style('opacity', 0.75)
 		const chartsDiv = div
 			.append('div')
@@ -41,7 +41,7 @@ class TdbBoxplot extends RxComponentInner {
 			div,
 			error: errorDiv,
 			charts: chartsDiv,
-			legend: div.append('div').attr('class', 'sjpp-boxplot-legend'),
+			legend: div.append('div').attr('class', 'sjpp-boxplot-legend').style('margin-top', '10px'),
 			tip: new Menu()
 		}
 		if (opts.header) this.dom.header = opts.header.html('Box plot')
@@ -90,7 +90,14 @@ class TdbBoxplot extends RxComponentInner {
 					{ label: 'Default', value: false },
 					{ label: 'Median values', value: true }
 				],
-				getDisplayStyle: (plot: BoxPlotConfig) => (plot.term2 ? '' : 'none')
+				getDisplayStyle: () => {
+					let style = 'none'
+					for (const k of Object.keys(this.data.charts)) {
+						const chart = this.data.charts[k]
+						if (chart.plots.length > 1) style = ''
+					}
+					return style
+				}
 			},
 			{
 				label: 'Scale',
@@ -159,7 +166,14 @@ class TdbBoxplot extends RxComponentInner {
 				type: 'color',
 				chartType: 'boxplot',
 				settingsKey: 'color',
-				getDisplayStyle: (plot: BoxPlotConfig) => (plot.term2 ? 'none' : '')
+				getDisplayStyle: () => {
+					let style = ''
+					for (const k of Object.keys(this.data.charts)) {
+						const chart = this.data.charts[k]
+						if (chart.plots.length > 1) style = 'none'
+					}
+					return style
+				}
 			},
 			{
 				label: 'Display mode',
@@ -205,7 +219,7 @@ class TdbBoxplot extends RxComponentInner {
 	}
 
 	async init() {
-		this.dom.div.style('display', 'inline-block').style('margin', '10px')
+		this.dom.div.style('display', 'inline-block').style('margin-left', '10px')
 		this.interactions = new BoxPlotInteractions(this.app, this.dom, this.id)
 		try {
 			await this.setControls()
@@ -257,7 +271,7 @@ class TdbBoxplot extends RxComponentInner {
 					.style('display', config.term0 ? 'block' : 'none')
 					.style('text-align', 'center')
 					.style('font-size', '1.1em')
-					.style('margin-bottom', '24px')
+					.style('margin-bottom', '20px')
 				const chartSvg = chartDiv.append('svg').attr('class', 'sjpp-boxplot-svg')
 				chart.svg = chartSvg
 				const chartDom = Object.assign({}, this.dom, {

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -41,7 +41,7 @@ class TdbBoxplot extends RxComponentInner {
 			div,
 			error: errorDiv,
 			charts: chartsDiv,
-			legend: div.append('div').attr('class', 'sjpp-boxplot-legend').style('margin-top', '10px'),
+			legend: div.append('div').attr('class', 'sjpp-boxplot-legend').style('margin-top', '25px'),
 			tip: new Menu()
 		}
 		if (opts.header) this.dom.header = opts.header.html('Box plot')
@@ -219,7 +219,7 @@ class TdbBoxplot extends RxComponentInner {
 	}
 
 	async init() {
-		this.dom.div.style('display', 'inline-block').style('margin-left', '10px')
+		this.dom.div.style('display', 'inline-block').style('margin-left', '20px')
 		this.interactions = new BoxPlotInteractions(this.app, this.dom, this.id)
 		try {
 			await this.setControls()
@@ -264,7 +264,10 @@ class TdbBoxplot extends RxComponentInner {
 			for (const key of Object.keys(data.charts)) {
 				const chart = data.charts[key]
 				// setup a dom{} object for the chart
-				const chartDiv = this.dom.charts.append('div')
+				const chartDiv = this.dom.charts
+					.append('div')
+					.attr('class', 'sjpp-boxplot-chartDiv')
+					.style('padding', Object.keys(data.charts).length > 1 ? '20px 20px 0px 0px' : '0px')
 				const chartTitle = chartDiv
 					.append('div')
 					.attr('class', 'pp-chart-title')
@@ -272,7 +275,7 @@ class TdbBoxplot extends RxComponentInner {
 					.style('text-align', 'center')
 					.style('font-size', '1.1em')
 					.style('margin-bottom', '20px')
-				const chartSvg = chartDiv.append('svg').attr('class', 'sjpp-boxplot-svg')
+				const chartSvg = chartDiv.append('svg')
 				chart.svg = chartSvg
 				const chartDom = Object.assign({}, this.dom, {
 					svg: chartSvg,

--- a/client/plots/boxplot/BoxPlotTypes.ts
+++ b/client/plots/boxplot/BoxPlotTypes.ts
@@ -1,7 +1,7 @@
 import type { Menu } from '#dom'
 import type { PlotConfig } from '#mass/types/mass'
 import type { BoxPlotEntry, BoxPlotData, TermWrapper } from '#types'
-import type { Div, Elem, SvgG, SvgSvg, SvgText } from '../../types/d3'
+import type { Div, Elem } from '../../types/d3'
 
 /** Opts sent from mass */
 export type TdbBoxPlotOpts = {
@@ -52,8 +52,6 @@ export type BoxPlotSettings = {
 
 /** Descriptions of the dom elements for the box plot */
 export type BoxPlotDom = {
-	/** Div for boxplots below the scale */
-	boxplots: SvgG
 	/** Controls div for the hamburger menu */
 	controls: Elem
 	/** Main div */
@@ -64,12 +62,8 @@ export type BoxPlotDom = {
 	header?: Elem
 	/** Legend */
 	legend: Div
-	/** Displays the term1 name as the plot title */
-	plotTitle: SvgText
-	/** Main svg holder */
-	svg: SvgSvg
-	/** Y-axis shown above the boxplots */
-	axis: any
+	/** Div for charts, each chart contains a set of boxplots */
+	charts: Div
 	/** box plot tooltip (e.g. over the outliers) */
 	tip: Menu
 }
@@ -130,6 +124,8 @@ export type PlotDimensions = {
 	/** Changes text color for the axis, plot labels, and legend
 	 * between black and white based on displayMode selection */
 	textColor: string
+	/** Title of chart */
+	chartTitle: string
 	/** Title of the plot and coordinates */
 	title: { x: number; y: number; text: string }
 	/** axis coordinates */

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -3,6 +3,7 @@ import type { MassAppApi } from '#mass/types/mass'
 import type { RenderedPlot } from '../view/RenderedPlot'
 import { ListSamples } from './ListSamples'
 import { filterJoin, getFilterItemByTag } from '#filter'
+import { DownloadMenu } from '#dom/downloadMenu'
 
 export class BoxPlotInteractions {
 	app: MassAppApi
@@ -12,6 +13,22 @@ export class BoxPlotInteractions {
 		this.app = app
 		this.dom = dom
 		this.id = id
+	}
+
+	download(event, data) {
+		const name2svg = {}
+		const node = this.dom.charts.select('.sjpp-boxplot-svg').node() //node to read the style
+		for (const k of Object.keys(data.charts)) {
+			const chart = data.charts[k]
+			name2svg[chart.chartId] = { svg: chart.svg, parent: node }
+		}
+		const menu = new DownloadMenu(name2svg)
+		menu.show(event.clientX, event.clientY)
+	}
+
+	help() {
+		//May add more options in the future
+		window.open('https://github.com/stjude/proteinpaint/wiki/Box-plot')
 	}
 
 	/** Option to add a global filter from the box plot label menu. */
@@ -75,5 +92,11 @@ export class BoxPlotInteractions {
 			id: this.id,
 			config
 		})
+	}
+
+	clearDom() {
+		this.dom.error.style('padding', '').text('')
+		this.dom.charts.selectAll('*').remove()
+		this.dom.legend.selectAll('*').remove()
 	}
 }

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -1,7 +1,6 @@
 import type { BoxPlotDom, LegendItemEntry, BoxPlotConfig } from '../BoxPlotTypes'
 import type { MassAppApi } from '#mass/types/mass'
 import type { RenderedPlot } from '../view/RenderedPlot'
-import { to_svg } from '#src/client'
 import { ListSamples } from './ListSamples'
 import { filterJoin, getFilterItemByTag } from '#filter'
 
@@ -13,18 +12,6 @@ export class BoxPlotInteractions {
 		this.app = app
 		this.dom = dom
 		this.id = id
-	}
-
-	download() {
-		//May add more options in the future
-		const svg = this.dom.svg.node() as Node
-		const plotConfig = this.app.getState().plots.find((p: BoxPlotConfig) => p.id === this.id)
-		to_svg(svg, `${plotConfig.term.term.name} box plot`, { apply_dom_styles: true })
-	}
-
-	help() {
-		//May add more options in the future
-		window.open('https://github.com/stjude/proteinpaint/wiki/Box-plot')
 	}
 
 	/** Option to add a global filter from the box plot label menu. */
@@ -88,13 +75,5 @@ export class BoxPlotInteractions {
 			id: this.id,
 			config
 		})
-	}
-
-	clearDom() {
-		this.dom.error.style('padding', '').text('')
-		this.dom.plotTitle.text('')
-		this.dom.axis.selectAll('*').remove()
-		this.dom.boxplots.selectAll('*').remove()
-		this.dom.legend.selectAll('*').remove()
 	}
 }

--- a/client/plots/boxplot/model/Model.ts
+++ b/client/plots/boxplot/model/Model.ts
@@ -36,6 +36,8 @@ export class Model {
 		if (this.config.term2)
 			opts.overlayTw = this.getContinousTerm() == this.config.term ? this.config.term2 : this.config.term
 
+		if (this.config.term0) opts.divideTw = this.config.term0
+
 		opts.orderByMedian = this.settings.orderByMedian
 		opts.isLogScale = this.settings.isLogScale
 

--- a/client/plots/boxplot/test/boxplot.integration.spec.ts
+++ b/client/plots/boxplot/test/boxplot.integration.spec.ts
@@ -65,10 +65,13 @@ tape('Default box plot', test => {
 		boxplot.on('postRender.test', null)
 		const dom = boxplot.Inner.dom
 		const config = boxplot.Inner.state.config
-
-		test.equal(dom.plotTitle.text(), config.term.term.name, `Should render ${config.term.term.name} title`)
-		test.true(dom.axis.select('path'), 'Should render y axis')
-		test.equal(dom.boxplots.selectAll("g[id^='sjpp-boxplot-']").size(), 1, 'Should render 1 boxplot')
+		test.equal(
+			dom.charts.select('.sjpp-boxplot-title').text(),
+			config.term.term.name,
+			`Should render ${config.term.term.name} title`
+		)
+		test.true(dom.charts.select('.sjpp-boxplot-axis').select('path'), 'Should render y axis')
+		test.equal(dom.charts.selectAll('.sjpp-boxplot-plot').size(), 1, 'Should render 1 boxplot')
 
 		if (test['_ok']) boxplot.Inner.app.destroy()
 		test.end()
@@ -106,11 +109,7 @@ tape('Box plot with overlay term = sex', test => {
 		const dom = boxplot.Inner.dom
 		const config = boxplot.Inner.state.config
 		const numValues = Object.keys(config.term2.term.values).length
-		test.equal(
-			dom.boxplots.selectAll("g[id^='sjpp-boxplot-']").size(),
-			numValues,
-			`Should render ${numValues} boxplots`
-		)
+		test.equal(dom.charts.selectAll('.sjpp-boxplot-plot').size(), numValues, `Should render ${numValues} boxplots`)
 
 		if (test['_ok']) boxplot.Inner.app.destroy()
 		test.end()
@@ -148,11 +147,7 @@ tape('Box plot with continuous overlay term = agedx', test => {
 		const dom = boxplot.Inner.dom
 		const config = boxplot.Inner.state.config
 		const numValues = Object.keys(config.term.term.values).length
-		test.equal(
-			dom.boxplots.selectAll("g[id^='sjpp-boxplot-']").size(),
-			numValues,
-			`Should render ${numValues} boxplots`
-		)
+		test.equal(dom.charts.selectAll('.sjpp-boxplot-plot').size(), numValues, `Should render ${numValues} boxplots`)
 
 		if (test['_ok']) boxplot.Inner.app.destroy()
 		test.end()
@@ -279,7 +274,7 @@ tape('Box plot with user settings', test => {
 	async function runTests(boxplot) {
 		boxplot.on('postRender.test', null)
 		const dom = boxplot.Inner.dom
-		const bp = dom.boxplots.selectAll("g[id^='sjpp-boxplot-']")
+		const bp = dom.charts.selectAll('.sjpp-boxplot-plot')
 		const lines = bp.selectAll('line').nodes()
 		let wrongColorLine = 0
 		for (const line of lines) {
@@ -288,7 +283,8 @@ tape('Box plot with user settings', test => {
 		test.equal(wrongColorLine, 0, `Should render boxplot with ${settings.color} lines.`)
 
 		test.true(
-			dom.div.style('background-color') == 'black' && dom.axis.select('path').attr('stroke') == 'white',
+			dom.div.style('background-color') == 'black' &&
+				dom.charts.select('.sjpp-boxplot-axis').select('path').attr('stroke') == 'white',
 			`Should render boxplot with dark background and white text when displayMode == dark is ${
 				settings.displayMode == 'dark'
 			}.`

--- a/client/plots/boxplot/test/boxplot.integration.spec.ts
+++ b/client/plots/boxplot/test/boxplot.integration.spec.ts
@@ -1,11 +1,14 @@
 import tape from 'tape'
 import * as helpers from '../../../test/front.helpers.js'
+import { detectGte } from '../../../test/test.helpers.js'
 
 /*
 Tests:
 	- Default box plot
 	- Box plot with overlay term = sex
 	- Box plot with continuous overlay term = agedx
+	- Box plot with divide term = sex
+	- Box plot with overlay term = aaclassic_5 and divide term = sex
 	- Box plot with user settings
  */
 
@@ -150,6 +153,87 @@ tape('Box plot with continuous overlay term = agedx', test => {
 			numValues,
 			`Should render ${numValues} boxplots`
 		)
+
+		if (test['_ok']) boxplot.Inner.app.destroy()
+		test.end()
+	}
+})
+
+tape('Box plot with divide term = sex', test => {
+	test.timeoutAfter(3000)
+
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary',
+					childType: 'boxplot',
+					term: {
+						id: 'agedx',
+						q: { mode: 'continuous' }
+					},
+					term0: {
+						id: 'sex'
+					}
+				}
+			]
+		},
+		boxplot: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	async function runTests(boxplot) {
+		boxplot.on('postRender.test', null)
+		const dom = boxplot.Inner.dom
+		const chartDivs = await detectGte({ elem: dom.charts.node(), selector: '.sjpp-boxplot-chartDiv' })
+		test.equal(chartDivs.length, 2, 'Should have 2 charts')
+		const boxplots = await detectGte({ elem: dom.charts.node(), selector: '.sjpp-boxplot-plot' })
+		test.equal(boxplots.length, 2, 'Should have 2 boxplots')
+
+		if (test['_ok']) boxplot.Inner.app.destroy()
+		test.end()
+	}
+})
+
+tape('Box plot with overlay term = aaclassic_5 and divide term = sex', test => {
+	test.timeoutAfter(3000)
+
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary',
+					childType: 'boxplot',
+					term: {
+						id: 'agedx',
+						q: { mode: 'continuous' }
+					},
+					term2: {
+						id: 'aaclassic_5'
+					},
+					term0: {
+						id: 'sex'
+					}
+				}
+			]
+		},
+		boxplot: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	async function runTests(boxplot) {
+		boxplot.on('postRender.test', null)
+		const dom = boxplot.Inner.dom
+		const chartDivs = await detectGte({ elem: dom.charts.node(), selector: '.sjpp-boxplot-chartDiv' })
+		test.equal(chartDivs.length, 2, 'Should have 2 charts')
+		const boxplots = await detectGte({ elem: dom.charts.node(), selector: '.sjpp-boxplot-plot' })
+		test.equal(boxplots.length, 10, 'Should have 10 boxplots')
 
 		if (test['_ok']) boxplot.Inner.app.destroy()
 		test.end()

--- a/client/plots/boxplot/test/boxplot.unit.spec.ts
+++ b/client/plots/boxplot/test/boxplot.unit.spec.ts
@@ -96,10 +96,11 @@ const mockPlot2 = {
 	y: 155
 }
 
-const mockData = {
+const mockData: any = {
+	chartId: '',
+	plots: [mockPlot1, mockPlot2],
 	absMin: 0,
 	absMax: 100,
-	plots: [mockPlot1, mockPlot2],
 	uncomputableValues: [{ label: 'test', value: 1 }]
 }
 

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -29,7 +29,6 @@ export class View {
 		this.interactions = interactions
 		this.settings = settings
 		if (!data || !data.plots.length) return
-		this.interactions.clearDom()
 
 		const plotDim = data.plotDim
 
@@ -52,6 +51,9 @@ export class View {
 	}
 
 	renderTitle(plotDim: PlotDimensions, dom: BoxPlotDom) {
+		//Title of the chart
+		dom.chartTitle.text(plotDim.chartTitle)
+
 		//Title of the plot
 		const transformStr = `translate(${plotDim.title.x}, ${plotDim.title.y})${
 			this.settings.isVertical ? `,rotate(-90)` : ''

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -109,7 +109,7 @@ export class View {
 	) {
 		/** Draw boxplots, incrementing by the total row height */
 		for (const plot of data.plots) {
-			const g = dom.boxplots.append('g').attr('id', `sjpp-boxplot-${plot.boxplot.label}`).attr('padding', '5px')
+			const g = dom.boxplots.append('g').attr('class', 'sjpp-boxplot-plot').attr('padding', '5px')
 
 			drawBoxplot({
 				bp: plot.boxplot,

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -3,7 +3,7 @@ import { drawBoxplot, Menu } from '#dom'
 import { scaleLinear, scaleLog } from 'd3-scale'
 import { axisstyle } from '#src/client'
 import { axisTop, axisLeft } from 'd3-axis'
-import type { BoxPlotDom, BoxPlotSettings, ViewData, PlotDimensions } from '../BoxPlotTypes'
+import type { BoxPlotSettings, ViewData, PlotDimensions } from '../BoxPlotTypes'
 import type { MassAppApi } from '#mass/types/mass'
 import type { BoxPlotInteractions } from '../interactions/BoxPlotInteractions'
 import type { RenderedPlot } from './RenderedPlot'
@@ -13,16 +13,10 @@ import { BoxPlotLabelMenu } from './BoxPlotLabelMenu'
 /** Handles all the rendering logic for the boxplot. */
 export class View {
 	app: MassAppApi
-	dom: BoxPlotDom
+	dom: any
 	interactions: BoxPlotInteractions
 	settings: BoxPlotSettings
-	constructor(
-		data: ViewData,
-		settings: BoxPlotSettings,
-		dom: BoxPlotDom,
-		app: MassAppApi,
-		interactions: BoxPlotInteractions
-	) {
+	constructor(data: ViewData, settings: BoxPlotSettings, dom: any, app: MassAppApi, interactions: BoxPlotInteractions) {
 		this.app = app
 		this.dom = dom
 		this.interactions = interactions
@@ -48,7 +42,7 @@ export class View {
 		this.renderAxis(plotDim, dom, scale, settings)
 	}
 
-	renderTitle(plotDim: PlotDimensions, dom: BoxPlotDom) {
+	renderTitle(plotDim: PlotDimensions, dom: any) {
 		//Title of the chart
 		dom.chartTitle.text(plotDim.chartTitle)
 
@@ -66,12 +60,7 @@ export class View {
 	}
 
 	//Fix for the axis rendering min -> max when the plot is vertical
-	renderAxis(
-		plotDim: PlotDimensions,
-		dom: BoxPlotDom,
-		scale: ScaleLinear<number, number, never>,
-		settings: BoxPlotSettings
-	) {
+	renderAxis(plotDim: PlotDimensions, dom: any, scale: ScaleLinear<number, number, never>, settings: BoxPlotSettings) {
 		/** draw_boxplot renders the boxplot from min-max but the scale
 		 * renders the axis from max - min. Render the box plots, then change
 		 * the scale vector to match. */
@@ -101,12 +90,7 @@ export class View {
 		})
 	}
 
-	renderBoxPlots(
-		dom: BoxPlotDom,
-		data: ViewData,
-		scale: ScaleLinear<number, number, never>,
-		settings: BoxPlotSettings
-	) {
+	renderBoxPlots(dom: any, data: ViewData, scale: ScaleLinear<number, number, never>, settings: BoxPlotSettings) {
 		/** Draw boxplots, incrementing by the total row height */
 		for (const plot of data.plots) {
 			const g = dom.boxplots.append('g').attr('class', 'sjpp-boxplot-plot').attr('padding', '5px')

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -57,7 +57,7 @@ export class View {
 			this.settings.isVertical ? `,rotate(-90)` : ''
 		}`
 		dom.plotTitle
-			.attr('id', 'sjpp-boxplot-title')
+			.attr('class', 'sjpp-boxplot-title')
 			.style('font-weight', 600)
 			.attr('text-anchor', 'middle')
 			.attr('transform', transformStr)
@@ -79,7 +79,7 @@ export class View {
 		const ticks = scale.ticks()
 		const tickValues = plotDim.axis.values(ticks)
 		dom.axis
-			.attr('id', 'sjpp-boxplot-axis')
+			.attr('class', 'sjpp-boxplot-axis')
 			.attr('transform', `translate(${plotDim.axis.x}, ${plotDim.axis.y})`)
 			.transition()
 			.call(

--- a/client/plots/boxplot/view/View.ts
+++ b/client/plots/boxplot/view/View.ts
@@ -9,7 +9,6 @@ import type { BoxPlotInteractions } from '../interactions/BoxPlotInteractions'
 import type { RenderedPlot } from './RenderedPlot'
 import { BoxPlotToolTips } from './BoxPlotToolTips'
 import { BoxPlotLabelMenu } from './BoxPlotLabelMenu'
-import { LegendRenderer } from './LegendRender'
 
 /** Handles all the rendering logic for the boxplot. */
 export class View {
@@ -47,7 +46,6 @@ export class View {
 		this.renderTitle(plotDim, dom)
 		this.renderBoxPlots(dom, data, scale, settings)
 		this.renderAxis(plotDim, dom, scale, settings)
-		if (data.legend) new LegendRenderer(dom.legend, data.legend, this.interactions, plotDim.textColor)
 	}
 
 	renderTitle(plotDim: PlotDimensions, dom: BoxPlotDom) {

--- a/client/plots/boxplot/viewModel/LegendDataMapper.ts
+++ b/client/plots/boxplot/viewModel/LegendDataMapper.ts
@@ -23,7 +23,7 @@ export class LegendDataMapper {
 				?.map(p => {
 					const total = p.descrStats.find(d => d.id === 'total')
 					if (!total || !total.value) throw `Missing total value for ${p.key}`
-					return { key: p.key, text: `${p.key}, n=${total.value}`, isHidden: true, isPlot: true }
+					return { key: p.key, text: p.key, n: total.value, isHidden: true, isPlot: true }
 				}) || []
 		if (config.term.term?.values) {
 			const term1Label = config.term2 ? config.term.term.name : 'Other categories'

--- a/client/plots/boxplot/viewModel/LegendDataMapper.ts
+++ b/client/plots/boxplot/viewModel/LegendDataMapper.ts
@@ -1,9 +1,9 @@
 import type { FormattedPlotEntry, LegendData, LegendItemEntry, BoxPlotConfig } from '../BoxPlotTypes'
-import type { BoxPlotResponse } from '#types'
+import type { BoxPlotChartEntry } from '#types'
 
 export class LegendDataMapper {
 	legendData: LegendData = []
-	constructor(config: BoxPlotConfig, data: BoxPlotResponse, plots: FormattedPlotEntry[]) {
+	constructor(config: BoxPlotConfig, data: BoxPlotChartEntry, plots: FormattedPlotEntry[]) {
 		const isTerm2 = config?.term2
 		if (config.term.q?.descrStats) {
 			this.legendData.push({

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -68,6 +68,7 @@ export class ViewModel {
 			domain: [data.absMin, data.absMax! <= 1 ? data.absMax : data.absMax! + 1],
 			range: [0, settings.boxplotWidth],
 			svg,
+			chartTitle: this.getChartTitle(config, data.chartId),
 			title: this.setTitleDimensions(config, settings, svg.height),
 			axis: {
 				x: settings.isVertical ? this.horizPad / 2 + this.incrPad + this.topPad : this.totalLabelSize,
@@ -115,6 +116,13 @@ export class ViewModel {
 			width: settings.isVertical ? plotsSpace + this.horizPad : depth,
 			height: settings.isVertical ? depth : plotsSpace
 		}
+	}
+
+	getChartTitle(config, chartId) {
+		if (!config.term0) return chartId
+		return config.term0.term.values && chartId in config.term0.term.values
+			? config.term0.term.values[chartId].label
+			: chartId
 	}
 
 	setTitleDimensions(config: any, settings: BoxPlotSettings, height: number) {

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -1,7 +1,7 @@
 import { format } from 'd3-format'
 import { decimalPlacesUntilFirstNonZero } from '#shared/roundValue.js'
 import { rgb } from 'd3-color'
-import type { BoxPlotResponse } from '#types'
+import type { BoxPlotChartEntry } from '#types'
 import type { BoxPlotSettings, PlotDimensions, ViewData, BoxPlotConfig } from '../BoxPlotTypes'
 import { LegendDataMapper } from './LegendDataMapper'
 
@@ -27,7 +27,7 @@ export class ViewModel {
 	viewData: ViewData
 	constructor(
 		config: BoxPlotConfig,
-		data: BoxPlotResponse,
+		data: BoxPlotChartEntry,
 		settings: BoxPlotSettings,
 		maxLabelLgth: number,
 		useDefaultSettings: boolean
@@ -60,7 +60,7 @@ export class ViewModel {
 		}
 	}
 
-	setPlotDimensions(data: BoxPlotResponse, config: any, settings: BoxPlotSettings) {
+	setPlotDimensions(data: BoxPlotChartEntry, config: any, settings: BoxPlotSettings) {
 		const svg = this.setSvgDimensions(settings, data)
 		const plotDim = {
 			//Add 1 to the max is big enough so the upper line to boxplot isn't cutoff
@@ -108,7 +108,7 @@ export class ViewModel {
 		return formattedTicks
 	}
 
-	setSvgDimensions(settings: BoxPlotSettings, data: BoxPlotResponse) {
+	setSvgDimensions(settings: BoxPlotSettings, data: BoxPlotChartEntry) {
 		const plotsSpace =
 			data.plots.filter(p => !p.isHidden).length * this.totalRowSize + this.topPad + this.bottomPad + this.incrPad
 		const depth = settings.boxplotWidth + this.totalLabelSize + this.horizPad / 2

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -277,7 +277,7 @@ export function setInteractivity(self) {
 		if (t2) {
 			if (
 				t2.q?.mode === 'continuous' ||
-				((t2.term?.type === 'float' || t2.term?.type === 'integer') && plot.divideTwBins != null)
+				((t2.term?.type === 'float' || t2.term?.type === 'integer') && plot.overlayTwBins != null)
 			) {
 				createTvsLstValues(t1, plot, tvslst, 0)
 				self.createTvsLstRanges(t2, tvslst, rangeStart, rangeStop, 1)
@@ -307,17 +307,17 @@ function getAddFilterCallback(t1, t2, self, plot, rangeStart, rangeStop, isBrush
 			}
 		} else if (
 			t2.q?.mode === 'continuous' ||
-			((t2.term?.type === 'float' || t2.term?.type === 'integer') && plot.divideTwBins != null)
+			((t2.term?.type === 'float' || t2.term?.type === 'integer') && plot.overlayTwBins != null)
 		) {
 			createTvsTerm(t2, tvslst)
 			tvslst.lst[0].tvs.ranges = [
 				{
-					start: plot.divideTwBins?.start || null,
-					stop: plot.divideTwBins?.stop || null,
-					startinclusive: plot.divideTwBins?.startinclusive || true,
-					stopinclusive: plot.divideTwBins?.stopinclusive || false,
-					startunbounded: plot.divideTwBins?.startunbounded ? plot.divideTwBins?.startunbounded : null,
-					stopunbounded: plot.divideTwBins?.stopunbounded ? plot.divideTwBins?.stopunbounded : null
+					start: plot.overlayTwBins?.start || null,
+					stop: plot.overlayTwBins?.stop || null,
+					startinclusive: plot.overlayTwBins?.startinclusive || true,
+					stopinclusive: plot.overlayTwBins?.stopinclusive || false,
+					startunbounded: plot.overlayTwBins?.startunbounded ? plot.overlayTwBins?.startunbounded : null,
+					stopunbounded: plot.overlayTwBins?.stopunbounded ? plot.overlayTwBins?.stopunbounded : null
 				}
 			]
 			if (isBrush) {

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -26,7 +26,7 @@ export function setInteractivity(self) {
 	}
 
 	self.displayLabelClickMenu = function (t1, t2, plot, event) {
-		if (!t2 || self.data.plots.length === 1) return // when no term 2 and just one violin, do not show options on the sole violin label
+		if (!t2) return // when no term 2 do not show options on the sole violin label
 		if (self.config.term.term.type == TermTypes.SINGLECELL_GENE_EXPRESSION) return // is sc gene exp data, none of the options below work, thus disable
 
 		const label = t1.q.mode === 'continuous' ? 'term2' : 'term'

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -28,7 +28,7 @@ class ViolinPlot {
 			.append('div')
 			.style('display', 'inline-block')
 			.style('padding', this.opts.mode != 'minimal' ? '5px' : '0px')
-			.style('padding-left', this.opts.mode != 'minimal' ? '45px' : '0px')
+			.style('padding-left', this.opts.mode != 'minimal' ? '10px' : '0px')
 			.attr('id', 'sjpp-vp-holder')
 
 		this.dom = {
@@ -49,7 +49,11 @@ class ViolinPlot {
 				.style('flex-wrap', 'wrap')
 				.style('max-width', '100vw')
 				.style('padding-left', this.opts.mode != 'minimal' ? '10px' : '0px'),
-			legendDiv: holder.append('div').classed('sjpp-vp-legend', true).style('padding-left', '5px')
+			legendDiv: holder
+				.append('div')
+				.classed('sjpp-vp-legend', true)
+				.style('padding-left', '5px')
+				.style('padding-top', '10px')
 		}
 
 		setViolinRenderer(this)

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -28,7 +28,7 @@ class ViolinPlot {
 			.append('div')
 			.style('display', 'inline-block')
 			.style('padding', this.opts.mode != 'minimal' ? '5px' : '0px')
-			.style('padding-left', this.opts.mode != 'minimal' ? '10px' : '0px')
+			.style('padding-left', this.opts.mode != 'minimal' ? '20px' : '0px')
 			.attr('id', 'sjpp-vp-holder')
 
 		this.dom = {
@@ -47,13 +47,12 @@ class ViolinPlot {
 				.style('display', 'flex')
 				.style('flex-direction', 'row')
 				.style('flex-wrap', 'wrap')
-				.style('max-width', '100vw')
-				.style('padding-left', this.opts.mode != 'minimal' ? '10px' : '0px'),
+				.style('max-width', '100vw'),
 			legendDiv: holder
 				.append('div')
 				.classed('sjpp-vp-legend', true)
-				.style('padding-left', '5px')
-				.style('padding-top', '10px')
+				.style('margin-left', '-15px')
+				.style('padding-top', '20px')
 		}
 
 		setViolinRenderer(this)

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -41,7 +41,7 @@ export default function setViolinRenderer(self) {
 		}
 
 		//filter out hidden values and only keep plots which are not hidden in term2.q.hiddenvalues
-		self.dom.violinDiv.select('*').remove()
+		self.dom.violinDiv.selectAll('*').remove()
 		for (const chartKey of Object.keys(self.data.charts)) {
 			const chart = self.data.charts[chartKey]
 			const plots = chart.plots.filter(p => !termNum?.q?.hiddenValues?.[p.label || p.seriesId])
@@ -54,7 +54,9 @@ export default function setViolinRenderer(self) {
 			this.k2c = getColors(plots.length)
 			if (self.legendRenderer) self.legendRenderer(getLegendGrps(termNum, self))
 
-			const chartDiv = self.dom.violinDiv.append('div').style('padding', '20px')
+			const chartDiv = self.dom.violinDiv
+				.append('div')
+				.style('padding', Object.keys(self.data.charts).length > 1 ? '20px' : '0px')
 			if (plots.length === 0) {
 				chartDiv.html(` <span style="opacity:.6;font-size:1em;margin-left:90px;">No data to render Violin Plot</span>`)
 				return
@@ -70,7 +72,7 @@ export default function setViolinRenderer(self) {
 				.style('display', chart.chartId ? 'block' : 'none')
 				.style('text-align', 'center')
 				.style('font-size', '1.1em')
-				.style('margin-bottom', '24px')
+				.style('margin-bottom', '20px')
 				.html(getChartTitle(chart.chartId))
 
 			// render chart data
@@ -134,9 +136,13 @@ export default function setViolinRenderer(self) {
 		}
 	}
 	self.getAutoThickness = function () {
-		/*if (self.data.plots.length === 1) */ return 150
-		const count = self.data.plots.length
-		return Math.min(130, Math.max(60, 600 / count)) //clamp between 60 and 130
+		let maxPlotCount = 0
+		for (const k of Object.keys(this.data.charts)) {
+			const chart = this.data.charts[k]
+			maxPlotCount = Math.max(maxPlotCount, chart.plots.length)
+		}
+		if (maxPlotCount == 1) return 150
+		return Math.min(130, Math.max(60, 600 / maxPlotCount)) //clamp between 60 and 130
 	}
 
 	self.getPlotThicknessWithPadding = function () {

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -56,7 +56,8 @@ export default function setViolinRenderer(self) {
 
 			const chartDiv = self.dom.violinDiv
 				.append('div')
-				.style('padding', Object.keys(self.data.charts).length > 1 ? '20px' : '0px')
+				.attr('class', 'sjpp-vp-chartDiv')
+				.style('padding', Object.keys(self.data.charts).length > 1 ? '20px 20px 0px 0px' : '0px')
 			if (plots.length === 0) {
 				chartDiv.html(` <span style="opacity:.6;font-size:1em;margin-left:90px;">No data to render Violin Plot</span>`)
 				return

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -67,11 +67,11 @@ export default function setViolinRenderer(self) {
 			chartDiv
 				.append('div')
 				.attr('class', 'pp-chart-title')
-				.style('display', chartKey ? 'block' : 'none')
+				.style('display', chart.chartId ? 'block' : 'none')
 				.style('text-align', 'center')
 				.style('font-size', '1.1em')
 				.style('margin-bottom', '24px')
-				.html(getChartTitle(chartKey))
+				.html(getChartTitle(chart.chartId))
 
 			// render chart data
 			const svgData = renderSvg(t1, plots, chartDiv, self, isH, settings)
@@ -209,11 +209,11 @@ export default function setViolinRenderer(self) {
 		})
 	}
 
-	function getChartTitle(chartKey) {
-		if (!self.config.term0) return chartKey
-		return self.config.term0.term.values && chartKey in self.config.term0.term.values
-			? self.config.term0.term.values[chartKey].label
-			: chartKey
+	function getChartTitle(chartId) {
+		if (!self.config.term0) return chartId
+		return self.config.term0.term.values && chartId in self.config.term0.term.values
+			? self.config.term0.term.values[chartId].label
+			: chartId
 	}
 
 	function createMargins(labelsize, settings, isH, isMinimal) {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -444,10 +444,13 @@ export class TermdbVocab extends Vocab {
 
     arg{}
         .tw main term to create violin/boxplot with
-        .divideTw={}
-            optional termwrapper of 2nd term to divide cohort
+        .overlayTw={}
+            optional termwrapper of 2nd term
             if given, will result in multiple plots, and pvalue computed for each pair of plots
             if missing, will result in one plot
+		.divideTw={}
+			optional termwrapper of term0
+			if given, will result in multiple charts, each of which contains one or more violin plots
         .filter={}
             optional
         .svgw=int
@@ -479,6 +482,7 @@ export class TermdbVocab extends Vocab {
 		// but not have an option to list samples
 		const headers = this.mayGetAuthHeaders('termdb')
 		arg.tw = this.getTwMinCopy(arg.tw)
+		if (arg.overlayTw) arg.overlayTw = this.getTwMinCopy(arg.overlayTw)
 		if (arg.divideTw) arg.divideTw = this.getTwMinCopy(arg.divideTw)
 		const body = Object.assign(
 			{

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -512,6 +512,7 @@ export class TermdbVocab extends Vocab {
 		const headers = this.mayGetAuthHeaders('termdb')
 		arg.tw = this.getTwMinCopy(arg.tw)
 		if (arg.overlayTw) arg.overlayTw = this.getTwMinCopy(arg.overlayTw)
+		if (arg.divideTw) arg.divideTw = this.getTwMinCopy(arg.divideTw)
 		const body = Object.assign(
 			{
 				genome: this.vocab.genome,

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -54,7 +54,7 @@ function init({ genomes }) {
 			const charts: any = {}
 			for (const [chart, plot2values] of chart2plot2values) {
 				const plots: any = []
-				for (const [key, values] of sortPlot2Values(data, plot2values, overlayTerm)) {
+				for (const [key, values] of sortPlot2Values(data as ValidGetDataResponse, plot2values, overlayTerm)) {
 					const sortedValues = values.sort((a, b) => a - b)
 
 					const vs = sortedValues.map((v: number) => {

--- a/server/routes/termdb.boxplot.ts
+++ b/server/routes/termdb.boxplot.ts
@@ -48,6 +48,9 @@ function init({ genomes }) {
 				divideTerm
 			)
 
+			if (!absMin && absMin !== 0) throw 'absMin is undefined [termdb.boxplot init()]'
+			if (!absMax && absMax !== 0) throw 'absMax is undefined [termdb.boxplot init()]'
+
 			const charts: any = {}
 			for (const [chart, plot2values] of chart2plot2values) {
 				const plots: any = []
@@ -89,8 +92,6 @@ function init({ genomes }) {
 						plots.push(plot)
 					}
 				}
-
-				if (absMin == null || absMax == null) throw 'absMin or absMax is null [termdb.boxplot init()]'
 
 				if (q.tw.term?.values) setHiddenPlots(q.tw, plots)
 				if (overlayTerm && overlayTerm.term?.values) setHiddenPlots(overlayTerm, plots)

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -210,7 +210,7 @@ function setResponse(valuesObject: any, data: ValidGetDataResponse, q: ViolinReq
 			})
 		}
 
-		charts[chart] = { plots }
+		charts[chart] = { chartId: chart, plots }
 	}
 
 	const result = {

--- a/shared/types/src/routes/termdb.boxplot.ts
+++ b/shared/types/src/routes/termdb.boxplot.ts
@@ -15,6 +15,8 @@ export type BoxPlotRequest = {
 	orderByMedian: boolean
 	/** term2 */
 	overlayTw?: TermWrapper
+	/** term0 */
+	divideTw?: TermWrapper
 	filter?: Filter
 	filter0?: any
 	__protected__: any
@@ -25,11 +27,31 @@ export type BoxPlotResponse = {
 	absMin?: number
 	/** Absolute max value for all plots */
 	absMax?: number
-	plots: BoxPlotEntry[]
+	/** Charts data */
+	charts: {
+		[chartId: string]: BoxPlotChartEntry
+	}
 	/** Categories not shown in the final plot */
 	uncomputableValues: { label: string; value: number }[] | null
+	error?: any
 }
 
+// chart containing a set of boxplots
+export type BoxPlotChartEntry = {
+	/** Chart ID */
+	chartId: string
+	/** Boxplot data within the chart */
+	plots: BoxPlotEntry[]
+	/** svg of chart, necessary for svg download */
+	svg?: any
+	/** Copied from BoxPlotResponse, necessary for
+	ViewModel to process chart data */
+	absMin?: number
+	absMax?: number
+	uncomputableValues?: { label: string; value: number }[] | null
+}
+
+// individual boxplot
 export type BoxPlotEntry = {
 	boxplot: BoxPlotData & { label: string }
 	/** color matching the value/category color */

--- a/shared/types/src/routes/termdb.violin.ts
+++ b/shared/types/src/routes/termdb.violin.ts
@@ -14,7 +14,9 @@ export type ViolinRequest = {
 	/** A number representing the device's pixel ratio, which may be used for
 	 * rendering quality adjustments */
 	devicePixelRatio: number
-	/** optional tw to divide tw data into multiple violins and show under one axis */
+	/** optional overlay tw, will generate multiple violin plots */
+	overlayTw?: any
+	/** optional divide tw, will generate multiple charts, each of which will contain violin plots */
 	divideTw?: any
 	/** Reference label (i.e. short label) for the ds */
 	dslabel: string
@@ -81,7 +83,7 @@ export type ViolinPlotEntry = {
 	/** Color to render */
 	color: string
 	density: ViolinDensity
-	divideTwBins: any
+	overlayTwBins: any
 	/** Text for label */
 	label: string
 	/** Number of samples/cases/patients/etc. */

--- a/shared/types/src/termdb.matrix.ts
+++ b/shared/types/src/termdb.matrix.ts
@@ -23,6 +23,8 @@ type CategoryEntry = {
 	samplecount: number
 }
 
+// TODO: need to add a discriminant property (e.g. ".kind") to
+// distinguish between ValidGetDataResponse and { error: string }
 export type ValidGetDataResponse = {
 	samples: {
 		[index: string | number]: SampleEntry


### PR DESCRIPTION
# Description

This PR adds support for term0 (i.e. divideBy term) in violin and box plots. This support required changing the structure of the data for these plots by nesting the plot data under a `charts{}` object (similar to barchart). Please advise on whether this approach is acceptable. Further refactoring will likely be needed, and I will be happy to help with this as well.

I added new integration tests for divideBy term in both violin and box plots. All unit and integration tests pass.

Please thoroughly test violin and box plots with term1, term2, and term0.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
