### PR TITLE
Use the `.maxGeneVariantGeneSetSize` dataset parameter to specify max gene set size

### DIFF
--- a/client/termdb/handlers/geneVariant.ts
+++ b/client/termdb/handlers/geneVariant.ts
@@ -20,6 +20,7 @@ export class SearchHandler {
 	term: any // tw.term
 	q: any // tw.q
 	callback: any
+	maxNumGenes: any
 
 	async init(opts: Opts) {
 		this.opts = opts
@@ -27,6 +28,7 @@ export class SearchHandler {
 		this.term = { type: 'geneVariant' }
 		this.q = { type: 'predefined-groupset' }
 		this.callback = opts.callback
+		this.maxNumGenes = this.opts.app.vocabApi.termdbConfig?.maxGeneVariantGeneSetSize || 200 // max # genes allowed
 		opts.holder.style('padding', '5px 10px 10px 25px')
 		this.dom.typeSettingDiv = opts.holder.append('div')
 		this.dom.searchDiv = opts.holder
@@ -149,7 +151,7 @@ export class SearchHandler {
 			genome: this.opts.genomeObj,
 			vocabApi: this.opts.app.vocabApi,
 			nameInput: true,
-			maxNumGenes: 200, // max limit for # genes
+			maxNumGenes: this.maxNumGenes,
 			callback: async result => await this.selectGeneSet(result)
 		})
 		this.dom.searchDiv.select('.sja_genesetinput').style('padding', '0px').style('margin-top', '-10px')

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -119,6 +119,7 @@ function make(q, req, res, ds: Mds3WithCohort, genome) {
 	if (ds.assayAvailability) c.assayAvailability = ds.assayAvailability
 	if (ds.cohort.correlationVolcano) c.correlationVolcano = ds.cohort.correlationVolcano
 	if (ds.cohort.boxplots) c.boxplots = ds.cohort.boxplots
+	if (tdb.maxGeneVariantGeneSetSize) c.maxGeneVariantGeneSetSize = tdb.maxGeneVariantGeneSetSize
 	addRestrictAncestries(c, tdb)
 	addScatterplots(c, ds)
 	addMatrixplots(c, ds)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2715,7 +2715,8 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 		// query genes concurrently to speed up geneset query
 		// limit to 50 genes at a time (otherwise gdc query can fail)
 		if (!tw.term.genes?.length) throw 'tw.term.genes[] is empty'
-		if (tw.term.genes.length > 200) throw 'gene set size exceeds 200 genes'
+		const maxNumGenes = ds.cohort.termdb.maxGeneVariantGeneSetSize || 200
+		if (tw.term.genes.length > maxNumGenes) throw `gene set size exceeds ${maxNumGenes} genes`
 		const termdbmclass = q.ds?.cohort?.termdb?.mclass // custom mclass labels from dataset
 		const chunkSize = 50
 		for (let i = 0; i < tw.term.genes.length; i += chunkSize) {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1586,6 +1586,8 @@ keep this setting here for reason of:
 		/** key is string as disease/survial etc, value is tw */
 		[index: string]: Tw
 	}
+	/** maximum number of genes to query in geneVariant gene set */
+	maxGeneVariantGeneSetSize?: number
 	//terms  are shown in the dictionary based on term and user role.
 	isTermVisible?: (clientAuthResult: any, ids: string) => boolean
 	hiddenIds?: string[]


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1174

Use the new `.maxGeneVariantGeneSetSize` parameter specified in dataset to set the maximum number of genes allowed in geneVariant gene set. If this parameter is not provided, the max number will default to 200.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
