### PR TITLE
Add loading spinner to wsi viewer.

### DIFF
--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -51,7 +51,9 @@ class WSIViewer extends PlotBase implements RxComponent {
 				.style('width', '100%')
 				.style('height', '100%')
 				.style('background-color', 'rgba(255, 255, 255, 0.95)')
-				.style('text-align', 'center'),
+				.style('text-align', 'center')
+				.style('display', 'none'),
+
 			errorDiv: opts.holder.append('div').attr('class', 'wsiViewer-error').style('margin-left', '10px'),
 			mapHolder: opts.holder.append('div').attr('id', 'wsiviewer-mapHolder'),
 			annotationsHolder: opts.holder
@@ -127,7 +129,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 		const imageViewData: ImageViewData = viewModel.getImageViewData(settings.displayedImageIndex)
 
 		if (settings.renderWSIViewer) {
-			this.wsiViewerInteractions.toggleLoadingDiv(true)
+			this.wsiViewerInteractions.toggleLoadingDiv(settings.renderAnnotationTable)
 
 			this.thumbnailsContainer = this.thumbnailRenderer.render(
 				this.dom.mapHolder,

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -101,8 +101,6 @@ class WSIViewer extends PlotBase implements RxComponent {
 		// }
 		// this.loadingDiv = loadingDiv
 
-		this.wsiViewerInteractions.toggleLoadingDiv(true)
-
 		const buffers = {
 			annotationsIdx: new Buffer<number>(0),
 			tmpClass: new Buffer<{ label: string; color: string }>({ label: '', color: '' })
@@ -148,6 +146,8 @@ class WSIViewer extends PlotBase implements RxComponent {
 		const imageViewData: ImageViewData = viewModel.getImageViewData(settings.displayedImageIndex)
 
 		if (settings.renderWSIViewer) {
+			this.wsiViewerInteractions.toggleLoadingDiv(true)
+
 			this.thumbnailsContainer = this.thumbnailRenderer.render(
 				this.dom.mapHolder,
 				this.thumbnailsContainer,

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -32,6 +32,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 	private metadataRenderer = new MetadataRenderer()
 	private legendRenderer = new LegendRenderer()
 	private map: OLMap | undefined = undefined
+	loadingDiv: any
 
 	constructor(opts: any, api) {
 		super(opts, api)
@@ -54,6 +55,16 @@ class WSIViewer extends PlotBase implements RxComponent {
 		const state = structuredClone(this.state)
 		const settings = state.plots.find(p => p.id === this.id).settings as Settings
 		const holder = this.opts.holder
+
+		this.loadingDiv = holder
+			.append('div')
+			.style('position', 'absolute')
+			.style('top', '0')
+			.style('left', '0')
+			.style('width', '100%')
+			.style('height', '100%')
+			.style('background-color', 'rgba(255, 255, 255, 0.95)')
+			.style('text-align', 'center')
 
 		const buffers = {
 			annotationsIdx: new Buffer<number>(0),
@@ -156,6 +167,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 				)
 			}
 		}
+		this.wsiViewerInteractions.toggleLoadingDiv(false)
 	}
 }
 

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -33,10 +33,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 	private metadataRenderer = new MetadataRenderer()
 	private legendRenderer = new LegendRenderer()
 	private map: OLMap | undefined = undefined
-	// private loadingDiv: any
 	private annotationTable: any
-	// private mapHolder: any
-	// private legendHolder: any
 
 	constructor(opts: any, api) {
 		super(opts, api)
@@ -85,22 +82,6 @@ class WSIViewer extends PlotBase implements RxComponent {
 		const settings = state.plots.find(p => p.id === this.id).settings as Settings
 		const holder = this.opts.holder
 
-		// Check if wsiViewer-progress already exists
-		// let loadingDiv = holder.select('.wsiViewer-progress')
-		// if (loadingDiv.empty()) {
-		// 	loadingDiv = holder
-		// 		.append('div')
-		// 		.attr('class', 'wsiViewer-progress')
-		// 		.style('position', 'absolute')
-		// 		.style('top', '0')
-		// 		.style('left', '0')
-		// 		.style('width', '100%')
-		// 		.style('height', '100%')
-		// 		.style('background-color', 'rgba(255, 255, 255, 0.95)')
-		// 		.style('text-align', 'center')
-		// }
-		// this.loadingDiv = loadingDiv
-
 		const buffers = {
 			annotationsIdx: new Buffer<number>(0),
 			tmpClass: new Buffer<{ label: string; color: string }>({ label: '', color: '' })
@@ -130,13 +111,13 @@ class WSIViewer extends PlotBase implements RxComponent {
 
 		if (wsimages.length === 0) {
 			sayerror(this.dom.errorDiv, 'No WSI images found.')
-			// holder.append('div').style('margin-left', '10px').text('No WSI images.')
+			this.wsiViewerInteractions.toggleLoadingDiv(false)
 			return
 		}
 
 		if (wsimageLayersLoadError) {
 			sayerror(this.dom.errorDiv, wsimageLayersLoadError)
-			// holder.append('div').style('margin-left', '10px').text(wsimageLayersLoadError)
+			this.wsiViewerInteractions.toggleLoadingDiv(false)
 			return
 		}
 
@@ -164,8 +145,6 @@ class WSIViewer extends PlotBase implements RxComponent {
 				settings
 			).render(this.dom.mapHolder, settings)
 
-			// this.mapHolder = holder.select('div[id="wsi-viewer"]')
-
 			if (activeImageExtent && this.map) {
 				this.map.getView().fit(activeImageExtent)
 			}
@@ -184,11 +163,6 @@ class WSIViewer extends PlotBase implements RxComponent {
 				this.map
 			)
 			this.dom.legendHolder.selectAll('*').remove()
-			// this.legendHolder = holder
-			// 	.append('div')
-			// 	.attr('id', 'sjpp-legendHolder')
-			// 	.style('display', 'inline-block')
-			// 	.style('vertical-align', 'top')
 			modelTrainerRenderer.render(this.dom.legendHolder, aiProjectID, genome, dslabel)
 			this.legendRenderer.render(this.dom.legendHolder, imageViewData)
 

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -296,33 +296,37 @@ export class WSIViewerInteractions {
 		}
 
 		this.onRetrainModelClicked = async (genome: string, dslabel: string, projectId: string) => {
-			await dofetch3('/aiProjectTrainModel', {
-				body: {
-					genome,
-					dslabel,
-					projectId
-				}
-			})
-
-			clearServerDataCache()
-
-			wsiApp.app.dispatch({
-				type: 'plot_edit',
-				id: opts.id,
-				config: {
-					settings: {
-						renderWSIViewer: true,
-						renderAnnotationTable: true,
-						activeAnnotation: Math.random()
+			try {
+				await dofetch3('/aiProjectTrainModel', {
+					body: {
+						genome,
+						dslabel,
+						projectId
 					}
-				}
-			})
+				})
+				clearServerDataCache()
+
+				wsiApp.app.dispatch({
+					type: 'plot_edit',
+					id: opts.id,
+					config: {
+						settings: {
+							renderWSIViewer: true,
+							renderAnnotationTable: true,
+							activeAnnotation: Math.random()
+						}
+					}
+				})
+			} catch (e: any) {
+				this.toggleLoadingDiv(false)
+				wsiApp.app.printError('Error retraining model: ' + (e.message || e))
+			}
 		}
 
 		this.toggleLoadingDiv = (show: boolean) => {
 			if (show) {
-				wsiApp.loadingDiv.selectAll('*').remove()
-				wsiApp.loadingDiv
+				wsiApp.dom.loadingDiv.selectAll('*').remove()
+				wsiApp.dom.loadingDiv
 					.style('display', 'block')
 					.append('div')
 					.style('position', 'relative')
@@ -330,14 +334,14 @@ export class WSIViewerInteractions {
 					.append('span')
 					.attr('class', 'sjpp-spinner')
 
-				wsiApp.mapHolder.style('display', 'none')
-				wsiApp.annotationTable.style('display', 'none')
-				wsiApp.legendHolder.style('display', 'none')
+				wsiApp.dom.mapHolder.style('display', 'none')
+				wsiApp.dom.annotationsHolder.style('display', 'none')
+				wsiApp.dom.legendHolder.style('display', 'none')
 			} else {
-				wsiApp.loadingDiv.style('display', 'none')
-				wsiApp.mapHolder.style('display', 'block')
-				wsiApp.annotationTable.style('display', 'inline-block')
-				wsiApp.legendHolder.style('display', 'inline-block')
+				wsiApp.dom.loadingDiv.style('display', 'none')
+				wsiApp.dom.mapHolder.style('display', 'block')
+				wsiApp.dom.annotationsHolder.style('display', 'inline-block')
+				wsiApp.dom.legendHolder.style('display', 'inline-block')
 			}
 		}
 	}

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -40,6 +40,7 @@ export class WSIViewerInteractions {
 	) => void
 
 	onRetrainModelClicked: (genome: string, dslabel: string, projectId: string) => void
+	toggleLoadingDiv: (show: boolean) => void
 
 	constructor(wsiApp: any, opts: any) {
 		this.thumbnailClickListener = (index: number) => {
@@ -316,6 +317,21 @@ export class WSIViewerInteractions {
 					}
 				}
 			})
+		}
+
+		this.toggleLoadingDiv = (show: boolean) => {
+			if (show) {
+				wsiApp.loadingDiv.selectAll('*').remove()
+				wsiApp.loadingDiv
+					.style('display', '')
+					.append('div')
+					.style('position', 'relative')
+					.style('top', '50%')
+					.append('span')
+					.attr('class', 'sjpp-spinner')
+			} else {
+				wsiApp.loadingDiv.style('display', 'none')
+			}
 		}
 	}
 

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -323,14 +323,21 @@ export class WSIViewerInteractions {
 			if (show) {
 				wsiApp.loadingDiv.selectAll('*').remove()
 				wsiApp.loadingDiv
-					.style('display', '')
+					.style('display', 'block')
 					.append('div')
 					.style('position', 'relative')
 					.style('top', '50%')
 					.append('span')
 					.attr('class', 'sjpp-spinner')
+
+				wsiApp.mapHolder.style('display', 'none')
+				wsiApp.annotationTable.style('display', 'none')
+				wsiApp.legendHolder.style('display', 'none')
 			} else {
 				wsiApp.loadingDiv.style('display', 'none')
+				wsiApp.mapHolder.style('display', 'block')
+				wsiApp.annotationTable.style('display', 'inline-block')
+				wsiApp.legendHolder.style('display', 'inline-block')
 			}
 		}
 	}

--- a/client/plots/wsiviewer/plot.wsi.js
+++ b/client/plots/wsiviewer/plot.wsi.js
@@ -21,8 +21,7 @@ export default async function (
 	aiWSIMageFiles,
 	renderAnnotationTable = false
 ) {
-	// Replaced by temp spinner. May completely replace with progress bar.
-	// const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
+	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
 
 	try {
 		const opts = {
@@ -46,9 +45,9 @@ export default async function (
 		}
 		const plot = await import('#plots/plot.app.js')
 		const plotAppApi = await plot.appInit(opts)
-		// loadingDiv.remove()
+		loadingDiv.remove()
 	} catch (e) {
-		// loadingDiv.text('Error: ' + (e.message || e))
+		loadingDiv.text('Error: ' + (e.message || e))
 		console.error(e.message || e)
 	}
 }

--- a/client/plots/wsiviewer/plot.wsi.js
+++ b/client/plots/wsiviewer/plot.wsi.js
@@ -21,7 +21,8 @@ export default async function (
 	aiWSIMageFiles,
 	renderAnnotationTable = false
 ) {
-	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
+	// Replaced by temp spinner. May completely replace with progress bar.
+	// const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
 
 	try {
 		const opts = {
@@ -45,8 +46,9 @@ export default async function (
 		}
 		const plot = await import('#plots/plot.app.js')
 		const plotAppApi = await plot.appInit(opts)
-		loadingDiv.remove()
+		// loadingDiv.remove()
 	} catch (e) {
-		loadingDiv.text('Error: ' + (e.message || e))
+		// loadingDiv.text('Error: ' + (e.message || e))
+		console.error(e.message || e)
 	}
 }

--- a/client/plots/wsiviewer/view/LegendRenderer.ts
+++ b/client/plots/wsiviewer/view/LegendRenderer.ts
@@ -4,7 +4,6 @@ import type { ImageViewData } from '#plots/wsiviewer/viewModel/ImageViewData.ts'
 export class LegendRenderer {
 	render(holder: any, imageViewData: ImageViewData) {
 		if (!imageViewData.classesTable) return
-		// holder.selectAll('div[id="legend-wrapper"]').remove()
 
 		const legendHolder = holder
 			.append('div')

--- a/client/plots/wsiviewer/view/LegendRenderer.ts
+++ b/client/plots/wsiviewer/view/LegendRenderer.ts
@@ -4,7 +4,7 @@ import type { ImageViewData } from '#plots/wsiviewer/viewModel/ImageViewData.ts'
 export class LegendRenderer {
 	render(holder: any, imageViewData: ImageViewData) {
 		if (!imageViewData.classesTable) return
-		holder.select('div[id="legend-wrapper"]').remove()
+		// holder.selectAll('div[id="legend-wrapper"]').remove()
 
 		const legendHolder = holder
 			.append('div')

--- a/client/plots/wsiviewer/view/MapRenderer.ts
+++ b/client/plots/wsiviewer/view/MapRenderer.ts
@@ -51,7 +51,7 @@ export class MapRenderer {
 			.attr('id', 'wsi-viewer')
 			.style('width', settings.imageWidth)
 			.style('height', settings.imageHeight)
-			.style('display', 'none') // Initially hidden
+		// .style('display', 'none') // Initially hidden
 
 		const activeImage: TileLayer = this.wSImageLayers.wsimage
 		const extent = activeImage?.getSource()?.getTileGrid()?.getExtent()

--- a/client/plots/wsiviewer/view/MapRenderer.ts
+++ b/client/plots/wsiviewer/view/MapRenderer.ts
@@ -51,6 +51,7 @@ export class MapRenderer {
 			.attr('id', 'wsi-viewer')
 			.style('width', settings.imageWidth)
 			.style('height', settings.imageHeight)
+			.style('display', 'none') // Initially hidden
 
 		const activeImage: TileLayer = this.wSImageLayers.wsimage
 		const extent = activeImage?.getSource()?.getTileGrid()?.getExtent()

--- a/client/plots/wsiviewer/view/ModelTrainerRenderer.ts
+++ b/client/plots/wsiviewer/view/ModelTrainerRenderer.ts
@@ -25,7 +25,9 @@ export class ModelTrainerRenderer {
 			.style('cursor', 'pointer')
 			.text('Retrain Model')
 			.on('click', async () => {
-				this.wsiinteractions.onRetrainModelClicked(genome, dslabel, projectId)
+				this.wsiinteractions.toggleLoadingDiv(true)
+				await this.wsiinteractions.onRetrainModelClicked(genome, dslabel, projectId)
+				this.wsiinteractions.toggleLoadingDiv(false)
 				//temp implementation to call route
 			})
 	}

--- a/client/plots/wsiviewer/view/ModelTrainerRenderer.ts
+++ b/client/plots/wsiviewer/view/ModelTrainerRenderer.ts
@@ -27,8 +27,8 @@ export class ModelTrainerRenderer {
 			.on('click', async () => {
 				this.wsiinteractions.toggleLoadingDiv(true)
 				await this.wsiinteractions.onRetrainModelClicked(genome, dslabel, projectId)
-				this.wsiinteractions.toggleLoadingDiv(false)
 				//temp implementation to call route
+				//Spinner will be removed when main() is called
 			})
 	}
 }

--- a/client/plots/wsiviewer/view/ThumbnailRenderer.ts
+++ b/client/plots/wsiviewer/view/ThumbnailRenderer.ts
@@ -18,6 +18,7 @@ export class ThumbnailRenderer {
 			thumbnailsContainer = holder
 				.append('div')
 				.attr('id', 'thumbnails')
+				.style('display', 'none') // Initially hidden
 				.attr('data-testid', 'sjpp-thumbnails')
 				.style('width', '600px')
 				.style('height', '80px')

--- a/client/plots/wsiviewer/view/WSIAnnotationsRenderer.ts
+++ b/client/plots/wsiviewer/view/WSIAnnotationsRenderer.ts
@@ -15,13 +15,6 @@ export class WSIAnnotationsRenderer {
 
 	render(holder: any, imageViewData: ImageViewData, activeImageExtent: Extent, map: OLMap) {
 		holder.select('div[id="annotations-table"]').remove()
-
-		// const tablesWrapper = holder
-		// 	// .append('div')
-		// 	// .attr('id', 'annotations-table-wrapper')
-		// 	.style('display', 'none')
-		// 	.style('padding', '20px')
-
 		if (!imageViewData.tilesTable) return
 		const selectedColor = '#fcfc8b'
 

--- a/client/plots/wsiviewer/view/WSIAnnotationsRenderer.ts
+++ b/client/plots/wsiviewer/view/WSIAnnotationsRenderer.ts
@@ -14,13 +14,13 @@ export class WSIAnnotationsRenderer {
 	}
 
 	render(holder: any, imageViewData: ImageViewData, activeImageExtent: Extent, map: OLMap) {
-		holder.select('div[id="annotations-table-wrapper"]').remove()
+		holder.select('div[id="annotations-table"]').remove()
 
-		const tablesWrapper = holder
-			.append('div')
-			.attr('id', 'annotations-table-wrapper')
-			.style('display', 'none')
-			.style('padding', '20px')
+		// const tablesWrapper = holder
+		// 	// .append('div')
+		// 	// .attr('id', 'annotations-table-wrapper')
+		// 	.style('display', 'none')
+		// 	.style('padding', '20px')
 
 		if (!imageViewData.tilesTable) return
 		const selectedColor = '#fcfc8b'
@@ -28,7 +28,7 @@ export class WSIAnnotationsRenderer {
 		renderTable({
 			columns: imageViewData.tilesTable.columns,
 			rows: imageViewData.tilesTable.rows,
-			div: tablesWrapper
+			div: holder
 				.append('div')
 				.attr('id', 'annotations-table')
 				.style('margins', '20px')
@@ -92,6 +92,6 @@ export class WSIAnnotationsRenderer {
 			}
 		})
 
-		return tablesWrapper
+		return holder
 	}
 }

--- a/client/plots/wsiviewer/view/WSIAnnotationsRenderer.ts
+++ b/client/plots/wsiviewer/view/WSIAnnotationsRenderer.ts
@@ -19,7 +19,7 @@ export class WSIAnnotationsRenderer {
 		const tablesWrapper = holder
 			.append('div')
 			.attr('id', 'annotations-table-wrapper')
-			.style('display', 'inline-block')
+			.style('display', 'none')
 			.style('padding', '20px')
 
 		if (!imageViewData.tilesTable) return
@@ -91,5 +91,7 @@ export class WSIAnnotationsRenderer {
 				})
 			}
 		})
+
+		return tablesWrapper
 	}
 }

--- a/server/routes/aiProjectSelectedWSImages.ts
+++ b/server/routes/aiProjectSelectedWSImages.ts
@@ -50,7 +50,12 @@ function init({ genomes }) {
 
 					if (ds.queries.WSImages.getWSIPredictionPatches) {
 						const predictions = await ds.queries.WSImages.getWSIPredictionPatches(projectId, wsimageFilename)
-						wsimage.predictions = predictions
+
+						const classMap = new Map<number, string>((wsimage.classes || []).map((c: any) => [c.id, c.label]))
+						wsimage.predictions = (predictions || []).map((p: any) => {
+							const label = classMap.get(p.class) ?? p.class
+							return { ...p, class: label }
+						})
 					}
 
 					wsimages.push(wsimage)

--- a/server/routes/aiProjectTrainModel.ts
+++ b/server/routes/aiProjectTrainModel.ts
@@ -52,6 +52,7 @@ function init({ genomes }) {
 					status: 'error',
 					error: 'No retraining script defined'
 				})
+				return
 			}
 
 			res.status(200).send({


### PR DESCRIPTION
# Description

Shows a loading spinner over the whole area when the model is retraining. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
