### PR TITLE
GRIN2: Fix for Rust Plot Q-filtering

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- GRIN2: Improved rust plotting logic to not filter out q-value = 0 values

--- a/rust/src/manhattan_plot.rs
+++ b/rust/src/manhattan_plot.rs
@@ -217,8 +217,10 @@ fn grin2_file_read(
                 Some(q) => q,
                 None => continue,
             };
+
             let q_val: f64 = match q_val_str.parse() {
                 Ok(v) if v > 0.0 => v,
+                Ok(v) if v == 0.0 => 1e-300, // Treat exact 0 as ~1e-300 so we can still show q-values that are 0 and not filter them out
                 _ => continue,
             };
             let neg_log10_q = -q_val.log10();


### PR DESCRIPTION
# Description
Improved rust plotting logic to not filter out q-value = 0 values. Rust will need to be recompiled.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
