### PR TITLE
Do not overwrite CNV cutoffs in tw.q when filling geneVariant tw

### DIFF
--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -99,11 +99,10 @@ export class GvBase extends TwBase {
 				// continuous cnv data
 				// assign cnv cutoffs to tw.q
 				// priority of cnv cutoffs: tw.q > cnvCutoffsByGene > dsCnvCutoffs
-				const dsCnvCutoffs = {
-					cnvGainCutoff: cnv.cnvGainCutoff,
-					cnvLossCutoff: cnv.cnvLossCutoff,
-					cnvMaxLength: cnv.cnvMaxLength
-				}
+				const dsCnvCutoffs: { [key: string]: number } = {}
+				if ('cnvGainCutoff' in cnv) dsCnvCutoffs.cnvGainCutoff = cnv.cnvGainCutoff
+				if ('cnvLossCutoff' in cnv) dsCnvCutoffs.cnvLossCutoff = cnv.cnvLossCutoff
+				if ('cnvMaxLength' in cnv) dsCnvCutoffs.cnvMaxLength = cnv.cnvMaxLength
 				const cnvCutoffsByGene = cnv.cnvCutoffsByGene?.[tw.term.name]
 				const defaultCnvCutoffs = cnvCutoffsByGene || dsCnvCutoffs
 				tw.q = Object.assign({}, defaultCnvCutoffs, tw.q)


### PR DESCRIPTION
# Description

Addresses `BUG matrix cnv filtering cutoffs are not saved in state/session` in https://github.com/stjude/sjpp/issues/1009

CNV cutoffs in geneVariant `tw.q` were getting overwritten by dataset CNV cutoffs during termwrapper filling. Now cutoffs in `tw.q` are no longer overwritten.

Can test with [ASH matrix](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22BCR%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22ABL1%22,%22type%22:%22geneVariant%22}}]}]}]}), change CNV cutoffs, save session, correct cutoffs should load.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
