### PR TITLE
Numeric series label in survival plot

### DIFF
--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -19,6 +19,7 @@ import { renderPvalues } from '#dom/renderPvalueTable'
 import { downloadChart } from '#common/svg.download'
 import { getCombinedTermFilter } from '#filter'
 import { DownloadMenu } from '#dom/downloadMenu'
+import { isNumericTerm } from '#shared/terms.js'
 
 export const t0_t2_defaultQ = structuredClone(term0_term2_defaultQ)
 Object.assign(t0_t2_defaultQ, {
@@ -1377,6 +1378,12 @@ function getPj(self) {
 				const seriesId = context.self.seriesId
 				if (t2?.q?.type == 'predefined-groupset' || t2?.q?.type == 'custom-groupset') return seriesId
 				if (t2 && t2.term.values && seriesId in t2.term.values) return t2.term.values[seriesId].label
+				if (isNumericTerm(t2.term)) {
+					// numeric term
+					// seriesId on its own (e.g. "<5") will be vague,
+					// so include term name in series label
+					return t2.term.name + ' ' + seriesId
+				}
 				return seriesId
 			},
 			timeCensored(row) {


### PR DESCRIPTION
# Description

Addresses issue in: https://github.com/stjude/sjpp/issues/1009

For numeric terms in survival plot, the series label now includes the term name. Can test with [numeric dictionary term](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22survival%22,%22term%22:{%22id%22:%22Overall_Survival%22},%22term2%22:{%22id%22:%22AgeAtDiagnosis%22}}]}) and [geneExpression term](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22survival%22,%22term%22:{%22id%22:%22Overall_Survival%22},%22term2%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22}}}]}). Please test further.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
