### PR TITLE
Added support for a default filter in a dataset

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -29,7 +29,8 @@ const defaultApiMethods = {
 	getHealth: () => undefined,
 	// credentialed embedders, using an array which can be frozen with Object.freeze(), unlike a Set()
 	credEmbedders: [],
-	mayAdjustFilter: (_, __, ___) => {}
+	mayAdjustFilter: (_, __, ___) => {},
+	adjustFilter: (_, __) => {}
 }
 
 // these may be overriden within maySetAuthRoutes()

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -734,7 +734,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 	//   - if an array with 1+ entries: these are the only terms to be matched against a dataset's hidden terms,
 	//     and the ds should construct an actual or undefined auth filter based on matched terms
 	authApi.mayAdjustFilter = function (q, ds, routeTwLst) {
-		if (!ds.cohort?.termdb?.getAdditionalFilter || !ds.cohort?.termdb?.getFilter) return
+		if (!ds.cohort?.termdb?.getAdditionalFilter && !ds.cohort?.termdb?.getFilter) return
 		if (!q.__protected__) throw `missing q.__protected__`
 		if (ds.cohort?.termdb?.getFilter) {
 			const authFilter = ds.cohort.termdb.getFilter(q.__protected__.clientAuthResult)

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -81,6 +81,7 @@ tape(`initialization, empty credentials`, async test => {
 	test.deepEqual(
 		Object.keys(authApi).sort(),
 		[
+			'adjustFilter',
 			'canDisplaySampleIds',
 			'credEmbedders',
 			'getDsAuth',
@@ -599,7 +600,6 @@ tape(`invalid jwt`, async test => {
 	}
 
 	await authApi.maySetAuthRoutes(app, {}, '', serverconfig) //; console.log(app.routes)
-
 	{
 		const req = {
 			query: { embedder: 'localhost', dslabel: 'ds0' },

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -77,7 +77,6 @@ tape(`initialization, empty credentials`, async test => {
 	const routes = Object.keys(app.routes)
 	routes.sort()
 	test.deepEqual(routes, [], 'should NOT set the expected routes when there are NO dsCredentials in serverconfig')
-
 	test.deepEqual(
 		Object.keys(authApi).sort(),
 		[
@@ -190,6 +189,7 @@ tape(`initialization, non-empty credentials`, async test => {
 		test.deepEqual(
 			Object.keys(authApi).sort(),
 			[
+				'adjustFilter',
 				'canDisplaySampleIds',
 				'credEmbedders',
 				'getDsAuth',

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1592,6 +1592,7 @@ keep this setting here for reason of:
 	//terms  are shown in the dictionary based on term and user role.
 	isTermVisible?: (clientAuthResult: any, ids: string) => boolean
 	getAdditionalFilter?: (clientAuthResult: any, term: any) => Filter | undefined
+	getFilter?: (clientAuthResult: any) => Filter | undefined
 }
 
 type SampleType = {


### PR DESCRIPTION
# Description

@congyu-lu and I worked on this draft PR showing a possible implementation for the login in panMB. The idea is to add to the dataset a method getFilter that returns a filter that needs to be applied always in the portal. If this method is provided authApi.mayAdjustFilter will apply this filter instead. You can test it by opening a dictionary term through the [user](http://localhost:3000/panMB/?role=user) link and comparing it to the [public](http://localhost:3000/panMB) link. The barcharts show a different number of samples. Note that the about tab does not reflect the real number of samples, as this calculation would need to apply the user filter too. See corresponding PR in sjpp.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
