### PR TITLE
do not automatically shift the focus away from a search input 

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -279,10 +279,10 @@ export class Menu {
 				elem.focus() // shift focus back to the clicked elem that launched the menu, when shift-tabbing from the firt focusable child element
 				this.hide()
 			})
-		// .node()
-		// .focus(); console.log(270, clickableElems[0]);
 
-		setTimeout(() => (clickableElems.find(priorityFocusElem) || clickableElems[0]).focus(), renderWait)
+		if (elem?.type !== 'search') {
+			setTimeout(() => (clickableElems.find(priorityFocusElem) || clickableElems[0]).focus(), renderWait)
+		}
 	}
 
 	showunderoffset(dom) {
@@ -424,8 +424,10 @@ export class Menu {
 	}
 }
 
+// within the menu, the focus should go to what the user would likely use first,
+// instead of going by the layout order
 function priorityFocusElem(elem, i) {
-	return elem.tagName == 'INPUT' && (elem.type == 'search' || elem.type == 'text')
+	return elem.tagName == 'INPUT' && elem.type == 'search'
 }
 
 // find an element that has a matching computed CSS key-value

--- a/client/dom/search.ts
+++ b/client/dom/search.ts
@@ -51,7 +51,7 @@ export class InputSearch {
 
 	constructor(opts: InputSearchOpts) {
 		this.holder = opts.holder
-		this.input = opts.holder.append('input')
+		this.input = opts.holder.append('input').attr('type', 'search')
 		this.tip = opts.tip || new Menu({ border: '', padding: '0px' })
 		this.style = opts.style || {}
 		this.size = opts.size || 20


### PR DESCRIPTION
# Description

... when it launches a menu.

This fixes an issue with omnisearch and other search inputs losing focus, such as while typing in the input. This bug was introduced by a recent Section 508 fix. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
