### PR TITLE
Add loading message prior to fillMenu() in tvs.js

### DIFF
--- a/client/filter/tvs.js
+++ b/client/filter/tvs.js
@@ -285,11 +285,15 @@ export async function showTvsMenu(opts) {
 
 	const loadingDiv = opts.holder.append('div').style('padding', '10px').text('Loading ...')
 
-	await self.setHandler()
-	if (self.handler.setTvsDefaults) self.handler.setTvsDefaults(self.tvs)
-	await self.handler.fillMenu(self, opts.holder, self.tvs)
-
-	loadingDiv.style('display', 'none')
+	try {
+		await self.setHandler()
+		if (self.handler.setTvsDefaults) self.handler.setTvsDefaults(self.tvs)
+		await self.handler.fillMenu(self, opts.holder, self.tvs)
+		loadingDiv.remove()
+	} catch (e) {
+		loadingDiv.text('Error: ' + (e.message || e))
+		if (e.stack) console.log(e)
+	}
 }
 
 function addExcludeCheckbox(holder, tvs, self) {


### PR DESCRIPTION
# Description

Addresses this [JIRA ticket](https://gdc-ctds.atlassian.net/browse/SV-2678).

Variables load fine in filter UI, but it just takes some time. So a loading message is now displayed while `fillMenu()` is running.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
