### PR TITLE
Don't resume release in no recover and no workspaces changes.

### DIFF
--- a/.github/workflows/CD-create-release.yml
+++ b/.github/workflows/CD-create-release.yml
@@ -93,7 +93,7 @@ jobs:
           fi
 
           # NOTE: inputs.release_type may be ignored based on unreleased entries in CHANGELOG
-          . ./build/ci-version-update.sh ${{ github.event.inputs.release_type }} -w $exclude
+          . ./build/ci-version-update.sh "${{ github.event.inputs.release_type }}" "${{ github.event.inputs.recover }}" -w $exclude
           
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
           


### PR DESCRIPTION
# Description

In case there is not recover input don't resume release in there are not workspace changes. 

I don't see an easy way to test this before we merge this to master and then try to release two times.  

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
