### PR TITLE
fix chart button menu visibility

### DIFF
--- a/client/dom/menu.js
+++ b/client/dom/menu.js
@@ -346,7 +346,9 @@ export class Menu {
 		// if there is no sticky ancestor, allow showunder() and showunderoffset() to work as usual
 		if (!stickyAncestor) return false
 
-		const yPos = Number(this.d.style('top').replace('px', '')) // y-position before any relevant scrolling has occurred
+		const top = this.d.style('top')
+		if (!top.endsWith('px')) return
+		const yPos = Number(top.replace('px', '')) // y-position before any relevant scrolling has occurred
 		let yStickyScroll = 0
 
 		// The IntersectionObserver approach below is much reliable than a previous fix

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -7,6 +7,8 @@ import { importPlot } from '#plots/importPlot.js'
 class MassCharts {
 	constructor(opts = {}) {
 		this.type = 'charts'
+		// stickyAncestor will attached to button data, to be used by menu.stickyPosition()
+		// when showing the menu tip near a clicked chart button
 		this.stickyAncestor = getAncestorWithComputedStyle(opts.holder.node(), 'position', new Set(['sticky', 'fixed']))
 		setRenderers(this)
 	}


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2716.

Test:
- pull `sjpp/master`
- open http://localhost:3000/example.gdc.correlation.html?noheader=1&cohort=APOLLO-LUAD: there should be a footer
- follow the steps in the JIRA ticket and also scroll up and down once the chart button menu is open

Also tested in local GFF:

<img width="1464" height="594" alt="Screenshot 2026-02-01 at 12 49 26 PM" src="https://github.com/user-attachments/assets/cb3bd7e7-b2c8-4fd3-8e58-01062f70c59b" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
