### PR TITLE
Numeric dict term cluster bulk edit

### DIFF
--- a/client/plots/matrix/hierCluster.interactivity.js
+++ b/client/plots/matrix/hierCluster.interactivity.js
@@ -313,8 +313,6 @@ export function setClusteringBtn(holder, callback) {
 			? 'Gene Expression Clustering'
 			: dataType == 'metaboliteIntensity'
 			? 'Metabolite Intensity Clustering'
-			: dataType == 'numericDictTerm'
-			? 'Term Value Clustering'
 			: 'Clustering'
 	holder
 		.append('button')

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -5,7 +5,7 @@ import { fillTermWrapper, get$id } from '#termsetting'
 import { Menu, zoom, icons, svgScroll, make_radios, make_one_checkbox, GeneSetEditUI } from '#dom'
 import { select } from 'd3-selection'
 import { mclass, dt2label, dtsnvindel, dtcnv, dtfusionrna, dtgeneexpression, dtsv } from '#shared/common.js'
-import { TermTypes, TermTypeGroups, isNumericTerm } from '#shared/terms.js'
+import { TermTypes, NUMERIC_DICTIONARY_TERM, isNumericTerm } from '#shared/terms.js'
 
 const tip = new Menu({ padding: '' })
 
@@ -28,6 +28,8 @@ export class MatrixControls {
 			(this.parent.chartType == 'hierCluster' && this.parent.config.dataType == TermTypes.GENE_EXPRESSION)
 		) {
 			this.setGenesBtn(s)
+		} else if (this.parent.chartType == 'hierCluster' && this.parent.config.dataType == NUMERIC_DICTIONARY_TERM) {
+			this.setNumericDictTermsBtn()
 		}
 		if (s.addMutationCNVButtons && this.parent.chartType !== 'hierCluster') {
 			this.setMutationBtn()
@@ -424,6 +426,19 @@ export class MatrixControls {
 			.on('click', (event, d) => this.callback(event, d))
 	}
 
+	setNumericDictTermsBtn() {
+		this.opts.holder
+			.append('button')
+			.datum({
+				label: `${this.parent.app.vocabApi.termdbConfig.numericDictTermCluster.appName} Terms`,
+				getCount: () => this.parent.hcTermGroup.lst.length || 0,
+				rows: [],
+				customInputs: this.addNumericDictTermsInputs
+			})
+			.html(d => d.label)
+			.style('margin', '2px 0')
+			.on('click', (event, d) => this.callback(event, d))
+	}
 	setVariablesBtn(s) {
 		const l = s.controlLabels
 		this.opts.holder
@@ -1120,6 +1135,11 @@ export class MatrixControls {
 		const tr = table.append('tr')
 		tr.append('td').text(header).attr('class', 'sja-termdb-config-row-label')
 		tr.append('td').text(value)
+	}
+
+	async addNumericDictTermsInputs(self, app, parent, table) {
+		const holder = app.tip.d.append('div')
+		self.parent.showDictTermSelection(holder)
 	}
 
 	async addGeneInputs(self, app, parent, table) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Numeric dictionary term cluster: add a button to control panel to allow batch edit the terms in the clustering group. 


### PR DESCRIPTION
# Description

could use this link to test: [numericDictTermCluster](http://localhost:3000/?mass=%7B%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22hierCluster%22,%22dataType%22:%22numericDictTerm%22,%22termgroups%22:%5B%7B%22name%22:%22Drug%20Sensitivity%20Cluster%22,%22lst%22:%5B%7B%22id%22:%22Asparaginase_normalizedLC50%22%7D,%7B%22id%22:%22Bortezomib_normalizedLC50%22%7D,%7B%22id%22:%22Daunorubicin_normalizedLC50%22%7D,%7B%22id%22:%22Prednisolone_normalizedLC50%22%7D,%7B%22id%22:%22Vincristine_normalizedLC50%22%7D%5D,%22type%22:%22hierCluster%22%7D%5D%7D%5D%7D)

Added a button "n drug sensitivity terms" to control panel to allow batch edit the terms in the clustering group. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
