### PR TITLE
feature toggle to override embed and test session on local

### DIFF
--- a/client/common/embedder-helpers.ts
+++ b/client/common/embedder-helpers.ts
@@ -65,7 +65,7 @@ export function parentCorsMessage(res, flag = '') {
 				`\n- After the session is recovered, this browser window should automatically close.`
 		)
 		if (ok) {
-			if (embedder.origin && !confirmedCorsWindow.incldues(embedder.origin)) confirmedCorsWindow.push(embedder.origin)
+			if (embedder.origin && !confirmedCorsWindow.includes(embedder.origin)) confirmedCorsWindow.push(embedder.origin)
 			localStorage.setItem('confirmedCorsWindow', JSON.stringify(confirmedCorsWindow.filter(d => d != undefined))) // not falsy
 		}
 	}

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -30,6 +30,7 @@ arg
 upon error, throw err message as a string
 */
 	const urlp = urlmap()
+	const features = JSON.parse(sessionStorage.getItem('optionalFeatures'))
 
 	if (urlp.has('appcard')) {
 		const ad = await import('../appdrawer/adSandbox')
@@ -52,7 +53,6 @@ upon error, throw err message as a string
 		//Check if track/app can be shown on this server
 		//If not show error message
 		if (re.elements[element]?.configFeature) {
-			const features = JSON.parse(sessionStorage.getItem('optionalFeatures'))
 			if (!features[re.elements[element].configFeature]) {
 				sayerror(arg.holder, `This track or app is not enabled on this site.`)
 				return
@@ -168,6 +168,15 @@ upon error, throw err message as a string
 			if (d.error) throw d.error
 			if (!d.text) throw 'data.text missing'
 			const state = JSON.parse(d.text)
+
+			if (features.overrideEmbedderHostInMassSession) {
+				// on local dev, set this to override "embedder{}" setting in session file
+				// to prevent redirecting to portal site and test the session with local pp
+				state.embedder.host = features.overrideEmbedderHostInMassSession
+				state.embedder.origin = 'http://' + features.overrideEmbedderHostInMassSession
+				state.embedder.href = `http://${features.overrideEmbedderHostInMassSession}/`
+			}
+
 			if (state.embedder?.origin && state.embedder.origin != window.location.origin) {
 				parentCorsMessage({ state })
 				return


### PR DESCRIPTION
# Description
instruction are at https://github.com/stjude/sjpp/wiki/Session-recovery-in-external-portals
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
