### PR TITLE
Do not join to global filter in getTreeFilter() if the join argument='or'

### DIFF
--- a/client/filter/filter.interactivity.js
+++ b/client/filter/filter.interactivity.js
@@ -244,17 +244,18 @@ export function setInteractivity(self) {
 		})
 	}
 
-	self.getTreeFilter = (d, filter) => {
+	// join='and' | 'or'
+	self.getTreeFilter = (join, filter) => {
 		const filterCopy = filter
 			? filter
 			: self.activeData
-			? self.getAdjustedRoot(self.activeData.filter.$id, d)
+			? self.getAdjustedRoot(self.activeData.filter.$id, join)
 			: JSON.parse(self.rawCopy)
 
 		if (filterCopy.lst.length < 2) filterCopy.join = ''
 
 		const globalFilter = self.opts?.app?.getState()?.termfilter?.filter
-		return globalFilter ? filterJoin([filterCopy, globalFilter]) : filterCopy
+		return globalFilter && join != 'or' ? filterJoin([filterCopy, globalFilter]) : filterCopy
 	}
 
 	/*

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- do not join to global filter in getTreeFilter() if the join argument is 'or', so that the edit menu will list all applicable categories


### PR DESCRIPTION
# Description

… so that the edit menu will list all applicable categories

[Test link](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:3%7D,%22termfilter%22:%7B%22filter%22:%7B%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22sex%22%7D,%22values%22:%5B%7B%22key%22:%221%22%7D%5D%7D%7D%5D%7D%7D%7D) - click +OR and select diaggrp, should show a full set of categories

Also tested locally with all unit and integration tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
