### PR TITLE
apply a user-assigned custom bin label

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- apply a user-assigned custom bin label if present

--- a/shared/utils/src/termdb.bins.js
+++ b/shared/utils/src/termdb.bins.js
@@ -267,6 +267,8 @@ export function get_bin_label(bin, binconfig, valueConversion) {
 	/*
   Generate a numeric bin label given a bin configuration and an optional term valueConversion object
 */
+	if ('label' in bin) return bin.label
+
 	const bc = binconfig
 	if (!bc.binLabelFormatter) bc.binLabelFormatter = getNumDecimalsFormatter(bc)
 	if (!bin.startunbounded && !bin.stopunbounded && !('startinclusive' in bin) && !('stopinclusive' in bin)) {

--- a/shared/utils/src/test/termdb.bins.unit.spec.js
+++ b/shared/utils/src/test/termdb.bins.unit.spec.js
@@ -411,6 +411,38 @@ tape('get_bin_label(), force label_offset == 1', function (test) {
 	test.end()
 })
 
+tape('get_bin_label(), user-assigned custom bin label', function (test) {
+	const binconfig = {
+		type: 'custom-bin',
+		lst: [
+			{
+				startunbounded: true,
+				stopinclusive: true,
+				stop: 10,
+				label: 'TEST ABC'
+			},
+			{
+				start: 20,
+				startinclusive: true,
+				stopunbounded: true,
+				label: 'TEST XYZ'
+			}
+		]
+	}
+
+	test.equal(
+		b.get_bin_label(binconfig.lst[0], binconfig),
+		binconfig.lst[0].label,
+		`should apply the user-assigned bin[0] label='${binconfig.lst[0].label}'`
+	)
+	test.equal(
+		b.get_bin_label(binconfig.lst[1], binconfig),
+		binconfig.lst[1].label,
+		`should apply the user-assigned bin[1] label='${binconfig.lst[1].label}'`
+	)
+	test.end()
+})
+
 tape('compute_bins() unbounded', function (test) {
 	let bins = b.compute_bins({ bin_size: 5, label_offset: 1, first_bin: { startunbounded: 1, stop: 5 } }, get_summary)
 	removeColorAttr(bins)


### PR DESCRIPTION
# Description

Tested by running all unit and integration tests. Also [open a barchart](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22%7D,%22q%22:%7B%22mode%22:%22discrete%22%7D%7D%7D%5D%7D), edit the term to `Varying bin sizes`, and assign custom labels to the bins.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
