### PR TITLE
Allow querying both `term.id` and `term.name` for search string in gdc

### DIFF
--- a/server/src/gdc.buildDictionary.js
+++ b/server/src/gdc.buildDictionary.js
@@ -691,7 +691,11 @@ function makeTermdbQueries(ds, id2term) {
 		const terms = []
 		for (const term of id2term.values()) {
 			if (usecase && !isUsableTerm(term, usecase)) continue
-			if (term.id.includes(searchStr)) terms.push(JSON.parse(JSON.stringify(term)))
+			const id = term.id.toLowerCase()
+			const name = term.name.toLowerCase()
+			// allow to search both id and name to accommodate differences between
+			// these properties (e.g. for gender term, id=*gender* and name=*sex*)
+			if (id.includes(searchStr) || name.includes(searchStr)) terms.push(JSON.parse(JSON.stringify(term)))
 		}
 		await mayAddSamplecount4treeFilter(terms, treeFilter)
 		return terms
@@ -711,7 +715,14 @@ function makeTermdbQueries(ds, id2term) {
 		}
 		return ancestorIds
 	}
-	q.getAncestorNames = q.getAncestorIDs
+	q.getAncestorNames = id => {
+		const ancestorIds = q.getAncestorIDs(id)
+		const ancestorNames = ancestorIds.map(ancestorId => {
+			const ancestorTerm = id2term.get(ancestorId)
+			return ancestorTerm.name
+		})
+		return ancestorNames
+	}
 
 	q.termjsonByOneid = id => {
 		const t = id2term.get(id)


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2736

When searching gdc dictionary, the search string will now query both `term.id` and `term.name` for a match. This allows the search string `sex` to match the gender term which has `id=*gender*` and `name=*sex*`. Note that the search string `gender` will also match this term.

Also, `q.getAncestorNames()` in gdc will now retrieve term names of ancestors instead of term ids.

<img width="728" height="332" alt="Screenshot 2026-02-06 at 3 03 54 PM" src="https://github.com/user-attachments/assets/90e5fc05-8342-44ee-8abe-70087f5d98ee" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
