### PR TITLE
Redesign `Mutation vs CNV` submission UI

### DIFF
--- a/client/plots/summarizeMutationCnv.ts
+++ b/client/plots/summarizeMutationCnv.ts
@@ -59,32 +59,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 			callback: async () => {
 				mutSearchPrompt.text('LOADING ...')
 				try {
-					const name = result.geneSymbol
-					mutTw = {
-						term: {
-							id: name,
-							name,
-							genes: [
-								{
-									kind: 'gene',
-									id: name,
-									gene: name,
-									name,
-									type: 'geneVariant'
-								}
-							],
-							type: 'geneVariant'
-						},
-						q: { type: 'predefined-groupset' }
-					}
-					await fillTermWrapper(mutTw, chartsInstance.app.vocabApi)
-					// get index of groupset corresponding to dtsnvindel
-					const i = mutTw.term.groupsetting.lst.findIndex(groupset => groupset.dt == dtsnvindel)
-					if (i == -1) throw 'dtsnvindel not found in groupsets'
-					mutTw.q.predefined_groupset_idx = i
-					// update $id after setting predefined_groupset_idx (to distinguish from cnvTw)
-					mutTw.$id = await get$id(chartsInstance.app.vocabApi.getTwMinCopy(mutTw))
-
+					mutTw = await fillGeneTw(result.geneSymbol, dtsnvindel)
 					await updateUi()
 					if (cnvGeneSameAsMut) launch()
 					mutSearchPrompt.text('')
@@ -111,32 +86,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 			callback: async () => {
 				cnvSearchPrompt.text('LOADING ...')
 				try {
-					const name = result.geneSymbol
-					cnvTw = {
-						term: {
-							id: name,
-							name,
-							genes: [
-								{
-									kind: 'gene',
-									id: name,
-									gene: name,
-									name,
-									type: 'geneVariant'
-								}
-							],
-							type: 'geneVariant'
-						},
-						q: { type: 'predefined-groupset' }
-					}
-					await fillTermWrapper(cnvTw, chartsInstance.app.vocabApi)
-					// get index of groupset corresponding to dtcnv
-					const i = cnvTw.term.groupsetting.lst.findIndex(groupset => groupset.dt == dtcnv)
-					if (i == -1) throw 'dtcnv not found in groupsets'
-					cnvTw.q.predefined_groupset_idx = i
-					// update $id after setting predefined_groupset_idx (to distinguish from mutTw)
-					cnvTw.$id = await get$id(chartsInstance.app.vocabApi.getTwMinCopy(cnvTw))
-
+					cnvTw = await fillGeneTw(result.geneSymbol, dtcnv)
 					await updateUi()
 					cnvSearchPrompt.text('')
 				} catch (e: any) {
@@ -174,6 +124,35 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 	}
 
 	updateUi()
+
+	async function fillGeneTw(geneSymbol, dt) {
+		const name = geneSymbol
+		const tw: any = {
+			term: {
+				id: name,
+				name,
+				genes: [
+					{
+						kind: 'gene',
+						id: name,
+						gene: name,
+						name,
+						type: 'geneVariant'
+					}
+				],
+				type: 'geneVariant'
+			},
+			q: { type: 'predefined-groupset' }
+		}
+		await fillTermWrapper(tw, chartsInstance.app.vocabApi)
+		// get index of groupset corresponding to dt
+		const i = tw.term.groupsetting.lst.findIndex(groupset => groupset.dt == dt)
+		if (i == -1) throw 'dt not found in groupsets'
+		tw.q.predefined_groupset_idx = i
+		// update $id after setting predefined_groupset_idx (to distinguish from other gene tw)
+		tw.$id = await get$id(chartsInstance.app.vocabApi.getTwMinCopy(tw))
+		return tw
+	}
 
 	function launch() {
 		if (!mutTw || !cnvTw) throw 'either tw is missing'


### PR DESCRIPTION
# Description

Redesigned submission UI of `Mutation vs CNV` plot to be similar to that of `CNV vs Gene Expression` plot. Open [GDC correlation plot](http://localhost:3000/?noheader=1&gdccorrelation=1&filter0={%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.primary_site%22,%22value%22:[%22brain%22,%22breast%22]}}) and click on `Mutation vs CNV` chart button.

Partially addresses https://gdc-ctds.atlassian.net/browse/FEAT-894.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
