### PR TITLE
Fix `case.diagnoses.age_at_diagnosis` variable in GDC

### DIFF
--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -93,15 +93,27 @@ export class NumericBase extends TwBase {
 			copyMerge(tw.q, opts.defaultQ)
 		}
 
-		// remove q.type for continuous or spline mode
-		if (tw.q.mode == 'continuous' || tw.q.mode == 'spline') {
-			delete tw.q.type
-		} else if (!tw.q.type) {
-			if (tw.q.mode == 'binary') tw.q.type = 'custom-bin'
-			else if (tw.q.mode == 'discrete') tw.q.type = 'regular-bin'
-		}
+		// set q.type based on q.mode
+		switch (tw.q.mode) {
+			case 'discrete':
+				if (!tw.q.type) {
+					if (tw.term.bins) mayFillQWithPresetBins(tw)
+					else tw.q.type = 'regular-bin'
+				}
+				break
 
-		if (tw.q.type == 'regular-bin' && tw.term.bins) mayFillQWithPresetBins(tw)
+			case 'binary':
+				tw.q.type = 'custom-bin'
+				break
+
+			case 'continuous':
+			case 'spline':
+				delete tw.q.type
+				break
+
+			default:
+				throw 'tw.q.mode not supported'
+		}
 
 		/* 
 			Pre-fill the tw.type, since it's required for ROUTING to the


### PR DESCRIPTION
# Description

Related to https://github.com/stjude/proteinpaint/issues/3552

The GDC `case.diagnoses.age_at_diagnosis` variable is hardcoded to have custom bins as shown in `server/src/gdc.buildDictionary.js`:
```
const hardcodedBins = {
	'case.diagnoses.age_at_diagnosis': {
		default: {
			type: 'custom-bin',
			mode: 'discrete',
			lst: [
				{ startunbounded: true, stop: 10950, stopinclusive: true, label: '<=30 years' },
				{ start: 10950, stop: 21900, stopinclusive: true, label: '30-60 years' },
				{ start: 21900, stopunbounded: true, startinclusive: false, label: '>60years' }
			]
		}
	}
}
```

In master, this variable could not be loaded in [correlation plot](http://localhost:3000/?mass=%7B%22dslabel%22:%22GDC%22,%22termfilter%22:%7B%22filter0%22:%7B%22op%22:%22in%22,%22content%22:%7B%22field%22:%22cases.disease_type%22,%22value%22:%5B%22Gliomas%22%5D%7D%7D%7D,%22nav%22:%7B%22header_mode%22:%22hidden%22%7D,%22genome%22:%22hg38%22,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22case.diagnoses.age_at_diagnosis%22%7D%7D%5D%7D) because it was defaulting to `q.type='regular-bin`, which conflicted with its default bin config. This PR solves this issue by using the default bin config when `q.type` is absent.

All unit and integration tests pass, but please test further with numeric termsetting.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
