### PR TITLE
Solved Issue #3873

### DIFF
--- a/client/plots/disco/waterfall/MutationWaterfallDatum.ts
+++ b/client/plots/disco/waterfall/MutationWaterfallDatum.ts
@@ -2,6 +2,10 @@ export interface MutationWaterfallDatum {
 	chr: string
 	position: number
 	logDistance: number
+
+	type?: string           
+	sample?: string          
+	samples?: string[]       
 }
 
 export interface MutationWaterfallLogRange {

--- a/client/plots/disco/waterfall/MutationWaterfallMapper.ts
+++ b/client/plots/disco/waterfall/MutationWaterfallMapper.ts
@@ -35,21 +35,45 @@ export default class MutationWaterfallMapper {
 			const normalized = Math.max(0, Math.min(1, (datum.logDistance - min) / span))
 			const radius = this.innerRadius + this.ringWidth * normalized
 
+			let mclass = 'SNV' 
+			if (datum.type === 'CNV_amp') mclass = 'CNV_amp'
+			else if (datum.type === 'CNV_loss') mclass = 'CNV_loss'
+			
+			let color = '#4d4d4d' 
+			if (mclass === 'CNV_amp') color = '#FF4136' 
+			else if (mclass === 'CNV_loss') color = '#0074D9' 
+
+			const existing = points.find(p => 
+				p.chr === datum.chr &&
+				p.position === datum.position &&
+				(p.class === 'CNV_amp' || p.class === 'CNV_loss')
+			)
+
+			if (existing) {
+				existing.samples = [...(existing.samples ?? []), ...(datum.sample ? [datum.sample] : [])]
+				continue 
+			}
+
+
+
 			points.push({
-				startAngle: angle,
-				endAngle: angle,
-				innerRadius: radius,
-				outerRadius: radius,
-				text: chromosome.text,
-				color: '#4d4d4d',
-				chr: datum.chr,
-				position: datum.position,
-				logDistance: datum.logDistance,
-				ringInnerRadius: this.innerRadius,
-				ringWidth: this.ringWidth,
-				rangeMin: min,
-				rangeMax: max
+			startAngle: angle,
+			endAngle: angle,
+			innerRadius: radius,
+			outerRadius: radius,
+			text: chromosome.text,
+			color: color,      
+			class: mclass,     
+			chr: datum.chr,
+			position: datum.position,
+			logDistance: datum.logDistance,
+			ringInnerRadius: this.innerRadius,
+			ringWidth: this.ringWidth,
+			rangeMin: min,
+			rangeMax: max,
+			samples: datum.samples ?? (datum.sample ? [datum.sample] : [])
 			})
+
 		}
 
 		return points

--- a/client/plots/disco/waterfall/MutationWaterfallPoint.ts
+++ b/client/plots/disco/waterfall/MutationWaterfallPoint.ts
@@ -8,4 +8,8 @@ export default interface MutationWaterfallPoint extends Arc {
 	readonly ringWidth: number
 	readonly rangeMin: number
 	readonly rangeMax: number
+
+	class?: string          
+	samples?: string[]      
 }
+


### PR DESCRIPTION
# Description

This PR adds support for CNV_amp and CNV_loss in `MutationWaterfallMapper`. Key changes include:
- Assign `class` and `color` for CNV_amp (red) and CNV_loss (blue)
- Group multiple samples with identical CNV positions into a single point
- Add optional `class` and `samples` fields to `MutationWaterfallPoint` and `MutationWaterfallDatum` types
- Ensure TypeScript type safety for optional `sample` and `samples` fields
- Enable legend filtering and proper visualization of CNVs in the waterfall plot

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
