### PR TITLE
track ignored errors during dataset init and show in healthcheck

### DIFF
--- a/server/routes/healthcheck.ts
+++ b/server/routes/healthcheck.ts
@@ -12,7 +12,8 @@ export const api: RouteApi = {
 	}
 }
 
-function init({ genomes }) {
+function init(arg) {
+	const genomes: any = arg.genomes
 	return async (req, res): Promise<void> => {
 		try {
 			const q: HealthCheckRequest = req.query

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -20,6 +20,7 @@ const dsHelpers = {
 	may_add_readdepth,
 	mapGenes2isoforms,
 	isUsableTerm,
+	cachedFetch: utils.cachedFetch,
 	joinUrl
 }
 

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -862,13 +862,15 @@ const RecoverableErrorCodes = new Set([
 const RecoverableHTTPcodes = new Set([500, 502, 503, 504])
 
 // for convenience, combine custom pp status strings with http status number codes
-export const nonFatalStatus = new Set(['done', 'nonblocking', 'recoverableError', ...RecoverableHTTPcodes])
+export const nonFatalStatus = new Set(['started', 'done', 'nonblocking', 'recoverableError', ...RecoverableHTTPcodes])
 
 // only use this helper when catching errors that may be due to
 // external API server errors or network connection failures;
 // the `e` argument is expected to have a network-related error code, some of which
 // may be recovered from (temp maintenance or disconnect), others are fatal
-export function isRecoverableError(e) {
+export function isRecoverableError(e, opts = {}) {
+	if (e.status == 'fatalError') return false
+
 	// detect if status maps to a known HTTP 5xx server error code
 	if (typeof e.status == 'number') return RecoverableHTTPcodes.has(e.status)
 	if (e.status == 'recoverableError') return true

--- a/shared/types/src/routes/healthcheck.ts
+++ b/shared/types/src/routes/healthcheck.ts
@@ -55,6 +55,7 @@ export type HealthCheckResponse = {
 	}
 	w?: number[]
 	rs?: number
+	dsInitStatus: any[]
 }
 
 export const healthcheckPayload: RoutePayload = {


### PR DESCRIPTION
# Description

To test, uncomment line ~472 of `gdc.buildDictionary.ts`. The `ignoredErrors` property should be shown in 
- a `byDataset{}` entry in http://localhost:3000/healthcheck?dslabel=GDC
- a `dsInitStatus` entry in  http://localhost:3000/healthcheck

Also tested by running all unit and integration tests locally.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
