### PR TITLE
menu.showunder() always return self for chaining

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -226,7 +226,7 @@ export class Menu {
 	showunder(elem, _opts = {}) {
 		// route to .show()
 		const opts = Object.assign({ offsetX: 0, offsetY: 0 }, _opts)
-		if (this.stickyPosition(elem, opts)) return
+		if (this.stickyPosition(elem, opts)) return this
 		const p = elem.getBoundingClientRect()
 		const x = p.left + window.scrollX + opts.offsetX
 		const y = p.top + p.height + window.scrollY + 5 + opts.offsetY
@@ -312,7 +312,7 @@ export class Menu {
 
 	showunderoffset(dom) {
 		const p = dom.getBoundingClientRect()
-		if (this.stickyPosition(dom, { offsetY: -p.height, offsetX: p.width })) return
+		if (this.stickyPosition(dom, { offsetY: -p.height, offsetX: p.width })) return this
 
 		const y = p.top + p.height + window.scrollY + 5
 		return this.show(p.left, y, true, true, false)

--- a/client/dom/select2Terms.js
+++ b/client/dom/select2Terms.js
@@ -87,10 +87,8 @@ export function select2Terms(tip, app, chartType, detail, callback, detail2) {
 		const disable_terms = []
 		if (xterm) disable_terms.push(xterm)
 		if (yterm) disable_terms.push(yterm)
-		tip2.clear()
-		tip2.showunder(div.node())
 		appInit({
-			holder: tip2.d,
+			holder: tip2.clear().showunder(div.node()).d,
 			vocabApi: app.vocabApi,
 			state: {
 				activeCohort: app.getState().activeCohort,


### PR DESCRIPTION
# Description
term selection in dynamic scatter works
all CI tests passed
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
