### PR TITLE
fix: to enable blat, run gfServer as a child process

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- to enable blat, run gfServer as a child process

--- a/shared/types/src/genome.ts
+++ b/shared/types/src/genome.ts
@@ -109,11 +109,23 @@ type HicDomain = {
 export type MinGenome = {
 	isMinGenome?: boolean
 	species: string
+	/** relative path to bgzipped- and samtools-indexed fasta file. 
+	or use "NA" for not available. this is used for termdbtest to avoid tracking a large fasta file in repo
+	*/
 	genomefile: string
 	genedb: GeneDb
 	defaultcoord: DefaultCoord
 	hicenzymefragment?: HicEnzymeFragment[]
 	majorchr: string
+}
+
+/** not part of genome ts file but defined in bootstrap object in serverconfig and copied to genome obj during server launch
+ */
+type Blat = {
+	port: string
+	host: string
+	// full path to the folder (/path/to/tp/genomes/) where the 2bit file for this genome is found as "<genome>.2bit"
+	seqDir: string
 }
 
 export type Genome = MinGenome & {
@@ -126,4 +138,5 @@ export type Genome = MinGenome & {
 	geneset?: GeneSet[]
 	hicdomain?: HicDomain
 	minorchr?: string
+	blat?: Blat
 }


### PR DESCRIPTION
# Description
this runs gfServer as a long-running child process inside the PP container
as alternative to `container/blat/Dockerfile` that runs gfServer in a separate container
this might facilitate enabling blat for GDC
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
