### PR TITLE
shrink localfilter ui in sandbox header

### DIFF
--- a/client/filter/FilterRxComp.js
+++ b/client/filter/FilterRxComp.js
@@ -63,11 +63,9 @@ class FilterRxComp extends Filter {
 
 	initHolder() {
 		const div = this.dom.holder
-			.attr('class', 'filter_div')
+			.attr('class', 'sjpp_filter_div')
 			.style('position', 'relative')
 			.style('width', 'fit-content')
-			.style('margin', '10px')
-			.style('margin-top', '5px')
 			.style('display', 'table')
 			.style('border', this.opts.hideLabel ? 'none' : 'solid 1px #ddd')
 

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -79,7 +79,7 @@ class TdbNav {
 				filter: filterRxCompInit({
 					app: this.app,
 					vocabApi: this.app.vocabApi,
-					holder: this.dom.subheader.filter.append('div'),
+					holder: this.dom.subheader.filter.append('div').style('margin', '5px'),
 					hideLabel: this.opts.header_mode === 'with_tabs',
 					emptyLabel: '+Add new filter',
 					callback: filter => {
@@ -247,11 +247,7 @@ function setRenderers(self) {
 
 			helpDiv: controlsDiv.append('div').style('display', 'none'),
 			sessionElapsedMessageDiv: controlsDiv.append('div').style('display', 'none'),
-			subheaderDiv: self.opts.holder
-				.append('div')
-				.style('display', 'block')
-				.style('padding-top', '5px')
-				.style('border-bottom', '1px solid #000'),
+			subheaderDiv: self.opts.holder.append('div').style('display', 'block').style('border-bottom', '1px solid #000'),
 			messageDiv: self.opts.holder.append('div').style('margin', '30px').style('display', 'none'),
 			titleDiv,
 			tip: new Menu({ padding: '5px' })

--- a/client/mass/plot.js
+++ b/client/mass/plot.js
@@ -151,11 +151,8 @@ function setRenderers(self) {
 					.style('padding-left', '7px')
 					.style('vertical-align', 'sub'),
 				localRecoverDiv: holder.header.append('div').style('display', 'inline-block'),
-				filterDiv: holder.header.append('div').style('display', 'inline-block'),
-				body: holder.body
-					// .style('margin-top', '-1px')
-					.style('white-space', 'nowrap')
-					.style('overflow-x', 'auto'),
+				filterDiv: holder.header.append('div').style('display', 'inline-block').style('zoom', 0.9),
+				body: holder.body.style('white-space', 'nowrap').style('overflow-x', 'auto'),
 
 				// will hold no data notice or the page title in multichart views
 				errdiv: holder.body

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -1,14 +1,12 @@
 import { getCompInit, copyMerge, type ComponentApi, type RxComponent } from '#rx'
 import { PlotBase, defaultUiLabels } from './PlotBase.ts'
-import { Menu } from '#dom/menu'
+import { Menu, Tabs } from '#dom'
 import { fillTermWrapper } from '#termsetting'
 import { recoverInit } from '../rx/src/recover'
-// import { select } from 'd3-selection'
 import { getDefaultViolinSettings } from './violin.js'
 import { getDefaultBarSettings } from './barchart.js'
 import { getDefaultBoxplotSettings } from './boxplot/defaults'
 import { getDefaultScatterSettings } from './scatter/scatter.js'
-import { Tabs } from '../dom/toggleButtons'
 import { isNumericTerm } from '#shared/terms.js'
 import { term0_term2_defaultQ } from './controls'
 import { importPlot } from './importPlot.js'
@@ -84,7 +82,7 @@ class SummaryPlot extends PlotBase implements RxComponent {
 				.style('vertical-align', 'sub'),
 			chartToggles: paneTitleDiv.append('div').style('display', 'inline-block').style('margin-left', '10px'),
 			localRecoverDiv: paneTitleDiv.append('div').style('display', 'inline-block'),
-			filterDiv: holder.header.append('div').style('display', 'inline-block')
+			filterDiv: holder.header.append('div').style('display', 'inline-block').style('zoom', 0.9)
 		}
 	}
 


### PR DESCRIPTION
# Description
current plot sandbox header is too tall due to use of localfilter ui
<img width="399" height="73" alt="image" src="https://github.com/user-attachments/assets/2fda22a9-ef0d-4fe5-b51b-9d2cd71323b9" />

this pr updated summary sandbox header as below

<img width="431" height="48" alt="image" src="https://github.com/user-attachments/assets/d61c8015-235a-4e29-83c0-ccf5284f60cd" />

TODOs:
1. non-summary plot sandbox headers are taller than summary e.g. scatter

<img width="545" height="58" alt="image" src="https://github.com/user-attachments/assets/5f079a67-bb04-445e-af60-e78be610dad4" />

2. filterUI gets taller by adding a tvs compared to placeholder. this is minor annoyance and see if you can find a fix
<img width="267" height="59" alt="image" src="https://github.com/user-attachments/assets/9d8e79c4-220b-4473-80a4-9ca568475bf4" />


all integration tests pass (except one summaryInput test always break on terminal also on master)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
