### PR TITLE
fix numericDictTermCluster

### DIFF
--- a/client/plots/matrix/hierCluster.js
+++ b/client/plots/matrix/hierCluster.js
@@ -127,7 +127,7 @@ export class HierCluster extends Matrix {
 		for (const [i, column] of c.col.order.entries()) {
 			samples[column.name] = { sample: column.name }
 			for (const [j, row] of c.row.order.entries()) {
-				const tw = twlst.find(tw => tw.$id === row.name)
+				const tw = twlst.find(tw => tw.$id === row.name || tw.id === row.name)
 				const value = c.matrix[j][i]
 				samples[column.name][tw.$id] = {
 					key: tw.term.name,


### PR DESCRIPTION
# Description
Fix broken numericDictTermCluster: [test](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22hierCluster%22,%22dataType%22:%22numericDictTerm%22,%22termgroups%22:[{%22name%22:%22Drug%20Sensitivity%20Cluster%22,%22lst%22:[{%22id%22:%22Asparaginase_normalizedLC50%22},{%22id%22:%22Bortezomib_normalizedLC50%22},{%22id%22:%22Daunorubicin_normalizedLC50%22},{%22id%22:%22Prednisolone_normalizedLC50%22},{%22id%22:%22Vincristine_normalizedLC50%22}],%22type%22:%22hierCluster%22}]}]})


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
