### PR TITLE
option to disable mayAddDataAvailability() for matrix data requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+Fixes
+- prevent excessive memory usage during OncoMatrix data requests
+
+
 ## 2.170.11
 
 Fixes

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -112,6 +112,9 @@ export function setAppMiddlewares(app, genomes, doneLoading) {
 			Object.assign(req.query, req.body)
 		}
 
+		// log the request before adding additional or protected info
+		log(req)
+
 		let { genome, dslabel, mds3, dsname } = req.query
 		dslabel = dslabel || mds3 || dsname
 		if (genome && dslabel) {
@@ -144,9 +147,6 @@ export function setAppMiddlewares(app, genomes, doneLoading) {
 		}
 
 		maySetAbortCtrl(req, res)
-
-		// log the request before adding protected info
-		log(req)
 		next()
 	})
 

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2838,9 +2838,11 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 				}
 			}
 
-			// add data availability for each dt
-			for (const dt of dts) {
-				mayAddDataAvailability(sample2mlst, dt, ds, gene, sampleFilter)
+			if (!q.disableAssayAvailability) {
+				// add data availability for each dt
+				for (const dt of dts) {
+					mayAddDataAvailability(sample2mlst, dt, ds, gene, sampleFilter)
+				}
 			}
 		}
 

--- a/server/src/termdb.get_matrix.js
+++ b/server/src/termdb.get_matrix.js
@@ -70,6 +70,12 @@ export async function get_matrix(q, req, res, ds, genome) {
 		res.send(plot.matrixConfig)
 		return
 	}
+
+	q.disableAssayAvailability =
+		typeof ds.cohort.termdb.disableAssayAvailability === 'function'
+			? ds.cohort.termdb.disableAssayAvailability(req.path, q)
+			: false
+
 	const data = await getData(q, ds, true) // FIXME hardcoded to true
 	if (data.error) {
 		if (String(data.error).includes('operation was aborted')) console.log(`(!) abort error`)

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1592,6 +1592,8 @@ keep this setting here for reason of:
 	maxConcurrentQueries?: number
 	/** (client-side) maximum number of terms that should be submitted in one fetch request in TermdbVocab.getAnnotatedSampleData() */
 	maxAnnoTermsPerClientRequest?: number
+	/** option to disable mayAddDataAvailability() based on request path and query parameters */
+	disableAssayAvailability?: (path: string, query: { [key: string]: any }) => boolean
 	//terms  are shown in the dictionary based on term and user role.
 	isTermVisible?: (clientAuthResult: any, ids: string) => boolean
 	hiddenIds?: string[]


### PR DESCRIPTION
# Description

This branch prevents excessive PP server memory usage in GDC portal. 

Test with `sjpp/skip-data-availability` branch. Follow the steps in `ppgdc/stats.sh` to inspect the memory usage of a running container.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
