### PR TITLE
Re-enable check in QualValues.fill() for q.mode=binary

### DIFF
--- a/client/tw/qualitative.ts
+++ b/client/tw/qualitative.ts
@@ -183,19 +183,10 @@ export class QualValues extends QualitativeBase {
 		// GDC or other dataset may allow missing term.values
 		if (!term.values) term.values = {}
 
-		/*
-		logistic regression outcome variable will have q.mode='binary' and q.type='values' and will error out at here when Object.keys(tw.term.values).length != 2
-		for a quick fix, will skip this check
-		this will allow binary groups to be filled by maySetTwoGroups() in client/plots/regression.inputs.term.js
-		for long-term fix:
-			- In QualitativeBase.fill(), when tw.q.mode='binary', should route the tw to QualValues.fill() when Object.keys(tw.term.values).length == 2 to ensure that no groups are created
-			- Otherwise should route to QualCustomGS.fill() to fill 2 custom groups
-		*/
-		/*if (q.mode == 'binary') {
+		if (q.mode == 'binary') {
 			// a tw with q.type = 'values' can only have mode='binary' if it has exactly 2 values
-			if (tw.term.type == 'categorical' && Object.keys(tw.term.values).length != 2)
-				throw 'term.values must have exactly two keys'
-		}*/
+			if (Object.keys(term.values).length != 2) throw 'term.values must have two keys'
+		}
 
 		set_hiddenvalues(q, term as Term) // TODO: do not force type
 		// TODO: figure out not having to force the returned type


### PR DESCRIPTION
# Description

Re-enable check for binary terms in QualValues.fill(). Should have been included in recent PR (see https://github.com/stjude/proteinpaint/pull/3986).

Can test by using the `sex` term as outcome in logistic regression ([example](http://localhost:3000/?mass={%22dslabel%22:%22SJLife%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22regression%22,%22regressionType%22:%22logistic%22,%22outcome%22:{%22id%22:%22sex_s%22}}]})).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
