### PR TITLE
Removed second request for stats in the barchart

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -345,13 +345,13 @@ export class Barchart {
 			this.toggleLoadingDiv()
 
 			const reqOpts = this.getDataRequestOpts()
-			await this.getDescrStats()
 			await this.setControls() //needs to be called after getDescrStats() to set hasStats
 
 			const results = await this.app.vocabApi.getNestedChartSeriesData(reqOpts)
 			if (results.error) throw results
 			const data = results.data
 			this.charts = data.charts
+			if (results.descrStats) this.config.term.q.descrStats = results.descrStats
 			this.sampleType = results.sampleType
 			this.bins = results.bins
 			if (results.chartid2dtterm) this.chartid2dtterm = results.chartid2dtterm
@@ -390,21 +390,6 @@ export class Barchart {
 		if (c.term2) opts.term2 = c.term2
 		if (c.term0) opts.term0 = c.term0
 		return opts
-	}
-
-	async getDescrStats() {
-		// get descriptive statistics for numerical terms
-		const terms = [this.config.term]
-		if (this.config.term2) terms.push(this.config.term2)
-		if (this.config.term0) terms.push(this.config.term0)
-
-		for (const t of terms) {
-			if (isNumericTerm(t.term)) {
-				const data = await this.app.vocabApi.getDescrStats(t, this.state.termfilter)
-				if (data.error) throw data.error
-				t.q.descrStats = data.values
-			}
-		}
 	}
 
 	updateSettings(config) {

--- a/client/plots/test/barchart.unit.spec.ts
+++ b/client/plots/test/barchart.unit.spec.ts
@@ -54,7 +54,6 @@ tape('Default barchart component', test => {
 	test.equal(typeof testBarchart.reactsTo, 'function', 'Should have a .reactsTo() function')
 	test.equal(typeof testBarchart.getState, 'function', 'Should have a .getState() function')
 	test.equal(typeof testBarchart.getDataRequestOpts, 'function', 'Should have a .getDataRequestOpts() function')
-	test.equal(typeof testBarchart.getDescrStats, 'function', 'Should have a .getDescrStats() function')
 	test.equal(typeof testBarchart.updateSettings, 'function', 'Should have a .updateSettings() function')
 	test.equal(typeof testBarchart.mayResetHidden, 'function', 'Should have a .mayResetHidden() function')
 	test.equal(typeof testBarchart.mayEditHiddenValues, 'function', 'Should have a .mayEditHiddenValues() function')

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -5,6 +5,7 @@ import { format } from 'd3-format'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
 import { getData } from './termdb.matrix.js'
 import { mclass, dt2label, dtTerms } from '#shared/common.js'
+import { summaryStats } from '#shared/descriptive.stats'
 
 const binLabelFormatter = format('.3r')
 
@@ -114,8 +115,15 @@ export async function barchart_data(q, ds, tdb) {
 	const bins = []
 	const categories = []
 	const chartid2dtterm = {}
+	let descrStats
 	if (data.samples) {
 		const t1 = map.get(1)
+		const samples = Object.values(data.samples)
+		let values = samples
+			.map(s => s?.[t1.$id]?.value)
+			.filter(v => typeof v === 'number' && !t1.term.values?.[v]?.uncomputable)
+		descrStats = summaryStats(values).values
+
 		const t2 = map.get(2)
 		if (
 			(t1?.term?.type == 'geneVariant' && t1.q.type == 'values') ||
@@ -194,7 +202,7 @@ export async function barchart_data(q, ds, tdb) {
 			pj: pj.times
 		}
 	}
-	const result = { data: pj.tree.results, bins, categories, sampleType: data.sampleType }
+	const result = { data: pj.tree.results, bins, categories, sampleType: data.sampleType, descrStats }
 	if (Object.keys(chartid2dtterm).length) result.chartid2dtterm = chartid2dtterm
 	return result
 }

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -6,6 +6,7 @@ import { run_rust } from '@sjcrh/proteinpaint-rust'
 import { getData } from './termdb.matrix.js'
 import { mclass, dt2label, dtTerms } from '#shared/common.js'
 import { summaryStats } from '#shared/descriptive.stats'
+import { isNumericTerm } from '#shared/terms'
 
 const binLabelFormatter = format('.3r')
 
@@ -118,12 +119,13 @@ export async function barchart_data(q, ds, tdb) {
 	let descrStats
 	if (data.samples) {
 		const t1 = map.get(1)
-		const samples = Object.values(data.samples)
-		let values = samples
-			.map(s => s?.[t1.$id]?.value)
-			.filter(v => typeof v === 'number' && !t1.term.values?.[v]?.uncomputable)
-		descrStats = summaryStats(values).values
-
+		if (isNumericTerm(t1.term)) {
+			const samples = Object.values(data.samples)
+			let values = samples
+				.map(s => s?.[t1.$id]?.value)
+				.filter(v => typeof v === 'number' && !t1.term.values?.[v]?.uncomputable)
+			descrStats = summaryStats(values).values
+		}
 		const t2 = map.get(2)
 		if (
 			(t1?.term?.type == 'geneVariant' && t1.q.type == 'values') ||


### PR DESCRIPTION
# Description
Removed second request for stats in the barchart. @gavrielm pointed out we needed to consider the uncomputable values. Added here and also on his branch.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
