### PR TITLE
hierCluster: if the genes are not clustered, after users reorder the …

### DIFF
--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -136,7 +136,9 @@ export class GeneSetEditUI {
 		if ('mode' in opts) this.mode = opts.mode
 		if ('titleText' in opts) this.titleText = opts.titleText
 		this.origLst = structuredClone(this.geneList)
-		this.origNames = JSON.stringify(this.geneList.map(t => t.gene).sort())
+		this.origNames = opts.termsAsListed
+			? JSON.stringify(this.geneList.map(t => t.gene))
+			: JSON.stringify(this.geneList.map(t => t.gene).sort())
 
 		this.holder.selectAll('*').remove()
 		const div = this.holder.append('div').attr('class', 'sja_genesetinput').style('padding', '5px')
@@ -551,7 +553,11 @@ export class GeneSetEditUI {
 		this.renderStatLegend() // api.statColor2label has been accumulated if available
 
 		this.api.dom.clearBtn.property('disabled', !this.geneList?.length)
-		const hasChanged = this.origNames !== JSON.stringify(this.geneList.map(t => t.gene).sort())
+		const hasChanged =
+			this.origNames !==
+			(this.termsAsListed
+				? JSON.stringify(this.geneList.map(t => t.gene))
+				: JSON.stringify(this.geneList.map(t => t.gene).sort()))
 		this.api.dom.restoreBtn?.property('disabled', !hasChanged)
 		// disable submit button when gene list not changed or is empty in expression mode
 		this.api.dom.submitBtn.property(

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- hierCluster: if the genes are not clustered, after users reorder the genes, the submit button should not be disabled. 


### PR DESCRIPTION
…genes, the submit button should not be disabled.

# Description
related JIRA ticket: https://gdc-ctds.atlassian.net/browse/SV-2595

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
