### PR TITLE
add SJG region filter to PrOFILE

### DIFF
--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -231,6 +231,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 				showAll: true
 			})
 			const regions = this.filteredTermValues[this.config.regionTW.id]
+			const sjgRegions = this.filteredTermValues[this.config.sjgRegionTW.id]
 			const countries = this.filteredTermValues[this.config.countryTW.id]
 			const incomes = this.filteredTermValues[this.config.incomeTW.id]
 			const teachingStates = this.filteredTermValues[this.config.teachingStatusTW.id]
@@ -313,12 +314,20 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 				inputs.push(
 					...[
 						{
-							label: 'Region',
+							label: 'WHO Region',
 							type: 'dropdown',
 							chartType,
 							settingsKey: this.config.regionTW.term.id,
 							options: regions,
 							callback: value => this.setFilterValue(this.config.regionTW.term.id, value)
+						},
+						{
+							label: 'SJG Region',
+							type: 'dropdown',
+							chartType,
+							settingsKey: this.config.sjgRegionTW.term.id,
+							options: sjgRegions,
+							callback: value => this.setFilterValue(this.config.sjgRegionTW.term.id, value)
 						},
 						{
 							label: 'Country',
@@ -669,6 +678,8 @@ export async function loadFilterTerms(config, activeCohort, app) {
 	const cohortPreffix = activeCohort == FULL_COHORT ? 'F' : 'A'
 	config.countryTW = { id: cohortPreffix + 'country' }
 	config.regionTW = { id: cohortPreffix + 'WHO_region' }
+	config.sjgRegionTW = { id: cohortPreffix + 'WHO_region' }
+	// TODO - termid needs to be updated.
 	config.incomeTW = { id: cohortPreffix + 'Income_group' }
 	config.typeTW = { id: cohortPreffix + 'FC_TypeofFacility' }
 	config.teachingStatusTW = { id: cohortPreffix + 'FC_TeachingFacility' }
@@ -682,6 +693,7 @@ export async function loadFilterTerms(config, activeCohort, app) {
 		config.facilityTW,
 		config.countryTW,
 		config.regionTW,
+		config.sjgRegionTW,
 		config.incomeTW,
 		config.typeTW,
 		config.teachingStatusTW,

--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -678,8 +678,7 @@ export async function loadFilterTerms(config, activeCohort, app) {
 	const cohortPreffix = activeCohort == FULL_COHORT ? 'F' : 'A'
 	config.countryTW = { id: cohortPreffix + 'country' }
 	config.regionTW = { id: cohortPreffix + 'WHO_region' }
-	config.sjgRegionTW = { id: cohortPreffix + 'WHO_region' }
-	// TODO - termid needs to be updated.
+	config.sjgRegionTW = { id: cohortPreffix + 'SJG_region' }
 	config.incomeTW = { id: cohortPreffix + 'Income_group' }
 	config.typeTW = { id: cohortPreffix + 'FC_TypeofFacility' }
 	config.teachingStatusTW = { id: cohortPreffix + 'FC_TeachingFacility' }

--- a/server/src/routes/profile.barchart2.ts
+++ b/server/src/routes/profile.barchart2.ts
@@ -99,12 +99,14 @@ async function getScores(query: any, ds: any) {
 
 	// 5. Build eligible sites list (filter to user's accessible sites if needed)
 	const sampleList: any[] = Object.values(raw.samples)
-	let sites = sampleList.map(s => {
-		const val = s[facilityTW.$id].value
-		let label = facilityTW.term.values?.[val]?.label || val
-		if (label.length > 50) label = label.slice(0, 47) + '...'
-		return { value: val, label }
-	})
+	let sites = sampleList
+		.filter(s => s[facilityTW.$id])
+		.map(s => {
+			const val = s[facilityTW.$id].value
+			let label = facilityTW.term.values?.[val]?.label || val
+			if (label.length > 50) label = label.slice(0, 47) + '...'
+			return { value: val, label }
+		})
 	if (userSites && query.filterByUserSites) {
 		sites = sites.filter(s => userSites.includes(s.value))
 	}
@@ -113,7 +115,9 @@ async function getScores(query: any, ds: any) {
 	// 6. Compute median percentage per score term across all eligible sites.
 	const samples: any[] = Object.values(raw.samples)
 	const eligibleSamples =
-		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
+		userSites && query.filterByUserSites
+			? samples.filter(s => s[facilityTW.$id] && userSites.includes(s[facilityTW.$id].value))
+			: samples
 
 	const term2Score: Record<string, number> = {}
 	for (const d of query.scoreTerms) {

--- a/server/src/routes/profile.forms2.ts
+++ b/server/src/routes/profile.forms2.ts
@@ -76,18 +76,22 @@ async function getScores(query: any, ds: any) {
 	if (raw.error) throw raw.error
 	const samples: any[] = Object.values(raw.samples)
 
-	let sites = samples.map(s => {
-		const val = s[facilityTW.$id].value
-		let label = facilityTW.term.values?.[val]?.label || val
-		if (label.length > 50) label = label.slice(0, 47) + '...'
-		return { value: val, label }
-	})
+	let sites = samples
+		.filter(s => s[facilityTW.$id])
+		.map(s => {
+			const val = s[facilityTW.$id].value
+			let label = facilityTW.term.values?.[val]?.label || val
+			if (label.length > 50) label = label.slice(0, 47) + '...'
+			return { value: val, label }
+		})
 	if (userSites && query.filterByUserSites) sites = sites.filter(s => userSites.includes(s.value))
 	sites.sort((a, b) => a.label.localeCompare(b.label))
 
 	// Narrow eligible samples to user's sites only when filterByUserSites=true; otherwise aggregate globally.
 	const eligibleSamples =
-		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
+		userSites && query.filterByUserSites
+			? samples.filter(s => s[facilityTW.$id] && userSites.includes(s[facilityTW.$id].value))
+			: samples
 
 	const term2Score: Record<string, { [k: string]: number }> = {}
 	for (const d of query.scoreTerms) {

--- a/server/src/routes/profile.polar2.ts
+++ b/server/src/routes/profile.polar2.ts
@@ -99,12 +99,14 @@ async function getScores(query: any, ds: any) {
 
 	// 5. Build eligible sites list (filter to user's accessible sites if needed)
 	const sampleList: any[] = Object.values(raw.samples)
-	let sites = sampleList.map(s => {
-		const val = s[facilityTW.$id].value
-		let label = facilityTW.term.values?.[val]?.label || val
-		if (label.length > 50) label = label.slice(0, 47) + '...'
-		return { value: val, label }
-	})
+	let sites = sampleList
+		.filter(s => s[facilityTW.$id])
+		.map(s => {
+			const val = s[facilityTW.$id].value
+			let label = facilityTW.term.values?.[val]?.label || val
+			if (label.length > 50) label = label.slice(0, 47) + '...'
+			return { value: val, label }
+		})
 	if (userSites && query.filterByUserSites) {
 		// getData() already enforces access control via checkAccessToSampleData();
 		// this further narrows the site list to what the user is authorised to see
@@ -120,7 +122,9 @@ async function getScores(query: any, ds: any) {
 	// When filterByUserSites is false, facilityTW is in ignoredTermIds so getData()
 	// returns all sites — median should be computed across all sites (global aggregate)
 	const eligibleSamples =
-		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
+		userSites && query.filterByUserSites
+			? samples.filter(s => s[facilityTW.$id] && userSites.includes(s[facilityTW.$id].value))
+			: samples
 
 	const term2Score: Record<string, number> = {}
 	for (const d of query.scoreTerms) {

--- a/server/src/routes/profile.radar2.ts
+++ b/server/src/routes/profile.radar2.ts
@@ -91,12 +91,14 @@ async function getScores(query: any, ds: any) {
 	if (raw.error) throw raw.error
 
 	const sampleList: any[] = Object.values(raw.samples)
-	let sites = sampleList.map(s => {
-		const val = s[facilityTW.$id].value
-		let label = facilityTW.term.values?.[val]?.label || val
-		if (label.length > 50) label = label.slice(0, 47) + '...'
-		return { value: val, label }
-	})
+	let sites = sampleList
+		.filter(s => s[facilityTW.$id])
+		.map(s => {
+			const val = s[facilityTW.$id].value
+			let label = facilityTW.term.values?.[val]?.label || val
+			if (label.length > 50) label = label.slice(0, 47) + '...'
+			return { value: val, label }
+		})
 	if (userSites && query.filterByUserSites) {
 		sites = sites.filter(s => userSites.includes(s.value))
 	}
@@ -104,7 +106,9 @@ async function getScores(query: any, ds: any) {
 
 	const samples: any[] = Object.values(raw.samples)
 	const eligibleSamples =
-		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
+		userSites && query.filterByUserSites
+			? samples.filter(s => s[facilityTW.$id] && userSites.includes(s[facilityTW.$id].value))
+			: samples
 
 	const term2Score: Record<string, number> = {}
 	for (const d of query.scoreTerms) {

--- a/server/src/routes/profile.radarFacility2.ts
+++ b/server/src/routes/profile.radarFacility2.ts
@@ -101,12 +101,14 @@ async function getScores(query: any, ds: any) {
 	const samples: any[] = Object.values(raw.samples)
 
 	// Build the sites list — user sees their own accessible sites; admin sees all.
-	let sites = samples.map(s => {
-		const val = s[facilityTW.$id].value
-		let label = facilityTW.term.values?.[val]?.label || val
-		if (label.length > 50) label = label.slice(0, 47) + '...'
-		return { value: val, label }
-	})
+	let sites = samples
+		.filter(s => s[facilityTW.$id])
+		.map(s => {
+			const val = s[facilityTW.$id].value
+			let label = facilityTW.term.values?.[val]?.label || val
+			if (label.length > 50) label = label.slice(0, 47) + '...'
+			return { value: val, label }
+		})
 	if (userSites && !isAdmin) {
 		sites = sites.filter(s => userSites.includes(s.value))
 	}
@@ -114,7 +116,9 @@ async function getScores(query: any, ds: any) {
 
 	// Aggregate median — scope depends on filterByUserSites
 	const eligibleSamples =
-		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
+		userSites && query.filterByUserSites
+			? samples.filter(s => s[facilityTW.$id] && userSites.includes(s[facilityTW.$id].value))
+			: samples
 
 	const aggregateScore: Record<string, number> = {}
 	for (const d of query.scoreTerms) {
@@ -134,7 +138,7 @@ async function getScores(query: any, ds: any) {
 
 	let sampleData: any = undefined
 	if (!isPublic && targetSiteValue) {
-		const sampleRow = samples.find(s => s[facilityTW.$id].value == targetSiteValue)
+		const sampleRow = samples.find(s => s[facilityTW.$id]?.value == targetSiteValue)
 		if (sampleRow) {
 			const site = sites.find(s => s.value == targetSiteValue) || {
 				value: targetSiteValue,

--- a/server/src/termdb.profileScores.ts
+++ b/server/src/termdb.profileScores.ts
@@ -26,12 +26,14 @@ const LABEL_MAX_LENGTH = 50
 const LABEL_TRUNCATE_AT = 47
 
 export function buildSitesList(samples: any[], facilityTW: any): Site[] {
-	return samples.map(s => {
-		const rawValue = s[facilityTW.$id].value
-		let label = facilityTW.term.values[rawValue]?.label || rawValue
-		if (label.length > LABEL_MAX_LENGTH) label = label.slice(0, LABEL_TRUNCATE_AT) + '...'
-		return { value: rawValue, label }
-	})
+	return samples
+		.filter(s => s[facilityTW.$id])
+		.map(s => {
+			const rawValue = s[facilityTW.$id].value
+			let label = facilityTW.term.values[rawValue]?.label || rawValue
+			if (label.length > LABEL_MAX_LENGTH) label = label.slice(0, LABEL_TRUNCATE_AT) + '...'
+			return { value: rawValue, label }
+		})
 }
 
 export function filterSitesByUserAccess(sites: Site[], userSites: any[] | undefined): Site[] {
@@ -54,7 +56,7 @@ export function pickSampleAndSite(
 ): { sampleData: any; site: Site | undefined } {
 	if ('facilitySite' in query) {
 		const facilitySite = query.facilitySite || sites[0]?.value
-		const sampleData = samplesList.find(s => s[facilityTW.$id].value == facilitySite)
+		const sampleData = samplesList.find(s => s[facilityTW.$id]?.value == facilitySite)
 		const site = sites.find(s => s.value == facilitySite)
 		return { sampleData, site }
 	}


### PR DESCRIPTION
This pull request introduces a new "SJG Region" filter to the profile plots and improves the robustness of site and sample filtering across the server-side profile routes. The main focus is on ensuring that only samples with valid facility identifiers are included in site lists and user-specific aggregations, which helps prevent errors when data is incomplete or missing.

**Profile plots: new filter and UI improvements**
- Added support for an "SJG Region" filter alongside the existing "WHO Region" in the profile plot UI, including configuration, data loading, and dropdown rendering. 

**Server-side robustness and filtering improvements**
- Updated all relevant server-side routes (`profile.barchart2.ts`, `profile.forms2.ts`, `profile.polar2.ts`, `profile.radar2.ts`, `profile.radarFacility2.ts`) and the `termdb.profileScores.ts` utility to filter out samples that lack a facility identifier before building site lists or aggregating scores, preventing runtime errors and ensuring data integrity. 
- Improved sample and site lookup logic to safely handle cases where the facility identifier may be missing, using optional chaining in relevant places. 


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
