### PR TITLE
Add maxSessions, maxIdleTime and invalidationThreshold to serverconfig

### DIFF
--- a/server/routes/wsimages.ts
+++ b/server/routes/wsimages.ts
@@ -102,7 +102,16 @@ async function getSessionId(
 ): Promise<SessionData> {
 	const sessionManager = SessionManager.getInstance()
 
-	const invalidateResult = await sessionManager.syncAndInvalidateSessions(wsimage)
+	const maxSessions = serverconfig.features?.tileserver?.maxSessions
+	const maxIdleTime = serverconfig.features?.tileserver?.maxIdleTime
+	const invalidationThreshold = serverconfig.features?.tileserver?.invalidationThreshold
+
+	const invalidateResult = await sessionManager.syncAndInvalidateSessions(
+		wsimage,
+		maxSessions,
+		maxIdleTime,
+		invalidationThreshold
+	)
 
 	if (!invalidateResult) throw new Error('Session invalidation failed')
 


### PR DESCRIPTION
# Description
Add maxSessions, maxIdleTime and invalidationThreshold to serverconfig to define TileServer and Redis caching strategy. 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
