### PR TITLE
Fixed changing legend order in survival plot

### DIFF
--- a/client/dom/renderAtRisk.js
+++ b/client/dom/renderAtRisk.js
@@ -10,12 +10,12 @@ input parameter:
     g: selection
     s: {} self.settings
     chart: {} chart object
-    term2values: TODO: is this ever defined?
+    order: [] array of series ids to specify series order
     term2toColor: {} map term2 values to colors
 }
 */
 
-export function renderAtRiskG({ g, s, chart, term2values, term2toColor, onSerieClick }) {
+export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }) {
 	const bySeries = {}
 
 	// do not compute at-risk counts of tick values that are
@@ -63,22 +63,7 @@ export function renderAtRiskG({ g, s, chart, term2values, term2toColor, onSerieC
 	// fully rerender, later may reuse previously rendered elements
 	// g.selectAll('*').remove()
 
-	const seriesOrder = chart.serieses.map(s => s.seriesId)
-	if (term2values) {
-		seriesOrder.sort((aId, bId) => {
-			const av = term2values[aId]
-			const bv = term2values[bId]
-			if (av && bv) {
-				if ('order' in av && 'order' in bv) return av.order - bv.order
-				if (av.order) return av.order
-				if (bv.order) return bv.order
-				return 0
-			}
-			if (av) return av.order || 0
-			if (bv) return bv.order || 0
-			return 0
-		})
-	}
+	const seriesOrder = order || chart.serieses.map(s => s.seriesId)
 
 	let data
 	g.selectAll('.sjpp-atrisk-title').remove()

--- a/client/plots/cuminc.js
+++ b/client/plots/cuminc.js
@@ -942,7 +942,6 @@ function setRenderers(self) {
 			g: atRiskG,
 			s,
 			chart,
-			term2values: self.config.term2?.values,
 			term2toColor: self.term2toColor,
 			onSerieClick: self.legendClick
 		})


### PR DESCRIPTION
# Description

Fixed JIRA issue: https://gdc-ctds.atlassian.net/browse/SV-2682

Can now move series up and down in survival plot legend. Can test with this [example](http://localhost:3000/?mass={%22dslabel%22:%22MB_meta_analysis2%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22survival%22,%22term2%22:{%22id%22:%22Molecular%20Subgroup%22},%22term%22:{%22id%22:%22Overall%20Survival%22}}]}).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
