### PR TITLE
fix: currentGeneNames[] from matrix query supports coord string so no…

### DIFF
--- a/client/termdb/test/vocabulary.integration.spec.js
+++ b/client/termdb/test/vocabulary.integration.spec.js
@@ -727,7 +727,7 @@ tape('getTermInfo()', async test => {
 	test.ok(result.terminfo, `Should return a terminfo object`)
 
 	//Returns empty object for non-conditional term
-	testId = 'diaggrp'
+	testId = 'date'
 	result = await termdbVocabApi.getTermInfo(testId)
 	test.ok(!result.terminfo, `Should return an empty object`)
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- currentGeneNames[] from matrix query supports coord string so not to break getData

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -65,6 +65,8 @@ async function getViolin(q: ViolinRequest, ds: any) {
 		},
 		ds
 	)
+	if (!data) throw 'getData() returns nothing'
+	if (data.error) throw data.error
 
 	const samples = Object.values(data.samples)
 	let values = samples


### PR DESCRIPTION
…t to break getData

# Description
Edgar found this breaks on master: [link](http://localhost:3000/?mass={%22dslabel%22:%22PNET%22,%22genome%22:%22hg19%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22BCOR%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22name%22:%22C19MC%22,%22id%22:%22C19MC%22,%22chr%22:%22chr19%22,%22start%22:54169933,%22stop%22:54292028,%22type%22:%22geneVariant%22}},{%22id%22:%22Gender%22},{%22id%22:%22Age%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22TSNE%20Category%22}]}]}]}), click Age > Edit, backend breaks for lack of handling of coord string in currentGeneNames[]

also fixed a broken integration test from last night's change
all ci tests pass
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
