### PR TITLE
Scatter legend fix

### DIFF
--- a/client/plots/scatter/viewmodel/scatterLegend.ts
+++ b/client/plots/scatter/viewmodel/scatterLegend.ts
@@ -100,7 +100,7 @@ export class ScatterLegend {
 					scale
 				)
 			} else {
-				this.addLegendTitle(legendG, title, offsetX, offsetY, this.scatter.config.colorTW)
+				this.addLegendTitle(legendG, title, offsetX, offsetY, this.scatter.config.colorTW, 'COLOR')
 				offsetY += step
 
 				if (this.scatter.config.colorTW?.q?.mode === 'continuous') {
@@ -254,7 +254,7 @@ export class ScatterLegend {
 			} else {
 				const shapeG = legendG.append('g').style('font-size', `${this.getFontSize(chart, chart.shapeLegend)}em`)
 
-				this.addLegendTitle(legendG, title, offsetX, offsetY, this.scatter.config.shapeTW)
+				this.addLegendTitle(legendG, title, offsetX, offsetY, this.scatter.config.shapeTW, 'SHAPE')
 
 				offsetY += step
 				const color = 'gray'
@@ -320,7 +320,7 @@ export class ScatterLegend {
 		return [circleG, itemG]
 	}
 
-	addLegendTitle(G, title, x, y, tw) {
+	addLegendTitle(G, title, x, y, tw, extraText) {
 		const _t = G.append('text')
 			.attr('data-testid', 'legendTitle') // may replace id with data-testid to avoid conflict with portal
 			.attr('x', x)
@@ -329,13 +329,6 @@ export class ScatterLegend {
 			.style('font-weight', 'bold')
 		//.on('click',()=>{}) TODO allow click on text to get edit/replace options for tw
 
-		// when plot has both color & shape and tw is either, since color legend hardcodes circles which may confuse with shape, thus put word "color/shape" at legend title to disambiguate
-		let extraText: any = null
-		if (tw == this.scatter.config.colorTW && this.scatter.config.shapeTW) {
-			extraText = 'COLOR'
-		} else if (tw == this.scatter.config.shapeTW && this.scatter.config.colorTW) {
-			extraText = 'SHAPE'
-		}
 		if (extraText) {
 			_t.append('tspan').text(extraText).attr('dx', 7).style('font-weight', 'normal').attr('font-size', '.7em')
 		}
@@ -347,7 +340,7 @@ export class ScatterLegend {
 		const title = name
 		const G = legendG.append('g').style('font-size', '0.9em')
 
-		this.addLegendTitle(G, title, offsetX, offsetY, tw)
+		this.addLegendTitle(G, title, offsetX, offsetY, tw, cname == 'category' ? 'COLOR' : 'SHAPE')
 
 		offsetX += step
 		const mutations: any = []

--- a/client/plots/scatter/viewmodel/scatterLegend.ts
+++ b/client/plots/scatter/viewmodel/scatterLegend.ts
@@ -79,11 +79,11 @@ export class ScatterLegend {
 		const scale = chart.colorLegend.size > 20 || chart.shapeLegend.size > 20 ? 0.6 : 0.7 //if many categories, reduce size
 
 		const colorG = legendG.append('g').style('font-size', `${fontSize}em`)
-		offsetY += step + 10
+		offsetY += step + 20
 		if (this.scatter.config.colorTW || this.scatter.config.colorColumn) {
 			title = `${getTitle(
 				this.scatter.config.colorTW?.term?.name || this.scatter.config.colorColumn.name,
-				30,
+				40,
 				this.scatter.config.shapeTW == undefined
 			)}`
 			const colorRefCategory = chart.colorLegend.get('Ref')
@@ -239,7 +239,7 @@ export class ScatterLegend {
 		if (this.scatter.config.shapeTW) {
 			offsetX = chart.colorLegendWidth
 			offsetY = 60
-			title = `${getTitle(this.scatter.config.shapeTW.term.name)}`
+			title = `${getTitle(this.scatter.config.shapeTW.term.name, 40)}`
 			if (this.scatter.config.shapeTW.term.type == 'geneVariant' && this.scatter.config.shapeTW.q.type == 'values') {
 				this.renderGeneVariantLegend(
 					chart,

--- a/client/plots/scatter/viewmodel/scatterViewModelBase.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModelBase.ts
@@ -76,8 +76,9 @@ export class ScatterViewModelBase {
 		 * When in continuous mode, color scale renders with a
 		 * default width of 150. */
 		const labels: any = []
-		if (this.scatter.config.colorTW) labels.push(this.scatter.config.colorTW.term.name + ' COLOR')
-		if (this.scatter.config.scaleDotTW) labels.push(this.scatter.config.scaleDotTW.term.name + ' SHAPE')
+
+		if (this.scatter.config.colorTW) labels.push(getTitle(this.scatter.config.colorTW.term.name, 40) + ' COLOR')
+		if (this.scatter.config.scaleDotTW) labels.push(getTitle(this.scatter.config.scaleDotTW.term.name, 40) + ' SHAPE')
 		if (labels.length > 0) {
 			const labelsWidth = getMaxLabelWidth(svg, labels) + 40
 			chart.colorLegendWidth =

--- a/client/plots/scatter/viewmodel/scatterViewModelBase.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModelBase.ts
@@ -76,8 +76,8 @@ export class ScatterViewModelBase {
 		 * When in continuous mode, color scale renders with a
 		 * default width of 150. */
 		const labels: any = []
-		if (this.scatter.config.colorTW) labels.push(this.scatter.config.colorTW.term.name)
-		if (this.scatter.config.scaleDotTW) labels.push(this.scatter.config.scaleDotTW.term.name)
+		if (this.scatter.config.colorTW) labels.push(this.scatter.config.colorTW.term.name + ' COLOR')
+		if (this.scatter.config.scaleDotTW) labels.push(this.scatter.config.scaleDotTW.term.name + ' SHAPE')
 		if (labels.length > 0) {
 			const labelsWidth = getMaxLabelWidth(svg, labels) + 40
 			chart.colorLegendWidth =


### PR DESCRIPTION
# Description
Always add suffix color and shape in the respective legends (Looks nice and better to add it always). Consider suffix when calculating the legend size. Fixes glitch noticed [here](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22TermdbTest%20TSNE%22,%22colorTW%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},%22shapeTW%22:{%22id%22:%22diaggrp%22}}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
