### PR TITLE
GRIN2: Moving dtUsage into state

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -13,7 +13,6 @@ class GRIN2 extends PlotBase implements RxComponent {
 	readonly type = 'grin2'
 	dom: GRIN2Dom
 	private runButton!: any
-	// private dtUsage: Record<number, { checked: boolean; label: string }> = {}
 
 	// Colors
 	readonly borderColor = '#eee'
@@ -340,6 +339,7 @@ class GRIN2 extends PlotBase implements RxComponent {
 				const dtu = structuredClone(this.state.config.settings.dtUsage)
 				dtu[dtsv].checked = checked
 
+				// FIXME on every check/uncheck, app dispatches and call main(), which is undesirable. tried app.save() and somehow not all box status can be saved
 				this.app.dispatch({
 					type: 'plot_edit',
 					id: this.id,


### PR DESCRIPTION
# Description
Moving dtUsage from class into state.

# To test
Go [here](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22grin2%22}],%22termfilter%22:{%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Diagnosis%22},%22values%22:[{%22key%22:%22AML%22}]}}]}}}) and select various data types. Click session and share and open link in new tab. Should see the saved state. Run analysis. Should complete successfully.

# Closes
Closes roadmap number 7 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
