### PR TITLE
fix: restore old singlecell gene exp violin by supplying q.mode=conti…

### DIFF
--- a/client/plots/singleCellPlot.js
+++ b/client/plots/singleCellPlot.js
@@ -627,7 +627,8 @@ class singleCellPlot {
 									sID: this.state.config.sample,
 									eID: this.state.config.experimentID
 								}
-							}
+							},
+							q: { mode: 'continuous' }
 						},
 						term2: {
 							$id: await digestMessage(`${colorBy}-${this.state.config.sample}-${this.state.config.experimentID}`),

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- restore old singlecell gene exp violin by supplying q.mode=continuous


### PR DESCRIPTION
…nuous

# Description

[test link](http://localhost:3000/?mass={%22genome%22:%22hg38-test%22,%22dslabel%22:%22TermdbTest%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22singleCellPlot%22,%22sample%22:%221_patient%22,%22activeTab%22:2}]}) same for gdc

sc gene violin should be broken on qa now and this fix is required

no need to create any test as the old singlecell plot will be replaced by sc soon @creilly8 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
