### PR TITLE
Remove violin plot error message when plot re-renders

### DIFF
--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -319,6 +319,12 @@ class ViolinPlot extends PlotBase {
 				this.config.term.term.name + ` <span style="opacity:.6;font-size:1em;margin-left:10px;">Violin Plot</span>`
 			)
 
+		//Fix for rm'ing error message when plot re-renders
+		//Leave in main() so the message doesn't linger whilst
+		//the plot is rendering
+		const existingMsg = this.dom.banner.select('span')
+		if (!existingMsg.empty()) existingMsg.remove()
+
 		const args = this.validateArgs()
 		let data
 		try {


### PR DESCRIPTION
# Description

Minor fix: If the violin plot shows the error message "No visible violin plot data to render", the message remains after the plot re-renders from a state change. 

Test: 
Use[this example](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22},%22q%22:{%22mode%22:%22continuous%22}},%22term2%22:{%22id%22:%22sex%22}}]}) and replace `Sex` with any other term. The error message should disappear when the plot re-renders. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
