### PR TITLE
Add test coverage for `.mcount='all'` in geneVariant tvs

### DIFF
--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -427,7 +427,7 @@ test('filterByItem: mcount=multiple', t => {
 })
 
 test('filterByItem: mcount=all', t => {
-	t.plan(18)
+	t.plan(22)
 	const filter = {
 		type: 'tvs',
 		tvs: {
@@ -498,6 +498,12 @@ test('filterByItem: mcount=all', t => {
 		t.equal(tested, true, 'Sample is tested')
 	}
 	{
+		const mlst = [{ dt: 1, class: 'Blank' }]
+		const [pass, tested] = filterByItem(filter, mlst)
+		t.equal(pass, false, 'Sample passes filter')
+		t.equal(tested, false, 'Sample is tested')
+	}
+	{
 		const mlst = [
 			{ dt: 1, class: 'L' },
 			{ dt: 1, class: 'L' }
@@ -515,6 +521,12 @@ test('filterByItem: mcount=all', t => {
 		const [pass, tested] = filterByItem(filter, mlst)
 		t.equal(pass, true, 'Sample passes filter')
 		t.equal(tested, true, 'Sample is tested')
+	}
+	{
+		const mlst = [{ dt: 4, class: 'CNV_amp' }]
+		const [pass, tested] = filterByItem(filter, mlst)
+		t.equal(pass, false, 'Sample passes filter')
+		t.equal(tested, false, 'Sample is tested')
 	}
 
 	t.end()


### PR DESCRIPTION
# Description

Add test coverage for the `.mcount='all'` value that was introduced in geneVariant tvs here: https://github.com/stjude/proteinpaint/pull/4179

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
