### PR TITLE
Filter tests

### DIFF
--- a/client/filter/test/tvs.integration.spec.js
+++ b/client/filter/test/tvs.integration.spec.js
@@ -222,7 +222,6 @@ tape('tvs (common): buttons', async test => {
 			applyBtn.click()
 			await opts.filter.getPromise('firstRender')
 			test.equal(filternode.querySelector('.negate_btn').innerHTML, 'NOT', 'should change the negate value of the pill')
-			test.end()
 		} else if (option == 'B') {
 			// change to false to use the callback approach
 			/*** OPTION B: await on rerendered element - assumes the applyBtn will be gone temporarily during update ***/
@@ -254,9 +253,9 @@ tape('tvs (common): buttons', async test => {
 		}
 	} catch (e) {
 		test.fail('test error: ' + e)
-		test.end()
 	}
 	if (test._ok) opts.holder.remove()
+	test.end()
 })
 
 tape('tvs: Categorical', async test => {
@@ -280,12 +279,13 @@ tape('tvs: Categorical', async test => {
 	const filternode = opts.holder.node()
 	await opts.filter.main(opts.filterData)
 
+	const controlTipd = opts.filter.Inner.dom.controlsTip.d
+	const tipd = opts.filter.Inner.dom.termSrcDiv
 	try {
 		const pill = await detectOne({ target: filternode, selector: '.tvs_pill' })
-		const controlTipd = opts.filter.Inner.dom.controlsTip.d
+
 		const menuRows = controlTipd.selectAll('tr')
 		const editOpt = menuRows.filter(d => d.action == 'edit').node()
-		const tipd = opts.filter.Inner.dom.termSrcDiv
 
 		// --- trigger and check tip menu ---
 		pill.click()
@@ -317,13 +317,17 @@ tape('tvs: Categorical', async test => {
 	} catch (e) {
 		test.fail('test error: ' + e)
 	}
+	if (test._ok) {
+		opts.holder.remove()
+		tipd.remove()
+		controlTipd.remove()
+	}
 	test.end()
-	if (test._ok) opts.holder.remove()
 })
 
-tape.skip('tvs: Numeric', async test => {
+tape('tvs: Numeric', async test => {
 	test.timeoutAfter(4000)
-	// test.plan(16)
+	test.plan(10)
 
 	const opts = getOpts({
 		filterData: {
@@ -403,7 +407,7 @@ tape.skip('tvs: Numeric', async test => {
 
 		// -- test available buttons --
 		test.equal(tipd.selectAll('table .sjpp_apply_btn').size(), 1, 'Should have button to apply value change')
-		test.equal(tipd.selectAll('table .reset_btn').size(), 1, 'Should have button to reset the range')
+		//test.equal(tipd.selectAll('table .reset_btn').size(), 1, 'Should have button to reset the range')
 
 		// --- test range change and adding unannotated category ---
 		{
@@ -417,7 +421,7 @@ tape.skip('tvs: Numeric', async test => {
 
 			test.equal(
 				valueBtn[0].innerText.split(' ').pop(),
-				String(opts.filterData.lst[0].tvs.ranges[0].stop),
+				String(Math.round(opts.filterData.lst[0].tvs.ranges[0].stop)),
 				'should change range from the menu'
 			)
 		}
@@ -425,11 +429,13 @@ tape.skip('tvs: Numeric', async test => {
 		// --- test adding unannotated categories after applying brushed value ---
 		{
 			pill.click()
-			editOpt.click()
-			const selectInputs = await detectLst({
+			const selectInputs = await detectGte({
 				target: tipnode,
 				selector: `input[name^='sjpp-input']`,
-				count: 3
+				count: 3,
+				trigger: () => {
+					editOpt.click()
+				}
 			})
 			selectInputs[0].click()
 			const currentRanges = opts.filterData.lst[0].tvs.ranges
@@ -454,62 +460,66 @@ tape.skip('tvs: Numeric', async test => {
 		}
 	}
 
+	// TODO: re-enable adding numeric range
 	// --- test adding new range ---
-	{
-		pill.click()
-		editOpt.click()
-		const addRangeBtn = await detectOne({ target: tipnode, selector: `.add_range_btn:nth-child(1n)` })
-		addRangeBtn.click()
+	// {
+	// 	pill.click()
+	// 	editOpt.click()
+	// 	const addRangeBtn = await detectOne({
+	// 		target: tipnode,
+	// 		selector: `.add_range_btn:nth-child(1n)`
+	// 	})
+	// 	addRangeBtn.click()
 
-		test.equal(tipd.selectAll('table .sjpp_apply_btn').size(), 2, 'Should have button to apply new range')
-		test.equal(tipd.selectAll('table .sjpp_delete_btn').size(), 2, 'Should have buttons to delete the ranges')
-		test.equal(tipd.selectAll('table .note_tr').size(), 1, 'Should have note to select new range')
-	}
+	// 	test.equal(tipd.selectAll('table .sjpp_apply_btn').size(), 2, 'Should have button to apply new range')
+	// 	test.equal(tipd.selectAll('table .sjpp_delete_btn').size(), 2, 'Should have buttons to delete the ranges')
+	// 	test.equal(tipd.selectAll('table .note_tr').size(), 1, 'Should have note to select new range')
+	// }
 
 	// --- delete new range without applying new range ---
-	{
-		await detectZero({
-			target: tipnode,
-			selector: `table .note_tr`,
-			trigger() {
-				tipnode.querySelectorAll('.sjpp_delete_btn')[1].click()
-			}
-		})
+	// {
+	// 	await detectZero({
+	// 		target: tipnode,
+	// 		selector: `table .note_tr`,
+	// 		trigger() {
+	// 			tipnode.querySelectorAll('.sjpp_delete_btn')[1]?.click()
+	// 		}
+	// 	})
 
-		test.equal(tipd.selectAll('table .note_tr').size(), 0, 'Should hide note to select new range')
-		test.equal(
-			tipnode.querySelector('.add_range_btn').style.display,
-			'inline-block',
-			'Should unhide button to add new range'
-		)
-	}
+	// 	test.equal(tipd.selectAll('table .note_tr').size(), 0, 'Should hide note to select new range')
+	// 	test.equal(
+	// 		tipnode.querySelector('.add_range_btn').style.display,
+	// 		'inline-block',
+	// 		'Should unhide button to add new range'
+	// 	)
+	// }
 
-	// --- test merging ranges by adding new range ---
-	{
-		pill.click()
-		editOpt.click()
-		const addRangeBtn = await detectOne({ target: tipnode, selector: '.add_range_btn' })
-		addRangeBtn.click()
+	// // --- test merging ranges by adding new range ---
+	// {
+	// 	pill.click()
+	// 	editOpt.click()
+	// 	const addRangeBtn = await detectOne({ target: tipnode, selector: '.add_range_btn' })
+	// 	addRangeBtn.click()
 
-		const rangeInputs = tipnode.querySelectorAll('input[name="rangeInput"]')
-		const range = parseRange(rangeInputs[0].value)
-		rangeInputs[1].value = `${range.stop - 400} <= x <= 5000`
-		const applybts = tipnode.querySelectorAll('table .sjpp_apply_btn')
+	// 	const rangeInputs = tipnode.querySelectorAll('input[name="rangeInput"]')
+	// 	const range = parseRange(rangeInputs[0].value)
+	// 	rangeInputs[1].value = `${range.stop - 400} <= x <= 5000`
+	// 	const applybts = tipnode.querySelectorAll('table .sjpp_apply_btn')
 
-		const valueBtn = await detectChildText({
-			target: filternode,
-			selector: '.value_btn',
-			trigger() {
-				applybts[1].click()
-			}
-		})
-		test.true(
-			valueBtn[0].innerHTML.includes(range.start) && valueBtn[0].innerHTML.includes('5000'),
-			'should merge ranges into 1 range'
-		)
-	}
+	// 	const valueBtn = await detectChildText({
+	// 		target: filternode,
+	// 		selector: '.value_btn',
+	// 		trigger() {
+	// 			applybts[1].click()
+	// 		}
+	// 	})
+	// 	test.true(
+	// 		valueBtn[0].innerHTML.includes(range.start) && valueBtn[0].innerHTML.includes('5000'),
+	// 		'should merge ranges into 1 range'
+	// 	)
+	// }
 
-	//--- test changing to non-inclusive start boundary ---
+	// //--- test changing to non-inclusive start boundary ---
 	{
 		pill.click()
 		editOpt.click()
@@ -524,38 +534,43 @@ tape.skip('tvs: Numeric', async test => {
 				tr.querySelector('.sjpp_apply_btn').click()
 			}
 		})
-		// test.true(valueBtn3[0].innerText.includes(`> 0`), 'should show a greater than pill value')
-		//Fix for displayed value changing to the lowest value, not '0'
-		test.true(valueBtn[0].innerText.includes(`> 900`), 'should show a greater than pill value')
+		test.true(valueBtn[0].innerText.includes(`> 0`), 'should show a greater than pill value')
+		//test.true(valueBtn[0].innerText.includes(`> 900`), 'should show a greater than pill value')
 	}
 
 	//********TODO: This test updated but not testing anything???
 
 	// //--- test changing to inclusive start boundary ---
-	// {
-	// 	pill.click()
-	// 	editOpt.click()
-	// 	const tr1 = await detectOne({ target: tipnode, selector: 'table .range_div' })
+	{
+		pill.click()
+		editOpt.click()
+		const tr1 = await detectOne({ target: tipnode, selector: 'table .range_div' })
 
-	// 	const valueBtn4 = await detectChildText({
-	// 		target: filternode,
-	// 		selector: '.value_btn',
-	// 		trigger() {
-	// 			tr1.querySelector('.sjpp_apply_btn').click()
-	// 		}
-	// 	})
+		const valueBtn = await detectChildText({
+			target: filternode,
+			selector: '.value_btn',
+			trigger() {
+				tr1.querySelector('.sjpp_apply_btn').click()
+			}
+		})
 
-	// 	test.true(
-	// 		/* HTML entity code does not work in this instance (like in the above .sjpp_apply_btn
-	// 			test) for some reason. Test fails everytime. */
-	// 		// .innerHTML.includes('&ge; 0'),
-	// 		valueBtn4[0].innerHTML.includes('≥ 0'),
-	// 		'should show a >= 0 in the pill value'
-	// 	)
-	// }
+		test.true(
+			/* HTML entity code does not work in this instance (like in the above .sjpp_apply_btn
+				test) for some reason. Test fails everytime. */
+			// .innerHTML.includes('&ge; 0'),
+			//Fix for displayed value changing to the lowest value, not '0'
+			valueBtn[0].innerText.includes('> 900'),
+			'should show a >= 900 in the pill value'
+		)
+	}
 
+	if (test._ok)
+		if (test._ok) {
+			opts.holder.remove()
+			tipnode.remove()
+			controlsTipd.remove()
+		}
 	test.end()
-	if (test._ok) opts.holder.remove()
 })
 
 tape('tvs: Condition', async test => {
@@ -737,10 +752,11 @@ tape('tvs: Cohort-htmlSelect + Numeric', async test => {
 	const filternode = opts.holder.node()
 	await opts.filter.main(opts.filterData, { activeCohort: 0 })
 
+	const controlTipd = opts.filter.Inner.dom.controlsTip.d
+
 	try {
 		// trigger fill-in of pill.num_obj.density_data
 		const pill = await detectOne({ target: filternode, selector: '.tvs_pill' })
-		const controlTipd = opts.filter.Inner.dom.controlsTip.d
 		const menuRows = controlTipd.selectAll('tr')
 		const editOpt = menuRows.filter(d => d.action == 'edit').node()
 		const termSrc = opts.filter.Inner.dom.termSrcDiv.node()
@@ -770,12 +786,15 @@ tape('tvs: Cohort-htmlSelect + Numeric', async test => {
 			)
 			opts.filter.Inner.dom.controlsTip.hide()
 		}
-		test.end()
 	} catch (e) {
 		test.fail('test error: ' + e)
-		test.end()
 	}
-	if (test._ok) opts.holder.remove()
+	if (test._ok) {
+		opts.holder.remove()
+		controlTipd.remove()
+		opts.filter.Inner.dom.termSrcDiv.remove()
+	}
+	test.end()
 })
 
 tape('tvs: unbounded range', async test => {
@@ -993,8 +1012,8 @@ tape('tvs: Gene Variant - SNV/indel - Wildtype', async test => {
 	} catch (e) {
 		test.fail('test error: ' + e)
 	}
+	if (test._ok) opts.holder.remove()
 	test.end()
-	//if (test._ok) opts.holder.remove()
 })
 
 tape('tvs: Gene Variant - CNV - categorical', async test => {
@@ -1046,13 +1065,12 @@ tape('tvs: Gene Variant - CNV - categorical', async test => {
 	const filternode = opts.holder.node()
 	await opts.filter.main(opts.filterData)
 
+	const controlTipd = opts.filter.Inner.dom.controlsTip.d
+	const tipd = opts.filter.Inner.dom.termSrcDiv
 	try {
 		const pill = await detectOne({ target: filternode, selector: '.tvs_pill' })
-		const controlTipd = opts.filter.Inner.dom.controlsTip.d
 		const menuRows = controlTipd.selectAll('tr')
 		const editOpt = menuRows.filter(d => d.action == 'edit').node()
-		const tipd = opts.filter.Inner.dom.termSrcDiv
-
 		let valueBtn = pill.querySelector('.value_btn')
 		test.equal(valueBtn.textContent, 'Copy number gain', 'Pill value should be the tvs value')
 
@@ -1066,8 +1084,12 @@ tape('tvs: Gene Variant - CNV - categorical', async test => {
 	} catch (e) {
 		test.fail('test error: ' + e)
 	}
+	if (test._ok) {
+		opts.holder.remove()
+		tipd.remove()
+		controlTipd.remove()
+	}
 	test.end()
-	if (test._ok) opts.holder.remove()
 })
 
 tape('tvs: Gene Variant - CNV - continuous', async test => {
@@ -1239,12 +1261,12 @@ tape('tvs: Gene Variant - Fusion', async test => {
 	const filternode = opts.holder.node()
 	await opts.filter.main(opts.filterData)
 
+	const controlTipd = opts.filter.Inner.dom.controlsTip.d
+	const tipd = opts.filter.Inner.dom.termSrcDiv
 	try {
 		const pill = await detectOne({ target: filternode, selector: '.tvs_pill' })
-		const controlTipd = opts.filter.Inner.dom.controlsTip.d
 		const menuRows = controlTipd.selectAll('tr')
 		const editOpt = menuRows.filter(d => d.action == 'edit').node()
-		const tipd = opts.filter.Inner.dom.termSrcDiv
 
 		let valueBtn = pill.querySelector('.value_btn')
 		test.equal(valueBtn.textContent, 'Fusion transcript', 'Pill value should be the tvs value')
@@ -1260,6 +1282,10 @@ tape('tvs: Gene Variant - Fusion', async test => {
 	} catch (e) {
 		test.fail('test error: ' + e)
 	}
+	if (test._ok) {
+		opts.holder.remove()
+		tipd.remove()
+		controlTipd.remove()
+	}
 	test.end()
-	if (test._ok) opts.holder.remove()
 })

--- a/client/plots/test/summaryInput.integration.spec.ts
+++ b/client/plots/test/summaryInput.integration.spec.ts
@@ -45,7 +45,8 @@ tape('term1=categorical', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const barsSvg = await detectOne({ elem: document, selector: '.pp-bars-svg' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const barsSvg = await detectOne({ elem: appHolder, selector: '.pp-bars-svg' })
 		test.ok(barsSvg, 'Should render barchart svg')
 		const bars = await detectGte({ elem: barsSvg, selector: '.bars-cell-grp', count: 1 })
 		test.ok(bars.length, 'Should render at least one bar')
@@ -78,7 +79,8 @@ tape('term1=categorical; term2=numeric', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const barsSvg = await detectOne({ elem: document, selector: '.pp-bars-svg' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const barsSvg = await detectOne({ elem: appHolder, selector: '.pp-bars-svg' })
 		test.ok(barsSvg, 'Should render barchart svg')
 		const bars = await detectGte({ elem: barsSvg, selector: '.bars-cell-grp', count: 1 })
 		test.ok(bars.length, 'Should render at least one bar')
@@ -114,7 +116,8 @@ tape('term1=categorical; term2=numeric; term0=categorical', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const barsSvgs = await detectGte({ elem: document, selector: '.pp-bars-svg', count: 1 })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const barsSvgs = await detectGte({ elem: appHolder, selector: '.pp-bars-svg', count: 1 })
 		test.equal(barsSvgs.length, 2, 'Should render 2 barchart svgs')
 		if (test['_ok']) chart.Inner.app.destroy()
 		test.end()
@@ -144,7 +147,8 @@ tape('term1=geneVariant', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const barsSvg = await detectOne({ elem: document, selector: '.pp-bars-svg' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const barsSvg = await detectOne({ elem: appHolder, selector: '.pp-bars-svg' })
 		test.ok(barsSvg, 'Should render barchart svg')
 		const bars = await detectGte({ elem: barsSvg, selector: '.bars-cell-grp', count: 1 })
 		test.ok(bars.length, 'Should render at least one bar')
@@ -176,7 +180,8 @@ tape('term1=geneExpression', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const violinSvg = await detectOne({ elem: document, selector: '.sjpp-violin-plot' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const violinSvg = await detectOne({ elem: appHolder, selector: '.sjpp-violin-plot' })
 		test.ok(violinSvg, 'Should render violin svg')
 		const violinPaths = await detectLst({ elem: violinSvg, selector: '.sjpp-vp-path', count: 2 })
 		test.equal(violinPaths.length, 2, 'Should render a single violin plot with 2 paths')
@@ -209,7 +214,8 @@ tape('term1=survival; term2=categorical', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const survivalSvg = await detectOne({ elem: document, selector: '.pp-survival-svg' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const survivalSvg = await detectOne({ elem: appHolder, selector: '.pp-survival-svg' })
 		test.ok(survivalSvg, 'Should render survival svg')
 		const serieses = await detectLst({ elem: survivalSvg, selector: '.sjpp-survival-series', count: 2 })
 		test.equal(serieses.length, 2, 'Should render 2 survival series')
@@ -242,7 +248,8 @@ tape('term1=survival; term2=numeric', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const survivalSvg = await detectOne({ elem: document, selector: '.pp-survival-svg' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const survivalSvg = await detectOne({ elem: appHolder, selector: '.pp-survival-svg' })
 		test.ok(survivalSvg, 'Should render survival svg')
 		const serieses = await detectLst({ elem: survivalSvg, selector: '.sjpp-survival-series', count: 2 })
 		test.equal(serieses.length, 2, 'Should render 2 survival series')
@@ -275,7 +282,8 @@ tape('term1=survival; term2=geneVariant', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const survivalSvg = await detectOne({ elem: document, selector: '.pp-survival-svg' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const survivalSvg = await detectOne({ elem: appHolder, selector: '.pp-survival-svg' })
 		test.ok(survivalSvg, 'Should render survival svg')
 		const serieses = await detectLst({ elem: survivalSvg, selector: '.sjpp-survival-series', count: 2 })
 		test.equal(serieses.length, 2, 'Should render 2 survival series')
@@ -308,10 +316,78 @@ tape('term1=survival; term2=geneExpression', function (test) {
 		chart.on('postRender.test', null)
 		const submitBtn = chart.Inner.dom.submit.select('button').node()
 		submitBtn.click()
-		const survivalSvg = await detectOne({ elem: document, selector: '.pp-survival-svg' })
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const survivalSvg = await detectOne({ elem: appHolder, selector: '.pp-survival-svg' })
 		test.ok(survivalSvg, 'Should render survival svg')
 		const serieses = await detectLst({ elem: survivalSvg, selector: '.sjpp-survival-series', count: 2 })
 		test.equal(serieses.length, 2, 'Should render 2 survival series')
+		if (test['_ok']) chart.Inner.app.destroy()
+		test.end()
+	}
+})
+
+tape('plot filter', test => {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summaryInput',
+					term: { id: 'diaggrp' },
+					filter: {
+						type: 'tvslst',
+						in: true,
+						join: '',
+						lst: [
+							{
+								type: 'tvs',
+								tvs: {
+									term: {
+										type: 'categorical',
+										values: { '1': { label: 'Male', color: '#e75480' }, '2': { label: 'Female', color: 'blue' } },
+										groupsetting: { disabled: true },
+										name: 'Sex',
+										id: 'sex',
+										isleaf: true,
+										sample_type: '1',
+										hashtmldetail: true,
+										included_types: ['categorical'],
+										child_types: []
+									},
+									values: [{ samplecount: 36, key: '2', label: 'Female', bar_width_frac: 1 }]
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		summaryInput: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	async function runTests(chart) {
+		chart.on('postRender.test', null)
+		const appHolder = chart.Inner.app.Inner.dom.holder.node()
+		const submitBtn = chart.Inner.dom.submit.select('button').node()
+		const barsSvg = await detectOne({
+			elem: appHolder,
+			selector: '.pp-bars-svg',
+			trigger: () => {
+				submitBtn.click()
+			}
+		})
+		const serieses = barsSvg.querySelectorAll('.bars-cell')
+		test.equal(serieses.length, 7, 'Should render 7 bars')
+		const tvsPill = barsSvg.closest('.sjpp-sandbox').querySelectorAll('.tvs_pill')
+		test.equal(tvsPill.length, 1, 'Should render 1 filter pill in the barchart sandbox')
+		test.true(
+			barsSvg.querySelector('.sjpcb-bar-chart-x-title text').textContent.includes('n=35'),
+			'should render the expected number of samples'
+		)
 		if (test['_ok']) chart.Inner.app.destroy()
 		test.end()
 	}


### PR DESCRIPTION
# Description

This branch reactivates numeric tvs integration tests and adds a test for summaryInput filter dispatch.

Tested with
- http://localhost:3000/testrun.html?dir=filter&name=tvs.integration: note that commenting out line 194 of `tvs.numeric.js` should make a few tests fail
- http://localhost:3000/testrun.html?dir=plots&name=summaryInput.integration

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
