### PR TITLE
Only allow searching by gene for geneVariant term

### DIFF
--- a/client/termdb/handlers/geneVariant.ts
+++ b/client/termdb/handlers/geneVariant.ts
@@ -88,6 +88,12 @@ export class SearchHandler {
 			tip: new Menu({ padding: '0px' }),
 			genome: this.opts.genomeObj,
 			row: this.dom.searchDiv,
+			/* only allowing gene search for now because:
+			- coordinate search is not yet supported for gdc
+			- for other datasets, even though coordinate search is supported, it is not compatible with input type radios (single gene vs. geneset) because a coordinate may include one or more genes.
+			TODO: fully support coordinate search
+			*/
+			searchOnly: 'gene',
 			callback: async () => await this.selectGene(geneSearch)
 		})
 		this.dom.searchDiv.select('.sja_genesearchinput').style('margin', '0px')


### PR DESCRIPTION
# Description

Addresses https://gdc-ctds.atlassian.net/browse/SV-2715?focusedCommentId=79003&sourceType=mention

Only allowing user to search by gene name for geneVariant term for now because:
- coordinate search is not yet supported for gdc
- for other datasets, even though coordinate search is supported, it is not compatible with input type radios (single gene vs. geneset) because a coordinate may include one or more genes.

In future, will fully support coordinate search for geneVariant term.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
