### PR TITLE
Fix for displaying tooltip upon brushing to end of violin plot

### DIFF
--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -70,7 +70,8 @@ export function setInteractivity(self) {
 		self.displayMenu(event, options, plot)
 	}
 
-	self.displayBrushMenu = function (t1, t2, self, plot, selection, scale, isH) {
+	self.displayBrushMenu = function (t1, t2, self, plot, event, scale, isH) {
+		const selection = event.selection
 		const [start, end] = isH
 			? [scale.invert(selection[0]), scale.invert(selection[1])]
 			: [scale.invert(selection[1]), scale.invert(selection[0])]
@@ -87,14 +88,14 @@ export function setInteractivity(self) {
 			options.push({
 				label: `List samples`,
 				testid: 'sjpp-violinBrushOpt-list',
-				callback: async () => self.callListSamples(event, t1, t2, plot, start, end)
+				callback: async () => self.callListSamples(event.sourceEvent, t1, t2, plot, start, end)
 			})
 		}
-		self.displayMenu(event, options, plot, start, end)
+		self.displayMenu(event.sourceEvent, options, plot, start, end)
 	}
 
 	self.displayMenu = function (event, options, plot, start, end) {
-		const tip = self.dom.clicktip.clear().showunder(event.target)
+		const tip = self.dom.clicktip.clear().show(event.clientX, event.clientY)
 
 		const isBrush = start != null && end != null
 

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -466,13 +466,9 @@ export default function setViolinRenderer(self) {
 							[0, -20],
 							[settings.svgw, 20]
 						])
-						.on('end', async event => {
-							const selection = event.selection
-
-							if (!selection) return
-
-							self.displayBrushMenu(t1, t2, self, plot, selection, svgData.axisScale, isH)
-
+						.on('end', event => {
+							if (!event.selection) return
+							self.displayBrushMenu(t1, t2, self, plot, event, svgData.axisScale, isH)
 							document.body.addEventListener('pointerdown', onClickOut, true)
 						})
 				: brushY()
@@ -480,13 +476,9 @@ export default function setViolinRenderer(self) {
 							[-20, 0],
 							[20, settings.svgw]
 						])
-						.on('end', async event => {
-							const selection = event.selection
-
-							if (!selection) return
-
-							self.displayBrushMenu(t1, t2, self, plot, selection, svgData.axisScale, isH)
-
+						.on('end', event => {
+							if (!event.selection) return
+							self.displayBrushMenu(t1, t2, self, plot, event, svgData.axisScale, isH)
 							document.body.addEventListener('pointerdown', onClickOut, true)
 						})
 


### PR DESCRIPTION
# Description

Fixes issue of not being able to list samples in violin plot when brushing to end of plot. Test with this [example](http://localhost:3000/?mass={%22dslabel%22:%22sjmb12%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22MYC%22}},%22term2%22:{%22id%22:%22Molecular%20Group%22}}]}), brush the `MB, G3` plot up to the end of the plot, tooltip should now display to allow user to list samples.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
