### PR TITLE
Profile comparison now can be enabled/disabled. Table is shown unless on comparison mode.

### DIFF
--- a/client/mass/plot.js
+++ b/client/mass/plot.js
@@ -20,7 +20,13 @@ class MassPlot {
 		if (action.type.includes('cache_termq')) return true
 		if (action.type.endsWith('_group')) return true
 		if (action.type.startsWith('plot_')) {
-			return action.id === this.id || action.id == this.parentId
+			//action.parentId == this.id is a special case to react when deleting a child plot of this plot, for example in the profile comparison, when closing one of the comparison plots
+			return (
+				action.id === this.id ||
+				action.id == this.parentId ||
+				action.config?.parentId === this.id ||
+				action.parentId === this.id
+			)
 		}
 		if (action.type.startsWith('filter')) return true
 		if (action.type.startsWith('cohort')) return true

--- a/client/plots/profile/polar.ts
+++ b/client/plots/profile/polar.ts
@@ -144,7 +144,7 @@ class ProfilePolar extends profilePlot {
 			i++
 		}
 		this.dom.tableDiv.selectAll('*').remove()
-		if (this.settings.showTable && !this.isComparison)
+		if (!this.isComparison)
 			renderTable({
 				rows,
 				columns,

--- a/client/plots/profileRadar.js
+++ b/client/plots/profileRadar.js
@@ -140,7 +140,7 @@ class profileRadar extends profilePlot {
 			})
 			if (leftSide) textElem.attr('text-anchor', 'end')
 		}
-		if (this.settings.showTable && !this.isComparison) {
+		if (!this.isComparison) {
 			renderTable({
 				rows,
 				columns,

--- a/client/plots/profileRadarFacility.js
+++ b/client/plots/profileRadarFacility.js
@@ -145,7 +145,7 @@ class profileRadarFacility extends profilePlot {
 			})
 			if (leftSide) textElem.attr('text-anchor', 'end')
 		}
-		if (this.settings.showTable && !this.isComparison) {
+		if (!this.isComparison) {
 			renderTable({
 				rows,
 				columns,


### PR DESCRIPTION
# Description
Made comparison a toggle that when clicked shows a second plot and when clicked again closes the second plot. Removed show table property. Table is shown unless on comparison mode. I worked on this with @siosonel 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
