### PR TITLE
Synchronize `q.dtLst[]` and `q.predefined_groupset_idx` when filling geneVariant tw

### DIFF
--- a/client/plots/summarizeCnvGeneexp.ts
+++ b/client/plots/summarizeCnvGeneexp.ts
@@ -2,7 +2,7 @@ import { table2col, addGeneSearchbox, make_one_checkbox, Menu } from '#dom'
 import { dtcnv } from '#shared/common.js'
 import { select } from 'd3-selection'
 import { launchPlot } from './summarizeMutationDiagnosis'
-import { fillTermWrapper, get$id } from '#termsetting'
+import { fillTermWrapper } from '#termsetting'
 
 /*
 same design as summarizeMutationDiagnosis.ts
@@ -136,15 +136,9 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 				],
 				type: 'geneVariant'
 			},
-			q: { type: 'predefined-groupset' }
+			q: { type: 'predefined-groupset', dtLst: [dt] }
 		}
 		await fillTermWrapper(tw, chartsInstance.app.vocabApi)
-		// get index of groupset corresponding to dt
-		const i = tw.term.groupsetting.lst.findIndex(groupset => groupset.dt == dt)
-		if (i == -1) throw 'dt not found in groupsets'
-		tw.q.predefined_groupset_idx = i
-		// update $id after setting predefined_groupset_idx (to distinguish from other gene tw)
-		tw.$id = await get$id(chartsInstance.app.vocabApi.getTwMinCopy(tw))
 		return tw
 	}
 

--- a/client/plots/summarizeMutationCnv.ts
+++ b/client/plots/summarizeMutationCnv.ts
@@ -2,7 +2,7 @@ import { table2col, addGeneSearchbox, make_one_checkbox, Menu } from '#dom'
 import { dtsnvindel, dtcnv } from '#shared/common.js'
 import { select } from 'd3-selection'
 import { launchPlot } from './summarizeMutationDiagnosis'
-import { fillTermWrapper, get$id } from '#termsetting'
+import { fillTermWrapper } from '#termsetting'
 
 /*
 similar design as summarizeCnvGeneexp.ts
@@ -109,13 +109,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 	async function updateUi() {
 		if (cnvGeneSameAsMut) {
 			if (mutTw) {
-				cnvTw = structuredClone(mutTw)
-				// get index of groupset corresponding to dtcnv
-				const i = cnvTw.term.groupsetting.lst.findIndex(groupset => groupset.dt == dtcnv)
-				if (i == -1) throw 'dtcnv not found in groupsets'
-				cnvTw.q.predefined_groupset_idx = i
-				// update $id after setting q.predefined_groupset_idx (to distinguish from mutTw)
-				cnvTw.$id = await get$id(chartsInstance.app.vocabApi.getTwMinCopy(cnvTw))
+				cnvTw = await fillGvTw(mutTw.term.id, dtcnv)
 			}
 		}
 		cnvTableRow.style('display', cnvGeneSameAsMut ? 'none' : '')
@@ -142,15 +136,9 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 				],
 				type: 'geneVariant'
 			},
-			q: { type: 'predefined-groupset' }
+			q: { type: 'predefined-groupset', dtLst: [dt] }
 		}
 		await fillTermWrapper(tw, chartsInstance.app.vocabApi)
-		// get index of groupset corresponding to dt
-		const i = tw.term.groupsetting.lst.findIndex(groupset => groupset.dt == dt)
-		if (i == -1) throw 'dt not found in groupsets'
-		tw.q.predefined_groupset_idx = i
-		// update $id after setting predefined_groupset_idx (to distinguish from other gene tw)
-		tw.$id = await get$id(chartsInstance.app.vocabApi.getTwMinCopy(tw))
 		return tw
 	}
 

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -220,11 +220,26 @@ export class GvPredefinedGS extends GvBase {
 
 		const { term, q } = tw
 		if (!term.groupsetting?.lst?.length) throw 'term.groupsetting.lst[] is empty'
-		if (!q.dtLst?.length) {
+		if (q.dtLst?.length) {
+			// query dts specified
+			// select the groupset that has the query dts
+			const groupsetIdx = term.groupsetting.lst.findIndex(groupset => {
+				const dts = Number.isInteger(groupset.dt) ? [groupset.dt] : getDtsFromGroups(groupset.groups)
+				if (!dts?.length) return false
+				if (dts.length != q.dtLst?.length) return false
+				if (dts.some(dt => !q.dtLst?.includes(dt))) return false
+				return true
+			})
+			if (groupsetIdx == -1) throw new Error('groupset with query dt(s) not found')
+			q.predefined_groupset_idx = groupsetIdx
+		} else {
+			// query dts not specified
+			// set the query dts to be the dts of the selected groupset
 			// TODO: remove these type assertions
 			const idx = q.predefined_groupset_idx as number
 			const lst = term.groupsetting.lst as any[]
-			q.dtLst = [lst[idx].dt]
+			const groupset = lst[idx]
+			q.dtLst = Number.isInteger(groupset.dt) ? [groupset.dt] : getDtsFromGroups(groupset.groups)
 		}
 		set_hiddenvalues(q, term)
 		return tw as GvPredefinedGsTW


### PR DESCRIPTION
Fixes https://gdc-ctds.atlassian.net/browse/SV-2741

Issue was caused by the new `q.dtLst[]` parameter not getting specified in the `client/plots/summarize*.ts` files. As a result, it was defaulting to the first available dt in the dataset (which is SNV/indel) and as a result there was no CNV data in the CNV/geneExp plot.

Issue is fixed by specifying `q.dtLst[]` in the relevant `client/plots/summarize*.ts` files and also by synchronizing `q.dtLst[]` and `q.predefined_groupset_idx` when filling geneVariant termwrapper.

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
