### PR TITLE
Always set protected sessionid in middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## Unreleased
+
+Fixes
+- set __protected__.sessionid even when there are no dsCredentials
+
+
 ## 2.170.12
 
 Fixes
 - prevent excessive memory usage during OncoMatrix data requests
-- do not allow repeated term id for correlation plot primary, correlation, and divide-by variables
+- do not allow repeated term id for correlation plot primary, correlation, and Fdivide-by variables
 - hide survival terms in dictionary tree for violin and boxplot
 - do not allow hiding all chart serieses/overlay, there should at least be one visible rendered data 
-
+- restore geneORA by passing gene names but not tw.$id
 
 ## 2.170.11
 

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,0 @@
-Fixes:
-- restore geneORA by passing gene names but not tw.$id

--- a/server/routes/termdb.cohort.summary.ts
+++ b/server/routes/termdb.cohort.summary.ts
@@ -1,7 +1,6 @@
 import type { TermdbCohortSummaryRequest, TermdbCohortSummaryResponse, RouteApi } from '#types'
 import { termdbCohortSummaryPayload } from '#types/checkers'
 import { get_ds_tdb } from '#src/termdb.js'
-import { mayCopyFromCookie } from '#src/utils.js' // ??? is this needed for this route ???
 import { get_samples } from '#src/termdb.sql.js'
 import { authApi } from '#src/auth.js'
 export const api: RouteApi = {
@@ -17,7 +16,6 @@ export const api: RouteApi = {
 function init({ genomes }) {
 	return async (req, res) => {
 		const q: TermdbCohortSummaryRequest = req.query
-		mayCopyFromCookie(q, req.cookies) // ??? is this needed for this route ???
 		try {
 			const genome = genomes[q.genome]
 			if (!genome) throw 'invalid genome'

--- a/server/routes/termdb.cohorts.ts
+++ b/server/routes/termdb.cohorts.ts
@@ -1,7 +1,6 @@
 import type { TermdbCohortsRequest, TermdbCohortsResponse, RouteApi } from '#types'
 import { termdbCohortsPayload } from '#types/checkers'
 import { get_ds_tdb } from '#src/termdb.js'
-import { mayCopyFromCookie } from '#src/utils.js' // ??? is this needed for this route ???
 
 export const api: RouteApi = {
 	endpoint: 'termdb/cohorts',
@@ -16,7 +15,6 @@ export const api: RouteApi = {
 function init({ genomes }) {
 	return async (req, res) => {
 		const q: TermdbCohortsRequest = req.query
-		mayCopyFromCookie(q, req.cookies) // ??? is this needed for this route ???
 		try {
 			const genome = genomes[q.genome]
 			if (!genome) throw 'invalid genome'

--- a/server/routes/termdb.config.ts
+++ b/server/routes/termdb.config.ts
@@ -1,7 +1,6 @@
 import serverconfig from '#src/serverconfig.js'
 import { authApi } from '#src/auth.js'
 import { get_ds_tdb } from '#src/termdb.js'
-import { mayCopyFromCookie } from '#src/utils.js'
 import { TermTypes } from '#shared/terms.js'
 import type { Mds3WithCohort } from '#types'
 
@@ -23,7 +22,6 @@ export const api: any = {
 function init({ genomes }) {
 	return async (req, res) => {
 		const q = req.query
-		mayCopyFromCookie(q, req.cookies)
 		try {
 			const genome = genomes[q.genome]
 			if (!genome) throw 'invalid genome'

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -1,4 +1,4 @@
-import { mayCopyFromCookie, fileurl, validateRglst } from './utils.js'
+import { fileurl, validateRglst } from './utils.js'
 import { snvindelByRangeGetter_bcf } from './mds3.init.js'
 import { validate_variant2samples } from './mds3.variant2samples.js'
 import { dtcnv, mclasscnvgain, mclasscnvAmp, mclasscnvloss, mclasscnvHomozygousDel } from '#shared/common.js'
@@ -62,8 +62,6 @@ function init_q(req, genome) {
 		// user token may be provided from request header, the logic could be specific to gdc or another dataset
 		query.token = req.get('X-Auth-Token')
 	}
-
-	mayCopyFromCookie(query, req.cookies)
 
 	// cannot validate filter0 here as ds will be required and is not made yet
 	if (query.hiddenmclasslst) {

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -8,7 +8,7 @@ import { validate as snpValidate } from './termdb.snp.js'
 import { isUsableTerm } from '#shared/termdb.usecase.js'
 import { trigger_getLowessCurve } from '../routes/termdb.sampleScatter.ts'
 import { get_mds3variantData } from './mds3.variant.js'
-import { get_lines_bigfile, mayCopyFromCookie } from './utils.js'
+import { get_lines_bigfile } from './utils.js'
 import { authApi } from './auth.js'
 import { getResult as geneSearch } from './gene.js'
 import { searchSNP } from '../routes/snp.ts'
@@ -32,8 +32,6 @@ export function handle_request_closure(genomes) {
 
 	return async (req, res) => {
 		const q = req.query
-
-		mayCopyFromCookie(q, req.cookies)
 
 		try {
 			const genome = genomes[q.genome]

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -807,14 +807,6 @@ export function validateRglst(q, genome) {
 	}
 }
 
-export function mayCopyFromCookie(q, cookies) {
-	if (cookies.sessionid) {
-		if ('sessionid' in q) throw 'q.sessionid already exists so cannot copy from cookies.sessionid'
-		// sessionid is available after user logs into gdc portal
-		q.sessionid = cookies.sessionid
-	}
-}
-
 export function boxplot_getvalue(lst, removeOutliers = false) {
 	/* ascending order
     each element: {value}


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2747 and https://gdc-ctds.atlassian.net/browse/SV-2748.

Previously, the `sessionid` was not set if there were no `serverconfig.dsCredentials` entry. This breaks GDC usage, since it has its own domain-based session cookie that doesn't use PP's auth code that is based on `dsCredentials`.

Tested with a local container and making sure that the `gdcPermssionCheck()` works as expected.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
