### PR TITLE
Prevent one rendered chart per unique float/integer value 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## Unreleased
+
+Fixes:
+- limit divide-by terms to discrete mode to avoid a nonsensical one rendered chart per unique float/integer value
+
+
 ## 2.170.14
 
 Fixes:

--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -119,7 +119,7 @@ export class Barchart extends PlotBase {
 					title: controlLabels.term2.title || controlLabels.term2.label,
 					label: controlLabels.term2.label,
 					vocabApi: this.app.vocabApi,
-					numericEditMenuVersion: this.opts.numericEditMenuVersion,
+					numericEditMenuVersion: this.opts.numericEditMenuVersion || ['continuous', 'discrete'],
 					defaultQ4fillTW: term0_term2_defaultQ,
 					// overlay option should always be visible, but must convert unit from log to abs
 					// when an overlay is added
@@ -149,7 +149,10 @@ export class Barchart extends PlotBase {
 					title: controlLabels.term0.title || controlLabels.term0.label,
 					label: controlLabels.term0.label,
 					vocabApi: this.app.vocabApi,
-					numericEditMenuVersion: this.opts.numericEditMenuVersion,
+					// by default, do not allow continuous mode for divide-by term, since
+					// it will create a separate violin-overlay group per unique float or integer value
+					// and there will nonsensical tens/hundreds of these charts based on the cohort size
+					numericEditMenuVersion: this.opts.numericEditMenuVersion || ['discrete'],
 					defaultQ4fillTW: term0_term2_defaultQ,
 					getBodyParams: () => {
 						const tw = this.config['term0']

--- a/client/plots/boxplot/BoxPlotControlInputs.ts
+++ b/client/plots/boxplot/BoxPlotControlInputs.ts
@@ -33,7 +33,10 @@ export function setBoxPlotControlInputs(state: any, app: any, opts: any, getChar
 			title: controlLabels.term0.title || controlLabels.term0.label,
 			label: controlLabels.term0.label,
 			vocabApi: app.vocabApi,
-			numericEditMenuVersion: opts.numericEditMenuVersion || ['continuous', 'discrete'],
+			// by default, do not allow continuous mode for divide-by term, since
+			// it will create a separate violin-overlay group per unique float or integer value
+			// and there will nonsensical tens/hundreds of these charts based on the cohort size
+			numericEditMenuVersion: opts.numericEditMenuVersion || ['discrete'],
 			defaultQ4fillTW: term0_term2_defaultQ
 		},
 		{

--- a/client/plots/scatter/view/scatterView.ts
+++ b/client/plots/scatter/view/scatterView.ts
@@ -292,7 +292,11 @@ export class ScatterView {
 				title: 'Term to to divide by categories or to use as Z coordinate',
 				label: 'Z / Divide by',
 				vocabApi: this.scatter.app.vocabApi,
-				numericEditMenuVersion: ['discrete', 'continuous'],
+				// do not allow 'continuous' mode for now, even if it can be rendered along z-axis,
+				// since clicking to barchart/violin/boxplot tab from the scatter tab does not
+				// automatically convert the divide-by term to discrete; a continuous mode in those
+				// other charts leads to nonsensical chart per unique float/integer value
+				numericEditMenuVersion: ['discrete'],
 				processInput: tw => {
 					if (!isPremade && isNumericTerm(tw?.term)) tw.q = { mode: 'continuous' } //use continuous mode by default if not premade plot
 				}

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -135,7 +135,10 @@ class ViolinPlot extends PlotBase {
 				title: controlLabels.term0.title || controlLabels.term0.label,
 				label: controlLabels.term0.label,
 				vocabApi: this.app.vocabApi,
-				numericEditMenuVersion: this.opts.numericEditMenuVersion,
+				// by default, do not allow continuous mode for divide-by term, since
+				// it will create a separate violin-overlay group per unique float or integer value
+				// and there will nonsensical tens/hundreds of these charts based on the cohort size
+				numericEditMenuVersion: this.opts.numericEditMenuVersion || ['discrete'],
 				defaultQ4fillTW: term0_term2_defaultQ
 			},
 			{


### PR DESCRIPTION
# Description

... by limiting divide-by terms to discrete mode in chart edit menu.

Fixes https://gdc-ctds.atlassian.net/browse/SV-2753 (reopened). Can test using http://localhost:3000/example.gdc.correlation.html?noheader=1&cohort=TCGA-LGG

Manually tested based on steps in the linked JIRA task, but also test in violin, boxplot, and scatter tabs.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
