### PR TITLE
GRIN2: Improved precision of reported time for GRIN2 steps

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -860,7 +860,7 @@ class GRIN2 extends PlotBase implements RxComponent {
 				.style('font-size', `${this.optionsTextFontSize}px`)
 				.style('color', this.optionsTextColor)
 				.text(
-					`Analysis completed in ${result.timing.totalTime}s (Processing: ${result.timing.processingTime}s, GRIN2: ${result.timing.grin2Time}s, Plotting: ${result.timing.plottingTime}s)`
+					`Analysis completed in ${result.timing.totalTime} (Processing: ${result.timing.processingTime}, GRIN2: ${result.timing.grin2Time}, Plotting: ${result.timing.plottingTime})`
 				)
 		}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GRIN2: Improved precision of reported time for GRIN2 steps

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -148,13 +148,13 @@ export type GRIN2Response = {
 	/** Timing info for the analysis */
 	timing?: {
 		/** Time taken to run data processing */
-		processingTime: number
+		processingTime: string
 		/** Time taken to run GRIN2 processing */
-		grin2Time: number
+		grin2Time: string
 		/** Time taken to run Manhattan plot generation */
-		plottingTime: number
+		plottingTime: string
 		/** Total time taken for the entire run */
-		totalTime: number
+		totalTime: string
 	}
 	/** Detailed processing summary */
 	processingSummary?: {

--- a/shared/utils/src/time.ts
+++ b/shared/utils/src/time.ts
@@ -1,36 +1,31 @@
 /**
- * Formats elapsed time in milliseconds to a human-readable string with appropriate units
- * @param ms - Elapsed time in milliseconds
- * @returns Formatted time string with appropriate unit
+ * Format elapsed time in milliseconds to a human-readable string
+ * Handles negative times (preserves sign) for defensive programming - useful when
+ * calculating time differences that might be in the wrong order (e.g., startTime - endTime)
+ * @param {number} ms - Time in milliseconds
+ * @param {number} [precision=2] - Number of decimal places for seconds (optional, defaults to 2)
+ * @returns {string} Formatted time string with units
  */
-export function formatElapsedTime(ms: number | unknown): string {
-	// Handle non-numeric inputs
-	if (typeof ms !== 'number') {
-		return 'Invalid time: not a number'
+export function formatElapsedTime(ms: number | unknown, precision: number = 2): string {
+	// Handle all invalid cases
+	if (typeof ms !== 'number' || isNaN(ms)) {
+		return typeof ms !== 'number' ? 'Invalid time: not a number' : 'Invalid time: NaN'
 	}
-
-	// Handle NaN
-	if (isNaN(ms)) {
-		return 'Invalid time: NaN'
-	}
-
-	// Handle infinite values
 	if (!isFinite(ms)) {
 		return ms > 0 ? 'Infinite time' : '-Infinite time'
 	}
 
-	// Handle negative times (use absolute value but preserve sign in output)
+	// This additional logic is for handling negative times and preserving the sign in the output
 	const absMs = Math.abs(ms)
 	const sign = ms < 0 ? '-' : ''
 
-	if (absMs < 1000) {
+	if (absMs < 1e3) {
 		return `${sign}${absMs}ms`
-	} else if (absMs < 60000) {
-		const seconds = (absMs / 1000).toFixed(2)
-		return `${sign}${seconds}s`
-	} else {
-		const minutes = Math.floor(absMs / 60000)
-		const seconds = ((absMs % 60000) / 1000).toFixed(2)
-		return `${sign}${minutes}m ${seconds}s`
 	}
+	if (absMs < 6e4) {
+		return `${sign}${(absMs / 1e3).toFixed(precision)}s`
+	}
+	const minutes = Math.floor(absMs / 6e4)
+	const seconds = ((absMs % 6e4) / 1e3).toFixed(precision)
+	return `${sign}${minutes}m ${seconds}s`
 }


### PR DESCRIPTION
# Description
Now that we have plotting that can can finish in less than a second I thought I would use `formatElapsedTime` to improve the precision of the time displayed. This is helpful to users instead of seeing 0s for processing or plotting they now see that those steps took up time. I also took this time to improve `formatElapsedTime`. It now has an optional `precision` parameter that allows passing in how many decimal places you want. Also just cleaned up the function a little to make it more concise.

# To test
Go to [termdbtest](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22grin2%22}]}) and run the analysis. You should now see the non-zero times reported for processing and plotting in the time section of the stats. The times should sum to the total time (when rounded)
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
