### PR TITLE
correctly handle the case of rawFilter == global filter in getFilterExcludingPill()

### DIFF
--- a/client/filter/FilterClass.js
+++ b/client/filter/FilterClass.js
@@ -3,6 +3,7 @@ import { setInteractivity } from './filter.interactivity'
 import { findItem, findParent, getFilterItemByTag, getNormalRoot, filterJoin } from './filter.utils'
 import { vocabInit } from '#termdb/vocabulary'
 import { Menu } from '#dom/menu'
+import { deepEqual } from '#rx'
 
 const defaults = {
 	joinWith: ['and', 'or']
@@ -37,6 +38,9 @@ const defaults = {
 		non-child elements with the same classnames
 */
 
+// filter it should increment across all filter instances
+// let id=0
+
 export class Filter {
 	constructor(opts) {
 		this.opts = this.validateOpts(opts)
@@ -61,7 +65,7 @@ export class Filter {
 			})
 		}
 		this.durations = { exit: 500 }
-		this.lastId = 0
+		this.lastId = 0 //id++
 		this.categoryData = {}
 		this.pills = {}
 		setInteractivity(this)
@@ -209,7 +213,11 @@ export class Filter {
 		parentCopy.lst.splice(i, 1)
 		if (parentCopy.lst.length < 2) parentCopy.join = ''
 		const globalFilter = this.app?.getState().termfilter?.filter
-		return getNormalRoot(!globalFilter ? rootCopy : filterJoin([rootCopy, globalFilter]))
+		if (!globalFilter) return rootCopy
+		// detect if the rawFilter is equivalent to the global filter
+		if (deepEqual(getNormalRoot(this.rawFilter), getNormalRoot(globalFilter))) return rootCopy
+		// the rawFilter must be a local (plot) filter
+		return getNormalRoot(filterJoin([rootCopy, globalFilter]))
 		/*
 		!!! 
 			The logic below incorectly assumes that there are at most 2 root tvslst.lst entries,

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- correctly handle the case of rawFilter == global filter in getFilterExcludingPill()

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2843,7 +2843,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		let geneVariantFilter
 		if (q.filter) {
 			geneVariantFilter = structuredClone(q.filter)
-			geneVariantFilter.lst = q.filter.lst.filter(item => dtTermTypes.has(item.tvs.term.type))
+			geneVariantFilter.lst = q.filter.lst.filter(item => dtTermTypes.has(item.tvs?.term.type))
 		}
 		const groupset = get_active_groupset(tw.term, tw.q)
 		for (const [sample, mlst] of sample2mlst) {


### PR DESCRIPTION
# Description

Tested with [ASH dataset,](http://localhost:3000/?mass=%7B%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:3%7D,%22termfilter%22:%7B%22filter%22:%7B%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22Diagnosis%22%7D,%22values%22:%5B%7B%22key%22:%22AML%22%7D%5D%7D%7D%5D%7D%7D%7D) the filter edit menu should show all categories.

Also tested locally with all unit and integration tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
