### PR TITLE
fix the apply/reset button position 

### DIFF
--- a/client/termsetting/handlers/NumericHandler.ts
+++ b/client/termsetting/handlers/NumericHandler.ts
@@ -165,7 +165,7 @@ export class NumericHandler extends HandlerBase implements Handler {
 				tabs: this.tabs
 			}).main()
 		} else {
-			this.editHandler.showEditMenu(div)
+			this.editHandler.showEditMenu(this.dom.editDiv)
 		}
 	}
 

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -515,7 +515,7 @@ tape('Numerical term.bins.default.type=custom-bin', async test => {
 
 	await opts.pill.main(opts.tsData)
 	await opts.pillMenuClick('Edit')
-	await sleep(10)
+	await sleep(100)
 	const tip = opts.pill.Inner.dom.tip
 	const lines = tip.d.select('.binsize_g').node().querySelectorAll('line')
 	test.equal(lines.length, 1, 'should have 1 line')
@@ -542,6 +542,7 @@ tape('Numerical term: toggle menu - 4 options', async test => {
 
 	await opts.pill.main(opts.tsData)
 	await opts.pillMenuClick('Edit')
+	await sleep(100)
 	const tip = opts.pill.Inner.dom.tip
 	const toggleButtons = tip.d.node().querySelectorAll('.sj-toggle-button')
 
@@ -608,6 +609,7 @@ tape('Numerical term: toggle menu - 2 options', async test => {
 
 	await opts.pill.main(opts.tsData)
 	await opts.pillMenuClick('Edit')
+	await sleep(100)
 	test.equal(
 		opts.pill.Inner.handler.dom.topBar.node().querySelectorAll('.sj-toggle-button').length,
 		2,


### PR DESCRIPTION
# Description

... when there are no numeric mode toggles.

Apply/Reset buttons are now at the bottom.

<img width="348" height="292" alt="Screenshot 2025-10-24 at 4 38 48 PM" src="https://github.com/user-attachments/assets/fbcb5af0-4a57-4281-a672-4148b4d3e060" />

Tested locally and also in https://github.com/stjude/proteinpaint/actions/workflows/CI-integration.yml.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
