### PR TITLE
Improve the no data message in the edit menus of variable and filter inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 
+## Unreleased
+
+Fixes:
+- improve the error message when there is no numeric data for a variable or filter edit menu
+
 ## 2.170.17
 
 Fixes:

--- a/client/dom/violinRenderer.js
+++ b/client/dom/violinRenderer.js
@@ -22,7 +22,7 @@ export class violinRenderer {
 		this.holder = holder
 		this.rd = rd // ViolinResponse route data
 		this.vd = rd.charts?.['']?.plots?.[0] // the only violin data from route data
-		if (!this.vd) throw "rd.charts?.['']?.plots?.[0] missing"
+		if (!this.vd) throw 'No density plot data to render.'
 		this.width = width
 		this.height = height
 		this.radius = radius

--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -141,7 +141,9 @@ async function fillMenu(self, div, tvs) {
 				self.opts.getCategoriesArguments
 			)
 			if (data.error) throw data.error
-			if (data.max === null && data.min === null) throw `no available data`
+			if (data.max === null && data.min === null) {
+				throw `No data available under current filter conditions.`
+			}
 			self.num_obj.density_data = data
 		} catch (err) {
 			throw err


### PR DESCRIPTION
# Description

Tested locally with http://localhost:3000/example.gdc.correlation.html?noheader=1&cohort=HCMI-CMDC, or in GFF using any cohort without data for a selected variable. When selecting a numeric divide-by variable like `Age at index`, clicking on the pill and edit menu will now show a more user-friendly error message instead of the cryptic `rd.charts?.['']?.plots?.[0] missing`. The improved messages are:

<img width="299" height="179" alt="Screenshot 2026-02-25 at 4 10 29 PM" src="https://github.com/user-attachments/assets/f14604d5-045b-4121-a934-6f0a18d818ac" />

and

<img width="467" height="193" alt="Screenshot 2026-02-25 at 4 11 18 PM" src="https://github.com/user-attachments/assets/daf131fa-6a4a-4c04-a9ee-943391181b67" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
