### PR TITLE
convert legacy qualitative q.mode='values' to discrete

### DIFF
--- a/client/tw/qualitative.ts
+++ b/client/tw/qualitative.ts
@@ -73,9 +73,11 @@ export class QualitativeBase extends TwBase {
 			copyMerge(tw.q, opts.defaultQ)
 		}
 		// set a default q.mode for clarity, otherwise `mode?: 'binary'` may seem like the only option
-		// NOTE: many code that process categorical tw already assume discrete mode, without checking q.mode,
+		// NOTES:
+		// - many code that process categorical tw already assume discrete mode, without checking q.mode,
 		// except for applications that allow or require q.mode='binary'
-		if (!tw.q.mode) tw.q.mode = 'discrete'
+		// - may convert legacy q.mode
+		if (!tw.q.mode || tw.q.mode == 'values') tw.q.mode = 'discrete'
 
 		// set q.type based on q.mode
 		switch (tw.q.mode) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- convert legacy qualitative q.mode='values' to discrete

--- a/shared/types/src/terms/q.ts
+++ b/shared/types/src/terms/q.ts
@@ -22,7 +22,10 @@ export type CategoricalBaseQ = MinBaseQ & {
 	mode?: 'discrete' | 'binary'
 }
 
-export type RawValuesQ = MinBaseQ & { type?: 'values'; mode?: 'binary' | 'discrete' }
+export type RawValuesQ = MinBaseQ & {
+	type?: 'values'
+	mode?: 'binary' | 'discrete' | 'values' // legacy support for 'values', will be converted to 'discrete'
+}
 
 export type RawPredefinedGroupsetQ = MinBaseQ & {
 	type: 'predefined-groupset'


### PR DESCRIPTION
# Description

Tested with http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22IHG%22}, there should not be an error (`qualitative tw.q.mode not supported`).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
