### PR TITLE
Restored GDCGRIN2

### DIFF
--- a/client/gdc/grin2.ts
+++ b/client/gdc/grin2.ts
@@ -23,7 +23,7 @@ import {
 	createDataTypeRow,
 	createInfoPanel
 } from './grin2/ui-components'
-import { plotManhattan } from '#plots/manhattan/manhattan.ts'
+import { plotManhattanGDC } from '#plots/manhattan/manhattanGDC.ts'
 
 // ================================================================================
 // TYPE DEFINITIONS, INTERFACES, & DEFAULTS
@@ -1780,7 +1780,7 @@ async function getFilesAndShowTable(obj) {
 
 			const plotDiv = resultContainer.append('div')
 
-			plotManhattan(plotDiv, plotData, {})
+			plotManhattanGDC(plotDiv, plotData, { yAxisSpace: 0 })
 
 			// Add error handler for image
 			resultContainer.node().onerror = () => {

--- a/client/plots/manhattan/manhattanGDC.ts
+++ b/client/plots/manhattan/manhattanGDC.ts
@@ -1,0 +1,272 @@
+import { scaleLinear } from 'd3-scale'
+import * as d3axis from 'd3-axis'
+import { Menu, table2col, icons } from '#dom'
+import { to_svg } from '#src/client'
+
+/**
+ * Creates an interactive Manhattan plot on top of a PNG background plot image.
+ *
+ * @param {Object} div - div element to contain the plot
+ * @param {Object} data - Plot data
+ * @param {Object} settings - Display configuration options:
+ *   @param {number} [settings.plotWidth=1000] - Plot area width
+ *   @param {number} [settings.plotHeight=400] - Plot area height
+ *   @param {boolean} [settings.showLegend=true] - Whether to display legend
+ *   @param {boolean} [settings.showDownload=true] - Whether to show download button
+ *   @param {boolean} [settings.showInteractiveDots=true] - Whether to show hoverable data points
+ *   @param {number} [settings.yAxisX=70] - Y-axis positioning
+ *   @param {number} [settings.yAxisSpace=40] - Space between Y-axis and plot
+ *   @param {number} [settings.yAxisY=40] - Top margin
+ *   @param {number} [settings.fontSize=12] - Base font size
+ *   @param {number} [settings.pngDotRadius=2] - Radius of dots in PNG plot
+ *   @param {number} [settings.legendItemWidth=80] - Horizontal space per legend item
+ *   @param {number} [settings.legendDotRadius=3] - Size of legend dots
+ *   @param {number} [settings.legendRightOffset=15] - Offset from right edge
+ *   @param {number} [settings.legendTextOffset=12] - Distance between dot and text
+ *   @param {number} [settings.legendVerticalOffset=4] - Vertical offset for legend items
+ *   @param {number} [settings.legendFontSize=12] - Font size for legend text
+ *   @param {number} [settings.interactiveDotRadius=3] - Radius of interactive dots
+ *   @param {number} [settings.interactiveDotStrokeWidth=1] - Stroke width for interactive dots
+ * @param {Object} [app] - Optional app context for dispatching events
+ *
+ *
+ * @description
+ * Renders a genomic Manhattan plot by overlaying interactive elements on the base PNG plot image.
+ * Features include chromosome labels, legend, hoverable data points with tooltips,
+ * and proper axis scaling. The plot combines a static PNG plot image of all points with dynamic SVG elements
+ * including axes, labels, legend, and top genes (represented as interactive dots) for detailed information on hover.
+ */
+
+export function plotManhattanGDC(div: any, data: any, settings: any, app?: any) {
+	// Default settings
+	settings = {
+		pngDotRadius: 2,
+		plotWidth: 1000,
+		plotHeight: 400,
+		yAxisX: 70,
+		yAxisY: 40,
+		yAxisSpace: 40,
+		fontSize: 12,
+		showLegend: true,
+		legendItemWidth: 80,
+		legendDotRadius: 3,
+		legendRightOffset: 15,
+		legendTextOffset: 12,
+		legendVerticalOffset: 4,
+		legendFontSize: 12,
+		showInteractiveDots: true,
+		showDownload: true,
+		interactiveDotRadius: 3,
+		interactiveDotStrokeWidth: 1,
+		...settings
+	}
+
+	// Set the  positioning up for download button to work properly
+	div.style('position', 'relative')
+
+	// Create tooltip menu
+	const geneTip = new Menu({ padding: '' })
+
+	const svg = div
+		.append('svg')
+		.attr('width', data.plotData.png_width + settings.yAxisX + settings.yAxisSpace)
+		.attr('height', data.plotData.png_height + settings.yAxisY * 4) // Extra space for x-axis labels, legend, and title
+
+	// Add y-axis
+	const yAxisG = svg
+		.append('g')
+		.attr('transform', `translate(${settings.yAxisX + settings.yAxisSpace},${settings.yAxisY})`)
+	const yScale = scaleLinear().domain([0, data.plotData.y_max]).range([data.plotData.png_height, 0])
+	yAxisG.call(d3axis.axisLeft(yScale))
+
+	// Add y-axis label
+	svg
+		.append('text')
+		.attr('x', -(data.plotData.png_height / 2) - settings.yAxisY)
+		.attr('y', settings.yAxisX / 2)
+		.attr('transform', 'rotate(-90)')
+		.attr('text-anchor', 'middle')
+		.attr('font-size', `${settings.fontSize}px`)
+		.attr('fill', 'black')
+		.text('-log₁₀(q-value)')
+
+	// Add png image
+	svg
+		.append('image')
+		.attr('transform', `translate(${settings.yAxisX + settings.yAxisSpace},${settings.yAxisY})`)
+		.attr('width', data.plotData.png_width)
+		.attr('height', data.plotData.png_height)
+		.attr('href', `data:image/png;base64,${data.pngImg || data.png}`)
+
+	// Create scales for positioning elements
+	const xScale = scaleLinear()
+		.domain([-data.plotData.x_buffer, data.plotData.total_genome_length + data.plotData.x_buffer])
+		.range([0, data.plotData.png_width])
+
+	// Add interactive dots layer
+	if (settings.showInteractiveDots && data.plotData.points && data.plotData.points.length > 0) {
+		const pointsLayer = svg
+			.append('g')
+			.attr('transform', `translate(${settings.yAxisX + settings.yAxisSpace},${settings.yAxisY})`)
+
+		pointsLayer
+			.selectAll('circle')
+			.data(data.plotData.points)
+			.enter()
+			.append('circle')
+			.attr('cx', d => xScale(d.x)) // Use xScale to convert pre-calculated genomic coordinates because of our chromosome scaling on the x-axis
+			.attr('cy', d => yScale(d.y)) // Use pre-calculated coordinates for y and yScale for proper scaling from the scale we made earlier
+			.attr('r', settings.interactiveDotRadius)
+			.attr('fill-opacity', 0)
+			.attr('stroke', 'black')
+			.attr('stroke-width', settings.interactiveDotStrokeWidth)
+			.attr('stroke-opacity', 0)
+			.on('mouseover', (event, d) => {
+				// Show stroke on hover
+				event.target.setAttribute('stroke-opacity', 1)
+
+				geneTip.clear().show(event.clientX, event.clientY)
+
+				const table = table2col({
+					holder: geneTip.d.append('div'),
+					margin: '10px'
+				})
+				table.addRow('Gene', d.gene)
+				const [t1, t2] = table.addRow()
+				t1.text('Type')
+				t2.html(`<span style="color:${d.color}">●</span> ${d.type.charAt(0).toUpperCase() + d.type.slice(1)}`)
+				table.addRow('-log₁₀(q-value)', d.y.toFixed(3))
+				if (d.nsubj) table.addRow('Subject count', d.nsubj)
+				table.addRow('Chromosome', d.chrom)
+			})
+			.on('mouseout', event => {
+				// Hide stroke on mouseout
+				event.target.setAttribute('stroke-opacity', 0)
+				geneTip.hide()
+			})
+			.on('click', (event, d) => {
+				if (app) {
+					// Open the genome browser with the current gene that is being clicked on
+					app.dispatch({
+						type: 'plot_create',
+						config: {
+							chartType: 'genomeBrowser',
+							geneSearchResult: { geneSymbol: d.gene }
+						}
+					})
+				}
+			})
+	}
+
+	// Add chromosome labels
+	if (data.plotData.chrom_data) {
+		const chromLabelY = data.plotData.png_height + settings.yAxisY + 20
+
+		Object.entries(data.plotData.chrom_data).forEach(([chrom, chromData]: [string, any]) => {
+			const chromLabel = chrom.replace('chr', '')
+
+			// Skip chrM if desired
+			if (chromLabel === 'M') return
+
+			// Calculate center position for label
+			const centerPos = settings.yAxisX + settings.yAxisSpace + xScale(chromData.center)
+
+			// Append chromosome label
+			svg
+				.append('text')
+				.attr('x', centerPos)
+				.attr('y', chromLabelY)
+				.attr('text-anchor', 'middle')
+				.attr('font-size', `${settings.fontSize - 2}px`)
+				.attr('fill', 'black')
+				.text(chromLabel)
+		})
+	}
+
+	// Add x-axis label
+	svg
+		.append('text')
+		.attr('x', settings.yAxisX + settings.yAxisSpace + data.plotData.png_width / 2)
+		.attr('y', data.plotData.png_height + settings.yAxisY + 45)
+		.attr('text-anchor', 'middle')
+		.attr('font-size', `${settings.fontSize}px`)
+		.attr('fill', 'black')
+		.text('Chromosomes')
+
+	// Add title
+	svg
+		.append('text')
+		.attr('x', settings.yAxisX + settings.yAxisSpace)
+		.attr('y', settings.yAxisY / 2)
+		.attr('text-anchor', 'left')
+		.attr('font-weight', 'bold')
+		.attr('font-size', `${settings.fontSize + 2}px`)
+		.attr('fill', 'black')
+		.text('Manhattan Plot')
+
+	if (settings.showDownload) {
+		const downloadDiv = div
+			.append('div')
+			.style('position', 'absolute')
+			.style('top', '5px')
+			.style('left', `${settings.yAxisX + settings.yAxisSpace + 108}px`)
+			.style('z-index', '10')
+			.style('background', `${settings.background}`)
+			.style('padding', `${settings.padding + 2}px`)
+			.style('border-radius', `${settings.borderRadius + 10}px`)
+
+		icons['download'](downloadDiv, {
+			width: 16,
+			height: 16,
+			title: 'Download Manhattan plot',
+			handler: () => {
+				to_svg(
+					svg.node() as SVGSVGElement,
+					`manhattan_plot_${new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5)}`,
+					{ apply_dom_styles: true }
+				)
+			}
+		})
+	}
+
+	// Generate legend data
+	const mutationTypes = [...new Set(data.plotData.points.map((p: any) => p.type))]
+	const legendData = mutationTypes.map(type => {
+		const point = data.plotData.points.find((p: any) => p.type === type)
+		return {
+			type: String(type).charAt(0).toUpperCase() + String(type).slice(1),
+			color: point?.color
+		}
+	})
+
+	// Add legend
+	if (settings.showLegend && legendData.length > 0) {
+		const legendY = settings.yAxisY / 2
+		const totalWidth = legendData.length * settings.legendItemWidth
+		const legendX =
+			settings.yAxisX + settings.yAxisSpace + data.plotData.png_width - totalWidth - settings.legendRightOffset
+
+		legendData.forEach((item, i) => {
+			const x = legendX + i * settings.legendItemWidth
+
+			// Legend dot
+			svg
+				.append('circle')
+				.attr('cx', x + 8)
+				.attr('cy', legendY)
+				.attr('r', settings.legendDotRadius)
+				.attr('fill', item.color)
+				.attr('stroke', 'black')
+				.attr('stroke-width', 1)
+
+			// Legend text
+			svg
+				.append('text')
+				.attr('x', x + 8 + settings.legendTextOffset)
+				.attr('y', legendY + settings.legendVerticalOffset)
+				.attr('font-size', `${settings.legendFontSize}px`)
+				.attr('fill', 'black')
+				.text(item.type)
+		})
+	}
+}

--- a/python/src/grin2PpWrapperGDC.py
+++ b/python/src/grin2PpWrapperGDC.py
@@ -1,0 +1,765 @@
+###################
+# grin2PpWrapper  #
+###################
+
+########
+# USAGE
+########
+
+"""
+# Usage: echo <in_json> | python3 grin2PpWrapper.py
+
+# in_json: [string] input data in JSON format. Streamed through stdin
+
+# Input JSON:
+# {
+#  genedb: gene db file path
+#  chromosomelist={ <key>: <len>, }
+#  lesion: JSON string containing array of lesion data from gdcGRIN2.rs or other source such as the filter object in ProteinPaint
+#  devicePixelRatio: float (default=2.0)
+#  width: int (default=1000)
+#  height: int (default=400)
+#  pngDotRadius: int (default=2)
+#  cacheFileName: string - will save GRIN2 results to this file in cache directory
+# }
+
+# Output JSON:
+# {
+#  png: [<base64 string>]
+#  topGeneTable: [<list>]
+#  totalGenes: int
+#  showingTop: int
+# }
+"""
+
+import warnings, json, sys, os
+import sqlite3
+import base64
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import numpy as np
+from io import BytesIO
+from grin2_core import order_index_gene_data, order_index_lsn_data, prep_gene_lsn_data, find_gene_lsn_overlaps, count_hits, row_bern_conv
+from grin2_core import row_prob_subj_hit, p_order, process_block_in_chunks, prob_hits, grin_stats, write_grin_xlsx
+from typing import Dict, Optional
+
+# Suppress all warnings 
+warnings.filterwarnings('ignore')
+
+def write_error(msg):
+	"Write error messages to stderr"
+	print(f"ERROR: {msg}", file=sys.stderr)
+
+def assign_lesion_colors(lesion_types):
+	"""
+	Function to determine color assignment based on mutation type
+	Assign colors to lesion types based on what's present in the data
+	"""
+	color_map = {
+		"mutation" : "#44AA44",   
+        "gain" : "#FF4444",       
+        "loss" : "#4444FF",
+        "fusion" : "#FFA500",
+        "sv" : "#9932CC"
+	}
+	# Find unique lesion types 
+	unique_types = pd.Series(lesion_types).unique()
+	# Check for unknown types
+	unknown_types = set(unique_types) - set(color_map.keys())
+	if unknown_types:
+		warnings.warn(f"Unknown lesion types found: {', '.join(unknown_types)}")
+	# Return colors for types present in data
+	available_colors = {k: color_map[k] for k in unique_types if k in color_map}
+	return available_colors
+
+def plot_grin2_manhattan(grin_results: dict, 
+                        chrom_size: pd.DataFrame,
+                        colors: Optional[Dict[str, str]] = None,
+                        plot_width: int = 1000,
+                        plot_height: int = 400,
+                        device_pixel_ratio: float = 2.0,
+                        png_dot_radius: int = 2) -> tuple[plt.Figure, dict]:
+    """
+    Create a Manhattan plot for GRIN2 genomic analysis results using colored scatter points.
+    
+    This function generates a genome-wide visualization showing the statistical 
+    significance of genomic alterations across all chromosomes. Each point represents 
+    a gene with its significance level (-log₁₀(q-value)) plotted against its chromosome
+    start position. Different mutation types (gain, loss, mutation, fusion, sv) are shown in different colors.
+    
+    Args:
+        grin_results (dict): Results dictionary from grin_stats() function containing:
+            - 'gene.hits': DataFrame with gene-level statistical results
+        chrom_size (pd.DataFrame): Chromosome size information with columns:
+            - 'chrom': Chromosome names
+            - 'size': Chromosome lengths in base pairs
+        colors (Optional[Dict[str, str]]): Color mapping for mutation types.
+        plot_width (int): Desired plot width in pixels.
+        plot_height (int): Desired plot height in pixels.
+		png_dot_radius (int): Radius of dots in the PNG output.
+        device_pixel_ratio (float): Device pixel ratio for rendering.
+    Returns:
+        tuple[plt.Figure, dict]: Matplotlib figure and interactive data dictionary
+    """
+    # Set default colors if not provided
+    if colors is None:
+        colors = {
+            'gain': '#FF4444',
+            'loss': '#4444FF', 
+            'mutation': '#44AA44',
+            'fusion': '#FFA500',
+            'sv': '#9932CC'
+        }
+
+    # Calculate PNG dimensions with padding for dot radius
+    png_width = plot_width + 2 * png_dot_radius
+    png_height = plot_height + 2 * png_dot_radius
+
+	# Set up matplotlib margins to 0
+    plt.rcParams['figure.subplot.left'] = 0
+    plt.rcParams['figure.subplot.right'] = 1
+    plt.rcParams['figure.subplot.top'] = 1
+    plt.rcParams['figure.subplot.bottom'] = 0
+    plt.rcParams['axes.xmargin'] = 0
+    plt.rcParams['axes.ymargin'] = 0
+
+    # Calculate DPI and figure size based on PNG dimensions
+    base_dpi = 100
+    plot_dpi = int(base_dpi * device_pixel_ratio)
+    fig_width = png_width / base_dpi
+    fig_height = png_height / base_dpi
+    
+    # Extract gene.hits data
+    gene_hits = grin_results['gene.hits']
+    
+    # Find which mutation types have data
+    mutation_cols = []
+    for mut_type in ['gain', 'loss', 'mutation', 'fusion', 'sv']:
+        q_col = f'q.nsubj.{mut_type}'
+        if q_col in gene_hits.columns:
+            mutation_cols.append((mut_type, q_col))
+    
+    # Calculate cumulative chromosome positions
+    chrom_data = {}
+    cumulative_pos = 0
+    
+    for chrom_index, (_, row) in enumerate(chrom_size.iterrows()):
+        chrom = row['chrom']
+        size = row['size']
+        
+        chrom_data[chrom] = {
+            'start': cumulative_pos,
+            'size': size,
+            'center': cumulative_pos + size / 2
+        }
+        cumulative_pos += size
+    
+    total_genome_length = cumulative_pos
+    
+    # Collect all points to plot
+    plot_data = {'x': [], 'y': [], 'colors': [], 'types': [], 'nsubj.mutation': [], 'nsubj.gain': [], 'nsubj.loss': []}
+    point_details = []
+    
+    # Process each gene
+    for _, gene_row in gene_hits.iterrows():
+        chrom = gene_row['chrom']
+        gene_name = gene_row.get('gene', 'Unknown') 
+        
+        if chrom not in chrom_data:
+            continue
+            
+        gene_start = gene_row.get('loc.start', 0)
+        x_pos = chrom_data[chrom]['start'] + gene_start
+        
+        # Add points for each mutation type
+        for mut_type, q_col in mutation_cols:
+            if q_col not in gene_row or pd.isna(gene_row[q_col]) or gene_row[q_col] <= 0:
+                continue
+
+            q_value = gene_row[q_col]
+            neg_log10_q = -np.log10(q_value)
+            n_subj_count = gene_row.get(f'nsubj.{mut_type}', None)
+            
+            color = colors.get(mut_type, '#888888')
+            
+            # Add ALL points to plot_data for PNG generation
+            plot_data['x'].append(x_pos)
+            plot_data['y'].append(neg_log10_q)
+            plot_data['colors'].append(color)
+            plot_data['types'].append(mut_type)
+
+            # Only add significant points for interactivity - store raw coordinates
+            if q_value <= 0.05:
+                point_details.append({
+                    'x': x_pos,  # Raw genomic coordinate
+                    'y': neg_log10_q,  # Raw -log10(q-value)
+                    'color': color,
+                    'type': mut_type,
+                    'gene': gene_name,
+                    'chrom': chrom,
+                    'pos': gene_start,
+                    'q_value': q_value,
+                    'nsubj': n_subj_count
+                })
+    
+    # Create matplotlib figure
+    fig, ax = plt.subplots(1, 1, figsize=(fig_width, fig_height), dpi=plot_dpi)
+    ax.set_position([0, 0, 1, 1])
+
+    # Calculate y-axis limits
+    y_axis_scaled = False
+    scale_factor_y = 1.0
+    y_min = 0
+	# Calculate x-axis buffer as percentage of total genome length
+    x_buffer = total_genome_length * 0.005  # 0.5% buffer on each side
+    
+    if plot_data['y']:
+        max_y = max(plot_data['y'])
+        
+        # Scale for very high values
+        if max_y > 40:
+            target_max = 40
+            scale_factor_y = target_max / max_y
+            plot_data['y'] = [y * scale_factor_y for y in plot_data['y']]
+            # Also scale point_details for consistency
+            for point in point_details:
+                point['y'] *= scale_factor_y
+            scaled_max = max(plot_data['y'])
+            y_max = scaled_max + 0.35
+            y_axis_scaled = True
+        else:
+            y_max = max_y + 0.35
+
+    # Set matplotlib to use raw genomic coordinates
+    ax.set_xlim(-x_buffer, total_genome_length + x_buffer)
+    ax.set_ylim(y_min, y_max)
+
+    # Create alternating chromosome backgrounds
+    for i, (_, row) in enumerate(chrom_size.iterrows()):
+        chrom = row['chrom']
+        if chrom in chrom_data:
+            start_pos = chrom_data[chrom]['start']
+            end_pos = chrom_data[chrom]['start'] + chrom_data[chrom]['size']
+            
+            # Alternate between light and slightly darker gray
+            if i % 2 == 0:
+                ax.axvspan(start_pos, end_pos, facecolor='#FFFFFF', alpha=0.5, zorder=0)
+            else:
+                ax.axvspan(start_pos, end_pos, facecolor='#D3D3D3', alpha=0.5, zorder=0)
+
+    # Plot data points using raw coordinates
+    if plot_data['x']:
+        point_size = png_dot_radius * 3 ** 2 
+        ax.scatter(plot_data['x'], plot_data['y'], c=plot_data['colors'], 
+                   s=point_size, alpha=0.7, edgecolors='none', zorder=2)
+
+    # Remove axes, labels, and ticks
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_xlabel('')
+    ax.set_ylabel('')
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['bottom'].set_visible(False)
+    ax.spines['left'].set_visible(False)
+    
+    # Remove all margins
+    plt.subplots_adjust(left=0, right=1, top=1, bottom=0)
+
+    fig.canvas.draw()
+
+    # Return raw coordinates and scale info for client-side D3 handling
+    interactive_data = {
+        'points': point_details,  # Raw genomic x, raw -log10(q) y coordinates
+        'chrom_data': chrom_data,
+        'y_axis_scaled': y_axis_scaled,
+        'scale_factor': scale_factor_y,
+        'total_genome_length': total_genome_length,
+        'x_buffer': x_buffer,
+        'y_min': y_min,
+        'y_max': y_max,
+        'plot_width': plot_width,
+        'plot_height': plot_height,
+        'png_width': png_width,
+        'png_height': png_height,
+        'device_pixel_ratio': device_pixel_ratio,
+        'dpi': plot_dpi,
+        'png_dot_radius': png_dot_radius
+    }
+    
+    return fig, interactive_data
+
+def sort_grin2_data(data):
+	"""
+	Sort Mutation data based on available p.nsubj columns with priority system
+	Priority order:
+		1. p.nsubj.mutation (highest priority - if available, always use this)
+		2. p.nsubj.gain (medium priority - use if mutation not available)
+		3. p.nsubj.loss (use if neither mutation nor gain available)
+		4. p.nsubj.fusion (use if mutation, gain, loss not available)
+		5. p.nsubj.sv (lowest priority - use only if no other columns available)
+	"""
+	# Define possible columns in priority order
+	possible_cols = ["p.nsubj.mutation", "p.nsubj.gain", "p.nsubj.loss", "p.nsubj.fusion", "p.nsubj.sv"]
+	# Find the first existing column
+	for col in possible_cols:
+		if col in data.columns:
+			sort_column = col
+			break
+	else:
+		raise ValueError("No sorting columns (p.nsubj.*) found in data")
+	# Sort data
+	sorted_data = data.sort_values(by=sort_column)
+	return sorted_data
+
+def get_chrom_key(chrom):
+	"""
+	Create a sorting key for chromosomes
+	"""
+	# Remove 'chr' prefix
+	num = chrom.replace("chr","")
+	# Check if numeric
+	try:
+		return int(num)
+	except ValueError:
+		# Assign fixed values for non-numeric
+		if num == "X":
+			return 23
+		elif num == "Y":
+			return 24
+		else:
+			return 100
+def get_sig_values(data):
+	"""
+	Find all existing p-value columns and return corresponding q-value columns
+	Since q-values are guaranteed to exist whenever p-values exist,
+	we only need to check for p-value columns and construct the corresponding
+	q-value column names.
+	"""
+	# Define all possible column types to check for
+	column_types = ["mutation", "gain", "loss", "fusion", "sv"]
+	# Get all column names from the dataframe
+	available_cols = data.columns
+	# Create expected p-value column names
+	expected_p_cols = [f"p.nsubj.{ct}" for ct in column_types]
+	expected_n_cols = [f"nsubj.{ct}" for ct in column_types]
+	# Find which p-value columns actually exist
+	existing_p_cols = [col for col in expected_p_cols if col in available_cols]
+	existing_n_cols = [col for col in expected_n_cols if col in available_cols]
+	# Create corresponding q-value column names
+	# Simply replace "p.nsubj." with "q.nsubj."
+	existing_q_cols = [col.replace("p.nsubj.", "q.nsubj.") for col in existing_p_cols]
+	return {
+		"p_cols": existing_p_cols,
+		"q_cols": existing_q_cols,
+		"n_cols": existing_n_cols
+	}
+def has_data(column_data, sample_size=20):
+	"""
+	Check if a column has meaningful data
+	"""
+	# Take a sample of the column (first 20 rows or whatever exists)
+	sample_data = column_data.head(sample_size)
+	# Remove NA, NULL, empty strings, and 0 values
+	meaningful_data = sample_data[
+		sample_data.notna() &
+		(sample_data != "")
+	]
+	return len(meaningful_data) > 0
+
+def smart_format(value):
+    """Format to 4 significant digits but keep as numbers for proper sorting"""
+    # Handle NaN, infinity, and other non-finite values
+    if pd.isna(value) or not np.isfinite(value):
+        return None  # Return None instead of NaN (becomes null in JSON)
+    if value == 0:
+        return 0
+    else:
+        # Convert to 4 significant digits and back to float
+        return float(f"{value:.3g}")  # .3g gives 4 significant digits total
+def simple_column_filter(sorted_results, num_rows_to_process=50):
+	"""
+	Dynamically generate columns and rows for topGeneTable based on available data
+	"""
+	result = get_sig_values(sorted_results)
+	p_cols = result["p_cols"]
+	q_cols = result["q_cols"]
+	n_cols = result["n_cols"]
+	
+	# Check which column groups have data
+	mutation_has_data = has_data(sorted_results[p_cols[0]]) if len(p_cols) > 0 and p_cols[0] in sorted_results.columns else False
+	cnv_gain_has_data = has_data(sorted_results[p_cols[1]]) if len(p_cols) > 1 and p_cols[1] in sorted_results.columns else False
+	cnv_loss_has_data = has_data(sorted_results[p_cols[2]]) if len(p_cols) > 2 and p_cols[2] in sorted_results.columns else False
+	fusion_has_data = has_data(sorted_results[p_cols[3]]) if len(p_cols) > 3 and p_cols[3] in sorted_results.columns else False
+	sv_has_data = has_data(sorted_results[p_cols[4]]) if len(p_cols) > 4 and p_cols[4] in sorted_results.columns else False
+	
+	# Check CNV data availability (gain OR loss)
+	has_cnv_data = cnv_gain_has_data or cnv_loss_has_data
+	# Check structural variant data availability (fusion OR sv)
+	has_sv_data = fusion_has_data or sv_has_data
+	# Check combinations for constellation tests
+	has_both_maf_and_cnv = mutation_has_data and has_cnv_data
+	has_both_maf_and_sv = mutation_has_data and has_sv_data
+	
+	# Check if constellation columns actually exist
+	p1_exists = 'p1.nsubj' in sorted_results.columns
+	q1_exists = 'q1.nsubj' in sorted_results.columns
+	p2_exists = 'p2.nsubj' in sorted_results.columns
+	q2_exists = 'q2.nsubj' in sorted_results.columns
+	p3_exists = 'p3.nsubj' in sorted_results.columns
+	q3_exists = 'q3.nsubj' in sorted_results.columns
+	p4_exists = 'p4.nsubj' in sorted_results.columns
+	q4_exists = 'q4.nsubj' in sorted_results.columns
+	
+	# Improved sorting logic with fallbacks
+	# Priority: p1 (CNV constellation) > p.nsubj.mutation > p.nsubj.gain > p.nsubj.fusion > p.nsubj.loss > p.nsubj.sv
+	if p1_exists and has_cnv_data:
+		sorted_results = sorted_results.sort_values('p1.nsubj', ascending=True)
+	elif 'p.nsubj.mutation' in sorted_results.columns:
+		sorted_results = sorted_results.sort_values('p.nsubj.mutation', ascending=True)
+	elif 'p.nsubj.gain' in sorted_results.columns:
+		sorted_results = sorted_results.sort_values('p.nsubj.gain', ascending=True)
+	elif 'p.nsubj.fusion' in sorted_results.columns:
+		sorted_results = sorted_results.sort_values('p.nsubj.fusion', ascending=True)
+	elif 'p.nsubj.loss' in sorted_results.columns:
+		sorted_results = sorted_results.sort_values('p.nsubj.loss', ascending=True)
+	elif 'p.nsubj.sv' in sorted_results.columns:
+		sorted_results = sorted_results.sort_values('p.nsubj.sv', ascending=True)
+
+	# Build columns list
+	columns = [
+		{"label": "Gene", "sortable": True},
+		{"label": "Chromosome", "sortable": True}
+	]
+	
+	# Add individual mutation type columns based on what data exists
+	if mutation_has_data:
+		columns.extend([
+			{"label": p_cols[0], "sortable": True},
+			{"label": q_cols[0], "sortable": True},
+			{"label": n_cols[0], "sortable": True}
+		])
+	if cnv_gain_has_data:
+		columns.extend([
+			{"label": p_cols[1], "sortable": True},
+			{"label": q_cols[1], "sortable": True},
+			{"label": n_cols[1], "sortable": True}
+		])
+	if cnv_loss_has_data:
+		columns.extend([
+			{"label": p_cols[2], "sortable": True},
+			{"label": q_cols[2], "sortable": True},
+			{"label": n_cols[2], "sortable": True}
+		])
+	if fusion_has_data:
+		columns.extend([
+			{"label": p_cols[3], "sortable": True},
+			{"label": q_cols[3], "sortable": True},
+			{"label": n_cols[3], "sortable": True}
+		])
+	if sv_has_data:
+		columns.extend([
+			{"label": p_cols[4], "sortable": True},
+			{"label": q_cols[4], "sortable": True},
+			{"label": n_cols[4], "sortable": True}
+		])
+	
+	# Add constellation columns based on what data combinations we have
+	# p1/q1: CNV constellation (gain OR loss present)
+	if has_cnv_data and p1_exists and q1_exists:
+		columns.extend([
+			{"label": "p1.nsubj", "sortable": True},
+			{"label": "q1.nsubj", "sortable": True}
+		])
+	
+	# p2/q2: SV constellation (fusion OR sv present)
+	if has_sv_data and p2_exists and q2_exists:
+		columns.extend([
+			{"label": "p2.nsubj", "sortable": True},
+			{"label": "q2.nsubj", "sortable": True}
+		])
+	
+	# p3/q3: MAF + CNV constellation (mutation AND (gain OR loss) present)
+	if has_both_maf_and_cnv and p3_exists and q3_exists:
+		columns.extend([
+			{"label": "p3.nsubj", "sortable": True},
+			{"label": "q3.nsubj", "sortable": True}
+		])
+	
+	# p4/q4: MAF + SV constellation (mutation AND (fusion OR sv) present)
+	if has_both_maf_and_sv and p4_exists and q4_exists:
+		columns.extend([
+			{"label": "p4.nsubj", "sortable": True},
+			{"label": "q4.nsubj", "sortable": True}
+		])
+	
+	# Build rows to match the active columns
+	topgene_table_data = []
+	for i in range(min(len(sorted_results), num_rows_to_process)):
+		row_data = [
+			{"value": str(sorted_results.iloc[i]["gene"])},
+			{"value": str(sorted_results.iloc[i]["chrom"])}
+		]
+		
+		# Add individual mutation type data based on what exists
+		if mutation_has_data:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i][p_cols[0]])},
+				{"value": smart_format(sorted_results.iloc[i][q_cols[0]])},
+				{"value": smart_format(sorted_results.iloc[i][n_cols[0]])}
+			])
+		if cnv_gain_has_data:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i][p_cols[1]])},
+				{"value": smart_format(sorted_results.iloc[i][q_cols[1]])},
+				{"value": smart_format(sorted_results.iloc[i][n_cols[1]])}
+			])
+		if cnv_loss_has_data:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i][p_cols[2]])},
+				{"value": smart_format(sorted_results.iloc[i][q_cols[2]])},
+				{"value": smart_format(sorted_results.iloc[i][n_cols[2]])}
+			])
+		if fusion_has_data:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i][p_cols[3]])},
+				{"value": smart_format(sorted_results.iloc[i][q_cols[3]])},
+				{"value": smart_format(sorted_results.iloc[i][n_cols[3]])}
+			])
+		if sv_has_data:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i][p_cols[4]])},
+				{"value": smart_format(sorted_results.iloc[i][q_cols[4]])},
+				{"value": smart_format(sorted_results.iloc[i][n_cols[4]])}
+			])
+		
+		# Add constellation data based on what combinations we have
+		if has_cnv_data and p1_exists and q1_exists:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i]["p1.nsubj"])},
+				{"value": smart_format(sorted_results.iloc[i]["q1.nsubj"])}
+			])
+		
+		if has_sv_data and p2_exists and q2_exists:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i]["p2.nsubj"])},
+				{"value": smart_format(sorted_results.iloc[i]["q2.nsubj"])}
+			])
+		
+		if has_both_maf_and_cnv and p3_exists and q3_exists:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i]["p3.nsubj"])},
+				{"value": smart_format(sorted_results.iloc[i]["q3.nsubj"])}
+			])
+		
+		if has_both_maf_and_sv and p4_exists and q4_exists:
+			row_data.extend([
+				{"value": smart_format(sorted_results.iloc[i]["p4.nsubj"])},
+				{"value": smart_format(sorted_results.iloc[i]["q4.nsubj"])}
+			])
+		
+		topgene_table_data.append(row_data)
+	
+	return {
+		"columns": columns,
+		"rows": topgene_table_data
+	}
+
+try:
+	# 1. Stream in JSON input data
+	json_input = sys.stdin.read().strip()
+	if not json_input:
+		write_error("No input data provided")
+		sys.exit(1)
+	try:
+		input_data = json.loads(json_input)
+	except json.JSONDecodeError as e:
+		write_error(f"Invalid JSON input: {str(e)}")
+		sys.exit(1)
+	# 2. Generate gene annotation table from gene2coord
+	dbfile = input_data["genedb"]
+	try:
+		con = sqlite3.connect(dbfile)
+		query = "SELECT name, chr, start, stop FROM gene2coord"
+		gene_anno = pd.read_sql_query(query, con)
+		con.close()
+	except Exception as e:
+		write_error(f"Failed to connect or query the gene database: {str(e)}")
+		sys.exit(1)
+	if gene_anno.empty:
+		write_error("No data retrieved from gene2coord table")
+		sys.exit(1)
+
+	# Remove problematic header-like row
+	gene_anno = gene_anno[
+		~((gene_anno["name"] == "name") &
+		(gene_anno["chr"] == "chr") &
+		(gene_anno["start"] == "start") &
+		(gene_anno["stop"] == "stop"))
+	]
+	# Ensure start and stop are integers and normalize chromosome names
+	try:
+		gene_anno = gene_anno.assign(
+			start=lambda x: pd.to_numeric(x["start"], errors="coerce").astype("int64"),
+			stop=lambda x: pd.to_numeric(x["stop"], errors="coerce").astype("int64"),
+			chr=lambda x: x["chr"].apply(lambda c: f"chr{c}" if not c.startswith("chr") else c)
+		)
+	except Exception as e:
+		write_error(f"Failed to convert start/stop to integers: {str(e)}")
+		sys.exit(1)
+	# Rename columns and add gene column
+	gene_anno = gene_anno.rename(columns={
+		"name": "gene.name",
+		"chr": "chrom",
+		"start": "loc.start",
+		"stop": "loc.end"
+	})
+	gene_anno["gene"] = gene_anno["gene.name"]
+	# Reorder columns
+	gene_anno = gene_anno[["gene", "chrom", "loc.start", "loc.end"]]
+	
+
+	# 3. Generate chromosome size table
+	try:
+		chromosomelist = input_data["chromosomelist"]
+		chrom_size = pd.DataFrame({
+			"chrom": list(chromosomelist.keys()),
+			"size": pd.to_numeric(list(chromosomelist.values()), errors="coerce").astype("int64")
+		})
+		chrom_size["sort_key"] = chrom_size["chrom"].apply(get_chrom_key)
+		chrom_size = chrom_size.sort_values("sort_key").drop(columns="sort_key")
+	except Exception as e:
+		write_error(f"Failed to read chromosome size file: {str(e)}")
+		sys.exit(1)
+
+	# 4. Receive lesion data
+	try:
+		lesion_data = input_data["lesion"] 
+		
+		# Parse the JSON string to get the actual array
+		lesion_array = json.loads(lesion_data)
+		
+		# Validate we have data
+		if not lesion_array:
+			write_error("No lesion data provided")
+			sys.exit(1)
+		
+		# Create DataFrame from the parsed array
+		lesion_df = pd.DataFrame(lesion_array, columns=["ID", "chrom", "loc.start", "loc.end", "lsn.type"])
+		lesion_df = lesion_df.astype({
+			"ID": str,
+			"chrom": str,
+			"loc.start": "int64",
+			"loc.end": "int64",
+			"lsn.type": str
+		})
+		lesion_df["chrom"] = lesion_df["chrom"].apply(lambda c: f"chr{c}" if not c.startswith("chr") else c)
+		lsn_colors = assign_lesion_colors(lesion_df["lsn.type"])
+	except json.JSONDecodeError as json_err:
+		write_error(f"Failed to parse lesion JSON: {json_err}")
+		sys.exit(1)
+	except Exception as e:
+		write_error(f"Failed to read lesion data from input JSON: {str(e)}")
+		sys.exit(1)
+
+	# 5. Run GRIN2 analysis
+	try:
+		grin_results = grin_stats(lesion_df, gene_anno, chrom_size)
+		if not isinstance(grin_results, dict) or grin_results is None:
+			write_error("grin_stats returned invalid or null results")
+			sys.exit(1)
+	except Exception as e:
+		write_error(f"Failed to compute grin_stats: {str(e)}")
+		sys.exit(1)
+
+	# Extract and sort gene.hits
+	try:
+		grin_table = grin_results["gene.hits"]
+		sorted_results = sort_grin2_data(grin_table)
+
+		cache_file_path = input_data.get("cacheFileName")
+		if cache_file_path:
+			cache_columns = ['gene', 'chrom']
+			possible_types = ['mutation', 'gain', 'loss', 'fusion', 'sv'] # TODO: maybe get this dynamically
+			for t in possible_types:
+				nsub_col = f'nsubj.{t}'
+				q_col = f'q.nsubj.{t}'
+
+				if nsub_col in sorted_results.columns:
+					cache_columns.append(nsub_col)
+				if q_col in sorted_results.columns:
+					cache_columns.append(q_col)
+				
+				# Create filtered dataframe with only cache columns
+				results_to_cache = sorted_results[cache_columns].copy()
+
+				# Save to TSV
+				results_to_cache.to_csv(cache_file_path, index=False, sep='\t')
+	except Exception as e:
+		write_error(f"Failed to extract gene.hits or sort grin_table: {str(e)}")
+		sys.exit(1)
+
+
+	# 6. Generate Manhattan plot and encode as Base64
+
+	# Get parameters from input, with defaults
+	device_pixel_ratio = input_data.get("devicePixelRatio", 2.0)
+	plot_width = input_data.get("width", 1000)
+	plot_height = input_data.get("height", 400)
+	png_dot_radius = input_data.get("pngDotRadius", 2)
+
+	try:
+		# Create the Manhattan plot
+		fig, plot_data = plot_grin2_manhattan(
+			grin_results, 
+			chrom_size, 
+			lsn_colors,
+			plot_width,
+			plot_height,
+			device_pixel_ratio,
+			png_dot_radius
+		)
+
+		# Save to BytesIO buffer - use the DPI from the plot_data
+		save_dpi = plot_data['dpi']
+		plt.tight_layout(pad=0)
+		buffer = BytesIO()
+		fig.savefig(buffer, format="png", bbox_inches="tight", dpi=save_dpi, pad_inches=0, facecolor='white')
+		plt.close(fig)
+
+		# Get bytes and encode as base64
+		buffer.seek(0)
+		plot_bytes = buffer.getvalue()
+		base64_string = base64.b64encode(plot_bytes).decode("utf-8")
+		
+	except Exception as e:
+		write_error(f"Failed to generate Manhattan plot: {str(e)}")
+		sys.exit(1)
+	finally:
+		plt.close("all")
+		
+	# 7. Generate topGeneTable
+	max_genes_to_show = 500 # TODO: make this configurable
+	num_rows_to_process = min(len(sorted_results), max_genes_to_show)
+	table_result = simple_column_filter(sorted_results, num_rows_to_process)
+	columns = table_result["columns"]
+	topgene_table_data = table_result["rows"]
+
+	# 8. Prepare response
+	grin2_response = {
+		"png": [base64_string],
+		"plotData": plot_data,
+		"topGeneTable": {
+			"columns": columns,
+			"rows": topgene_table_data
+		},
+		"totalGenes": len(sorted_results),
+		"showingTop": num_rows_to_process
+	}
+
+	# Output JSON
+	print(json.dumps(grin2_response))
+except Exception as e:
+	write_error(f"Unexpected error: {str(e)}")
+	sys.exit(1)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Restored GDCGRIN2

--- a/server/routes/gdc.grin2.run.ts
+++ b/server/routes/gdc.grin2.run.ts
@@ -134,7 +134,7 @@ async function runGrin2(genomes: any, req: any, res: any) {
 
 	// Call the python script
 	const grin2AnalysisStart = Date.now()
-	const pyResult = await run_python('grin2PpWrapper.py', JSON.stringify(pyInput))
+	const pyResult = await run_python('grin2PpWrapperGDC.py', JSON.stringify(pyInput))
 
 	// mayLog(`[GRIN2] python execution completed, result: ${pyResult}`)
 	if (pyResult.stderr?.trim()) {


### PR DESCRIPTION
# Description
To restore GDC-GRIN2 I went back to our pure python (before rust plotting) plotter. This also required using an older version of `manhattan.ts`. I simply downloaded those versions of the `manhattan.ts` and `grin2PpWrapper.py` and appended GDC to both and updated the function calls. Long term will try to unify the GDC route with our current general route

# To Test
Go to [GDCGRIN2](http://localhost:3000/prp1Public/gdcgrin2/) and test. Should all work as expected. 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
