### PR TITLE
Fixes/improvements for qualitative binary term

### DIFF
--- a/shared/types/src/terms/q.ts
+++ b/shared/types/src/terms/q.ts
@@ -22,7 +22,7 @@ export type CategoricalBaseQ = MinBaseQ & {
 	mode?: 'discrete' | 'binary'
 }
 
-export type RawValuesQ = MinBaseQ & { type?: 'values'; mode?: 'binary' }
+export type RawValuesQ = MinBaseQ & { type?: 'values'; mode?: 'binary' | 'discrete' }
 
 export type RawPredefinedGroupsetQ = MinBaseQ & {
 	type: 'predefined-groupset'


### PR DESCRIPTION
# Description

Added a routing step for qualitative terms based on `q.mode`. For `q.mode=binary`, term will be routed to `QualCustomGS`, unless it has exactly 2 entries in `tw.term.values`, in which case it will be routed to `QualValues`.

Also, now `q.customset` will be filled in if it is missing. For `q.mode=binary`, categories will be evenly divided into two groups. Can test with this [example](http://localhost:3000/?mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22logistic%22,%22outcome%22:{%22id%22:%22diaggrp_s%22}}]}), and notice that the binary grouping is more even than that on master.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
