### PR TITLE
mass ui should indicate ds error on init

### DIFF
--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -340,6 +340,7 @@ export async function validate_termdb(ds) {
 		}
 	}
 	if (tdb.numericTermCollections) {
+		throw 'xxx'
 		if (!Array.isArray(tdb.numericTermCollections)) throw 'termdb.numericTermCollections not array'
 		for (const c of tdb.numericTermCollections) {
 			if (!c.name) throw 'unamed tdb.numericTermCollections'


### PR DESCRIPTION
# Description
temp change now causes TermdbTest to fail with non-recoverable error
[mass ui](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22diaggrp%22},%22term2%22:{%22id%22:%22genetic_race%22},%22filter%22:{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22type%22:%22categorical%22,%22name%22:%22XX%22,%22id%22:%22sex%22},%22values%22:[{%22key%22:%222%22,%22label%22:%22Female%22}]}}]}}]}) still loads but chart query crashes with unrelated error. 

i think a fix should be termdb/config route detects if a ds has failed, and if so, return error and abort ui, rather than still returning a tdbcfg obj to allow mass ui to show, as if the ds is fine and misleading
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
