### PR TITLE
GRIN2: Updated run button in integration test

### DIFF
--- a/client/plots/test/grin2.integration.spec.ts
+++ b/client/plots/test/grin2.integration.spec.ts
@@ -29,10 +29,10 @@ tape('grin2', function (test) {
 		}
 	})
 	async function runTests(g) {
-		test.ok(g.Inner.runButton, 'Run button is created')
+		test.ok(g.Inner.dom.runButton, 'Run button is created')
 
 		// click submit button to run analysis
-		g.Inner.runButton.node().dispatchEvent(new Event('click'), { bubbles: true })
+		g.Inner.dom.runButton.node().dispatchEvent(new Event('click'), { bubbles: true })
 		const svg = await detectOne({ elem: g.Inner.dom.div.node(), selector: '[data-testid="sjpp-manhattan"]' })
 		test.ok(svg, '<svg> is rendered')
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GRIN2: Updated integration test to reference new location of run button


### PR DESCRIPTION
# Description
Updated integration test to reference new location of run button

# To test
Go to [here](http://localhost:3000/testrun.html?dir=plots&name=grin2.integration) and make sure all GRIN2 tests pass
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
