### PR TITLE
GRIN2: Enabled auto-running of analysis at live link

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -12,7 +12,6 @@ import { plotManhattan, createLollipopFromGene } from '#plots/manhattan/manhatta
 class GRIN2 extends PlotBase implements RxComponent {
 	readonly type = 'grin2'
 	dom: GRIN2Dom
-	private runButton!: any
 
 	// Colors
 	readonly borderColor = '#eee'
@@ -343,8 +342,13 @@ class GRIN2 extends PlotBase implements RxComponent {
 			.style('margin-left', '100px')
 			.text('Run GRIN2')
 			.on('click', () => this.runAnalysis())
-		// Set initial button state
-		this.updateRunButtonState()
+
+		if (this.state.config.settings.runAnalysis) {
+			this.runAnalysis()
+		} else {
+			// Set initial button state
+			this.updateRunButtonState()
+		}
 	}
 
 	// Helper method to add option rows to table2col instances
@@ -557,7 +561,8 @@ class GRIN2 extends PlotBase implements RxComponent {
 				...this.state.config,
 				settings: {
 					...this.state.config.settings,
-					dtUsage: dtUsage
+					dtUsage: dtUsage,
+					runAnalysis: true
 				}
 			}
 
@@ -892,6 +897,7 @@ export async function getPlotConfig(opts: GRIN2Opts, app: MassAppApi) {
 		settings: {
 			controls: {},
 			dtUsage: dtUsage,
+			runAnalysis: false,
 			manhattan: {
 				...defaultSettings.manhattan,
 				...opts?.manhattan

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GRIN2: Enabled auto-running of analysis at live link


### PR DESCRIPTION
# Description
Tracked analysis run in state. Made it auto run when runAnalysis is true enabling nicer live figure link.

# To test
Go [here](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22grin2%22}],%22termfilter%22:{%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22Diagnosis%22},%22values%22:[{%22key%22:%22AML%22}]}}]}}}). Select some data types, run analysis. Once done share session and when opening link it should auto run analysis

# Closes
Another item on the roadmap
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
