### PR TITLE
Css max-content fix

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1269,13 +1269,11 @@ sandbox header
     padding: 5px;
     opacity: 0;
     z-index: 10000;
-    width: max-content;
     max-width: 350px;
     white-space: wrap;
     pointer-events: none;
     box-shadow: 0px 2px 4px 1px #999;
     text-align: left;
-
 }
 
   .sja_root_holder [aria-label]:hover:after, .sja_menu_div [aria-label]:hover:after, .sja_pane [aria-label]:hover:after {
@@ -1286,11 +1284,13 @@ sandbox header
   @keyframes fadeOut {
     0% {
       opacity: 1;
+      width: max-content;
+    
     }
-    70% {
-      opacity: 1;
-    }
+
     100% {
-      opacity: 0;
+        opacity: 0;
+        width: max-content;
+
     }
   }


### PR DESCRIPTION
# Description
Only apply max-content on tooltip when showing it, to prevent side effect of width increased in page

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
