### PR TITLE
GRIN2: Fix to hide the cache file from stats table 

### DIFF
--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -875,6 +875,9 @@ class GRIN2 extends PlotBase implements RxComponent {
 		if (result.stats?.lst) {
 			const tablesContainer = this.dom.div.append('div').style('margin-top', '50px')
 
+			// Fields to hide from display
+			const hiddenFields = new Set(['Total Genes', 'Showing Top', 'Cache File Name'])
+
 			for (const section of result.stats.lst) {
 				tablesContainer
 					.append('h4')
@@ -885,7 +888,10 @@ class GRIN2 extends PlotBase implements RxComponent {
 
 				const table = table2col({ holder: tablesContainer.append('div'), margin: '2px 8px' })
 				for (const [k, v] of section.rows) {
-					table.addRow(k, v)
+					// Only add row if the key is not in the hidden fields set
+					if (!hiddenFields.has(k)) {
+						table.addRow(k, v)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# Description
Fix to hide the cache file and other miscellaneous fields (top genes and total genes) from the stats table while still returning them in the stats `lst` object as they are displayed in the top gene header title showing how many genes are shown in the table out of the total.

# Testing
Go to any test link and see that cache file name, top genes, and total genes are no longer reported in the stats table. 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
