### PR TITLE
mass nav search will navigate to charts tab if on about tab

### DIFF
--- a/client/mass/search.js
+++ b/client/mass/search.js
@@ -119,7 +119,14 @@ function setRenderers(self) {
 			button
 				.style('cursor', 'pointer')
 				.attr('class', 'sja_menuoption')
-				.on('click', () => {
+				.on('click', async () => {
+					if (self.state.nav?.activeTab == 0) {
+						// see notes in about.ts line 340
+						await self.app.dispatch({
+							type: 'tab_set',
+							activeTab: 1
+						})
+					}
 					self.app.dispatch({
 						type: 'plot_create',
 						config: {

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -812,7 +812,7 @@ function setRenderers(self) {
 		}
 
 		if (!svg.seriesTip) {
-			svg.seriesTip = getSeriesTip(line, plotRect, self.app?.tip)
+			svg.seriesTip = getSeriesTip(line, plotRect, self.dom.tip)
 		}
 
 		return [mainG, seriesesG, axisG, xAxis, yAxis, xTitle, yTitle, atRiskG, plotRect]


### PR DESCRIPTION
# Description

now looking to remove obsolete hover tooltip on bar label and cleanup code

[FIXED] remaining bug. [test link with both bar & survival](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38-test%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22diaggrp%22}},{%22chartType%22:%22survival%22,%22term2%22:{%22id%22:%22diaggrp%22},%22term%22:{%22id%22:%22efs%22}}]})

first hover on surv to show tooltip
next click on a bar. somehow `Time to Event` shows up at menu

<img width="541" height="168" alt="image" src="https://github.com/user-attachments/assets/ca48e8d9-2f39-469e-aad9-611f75fb4e4f" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
