### PR TITLE
Show max value in uncertainty legend

### DIFF
--- a/client/plots/wsiviewer/view/LegendRenderer.ts
+++ b/client/plots/wsiviewer/view/LegendRenderer.ts
@@ -52,7 +52,7 @@ export class LegendRenderer {
 			domain,
 			colors: imageViewData.uncertainty.map(u => u.color),
 			position: '25, 25',
-			// ticks: 2,
+			ticks: 10,
 			barwidth: width,
 			labels: {
 				left: imageViewData.uncertainty[0].label,


### PR DESCRIPTION
# Description
Should always show the max value in the uncertainty legend. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
