### PR TITLE
Do not render violin plots to global min/max

### DIFF
--- a/R/src/density.R
+++ b/R/src/density.R
@@ -1,21 +1,18 @@
 library(jsonlite)
 # This script reads in a json string from stdin with the parameters, 
 # calculates the densities of each plot and returns the densities as a json string
-# The input json string contains plot2Values, a dictionary where each field maps to an array of numbers and the 
-# global min and max values of the x axis.
+# The input json string contains plot2Values, a dictionary where each field maps to an array of numbers
 # The output json string is a dictionary  with the density for each plot. The density is represented 
 # by a an object where {x: [x density values], y: [y density values]}
-# In order to test it you can run the following command from the command line replacing plot2Values and min and max
+# In order to test it you can run the following command from the command line replacing plot2Values
 # with your values: 
-# echo '{plot2Values: {"plotA": [1.2, 2, 3], "plotB": [4.5, 5, 6]}, min: 1.2, max:6}' | Rscript ./density.R
+# echo '{plot2Values: {"plotA": [1.2, 2, 3], "plotB": [4.5, 5, 6]}}' | Rscript ./density.R
 
 con <- file("stdin", "r")
 json <- readLines(con)
 close(con)
 data <- fromJSON(json)
 plot2Values <- data$plot2Values
-min <- data$min
-max <- data$max
 densities <- list()
 for(plot in names(plot2Values)){
     values = plot2Values[[plot]]
@@ -25,7 +22,7 @@ for(plot in names(plot2Values)){
         densities[[plot]] <- list(x=values, y=y)
         next
     }
-    den = density(x = values, from=min, to=max)
+    den = density(x = values, cut = 0)
     x = den$x
     y = den$y
     result = list(x=x, y=y) #This is an object  with two keys x and y that are number arrays

--- a/server/routes/termdb.violin.ts
+++ b/server/routes/termdb.violin.ts
@@ -1,6 +1,6 @@
 import type { ViolinRequest, ViolinResponse, RouteApi, ValidGetDataResponse, TermWrapper } from '#types'
 import { violinPayload } from '#types/checkers'
-import { scaleLinear, scaleLog, extent } from 'd3'
+import { scaleLinear, scaleLog } from 'd3'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
 import { getData } from '../src/termdb.matrix.js'
 import { createCanvas } from 'canvas'
@@ -244,7 +244,7 @@ async function createCanvasImg(q: ViolinRequest, result: { [index: string]: any 
 		const chart = result.charts[k]
 		const plot2Values = {}
 		for (const plot of chart.plots) plot2Values[plot.label] = plot.values
-		const densities = await getDensities(plot2Values, result.min, result.max)
+		const densities = await getDensities(plot2Values)
 
 		let axisScale
 		const useLog = q.unit == 'log'
@@ -315,13 +315,12 @@ async function createCanvasImg(q: ViolinRequest, result: { [index: string]: any 
 export async function getDensity(
 	values: number[]
 ): Promise<{ bins: any[]; densityMin: number; densityMax: number; minvalue: number; maxvalue: number }> {
-	const [min, max] = extent(values) as [number, number]
-	const result = await getDensities({ plot: values }, min, max)
+	const result = await getDensities({ plot: values })
 	return result.plot
 }
 
-export async function getDensities(plot2Values, min: number, max: number): Promise<{ [plot: string]: any }> {
-	const plot2Density: any = JSON.parse(await run_R('density.R', JSON.stringify({ plot2Values, min, max })))
+export async function getDensities(plot2Values): Promise<{ [plot: string]: any }> {
+	const plot2Density: any = JSON.parse(await run_R('density.R', JSON.stringify({ plot2Values })))
 	const densities = {}
 	for (const plot in plot2Density) {
 		const result: { x: number[]; y: number[] } = plot2Density[plot]


### PR DESCRIPTION
# Description

Do not get densities based on global min/max. Instead use `cut=0` when computing densities to avoid plotting kernel estimates outside of range of values.

Can test with [violin plot](http://localhost:3000/?mass=%7B%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22MYC%22%7D%7D,%22term2%22:%7B%22term%22:%7B%22type%22:%22geneVariant%22,%22gene%22:%22MYC%22%7D%7D%7D%5D%7D).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
