### PR TITLE
add region-based geneV term to barchart integration test

### DIFF
--- a/client/plots/test/barchart.integration.spec.js
+++ b/client/plots/test/barchart.integration.spec.js
@@ -16,7 +16,7 @@ term1=categorical, term2=defaultbins
 term0=defaultbins, term1=categorical
 term1=geneVariant no group
 term1=geneVariant with groups
-term1=geneVariant using region but not gene
+term1=geneVariant, term2=geneVariant using region but not gene
 term1=geneVariant geneset with groups
 term1=categorical, term2=geneVariant
 term1=geneExp, term2=geneVariant SKIPPED
@@ -192,6 +192,7 @@ tape('term1=categorical, term2=defaultbins', function (test) {
 		await triggerUncomputableOverlay(barchart)
 		clickLegendToHideOverlay(barchart)
 		await testHiddenOverlayData(barchart)
+		if (test._ok) barchart.Inner.app.destroy()
 		test.end()
 	}
 
@@ -348,14 +349,15 @@ tape('term1=geneVariant with groups', function (test) {
 		test.end()
 	}
 })
-tape.only('term1=geneVariant using region but not gene', function (test) {
+tape('term1=geneVariant, term2=geneVariant using region but not gene', function (test) {
 	test.timeoutAfter(3000)
 	runpp({
 		state: {
 			plots: [
 				{
 					chartType: 'barchart',
-					term: getGeneVariantTw(true) // gives region but not gene
+					term: getGeneVariantTw(),
+					term2: getGeneVariantTw(true) // gives region but not gene
 				}
 			]
 		},
@@ -369,7 +371,7 @@ tape.only('term1=geneVariant using region but not gene', function (test) {
 		const barDiv = barchart.Inner.dom.barDiv
 		const numCharts = barDiv.selectAll('.pp-sbar-div').size()
 		test.true(numCharts == 1, 'Should have 1 chart from gene variant term')
-		//if (test._ok) barchart.Inner.app.destroy()
+		if (test._ok) barchart.Inner.app.destroy()
 		test.end()
 	}
 })
@@ -1058,7 +1060,8 @@ tape('click non-group bar to add filter', function (test) {
 			matchAs: '>='
 		})
 		testTermValues(barchart)
-		//test.end()
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
 	}
 
 	let clickedData, currData

--- a/client/test/testdata/data.ts
+++ b/client/test/testdata/data.ts
@@ -146,7 +146,7 @@ export function getGeneVariantTw(position = false) {
 		term: {
 			genes: [
 				position
-					? { kind: 'coord', chr: 'chr14', start: 104769349, stop: 104795747, name: 'AKT1region', type: 'geneVariant' }
+					? { kind: 'coord', chr: 'chr12', start: 25205246, stop: 25250936, name: 'KRASregion', type: 'geneVariant' }
 					: { kind: 'gene', gene: 'TP53', type: 'geneVariant' }
 			],
 			type: 'geneVariant'


### PR DESCRIPTION
# Description
as a follow up for this fix https://github.com/stjude/proteinpaint/pull/3809, start to add ci coverage on region-based geneVariant tw

however, [the newly added test example](http://localhost:3000/testrun.html?dir=plots&name=barchart.integration) cannot pull out any mutation samples and only gives one bar "AKT1region SNV/indel Wildtype (somatic), n=60"

please help troubleshoot thanks

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
