### PR TITLE
GRIN2: Improved Cap Message Display Logic

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -718,7 +718,8 @@ class GRIN2 extends PlotBase implements RxComponent {
 		}
 
 		// If we didn't process all samples, note that caps truncated the run
-		if (result.processingSummary.processedSamples < result.processingSummary.totalSamples) {
+		const expectedToProcessSamples = result.processingSummary.totalSamples - result.processingSummary.failedSamples
+		if (result.processingSummary.processedSamples < expectedToProcessSamples) {
 			this.dom.div
 				.append('div')
 				.style('margin', this.sectionMargin)
@@ -726,7 +727,7 @@ class GRIN2 extends PlotBase implements RxComponent {
 				.style('color', this.optionsTextColor)
 				.text(
 					`Note: Per-type lesion caps were reached before all samples could be processed. ` +
-						`Analysis ran on ${result.processingSummary?.processedSamples} of ${result.processingSummary?.totalSamples} samples.`
+						`Analysis ran on ${result.processingSummary.processedSamples} of ${expectedToProcessSamples} samples.`
 				)
 		}
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GRIN2: Improved cap reached message logic to account for high numbers of failed files


### PR DESCRIPTION
# Description
Improved cap reached message logic to account for high numbers of failed files. The issue is that many of the files fail because they are not present. My initial logic for displaying the message didn't account for this scenario. 

# To test
Go to [termdbtest](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22grin2%22}]}) and ensure you no longer see the lesion cap message. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
