### PR TITLE
Download pdf/svg improvements

### DIFF
--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -118,6 +118,6 @@ export function getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight) {
 	if (height > pageHeight) {
 		scaleHeight = pageHeight / height
 	}
-	const scale = Math.min(scaleWidth, scaleHeight) * 0.95 //leave padding
+	const scale = Math.min(scaleWidth, scaleHeight) * 0.9 //leave padding
 	return scale * ratio
 }

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -88,7 +88,8 @@ export async function downloadSVGsAsPdf(name2svg, filename) {
 			doc.addPage()
 			y = 50
 		}
-		doc.text(name, x + 10, y - 20)
+		if (name.trim()) doc.text(name.length > 90 ? name.slice(0, 90) + '...' : name, x + 10, y - 20)
+		else y -= 20
 		await doc.svg(svg, { x, y, width, height })
 		y = y + height + 50
 		parent.removeChild(svg)

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -57,7 +57,7 @@ export class DownloadMenu {
 	}
 }
 
-export async function downloadSVGsAsPdf(name2svg, filename, orientation) {
+export async function downloadSVGsAsPdf(chartImages, filename, orientation) {
 	const JSPDF = await import('jspdf')
 	const { jsPDF } = JSPDF
 	/*
@@ -71,13 +71,13 @@ export async function downloadSVGsAsPdf(name2svg, filename, orientation) {
 	const pageWidth = doc.internal.pageSize.getWidth()
 	const pageHeight = doc.internal.pageSize.getHeight()
 
-	const entries: any[] = Object.entries(name2svg)
 	let y = 50
-	const x = 20 //pt
+	const x = 0.05 * pageWidth
 
-	for (const [name, chart] of entries) {
-		const parent = chart.parent
-		const svg = chart.svg.node().cloneNode(true) //clone to avoid modifying the original
+	for (const chartImage of chartImages) {
+		const name = chartImage.name
+		const parent = chartImage.parent
+		const svg = chartImage.svg.node().cloneNode(true) //clone to avoid modifying the original
 		if (parent) {
 			const svgStyles = window.getComputedStyle(parent)
 			for (const [prop, value] of Object.entries(svgStyles)) {

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -79,7 +79,7 @@ export async function downloadSVGsAsPdf(name2svg, filename) {
 		parent.appendChild(svg) //Added otherwise does not print, will remove later
 		const svgWidth = svg.getAttribute('width')
 		const svgHeight = svg.getAttribute('height')
-		const scale = getScale(pageWidth, pageHeight, svgWidth, svgHeight)
+		const scale = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
 		const width = svgWidth * scale //convert to pt and fit to page size
 		const height = svgHeight * scale //convert to pt and fit to page size
 
@@ -98,7 +98,7 @@ export async function downloadSVGsAsPdf(name2svg, filename) {
 	doc.save(filename + '.pdf')
 }
 
-export function getScale(pageWidth, pageHeight, svgWidth, svgHeight) {
+export function getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight) {
 	const ratio = 72 / 96 //convert px to pt
 	const width = svgWidth * ratio //convert to pt
 	const height = svgHeight * ratio //convert to pt

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -102,13 +102,14 @@ export function getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight) {
 	const ratio = 72 / 96 //convert px to pt
 	const width = svgWidth * ratio //convert to pt
 	const height = svgHeight * ratio //convert to pt
-	let scaleWidth, scaleHeight
+	let scaleWidth = 1,
+		scaleHeight = 1
 	if (width > pageWidth) {
 		scaleWidth = pageWidth / width
 	}
 	if (height > pageHeight) {
 		scaleHeight = pageHeight / height
 	}
-	const scale = Math.min(scaleWidth || 1, scaleHeight || 1) * 0.95 //leave padding
+	const scale = Math.min(scaleWidth, scaleHeight) * 0.95 //leave padding
 	return scale * ratio
 }

--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -21,9 +21,17 @@ export class DownloadMenu {
 		menuDiv
 			.append('div')
 			.attr('class', 'sja_menuoption sja_sharp_border')
-			.text('PDF')
+			.text('PDF Portrait')
 			.on('click', () => {
-				downloadSVGsAsPdf(this.name2svg, this.filename)
+				downloadSVGsAsPdf(this.name2svg, this.filename, 'portrait')
+				this.menu.hide()
+			})
+		menuDiv
+			.append('div')
+			.attr('class', 'sja_menuoption sja_sharp_border')
+			.text('PDF Landscape')
+			.on('click', () => {
+				downloadSVGsAsPdf(this.name2svg, this.filename, 'landscape')
 				this.menu.hide()
 			})
 		menuDiv
@@ -49,7 +57,7 @@ export class DownloadMenu {
 	}
 }
 
-export async function downloadSVGsAsPdf(name2svg, filename) {
+export async function downloadSVGsAsPdf(name2svg, filename, orientation) {
 	const JSPDF = await import('jspdf')
 	const { jsPDF } = JSPDF
 	/*
@@ -58,7 +66,7 @@ export async function downloadSVGsAsPdf(name2svg, filename) {
 	Therefore, a simple import 'svg2pdf.js' without curly braces is all that is needed to apply its functionality. 
 	 */
 	await import('svg2pdf.js') // This import extends jsPDF with SVG functionality
-	const doc = new jsPDF('portrait', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
+	const doc = new jsPDF(orientation, 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
 	doc.setFontSize(12)
 	const pageWidth = doc.internal.pageSize.getWidth()
 	const pageHeight = doc.internal.pageSize.getHeight()

--- a/client/dom/test/pdfscale.unit.spec.js
+++ b/client/dom/test/pdfscale.unit.spec.js
@@ -1,0 +1,66 @@
+import tape from 'tape'
+import { getPdfScale } from '#dom'
+
+/**
+ * Tests
+ * 		getPdfScale()
+ */
+
+/**************
+ test sections
+***************/
+tape('\n', function (test) {
+	test.comment('-***- get pdf scale specs -***-')
+	test.end()
+})
+
+tape('getPdfScale()', function (test) {
+	const ratio = 72 / 96 //0.75 convert px to pt
+	let svgWidth = 800 //px
+	let svgHeight = 600 //px
+	const pageWidth = 585.28 //A4 width in pt
+	const pageHeight = 831.89 //A4 height in pt
+
+	const scale = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
+	//svgWidth in pt 800 * 0.75 = 600, bigger than the page width, svgHeight in pt 600 * 0.75 = 450, smaller than the page height
+	//It will scale to page width, will add some padding and will multiply by ratio to add the conversion to pt
+	const expected = (pageWidth / (svgWidth * ratio)) * 0.95 * ratio
+	test.equal(
+		scale,
+		expected,
+		`Should return scale=${expected.toFixed(
+			2
+		)} for input svgWidth=${svgWidth}, svgHeight=${svgHeight}. The svg width is bigger than the page width. It will scale to page width, will add some padding and will multiply by ratio to add the conversion to pt`
+	)
+
+	svgWidth = 600
+	svgHeight = 600
+	const scale2 = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
+	//svgWidth in pt 600 * 0.75 = 450, smaller than the page width, svgHeight in pt 600 * 0.75 = 450, smaller than the page height
+	//It does not need to scale to page width, will add some padding and will multiply by ratio to add the conversion to pt
+	const expected2 = 0.95 * ratio
+	test.equal(
+		scale2,
+		expected2,
+		`Should return scale=${expected2.toFixed(
+			2
+		)} for input svgWidth=${svgWidth}, svgHeight=${svgHeight}. Svg width and height are smaller than the page width and height. It does not need to scale to page width, will add some padding and will multiply by ratio to add the conversion to pt`
+	)
+
+	svgWidth = 800
+	svgHeight = 1200
+	const scale3 = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
+	//svgWidth in pt 800 * 0.75 = 600, bigger than the page width, svgHeight in pt 1200 * 0.75 = 900, bigger than the page height
+	//It will take the min scale that is the height scale, will add some padding and will multiply by ratio to add the conversion to pt
+	const minScale = Math.min(pageHeight / (svgHeight * ratio), pageWidth / (svgWidth * ratio))
+	const expected3 = minScale * 0.95 * ratio
+	test.equal(
+		scale3,
+		expected3,
+		`Should return scale=${expected3.toFixed(
+			2
+		)} for input svgWidth=${svgWidth}, svgHeight=${svgHeight}. Svg width and height are bigger than the page width and height. It will take the min scale that is the height scale, will add some padding and will multiply by ratio to add the conversion to pt`
+	)
+
+	test.end()
+})

--- a/client/dom/test/pdfscale.unit.spec.js
+++ b/client/dom/test/pdfscale.unit.spec.js
@@ -24,7 +24,7 @@ tape('getPdfScale()', function (test) {
 	const scale = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
 	//svgWidth in pt 800 * 0.75 = 600, bigger than the page width, svgHeight in pt 600 * 0.75 = 450, smaller than the page height
 	//It will scale to page width, will add some padding and will multiply by ratio to add the conversion to pt
-	const expected = (pageWidth / (svgWidth * ratio)) * 0.95 * ratio
+	const expected = (pageWidth / (svgWidth * ratio)) * 0.9 * ratio
 	test.equal(
 		scale,
 		expected,
@@ -38,7 +38,7 @@ tape('getPdfScale()', function (test) {
 	const scale2 = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
 	//svgWidth in pt 600 * 0.75 = 450, smaller than the page width, svgHeight in pt 600 * 0.75 = 450, smaller than the page height
 	//It does not need to scale to page width, will add some padding and will multiply by ratio to add the conversion to pt
-	const expected2 = 0.95 * ratio
+	const expected2 = 0.9 * ratio
 	test.equal(
 		scale2,
 		expected2,
@@ -53,7 +53,7 @@ tape('getPdfScale()', function (test) {
 	//svgWidth in pt 800 * 0.75 = 600, bigger than the page width, svgHeight in pt 1200 * 0.75 = 900, bigger than the page height
 	//It will take the min scale that is the height scale, will add some padding and will multiply by ratio to add the conversion to pt
 	const minScale = Math.min(pageHeight / (svgHeight * ratio), pageWidth / (svgWidth * ratio))
-	const expected3 = minScale * 0.95 * ratio
+	const expected3 = minScale * 0.9 * ratio
 	test.equal(
 		scale3,
 		expected3,

--- a/client/mass/app.ts
+++ b/client/mass/app.ts
@@ -5,10 +5,7 @@ import { vocabInit } from '#termdb/vocabulary'
 import { navInit } from './nav'
 import { plotInit } from './plot'
 import { summaryInit } from '#plots/summary.js'
-import { sayerror } from '../dom/sayerror.ts'
-import { Menu } from '#dom/menu'
-import { newSandboxDiv } from '../dom/sandbox.ts'
-import { getPdfScale } from '#dom'
+import { sayerror, Menu, newSandboxDiv, getPdfScale } from '#dom'
 
 /*
 opts{}
@@ -20,16 +17,12 @@ opts{}
  	.genome
  	.dslabel
  	.tree{} etc
-	see doc for full spec
-	https://docs.google.com/document/d/1gTPKS9aDoYi4h_KlMBXgrMxZeA_P4GXhWcQdNQs3Yp8/edit
 
 .app
 	.onFilterChange
 	If it is provided when the global filter is edited
 	this function is called (from mass/store). Used by the profile dataset so far,
 	to clear the profile local filters
-                
-
 */
 
 class MassApp extends AppBase implements RxAppInner {

--- a/client/mass/app.ts
+++ b/client/mass/app.ts
@@ -209,13 +209,9 @@ class MassApp extends AppBase implements RxAppInner {
 	}
 
 	async downloadSVGsAsPdf() {
+		// some duplication with dowloadMenu.ts/downloadSVGsAsPdf(), which contains notes on dependency usage
 		const JSPDF = await import('jspdf')
 		const { jsPDF } = JSPDF
-		/*
-		When imported, the svg2pdf.js module modifies or extends the jsPDF library (which we already imported).
-		The code inside svg2pdf.js adds a new method (.svg()) to the jsPDF object prototype, making that functionality available on all jsPDF instances.
-		Therefore, a simple import 'svg2pdf.js' without curly braces is all that is needed to apply its functionality. 
-		*/
 		await import('svg2pdf.js') // This import extends jsPDF with SVG functionality
 		const doc = new jsPDF('landscape', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
 		doc.setFontSize(12)

--- a/client/mass/app.ts
+++ b/client/mass/app.ts
@@ -8,7 +8,7 @@ import { summaryInit } from '#plots/summary.js'
 import { sayerror } from '../dom/sayerror.ts'
 import { Menu } from '#dom/menu'
 import { newSandboxDiv } from '../dom/sandbox.ts'
-import { getScale } from '#dom'
+import { getPdfScale } from '#dom'
 
 /*
 opts{}
@@ -259,7 +259,7 @@ class MassApp extends AppBase implements RxAppInner {
 				let height = svg.getAttribute('height')
 
 				svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
-				const scale = getScale(pageWidth, pageHeight, width, height)
+				const scale = getPdfScale(pageWidth, pageHeight, width, height)
 				width = scale * width
 				height = scale * height
 				if (y + height > pageHeight - 20) {

--- a/client/mass/app.ts
+++ b/client/mass/app.ts
@@ -224,7 +224,7 @@ class MassApp extends AppBase implements RxAppInner {
 		Therefore, a simple import 'svg2pdf.js' without curly braces is all that is needed to apply its functionality. 
 		*/
 		await import('svg2pdf.js') // This import extends jsPDF with SVG functionality
-		const doc = new jsPDF('portrait', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
+		const doc = new jsPDF('landscape', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
 		doc.setFontSize(12)
 		const pageWidth = doc.internal.pageSize.getWidth() - 10
 		const pageHeight = doc.internal.pageSize.getHeight() - 10

--- a/client/mass/app.ts
+++ b/client/mass/app.ts
@@ -134,7 +134,10 @@ class MassApp extends AppBase implements RxAppInner {
 					header_mode: this.state && this.state.nav && this.state.nav.header_mode,
 					vocab: this.state.vocab,
 					massSessionDuration: this.state.termdbConfig.massSessionDuration, // this.opts.massSessionDuration
-					pkgver: this.opts.pkgver
+					pkgver: this.opts.pkgver,
+					downloadPlots: () => {
+						console.log(this)
+					}
 				})
 			}
 			this.components.plots = {}

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -207,7 +207,7 @@ function setRenderers(self) {
 			.style('display', 'inline-block')
 			.style('float', 'right')
 			.style('font-size', '1.1em')
-			.style('margin-top', '50px')
+			.style('margin', '50px 100px 0 0')
 			.text(massNav?.title?.text) //this line will be executed in update UI to reflect cohort changes
 
 		const tabDiv = header.append('div').style('display', 'none').style('vertical-align', 'bottom')
@@ -237,7 +237,12 @@ function setRenderers(self) {
 			deleteAllDiv: controlsDiv
 				.append('div')
 				.style('display', 'inline-block')
-				.style('padding-top', '4px')
+				.style('padding', '4px')
+				.style('vertical-align', 'middle'),
+			pdfDiv: controlsDiv
+				.append('div')
+				.style('display', 'inline-block')
+				.style('padding', '4px')
 				.style('vertical-align', 'middle'),
 			helpDiv: controlsDiv.append('div').style('display', 'none'),
 			sessionElapsedMessageDiv: controlsDiv.append('div').style('display', 'none'),
@@ -253,6 +258,11 @@ function setRenderers(self) {
 		icon_functions['trash'](self.dom.deleteAllDiv, {
 			handler: self.deletePlots,
 			title: 'Delete all plots. To revert, click Undo button'
+		})
+
+		icon_functions['pdf'](self.dom.pdfDiv, {
+			handler: self.opts.downloadPlots,
+			title: 'Generate a PDF of all the plots opened'
 		})
 
 		if (self.opts.header_mode === 'with_cohortHtmlSelect') {

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -207,7 +207,7 @@ function setRenderers(self) {
 			.style('display', 'inline-block')
 			.style('float', 'right')
 			.style('font-size', '1.1em')
-			.style('margin', '50px 100px 0 0')
+			.style('margin', '50px 10px 0 0')
 			.text(massNav?.title?.text) //this line will be executed in update UI to reflect cohort changes
 
 		const tabDiv = header.append('div').style('display', 'none').style('vertical-align', 'bottom')
@@ -234,16 +234,17 @@ function setRenderers(self) {
 			searchDiv: controlsDiv.append('div').style('margin', '10px'),
 			sessionDiv: controlsDiv.append('div').style('display', 'inline-block'),
 			recoverDiv: controlsDiv.append('div').style('display', 'inline-block'),
-			deleteAllDiv: controlsDiv
-				.append('div')
-				.style('display', 'inline-block')
-				.style('padding', '4px')
-				.style('vertical-align', 'middle'),
 			pdfDiv: controlsDiv
 				.append('div')
 				.style('display', 'inline-block')
 				.style('padding', '4px')
 				.style('vertical-align', 'middle'),
+			deleteAllDiv: controlsDiv
+				.append('div')
+				.style('display', 'inline-block')
+				.style('padding', '4px')
+				.style('vertical-align', 'middle'),
+
 			helpDiv: controlsDiv.append('div').style('display', 'none'),
 			sessionElapsedMessageDiv: controlsDiv.append('div').style('display', 'none'),
 			subheaderDiv: self.opts.holder

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -1114,19 +1114,19 @@ function setInteractivity(self) {
 	self.handlers = getHandlers(self)
 
 	self.getChartImages = function () {
-		const name2svg = {}
+		const charts = []
 		const node = self.dom.barDiv.select('.sjpcb-bars-mainG').node() //node to read the style
 
 		for (const chart of self.charts) {
 			const name = `${this.config.term.term.name}  ${chart.name ? chart.name : ''}`
-			name2svg[name] = { svg: chart.svg, parent: node }
+			charts.push({ name, svg: chart.svg, parent: node })
 		}
-		return name2svg
+		return charts
 	}
 
 	self.download = function (event) {
-		const name2svg = self.getChartImages()
-		const dm = new DownloadMenu(name2svg, self.config.term.term.name)
+		const charts = self.getChartImages()
+		const dm = new DownloadMenu(charts, self.config.term.term.name)
 		dm.show(event.clientX, event.clientY)
 	}
 

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -23,7 +23,7 @@ export class Barchart {
 	//freeze the api of this class. don't want embedder functions to modify it.
 	preApiFreeze(api) {
 		api.download = this.download
-		api.getChartDict = () => this.getChartDict()
+		api.getChartImages = () => this.getChartImages()
 	}
 
 	async init(appState) {
@@ -1113,7 +1113,7 @@ function setRenderers(self) {
 function setInteractivity(self) {
 	self.handlers = getHandlers(self)
 
-	self.getChartDict = function () {
+	self.getChartImages = function () {
 		const name2svg = {}
 		const node = self.dom.barDiv.select('.sjpcb-bars-mainG').node() //node to read the style
 
@@ -1125,7 +1125,7 @@ function setInteractivity(self) {
 	}
 
 	self.download = function (event) {
-		const name2svg = self.getChartDict()
+		const name2svg = self.getChartImages()
 		const dm = new DownloadMenu(name2svg, self.config.term.term.name)
 		dm.show(event.clientX, event.clientY)
 	}

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -334,15 +334,15 @@ class TdbBoxplot extends RxComponentInner {
 	}
 
 	getChartImages() {
-		const name2svg = {}
+		const chartImages: any[] = []
 		const charts: any[] = this.data.charts
 		for (const [key, chart] of Object.entries(charts)) {
 			const svg: any = chart.svg
 			const title = getChartTitle(this.state.config, key)
 			const name = `${this.state.config.term.term.name}  ${title}`
-			name2svg[name] = { svg, parent: svg.node() }
+			chartImages.push({ name, svg, parent: svg.node() })
 		}
-		return name2svg
+		return chartImages
 	}
 
 	download(event) {

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -12,7 +12,8 @@ import { ViewModel } from './viewModel/ViewModel'
 import { View } from './view/View'
 import { BoxPlotInteractions } from './interactions/BoxPlotInteractions'
 import { LegendRenderer } from './view/LegendRender'
-
+import { DownloadMenu } from '#dom'
+import { getChartTitle } from './viewModel/ViewModel'
 class TdbBoxplot extends RxComponentInner {
 	readonly type = 'boxplot'
 	components: { controls: any }
@@ -197,7 +198,7 @@ class TdbBoxplot extends RxComponentInner {
 		})
 
 		this.components.controls.on('downloadClick.boxplot', event => {
-			this.interactions!.download(event, this.data)
+			this.download(event)
 		})
 		this.components.controls.on('helpClick.boxplot', () => {
 			this.interactions!.help()
@@ -326,10 +327,30 @@ class TdbBoxplot extends RxComponentInner {
 			const textColor = settings.displayMode == 'dark' ? 'white' : 'black'
 			if (legend.length) new LegendRenderer(this.dom.legend, legend, this.interactions, textColor)
 		} catch (e: any) {
+			if (e.stack) console.log(e.stack)
 			if (e instanceof Error) console.error(e.message || e)
-			else if (e.stack) console.log(e.stack)
 			throw e
 		}
+	}
+
+	getChartImages() {
+		const name2svg = {}
+		const charts: any[] = this.data.charts
+		for (const [key, chart] of Object.entries(charts)) {
+			const svg: any = chart.svg
+			const title = getChartTitle(this.state.config, key)
+			const name = `${this.state.config.term.term.name}  ${title}`
+			name2svg[name] = { svg, parent: svg.node() }
+		}
+		return name2svg
+	}
+
+	download(event) {
+		if (!this.state) return
+
+		const name2svg = this.getChartImages()
+		const dm = new DownloadMenu(name2svg, this.state.config.term.term.name)
+		dm.show(event.clientX, event.clientY)
 	}
 }
 

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -3,7 +3,6 @@ import type { MassAppApi } from '#mass/types/mass'
 import type { RenderedPlot } from '../view/RenderedPlot'
 import { ListSamples } from './ListSamples'
 import { filterJoin, getFilterItemByTag } from '#filter'
-import { DownloadMenu } from '#dom/downloadMenu'
 
 export class BoxPlotInteractions {
 	app: MassAppApi
@@ -13,17 +12,6 @@ export class BoxPlotInteractions {
 		this.app = app
 		this.dom = dom
 		this.id = id
-	}
-
-	download(event, data) {
-		const name2svg = {}
-		const node = this.dom.charts.select('.sjpp-boxplot-svg').node() //node to read the style
-		for (const k of Object.keys(data.charts)) {
-			const chart = data.charts[k]
-			name2svg[chart.chartId] = { svg: chart.svg, parent: node }
-		}
-		const menu = new DownloadMenu(name2svg)
-		menu.show(event.clientX, event.clientY)
 	}
 
 	help() {

--- a/client/plots/boxplot/viewModel/ViewModel.ts
+++ b/client/plots/boxplot/viewModel/ViewModel.ts
@@ -68,7 +68,7 @@ export class ViewModel {
 			domain: [data.absMin, data.absMax! <= 1 ? data.absMax : data.absMax! + 1],
 			range: [0, settings.boxplotWidth],
 			svg,
-			chartTitle: this.getChartTitle(config, data.chartId),
+			chartTitle: getChartTitle(config, data.chartId),
 			title: this.setTitleDimensions(config, settings, svg.height),
 			axis: {
 				x: settings.isVertical ? this.horizPad / 2 + this.incrPad + this.topPad : this.totalLabelSize,
@@ -118,13 +118,6 @@ export class ViewModel {
 		}
 	}
 
-	getChartTitle(config, chartId) {
-		if (!config.term0) return chartId
-		return config.term0.term.values && chartId in config.term0.term.values
-			? config.term0.term.values[chartId].label
-			: chartId
-	}
-
 	setTitleDimensions(config: any, settings: BoxPlotSettings, height: number) {
 		const depth = this.totalLabelSize + settings.boxplotWidth / 2
 		return {
@@ -162,4 +155,11 @@ export class ViewModel {
 		}
 		return plots
 	}
+}
+
+export function getChartTitle(config, chartId) {
+	if (!config.term0) return chartId
+	return config.term0.term.values && chartId in config.term0.term.values
+		? config.term0.term.values[chartId].label
+		: chartId
 }

--- a/client/plots/profileForms.ts
+++ b/client/plots/profileForms.ts
@@ -73,7 +73,7 @@ export class profileForms extends profilePlot {
 
 		const shift = 650
 		const shiftTop = 50
-		const width = settings.svgw + shift + 600
+		const width = settings.svgw + shift + 440
 		const svg = rightDiv.style('padding', '20px').append('svg').attr('width', width)
 		svg
 			.append('defs')
@@ -90,7 +90,7 @@ export class profileForms extends profilePlot {
 		this.shift = shift
 		const mainG = svg.append('g').attr('transform', `translate(${shift}, ${shiftTop})`)
 		const gridG = svg.append('g').attr('transform', `translate(${shift}, ${shiftTop})`)
-		this.filterG = svg.append('g').attr('transform', `translate(${shift + settings.svgw + 120}, ${shiftTop})`)
+		this.filterG = svg.append('g').attr('transform', `translate(${shift + settings.svgw + 60}, ${shiftTop})`)
 		const legendG = svg.append('g') //each plot will translate it to the right position
 
 		const xAxisG = svg.append('g').attr('transform', `translate(${shift}, ${shiftTop / 2})`)
@@ -305,7 +305,7 @@ export class profileForms extends profilePlot {
 		this.categories.add(category)
 
 		const percent = (value / total) * 100
-		const width = (percent / 100) * (this.settings.svgw - 150) //last 100 is for the not applicable category
+		const width = (percent / 100) * this.settings.svgw
 		itemG
 			.append('rect')
 			.attr('x', x)
@@ -438,7 +438,7 @@ export function getDefaultProfileFormsSettings() {
 		controls: {
 			isOpen: false
 		},
-		profileForms: { svgw: 400, svgh: 480 }
+		profileForms: { svgw: 420, svgh: 480 }
 	}
 	const profilePlotSettings = getDefaultProfilePlotSettings()
 	settings.profileForms = copyMerge(settings.profileForms, profilePlotSettings)

--- a/client/plots/profileForms.ts
+++ b/client/plots/profileForms.ts
@@ -71,9 +71,9 @@ export class profileForms extends profilePlot {
 				tabs: this.tabs
 			}).main()
 
-		const shift = 650
+		const shift = 620
 		const shiftTop = 50
-		const width = settings.svgw + shift + 440
+		const width = settings.svgw + shift + 500
 		const svg = rightDiv.style('padding', '20px').append('svg').attr('width', width)
 		svg
 			.append('defs')
@@ -90,7 +90,7 @@ export class profileForms extends profilePlot {
 		this.shift = shift
 		const mainG = svg.append('g').attr('transform', `translate(${shift}, ${shiftTop})`)
 		const gridG = svg.append('g').attr('transform', `translate(${shift}, ${shiftTop})`)
-		this.filterG = svg.append('g').attr('transform', `translate(${shift + settings.svgw + 60}, ${shiftTop})`)
+		this.filterG = svg.append('g').attr('transform', `translate(${shift + settings.svgw + 60}, ${shiftTop + 40})`)
 		const legendG = svg.append('g') //each plot will translate it to the right position
 
 		const xAxisG = svg.append('g').attr('transform', `translate(${shift}, ${shiftTop / 2})`)

--- a/client/plots/profileForms.ts
+++ b/client/plots/profileForms.ts
@@ -162,7 +162,7 @@ export class profileForms extends profilePlot {
 			y += step
 		}
 		y += step * 2
-		const width = this.settings.svgw - 150
+		const width = this.settings.svgw
 		const posScale = d3Linear()
 			.domain([0, 100])
 			.range([this.shift, this.shift + width])

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -569,7 +569,7 @@ export class profilePlot {
 	}
 
 	getChartImages() {
-		return { [this.chartName]: { svg: this.dom.svg, parent: this.dom.svg.node() } }
+		return [{ name: '', svg: this.dom.svg, parent: this.dom.svg.node() }]
 	}
 }
 

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -486,8 +486,10 @@ export class profilePlot {
 			.text(`${title} (n=${this.data.n})`)
 			.attr('transform', `translate(0, -5)`)
 		for (const tw of this.config.filterTWs) this.addFilterLegendItem(tw.term.name, this.settings[tw.term.id])
-		const hospital = this.data.hospital
+
 		if (this.settings.site) {
+			let hospital = this.data.hospital
+			if (hospital?.length > 50) hospital = hospital.slice(0, 50) + '...'
 			const label = this.sites.find(s => s.value == this.settings.site).label
 			this.addFilterLegendItem('Facility ID', label)
 			this.addFilterLegendItem('Facility', hospital)

--- a/client/plots/profilePlot.js
+++ b/client/plots/profilePlot.js
@@ -403,9 +403,7 @@ export class profilePlot {
 					title: 'Filters'
 				})
 			}
-			this.components.controls.on(`downloadClick.${chartType}`, () =>
-				downloadSingleSVG(this.dom.svg, this.getDownloadFilename(), this.dom.holder.node())
-			)
+			this.components.controls.on(`downloadClick.${chartType}`, event => this.download(event))
 			this.components.controls.on(`helpClick.${chartType}`, () => {
 				const activeCohort = this.state.activeCohort
 				let link
@@ -569,7 +567,7 @@ export class profilePlot {
 	}
 
 	getChartImages() {
-		return { ['']: { svg: this.dom.svg, parent: this.dom.svg.node() } }
+		return { [this.chartName]: { svg: this.dom.svg, parent: this.dom.svg.node() } }
 	}
 }
 

--- a/client/plots/profileRadar.js
+++ b/client/plots/profileRadar.js
@@ -3,7 +3,6 @@ import { fillTwLst } from '#termsetting'
 import * as d3 from 'd3'
 import { profilePlot } from './profilePlot.js'
 import { renderTable } from '../dom/table'
-import { loadFilterTerms } from './profilePlot.js'
 import { getDefaultProfilePlotSettings, ABBREV_COHORT, makeChartBtnMenu, getProfilePlotConfig } from './profilePlot.js'
 
 class profileRadar extends profilePlot {

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -131,12 +131,12 @@ export class Report extends RxComponentInner {
 		Therefore, a simple import 'svg2pdf.js' without curly braces is all that is needed to apply its functionality. 
 		*/
 		await import('svg2pdf.js') // This import extends jsPDF with SVG functionality
-		const doc: any = new jsPDF('p', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
+		const doc: any = new jsPDF('landscape', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
 		const pageWidth = doc.internal.pageSize.getWidth() - 10
 		const pageHeight = doc.internal.pageSize.getHeight() - 10
 
 		let y = 40
-		const x = 20
+		const x = 0.05 * pageWidth
 		doc.setFontSize(12)
 		doc.text(this.config.sections[0].name, x, y)
 		doc.setFontSize(10)

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -145,8 +145,8 @@ export class Report extends RxComponentInner {
 			newSection = true
 			for (const plotConfig of section.plots) {
 				const plot = this.components.plots[plotConfig.id]
-				if (plot?.getChartDict) {
-					const name2svg = plot.getChartDict()
+				if (plot?.getChartImages) {
+					const name2svg = plot.getChartImages()
 					const entries: any[] = Object.entries(name2svg)
 
 					for (const [name, chart] of entries) {

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -4,6 +4,7 @@ import { ReportView } from './view/reportView'
 import { RxComponentInner } from '../../types/rx.d'
 import { controlsInit } from '../controls.js'
 import { importPlot } from '#plots/importPlot.js'
+import { getScale } from '#dom/downloadMenu'
 
 export class Report extends RxComponentInner {
 	config: any
@@ -133,7 +134,6 @@ export class Report extends RxComponentInner {
 		const doc: any = new jsPDF('p', 'pt', 'a4') // p for portrait, l for landscape, points, A4 size
 		const pageWidth = doc.internal.pageSize.getWidth() - 10
 		const pageHeight = doc.internal.pageSize.getHeight() - 10
-		const ratio = 72 / 96 //convert pixels to pt
 
 		let y = 40
 		const x = 20
@@ -161,11 +161,12 @@ export class Report extends RxComponentInner {
 							}
 						}
 						chart.parent.appendChild(svg) //Added otherwise does not print, will remove later
-						let width = svg.getAttribute('width')
-						let height = svg.getAttribute('height')
-						svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
-						width = Math.min(pageWidth, width * ratio) - 20
-						height = Math.min(pageHeight, height * ratio) - 20
+						const svgWidth = svg.getAttribute('width')
+						const svgHeight = svg.getAttribute('height')
+						svg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`)
+						const scale = getScale(pageWidth, pageHeight, svgWidth, svgHeight)
+						const width = svgWidth * scale //convert to pt and fit to page size
+						const height = svgHeight * scale //convert to pt and fit to page size
 						if (y + height > pageHeight - 20) {
 							doc.addPage()
 							y = 40
@@ -179,10 +180,11 @@ export class Report extends RxComponentInner {
 						}
 						if (name.trim()) {
 							doc.text(name.length > 90 ? name.slice(0, 90) + '...' : name, x, y)
-							y += 20
+							y += 40
 						}
+						console.log(y)
 						await doc.svg(svg, { x, y, width, height })
-						y = y + height + 40
+						y = y + height + 60
 						chart.parent.removeChild(svg)
 						newSection = false
 					}

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -136,13 +136,11 @@ export class Report extends RxComponentInner {
 		const pageHeight = doc.internal.pageSize.getHeight() - 10
 
 		let y = 40
-		const x = 0.05 * pageWidth
-		doc.setFontSize(12)
-		doc.text(this.config.sections[0].name, x, y)
+		const padding = 0.05 * pageWidth
+		const x = padding
 		doc.setFontSize(10)
-		let newSection
+
 		for (const section of this.config.sections) {
-			newSection = true
 			for (const plotConfig of section.plots) {
 				const plot = this.components.plots[plotConfig.id]
 				if (plot?.getChartImages) {
@@ -167,26 +165,18 @@ export class Report extends RxComponentInner {
 						const scale = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
 						const width = svgWidth * scale //convert to pt and fit to page size
 						const height = svgHeight * scale //convert to pt and fit to page size
-						if (y + height > pageHeight - 20) {
+						if (y + height > pageHeight - padding) {
 							doc.addPage()
 							y = 40
 						}
-						if (y == 40 || newSection) {
-							//new page, add section
-							doc.setFontSize(12)
-							doc.text(section.name, x, y)
-							doc.setFontSize(10)
-							y += 30
-						}
-						if (name.trim()) {
-							doc.text(name.length > 90 ? name.slice(0, 90) + '...' : name, x, y)
-							y += 40
-						}
-						console.log(y)
+
+						const text = name.length > 90 ? name.slice(0, 90) + '...' : name
+						doc.text(`${section.name} / ${text}`, x, y)
+						y += 30
+
 						await doc.svg(svg, { x, y, width, height })
 						y = y + height + 60
 						chart.parent.removeChild(svg)
-						newSection = false
 					}
 				}
 			}

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -178,7 +178,7 @@ export class Report extends RxComponentInner {
 							y += 30
 						}
 						if (name.trim()) {
-							doc.text(name, x, y)
+							doc.text(name.length > 90 ? name.slice(0, 90) + '...' : name, x, y)
 							y += 20
 						}
 						await doc.svg(svg, { x, y, width, height })

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -4,7 +4,7 @@ import { ReportView } from './view/reportView'
 import { RxComponentInner } from '../../types/rx.d'
 import { controlsInit } from '../controls.js'
 import { importPlot } from '#plots/importPlot.js'
-import { getScale } from '#dom/downloadMenu'
+import { getPdfScale } from '#dom/downloadMenu'
 
 export class Report extends RxComponentInner {
 	config: any
@@ -164,7 +164,7 @@ export class Report extends RxComponentInner {
 						const svgWidth = svg.getAttribute('width')
 						const svgHeight = svg.getAttribute('height')
 						svg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`)
-						const scale = getScale(pageWidth, pageHeight, svgWidth, svgHeight)
+						const scale = getPdfScale(pageWidth, pageHeight, svgWidth, svgHeight)
 						const width = svgWidth * scale //convert to pt and fit to page size
 						const height = svgHeight * scale //convert to pt and fit to page size
 						if (y + height > pageHeight - 20) {

--- a/client/plots/report/report.ts
+++ b/client/plots/report/report.ts
@@ -4,7 +4,7 @@ import { ReportView } from './view/reportView'
 import { RxComponentInner } from '../../types/rx.d'
 import { controlsInit } from '../controls.js'
 import { importPlot } from '#plots/importPlot.js'
-import { getPdfScale } from '#dom/downloadMenu'
+import { getPdfScale } from '#dom'
 
 export class Report extends RxComponentInner {
 	config: any

--- a/client/plots/runchart/viewmodel/runchartViewModel.ts
+++ b/client/plots/runchart/viewmodel/runchartViewModel.ts
@@ -27,7 +27,7 @@ export class RunchartViewModel extends ScatterViewModelBase {
 		const color = this.runchart.config.term0 ? this.runchart.cat2Color(chart.id) : this.runchart.settings.defaultColor
 		const coords = chart.cohortSamples.map(s => this.model.getCoordinates(chart, s)).sort((a, b) => a.x - b.x)
 
-		const xtext = coords[coords.length - 1].x - 20
+		const xtext = coords[coords.length - 1].x - 30
 		const areaBuilder = line()
 			.x((d: any) => d.x)
 			.y((d: any) => d.y)

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -148,13 +148,13 @@ export class Scatter extends RxComponentInner {
 			const url = this.vm.canvas.toDataURL('image/png')
 			downloadImage(url)
 		} else {
-			const name2svg = this.getChartDict()
-			const menu = new DownloadMenu(name2svg, this.type)
+			const name2svg = this.getChartImages()
+			const menu = new DownloadMenu(name2svg, 'scatter')
 			menu.show(event.clientX, event.clientY)
 		}
 	}
 
-	getChartDict() {
+	getChartImages() {
 		const name2svg = {}
 		for (const chart of this.model.charts) {
 			const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
@@ -164,7 +164,7 @@ export class Scatter extends RxComponentInner {
 	}
 
 	preApiFreeze(api) {
-		api.getChartDict = () => this.getChartDict()
+		api.getChartImages = () => this.getChartImages()
 	}
 }
 

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -12,10 +12,12 @@ import { ScatterInteractivity, downloadImage } from './viewmodel/scatterInteract
 import { ScatterViewModel2DLarge } from './viewmodel/scatterViewModel2DLarge.js'
 import { ScatterViewModel3D } from './viewmodel/scatterViewModel3D.js'
 import { controlsInit } from '../controls'
-import { select2Terms, DownloadMenu } from '#dom'
-import type { MassState } from '../../mass/types/mass.js'
+import { select2Terms } from '#dom/select2Terms'
+import type { MassState } from '../../../client/mass/types/mass.js'
+import { DownloadMenu } from '#dom/downloadMenu'
+import { PlotBase } from '#plots/PlotBase.js'
 
-export class Scatter extends RxComponentInner {
+export class Scatter extends PlotBase implements RxComponentInner {
 	config: any
 	view!: ScatterView
 	model!: ScatterModel
@@ -30,9 +32,11 @@ export class Scatter extends RxComponentInner {
 	transform: any
 	parentId: any
 	zoom: any
+	dom: any
+	api: any
 
 	constructor(opts) {
-		super()
+		super(opts)
 		this.type = 'sampleScatter'
 		this.parentId = opts?.parentId //not working!!!, need to pass opts with the parentId to the component
 		this.zoom = 1
@@ -50,6 +54,7 @@ export class Scatter extends RxComponentInner {
 				this.zoom = parseFloat(match[1])
 			}
 		}
+		this.dom = this.view.dom
 	}
 
 	reactsTo(action) {
@@ -161,10 +166,6 @@ export class Scatter extends RxComponentInner {
 			name2svg[name] = { svg: chart.svg, parent: chart.svg.node() }
 		}
 		return name2svg
-	}
-
-	preApiFreeze(api) {
-		api.getChartImages = () => this.getChartImages()
 	}
 }
 

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -6,7 +6,7 @@ import { ScatterView } from './view/scatterView.js'
 import { getCurrentCohortChartTypes } from '#mass/charts'
 import { rebaseGroupFilter } from '#mass/groups'
 import { plotColor } from '#shared/common.js'
-import { RxComponentInner } from '../../types/rx.d.js'
+import { type RxComponentInner } from '../../types/rx.d.js'
 import { filterJoin, getCombinedTermFilter } from '#filter'
 import { ScatterInteractivity, downloadImage } from './viewmodel/scatterInteractivity.js'
 import { ScatterViewModel2DLarge } from './viewmodel/scatterViewModel2DLarge.js'
@@ -65,6 +65,11 @@ export class Scatter extends PlotBase implements RxComponentInner {
 			return react
 		}
 		return true
+	}
+
+	//for some reason the scatter getChartImages is not seen unless I do this
+	preApiFreeze(api) {
+		api.getChartImages = () => this.getChartImages()
 	}
 
 	getState(appState: MassState) {

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -165,12 +165,12 @@ export class Scatter extends PlotBase implements RxComponentInner {
 	}
 
 	getChartImages() {
-		const name2svg = {}
+		const chartImages: any[] = []
 		for (const chart of this.model.charts) {
 			const name = `${this.config.name || ''}${chart.id == 'Default' ? '' : ' ' + chart.id}	`
-			name2svg[name] = { svg: chart.svg, parent: chart.svg.node() }
+			chartImages.push({ name, svg: chart.svg, parent: chart.svg.node() })
 		}
-		return name2svg
+		return chartImages
 	}
 }
 

--- a/client/plots/scatter/viewmodel/scatterViewModelBase.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModelBase.ts
@@ -180,6 +180,7 @@ export class ScatterViewModelBase {
 				)
 				.attr('text-anchor', 'middle')
 				.text(termName)
+				.style('font-size', '0.9em')
 
 			if (termName.length > 65) {
 				text
@@ -203,7 +204,8 @@ export class ScatterViewModelBase {
 					.text(term0Name)
 			}
 			const isEvents = this.scatter.config.term2 ? false : true
-			const term2Name = isEvents ? 'Frequency' : getTitle(this.scatter.config.term2.term.name, 60)
+			const t2name = this.scatter.config.term2?.term?.name
+			const term2Name = isEvents ? 'Frequency' : getTitle(t2name, 60)
 			text = labelsG
 				.append('text')
 				.attr(
@@ -214,6 +216,7 @@ export class ScatterViewModelBase {
 				)
 				.attr('text-anchor', 'middle')
 				.text(term2Name)
+				.style('font-size', '0.9em')
 			if (term2Name.length > 60) {
 				text
 					.on('mouseenter', event => {

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -367,6 +367,14 @@ class SummaryPlot extends PlotBase implements RxComponentInner {
 
 		this.dom.plotDivs[this.config.childType].style('display', '')
 	}
+
+	getChartImages() {
+		const chart = this.components.plots[this.config.childType]
+		if (chart?.getChartImages) {
+			return chart.getChartImages()
+		}
+		return null
+	}
 }
 
 export const summaryInit = getCompInit(SummaryPlot)

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -1022,19 +1022,19 @@ function setRenderers(self) {
 
 function setInteractivity(self) {
 	self.download = function (event) {
-		const name2svg = self.getChartImages()
-		const menu = new DownloadMenu(name2svg, self.state.config.term.term.name)
+		const charts = self.getChartImages()
+		const menu = new DownloadMenu(charts, self.state.config.term.term.name)
 		menu.show(event.clientX, event.clientY)
 	}
 
 	self.getChartImages = function () {
-		const name2svg = {}
+		const charts: any[] = []
 		const node = self.dom.chartsDiv.select('.sjpp-survival-mainG').node() //node to read the style
 
 		for (const chart of self.pj.tree.charts) {
-			name2svg[chart.chartId] = { svg: chart.svg, parent: node }
+			charts.push({ name: chart.chartId, svg: chart.svg, parent: node })
 		}
-		return name2svg
+		return charts
 	}
 
 	// The logic is replaced by the downloadMenu SVG option

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -156,11 +156,6 @@ class TdbSurvival extends PlotBase implements RxComponentInner {
 		await this.setControls()
 	}
 
-	preApiFreeze(api) {
-		api.download = this.download
-		api.getChartImages = () => this.getChartImages()
-	}
-
 	async setControls() {
 		if (this.opts.controls) {
 			this.opts.controls.on('downloadClick.survival', this.download)

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -55,7 +55,7 @@ class TdbSurvival extends PlotBase implements RxComponentInner {
 	hiddenRenderer: any
 	legendClick = (_, __, ___) => {}
 	download: () => void = () => {}
-	getChartDict = () => this.getChartDict()
+	getChartImages = () => this.getChartImages()
 	loadingWait = 0
 
 	colorScale: any
@@ -158,7 +158,7 @@ class TdbSurvival extends PlotBase implements RxComponentInner {
 
 	preApiFreeze(api) {
 		api.download = this.download
-		api.getChartDict = () => this.getChartDict()
+		api.getChartImages = () => this.getChartImages()
 	}
 
 	async setControls() {
@@ -1027,12 +1027,12 @@ function setRenderers(self) {
 
 function setInteractivity(self) {
 	self.download = function (event) {
-		const name2svg = self.getChartDict()
+		const name2svg = self.getChartImages()
 		const menu = new DownloadMenu(name2svg, self.state.config.term.term.name)
 		menu.show(event.clientX, event.clientY)
 	}
 
-	self.getChartDict = function () {
+	self.getChartImages = function () {
 		const name2svg = {}
 		const node = self.dom.chartsDiv.select('.sjpp-survival-mainG').node() //node to read the style
 

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -8,15 +8,15 @@ import { DownloadMenu } from '#dom'
 
 export function setInteractivity(self) {
 	self.getChartImages = function () {
-		const name2svg = {}
+		const charts = []
 
 		for (const [key, chart] of Object.entries(self.data.charts)) {
 			const title = self.getChartTitle(chart.chartId)
 			const name = `${self.config.term.term.name}  ${title}`
 			const chartDiv = chart.chartDiv
-			name2svg[name] = { svg: chartDiv.select('svg'), parent: chartDiv.node() }
+			charts.push({ name, svg: chartDiv.select('svg'), parent: chartDiv.node() })
 		}
-		return name2svg
+		return charts
 	}
 
 	self.download = function (event) {

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -1,29 +1,39 @@
 import { filterJoin, getFilterItemByTag } from '#filter'
 import { niceNumLabels } from '#dom'
-import { to_svg } from '#src/client'
-import { rgb } from 'd3'
+import { rgb, select } from 'd3'
 import { TermTypes } from '#shared/terms.js'
 import { getSamplelstFilter } from '../mass/groups.js'
 import { listSamples } from './barchart.events.js'
+import { DownloadMenu } from '#dom'
 
 export function setInteractivity(self) {
-	self.download = () => {
+	self.getChartImages = function () {
+		const name2svg = {}
+
+		for (const [key, chart] of Object.entries(self.data.charts)) {
+			const title = self.getChartTitle(chart.chartId)
+			const name = `${self.config.term.term.name}  ${title}`
+			const chartDiv = chart.chartDiv
+			name2svg[name] = { svg: chartDiv.select('svg'), parent: chartDiv.node() }
+		}
+		return name2svg
+	}
+
+	self.download = function (event) {
 		if (!self.state) return
 
-		// has to be able to handle multichart view
-		// const mainGs = []
-		// const translate = { x: undefined, y: undefined }
-		// const titles = []
-		// let maxw = 0,
-		// 	maxh = 0,
-		// 	tboxh = 0
-		// let prevY = 0,
-		// 	numChartsPerRow = 0
-
-		self.dom.violinDiv.selectAll('.sjpp-violin-plot').each(function () {
-			to_svg(this, self.state.config.downloadFilename || 'violin', { apply_dom_styles: true })
-		})
+		const name2svg = self.getChartImages()
+		const dm = new DownloadMenu(name2svg, self.config.term.term.name)
+		dm.show(event.clientX, event.clientY)
 	}
+
+	//replaced by downloadMenu
+	// self.download = () => {
+	// 	if (!self.state) return
+	// 	self.dom.violinDiv.selectAll('.sjpp-violin-plot').each(function () {
+	// 		to_svg(this, self.state.config.downloadFilename || 'violin', { apply_dom_styles: true })
+	// 	})
+	// }
 
 	self.displayLabelClickMenu = function (t1, t2, plot, event) {
 		if (!t2) return // when no term 2 do not show options on the sole violin label

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -68,6 +68,11 @@ class ViolinPlot {
 		}
 	}
 
+	preApiFreeze(api) {
+		api.download = this.download
+		api.getChartImages = () => this.getChartImages()
+	}
+
 	async setControls() {
 		this.dom.controls.selectAll('*').remove()
 		this.components = {}

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -58,6 +58,7 @@ export default function setViolinRenderer(self) {
 				.append('div')
 				.attr('class', 'sjpp-vp-chartDiv')
 				.style('padding', Object.keys(self.data.charts).length > 1 ? '20px 20px 0px 0px' : '0px')
+			chart.chartDiv = chartDiv
 			if (plots.length === 0) {
 				chartDiv.html(` <span style="opacity:.6;font-size:1em;margin-left:90px;">No data to render Violin Plot</span>`)
 				return
@@ -74,7 +75,7 @@ export default function setViolinRenderer(self) {
 				.style('text-align', 'center')
 				.style('font-size', '1.1em')
 				.style('margin-bottom', '20px')
-				.html(getChartTitle(chart.chartId))
+				.html(self.getChartTitle(chart.chartId))
 
 			// render chart data
 			const svgData = renderSvg(t1, plots, chartDiv, self, isH, settings)
@@ -216,7 +217,7 @@ export default function setViolinRenderer(self) {
 		})
 	}
 
-	function getChartTitle(chartId) {
+	self.getChartTitle = function (chartId) {
 		if (!self.config.term0) return chartId
 		return self.config.term0.term.values && chartId in self.config.term0.term.values
 			? self.config.term0.term.values[chartId].label

--- a/client/rx/src/ComponentApi.ts
+++ b/client/rx/src/ComponentApi.ts
@@ -25,6 +25,7 @@ export interface RxComponentInner {
 	mainArg?: any
 	printError?: (any) => void
 	destroy?: () => void
+	getChartImages?: () => any
 
 	bus?: any
 	eventTypes?: string[]
@@ -275,4 +276,8 @@ export class ComponentApi {
 
 	// defaults for optional preApiFreeze addons
 	replaceLastState(_) {}
+
+	getChart() {
+		return this.#Inner.getChartImages ? this.#Inner.getChartImages() : null
+	}
 }

--- a/client/rx/src/ComponentApi.ts
+++ b/client/rx/src/ComponentApi.ts
@@ -277,7 +277,7 @@ export class ComponentApi {
 	// defaults for optional preApiFreeze addons
 	replaceLastState(_) {}
 
-	getChart() {
+	getChartImages() {
 		return this.#Inner.getChartImages ? this.#Inner.getChartImages() : null
 	}
 }

--- a/client/termdb/store.ts
+++ b/client/termdb/store.ts
@@ -3,8 +3,6 @@ import { root_ID } from './tree'
 import { getFilterItemByTag, findParent } from '#filter'
 import { isUsableTerm } from '#shared/termdb.usecase.js'
 
-// state definition: https://docs.google.com/document/d/1gTPKS9aDoYi4h_KlMBXgrMxZeA_P4GXhWcQdNQs3Yp8/edit#
-
 const defaultState = {
 	header_mode: 'search_only',
 	// will be ignored if there is no dataset termdb.selectCohort


### PR DESCRIPTION
# Description

Added support to download pdf/svg in the profile plots and the violin. Added icon to generate a pdf of the plots opened from the nav. Added misc improvements in the pdf generation. The plots that support the downloadMenu (have implemented getChartImages) will be included in the pdf, the plots that are not supported yet will add a note. I will continue to support more plots in coming PRs, but I wanted to share what I have so far( and avoid making bigger PR hard to review).
Plots supported: survival, scatter, frequencyChart, runChart, barchart, violin, boxplot and profile plots.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
