### PR TITLE
convert embedder-helpers to typescript

### DIFF
--- a/client/common/embedder-helpers.ts
+++ b/client/common/embedder-helpers.ts
@@ -21,7 +21,7 @@
      in downstream code
 */
 
-export function parentCorsMessage(res) {
+export function parentCorsMessage(res, flag = '') {
 	const embedder = res.state?.embedder || {}
 	const messageListener = event => {
 		if (event.origin !== embedder.origin) return
@@ -70,12 +70,15 @@ export function parentCorsMessage(res) {
 		}
 	}
 
-	document.body.innerHTML = `
-		<div style='margin: 20px; padding: 20px; font-size: 24px'>
-			The recovered session should be visible in another browser tab.
-			You may go back in your browser history or close this browser tab.
-		</div>
-	`
+	if (flag != 'noredirect') {
+		// only wipe document html if there is a redirect
+		document.body.innerHTML = `
+			<div style='margin: 20px; padding: 20px; font-size: 24px'>
+				The recovered session should be visible in another browser tab.
+				You may go back in your browser history or close this browser tab.
+			</div>
+		`
+	}
 
 	setTimeout(() => window.removeEventListener('message', messageListener), 8000)
 	const child = window.open(embedder.href, '_blank')

--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -411,7 +411,7 @@ class MassSessionBtn {
 				//
 				a.on('click', event => {
 					event.preventDefault()
-					parentCorsMessage({ state })
+					parentCorsMessage({ state }, 'noredirect')
 					return false
 				})
 			}


### PR DESCRIPTION
# Description

To test:
- change `public/index.html` to use `<script src='http://localhost:3000/bin/proteinpaint.js'>`
- open http://viz.localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22}
- click on session btn, then `Open link`, then `Copy link` + open a new tab + paste into browser address bar. Both of these should work, without wiping the original tab's html
- can also test using http://localhost:3000/mbportal/, but this requires editing `public/mbportal/index.html` to use `http://viz.localhost:3000` in links instead of localhost or proteinpaint.stjude.org

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
