### PR TITLE
recover discrete custom-bin properties from a malformed q object

### DIFF
--- a/client/termsetting/utils.ts
+++ b/client/termsetting/utils.ts
@@ -114,6 +114,8 @@ async function mayUseTwRouterFill(
 	// there will be some code duplication between TwRouter and the legacy code;
 	// the latter will be deleted once the refactor/migration is done
 	const fullTw = await TwRouter.fill(tw, { vocabApi, defaultQByTsHandler })
+	// TODO: return fullTW instead of mutating the input tw below,
+	// which is not type-safe, e.g., q.mode=continuous may have discrete q properties mixed-in
 	Object.assign(tw, fullTw)
 	mayValidateQmode(tw)
 	// this should be moved to the term-type specific handler??

--- a/client/tw/numeric.ts
+++ b/client/tw/numeric.ts
@@ -96,6 +96,10 @@ export class NumericBase extends TwBase {
 		// set q.type based on q.mode
 		switch (tw.q.mode) {
 			case 'discrete':
+				if (tw.q.type != 'regular-bin') {
+					// support malformed tw.q that combines properties from different modes, such as continuous and discrete
+					if (Array.isArray((tw as RawNumTWCustomBin).q.lst)) tw.q.type = 'custom-bin'
+				}
 				if (!tw.q.type) {
 					if (tw.term.bins) mayFillQWithPresetBins(tw)
 					else tw.q.type = 'regular-bin'


### PR DESCRIPTION
# Description

Addresses this item in https://github.com/stjude/sjpp/issues/1009:
- BUG [barchart with custom bin](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22%7D,%22q%22:%7B%22mode%22:%22discrete%22,%22type%22:%22custom-bin%22,%22lst%22:%5B%7B%22startunbounded%22:true,%22stopinclusive%22:true,%22stop%22:15,%22label%22:%22Low%20%3C15%22%7D,%7B%22startinclusive%22:false,%22stopunbounded%22:true,%22start%22:15,%22label%22:%22High%20%3E15%22%7D%5D%7D%7D%7D%5D%7D) > switch to violin > switch back to barchart. shows default bins and custom bins are lost

Also tested by running all unit and integration tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
