### PR TITLE
Clean up on stats and boxplot updates

### DIFF
--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -248,6 +248,9 @@ class TdbBoxplot extends RxComponent {
 			const settings = config.settings.boxplot
 			const model = new Model(config, this.state, this.app, settings)
 			const data = await model.getData()
+			console.log(data)
+			config.term.q.descrStats = data.descrStats
+
 			if (data.error) throw data.error
 			if (!data.charts || !Object.keys(data.charts).length) {
 				this.interactions!.clearDom()

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -248,7 +248,6 @@ class TdbBoxplot extends RxComponent {
 			const settings = config.settings.boxplot
 			const model = new Model(config, this.state, this.app, settings)
 			const data = await model.getData()
-			console.log(data)
 			config.term.q.descrStats = data.descrStats
 
 			if (data.error) throw data.error
@@ -258,7 +257,6 @@ class TdbBoxplot extends RxComponent {
 				return
 			}
 			this.data = data
-
 			this.dom.charts.selectAll('*').remove()
 
 			// determine max label length across all charts

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -188,6 +188,14 @@ class TdbBoxplot extends RxComponent {
 					{ label: 'Filled', value: 'filled' },
 					{ label: 'Dark mode', value: 'dark' }
 				]
+			},
+			{
+				label: 'Remove outliers',
+				boxLabel: '',
+				type: 'checkbox',
+				chartType: 'boxplot',
+				settingsKey: 'removeOutliers',
+				title: `Option to remove outliers from the analysis`
 			}
 		]
 		this.components.controls = await controlsInit({
@@ -367,7 +375,8 @@ export function getDefaultBoxplotSettings(app, overrides = {}) {
 		isVertical: false,
 		orderByMedian: false,
 		rowHeight: 50,
-		rowSpace: 15
+		rowSpace: 15,
+		removeOutliers: false
 	}
 	return Object.assign(defaults, overrides)
 }

--- a/client/plots/boxplot/BoxPlotTypes.ts
+++ b/client/plots/boxplot/BoxPlotTypes.ts
@@ -48,6 +48,8 @@ export type BoxPlotSettings = {
 	rowHeight: number
 	/** Space between the boxplots */
 	rowSpace: number
+	/** If true, remove outliers from the analysis */
+	removeOutliers: boolean
 }
 
 /** Descriptions of the dom elements for the box plot */

--- a/client/plots/boxplot/model/Model.ts
+++ b/client/plots/boxplot/model/Model.ts
@@ -40,7 +40,7 @@ export class Model {
 
 		opts.orderByMedian = this.settings.orderByMedian
 		opts.isLogScale = this.settings.isLogScale
-
+		opts.removeOutliers = this.settings.removeOutliers
 		return opts
 	}
 
@@ -60,7 +60,7 @@ export class Model {
 		if (this.config.term0) terms.push(this.config.term0)
 		for (const t of terms) {
 			if (isNumericTerm(t.term)) {
-				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter)
+				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter, true)
 				if (data.error) {
 					if (data.error instanceof Error) console.error(data.error)
 					throw data.error

--- a/client/plots/boxplot/model/Model.ts
+++ b/client/plots/boxplot/model/Model.ts
@@ -21,7 +21,6 @@ export class Model {
 	}
 
 	async getData() {
-		await this.getDescrStats()
 		const boxPlotDataArgs = this.setRequestOpts()
 		const data: BoxPlotResponse = await this.app.vocabApi.getBoxPlotData(boxPlotDataArgs)
 		return data
@@ -49,24 +48,5 @@ export class Model {
 		return isNumericTerm(this.config.term.term) && this.config.term.q.mode == 'continuous'
 			? this.config.term
 			: this.config.term2
-	}
-
-	//Consider consolidating this fn with identical fn in
-	//barchart and violin
-	async getDescrStats() {
-		//Requests desc stats for all values for each term
-		const terms = [this.config.term]
-		if (this.config.term2) terms.push(this.config.term2)
-		if (this.config.term0) terms.push(this.config.term0)
-		for (const t of terms) {
-			if (isNumericTerm(t.term)) {
-				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter, true)
-				if (data.error) {
-					if (data.error instanceof Error) console.error(data.error)
-					throw data.error
-				}
-				t.q.descrStats = data.values
-			}
-		}
 	}
 }

--- a/client/termdb/FrontendVocab.js
+++ b/client/termdb/FrontendVocab.js
@@ -6,6 +6,7 @@ import { roundValue } from '#shared/roundValue.js'
 import { isNumeric } from '#shared/helpers.js'
 import computePercentile from '#shared/compute.percentile.js'
 import { Vocab } from './Vocab'
+import { summaryStats } from '#shared/descriptive.stats.js'
 
 export class FrontendVocab extends Vocab {
 	constructor(opts) {
@@ -263,45 +264,7 @@ export class FrontendVocab extends Vocab {
 			values.push(_v)
 		}
 
-		values.sort((a, b) => a - b)
-
-		// compute statistics
-		// total
-		const total = values.length
-
-		// mean
-		const sum = values.reduce((a, b) => a + b, 0)
-		const mean = sum / total
-
-		// percentiles
-		const p25 = computePercentile(values, 25)
-		const median = computePercentile(values, 50)
-		const p75 = computePercentile(values, 75)
-
-		// standard deviation
-		// get sum of squared differences from mean
-		const sumSqDiff = values.map(v => (v - mean) ** 2).reduce((a, b) => a + b, 0)
-		// get variance
-		const variance = sumSqDiff / (values.length - 1)
-		// get standard deviation
-		const sd = Math.sqrt(variance)
-
-		// min/max
-		const min = Math.min(...values)
-		const max = Math.max(...values)
-
-		return {
-			values: [
-				{ id: 'total', label: 'n', value: total },
-				{ id: 'min', label: 'Minimum', value: roundValue(min, 2) },
-				{ id: 'p25', label: '1st quartile', value: roundValue(p25, 2) },
-				{ id: 'median', label: 'Median', value: roundValue(median, 2) },
-				{ id: 'mean', label: 'Mean', value: roundValue(mean, 2) },
-				{ id: 'p75', label: '3rd quartile', value: roundValue(p75, 2) },
-				{ id: 'max', label: 'Maximum', value: roundValue(max, 2) },
-				{ id: 'sd', label: 'Standard deviation', value: roundValue(sd, 2) }
-			]
-		}
+		return summaryStats(values)
 	}
 
 	async getTerms(ids, _dslabel = null, _genome = null) {

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -511,6 +511,7 @@ export class TermdbVocab extends Vocab {
 	async getBoxPlotData(arg, _body = {}) {
 		const headers = this.mayGetAuthHeaders('termdb')
 		arg.tw = this.getTwMinCopy(arg.tw)
+
 		if (arg.overlayTw) arg.overlayTw = this.getTwMinCopy(arg.overlayTw)
 		if (arg.divideTw) arg.divideTw = this.getTwMinCopy(arg.divideTw)
 		const body = Object.assign(

--- a/server/src/termdb.scatter.js
+++ b/server/src/termdb.scatter.js
@@ -138,12 +138,8 @@ export async function trigger_getSampleScatter(req, q, res, ds) {
 		if (samples.length > 0) {
 			if (q.excludeOutliers) {
 				const ystats = getDescriptiveStats(samples.map(s => s.y))
-				cohortSamples = cohortSamples.filter(
-					sample => sample.y > ystats.outlierRange.min && sample.y < ystats.outlierRange.max
-				)
-				refSamples = refSamples.filter(
-					sample => sample.y > ystats.outlierRange.min && sample.y < ystats.outlierRange.max
-				)
+				cohortSamples = cohortSamples.filter(sample => sample.y > ystats.outlierMin && sample.y < ystats.outlierMax)
+				refSamples = refSamples.filter(sample => sample.y > ystats.outlierMin && sample.y < ystats.outlierMax)
 			}
 			// Calculate global min/max range of x/y coordinates needed for the scatter plot. Needs to be done before colorAndShapeSamples that will dismiss
 			//  samples without color/shape or filtered out. If the plot is not premade and a filter on the coordinate terms is done, the coordinates excluded will be filtered out,

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -809,7 +809,7 @@ export function mayCopyFromCookie(q, cookies) {
 	}
 }
 
-export function boxplot_getvalue(lst) {
+export function boxplot_getvalue(lst, removeOutliers = false) {
 	/* ascending order
     each element: {value}
     */
@@ -836,7 +836,8 @@ export function boxplot_getvalue(lst) {
 		const j = lst.findIndex(i => i.value > p75 + iqr * 1.5)
 		w2 = lst[j == -1 ? l - 1 : j - 1].value
 	}
-	const out = lst.filter(i => i.value < p25 - iqr * 1.5 || i.value > p75 + iqr * 1.5)
+	let out = []
+	if (!removeOutliers) out = lst.filter(i => i.value < p25 - iqr * 1.5 || i.value > p75 + iqr * 1.5)
 	return { w1, w2, p05, p25, p50, p75, p95, iqr, out }
 }
 

--- a/shared/types/src/routes/termdb.boxplot.ts
+++ b/shared/types/src/routes/termdb.boxplot.ts
@@ -35,6 +35,7 @@ export type BoxPlotResponse = {
 	/** Categories not shown in the final plot */
 	uncomputableValues: { label: string; value: number }[] | null
 	error?: any
+	descrStats: any
 }
 
 // chart containing a set of boxplots

--- a/shared/types/src/routes/termdb.boxplot.ts
+++ b/shared/types/src/routes/termdb.boxplot.ts
@@ -20,6 +20,7 @@ export type BoxPlotRequest = {
 	filter?: Filter
 	filter0?: any
 	__protected__: any
+	removeOutliers?: boolean
 }
 
 export type BoxPlotResponse = {

--- a/shared/utils/src/test/descriptive.stats.unit.spec.js
+++ b/shared/utils/src/test/descriptive.stats.unit.spec.js
@@ -42,17 +42,17 @@ tape('getVariance()', function (test) {
 	let data, expected, result
 
 	data = [1, 2, 3, 4, 5]
-	expected = 2
+	expected = 2.5
 	result = getVariance(data)
 	test.equal(result, expected, `Should return variance=${expected} for input data=${data}`)
 
 	data = [-10, -2, 0, 3, 10, 11]
-	expected = 51.666666666666664
+	expected = 62
 	result = getVariance(data)
 	test.equal(result, expected, `Should return variance=${expected} for input data=${data}`)
 
 	data = [18903, 34892, 23498034]
-	expected = 122420986741716.2
+	expected = 183631480112574.3
 	result = getVariance(data)
 	test.equal(result, expected, `Should return variance=${expected} for input data=${data}`)
 
@@ -63,17 +63,17 @@ tape('getStdDev()', function (test) {
 	let data, expected, result
 
 	data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-	expected = 2.8722813232690143
+	expected = 3.0276503540974917
 	result = getStdDev(data)
 	test.equal(result, expected, `Should return variance=${expected} for input data=${data}`)
 
 	data = [-10, -2, 0, 3, 10, 11, 48, 50]
-	expected = 21.288200957337846
+	expected = 22.7580441037575
 	result = getStdDev(data)
 	test.equal(result, expected, `Should return variance=${expected} for input data=${data}`)
 
 	data = [2348, 13049, 18903, 34892, 23498034]
-	expected = 9392300.29505785
+	expected = 10500910.96242034
 	result = getStdDev(data)
 	test.equal(result, expected, `Should return variance=${expected} for input data=${data}`)
 
@@ -93,8 +93,8 @@ tape('getStdDev()', function (test) {
 			{ id: 'mean', label: 'Mean', value: 5.5 },
 			{ id: 'p75', label: '3rd quartile', value: 8 },
 			{ id: 'max', label: 'Maximum', value: 10 },
-			{ id: 'SD', label: 'Standard deviation', value: 2.87 },
-			{ id: 'variance', label: 'Variance', value: 8.25 },
+			{ id: 'SD', label: 'Standard deviation', value: 3.03 },
+			{ id: 'variance', label: 'Variance', value: 9.17 },
 			{ id: 'IQR', label: 'Inter-quartile range', value: 5 }
 		]
 	}
@@ -111,8 +111,8 @@ tape('getStdDev()', function (test) {
 			{ id: 'mean', label: 'Mean', value: 13.75 },
 			{ id: 'p75', label: '3rd quartile', value: 29.5 },
 			{ id: 'max', label: 'Maximum', value: 50 },
-			{ id: 'SD', label: 'Standard deviation', value: 21.29 },
-			{ id: 'variance', label: 'Variance', value: 453.19 },
+			{ id: 'SD', label: 'Standard deviation', value: 22.76 },
+			{ id: 'variance', label: 'Variance', value: 517.93 },
 			{ id: 'IQR', label: 'Inter-quartile range', value: 30.5 }
 		]
 	}
@@ -129,8 +129,8 @@ tape('getStdDev()', function (test) {
 			{ id: 'mean', label: 'Mean', value: '4.7e+6' },
 			{ id: 'p75', label: '3rd quartile', value: 34892 },
 			{ id: 'max', label: 'Maximum', value: 23498034 },
-			{ id: 'SD', label: 'Standard deviation', value: '9.4e+6' },
-			{ id: 'variance', label: 'Variance', value: '8.8e+13' },
+			{ id: 'SD', label: 'Standard deviation', value: '1.1e+7' },
+			{ id: 'variance', label: 'Variance', value: '1.1e+14' },
 			{ id: 'IQR', label: 'Inter-quartile range', value: 21843 }
 		]
 	}


### PR DESCRIPTION
# Description

In this PR I removed duplicated code on stats, fixed the variance calculation (should use n -1 always) and supported removing outliers in the boxplot. I also removed the need for a second request to caculate the stats as this can be calculated on the boxplot request and sent to client, and it  only needs to be done for the term plotted.  I see this second request is also done  in the barchart and the violin. The same logic applies in those cases, the stats can be done in the main request.  
I supported hiding outliers as I needed it to see the timelines in the sjcares report properly. There is a corresponding [PR](https://github.com/stjude/sjpp/compare/report-timeline?expand=1) showing boxplots on the sjcares report.

Default:

<img width="973" height="172" alt="Screenshot 2025-09-17 at 11 50 24 AM" src="https://github.com/user-attachments/assets/c847e735-6f56-465c-95f9-a0c420e4a77d" />

After hiding outliers:

<img width="973" height="172" alt="Screenshot 2025-09-17 at 11 50 30 AM" src="https://github.com/user-attachments/assets/67baccdc-ec2e-47f5-ad23-d358c7d5bbb4" />



Please check

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
