### PR TITLE
survival new timeUnit supports old survival session file

### DIFF
--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -415,8 +415,8 @@ class TdbSurvival extends PlotBase implements RxComponent {
 
 	// time factor that converts survival data from default time unit to the current time unit.
 	getTimeFactor() {
-		const numUnitInOneYear = this.settings.numUnitInOneYear
-		const timeUnit = this.settings.timeUnit
+		const numUnitInOneYear = this.settings.numUnitInOneYear || 1
+		const timeUnit = this.settings.timeUnit || 'years'
 		switch (timeUnit) {
 			case 'years':
 				return (1 / numUnitInOneYear) * 1


### PR DESCRIPTION
# Description
Current default timeUnit is "years", old survival session files have default timeUnit as **""**. This fix sets timeUnit to be "years" for old survival session files that have "" as timeUnit. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
