### PR TITLE
GRIN2: Minor grin2PpWrapper optimizations 

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GRIN2: Removed unnecessary data copy. Now using dynamic lesion types sent by client

--- a/server/routes/grin2.ts
+++ b/server/routes/grin2.ts
@@ -260,7 +260,6 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request): Promise<GRIN2Re
 		chromosomelist: {} as { [key: string]: number },
 		lesion: JSON.stringify(lesions),
 		cacheFileName: generateCacheFileName(),
-		availableDataTypes: availableDataTypes,
 		maxGenesToShow: request.maxGenesToShow,
 		lesionTypeMap: buildLesionTypeMap(availableDataTypes)
 	}


### PR DESCRIPTION
# Description
Removed unnecessary data copy. Now using dynamic lesion types sent by client. 

# Closes
GRIN2 roadmap number 2

# Testing
Tested on ASH, ASH2, and Termdbtest and a couple of other large molecular subtypes. Results are as expected

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
