### PR TITLE
fix hierCluster term order issue due to term.id and name change

### DIFF
--- a/client/plots/matrix/hierCluster.js
+++ b/client/plots/matrix/hierCluster.js
@@ -7,7 +7,7 @@ import { extent } from 'd3-array'
 import { scaleLinear } from 'd3-scale'
 import { filterJoin, getNormalRoot } from '#filter'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
-import { TermTypes, TermTypes2Dt } from '#shared/terms.js'
+import { TermTypes, TermTypes2Dt, NUMERIC_DICTIONARY_TERM } from '#shared/terms.js'
 import { colorScaleMap } from '#shared/common.js'
 
 export class HierCluster extends Matrix {
@@ -153,7 +153,11 @@ export class HierCluster extends Matrix {
 				? twlst.map(t => t.term.name)
 				: this.settings.hierCluster.sortClusterRows == 'byName'
 				? twlst.map(t => t.term.name).sort()
-				: c.row.order.map(row => row.name)
+				: this.config.dataType === NUMERIC_DICTIONARY_TERM
+				? c.row.order.map(row => twlst.find(t => t.term.id == row.name)?.term.name)
+				: c.row.order.map(row => twlst.find(t => t.$id == row.name)?.term.name)
+
+		if (this.hcTermNameOrder.includes(undefined)) throw `unable to map row.name to term.name`
 
 		this.hcTermSorter = (a, b) => {
 			const i = this.hcTermNameOrder.indexOf(a.tw.term.name)


### PR DESCRIPTION
# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
