### PR TITLE
fix the embedder.origin detection for when to use parentCorsMessage()

### DIFF
--- a/client/common/embedder-helpers.js
+++ b/client/common/embedder-helpers.js
@@ -65,8 +65,8 @@ export function parentCorsMessage(res, origin = '') {
 				`\n- After the session is recovered, this browser window should automatically close.`
 		)
 		if (ok) {
-			confirmedCorsWindow.push(embedder.origin)
-			localStorage.setItem('confirmedCorsWindow', JSON.stringify(confirmedCorsWindow))
+			if (embedder.origin && !confirmedCorsWindow.incldues(embedder.origin)) confirmedCorsWindow.push(embedder.origin)
+			localStorage.setItem('confirmedCorsWindow', JSON.stringify(confirmedCorsWindow.filter(d => d != undefined))) // not falsy
 		}
 	}
 

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -168,7 +168,7 @@ upon error, throw err message as a string
 			if (d.error) throw d.error
 			if (!d.text) throw 'data.text missing'
 			const state = JSON.parse(d.text)
-			if (state.embedder?.origin != window.location.origin) {
+			if (state.embedder?.origin && state.embedder.origin != window.location.origin) {
 				parentCorsMessage({ state })
 				return
 			}
@@ -192,7 +192,7 @@ upon error, throw err message as a string
 			if (!d.text) throw 'data.text missing'
 			const state = JSON.parse(d.text)
 
-			if (state.embedder && state.embedder.origin != window.location.origin) {
+			if (state.embedder?.origin && state.embedder.origin != window.location.origin) {
 				parentCorsMessage({ state })
 				return
 			}
@@ -234,7 +234,7 @@ upon error, throw err message as a string
 			if (res.error) throw res.error
 		}
 		const embedder = res.state?.embedder
-		if (embedder && embedder.origin != window.location.origin) {
+		if (embedder?.origin && embedder.origin != window.location.origin) {
 			parentCorsMessage(res)
 			return
 		}


### PR DESCRIPTION
# Description

To test:
- edit `sjpp/public/mbportal/index.html` to remove `https://proteinpaint.stjude.org` from all links, and then open a live viz link in https://localhost:3000/mbportal

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
