### PR TITLE
Disable term editing in matrix when term is under a group value filter

### DIFF
--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -730,12 +730,15 @@ function setTermActions(self) {
 		const termMenuWaitDiv = self.dom.menutop.append('div').style('display', 'block').text('Loading...')
 		self.dom.tip.show(event.clientX - 20, event.clientY - 20)
 
-		await self.pill.main(
-			Object.assign(
-				{ menuOptions: self.getMenuOptions(t), filter: self.state.filter },
-				t.tw ? t.tw : { term: null, q: null }
-			)
+		const pillArg = Object.assign(
+			{ menuOptions: self.getMenuOptions(t), filter: self.state.filter },
+			t.tw ? t.tw : { term: null, q: null }
 		)
+
+		mayAddEditMsg(pillArg, t)
+
+		await self.pill.main(pillArg)
+
 		termMenuWaitDiv.remove()
 
 		self.dom.shortcutDiv = self.dom.menutop.append('div').style('z-index', 10000)
@@ -3777,4 +3780,13 @@ function getLabel(c, v, p) {
 			: mclass[v.class].label
 
 	return label
+}
+
+// if group value filter is defined, then cannot reliably edit term
+// notify user in edit menu
+function mayAddEditMsg(arg, t) {
+	if (!t.grp.valueFilter) return
+	const editMsg =
+		'Cannot edit variable because group value filter is in use.<br>Please add new variable/variable group to enable editing.'
+	arg.editMsg = editMsg
 }

--- a/client/termsetting/TermSettingApi.ts
+++ b/client/termsetting/TermSettingApi.ts
@@ -183,7 +183,11 @@ export class TermSettingApi {
 			options.push({
 				label: 'Edit',
 				callback: async div => {
-					await self.handler.showEditMenu(div.append('div'))
+					if (self.data.editMsg) {
+						div.append('div').style('margin', '10px').html(self.data.editMsg)
+					} else {
+						await self.handler.showEditMenu(div.append('div'))
+					}
 				}
 			} as opt)
 		}


### PR DESCRIPTION
# Description

Addresses issue in https://github.com/stjude/sjpp/issues/1009

In master, when opening [panMB](http://localhost:3000/panMB/?role=user) -> `Sample Matrix` -> `Complete cohort view` prebuilt matrix, and then editing a geneVariant term to use groupsetting, the cells of the term in the matrix are not rendered properly.

This is because the group of geneVariant terms in this prebuilt matrix contains a group value filter (see `termgroups[].valueFilter{}` in the prebuilt json file) and this filter is not compatible with geneVariant groupsetting.

We decided on a general solution that it would not be appropriate to edit any term that is under a group value filter because the filter is not displayed in the UI and the user will not be aware of how the edits to the term interact with the filter. So now a message is displayed in the edit menu of a term when the term is under a group value filter.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
