### PR TITLE
Embed block in dnaMethylation search handler upon gene symbol search

### DIFF
--- a/client/termdb/handlers/dnaMethylation.ts
+++ b/client/termdb/handlers/dnaMethylation.ts
@@ -26,6 +26,7 @@ export class SearchHandler {
 			row: this.dom.geneSearchDiv,
 			callback: async () => {
 				try {
+					this.dom.errDiv.style('display', 'none')
 					await this.handleGeneSearch(geneSearch)
 				} catch (e: any) {
 					this.dom.errDiv.style('display', 'block')
@@ -44,6 +45,7 @@ export class SearchHandler {
 			if (!chr || !Number.isInteger(start) || !Number.isInteger(stop))
 				throw new Error('unable to retrieve gene coordinate')
 
+			this.dom.blockDiv.selectAll('*').remove()
 			this.dom.blockDiv.style('display', 'block')
 			this.dom.blockDiv.append('div').style('opacity', 0.6).text('Navigate genome browser to desired region')
 
@@ -55,6 +57,7 @@ export class SearchHandler {
 				stop,
 				tklst: [],
 				nobox: true,
+				width: 500,
 				hidegenelegend: true,
 				debugmode: this.opts.debug
 			}

--- a/client/termdb/test/dnaMethylation.integration.spec.ts
+++ b/client/termdb/test/dnaMethylation.integration.spec.ts
@@ -74,6 +74,8 @@ tape('Gene search', async test => {
 	geneSearchInput.value = geneSymbol
 	geneSearchInput.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', bubbles: true }))
 	await sleep(100)
+	const blockSvg = holder.select('[data-testid="sjpp_block_svg"]').node()
+	test.ok(blockSvg, 'should render block svg')
 	const submitBtn: any = holder.select('[data-testid="sjpp-dnaMethylation-submitDiv"]').select('button').node()
 	submitBtn.click()
 	await sleep(100)


### PR DESCRIPTION
# Description

In dnaMethylation search handler, a block is now embedded upon searching for gene symbol (e.g. `TP53`). Can use block to navigate to region of interest and then click `Submit Region` to fill `term{}` with chr/start/stop/etc. and launch plot.

If using coordinate (e.g. `chr17:7661778-7687537`) as input to search handler, no block is embedded and the coordinate input is used directly to fill `term{}`.

Also created test coverage for dnaMethylation search handler in `client/termdb/test/dnaMethylation.integration.spec.ts`.

Can test by using the dnaMethylation search handler in [TermdbTest](http://localhost:3000/?massnative=hg38-test,TermdbTest).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
