### PR TITLE
handle demoJwtInput as an initialized dataset option

### DIFF
--- a/public/static/js/login.js
+++ b/public/static/js/login.js
@@ -49,7 +49,7 @@ async function getJwt(dslabel, role) {
 
 	// !!! NOTE: to clear/refresh the stored fake jwt's, use the dslogout() function above or force the condition below to true !!!
 	// otherwise, should reuse saved fake tokens that have not changed in serverconfig.features
-	const body = JSON.stringify({ dslabel, role })
+	const body = JSON.stringify({ genome: 'hg38', dslabel, role })
 	const res = await fetch('/demoToken', { method: 'POST', body })
 		.then(r => r.json())
 		.catch(console.error)

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1922,12 +1922,33 @@ export type Mds3 = BaseMds & {
 		data during post-processing */
 		postProcessDtFilter?: boolean
 	}
+	demoJwtInput?: {
+		[role: string]: {
+			datasets?: string[]
+			clientAuthResult?: // sjcares, panMB, SJLife
+			| ClientAuthResult
+				// profile
+				| {
+						[cohort: string]: ClientAuthResult
+				  }
+			// below will be assigned by /demoToken route handler if not specified
+			iat?: number // jwt issued at time, unix time in seconds
+			exp?: number // jwt expiration, unix time in seconds
+			email?: string
+		}
+	}
 	// !!! TODO: improve these type definitions below !!!
 	getHostHeaders?: (q?: any) => any
 	serverconfigFeatures?: any
 	getHealth?: (ds: any) => {
 		[key: string]: any
 	}
+}
+
+export type ClientAuthResult = {
+	role?: string
+	datasets?: string[]
+	sites?: string[]
 }
 
 export type Mds3WithCohort = Mds3 & {


### PR DESCRIPTION
# Description

This PR improves demo token support by handling it as an initialized dataset option, instead of reading from a `serverconfig.features.demoJwtInputs` file (now deprecated).

Tested by running all unit and integration tests. Also tested manually by loading html pages that simulate login/roles.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
