### PR TITLE
Matrix stream end

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- may detect the end of matrix data streaming using sampleIndex instead of the lastSampleId, which may not have data

--- a/server/src/termdb.get_matrix.js
+++ b/server/src/termdb.get_matrix.js
@@ -104,7 +104,7 @@ export async function get_matrix(q, req, res, ds, genome) {
 				this.push(JSON.stringify([['samples', id], data.samples[id]]) + '\n')
 				delete data.samples[id]
 			}
-			if (unsentSampleIds.has(lastSampleId)) {
+			if (unsentSampleIds.has(lastSampleId) || sampleIndex >= sampleEntries.length) {
 				this.push(JSON.stringify([['refs'], data.refs]) + '\n')
 				// uncomment below to test warning message if rendered by client-side plot code
 				// this.push(JSON.stringify([['warning'], {message: '!!! TEST !!!'}]) + '\n')


### PR DESCRIPTION
# Description

Fixes the detection of end of data streaming in `/termdb?for=matrix`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
