### PR TITLE
Calculate violin stats on the server

### DIFF
--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -316,17 +316,8 @@ class ViolinPlot {
 			)
 
 		const args = this.validateArgs()
-		await Promise.all([
-			this.getDescrStats(),
-			this.app.vocabApi
-				.getViolinPlotData(args)
-				.then(data => {
-					this.data = data
-				})
-				.catch(e => {
-					throw e
-				})
-		])
+		this.data = await this.app.vocabApi.getViolinPlotData(args)
+
 		if (this.data.error) throw this.data.error
 		/*
 		.min
@@ -340,6 +331,8 @@ class ViolinPlot {
 				.x1
 				.density
 		*/
+		args.tw.q.descrStats = this.data.descrStats
+
 		this.toggleLoadingDiv(this.opts.mode == 'minimal' ? 'none' : '')
 		setTimeout(
 			() => {
@@ -348,26 +341,6 @@ class ViolinPlot {
 			this.opts.mode == 'minimal' ? 0 : 500
 		)
 		this.toggleLoadingDiv('none')
-	}
-
-	async getDescrStats() {
-		// get descriptive statistics for numerical terms
-		const terms = [this.config.term]
-		if (this.config.term2) terms.push(this.config.term2)
-		if (this.config.term0) terms.push(this.config.term0)
-		const promises = []
-		for (const t of terms) {
-			if (!isNumericTerm(t.term)) continue
-			promises.push(
-				this.app.vocabApi
-					.getDescrStats(t, this.state.termfilter, this.config.settings?.violin?.unit == 'log')
-					.then(data => {
-						if (data.error) throw data.error
-						t.q.descrStats = data.values
-					})
-			)
-		}
-		if (promises.length) await Promise.all(promises)
 	}
 
 	validateArgs() {

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -65,6 +65,12 @@ export async function trigger_getViolinPlotData(q: ViolinRequest, ds: any) {
 		},
 		ds
 	)
+
+	const samples = Object.values(data.samples)
+	let values = samples.map(s => s?.[q.tw.$id!]?.value).filter(v => typeof v === 'number')
+	if (q.unit == 'log') values = values.filter(v => v > 0)
+	//calculate stats here and pass them to client to avoid second request on client for getting stats
+	const descrStats = summaryStats(values).values
 	const sampleType = `All ${data.sampleType?.plural_name || 'samples'}`
 	if (data.error) throw data.error
 	//get ordered labels to sort keys in plot2values
@@ -86,7 +92,7 @@ export async function trigger_getViolinPlotData(q: ViolinRequest, ds: any) {
 	if (q.overlayTw) await getWilcoxonData(result)
 
 	await createCanvasImg(q, result, ds)
-
+	result['descrStats'] = descrStats
 	return result
 }
 


### PR DESCRIPTION
# Description

Calculated violin stats on the server to remove second request and extra logic not needed (as commented out in previous PR).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
