### PR TITLE
activate slack notification for spec coverage CI

### DIFF
--- a/.github/workflows/CI-spec-coverage.yml
+++ b/.github/workflows/CI-spec-coverage.yml
@@ -130,13 +130,13 @@ jobs:
           ./run.sh ppserver:latest
           sleep 10
           cd ../client
-          xvfb-run --auto-servernum npm run spec:coverage
+          xvfb-run --auto-servernum npm run spec:coverage || echo "TEST_FAILED=true" >> $GITHUB_ENV
 
       - name: Generate client unit-spec-only coverage report
         if: ${{ !contains(env.HAS_INTEGRATION_TESTS, 'true') }}
         run: |
           cd client
-          xvfb-run --auto-servernum npm run spec:coverage
+          xvfb-run --auto-servernum npm run spec:coverage || echo "TEST_FAILED=true" >> $GITHUB_ENV
 
       - name: Display coverage results
         run: |
@@ -182,9 +182,22 @@ jobs:
             git push origin $BRANCH
           fi
 
+      - name: Post build results on Slack
+        if:  ${{ env.TEST_FAILED == 'true' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "status": "Failed unit and/or integration test(s) - https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "commit": "${{ env.SHORT_SHA }}",
+              "date-time": "${{ steps.current-time.outputs.formattedTime }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK_URL }}
+
       - name: Detect failure
         run: |
           FAILEDTEXTFILE=./public/coverage/specs/failedTexts.txt
-          if [[ -f $FAILEDTEXTFILE ]]; then
+          if [[ -f $FAILEDTEXTFILE || "${{ env.TEST_FAILED }}" == "true" ]]; then
             exit 1
           fi

--- a/client/test/puppet.js
+++ b/client/test/puppet.js
@@ -128,8 +128,10 @@ async function runTest(patternsStr) {
 			})
 			.catch(e => {
 				console.error('--- page.goto().catch ---', e)
-				process.exit(1)
+				errors[pattern] = error
 			})
+
+		if (errors[pattern]) continue
 
 		await new Promise((resolve, reject) => {
 			const i = setInterval(async () => {


### PR DESCRIPTION
# Description

The notification is only sent for failed unit or integration tests. Later, can activate notification for failed coverage metrics.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
