### PR TITLE
add customVariables as root term so it can be used as dictionary terms

### DIFF
--- a/client/plots/matrix/matrix.config.js
+++ b/client/plots/matrix/matrix.config.js
@@ -217,11 +217,11 @@ export async function getPlotConfig(opts = {}, app) {
 			// may force the saved session to request the most up-to-data dictionary term data from server
 			// TODO: should skip samplelst term here
 			if (!tw.term?.type || isDictionaryType(tw.term.type)) {
-				if (!tw.id) {
+				if (!tw.id && tw.term.type != 'samplelst') {
 					if (!tw.term.id) throw `missing tw.id and tw.term.id`
 					tw.id = tw.term.id // tw.id will be used to rehydrate tw with new term data from server. tw.id will be deleted following rehydration.
 				}
-				delete tw.term
+				if (tw.term?.type != 'samplelst') delete tw.term
 			}
 			promises.push(fillTermWrapper(tw, app.vocabApi))
 		}

--- a/client/plots/matrix/matrix.serieses.js
+++ b/client/plots/matrix/matrix.serieses.js
@@ -86,8 +86,9 @@ export function getSerieses(data) {
 					const cellProps =
 						t.grp.type == 'hierCluster'
 							? setCellProps['hierCluster']
-							: t.tw.term.type == 'geneVariant' &&
-							  (t.tw?.q?.type == 'predefined-groupset' || t.tw?.q?.type == 'custom-groupset')
+							: (t.tw.term.type == 'geneVariant' &&
+									(t.tw?.q?.type == 'predefined-groupset' || t.tw?.q?.type == 'custom-groupset')) ||
+							  t.tw.term.type == 'samplelst'
 							? setCellProps['categorical']
 							: setCellProps[t.tw.term.type]
 

--- a/client/termdb/store.ts
+++ b/client/termdb/store.ts
@@ -1,5 +1,5 @@
 import { StoreApi, StoreBase, type AppApi, type RxStore } from '#rx'
-import { root_ID } from './tree'
+import { root_ID, custom_variables_ID } from './tree'
 import { getFilterItemByTag, findParent } from '#filter'
 import { isUsableTerm } from '#shared/termdb.usecase.js'
 
@@ -77,7 +77,7 @@ class TdbStore extends StoreBase implements RxStore {
 	validateState() {
 		const s = this.state
 		if (s.tree.expandedTermIds.length == 0) {
-			s.tree.expandedTermIds.push(root_ID)
+			s.tree.expandedTermIds.push(root_ID, custom_variables_ID)
 		} else {
 			if (s.tree.expandedTermIds[0] != root_ID) {
 				s.tree.expandedTermIds.unshift(root_ID)

--- a/client/termdb/tree.js
+++ b/client/termdb/tree.js
@@ -198,19 +198,19 @@ class TdbTree {
 				// not an expanded term
 				// if it's collapsing this term, must add back its children terms for toggle button to work
 				// see flag TERMS_ADD_BACK
-				const t0 = this.termsById[copy.id]
+				const t0 = this.termsById[copy.id || copy.name]
 				if (t0 && t0.terms) {
 					copy.terms = t0.terms
 				}
 			}
 
-			this.termsById[copy.id] = copy
+			this.termsById[copy.id || copy.name] = copy
 		}
 		return terms
 	}
 
 	bindKey(term) {
-		return term.id
+		return term.id || term.name
 	}
 
 	async mayGetCustomTerms() {
@@ -225,7 +225,7 @@ class TdbTree {
 			included_types: ['categorical'],
 			child_types: ['categorical'],
 			terms: tws.map(tw => {
-				this.termsById[tw.term.id] = tw.term
+				this.termsById[tw.term.id || tw.term.name] = tw.term
 				tw.term.isleaf = true
 				return tw.term
 			})
@@ -299,7 +299,8 @@ function setRenderers(self) {
 			self.included_terms.push(...term.terms)
 		}
 
-		if (!(term.id in self.termsById) || !self.included_terms.length) {
+		const id = term.id || term.name
+		if (!(id in self.termsById) || !self.included_terms.length) {
 			div.style('display', 'none')
 			return
 		}
@@ -339,13 +340,15 @@ function setRenderers(self) {
 
 	// this == the d3 selected DOM node
 	self.hideTerm = function (term) {
-		if (term.id in self.termsById && self.state.expandedTermIds.includes(term.id)) return
+		const id = term.id || term.name
+		if (id in self.termsById && self.state.expandedTermIds.includes(term.id)) return
 		select(this).style('display', 'none')
 	}
 
 	self.updateTerm = function (term) {
 		const div = select(this)
-		if (!(term.id in self.termsById)) {
+		const id = term.id || term.name
+		if (!(id in self.termsById)) {
 			div.style('display', 'none')
 			return
 		}
@@ -359,7 +362,8 @@ function setRenderers(self) {
 		// update other parts if needed, e.g. label
 		div.select('.' + cls_termchilddiv).style('display', isExpanded ? 'block' : 'none')
 
-		const isSelected = self.state.selectedTerms.find(t => t.id === term.id && t.type === term.type)
+		const tid = term.id || term.name
+		const isSelected = self.state.selectedTerms.find(t => (t.id ? t.id === id : t.name == id) && t.type === term.type)
 		div
 			.select('.' + cls_termlabel)
 			.style(
@@ -396,7 +400,8 @@ function setRenderers(self) {
 			if (self.expandAll) self.toggleBranch(term)
 		}
 
-		const isSelected = self.state.selectedTerms.find(t => t.id === term.id && t.type === term.type)
+		const id = term.id || term.name
+		const isSelected = self.state.selectedTerms.find(t => t.id === id && t.type === term.type)
 		const labeldiv = div
 			.append('div')
 			.attr('class', cls_termlabel)
@@ -483,7 +488,7 @@ function setInteractivity(self) {
 	self.toggleBranch = function (term) {
 		//event.stopPropagation()
 		if (term.isleaf) return
-		const t0 = self.termsById[term.id]
+		const t0 = self.termsById[term.id || term.name]
 		if (!t0) throw 'invalid term id'
 
 		if (!t0.terms) {
@@ -520,7 +525,8 @@ function setInteractivity(self) {
 		}
 
 		if (self.opts.submit_lst) {
-			const i = self.state.selectedTerms.findIndex(t => t.id === term.id && t.type === term.type)
+			const id = term.id || term.name
+			const i = self.state.selectedTerms.findIndex(t => (t.id ? t.id === id : t.name == id) && t.type === term.type)
 			if (i == -1) {
 				self.app.dispatch({
 					type: 'app_refresh',


### PR DESCRIPTION
# Description

Treat custom variables as root terms so they could be used as dictionary terms. 

could use this session file to test: 
[customVMatirx.txt](https://github.com/user-attachments/files/22367895/customVMatirx.txt)

[termdbTest.txt](https://github.com/user-attachments/files/22371486/termdbTest.txt)


From the variables panel, we could now select and add custom variables to matrix as rows. custom variable changed color and show green check and moved to selected terms panel just as the other dictionary terms after being selected


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
