### PR TITLE
Do not display termtypeselect toggles in geneVariant dictionary

### DIFF
--- a/client/filter/FilterClass.js
+++ b/client/filter/FilterClass.js
@@ -22,6 +22,10 @@ const defaults = {
 		button or prompt to add the 
 		first user-configurable filter item
 
+	.header_mode (e.g. 'hide_search')
+		optional setting for header of tree menu
+		will be supplied to termdb app state in filter.interactivity.js 
+
 
 	Coding convenience:
 	- use $id for data binding to match  

--- a/client/filter/filter.interactivity.js
+++ b/client/filter/filter.interactivity.js
@@ -228,7 +228,8 @@ export function setInteractivity(self) {
 			state: {
 				activeCohort: self.activeCohort,
 				termfilter: { filter: rootFilterCopy },
-				tree: { usecase: { target: 'filter' } }
+				tree: { usecase: { target: 'filter' } },
+				nav: { header_mode: self.opts.header_mode }
 			},
 			tree: {
 				disable_terms:
@@ -329,7 +330,7 @@ export function setInteractivity(self) {
 			getCategoriesArguments: self.opts.getCategoriesArguments,
 			state: {
 				activeCohort: self.activeCohort,
-				header_mode: 'search_only',
+				nav: { header_mode: self.opts.header_mode || 'search_only' },
 				termfilter: { filter: self.getAdjustedRoot(filter.$id, filter.join) },
 				tree: { usecase: { target: 'filter' } }
 			},

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -144,8 +144,10 @@ async function makeGroupUI(self: TermSetting, div) {
 
 	// build frontend vocab using child dt terms
 	const vocabApi: any = vocabInit({ vocab: { terms: self.term.childTerms } })
-	// including termdbConfig.queries, as it is needed for cnv tvs (see getDtCnvType() in filter/tvs.js and fillMenu() in filter/tvs.dtcnv.continuous.js)
-	// not passing entire termdbConfig as presence of .allowedTermTypes will trigger term type toggles (see init() in termdb/TermTypeSearch.ts)
+	// need termdbConfig.queries for cnv tvs (see getDtCnvType() in filter/tvs.js and
+	// fillMenu() in filter/tvs.dtcnv.continuous.js)
+	// not passing complete termdbConfig as presence of .allowedTermTypes will
+	// trigger term type toggles (see init() in termdb/TermTypeSearch.ts)
 	vocabApi.termdbConfig = { queries: self.vocabApi.termdbConfig.queries }
 
 	// filter prompt
@@ -153,6 +155,7 @@ async function makeGroupUI(self: TermSetting, div) {
 		holder: addNewGroupBtnHolder,
 		vocabApi,
 		emptyLabel: 'Add group',
+		header_mode: 'hide_search',
 		callback: f => {
 			const filter = getNormalRoot(f)
 			addNewGroup(filter, self.groups)
@@ -236,6 +239,7 @@ async function makeGroupUI(self: TermSetting, div) {
 		filterInit({
 			holder: row[3].__td,
 			vocabApi,
+			header_mode: 'hide_search',
 			callback: f => {
 				if (!f || f.lst.length == 0) {
 					// blank filter (user removed last tvs from this filter), delete this element from groups[]


### PR DESCRIPTION
# Description

`.allowedTermTypes` was present in termdbConfig of geneVariant frontend vocab, which was causing the termtype toggles to appear in frontend dictionary. Now only `.queries` is present, as it is needed for cnv tvs.

Can test by opening [matrix](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22matrix%22,%22divideBy%22:{%22id%22:%22sex%22},%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22AKT1%22,%22type%22:%22geneVariant%22}},{%22id%22:%22efs%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}},{%22id%22:%22diaggrp%22},{%22term%22:{%22gene%22:%22TP53%22,%22type%22:%22geneExpression%22}}]}]}]}), click on gene row label > Edit > Add group , the ui should not display termtypeselect toggles

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
