### PR TITLE
detect component triggerAbort() as a prototype method 

### DIFF
--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -77,7 +77,8 @@ export async function init(
 					]
 				})
 			}
-		}
+		},
+		triggerAbort: (reason = '') => massApi.triggerAbort(reason)
 	}
 
 	return api

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -105,9 +105,11 @@ class TdbConfigUiInit {
 				.style('left', 0)
 				.style('height', '100%')
 				.style('width', '100%')
-				.style('background-color', `rgba(240,240,240,0.6)`)
+				.style('background-color', `rgba(255,255,255,0.7)`)
 				.style('display', 'none')
 		}
+
+		this.dom.loadingDiv.append('div').attr('class', 'sjpp-spinner')
 
 		this.loadingMasks = [this.dom.loadingDiv]
 		if (this.opts.loadingMasks) this.loadingMasks.push(...this.opts.loadingMasks)

--- a/client/plots/summaryInput.ts
+++ b/client/plots/summaryInput.ts
@@ -156,7 +156,7 @@ class SummaryInputPlot extends PlotBase implements RxComponent {
 			.style('left', 0)
 			.style('height', '100%')
 			.style('width', '100%')
-			.style('background-color', `rgba(240,240,240,0.6)`)
+			.style('background-color', `rgba(255,255,255,0.7)`)
 			.style('display', 'none')
 	}
 

--- a/client/rx/src/AppApi.ts
+++ b/client/rx/src/AppApi.ts
@@ -220,15 +220,17 @@ export class AppApi {
 			const component = self.components[name]
 			if (!component) continue
 			if (Array.isArray(component)) {
-				for (const c of component) c.triggerAbort()
-			} else if (typeof component == 'object') {
-				if (Object.keys(component).includes('triggerAbort')) {
-					component.triggerAbort()
-				} else if (!component.main) {
-					for (const subname of Object.keys(component)) {
-						if (typeof component[subname].triggerAbort == 'function') {
-							component[subname].triggerAbort()
-						}
+				for (const c of component) c.triggerAbort?.()
+			} else if (!component || typeof component !== 'object') {
+				continue
+			} else if (typeof component.triggerAbort == 'function') {
+				// NOTE: triggerAbort() is a prototype method, cannot use Object.keys(component).includes('triggerAbort')
+				// which does not detect prototype/inherited methods
+				component.triggerAbort()
+			} else if (!component.main) {
+				for (const subname of Object.keys(component)) {
+					if (typeof component[subname].triggerAbort === 'function') {
+						component[subname].triggerAbort()
 					}
 				}
 			}

--- a/client/rx/src/ComponentApi.ts
+++ b/client/rx/src/ComponentApi.ts
@@ -268,12 +268,16 @@ export class ComponentApi {
 		for (const name of Object.keys(self.components)) {
 			const component = self.components[name]
 			if (Array.isArray(component)) {
-				for (const c of component) c.triggerAbort()
-			} else if (Object.keys(component).includes('triggerAbort')) {
+				for (const c of component) c.triggerAbort?.()
+			} else if (!component || typeof component !== 'object') {
+				continue
+			} else if (typeof component.triggerAbort === 'function') {
+				// NOTE: triggerAbort() is a prototype method, cannot use Object.keys(component).includes('triggerAbort')
+				// which does not detect prototype/inherited methods
 				component.triggerAbort()
-			} else if (component && typeof component == 'object' && !component.main) {
+			} else if (!component.main) {
 				for (const subname of Object.keys(component)) {
-					if (typeof component[subname].triggerAbort == 'function') {
+					if (typeof component[subname].triggerAbort === 'function') {
 						component[subname].triggerAbort()
 					}
 				}
@@ -290,6 +294,7 @@ export class ComponentApi {
 	}
 
 	destroy() {
+		this.triggerAbort()
 		const self = this.#Component
 		// delete references to other objects to make it easier
 		// for automatic garbage collection to find unreferenced objects

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,3 @@
+Fixes:
+- detect component triggerAbort() as an prototype method and support correlation plot triggerAbort() to cancel stale network requests
+- detect component triggerAbort() as a prototype method and support correlation plot triggerAbort() to cancel stale network requests


### PR DESCRIPTION
# Description

Fix the data request cancellation using triggerAbort, and support `triggerAbort()` for correlation plot.

Fixes https://gdc-ctds.atlassian.net/browse/SV-2737.

Tested in local GFF:
- have browser dev tools Network tab open
- open a correlation plot
- choose Overall Survival as Primary Variable
- correlate with Gene Expression KRAS
- nicer looking loading mask will show up
- click Submit once it's clickable
- close the analysis tool container div: the `/termdb` request should get cancelled

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
