### PR TITLE
Disco VAF array integration

### DIFF
--- a/client/plots/disco/data/Data.ts
+++ b/client/plots/disco/data/Data.ts
@@ -1,8 +1,8 @@
 export type Vaf = {
 	readonly id?: string
 	readonly name?: string
-	readonly refCount: number
-	readonly altCount: number
+	readonly refCount?: string | number
+	readonly altCount?: string | number
 }
 
 export default interface Data {
@@ -14,8 +14,6 @@ export default interface Data {
 	readonly chr: string
 	readonly ref: string
 	readonly alt: string
-	readonly refCount?: string | number
-	readonly altCount?: string | number
 	readonly vafs?: Vaf[]
 	readonly position: number
 	readonly poschr: any

--- a/client/plots/disco/data/DataObjectMapper.ts
+++ b/client/plots/disco/data/DataObjectMapper.ts
@@ -18,8 +18,6 @@ export default class DataObjectMapper {
 			chr: dObject.chr,
 			ref: dObject.ref,
 			alt: dObject.alt,
-			refCount: dObject.refCount,
-			altCount: dObject.altCount,
 			vafs: dObject.vafs,
 			position: dObject.pos ? dObject.pos : dObject.position,
 			poschr: dObject.poschr,

--- a/client/plots/disco/label/LabelsMapper.ts
+++ b/client/plots/disco/label/LabelsMapper.ts
@@ -132,8 +132,6 @@ export default class LabelsMapper {
 			dataClass: dataClass,
 			chr: data.chr,
 			position: data.position,
-			refCount: data.refCount,
-			altCount: data.altCount,
 			vafs: data.vafs
 		}
 		if (!label) {

--- a/client/plots/disco/label/LabelsRenderer.ts
+++ b/client/plots/disco/label/LabelsRenderer.ts
@@ -121,8 +121,8 @@ export default class LabelsRenderer implements IRenderer {
 						.style('color', 'black')
 						.style('font-size', '0.8em')
 						.text(` ${mutation.chr}:${mutation.position}`)
-					if (hasAnyValidVafEntry(mutation.vafs, mutation.refCount, mutation.altCount)) {
-						appendVafBars(td2, mutation.vafs, mutation.refCount, mutation.altCount)
+					if (hasAnyValidVafEntry(mutation.vafs)) {
+						appendVafBars(td2, mutation.vafs)
 					}
 				}
 			})

--- a/client/plots/disco/label/MutationTooltip.ts
+++ b/client/plots/disco/label/MutationTooltip.ts
@@ -6,7 +6,5 @@ export default interface MutationTooltip {
 	readonly dataClass: any
 	readonly chr: string
 	readonly position: number
-	readonly refCount?: Data['refCount']
-	readonly altCount?: Data['altCount']
 	readonly vafs?: Data['vafs']
 }

--- a/client/plots/disco/label/test/LabelsMapper.unit.spec.ts
+++ b/client/plots/disco/label/test/LabelsMapper.unit.spec.ts
@@ -240,7 +240,7 @@ test('When Two mutations on two genes LabelsMapper.map() and only one gene is pr
 	}
 	t.end()
 })
-test('When SNV has integer refCount/altCount, mutation tooltip should retain both counts', t => {
+test('When SNV has vafs array, mutation tooltip should retain vafs entries', t => {
 	const rawData = [
 		{
 			dt: 1,
@@ -252,8 +252,10 @@ test('When SNV has integer refCount/altCount, mutation tooltip should retain bot
 			ref: 'G',
 			alt: 'A',
 			position: 50,
-			refCount: 10,
-			altCount: 4
+			vafs: [
+				{ id: 'Tumor', refCount: 12, altCount: 3 },
+				{ name: 'Relapse', refCount: '5', altCount: '1' }
+			]
 		}
 	]
 
@@ -263,8 +265,53 @@ test('When SNV has integer refCount/altCount, mutation tooltip should retain bot
 
 	t.equal(labels.length, 1, 'Should create one label')
 	if (labels[0].mutationsTooltip) {
-		t.equal(labels[0].mutationsTooltip[0].refCount, 10, 'Mutation tooltip should include refCount')
-		t.equal(labels[0].mutationsTooltip[0].altCount, 4, 'Mutation tooltip should include altCount')
+		t.deepEqual(
+			labels[0].mutationsTooltip[0].vafs,
+			[
+				{ id: 'Tumor', refCount: 12, altCount: 3 },
+				{ name: 'Relapse', refCount: '5', altCount: '1' }
+			],
+			'Mutation tooltip should include vafs array'
+		)
+	} else {
+		t.error('No mutations tooltip')
+	}
+	t.end()
+})
+
+test('When SNV has vafs array, mutation tooltip should retain vafs entries', t => {
+	const rawData = [
+		{
+			dt: 1,
+			mname: 'Mutation1',
+			class: 'M',
+			gene: 'Gene1',
+			chr: 'chr1',
+			pos: 50,
+			ref: 'G',
+			alt: 'A',
+			position: 50,
+			vafs: [
+				{ id: 'Tumor', refCount: 12, altCount: 3 },
+				{ name: 'Relapse', refCount: '5', altCount: '1' }
+			]
+		}
+	]
+
+	const dataHolder = new DataMapper(settings, reference, sampleName, []).map(rawData)
+	const labelsMapper = new LabelsMapper(settings, sampleName, reference)
+	const labels = labelsMapper.map(dataHolder.labelData)
+
+	t.equal(labels.length, 1, 'Should create one label')
+	if (labels[0].mutationsTooltip) {
+		t.deepEqual(
+			labels[0].mutationsTooltip[0].vafs,
+			[
+				{ id: 'Tumor', refCount: 12, altCount: 3 },
+				{ name: 'Relapse', refCount: '5', altCount: '1' }
+			],
+			'Mutation tooltip should include vafs array'
+		)
 	} else {
 		t.error('No mutations tooltip')
 	}

--- a/client/plots/disco/snv/NonExonicSnvArcsMapper.ts
+++ b/client/plots/disco/snv/NonExonicSnvArcsMapper.ts
@@ -43,8 +43,6 @@ export default class NonExonicSnvArcsMapper {
 				mname: data.mname,
 				chr: data.chr,
 				pos: data.position,
-				refCount: data.refCount,
-				altCount: data.altCount,
 				vafs: data.vafs,
 				sampleName: [data.sampleName]
 			}

--- a/client/plots/disco/snv/NonExonicSnvRenderer.ts
+++ b/client/plots/disco/snv/NonExonicSnvRenderer.ts
@@ -63,10 +63,10 @@ export default class NonExonicSnvRenderer implements IRenderer {
 					td1.text('Occurrence')
 					td2.text(snv.occurrence)
 				}
-				if (hasAnyValidVafEntry(arc.vafs, arc.refCount, arc.altCount)) {
+				if (hasAnyValidVafEntry(arc.vafs)) {
 					const [td1, td2] = table.addRow()
 					td1.text('Read count')
-					appendVafBars(td2, arc.vafs, arc.refCount, arc.altCount)
+					appendVafBars(td2, arc.vafs)
 				}
 
 				menu.show(mouseEvent.x, mouseEvent.y)

--- a/client/plots/disco/snv/SnvArc.ts
+++ b/client/plots/disco/snv/SnvArc.ts
@@ -6,8 +6,6 @@ export default interface SnvArc extends Arc {
 	readonly mname: string
 	readonly chr: string
 	readonly pos: number
-	readonly refCount?: Data['refCount']
-	readonly altCount?: Data['altCount']
 	readonly vafs?: Data['vafs']
 	readonly sampleName: string[]
 }

--- a/client/plots/disco/snv/SnvArcsMapper.ts
+++ b/client/plots/disco/snv/SnvArcsMapper.ts
@@ -58,8 +58,6 @@ export default class SnvArcsMapper {
 						mname: data.mname,
 						chr: data.chr,
 						pos: data.position,
-						refCount: data.refCount,
-						altCount: data.altCount,
 						vafs: data.vafs,
 						sampleName: [data.sampleName]
 					}

--- a/client/plots/disco/snv/SnvRenderer.ts
+++ b/client/plots/disco/snv/SnvRenderer.ts
@@ -74,10 +74,10 @@ export default class SnvRenderer implements IRenderer {
 					td2.text(snv.occurrence)
 				}
 
-				if (hasAnyValidVafEntry(arc.vafs, arc.refCount, arc.altCount)) {
+				if (hasAnyValidVafEntry(arc.vafs)) {
 					const [td1, td2] = table.addRow()
 					td1.text('Read count')
-					appendVafBars(td2, arc.vafs, arc.refCount, arc.altCount)
+					appendVafBars(td2, arc.vafs)
 				}
 
 				menu.show(mouseEvent.x, mouseEvent.y)

--- a/client/plots/disco/snv/test/VafTooltip.unit.spec.ts
+++ b/client/plots/disco/snv/test/VafTooltip.unit.spec.ts
@@ -1,0 +1,43 @@
+import test from 'tape'
+import { getVafEntries, hasAnyValidVafEntry } from '#plots/disco/snv/vafTooltip.ts'
+
+test('getVafEntries extracts labeled entries from vafs array', t => {
+	const entries = getVafEntries([
+		{ id: 'Tumor', refCount: 10, altCount: 2 },
+		{ name: 'Relapse', refCount: '8', altCount: '1' }
+	] as any)
+
+	t.equal(entries.length, 2, 'Should include both entries with id/name labels')
+	t.equal(entries[0].label, 'Tumor', 'Should prefer id as label')
+	t.equal(entries[1].label, 'Relapse', 'Should use name as label')
+	t.end()
+})
+
+test('getVafEntries returns empty when vafs is missing', t => {
+	const entries = getVafEntries(undefined)
+
+	t.deepEqual(entries, [], 'Should return no entries without vafs array')
+	t.end()
+})
+
+test('getVafEntries filters invalid VAF entries', t => {
+	const entries = getVafEntries([
+		{ id: 'MissingRef', altCount: 2 },
+		{ name: 'MissingAlt', refCount: 3 },
+		{ refCount: 1, altCount: 1 },
+		{ id: 'Valid', refCount: 7, altCount: 2 }
+	] as any)
+
+	t.deepEqual(entries, [{ label: 'Valid', refCount: 7, altCount: 2 }], 'Should keep only valid labeled entries')
+	t.end()
+})
+
+test('hasAnyValidVafEntry accepts mixed vaf input with at least one valid entry', t => {
+	const hasAny = hasAnyValidVafEntry([
+		{ id: 'Bad', refCount: 'foo', altCount: 2 },
+		{ name: 'Good', refCount: '6', altCount: '2' }
+	] as any)
+
+	t.equal(hasAny, true, 'Should detect at least one valid vaf entry')
+	t.end()
+})

--- a/client/plots/disco/snv/vafTooltip.ts
+++ b/client/plots/disco/snv/vafTooltip.ts
@@ -1,7 +1,7 @@
 import { fillbar } from '#dom'
 import type Data from '#plots/disco/data/Data.ts'
 
-export type ReadCountValue = Data['refCount'] | Data['altCount']
+export type ReadCountValue = string | number | undefined
 export type VafEntry = {
 	label: string
 	refCount: ReadCountValue
@@ -23,33 +23,22 @@ export function hasValidReadCounts(refCountValue: ReadCountValue, altCountValue:
 	return refCount != null && altCount != null && refCount >= 0 && altCount >= 0 && refCount + altCount > 0
 }
 
-export function getVafEntries(
-	vafs: Data['vafs'],
-	fallbackRefCount?: ReadCountValue,
-	fallbackAltCount?: ReadCountValue
-): VafEntry[] {
+export function getVafEntries(vafs: Data['vafs']): VafEntry[] {
 	const entries: VafEntry[] = []
 	if (Array.isArray(vafs)) {
 		for (const vaf of vafs) {
 			const label = vaf?.id || vaf?.name
-			if (!label) continue
-			entries.push({ label, refCount: vaf.refCount, altCount: vaf.altCount })
+			const refCount = vaf?.refCount
+			const altCount = vaf?.altCount
+			if (!label || refCount == null || altCount == null) continue
+			entries.push({ label, refCount, altCount })
 		}
-	}
-	if (!entries.length && fallbackRefCount !== undefined && fallbackAltCount !== undefined) {
-		entries.push({ label: 'VAF', refCount: fallbackRefCount, altCount: fallbackAltCount })
 	}
 	return entries
 }
 
-export function hasAnyValidVafEntry(
-	vafs: Data['vafs'],
-	fallbackRefCount?: ReadCountValue,
-	fallbackAltCount?: ReadCountValue
-): boolean {
-	return getVafEntries(vafs, fallbackRefCount, fallbackAltCount).some(vaf =>
-		hasValidReadCounts(vaf.refCount, vaf.altCount)
-	)
+export function hasAnyValidVafEntry(vafs: Data['vafs']): boolean {
+	return getVafEntries(vafs).some(vaf => hasValidReadCounts(vaf.refCount, vaf.altCount))
 }
 
 export function appendVafBar(td2: any, refCountValue: ReadCountValue, altCountValue: ReadCountValue, label = 'VAF') {
@@ -71,13 +60,8 @@ export function appendVafBar(td2: any, refCountValue: ReadCountValue, altCountVa
 	fillbar(div, { f: fraction, v1: altCount, v2: totalCount })
 }
 
-export function appendVafBars(
-	td2: any,
-	vafs: Data['vafs'],
-	fallbackRefCount?: ReadCountValue,
-	fallbackAltCount?: ReadCountValue
-) {
-	for (const vaf of getVafEntries(vafs, fallbackRefCount, fallbackAltCount)) {
+export function appendVafBars(td2: any, vafs: Data['vafs']) {
+	for (const vaf of getVafEntries(vafs)) {
 		if (!hasValidReadCounts(vaf.refCount, vaf.altCount)) continue
 		appendVafBar(td2, vaf.refCount, vaf.altCount, vaf.label)
 	}


### PR DESCRIPTION
# Description
Integrated VAF array into disco
kept:
```
readonly refCount?: string | number
readonly altCount?: string | number
```
In case data is not given in vaf array.

Used both:
```
readonly id?: string
readonly name?: string
```
Because original request said VAF  source would express:

`{name:string, refCount:int, altCount:int}
`
but is actually:
```
"vafs": [
   {
    "altCount": 7,
    "id": "tumor_DNA_WGS",
    "refCount": 9
   }
  ]
```

Please test using data  from this pr https://github.com/stjude/proteinpaint/pull/4198

I had issues testing with http://localhost:3000/example.mds2.html#TermdbTest as my UI is not working fully
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
