### PR TITLE
Skip `case.samples` terms in GDC dictionary

### DIFF
--- a/server/src/gdc.buildDictionary.js
+++ b/server/src/gdc.buildDictionary.js
@@ -597,7 +597,7 @@ function maySkipFieldLine(line) {
 		line.startsWith('ssm') ||
 		line.startsWith('case.observation') ||
 		line.startsWith('case.available_variation_data') ||
-		line.startsWith('case.samples') // terms under this branch have multiple values (one for each sample), skipping for now until we can support them
+		line.startsWith('case.samples') // these terms have multiple values per case (one for each sample), skipping for now until we can support them
 	) {
 		// skip lines beginning with these
 		// uncomment to see what's skipped


### PR DESCRIPTION
# Description

Terms under the `case.samples` branch are now skipped in the GDC dictionary because these terms have multiple values for a given case (one per sample). We will revert this change once we can support these terms in correlation plot.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
