### PR TITLE
do not use a mutation observer for the root holder in puppet.html 

### DIFF
--- a/client/src/app.observer.js
+++ b/client/src/app.observer.js
@@ -40,6 +40,7 @@ const observedElems = new WeakSet()
   The 'client/menu.js' code has `setTabNavigation()` for this reason.
 */
 export function observeElem(elem) {
+	if (window.location.pathname === '/puppet.html') return
 	if (observedElems.has(elem)) return
 	observedElems.add(elem)
 	observer.observe(elem, { childList: true, subtree: true })


### PR DESCRIPTION
# Description

This branch fixes the headless integration test CI by not running `.sja_root_holder` mutation observer.

Tested locally and in https://github.com/stjude/proteinpaint/actions/runs/20138169515.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
