### PR TITLE
limit summaryInput divide-by variable to discrete mode

### DIFF
--- a/client/plots/summaryInput.ts
+++ b/client/plots/summaryInput.ts
@@ -93,6 +93,7 @@ class SummaryInputPlot extends PlotBase implements RxComponent {
 				usecase: { target: 'summaryInput', detail: 'term0' },
 				label: controlLabels.term0.label,
 				defaultQ4fillTW: term0_term2_defaultQ,
+				numericEditMenuVersion: this.opts.numericEditMenuVersion || ['discrete'],
 				getDisplayStyle: plot => (plot.config.term?.term.type == 'survival' ? 'none' : 'table-row')
 			},
 			{
@@ -109,6 +110,7 @@ class SummaryInputPlot extends PlotBase implements RxComponent {
 				usecase: { target: 'summaryInput', detail: 'term0' },
 				label: controlLabels.term0.label,
 				defaultQ4fillTW: term0_term2_defaultQ_surv + '_surv',
+				numericEditMenuVersion: this.opts.numericEditMenuVersion || ['discrete'],
 				getDisplayStyle: plot => (plot.config.term?.term.type == 'survival' ? 'table-row' : 'none')
 			}
 		]


### PR DESCRIPTION
# Description

Missed this fix for the correlation plot; the previous fix only applied to already rendered plots (barchart, violin, boxplot, scatter).

Tested with the reopened https://gdc-ctds.atlassian.net/browse/SV-2753, `continuous` mode should not be an option in the edit menu of a divide-by variable before submitting.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
