### PR TITLE
fix the detection of when to show the deduplicate input in barchart control menu

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -1,4 +1,4 @@
-import { getCompInit, copyMerge } from '../rx'
+import { getCompInit, copyMerge, deepEqual } from '../rx'
 import getHandlers from './barchart.events'
 import barsRenderer from './bars.renderer'
 import rendererSettings from './bars.settings'
@@ -212,7 +212,16 @@ export class Barchart extends PlotBase {
 					settingsKey: 'dedup',
 					boxLabel: 'Yes',
 					getDisplayStyle: plot =>
-						this.chartsData?.charts.find(c => c.serieses.length != c.dedupedSerieses.length) ? 'table-row' : 'none'
+						this.chartsData?.charts.find(
+							c =>
+								c.dedupedSerieses?.length &&
+								!deepEqual(
+									c.serieses.map(s => s.seriesId),
+									c.dedupedSerieses.map(s => s.seriesId)
+								)
+						)
+							? 'table-row'
+							: 'none'
 				}
 			]
 			if (isNumericTerm(this.config.term.term))


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2668.

Tested manually:
- see the description in the JIRA ticket
- also tested that an SJLife barchart with `Arrhythmias: Any grade` main term and `Sex` overlay still shows the `Deduplicate` input and is hidden when changed to `Arrhythmias: Max grade`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
