### PR TITLE
fix confusing scroll behavior of a menu for a clicked element

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- attach menu div to sticky-positioned ancestor element, instead of body, to prevent confusing scroll behavior


### PR DESCRIPTION
# Description

This fix attaches the menu div to sticky-positioned ancestor element (the MASS UI `nav` div) instead of `document.body`, to prevent confusing scroll behavior.

This fix replaces https://github.com/stjude/proteinpaint/pull/4033, since the `position-anchor` approach seems to have a browser bug where scrolling the body causes the `tethered`/anchored element to lose mouse events.

If this approach also uncovers new bugs, then the last-ditch fix might be to hide the menu when the body starts scrolling.

Tested locally with all unit and integration tests. Also tested manually:
- with [tall bachart](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:3%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22diaggrp%22%7D,%22settings%22:%7B%22barchart%22:%7B%22plotLength%22:799,%22orientation%22:%22vertical%22%7D%7D%7D%5D,%22termfilter%22:%7B%22filter%22:%7B%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22and%22,%22lst%22:%5B%7B%22tag%22:%22cohortFilter%22,%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22subcohort%22,%22type%22:%22multivalue%22%7D,%22values%22:%5B%7B%22key%22:%22ABC%22,%22label%22:%22ABC%22%7D%5D%7D%7D,%7B%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22snvindel_somatic%22,%22query%22:%22snvindel%22,%22name%22:%22SNV/indel%20(somatic)%22,%22parent_id%22:null,%22isleaf%22:true,%22type%22:%22dtsnvindel%22,%22dt%22:1,%22values%22:%7B%22M%22:%7B%22label%22:%22MISSENSE%22%7D,%22F%22:%7B%22label%22:%22FRAMESHIFT%22%7D,%22WT%22:%7B%22label%22:%22Wildtype%22%7D%7D,%22name_noOrigin%22:%22SNV/indel%22,%22origin%22:%22somatic%22,%22parentTerm%22:%7B%22type%22:%22geneVariant%22,%22id%22:%22TP53%22,%22name%22:%22TP53%22,%22genes%22:%5B%7B%22kind%22:%22gene%22,%22id%22:%22TP53%22,%22gene%22:%22TP53%22,%22name%22:%22TP53%22,%22type%22:%22geneVariant%22%7D%5D%7D%7D,%22values%22:%5B%7B%22key%22:%22M%22,%22label%22:%22MISSENSE%22,%22value%22:%22M%22,%22bar_width_frac%22:null%7D%5D%7D%7D%5D,%22tag%22:%22filterUiRoot%22,%22$id%22:2%7D%5D%7D%7D%7D): scroll down to the bottom of the barchart, then click on the filter pill to edit, then scroll the body. The edit menu should stay with the `Edit` label and not move with the body.
- using the same link as above, open the `Charts` tab and click on `Survival` button, the menu that launches should not scroll with the body
- repeat the above for the `Groups` tab and `Session` button: a menu that is launched from either DOM element should not scroll with the body

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
