### PR TITLE
move set edit option for metabolite intensity and numericDictionaryTe…

### DIFF
--- a/client/plots/matrix/hierCluster.interactivity.js
+++ b/client/plots/matrix/hierCluster.interactivity.js
@@ -1,6 +1,7 @@
 import { renderTable } from '#dom'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
 import { select } from 'd3-selection'
+import { TermTypes, NUMERIC_DICTIONARY_TERM } from '#shared/terms.js'
 
 // Given a clusterId, return all its children clusterIds
 export function getAllChildrenClusterIds(clickedClusterId, left) {
@@ -319,6 +320,8 @@ export function setClusteringBtn(holder, callback) {
 		//.property('disabled', d => d.disabled)
 		.datum({
 			label: cluteringButtonLabel,
+			getCount: () => this.hcTermGroup?.lst.length || 0,
+			showCount: dataType == TermTypes.METABOLITE_INTENSITY || dataType == NUMERIC_DICTIONARY_TERM ? 'append' : 'hide',
 			rows: [
 				{
 					label: `Cluster ${cl.Samples}`,
@@ -509,5 +512,39 @@ function updateClusteringControls(self, app, parent, table) {
 				.closest('tr')
 		)
 		colorSchemeControl.style('display', 'none')
+	}
+
+	// Only add set edit option for METABOLITE_INTENSITY and NUMERIC_DICTIONARY_TERM
+	if (
+		parent.chartType == 'hierCluster' &&
+		(parent.config.dataType == TermTypes.METABOLITE_INTENSITY || parent.config.dataType == NUMERIC_DICTIONARY_TERM)
+	) {
+		const geneInputTr = table.insert('tr', () => table.select('tr').node())
+		geneInputTr.append('td').attr('class', 'sja-termdb-config-row-label').html('Hierarchical Clustering Term Set')
+
+		const td1 = geneInputTr.append('td').style('display', 'block').style('padding', '5px 0px')
+		const editGrpDiv = td1.append('div').append('label')
+
+		const clusteringBtn = self.btns.node()
+		editGrpDiv
+			.append('button')
+			.html('Edit Set')
+			.on('click', () => {
+				app.tip.clear()
+				const backDiv = app.tip.d.append('div').style('padding', '5px')
+				backDiv
+					.attr('tabindex', 0)
+					.style('padding', '5px')
+					.style('text-decoration', 'underline')
+					.style('cursor', 'pointer')
+					.style('margin-bottom', '12px')
+					.html(`&#171; Back`)
+					.on('click', () => clusteringBtn.click())
+					.on('keyup', event => {
+						if (event.key == 'Enter') event.target.click()
+					})
+				const setEdiUiHolder = app.tip.d.append('div')
+				parent.showDictTermSelection(setEdiUiHolder)
+			})
 	}
 }

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -28,8 +28,6 @@ export class MatrixControls {
 			(this.parent.chartType == 'hierCluster' && this.parent.config.dataType == TermTypes.GENE_EXPRESSION)
 		) {
 			this.setGenesBtn(s)
-		} else if (this.parent.chartType == 'hierCluster' && this.parent.config.dataType == NUMERIC_DICTIONARY_TERM) {
-			this.setNumericDictTermsBtn()
 		}
 		if (s.addMutationCNVButtons && this.parent.chartType !== 'hierCluster') {
 			this.setMutationBtn()
@@ -426,19 +424,6 @@ export class MatrixControls {
 			.on('click', (event, d) => this.callback(event, d))
 	}
 
-	setNumericDictTermsBtn() {
-		this.opts.holder
-			.append('button')
-			.datum({
-				label: `${this.parent.app.vocabApi.termdbConfig.numericDictTermCluster.appName} Terms`,
-				getCount: () => this.parent.hcTermGroup.lst.length || 0,
-				rows: [],
-				customInputs: this.addNumericDictTermsInputs
-			})
-			.html(d => d.label)
-			.style('margin', '2px 0')
-			.on('click', (event, d) => this.callback(event, d))
-	}
 	setVariablesBtn(s) {
 		const l = s.controlLabels
 		this.opts.holder
@@ -1041,7 +1026,13 @@ export class MatrixControls {
 		this.parent.app.tip.hide()
 
 		this.btns
-			.text(d => (d.getCount ? `${d.getCount()} ` : '') + d.label)
+			.text(d =>
+				!d.getCount || d.showCount == 'hide'
+					? d.label
+					: d.showCount == 'append'
+					? `${d.label} (n=${d.getCount()})`
+					: `${d.getCount()} ${d.label}`
+			)
 			.each(function (d) {
 				if (d.updateBtn) d.updateBtn(select(this))
 			})
@@ -1135,11 +1126,6 @@ export class MatrixControls {
 		const tr = table.append('tr')
 		tr.append('td').text(header).attr('class', 'sja-termdb-config-row-label')
 		tr.append('td').text(value)
-	}
-
-	async addNumericDictTermsInputs(self, app, parent, table) {
-		const holder = app.tip.d.append('div')
-		self.parent.showDictTermSelection(holder)
 	}
 
 	async addGeneInputs(self, app, parent, table) {

--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -36,25 +36,22 @@ const useCasesExcluded = {
 	survival: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
 	//Used from the termsetting when searching for a term, as any term with categories is allowed
 	default: [TermTypeGroups.SNP_LOCUS, TermTypeGroups.SNP_LIST],
-	regression: [
-		TermTypeGroups.SNP_LIST,
-		TermTypeGroups.SNP_LOCUS,
-		TermTypeGroups.GENE_EXPRESSION,
-		TermTypeGroups.SSGSEA
-	],
+	regression: [TermTypeGroups.SNP_LIST, TermTypeGroups.SNP_LOCUS],
 	metaboliteIntensity: [
 		TermTypeGroups.SNP_LOCUS,
 		TermTypeGroups.SNP_LIST,
 		TermTypeGroups.MUTATION_CNV_FUSION,
 		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.GENE_EXPRESSION
+		TermTypeGroups.GENE_EXPRESSION,
+		TermTypeGroups.SSGSEA
 	],
 	geneExpression: [
 		TermTypeGroups.SNP_LOCUS,
 		TermTypeGroups.SNP_LIST,
 		TermTypeGroups.MUTATION_CNV_FUSION,
 		TermTypeGroups.DICTIONARY_VARIABLES,
-		TermTypeGroups.METABOLITE_INTENSITY
+		TermTypeGroups.METABOLITE_INTENSITY,
+		TermTypeGroups.SSGSEA
 	],
 	numericDictTermCluster: [
 		TermTypeGroups.SNP_LOCUS,


### PR DESCRIPTION
…rm clustering to Clustering panel

# Description
move the set edit option for metabolite intensity and numericDictionary to be under "clustering" control panel. could use [drug sensitivity](http://localhost:3000/?mass={%22dslabel%22:%22ALL-pharmacotyping%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22hierCluster%22,%22dataType%22:%22numericDictTerm%22,%22termgroups%22:[{%22name%22:%22Drug%20Sensitivity%20Cluster%22,%22lst%22:[{%22id%22:%22Asparaginase_normalizedLC50%22},{%22id%22:%22Bortezomib_normalizedLC50%22},{%22id%22:%22Daunorubicin_normalizedLC50%22},{%22id%22:%22Prednisolone_normalizedLC50%22},{%22id%22:%22Vincristine_normalizedLC50%22}],%22type%22:%22hierCluster%22}]}]}) to test



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
