### PR TITLE
Fix for sample view download button bug

### DIFF
--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -472,7 +472,10 @@ class SampleView {
 		for (const sample of this.state.samples) {
 			sampleData[sample.sampleId] = await this.app.vocabApi.getSingleSampleData({
 				sampleId: sample.sampleId,
-				filter: this.state.termfilter.filter
+				/** term_ids is required for getSingleSampleData but not
+				 * available in this instance. Pass empty array.*/
+				term_ids: [],
+				filter: this.state.termfilter.filter || []
 			})
 			lines += `\t${sample.sampleName}`
 		}

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -542,6 +542,8 @@ export function server_init_db_queries(ds) {
 
 	q.getSingleSampleData = async function (q, ds) {
 		const { sampleId, term_ids } = q
+		if (!sampleId) throw new Error('sampleId is missing for q.getSingleSampleData() request.')
+		if (!term_ids) throw new Error('term_ids are missing for q.getSingleSampleData() request.')
 
 		if (ds.cohort.termdb.checkAccessToSampleData) {
 			const samples = ds.cohort.db.connection.prepare(`SELECT name FROM sampleidmap WHERE id=?`).all(sampleId)
@@ -553,7 +555,7 @@ export function server_init_db_queries(ds) {
 			if (!access.canAccess) throw access.message || 'No accessible data found for the sample provided'
 		}
 
-		const termClause = !term_ids.length ? '' : `and term_id in (${term_ids.map(() => '?').join(',')})`
+		const termClause = !term_ids?.length ? '' : `and term_id in (${term_ids.map(() => '?').join(',')})`
 		const query = `
 		select term_id, value, jsondata from ( select term_id, value 
 		from anno_categorical 


### PR DESCRIPTION
# Description

Fix for the noted broken sample view download button in the [ASHOP issue tracker](https://github.com/stjude/sjpp/issues/1009). Test with [this example.](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22sampleView%22,%22samples%22:%5B%7B%22sampleId%22:1,%22sampleName%22:%22SJMB030539%22%7D%5D%7D%5D%7D) 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
