### PR TITLE
use 365.25 instead of 365 for converting days to years

### DIFF
--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -432,7 +432,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 			case 'weeks':
 				return (1 / numUnitInOneYear) * 52
 			case 'days':
-				return (1 / numUnitInOneYear) * 365
+				return (1 / numUnitInOneYear) * 365.25
 			default:
 				throw 'unknown time Unit for survival data'
 		}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- use 365.25 instead of 365 for converting days to years

--- a/server/src/gdc.buildDictionary.js
+++ b/server/src/gdc.buildDictionary.js
@@ -337,7 +337,7 @@ function mayAddTermAttribute(t) {
 		//show the term by other units
 		// print 25868 as '70 years, 318 days'
 		t.valueConversion = {
-			scaleFactor: 1 / 365,
+			scaleFactor: 1 / 365.25,
 			fromUnit: 'day',
 			toUnit: 'year'
 		}

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1451,7 +1451,7 @@ async function querySamplesSurvival(q, survivalTwLst, ds, samples, geneTwLst) {
 		// assign survival data for this sample
 		s[survivalTwLst[0].term.id] = {
 			key: d.censored ? 0 : 1,
-			value: Number((d.time / 365).toFixed(2)) // convert to years
+			value: Number((d.time / 365.25).toFixed(2)) // convert to years
 		}
 	}
 }


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2627. 

Tested manually using http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC, click on `I447V MISSENSE` disc/dot at the right end of the plot. The `Age at diagnosis` has different days value between `master` and this branch.

<img width="475" height="484" alt="Screenshot 2025-12-18 at 10 31 56 AM" src="https://github.com/user-attachments/assets/371173ea-5bbe-4a20-aaf2-8469dc9621b5" />

<img width="466" height="483" alt="Screenshot 2025-12-18 at 10 29 26 AM" src="https://github.com/user-attachments/assets/71133a9e-ad6c-415b-9091-c224fec33ab0" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
