### PR TITLE
Restrict drug terms

### DIFF
--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -3,7 +3,7 @@ import { format as d3format } from 'd3-format'
 import { fillTermWrapper, termsettingInit } from '#termsetting'
 import { icons, newSandboxDiv, Menu, renderTable, table2col } from '#dom'
 import { dofetch3 } from '#common/dofetch'
-import { TermTypes, isNumericTerm } from '#shared/terms.js'
+import { TermTypes, isNumericTerm, NUMERIC_DICTIONARY_TERM } from '#shared/terms.js'
 import { mclass, dt2label, dtsnvindel, dtcnv, dtgeneexpression, dtmetaboliteintensity } from '#shared/common.js'
 import { rgb2hex } from '#src/client'
 import { getSamplelstTW, getFilter, addNewGroup } from '../../mass/groups.js'
@@ -1253,9 +1253,14 @@ function setTermActions(self) {
 		//self.dom.textTermBtn.style('text-decoration', '')
 
 		const usecase = { target: 'matrix', detail: 'termgroups' }
-		if (self.activeLabel.grp.type == 'hierCluster') {
-			usecase.target = self.activeLabel.tw.term.type
-			usecase.detail = 'term'
+		if (self.chartType == 'hierCluster') {
+			if (self.config.dataType == NUMERIC_DICTIONARY_TERM) {
+				usecase.target = 'numericDictTermCluster'
+				usecase.detail = { exclude: self.state.termdbConfig.numericDictTermCluster?.exclude }
+			} else {
+				usecase.target = self.activeLabel.tw.term.type
+				usecase.detail = 'term'
+			}
 		}
 		const termdb = await import('#termdb/app')
 		self.dom.editbody.selectAll('*').remove()

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -56,7 +56,8 @@ const useCasesExcluded = {
 		TermTypeGroups.SNP_LIST,
 		TermTypeGroups.MUTATION_CNV_FUSION,
 		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.METABOLITE_INTENSITY
+		TermTypeGroups.METABOLITE_INTENSITY,
+		TermTypeGroups.SSGSEA
 	]
 }
 

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -36,7 +36,12 @@ const useCasesExcluded = {
 	survival: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
 	default: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
-	regression: [TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS],
+	regression: [
+		TermTypeGroups.SNP_LIST,
+		TermTypeGroups.SNP_LOCUS,
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.SSGSEA
+	],
 	metaboliteIntensity: [
 		TermTypeGroups.SNP_LOCUS,
 		TermTypeGroups.SNP_LIST,


### PR DESCRIPTION
# Description

clicking the ALL-pharm clustering group label and Add Rows restrict to add drug terms only
clicking the Drug sensitivity chart button allows to add drug terms only.
clicking "Select continuous outcome variable" allows to add dictionary terms only. 



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
