### PR TITLE
fix: tw "add new" icon appears identical to tw pill without visual di…

### DIFF
--- a/client/dom/select2Terms.js
+++ b/client/dom/select2Terms.js
@@ -47,7 +47,9 @@ export function select2Terms(tip, app, chartType, detail, callback, detail2) {
 			.style('font-family', 'Courier')
 		const xdiv = row
 			.append('div')
-			.attr('class', 'sja_filter_tag_btn add_term_btn')
+			.attr('class', 'ts_pill sja_filter_tag_btn')
+			.style('padding', '3px 6px')
+			.style('border-radius', '6px')
 			.text('+')
 			.on('click', e => {
 				getTreeTerm(xdiv, term => (xterm = term), detail)
@@ -61,7 +63,9 @@ export function select2Terms(tip, app, chartType, detail, callback, detail2) {
 			.style('font-family', 'Courier')
 		const ydiv = row
 			.append('div')
-			.attr('class', 'sja_filter_tag_btn add_term_btn')
+			.attr('class', 'ts_pill sja_filter_tag_btn')
+			.style('padding', '3px 6px')
+			.style('border-radius', '6px')
 			.text('+')
 			.on('click', e => {
 				getTreeTerm(ydiv, term => (yterm = term), detail2 || detail)

--- a/client/termsetting/TermSettingView.ts
+++ b/client/termsetting/TermSettingView.ts
@@ -48,7 +48,7 @@ export class TermSettingView {
 		self.dom.pilldiv = self.dom.holder.append('div')
 
 		// nopilldiv - placeholder label
-		if (self.opts.placeholder) {
+		if (self.placeholder) {
 			self.dom.nopilldiv
 				.append('div')
 				.html(self.placeholder)
@@ -59,14 +59,17 @@ export class TermSettingView {
 
 		// nopilldiv - plus button
 		if (self.opts.placeholderIcon) {
+			// margin & hover are applied so this icon looks identical to a pill without distracting visual diff on adding/removing tw; however the ts_pill class cannot be used for breaking termsetting ci test
 			self.dom.nopilldiv
 				.append('div')
 				.attr('class', 'sja_filter_tag_btn add_term_btn')
-				.style('padding', '3px 6px 3px 6px')
+				.style('padding', '3px 6px')
+				.style('margin', '2px')
 				.style('display', 'inline-block')
 				.style('border-radius', '6px')
-				.style('background-color', '#4888BF')
 				.text(self.opts.placeholderIcon)
+				.on('mouseover', e => (e.target.style.opacity = 0.8))
+				.on('mouseout', e => (e.target.style.opacity = 1))
 		}
 
 		self.dom.btnDiv = self.dom.holder.append('div')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- tw "add new" icon appears identical to tw pill without visual difference


### PR DESCRIPTION
…fference

# Description
please see if this fix is okay
all integration tests passed

old:
<img width="320" height="81" alt="image" src="https://github.com/user-attachments/assets/cf4f4f02-db56-4e64-b2b8-f2dbeb591ac1" />

new:
<img width="322" height="90" alt="image" src="https://github.com/user-attachments/assets/83384846-f478-438a-b56c-6f647646fa15" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
