### PR TITLE
add violin control for median color

### DIFF
--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -249,6 +249,13 @@ class ViolinPlot extends PlotBase {
 				debounceInterval: 1000
 			},
 			{
+				label: 'Median color',
+				title: 'color of median',
+				type: 'color',
+				chartType: 'violin',
+				settingsKey: 'medianColor'
+			},
+			{
 				label: 'Median thickness',
 				title: 'Width of median',
 				type: 'number',
@@ -259,9 +266,8 @@ class ViolinPlot extends PlotBase {
 				min: 3,
 				debounceInterval: 100
 			},
-
 			{
-				label: 'Default color',
+				label: 'Default violin color',
 				type: 'color',
 				chartType: 'violin',
 				settingsKey: 'defaultColor'
@@ -416,6 +422,7 @@ export function getDefaultViolinSettings(app, overrides = {}) {
 		unit: 'abs', // abs: absolute scale, log: log scale
 		rowSpace: 10,
 		medianLength: 7,
+		medianColor: '#FF0000',
 		medianThickness: 3,
 		ticks: 15,
 		defaultColor: plotColor,

--- a/client/plots/violin.renderer.js
+++ b/client/plots/violin.renderer.js
@@ -451,7 +451,7 @@ export default function setViolinRenderer(self) {
 				.append('line')
 				.attr('class', 'sjpp-median-line')
 				.style('stroke-width', s.medianThickness)
-				.style('stroke', 'red')
+				.style('stroke', s.medianColor)
 				.style('opacity', '0.5')
 				.attr('y1', isH ? -s.medianLength : median)
 				.attr('y2', isH ? s.medianLength : median)


### PR DESCRIPTION
# Description

Add control for changing median color, so that median bar is visible when violin is red color. Also increase upper limit for symbol/median length/thickness


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
