### PR TITLE
handle gdc correlation plot state override

### DIFF
--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -43,7 +43,7 @@ export async function init(
 			dslabel: gdcDslabel,
 			termfilter: { filter0: arg.filter0 },
 			nav: { activeTab: 1, header_mode: 'only_buttons' },
-			plots: [
+			plots: arg.state?.plots || [
 				{ chartType: 'summaryInput' } // default shows summaryInput ui, can change
 				//{ chartType: 'barchart', term: {id: 'case.demographic.gender'} }, // uncomment for quicker testing
 			]

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -345,7 +345,9 @@ export function bindProteinPaint({ rootElem, initArgs, updateArgs, isStale, hasC
 			initArgs,
 			updateArgs || {},
 			// may reapply previously rendered state from an unbound stale instance
-			{ state: rootElem._ppAppState || {} }
+			{
+				state: Object.assign(rootElem._ppAppState || {}, initArgs.state || {})
+			}
 		)
 
 		delete rootElem._ppAppState

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- support GDC correlation plot demo mode by handling state override


### PR DESCRIPTION
# Description

This branch supports initial state overrides to the GDC correlation plot, so that a demo mode can be more easily specified within the GFF code.

Tested locally with all unit and integration test. Also tested in GFF dev.

<img width="1108" height="588" alt="Screenshot 2025-10-31 at 3 41 35 PM" src="https://github.com/user-attachments/assets/fe812870-c7f3-4802-8f4f-89267bf548c4" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
