### PR TITLE
Regression geneVariant fix

### DIFF
--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -111,7 +111,6 @@ export class InputTerm {
 			// do not allow condition term
 			arg.numericEditMenuVersion = ['continuous', 'discrete', 'spline']
 			// for geneVariant term, only allow groupsetting
-			arg.defaultQ4fillTW['geneVariant'] = { type: 'predefined-groupset' }
 			arg.geneVariantEditMenuOnlyGrp = true
 			return
 		}

--- a/client/plots/regression.js
+++ b/client/plots/regression.js
@@ -208,6 +208,9 @@ export function get_defaultQ4fillTW(regressionType, useCase = '') {
 		}
 	}
 
+	// geneVariant term
+	defaultQ['geneVariant'] = { type: 'predefined-groupset' }
+
 	return defaultQ
 }
 


### PR DESCRIPTION
# Description

geneVariant should default to `q.type=predefined-groupset` in regression.

Added an integration test for geneVariant term in regression.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
