### PR TITLE
create a unit test of x-ndjson-nestedkeys handling on client side

### DIFF
--- a/client/filter/test/filter.unit.spec.js
+++ b/client/filter/test/filter.unit.spec.js
@@ -213,8 +213,6 @@ tape('getFilterExcludingPill()', async test => {
 		)
 	}
 
-	console.log(216, f0.getTreeFilter, f0)
-
 	if (test._ok) f0.destroy()
 	test.end()
 })


### PR DESCRIPTION
# Description

Tested with http://localhost:3000/testrun.html?dir=../shared/utils/src&name=fetch-helpers.unit

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
