### PR TITLE
GRIN2: More Cache File Improvements 

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -570,6 +570,7 @@ class GRIN2 extends PlotBase implements RxComponent {
 				height: this.state.config.settings.grin2.manhattan?.plotHeight,
 				pngDotRadius: this.state.config.settings.grin2.manhattan?.pngDotRadius,
 				devicePixelRatio: window.devicePixelRatio,
+				maxGenesToShow: this.state.config.settings.grin2?.manhattan?.maxGenesToShow,
 				...configValues
 			}
 
@@ -816,7 +817,10 @@ export function getDefaultSettings(opts) {
 			interactiveDotStrokeWidth: 1,
 
 			// Download options
-			showDownload: true
+			showDownload: true,
+
+			// Max genes to show in table
+			maxGenesToShow: 500
 		}
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GRIN2: Now determining data types available to python  cache file table from request data types. Returning cacheFileName in response. Made top gene table number of genes displayed a parameter sent by the request

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -79,6 +79,7 @@ export type GRIN2Request = {
 		/** Number of bases to include as 3' flank around the sv position */
 		threePrimeFlankSize?: number
 	}
+	maxGenesToShow?: number // Default: 500
 }
 
 /** Simple Interface to store the complex plot data from the python Manhattan plot */
@@ -166,6 +167,8 @@ export type GRIN2Response = {
 		processedLesions?: number
 		unprocessedSamples?: number
 	}
+	/** Cache file name for storing GRIN2 results */
+	cacheFileName?: string
 }
 
 /**


### PR DESCRIPTION
# Description
Now determining data types available for python  cache file table creation from request data types. Returning `cacheFileName` in response. Made top gene table number of genes displayed a parameter sent by the request that python then honors.

# To test
Go [here](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22grin2%22}],%22termfilter%22:{%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Diagnosis%22},%22values%22:[{%22key%22:%22AML%22}]}}]}}}) and then add a `console.log` to client/plots/grin2/grin2.ts at the top of `renderResults` function and see the return of the cache file name. In `getDefaultSettings` change `maxGenesToShow` to something else and see it change on the next run of GRIN2. Finally, in `server/routes/grin2.ts` add `console.log('GRIN2 data types available:', getAvailableDataTypes(request))` right before making `pyInput` to see the available data types being sent to python.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
