### PR TITLE
Prevent hiding series/cell of barchart if only 1 is visible

### DIFF
--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -399,7 +399,8 @@ function handle_click(event, self, chart) {
 
 	const options = []
 	if (self.opts.bar_click_opts.includes('hide_bar')) {
-		const visibleSerieses = chart.visibleSerieses || self.charts.find(c => c.chartId == chart.chartId).visibleSerieses
+		const chartId = chart.chartId === undefined ? '' : chart.chartId
+		const visibleSerieses = chart.visibleSerieses || self.charts.find(c => c.chartId == chartId).visibleSerieses
 		if (visibleSerieses.length > 1) {
 			options.push({
 				label: data.seriesId ? 'Hide "' + seriesLabel + '"' : 'Hide',


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2745

Prevents user from hiding series of barchart if only one series is visible. Also prevents user from hiding cell of barchart if only one cell is visible.

Can test using [sex barchart](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22sex%22}}]}) and [sex/agedx barchart](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22sex%22},%22term2%22:{%22id%22:%22agedx%22}}]}).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
