### PR TITLE
Do not throw error when gene expression term has no data

### DIFF
--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -324,7 +324,11 @@ export async function fillQWithMedianBin(tw, vocabApi) {
 	if (!result.values) throw '.values[] missing from vocab.getPercentile()'
 	const median = roundValueAuto(result.values[0])
 
-	if (!isNumeric(median)) throw 'median value not a number'
+	/* do not check if median is numeric here because median will be null
+	if term has no data in dataset, so instead of throwing error, should
+	proceed to plot code, which will report to user that no data is available */
+	//if (!isNumeric(median)) throw 'median value not a number'
+
 	tw.q.type = 'custom-bin'
 	tw.q.lst = [
 		{

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -344,13 +344,13 @@ async function getExpressionData(q, gene_ids, cases4clustering, ensg2id, term2sa
 	if (typeof re != 'string') throw 'response.body is not tsv text'
 	const lines = re.trim().split('\n')
 
-	if (lines.length <= 1) throw 'less than 1 line from tsv response.body'
+	const bySampleId = {}
+	if (lines.length <= 1) return bySampleId
 
 	// header line:
 	// gene \t case1 \t case 2 \t ...
 	const caseHeader = lines[0].split('\t').slice(1) // order of case uuid in tsv header
 
-	const bySampleId = {}
 	for (const c of caseHeader) {
 		const s = ds.__gdc.caseid2submitter.get(c)
 		if (!s) throw 'case submitter id unknown for a uuid'


### PR DESCRIPTION
# Description

This PR addresses the "BEAT-AML Cohort Correlation Plot Tool Errors" section of the feedback email regarding gdc correlation plot. Now gene expression code will not error out when no data is available. Instead plot will display a "no data available" message.

Can test with the `FM-AD` cohort, which lacks gene expression and survival data ([example](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.project.project_id%22,%22value%22:[%22FM-AD%22]}}},%22nav%22:{%22header_mode%22:%22hidden%22},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22IDH1%22}}}]}))

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
