### PR TITLE
Fix for broken GSEA tab in the DA app

### DIFF
--- a/client/plots/importPlot.js
+++ b/client/plots/importPlot.js
@@ -31,6 +31,9 @@ export async function importPlot(chartType, notFoundMessage = '') {
 		case 'grin2':
 			return await import('./grin2/grin2')
 
+		case 'gsea':
+			return await import(`./gsea.js`)
+
 		case 'sampleScatter':
 			return await import(`./scatter/scatter.js`)
 


### PR DESCRIPTION
# Description

Clicking on the GSEA tab in the DA app throws an error. This branch restores the gsea as a child component of the DA app. Also restored the mvvm pattern. 

Test with two groups in [ALL pharma](http://localhost:3000/?massnative=hg38,ALL-pharmacotyping) or [TermdbTest](http://localhost:3000/?massnative=hg38-test,TermdbTest) 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
