### PR TITLE
Make p-value and 2x2 table in barchart tooltip conditional

### DIFF
--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -88,8 +88,12 @@ export default function getHandlers(self) {
 							negateTerm2Label = visibleTerm2Labels[0] == term2Label ? visibleTerm2Labels[1] : visibleTerm2Labels[0]
 					}
 
-					rows.push(
-						`<tr>
+					//Only show the p-value and 2x2 table in tooltip
+					//when the user enabled association tests
+					//from control panel
+					if (self.settings.showAssociationTests) {
+						rows.push(
+							`<tr>
 							<td style='padding:3px; color:#aaa'>p-value</td>
 							<td style='padding:3px; text-align:center'>${
 								skipped ? 'N/A' : pvalue > 1e-4 ? Number(pvalue.toFixed(4)) : roundValueAuto(Number(pvalue))
@@ -112,7 +116,8 @@ export default function getHandlers(self) {
 								<td>${tableValues.R2C2}</td>
 							</tr>
 						</table>`
-					)
+						)
+					}
 				}
 				if (!t1.type == 'condition' && (!t2 || !t2.type == 'condition')) {
 					rows.push(
@@ -811,7 +816,7 @@ async function menuoption_add_filter(self, tvslst, arg) {
 		if barchart is single-term, tvslst will have only one element
 		if barchart is two-term overlay, tvslst will have two elements, one for term1, the other for term2
 	arg: object of parameters used by getSampleGrp to get sample group
-  	*/
+		*/
 	if (!tvslst) return
 	if (!self.state.termfilter || self.state.nav?.header_mode !== 'with_tabs') {
 		// do not display ui, and do not collect callbacks
@@ -905,7 +910,7 @@ function menuoption_select_group_add_to_cart(self, tvslst) {
 
 function getTermValues(d, self) {
 	/*
-    d: clicked bar data
+	d: clicked bar data
   */
 	const termValues = []
 	if (self.state.nav?.header_mode == 'with_cohortHtmlSelect') {


### PR DESCRIPTION
# Description

This is a small feature request from the [ASHOP issue tracker](https://github.com/stjude/sjpp/issues/1009). When `Show association tests` is unchecked, the p-value and 2x2 table does not appear in the bar tooltip on hover. Test with [this barchart example](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22diaggrp%22},%22term2%22:{%22id%22:%22genetic_race%22}}]})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
