### PR TITLE
Pass the GDC cohort filter to genome browser track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 
+## Unreleased
+
+Fixes:
+- add gdc cohort filter0 to gb data request and tklst entries
+
+
 ## 2.170.20
 
-Fixes
+Fixes:
 - do not show a geneset option when selecting CNV as mutation type
 
 

--- a/client/plots/gb/GB.ts
+++ b/client/plots/gb/GB.ts
@@ -64,6 +64,7 @@ class TdbGenomeBrowser extends PlotBase implements RxComponent {
 		return {
 			config,
 			filter: getNormalRoot(appState.termfilter.filter),
+			filter0: appState.termfilter.filter0,
 			vocab: appState.vocab
 		}
 	}

--- a/client/plots/gb/model/Model.ts
+++ b/client/plots/gb/model/Model.ts
@@ -30,6 +30,7 @@ export class Model {
 			stop: this.state.config.geneSearchResult.stop,
 			details: this.state.config.snvindel.details,
 			filter: this.state.filter,
+			filter0: this.state.filter0,
 			variantFilter: this.state.config.variantFilter?.filter
 		}
 

--- a/client/plots/gb/view/View.ts
+++ b/client/plots/gb/view/View.ts
@@ -157,7 +157,8 @@ export class View {
 			dslabel: this.state.vocab.dslabel,
 			name: 'Variants',
 			custom_variants: this.data.mlst,
-			skewerModes: [nm]
+			skewerModes: [nm],
+			filter0: this.state.filter0
 		}
 		return tk
 	}
@@ -277,7 +278,8 @@ export class View {
 			debugmode: this.opts.debug,
 			onAddRemoveTk: () => {
 				this.interactions.maySaveTrackUpdatesToState(this.blockInstance)
-			}
+			},
+			filter0: this.state.filter0
 		}
 
 		if (this.data) {

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,0 @@
-Fixes:
-- sample list should work when dragging a violin range


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2775. This branch adds filter0 to tklst and data request in the `plots/gb` code.

Tested with all unit and integration test, getting this error with http://localhost:3000/testrun.html?dir=plots/gb&name=genomeBrowser.integration.

@xzhou82 
<img width="497" height="312" alt="Screenshot 2026-03-03 at 4 00 51 PM" src="https://github.com/user-attachments/assets/cef596d7-bffe-44bf-837f-3cdf246082be" />



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
