### PR TITLE
Compute ticks helper for color scale in matrix legend

### DIFF
--- a/client/dom/ColorScale/helpers.ts
+++ b/client/dom/ColorScale/helpers.ts
@@ -108,3 +108,24 @@ export function removeInterpolatedOutliers(
 	const range = domain.map(d => domainRange.range[domainRange.domain.indexOf(d)])
 	return { domain, range }
 }
+
+/** Compute the num of desired ticks based on the domain range.
+ * Helper mimics the behavior of d3's scale.ticks() method,
+ * which calculates the tick num based on the domain
+ * range and a target number of intervals. Affords the caller more precision.
+ * @param domainRange - the range of the domain (max - min)
+ * @param targetIntervals - the desired number of intervals between ticks (i.e. numTicks -1)
+ * @returns the computed number of ticks
+ */
+export function computeTicks(domainRange: number, targetIntervals: number): number {
+	if (!isFinite(domainRange) || domainRange === 0) return 1
+	const intervals = Math.max(1, targetIntervals ?? 4)
+	const rawStep = domainRange / intervals
+
+	if (!isFinite(rawStep) || rawStep <= 0) return 1
+	const pow10 = Math.pow(10, Math.floor(Math.log10(rawStep)))
+	const norm = rawStep / pow10 // in [1, 10)
+	const nice = norm <= 1 ? 1 : norm <= 3 ? 3 : norm <= 5 ? 5 : 10
+	const niceStep = nice * pow10 >= 1 ? nice * pow10 : 1
+	return niceStep
+}

--- a/client/dom/svg.legend.js
+++ b/client/dom/svg.legend.js
@@ -1,5 +1,5 @@
 import { select } from 'd3-selection'
-import { ColorScale } from '#dom'
+import { ColorScale, computeTicks } from '#dom'
 
 export default function svgLegend(opts) {
 	let currlinex = 0
@@ -220,7 +220,7 @@ export default function svgLegend(opts) {
 				holder: g,
 				id: colorGradientId,
 				position: `${bbox.width + 25},${yPos}`,
-				ticks: 3,
+				ticks: computeTicks(domainRange, 2),
 				tickSize: 2,
 				topTicks: true
 			}
@@ -228,14 +228,7 @@ export default function svgLegend(opts) {
 				opts.labels = d.labels
 				if (d.text) opts.position = `${bbox.width + bbox.x + 45 + settings.padx},${yPos}`
 			}
-			// Ticks must be spaced appropriately for loss and gain
-			// scales. Lowering the range for smaller ranges
-			// appropriates spaces the scale ticks
-			if ((min == 0 || max == 0) && domainRange > 1) {
-				opts.ticks = domainRange > 5 ? 2 : 1
-			}
 			if (d.numericInputs) opts.numericInputs = d.numericInputs
-			if (d.removeDuplicates) opts.removeDuplicates = d.removeDuplicates
 
 			new ColorScale(opts)
 


### PR DESCRIPTION
# Description

Fixes the issue with ticks not appearing in the color scale when the domain range is larger. Also fixes similar issue in disco plots like [this example](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-BR-4257).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
