### PR TITLE
Fix group filter edit UI

### DIFF
--- a/client/filter/tvs.samplelst.js
+++ b/client/filter/tvs.samplelst.js
@@ -14,11 +14,8 @@ async function fillMenu(self, div, tvs) {
 	div.selectAll('*').remove()
 	div = div.append('div')
 	div.style('font-size', '0.8em')
-	const rows = []
-	let samples, name
 	for (const field in tvs.term.values) {
-		name = field
-		samples = tvs.term.values[field].list
+		if (tvs.term.values[field].in === false) continue
 		addTable(div, tvs, field)
 	}
 	div
@@ -82,6 +79,7 @@ function get_pill_label(tvs) {
 function getGroupLabel(term) {
 	let n = 0
 	for (const item in term.values) {
+		if (term.values[item].in === false) continue
 		n += term.values[item].list.length
 	}
 	return `${term.name} n=${n}`

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -1041,7 +1041,7 @@ export function getSamplelstTW2(groups) {
 	}
 }
 
-export function getSamplelstTW(groups, name = 'groups', notIn = true) {
+export function getSamplelstTW(groups, name = groups.length == 1 ? 'group' : 'groups', notIn = true) {
 	const values = {}
 	const qgroups = []
 	let samples
@@ -1057,7 +1057,7 @@ export function getSamplelstTW(groups, name = 'groups', notIn = true) {
 	}
 	if (groups.length == 1 && notIn) {
 		const name2 = 'Not in ' + groups[0].name
-		values[name2] = { key: name2, label: name2, color: '#aaa', list: samples }
+		values[name2] = { key: name2, label: name2, color: '#aaa', list: samples, in: false }
 		qgroups.push({
 			name: name2,
 			in: false,

--- a/client/mass/test/groups.unit.spec.ts
+++ b/client/mass/test/groups.unit.spec.ts
@@ -68,21 +68,29 @@ const mockSamplelstTW = {
 
 const mockSamplelstTWOther = {
 	isAtomic: true,
-	q: {
-		groups: [mockGrp1, { name: `Not in ${mockGrp1Name}`, in: false, values: mockGrp1Values }]
-	},
 	term: {
-		name: 'groups',
+		name: 'group',
 		type: 'samplelst',
 		values: {
+			[mockGrp1Name]: mockTermGrp1Obj,
 			[`Not in ${mockGrp1Name}`]: {
-				color: '#aaa',
 				key: `Not in ${mockGrp1Name}`,
-				label: `Not in ${mockGrp1Name}`,
-				list: mockGrp1Values
-			},
-			[mockGrp1Name]: mockTermGrp1Obj
+				label: 'Not in Test Group 1',
+				color: '#aaa',
+				list: mockGrp1Values,
+				in: false
+			}
 		}
+	},
+	q: {
+		groups: [
+			mockGrp1,
+			{
+				name: `Not in ${mockGrp1Name}`,
+				in: false,
+				values: mockGrp1Values
+			}
+		]
 	}
 }
 
@@ -213,23 +221,24 @@ tape('groups getFilter()', test => {
 		join: '',
 		lst: [
 			{
-				noEdit: false,
 				type: 'tvs',
 				tvs: {
 					term: {
-						name: 'groups',
+						name: 'group',
 						type: 'samplelst',
 						values: {
+							[mockGrp1Name]: mockTermGrp1Obj,
 							[`Not in ${mockGrp1Name}`]: {
-								color: '#aaa',
 								key: `Not in ${mockGrp1Name}`,
 								label: `Not in ${mockGrp1Name}`,
-								list: mockGrp1Values
-							},
-							[mockGrp1Name]: mockTermGrp1Obj
+								color: '#aaa',
+								list: mockGrp1Values,
+								in: false
+							}
 						}
 					}
-				}
+				},
+				noEdit: false
 			}
 		]
 	}


### PR DESCRIPTION
# Description
Could test by [termdbTest](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22sampleScatter%22,%22name%22:%22TermdbTest%20TSNE%22}]})

lasso --> add to a group, at groups tab, show "samples in group n = ..." with correct sample number, clicking it show only the samples in this group. Before it showed incorrect number of samples and samples not in this group. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
