### PR TITLE
fix geneset Edit UI issue

### DIFF
--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -1226,7 +1226,12 @@ export class MatrixControls {
 							}
 							//if it was present use the previous term, genomic range terms require chr, start and stop fields, found in the original term
 							let tw = group.lst.find(
-								tw => (tw.term.gene == d.symbol || tw.term.gene == d.gene) && tw.term.type == targetTermType
+								t =>
+									(d.symbol
+										? (t.term.gene || t.term.name) == d.symbol
+										: d.gene
+										? (t.term.gene || t.term.name) == d.gene
+										: undefined) && t.term.type == targetTermType
 							)
 							if (!tw) {
 								tw = { term }


### PR DESCRIPTION
# Description

Fix this geneset edit UI issue: Creating new matrix (AKT1, KRAS, BCR) and then modify genelist (remove AKT1) through geneset Edit UI, the matrix shows two AKT1 rows. This is caused by replacing tw.term.gene with tw.term.genes for geneVariant terms

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
