### PR TITLE
make the download menu tab-navigable 

### DIFF
--- a/client/dom/downloadMenu.ts
+++ b/client/dom/downloadMenu.ts
@@ -15,12 +15,13 @@ export class DownloadMenu {
 		this.filename = filename.replace(/\s/g, '_')
 	}
 
-	show(x, y) {
+	show(x, y, elem = null) {
 		this.menu.clear()
 		const menuDiv = this.menu.d.append('div')
 		menuDiv
 			.append('div')
 			.attr('class', 'sja_menuoption sja_sharp_border')
+			.attr('tabindex', 0)
 			.text('PDF Portrait')
 			.on('click', () => {
 				downloadSVGsAsPdf(this.chartImages, this.filename, 'portrait')
@@ -53,7 +54,7 @@ export class DownloadMenu {
 						downloadSingleSVG(chart.svg, chart.name.replace(/[^a-zA-Z0-9]/g, '_'), chart.svg.node(), chart.name)
 					this.menu.hide()
 				})
-		this.menu.show(x - 20, y - 10)
+		this.menu.show(x - 20, y - 10, true, true, true, elem)
 	}
 }
 

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -1155,7 +1155,7 @@ function setInteractivity(self) {
 	self.download = function (event) {
 		const charts = self.getChartImages()
 		const dm = new DownloadMenu(charts, self.config.term.term.name)
-		dm.show(event.clientX, event.clientY)
+		dm.show(event.clientX, event.clientY, event.target)
 	}
 
 	/** Downloads all charts as a single svg image, including the legend for each barchart, needs review as it

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -216,7 +216,7 @@ export class TdbBoxplot extends PlotBase implements RxComponent {
 		if (!this.state) return
 		const name2svg = this.getChartImages()
 		const dm = new DownloadMenu(name2svg, this.state.config.term.term.name)
-		dm.show(event.clientX, event.clientY)
+		dm.show(event.clientX, event.clientY, event.target)
 	}
 }
 

--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -589,7 +589,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 	async download(event) {
 		const chartImages = this.getChartImages()
 		const menu = new DownloadMenu(chartImages, this.getDownloadFilename())
-		menu.show(event.clientX, event.clientY)
+		menu.show(event.clientX, event.clientY, event.target)
 	}
 
 	preApiFreeze(api) {

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -179,7 +179,7 @@ export class Scatter extends PlotBase implements RxComponent {
 		} else {
 			const name2svg = this.getChartImages()
 			const menu = new DownloadMenu(name2svg, 'scatter')
-			menu.show(event.clientX, event.clientY)
+			menu.show(event.clientX, event.clientY, event.target)
 		}
 	}
 

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -1032,7 +1032,7 @@ function setInteractivity(self) {
 	self.download = function (event) {
 		const charts = self.getChartImages()
 		const menu = new DownloadMenu(charts, self.state.config.term.term.name)
-		menu.show(event.clientX, event.clientY)
+		menu.show(event.clientX, event.clientY, event.target)
 	}
 
 	self.getChartImages = function () {

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -21,7 +21,7 @@ export function setInteractivity(self) {
 		if (!self.state) return
 		const name2svg = self.getChartImages()
 		const dm = new DownloadMenu(name2svg, self.config.term.term.name)
-		dm.show(event.clientX, event.clientY)
+		dm.show(event.clientX, event.clientY, event.target)
 	}
 
 	self.displayLabelClickMenu = function (t1, t2, plot, event) {


### PR DESCRIPTION
# Description

... from the clicked download icon and back.

Tested locally with all unit and integration tests. Also tested by tabbing through the plot sandbox in an [example barchart URL](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22diaggrp%22},%22term2%22:{%22id%22:%22genetic_race%22},%22filter%22:{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22type%22:%22categorical%22,%22name%22:%22XX%22,%22id%22:%22sex%22},%22values%22:[{%22key%22:%222%22,%22label%22:%22Female%22}]}}]}}]}), tabbiing should reach the download button and after clicking `Enter` while that's in focus, should shift focus to the first option in the menu that opens, then `shift+tab` should move focus back to the download icon. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
