### PR TITLE
fix: stop RAF loops and event listener accumulation in 3D scatter

### DIFF
--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -113,6 +113,7 @@ export class Scatter extends PlotBase implements RxComponent {
 			return
 		}
 
+		this.vm?.dispose()
 		if (this.model.is3D) this.vm = new ScatterViewModel3D(this)
 		else if (this.model.is2DLarge) this.vm = new ScatterViewModel2DLarge(this)
 		else this.vm = new ScatterViewModel(this)

--- a/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
@@ -3,6 +3,10 @@ import * as THREE from 'three'
 import { ScatterViewModel } from './scatterViewModel.js'
 
 export class ScatterViewModel2DLarge extends ScatterViewModel {
+	private rafId: number | null = null
+	private renderer: THREE.WebGLRenderer | null = null
+	private mousewheelHandler: ((event: any) => void) | null = null
+
 	constructor(scatter) {
 		super(scatter)
 	}
@@ -46,25 +50,41 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		const particles = new THREE.Points(geometry, material)
 
 		scene.add(particles)
-		const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: this.canvas, preserveDrawingBuffer: true })
-		renderer.setSize(this.scatter.settings.svgw, this.scatter.settings.svgh)
-		renderer.setPixelRatio(window.devicePixelRatio)
+		this.renderer = new THREE.WebGLRenderer({ antialias: true, canvas: this.canvas, preserveDrawingBuffer: true })
+		this.renderer.setSize(this.scatter.settings.svgw, this.scatter.settings.svgh)
+		this.renderer.setPixelRatio(window.devicePixelRatio)
 
-		new DragControls.DragControls([particles], camera, renderer.domElement)
+		new DragControls.DragControls([particles], camera, this.renderer.domElement)
 
-		document.addEventListener('mousewheel', (event: any) => {
+		this.mousewheelHandler = (event: any) => {
 			if (event.ctrlKey) camera.position.z += event.deltaY / 500
-		})
+		}
+		document.addEventListener('mousewheel', this.mousewheelHandler)
 
 		this.addLegendSVG(chart)
-		this.animate(camera, scene, renderer)
+		this.animate(camera, scene, this.renderer)
 	}
 
 	animate(camera, scene, renderer) {
-		requestAnimationFrame(() => this.animate(camera, scene, renderer))
+		this.rafId = requestAnimationFrame(() => this.animate(camera, scene, renderer))
 		camera.zoom = this.scatter.vm.scatterZoom.zoom
 		camera.updateProjectionMatrix()
 		renderer.render(scene, camera)
+	}
+
+	dispose() {
+		if (this.rafId !== null) {
+			cancelAnimationFrame(this.rafId)
+			this.rafId = null
+		}
+		if (this.mousewheelHandler) {
+			document.removeEventListener('mousewheel', this.mousewheelHandler)
+			this.mousewheelHandler = null
+		}
+		if (this.renderer) {
+			this.renderer.dispose()
+			this.renderer = null
+		}
 	}
 
 	getVertices(chart) {

--- a/client/plots/scatter/viewmodel/scatterViewModel3D.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel3D.ts
@@ -11,6 +11,10 @@ import type { Scatter } from '../scatter.js'
 export class ScatterViewModel3D extends ScatterViewModel {
 	scatter!: Scatter
 	canvas: any
+	private rafId: number | null = null
+	private renderer: THREE.WebGLRenderer | null = null
+	private wheelHandler: ((event: WheelEvent) => void) | null = null
+	private canvasWheelHandler: ((event: any) => void) | null = null
 
 	constructor(scatter: Scatter) {
 		super(scatter)
@@ -76,14 +80,11 @@ export class ScatterViewModel3D extends ScatterViewModel {
 				this.addLabels(scene)
 			}
 
-			document.addEventListener(
-				'wheel',
-				event => {
-					if (event.ctrlKey) event.preventDefault()
-					controls.enableZoom = event.ctrlKey
-				},
-				{ passive: false }
-			)
+			this.wheelHandler = (event: WheelEvent) => {
+				if (event.ctrlKey) event.preventDefault()
+				controls.enableZoom = event.ctrlKey
+			}
+			document.addEventListener('wheel', this.wheelHandler, { passive: false })
 
 			const geometry = new THREE.BufferGeometry()
 			geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3))
@@ -92,20 +93,18 @@ export class ScatterViewModel3D extends ScatterViewModel {
 			scene.add(particles)
 		}
 
-		const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: this.canvas, preserveDrawingBuffer: true })
-		renderer.setSize(this.scatter.settings.svgw, this.scatter.settings.svgh)
-		renderer.setPixelRatio(window.devicePixelRatio)
-		renderer.outputColorSpace = THREE.LinearSRGBColorSpace
+		this.renderer = new THREE.WebGLRenderer({ antialias: true, canvas: this.canvas, preserveDrawingBuffer: true })
+		this.renderer.setSize(this.scatter.settings.svgw, this.scatter.settings.svgh)
+		this.renderer.setPixelRatio(window.devicePixelRatio)
+		this.renderer.outputColorSpace = THREE.LinearSRGBColorSpace
 
 		//document.addEventListener( 'pointermove', onPointerMove );
 
-		function animate() {
-			requestAnimationFrame(animate)
-			// required if controls.enableDamping or controls.autoRotate are set to true
-
-			renderer.render(scene, camera)
+		const tick = () => {
+			this.rafId = requestAnimationFrame(tick)
+			this.renderer!.render(scene, camera)
 		}
-		animate()
+		tick()
 		this.addLegendSVG(chart)
 	}
 
@@ -132,11 +131,12 @@ export class ScatterViewModel3D extends ScatterViewModel {
 		const DragControls = await import('three/examples/jsm/controls/DragControls.js')
 		new DragControls.DragControls([particles], camera, this.canvas)
 		scene.add(particles)
-		this.canvas.addEventListener('mousewheel', event => {
+		this.canvasWheelHandler = (event: any) => {
 			if (!event.ctrlKey) return
 			event.preventDefault()
 			particles.position.z -= event.deltaY / 500
-		})
+		}
+		this.canvas.addEventListener('mousewheel', this.canvasWheelHandler)
 
 		const data = chart.data.samples.map(s => ({ x: xAxisScale(s.x), y: yAxisScale(s.y), z: zAxisScale(s.z) }))
 		const width = this.scatter.settings.svgw
@@ -164,6 +164,25 @@ export class ScatterViewModel3D extends ScatterViewModel {
 			chart.plane = plane
 			particles.add(plane)
 		})
+	}
+
+	dispose() {
+		if (this.rafId !== null) {
+			cancelAnimationFrame(this.rafId)
+			this.rafId = null
+		}
+		if (this.wheelHandler) {
+			document.removeEventListener('wheel', this.wheelHandler)
+			this.wheelHandler = null
+		}
+		if (this.canvas && this.canvasWheelHandler) {
+			this.canvas.removeEventListener('mousewheel', this.canvasWheelHandler)
+			this.canvasWheelHandler = null
+		}
+		if (this.renderer) {
+			this.renderer.dispose()
+			this.renderer = null
+		}
 	}
 
 	async addLabels(scene) {


### PR DESCRIPTION
## **Summary**

This PR fixes a critical lifecycle issue in the WebGL-based scatter plots (`ScatterViewModel3D` and `ScatterViewModel2DLarge`) where **requestAnimationFrame loops and document-level event listeners were accumulating on every state update**.

The root cause is that `scatter.ts::main()` **recreates the view model on every dispatch** without cleaning up the previous instance:

```ts
if (this.model.is3D) this.vm = new ScatterViewModel3D(this)
else if (this.model.is2DLarge) this.vm = new ScatterViewModel2DLarge(this)

this.vm.render()
```

Each render path was:

* Creating a new `THREE.WebGLRenderer`
* Starting a new `requestAnimationFrame` loop
* Attaching `document` / `canvas` wheel listeners

But **none of these were ever cleaned up**, leading to:

* Multiple RAF loops running in parallel
* Accumulating WebGL contexts (eventually hitting browser limits)
* Increasing CPU/GPU usage over time
* Memory not being released (no `renderer.dispose()`)

---

## **Fix**

This PR introduces a proper **lifecycle + disposal mechanism** for both 3D and 2DLarge view models.

### 1. Explicit disposal before re-instantiation

```ts
this.vm?.dispose()
this.vm = new ScatterViewModel3D(this)
```

---

### 2. Track and clean RAF loops

RAF is now stored and cancelled:

```ts
this.rafId = requestAnimationFrame(tick)

cancelAnimationFrame(this.rafId)
this.rafId = null
```

---

### 3. Store event handler references (required for removal)

Instead of inline listeners:

```ts
this.wheelHandler = (event: WheelEvent) => {
    if (event.ctrlKey) event.preventDefault()
    controls.enableZoom = event.ctrlKey
}

document.addEventListener('wheel', this.wheelHandler, { passive: false })
```

Cleanup:

```ts
document.removeEventListener('wheel', this.wheelHandler)
this.wheelHandler = null
```

Same pattern applied for `mousewheel` on canvas.

---

### 4. Reuse and properly dispose WebGL renderer

```ts
this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas, ... })

this.renderer.dispose()
this.renderer = null
```

---

### 5. Unified `dispose()` method

```ts
dispose() {
    if (this.rafId !== null) {
        cancelAnimationFrame(this.rafId)
        this.rafId = null
    }

    if (this.wheelHandler) {
        document.removeEventListener('wheel', this.wheelHandler)
        this.wheelHandler = null
    }

    if (this.renderer) {
        this.renderer.dispose()
        this.renderer = null
    }
}
```

---

## **Verification**

Tested in a realistic SPA workflow with repeated state updates:

### Steps

* Open 3D / large scatter plot
* Perform multiple interactions (opacity, size, filters, term changes)
* Repeat ~20–50 updates

### Before fix

* RAF loops increased linearly per update
* WebGL contexts accumulated (eventually hitting browser cap)
* CPU usage continuously increased
* Multiple `wheel` / `mousewheel` listeners attached to `document`
* Memory did not stabilize

### After fix

* Only **one RAF loop active at any time**
* WebGL context count remains constant (no accumulation)
* CPU usage returns to baseline after updates
* Event listeners remain at **exactly one**
* Memory stabilizes across repeated renders

---

## **Impact**

* Eliminates long-session degradation (CPU/GPU/memory)
* Prevents WebGL context exhaustion (`CONTEXT_LOST_WEBGL`)
* Restores scroll performance (no passive=false listener buildup)
* Aligns Three.js usage with proper lifecycle management