### PR TITLE
require http referer URL for jwt-status verification

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -560,6 +560,20 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 	app.post(basepath + '/jwt-status', async (req, res) => {
 		let code = 401 // assume unauthorized by default
 
+		if (req.headers.referer) {
+			const referer = Array.isArray(req.headers.referer) ? req.headers.referer[0] : req.headers.referer
+			if (!referer.toLowerCase().startsWith('http')) {
+				// NOTE: The restriction below only applies to dsCredentials jwt. It does not apply
+				// to portal-wide serverconfig.jwt usage that is verified in app.middleware.js.
+				res.status(401)
+				res.send({
+					error:
+						'Token authorization is not supported from a non-HTTP page. The referer URL must start with http:// or https://.'
+				})
+				return
+			}
+		}
+
 		// To simulate a failed JWT signature verification uncomment the following lines
 		// res.status(code)
 		// res.send({"error":{"name":"JsonWebTokenError","message":"invalid signature"}})


### PR DESCRIPTION
# Description

Emit an error to prevent jwt usage from a non-http page. This prevents confusion from developer tests of dataset-level jwt that use `file://` URLs. This may also prevent developers from using browsers with CORS fully disabled when testing PP auth routes. 

NOTE: The fix checks the protocol in req.headers.referer, if it's not empty. Manual tests have not yet covered the case of having the PP server behind a proxy, so this fix may not be ready for prod.

Test:
- close all Chrome windows
- run `open -n -a /Applications/Google\ Chrome.app --args --disable-web-security --user-data-dir="/tmp/chrome_dev_test"` in a terminal window
- double-click `proteinpaint/public/index.html` to open it in the CORS-disabled Chrome window
- open dev tools
- paste the following in dev tools and enter, it should show an error
```js
fetch('/jwt-status', {method: 'POST', headers: {'content-type': 'application/json'}, body: '{}'}).then(r => r.json()).then(console.log).catch(console.log)
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
