### PR TITLE
Hide overlays on load.

### DIFF
--- a/client/plots/wsiviewer/viewModel/ViewModelProvider.ts
+++ b/client/plots/wsiviewer/viewModel/ViewModelProvider.ts
@@ -181,7 +181,8 @@ export class ViewModelProvider {
 						preview: `/tileserver/layer/${overlay.layerNumber}/${data.wsiSessionId}/zoomify/TileGroup0/0-0-0@1x.jpg?${predictionQueryParams}`,
 						metadata: wsimages[i].metadata,
 						source: sourceOverlay,
-						title: overlay.predictionOverlayType
+						title: overlay.predictionOverlayType,
+						visible: false
 					}
 
 					if (wsiImageLayers.overlays) {


### PR DESCRIPTION
# Description

Sets visible: false for prediction and uncertainty overlay during viewer initialization. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
