### PR TITLE
Disable selected terms in term inputs

### DIFF
--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -43,6 +43,8 @@ class TdbConfigUiInit {
 			this.inputs = {} // non-rx notified
 			const componentPromises = {} // rx-notified
 
+			this.disableSelectedTerms()
+
 			for (const key of this.opts.inputs) {
 				if (typeof key == 'object') {
 					const obj = key // reassign to be less confusing
@@ -105,6 +107,15 @@ class TdbConfigUiInit {
 			config,
 			isOpen: this.opts.isOpen()
 		}
+	}
+
+	// disable selected terms in all term inputs
+	// to prevent entering the same term in multiple inputs
+	disableSelectedTerms() {
+		const state = this.getState(this.app.getState())
+		const termInputs = this.opts.inputs.filter(i => i.type === 'term')
+		const selectedTerms = termInputs.map(i => state.config[i.configKey]?.term).filter(Boolean)
+		for (const i of termInputs) i.disable_terms = selectedTerms
 	}
 
 	main() {

--- a/client/plots/scatter/view/scatterView.ts
+++ b/client/plots/scatter/view/scatterView.ts
@@ -418,11 +418,6 @@ export class ScatterView {
 
 		this.mayAddControlLabels(inputs)
 
-		// disable already-selected terms in all term inputs
-		const termInputs = inputs.filter(i => i.type === 'term')
-		const selectedTerms = termInputs.map(i => this.scatter.config[i.configKey]?.term).filter(Boolean)
-		for (const i of termInputs) i.disable_terms = selectedTerms
-
 		return inputs
 	}
 


### PR DESCRIPTION
# Description

Fixes the following [JIRA ticket](https://gdc-ctds.atlassian.net/browse/SV-2672).

Previously, selected terms were disabled in term inputs for scatter plot to address a different JIRA issue (see https://github.com/stjude/proteinpaint/pull/3921). Now selected terms are disabled in term inputs for all plots to address this JIRA issue.

Can test using [GDC correlation input](http://localhost:3000/?noheader=1&gdccorrelation=1&filter0={%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.primary_site%22,%22value%22:[%22brain%22,%22breast%22]}}). Can also test in other chart types.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
