### PR TITLE
Display loading message in `GeneExp vs Survival` submission UI

### DIFF
--- a/client/plots/summarizeGeneexpSurvival.ts
+++ b/client/plots/summarizeGeneexpSurvival.ts
@@ -1,6 +1,7 @@
 import { addGeneSearchbox, Menu, table2col } from '#dom'
 import { termsettingInit, fillTermWrapper } from '#termsetting'
 import { launchPlot } from './summarizeMutationDiagnosis'
+import { t0_t2_defaultQ } from './survival/survival'
 
 /*
 duplicates code from summarizeMutationDiagnosis, with minute changes
@@ -28,15 +29,24 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 		const [td1, td2] = table.addRow()
 		td1.text('Search Gene For Expression')
 		const searchDiv = td2.append('div')
+		const loadingDiv = td2
+			.append('div')
+			.style('display', 'none')
+			.style('margin', '5px')
+			.style('font-size', '.7em')
+			.text('LOADING ...')
 		const result = addGeneSearchbox({
 			row: searchDiv,
 			tip,
 			searchOnly: 'gene',
 			genome: chartsInstance.app.opts.genome!,
 			callback: async () => {
+				loadingDiv.style('display', 'block')
+				const expTw: any = { term: { gene: result.geneSymbol, type: 'geneExpression' } }
+				await fillTermWrapper(expTw, chartsInstance.app.vocabApi, t0_t2_defaultQ)
 				launchPlot({
 					tw1: dictTw,
-					tw2: { term: { gene: result.geneSymbol, type: 'geneExpression' } },
+					tw2: expTw,
 					chartsInstance,
 					holder
 				})


### PR DESCRIPTION
# Description

Addresses the following issue:

Open [GDC correlation plot](http://localhost:3000/?noheader=1&gdccorrelation=1&filter0={%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.primary_site%22,%22value%22:[%22brain%22,%22breast%22]}}) -> click on `GeneExp vs Survival` button -> submit gene -> no loading message appears while variable is loading

Solve issue by filling geneExpression tw prior to launching plot and rendering loading message while term is loading.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
