### PR TITLE
Fix for unbounded start/stop in numeric tvs input

### DIFF
--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -334,8 +334,8 @@ function enterRange(self, tr, brush, i) {
 	async function apply(new_range) {
 		try {
 			brush.range = new_range
-			const minvalue = self.num_obj.density_data.minvalue
-			const maxvalue = self.num_obj.density_data.maxvalue
+			const minvalue = self.num_obj.density_data.min
+			const maxvalue = self.num_obj.density_data.max
 
 			const start =
 				new_range.value != undefined ? new_range.value : new_range.start != undefined ? new_range.start : minvalue


### PR DESCRIPTION
# Description

Addresses bug reported in https://github.com/stjude/sjpp/issues/1009

Use correct min/max properties in `density_data{}`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
