### PR TITLE
replace empty string bin label

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- replace empty string bin label

--- a/shared/utils/src/termdb.bins.js
+++ b/shared/utils/src/termdb.bins.js
@@ -267,7 +267,7 @@ export function get_bin_label(bin, binconfig, valueConversion) {
 	/*
   Generate a numeric bin label given a bin configuration and an optional term valueConversion object
 */
-	if ('label' in bin) return bin.label
+	if (bin.label) return bin.label
 
 	const bc = binconfig
 	if (!bc.binLabelFormatter) bc.binLabelFormatter = getNumDecimalsFormatter(bc)


### PR DESCRIPTION
# Description

Fix for BUG numeric termsetting custom bin label not auto populated after entering a break value in textarea at [link](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22%7D,%22q%22:%7B%22mode%22:%22discrete%22%7D%7D%7D%5D%7D)

Tested at the link in the bug report, also by running all unit and integration tests locally. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
