### PR TITLE
Hide survival terms in termdb tree for violin and boxplot

### DIFF
--- a/shared/utils/src/termdb.usecase.js
+++ b/shared/utils/src/termdb.usecase.js
@@ -79,6 +79,8 @@ export function isUsableTerm(term, _usecase, termdbConfig, ds) {
 	// default handling
 	switch (usecase.target) {
 		case 'barchart':
+		case 'violin':
+		case 'boxplot':
 		case 'summary':
 			if (term.type && term.type !== 'survival') uses.add('plot')
 			if (hasAllowedChildTypes(child_types, ['survival'])) uses.add('branch')


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2746

Hide survival terms in termdb tree for violin and boxplot (similar to barchart).

Can test with [violin plot](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22id%22:%22agedx%22,%22q%22:{%22mode%22:%22continuous%22}}}]}), select either overlay or divideby termsetting, should not see survival terms in termdb tree.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
