### PR TITLE
do not show matrix colspace when colw < 7, previously set to <2

### DIFF
--- a/client/plots/matrix/matrix.layout.js
+++ b/client/plots/matrix/matrix.layout.js
@@ -50,7 +50,7 @@ export function setAutoDimensions(xOffset) {
 		const colwNoSpace = Math.max(s.colwMin, Math.min(noSpacedColw, s.colwMax))
 
 		// when cell has very small width, do not show colspace and set colw without considering colspace
-		if (colwNoSpace * s.zoomLevel < 2) {
+		if (colwNoSpace * s.zoomLevel < 7) {
 			// do not show colspace
 			this.computedSettings.colw = noSpacedColw
 			this.computedSettings.colspace = 0

--- a/client/plots/matrix/test/matrix.integration.spec.js
+++ b/client/plots/matrix/test/matrix.integration.spec.js
@@ -2483,7 +2483,7 @@ tape('cell brush zoom in', function (test) {
 
 		matrix.on('postRender.test', () => {
 			matrix.on('postRender.test', null)
-			test.deepEqual(matrix.Inner.settings.matrix.zoomLevel, 4, 'should have the expected zoom level after zoom in')
+			test.deepEqual(matrix.Inner.settings.matrix.zoomLevel, 3.2, 'should have the expected zoom level after zoom in')
 			if (test._ok) matrix.Inner.app.destroy()
 			test.end()
 		})


### PR DESCRIPTION
# Description

Tested locally with all unit tests and matrix + hierCluster integration tests. Also with Mutation Signature plot in ASH dataset.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
