### PR TITLE
Passed local filter to DE endpoint

### DIFF
--- a/client/plots/diffAnalysis/DifferentialAnalysis.ts
+++ b/client/plots/diffAnalysis/DifferentialAnalysis.ts
@@ -147,7 +147,7 @@ export function getPlotConfig(opts: DiffAnalysisOpts) {
 		termType: opts.termType,
 		highlightedData: opts.highlightedData || [],
 		settings: {},
-		hidePlotFilter: true //TODO: Support filtering and reactivity in child plots
+		hidePlotFilter: false //TODO: Support filtering and reactivity in child plots
 	} as any
 
 	if (opts.termType == 'geneExpression') {

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -13,7 +13,10 @@ import { VolcanoPlotView } from './view/VolcanoPlotView'
 import { VolcanoControlInputs } from './VolcanoControlInputs'
 import { getCombinedTermFilter } from '#filter'
 
-class Volcano extends PlotBase implements RxComponent {
+// The max sample cutoff for volcano rendering
+const maxSampleCutoff = 4000
+
+export class Volcano extends PlotBase implements RxComponent {
 	static type = 'volcano'
 	type: string
 	components: { controls: any }
@@ -69,7 +72,6 @@ class Volcano extends PlotBase implements RxComponent {
 		}
 		const parentConfig: any = this.parentId && appState.plots.find(p => p.id === this.parentId)
 		const termfilter = getCombinedTermFilter(appState, config.filter || parentConfig?.filter)
-
 		return {
 			config: Object.assign({}, config, {
 				settings: {
@@ -119,7 +121,7 @@ class Volcano extends PlotBase implements RxComponent {
 			}, 500)
 
 			/** Fetch data */
-			const model = new VolcanoModel(this.app, config, settings)
+			const model = new VolcanoModel(this.app, this.state, settings)
 			const response = await model.getData()
 			if (!response || response.error || !response.data.length) {
 				sayerror(this.dom.error, response.error || 'No data returned from server')

--- a/client/plots/volcano/model/VolcanoModel.ts
+++ b/client/plots/volcano/model/VolcanoModel.ts
@@ -7,11 +7,14 @@ export class VolcanoModel {
 	config: VolcanoPlotConfig
 	settings: VolcanoSettings
 	termType: string
-	constructor(app: MassAppApi, config: VolcanoPlotConfig, settings: VolcanoSettings) {
+	state: any
+
+	constructor(app: MassAppApi, state: any, settings: VolcanoSettings) {
 		this.app = app
-		this.config = config
+		this.state = state
+		this.config = state.config
 		this.settings = settings
-		this.termType = config.termType
+		this.termType = state.config.termType
 	}
 
 	/** May use mapper instead as more termTypes are added */
@@ -28,7 +31,7 @@ export class VolcanoModel {
 
 	async getGERequestBody() {
 		await this.getOtherSamples(this.config.samplelst)
-		const state = this.app.getState()
+		const state = this.state
 		const body = {
 			genome: this.app.vocabApi.vocab.genome,
 			dslabel: this.app.vocabApi.vocab.dslabel,

--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -11,6 +11,7 @@ import serverconfig from '../src/serverconfig.js'
 import imagesize from 'image-size'
 import { get_header_txt } from '#src/utils.js'
 import { formatElapsedTime } from '@sjcrh/proteinpaint-shared/time.js'
+import { get_samples } from '#src/termdb.sql.js'
 
 export const api: RouteApi = {
 	endpoint: 'DEanalysis',
@@ -79,6 +80,7 @@ samplelst{}
 groups[]
 values[] // using integer sample id
 */
+	const filteredSamples = await get_samples(param, ds) //param is the query object from the request
 	if (param.samplelst?.groups?.length != 2) throw '.samplelst.groups.length!=2'
 	if (param.samplelst.groups[0].values?.length < 1) throw 'samplelst.groups[0].values.length<1'
 	if (param.samplelst.groups[1].values?.length < 1) throw 'samplelst.groups[1].values.length<1'
@@ -92,6 +94,7 @@ values[] // using integer sample id
 	const conf1_group1: (string | number)[] = []
 	const conf2_group1: (string | number)[] = []
 	for (const s of param.samplelst.groups[0].values) {
+		if (!filteredSamples.find(fs => fs.id === s.sampleId)) continue //sample filtered out
 		if (!Number.isInteger(s.sampleId)) continue
 		const n = ds.cohort.termdb.q.id2sampleName(s.sampleId)
 		if (!n) continue
@@ -153,6 +156,8 @@ values[] // using integer sample id
 	const conf2_group2: (string | number)[] = []
 	for (const s of param.samplelst.groups[1].values) {
 		if (!Number.isInteger(s.sampleId)) continue
+		if (!filteredSamples.find(fs => fs.id === s.sampleId)) continue //sample filtered out
+
 		const n = ds.cohort.termdb.q.id2sampleName(s.sampleId)
 		if (!n) continue
 		if (q.allSampleSet.has(n)) {


### PR DESCRIPTION
# Description

Passed local filter to DE endpoint and filtered out samples. Cleanup on the plots logic. The request needs to happen on main to detect a filter change. If there is no change in the request the request will use the cache, no need to handle cache logic on the plot. Removed second request to save the config gsea_params, not needed. 
I had been working on this some weeks ago so I thought is good to wrap it up. Please check.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
