### PR TITLE
Handle geneVariant q.type=custom-groupset when listing samples

### DIFF
--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -732,8 +732,10 @@ function addGvCols(tw, columns) {
 		if (tw.q.type == 'predefined-groupset') {
 			const groupset = tw.term.groupsetting.lst[tw.q.predefined_groupset_idx]
 			columns.push({ label: dt2label[groupset.dt] })
+		} else if (tw.q.type == 'custom-groupset') {
+			columns.push({ label: 'Genotype' })
 		} else {
-			columns.push({ label: seriesId })
+			throw 'unexpected tw.q.type'
 		}
 	}
 }


### PR DESCRIPTION
# Description

Fixes issue with listing samples in ASH geneset barchart usecase

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
