### PR TITLE
fix: Genevariant tvs edit menu no longer auto-scrolls to selected row…

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -44,6 +44,7 @@ export function renderTable({
 	inputName = null,
 	dataTestId = null,
 	download = undefined,
+	noAutoScroll = false,
 	hoverEffects
 }: TableArgs) {
 	validateInput()
@@ -250,14 +251,20 @@ export function renderTable({
 							tr.style(key, checked ? _selectedRowStyle[key] : '')
 						}
 					})
-				//Do not scroll when all rows are selected. Problem appears when sorting.
-				if (selectedRows.length != rows.length && rowIdx === selectedRows[0] && tr.node()) {
-					// if there is at least one selected row (but not all rows are selected),
-					// scroll to the  table row,so that it's visible and obvious to the user
-					// which rows are pre-selected
-					setTimeout(() => {
-						tr.node()?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-					}, 500)
+				if (noAutoScroll) {
+					// this setting prevents auto scrolling. this is needed due to an unresolved defect that on showing a small table e.g. categorical tvs, the page scrolls undesirably
+					// Edgar's comment: so the fix should just be to take the table height/table cell screen position into account. Somehow, scrollIntoView() is not accurate for the embedded table row
+				} else {
+					// table is allowed to auto scroll to selected rows. this is desirable to auto-show selected rows from a large table
+					//Do not scroll when all rows are selected. Problem appears when sorting.
+					if (selectedRows.length != rows.length && rowIdx === selectedRows[0] && tr.node()) {
+						// if there is at least one selected row (but not all rows are selected),
+						// scroll to the  table row,so that it's visible and obvious to the user
+						// which rows are pre-selected
+						setTimeout(() => {
+							tr.node()?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+						}, 500)
+					}
 				}
 
 				const checked = checkbox.property('checked')

--- a/client/dom/types/table.ts
+++ b/client/dom/types/table.ts
@@ -150,4 +150,6 @@ export type TableArgs = {
 	 * use noButtonCallback instead
 	 */
 	hoverEffects?: (tr: Tr, row: TableRow) => void
+	/** Table will not auto-scroll to selected row. quick fix. see comments in code */
+	noAutoScroll?: boolean
 }

--- a/client/filter/tvs.js
+++ b/client/filter/tvs.js
@@ -251,6 +251,7 @@ function setRenderers(self) {
 			striped: false,
 			showLines: false,
 			selectedRows: selectedIdxs,
+			noAutoScroll: true,
 			selectedRowStyle: {
 				'text-decoration': tvs.isnot ? 'line-through' : ''
 			}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Genevariant tvs edit menu no longer auto-scrolls to selected row that causes page to scroll


### PR DESCRIPTION
… that causes page to scroll

# Description

[genevariant tvs edit ui](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:3},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22diaggrp%22},%22settings%22:{%22barchart%22:{%22plotLength%22:799,%22orientation%22:%22vertical%22}}}],%22termfilter%22:{%22filter%22:{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22and%22,%22lst%22:[{%22tag%22:%22cohortFilter%22,%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22subcohort%22,%22type%22:%22multivalue%22},%22values%22:[{%22key%22:%22ABC%22,%22label%22:%22ABC%22}]}},{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22snvindel_somatic%22,%22query%22:%22snvindel%22,%22name%22:%22SNV/indel%20(somatic)%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22dtsnvindel%22,%22dt%22:1,%22values%22:{%22M%22:{%22label%22:%22MISSENSE%22},%22F%22:{%22label%22:%22FRAMESHIFT%22},%22WT%22:{%22label%22:%22Wildtype%22}},%22name_noOrigin%22:%22SNV/indel%22,%22origin%22:%22somatic%22,%22parentTerm%22:{%22type%22:%22geneVariant%22,%22id%22:%22TP53%22,%22name%22:%22TP53%22,%22genes%22:[{%22kind%22:%22gene%22,%22id%22:%22TP53%22,%22gene%22:%22TP53%22,%22name%22:%22TP53%22,%22type%22:%22geneVariant%22}]}},%22values%22:[{%22key%22:%22M%22,%22label%22:%22MISSENSE%22,%22value%22:%22M%22,%22bar_width_frac%22:null}]}}],%22tag%22:%22filterUiRoot%22,%22$id%22:2}]}}}) no longer scrolls page on opening

[scrna sample table](http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22GDC%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22singleCellPlot%22,%22sample%22:%222409%22,%22experimentID%22:%229f155433-3c2e-4b67-a452-eb32f06c93f7%22,%22activeTab%22:2}]}) still scrolls to selected sample
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
