### PR TITLE
Adding lesion cap by type and displaying it in processing summary

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -557,9 +557,23 @@ class GRIN2 extends PlotBase implements RxComponent {
 				margin: this.btnMargin
 			})
 
-			Object.entries(result.processingSummary).forEach(([key, value]) => {
+			Object.entries(result.processingSummary ?? {}).forEach(([key, value]) => {
 				const displayKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())
-				const displayValue = Array.isArray(value) ? value.join(', ') : String(value)
+
+				let displayValue: string
+
+				if (Array.isArray(value)) {
+					displayValue = value.join(', ')
+				} else if (typeof value === 'number') {
+					displayValue = value.toLocaleString()
+				} else if (value && typeof value === 'object') {
+					// Special handling for processedByType (record of type -> number)
+					const entries = Object.entries(value as Record<string, number>)
+					displayValue = entries.map(([t, v]) => `${t}: ${v.toLocaleString()}`).join(', ')
+				} else {
+					displayValue = value == null ? '' : String(value)
+				}
+
 				table.addRow(displayKey, displayValue)
 			})
 		}

--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -557,17 +557,18 @@ class GRIN2 extends PlotBase implements RxComponent {
 				margin: this.btnMargin
 			})
 
-			table.addRow('Total Samples', result.processingSummary.totalSamples)
-			table.addRow('Processed Samples', result.processingSummary.processedSamples)
-			table.addRow('Failed Samples', result.processingSummary.failedSamples)
+			table.addRow('Total Samples', result.processingSummary.totalSamples.toLocaleString())
+			table.addRow('Processed Samples', result.processingSummary.processedSamples.toLocaleString())
+			table.addRow('Unprocessed Samples', (result.processingSummary.unprocessedSamples ?? 0).toLocaleString())
+			table.addRow('Failed Samples', result.processingSummary.failedSamples.toLocaleString())
 			table.addRow(
 				'Failed Files',
 				result.processingSummary.failedFiles?.length
 					? result.processingSummary.failedFiles.map(f => f.sampleName).join(', ')
-					: ''
+					: '0'
 			)
-			table.addRow('Total Lesions', result.processingSummary.totalLesions)
-			table.addRow('Processed Lesions', result.processingSummary.processedLesions)
+			table.addRow('Total Lesions', result.processingSummary.totalLesions.toLocaleString())
+			table.addRow('Processed Lesions', result.processingSummary.processedLesions.toLocaleString())
 		}
 
 		// Display timing information

--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -557,23 +557,17 @@ class GRIN2 extends PlotBase implements RxComponent {
 				margin: this.btnMargin
 			})
 
-			const rows: Array<[string, any]> = [
-				['Total Samples', result.processingSummary.totalSamples],
-				['Processed Samples', result.processingSummary.processedSamples],
-				['Failed Samples', result.processingSummary.failedSamples],
-				[
-					'Failed Files',
-					result.processingSummary.failedFiles?.length
-						? result.processingSummary.failedFiles.map(f => f.sampleName).join(', ')
-						: ''
-				],
-				['Total Lesions', result.processingSummary.totalLesions],
-				['Processed Lesions', result.processingSummary.processedLesions]
-			]
-
-			rows.forEach(([label, value]) => {
-				table.addRow(label, value)
-			})
+			table.addRow('Total Samples', result.processingSummary.totalSamples)
+			table.addRow('Processed Samples', result.processingSummary.processedSamples)
+			table.addRow('Failed Samples', result.processingSummary.failedSamples)
+			table.addRow(
+				'Failed Files',
+				result.processingSummary.failedFiles?.length
+					? result.processingSummary.failedFiles.map(f => f.sampleName).join(', ')
+					: ''
+			)
+			table.addRow('Total Lesions', result.processingSummary.totalLesions)
+			table.addRow('Processed Lesions', result.processingSummary.processedLesions)
 		}
 
 		// Display timing information

--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -557,20 +557,22 @@ class GRIN2 extends PlotBase implements RxComponent {
 				margin: this.btnMargin
 			})
 
-			Object.entries(result.processingSummary ?? {}).forEach(([key, value]) => {
-				const displayKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())
+			const rows: Array<[string, any]> = [
+				['Total Samples', result.processingSummary.totalSamples],
+				['Processed Samples', result.processingSummary.processedSamples],
+				['Failed Samples', result.processingSummary.failedSamples],
+				[
+					'Failed Files',
+					result.processingSummary.failedFiles?.length
+						? result.processingSummary.failedFiles.map(f => f.sampleName).join(', ')
+						: ''
+				],
+				['Total Lesions', result.processingSummary.totalLesions],
+				['Processed Lesions', result.processingSummary.processedLesions]
+			]
 
-				let displayValue: string
-
-				if (Array.isArray(value)) {
-					displayValue = value.join(', ')
-				} else if (typeof value === 'number') {
-					displayValue = value.toLocaleString()
-				} else {
-					displayValue = value == null ? '' : String(value)
-				}
-
-				table.addRow(displayKey, displayValue)
+			rows.forEach(([label, value]) => {
+				table.addRow(label, value)
 			})
 		}
 

--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -566,10 +566,6 @@ class GRIN2 extends PlotBase implements RxComponent {
 					displayValue = value.join(', ')
 				} else if (typeof value === 'number') {
 					displayValue = value.toLocaleString()
-				} else if (value && typeof value === 'object') {
-					// Special handling for processedByType (record of type -> number)
-					const entries = Object.entries(value as Record<string, number>)
-					displayValue = entries.map(([t, v]) => `${t}: ${v.toLocaleString()}`).join(', ')
 				} else {
 					displayValue = value == null ? '' : String(value)
 				}
@@ -587,6 +583,19 @@ class GRIN2 extends PlotBase implements RxComponent {
 				.style('color', this.optionsTextColor)
 				.text(
 					`Analysis completed in ${result.timing.totalTime}s (Processing: ${result.timing.processingTime}s, GRIN2: ${result.timing.grin2Time}s)`
+				)
+		}
+
+		// If we didn't process all samples, note that caps truncated the run
+		if (result.processingSummary.processedSamples < result.processingSummary.totalSamples) {
+			this.dom.div
+				.append('div')
+				.style('margin', this.sectionMargin)
+				.style('font-size', `${this.optionsTextFontSize}px`)
+				.style('color', this.optionsTextColor)
+				.text(
+					`Note: Per-type lesion caps were reached before all samples could be processed. ` +
+						`Analysis ran on ${result.processingSummary?.processedSamples} of ${result.processingSummary?.totalSamples} samples.`
 				)
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GRIN2: Added lesion cap to route

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -249,7 +249,6 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request): Promise<GRIN2Re
 	mayLog(`[GRIN2] Python processing took ${grin2AnalysisTimeToPrint} seconds`)
 
 	// Step 5: Parse results and respond
-	// mayLog(`[GRIN2] Full pyResult object:`, pyResult)
 	const resultData = JSON.parse(pyResult)
 
 	// Validate Python script output

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -192,22 +192,22 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request): Promise<GRIN2Re
 	return response
 }
 
-/** Build the active type list from the request options */
-function lesionTypesForRequest(req: GRIN2Request): LesionType[] {
-	const out: LesionType[] = []
-	if (req.snvindelOptions) out.push('mutation')
-	if (req.cnvOptions) out.push('gain', 'loss')
-	if (req.fusionOptions) out.push('fusion')
-	return out
-}
-
 /**  Initializes a new, request-specific lesion tracker.
  * Builds a set of enabled lesion types from the request and a Map that tracks
  * per-type lesion counts and warning flags. */
 function getLesionTracker(req: GRIN2Request): LesionTracker {
-	const currentTypes = new Set<LesionType>(lesionTypesForRequest(req))
+	const currentTypes = new Set<LesionType>()
+
+	if (req.snvindelOptions) currentTypes.add('mutation')
+	if (req.cnvOptions) {
+		currentTypes.add('gain')
+		currentTypes.add('loss')
+	}
+	if (req.fusionOptions) currentTypes.add('fusion')
+
 	const track = new Map<LesionType, TrackState>()
 	for (const t of currentTypes) track.set(t, { count: 0, warned: false })
+
 	return { currentTypes, track }
 }
 

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -60,7 +60,6 @@ function init({ genomes }) {
 	return async (req: any, res: any): Promise<void> => {
 		try {
 			const request = req.query as GRIN2Request
-			console.log('[GRIN2] request:', request)
 
 			// Get genome and dataset from request parameters
 			const g = genomes[request.genome]
@@ -90,7 +89,7 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request): Promise<GRIN2Re
 	const startTime = Date.now()
 
 	// Step 1: Get samples using cohort infrastructure
-	mayLog('[GRIN2] Getting samples from cohort filter...')
+	//mayLog('[GRIN2] Getting samples from cohort filter...')
 
 	const samples = await get_samples(
 		request,
@@ -106,7 +105,7 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request): Promise<GRIN2Re
 	}
 
 	// Step 2: Process sample data, convert to lesion format, and apply filter caps per type
-	mayLog('[GRIN2] Processing sample data...')
+	// mayLog('[GRIN2] Processing sample data...')
 	const processingStartTime = Date.now()
 
 	const { lesions, processingSummary } = await processSampleData(samples, ds, request)
@@ -259,8 +258,6 @@ async function processSampleData(
 		unprocessedSamples: 0
 	}
 
-	mayLog(`[GRIN2] Processing JSON files for ${samples.length.toLocaleString()} samples`)
-
 	outer: for (let i = 0; i < samples.length; i++) {
 		// Stop before opening more files if all enabled types are already capped
 		if (allTypesCapped()) {
@@ -299,7 +296,6 @@ async function processSampleData(
 				filePath: filepath,
 				error: error instanceof Error ? error.message || 'Unknown error' : String(error)
 			})
-			mayLog(`[GRIN2] Error processing sample ${sample.name}: ${processingSummary.failedFiles!.at(-1)!.error}`)
 		}
 	}
 

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -34,7 +34,7 @@ import { dtsnvindel, dtcnv, dtfusionrna } from '#shared/common.js'
  */
 
 // Constants & types
-const MAX_LESIONS_PER_TYPE = 10000 // Maximum number of lesions to process per type to avoid overwhelming the production server
+const MAX_LESIONS_PER_TYPE = 50000 // Maximum number of lesions to process per type to avoid overwhelming the production server
 type LesionType = 'mutation' | 'gain' | 'loss' | 'fusion' // Defining lesion types. We can add more types in the future if needed
 type TrackState = { count: number; warned: boolean }
 type LesionTracker = {

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -137,7 +137,7 @@ export type GRIN2Response = {
 	/** Detailed processing summary */
 	processingSummary?: {
 		totalSamples?: number
-		successfulSamples?: number
+		processedSamples?: number
 		failedSamples?: number
 		failedFiles?: Array<{
 			sampleName: string
@@ -146,7 +146,6 @@ export type GRIN2Response = {
 		}>
 		totalLesions?: number
 		processedLesions?: number
-		processedByType?: Record<string, number>
 	}
 }
 

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -146,6 +146,7 @@ export type GRIN2Response = {
 		}>
 		totalLesions?: number
 		processedLesions?: number
+		unprocessedSamples?: number
 	}
 }
 

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -136,14 +136,17 @@ export type GRIN2Response = {
 	}
 	/** Detailed processing summary */
 	processingSummary?: {
-		totalSamples: number
-		successfulSamples: number
-		failedSamples: number
-		failedFiles: Array<{
+		totalSamples?: number
+		successfulSamples?: number
+		failedSamples?: number
+		failedFiles?: Array<{
 			sampleName: string
 			filePath: string
 			error: string
 		}>
+		totalLesions?: number
+		processedLesions?: number
+		processedByType?: Record<string, number>
 	}
 }
 


### PR DESCRIPTION
# Description
After generating lesion data we now filter it by mutation type before sending it to GRIN2. We add the results of the filtering to the processing summary table. Also added unprocessed file counter support and report it with the processing summary table.

# To Test
Go [here](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22grin2%22}],%22termfilter%22:{%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Diagnosis%22},%22values%22:[{%22key%22:%22AML%22}]}}]}}}) and test that we filter to the lesion max of 10,000 per type. Then test in ASH prod to see if it is performant. 

# Future work
Allow user to customize lesion max

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
