### PR TITLE
Remove loading message after rendering

### DIFF
--- a/client/termsetting/TermSettingApi.ts
+++ b/client/termsetting/TermSettingApi.ts
@@ -113,10 +113,12 @@ export class TermSettingApi {
 				click_term: async t => {
 					// set up timer to display loading message
 					let showLoading = true
+					let loadingShown = false
 					const loadingTimer = setTimeout(() => {
 						if (showLoading) {
 							self.dom.nopilldiv.text('Loading ...')
 							self.dom.pilldiv.text('Loading ...')
+							loadingShown = true
 						}
 					}, 200)
 
@@ -138,6 +140,10 @@ export class TermSettingApi {
 					// stop the loading message from appearing
 					showLoading = false
 					clearTimeout(loadingTimer)
+					if (loadingShown) {
+						self.dom.nopilldiv.text('')
+						self.dom.pilldiv.text('')
+					}
 				}
 			}
 		})


### PR DESCRIPTION
# Description

Open [boxplot](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:[%22Gliomas%22]}}},%22nav%22:{%22header_mode%22:%22hidden%22},%22genome%22:%22hg38%22,%22plots%22:[{%22chartType%22:%22summary%22,%22childType%22:%22boxplot%22,%22term%22:{%22id%22:%22case.demographic.age_at_index%22,%22q%22:{%22mode%22:%22continuous%22}}}]}) and then add a geneVariant term (e.g. IDH1) as overlay term. The `Loading...` message no longer remains in the controls panel.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
