### PR TITLE
Fixes/improvements to summary input plot

### DIFF
--- a/client/plots/summaryInput.ts
+++ b/client/plots/summaryInput.ts
@@ -70,13 +70,14 @@ class SummaryInputPlot extends PlotBase implements RxComponentInner {
 
 		this.dom.submit
 			.append('button')
-			.property('disabled', false)
+			.property('disabled', true)
 			.style('border', 'none')
 			.style('border-radius', '20px')
 			.style('padding', '10px 15px')
 			.text('Submit')
 			.on('click', () => {
 				const config = structuredClone(this.config)
+				if (!config.term) throw 'config.term is missing'
 				config.chartType = config.term.term.type == 'survival' ? 'survival' : 'summary'
 				this.app.dispatch({
 					type: 'plot_create',
@@ -104,13 +105,16 @@ class SummaryInputPlot extends PlotBase implements RxComponentInner {
 
 	async main() {
 		this.config = await this.getMutableConfig()
+		const submitBtn = this.dom.submit.select('button')
+		submitBtn.property('disabled', !this.config.term)
+		submitBtn.style('cursor', this.config.term ? 'pointer' : 'default')
 	}
 }
 
 export const summaryInputInit = getCompInit(SummaryInputPlot)
 export const componentInit = summaryInputInit
 
-export function getPlotConfig(/*opts, app*/) {
+export function getPlotConfig() {
 	const config = {
 		chartType: 'summaryInput',
 		settings: {}

--- a/client/plots/summaryInput.ts
+++ b/client/plots/summaryInput.ts
@@ -77,7 +77,7 @@ class SummaryInputPlot extends PlotBase implements RxComponentInner {
 			.text('Submit')
 			.on('click', () => {
 				const config = structuredClone(this.config)
-				config.chartType = config.term.type == 'survival' ? 'survival' : 'summary'
+				config.chartType = config.term.term.type == 'survival' ? 'survival' : 'summary'
 				this.app.dispatch({
 					type: 'plot_create',
 					config

--- a/client/termsetting/handlers/categorical.ts
+++ b/client/termsetting/handlers/categorical.ts
@@ -83,19 +83,19 @@ export async function getHandler(self: CategoricalTermSettingInstance) {
 		},
 
 		async showEditMenu() {
-			await new GroupSettingMethods(self).main()
-		},
-
-		async postMain() {
 			//for rendering groupsetting menu
+			const holder = self.dom.tip.d.append('div')
+			const loadingDiv = holder.append('div').style('margin', '10px').text('Getting categories...')
 			const body = self.opts.getBodyParams?.() || {}
 			const data = await self.vocabApi.getCategories(self.term, self.filter!, body)
+			loadingDiv.style('display', 'none')
 			/** Original code created a separate array (self.category2samplecount) and pushed only the key and label.
 			 * The new self.category2samplecount was used to create the groupsetting menu items. That logic was removed
 			 * as groupsetting.ts handles formating the data. However category2samplecount = [] is still used
 			 * in other client side code. The data shape may differ until all the code is refactored.
 			 */
 			self.category2samplecount = data.lst
+			await new GroupSettingMethods(self, { holder }).main()
 		}
 	}
 }


### PR DESCRIPTION
# Description

Made the following fixes/improvements to summary input plot:

- Display survival plot when term1 is survival term
- Disable submit button when term1 is missing
- In `client/termsetting/handlers/categorical.ts`, moved the `postMain()` code to `showEditMenu()`, which allows `getCategories()` to only be called when opening edit menu. As a result, the pill loads much quicker upon selecting categorical term in summary input plot.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
