### PR TITLE
Enable global filter in genome browser plot

### DIFF
--- a/client/plots/gb/GB.ts
+++ b/client/plots/gb/GB.ts
@@ -1,5 +1,5 @@
 import { PlotBase } from '../PlotBase.ts'
-import { getCompInit, type ComponentApi /*, type RxComponentInner */ } from '#rx'
+import { getCompInit, type ComponentApi, type RxComponent } from '#rx'
 import { addGeneSearchbox, Menu, sayerror } from '#dom'
 import { getNormalRoot } from '#filter'
 import { gbControlsInit, mayUpdateGroupTestMethodsIdx } from '../genomeBrowser.controls.js'
@@ -9,7 +9,7 @@ import { View } from './view/View.ts'
 
 const geneTip = new Menu({ padding: '0px' })
 
-class TdbGenomeBrowser extends PlotBase /* implements RxComponentInner*/ {
+class TdbGenomeBrowser extends PlotBase implements RxComponent {
 	static type = 'genomeBrowser'
 
 	// expected RxComponentInner props, some are already declared/set in PlotBase
@@ -72,12 +72,14 @@ class TdbGenomeBrowser extends PlotBase /* implements RxComponentInner*/ {
 
 	async main() {
 		this.dom.loadingDiv.style('display', 'inline')
+		const state = this.getState(this.app.getState())
+		if (state.config.chartType != this.type) return
 		try {
-			const model = new Model(this.state, this.app)
+			const model = new Model(state, this.app)
 			const data = await model.preComputeData()
-			const viewModel = new ViewModel(this.state, this.app, this.opts, data)
+			const viewModel = new ViewModel(state, this.app, this.opts, data)
 			const tklst = await viewModel.generateTracks()
-			const view = new View(this.state, this.app, this.dom, this.opts, this.id)
+			const view = new View(state, this.app, this.dom, this.opts, this.id)
 			await view.launchBlockWithTracks(tklst)
 		} catch (e: any) {
 			sayerror(this.dom.errDiv, e.message || e)

--- a/client/plots/gb/view/View.ts
+++ b/client/plots/gb/view/View.ts
@@ -65,6 +65,7 @@ export class View {
 
 		// no block instance, create new block
 
+		this.dom.blockHolder.selectAll('*').remove()
 		const arg: any = {
 			holder: this.dom.blockHolder,
 			genome: this.app.opts.genome, // genome obj

--- a/client/plots/gb/viewModel/ViewModel.ts
+++ b/client/plots/gb/viewModel/ViewModel.ts
@@ -33,7 +33,7 @@ export class ViewModel {
 				}
 			} else {
 				// official mds3 tk without precomputed tk data
-				const tk = {
+				const tk: any = {
 					type: 'mds3',
 					dslabel: this.app.opts.state.vocab.dslabel,
 					onClose: () => {
@@ -45,16 +45,15 @@ export class ViewModel {
 				}
 				// any cohort filter for this tk
 				{
-					//const lst = []
+					const lst: any = []
 					// register both global filter and local filter to pass to mds3 data queries
-					/** FIXME: address tsc issues here:
 					if (this.state.filter?.lst?.length) lst.push(this.state.filter)
 					if (this.state.config.snvindel.filter) lst.push(this.state.config.snvindel.filter)
 					if (lst.length == 1) {
 						tk.filterObj = structuredClone(lst[0])
 					} else if (lst.length > 1) {
 						tk.filterObj = filterJoin(lst)
-					} **/
+					}
 					// TODO this will cause mds3 tk to show a leftlabel to indicate the filtering, which should be hidden
 				}
 				tklst.push(tk)


### PR DESCRIPTION
# Description

Use current plot state instead of app state in genome browser plot. Now global filter will filter samples in mds3 track. Thank you to @creilly8 for help with implementing this code change.

Test by:

1. Enable `GB.ts` code by uncommenting the following in `client/plots/importPlot.js`:
```
switch (chartType) {
	/*// enable this when gb/GB.ts is ready to replace genomeBrowser.js
	case 'genomeBrowser':
		return await import('./gb/GB.ts')*/
```

2. Open [genome browser](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22genomeBrowser%22,%22geneSearchResult%22:{%22geneSymbol%22:%22p53%22}}]}) -> Variants tab -> Show variant track -> Add global filter -> Variant track should update

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
