### PR TITLE
Map renderer fix

### DIFF
--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -35,6 +35,9 @@ class WSIViewer extends PlotBase implements RxComponent {
 	private map: OLMap | undefined = undefined
 	private annotationTable: any
 
+	// New: persistent MapRenderer instance reused across main() calls
+	private mapRenderer: MapRenderer | undefined
+
 	constructor(opts: any, api) {
 		super(opts, api)
 		this.type = 'WSIViewer'
@@ -129,6 +132,16 @@ class WSIViewer extends PlotBase implements RxComponent {
 
 		const imageViewData: ImageViewData = viewModel.getImageViewData(settings.displayedImageIndex)
 
+		// set MapRenderer state here: ensure the persistent renderer receives current state
+		if (!this.mapRenderer) {
+			this.mapRenderer = new MapRenderer()
+		}
+		this.mapRenderer.setState(
+			activeLayerData,
+			this.wsiViewerInteractions.viewerClickListener,
+			viewModel.sampleWSImages[settings.displayedImageIndex]
+		)
+
 		if (settings.renderWSIViewer) {
 			this.wsiViewerInteractions.toggleLoadingDiv(settings.renderAnnotationTable)
 
@@ -148,14 +161,8 @@ class WSIViewer extends PlotBase implements RxComponent {
 				numTotalFiles
 			)
 
-			// TODO extract state from MapRenderer
-
-			this.map = new MapRenderer(
-				activeLayerData,
-				this.wsiViewerInteractions.viewerClickListener,
-				viewModel.sampleWSImages[settings.displayedImageIndex],
-				settings
-			).render(this.dom.mapHolder, settings)
+			// Use the reused mapRenderer instance to render/update the map
+			this.map = this.mapRenderer.render(this.dom.mapHolder, settings)
 
 			if (activeImageExtent && this.map) {
 				this.map.getView().fit(activeImageExtent)


### PR DESCRIPTION
# Description

Fix the MapRenderer state issue.

How to reproduce:

1. Select 4 tiles by mouse clicks.
2. Add 4 annotations 
3. Delete the annotation that was first added
4. Select the annotation that was added second

The viewer and the table get into a non-sync state:

<img width="663" height="448" alt="Screenshot 2026-01-15 at 6 57 52 PM" src="https://github.com/user-attachments/assets/62c2aab8-bec6-4eff-8426-42bd85f7ff63" />

This PR fixes this issue. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
