### PR TITLE
Fix for broken gene set edit UI

### DIFF
--- a/client/dom/GeneSetEdit/GeneSetEditUI.ts
+++ b/client/dom/GeneSetEdit/GeneSetEditUI.ts
@@ -334,7 +334,9 @@ export class GeneSetEditUI {
 			this.menuList.push({
 				label: 'Top variably expressed genes',
 				callback: (event: Event) => {
-					this.api.topVariablyExpressedGenesParams
+					/** Create a copy to avoid mutating the args in the state */
+					const copy = structuredClone(this.api.topVariablyExpressedGenesParams)
+					copy
 						.filter(p => p.param.type == 'radio' && p.param?.options)
 						.forEach(p => {
 							//Sets the default value of the radio button to the first option
@@ -358,8 +360,8 @@ export class GeneSetEditUI {
 							if (this.vocabApi.state.termfilter.filter0) args.filter0 = this.vocabApi.state.termfilter.filter0 // gdc filter
 						}
 
-						this.getInputs(this.api.topVariablyExpressedGenesParams, args)
-						const result = await this.vocabApi.getTopVariablyExpressedGenes(args)
+						this.getInputs(copy, args)
+						const result = await dofetch3('termdb/topVariablyExpressedGenes', { method: 'GET', body: args })
 
 						this.geneList = []
 						if (result.genes) {
@@ -368,7 +370,7 @@ export class GeneSetEditUI {
 						this.renderGenes()
 					}
 
-					const menuArgs = Object.assign(this.baseGeneMenuArgs(this.api.topVariablyExpressedGenesParams), { callback })
+					const menuArgs = Object.assign(this.baseGeneMenuArgs(copy), { callback })
 					new GenesMenu(menuArgs)
 				}
 			})
@@ -452,6 +454,7 @@ export class GeneSetEditUI {
 		}
 	}
 
+	/** Get the input value for the entire menu */
 	getInputs(arr, args) {
 		for (const { param, input } of arr) {
 			if (param.parentId) {
@@ -465,6 +468,7 @@ export class GeneSetEditUI {
 		}
 	}
 
+	/** Get value for single input based on type */
 	getInputValue({ param, input }) {
 		if (param.type == 'radio') return param.value
 		const value = input.node().value

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1257,9 +1257,6 @@ export class TermdbVocab extends Vocab {
 			}
 		})
 	}
-	async getTopVariablyExpressedGenes(arg) {
-		return await dofetch3('termdb/topVariablyExpressedGenes', { method: 'GET', body: arg })
-	}
 
 	async getTopTermsByType(args) {
 		args.genome = this.state.vocab.genome


### PR DESCRIPTION
# Description

Fixes issue with the gene set edit UI displaying cloning error. Test with [this ASH example](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22nav%22:{%22activeTab%22:1},%22genome%22:%22hg38%22 ) Gene Exp chart btn > topVE > Submit. Should also see the error resolved in [ALL-Pharma](http://localhost:3000/?massnative=hg38,ALL-pharmacotyping). 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
