### PR TITLE
Polar plot2

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -173,6 +173,12 @@ function getChartTypeList(self, state) {
 			config: { chartType: 'profilePolar' }
 		},
 		{
+			label: 'Polar 2',
+			chartType: 'profilePolar2',
+			clickTo: self.prepPlot,
+			config: { chartType: 'profilePolar2' }
+		},
+		{
 			label: 'Barchart',
 			clickTo: self.prepPlot,
 			chartType: 'profileBarchart',

--- a/client/plots/controls.btns.js
+++ b/client/plots/controls.btns.js
@@ -94,6 +94,7 @@ function helpBtnInit(opts) {
 	const self = {
 		plotTypes: [
 			'profilePolar',
+			'profilePolar2',
 			'profileBarchart',
 			'profileRadar',
 			'profileRadarFacility',

--- a/client/plots/importPlot.js
+++ b/client/plots/importPlot.js
@@ -96,6 +96,9 @@ export async function importPlot(chartType, notFoundMessage = '') {
 		case 'profilePolar':
 			return await import('./profile/polar.ts')
 
+		case 'profilePolar2':
+			return await import('./profile/polar2.ts')
+
 		case 'profileForms':
 			return await import('./profile/profileForms.ts')
 

--- a/client/plots/profile/README.md
+++ b/client/plots/profile/README.md
@@ -5,7 +5,7 @@ The [`PrOFILE dashboard`](http://localhost:3000/profile/?role=admin) provides se
 
  The plots within the PrOFILE dashboard inherit from the base [`profilePlot`]((../profilePlot.js)) that encapsulates common functionalities such as the data fetching and the creation of the chart filters. Each specific plot type (e.g., `profilePolar`, `profileBarchart`) inherits from this base component extending its logic to render their unique visualization. This structure promotes code reuse and consistency across the different plots. 
 
-The charts retrieve their data by calling either the termdb.profileScores or termdb.profileFormScores endpoint, depending on the type of visualization. Most plots, such as polar, radar, and the profile barchart use the termdb.profileScores endpoint to obtain aggregated scores for each module or domain. In contrast, the profileForms plot calls the termdb.profileFormScores endpoint to fetch detailed, question-level survey responses per domain. 
+The charts retrieve their data by calling dedicated or shared server endpoints, depending on the type of visualization. Most plots, such as polar, radar, and the profile barchart use the `termdb/profileScores` endpoint to obtain aggregated scores for each module or domain. The `profileForms` plot calls `termdb/profileFormScores` to fetch detailed, question-level survey responses per domain. Newer plots such as `profilePolar2` use their own dedicated endpoint (`termdb/profilePolar2Scores`), establishing a pattern where each plot owns its route and data logic independently. 
 
 ### How Filters Are Implemented
 
@@ -54,6 +54,37 @@ Here is a breakdown of the main plot types:
 **Title:** Score-based Results by PrOFILE Module  
 **Description:** This chart provides a high-level overview of the aggregated performance across different PrOFILE modules. Each slice of the polar represents a module (e.g., 'National Context', 'Personnel', 'Diagnostics').  
 **Calculation:** For each module, a percentage score is calculated for every participating institution by dividing its score by the maximum possible score. The value shown on the chart for each module is the **median** of these percentage scores across all institutions included in the current filter. This gives a snapshot of the central tendency of performance in each area.
+
+
+### Polar Chart v2 (profilePolar2)
+**Class:** [polar2.ts](./polar2.ts)
+**Server route:** [`profile.polar2.ts`](../../../../server/routes/profile.polar2.ts) at endpoint `termdb/profilePolar2Scores`
+**Title:** Score-based Results by PrOFILE Module (v2)
+**Description:** A redesigned polar chart that establishes the per-plot dedicated route architecture. Visually identical to the original polar chart but with a cleaner, more secure data flow.
+
+**Key differences from the original Polar Chart:**
+
+- **Dedicated server route:** Uses `termdb/profilePolar2Scores` instead of the shared `termdb/profileScores`. This is the first plot with its own route — future plots (radar, barchart, forms) will follow the same pattern.
+- **Server-side facility term derivation:** The client does not send `facilityTW`. The server derives the correct facility term (`FUNIT` for full cohort, `AUNIT` for abbreviated) by inspecting term ID prefixes already present in the request (`scoreTerms` or `filter`), eliminating any client influence over which facility term is used.
+- **Always aggregated:** Always returns the median percentage across all eligible sites. There is no single-site mode — when only one site is accessible, the median of a single value equals that value.
+- **Minimal client payload:** The client strips `scoreTerms` down to `{ term: { id }, q }` before sending via `dofetch3`. No `facilityTW`, no `$id`, no client-only term wrapper properties are sent.
+- **Consistent eligible sample scoping:** `eligibleSamples` is filtered to `userSites` only when `filterByUserSites` is explicitly `true`. When `filterByUserSites` is `false`, the median is computed across all sites (global aggregate), consistent with the original polar chart.
+- **Public role security:** `sites` is always `[]` for public users in both this route and `termdb/profileScores` — no site IDs or names are ever exposed to public-role users.
+- **Cleaner rendering structure:** The `plot()` method is split into focused private methods (`createSvg`, `drawGrid`, `drawArcs`, `drawTable`, `drawLegend`) instead of one large function.
+- **Documentation icon:** The help icon in the controls panel is enabled for `profilePolar2` in [`controls.btns.js`](../../plots/controls.btns.js). Clicking it opens the polar graph PDF for the active cohort (Abbreviated or Full), configured in [`profilePlot.ts`](./profilePlot.ts).
+
+**Calculation:** Identical to the original polar chart — for each module, computes `(score / maxScore) * 100` per eligible site, then returns the median across all eligible sites, rounded to the nearest integer.
+
+**Role and cohort coverage:**
+
+| Role | `filterByUserSites` | Eligible samples | `sites` in response |
+|------|---------------------|-----------------|---------------------|
+| Public | false | All sites | `[]` (never exposed) |
+| Admin | false | All sites | Full sorted list |
+| Site user | false | All sites (global aggregate) | Full sorted list |
+| Site user | true | User's sites only | User's sites only |
+
+Both Full (`FUNIT`) and Abbreviated (`AUNIT`) cohorts are handled automatically — `derivePrefix()` reads the `F`/`A` prefix from term IDs already present in the request, requiring no cohort-specific logic on the client.
 
 
 ### Facility Radar Chart

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -42,9 +42,9 @@ class ProfilePolar2 extends profilePlot {
 	 * Override setControls() to fetch data from the dedicated polar2 route.
 	 * The base class setControls() builds filter UI and sets this.filter but
 	 * skips the data fetch for profilePolar2 (see profilePlot.ts).
-	 * This method then calls termdb/profilePolar2Scores which derives
-	 * facilityTW (FUNIT/AUNIT) server-side from activeCohort and returns
-	 * aggregated (median) percentages across all eligible sites.
+	 * This method calls termdb/profilePolar2Scores, which derives the facility
+	 * term server-side from the request data and returns aggregated (median)
+	 * percentages across all eligible sites.
 	 */
 	async setControls(additionalInputs: any[] = []) {
 		await super.setControls(additionalInputs)
@@ -52,17 +52,14 @@ class ProfilePolar2 extends profilePlot {
 	}
 
 	private async fetchAggregatedScores() {
-		const args: any = {
-			// Strip to only term id and q — server fills the rest via termjsonByOneid
-			scoreTerms: this.scoreTerms.map((t: any) => ({
-				score: { term: { id: t.score.term.id }, q: t.score.q },
-				maxScore: typeof t.maxScore === 'number' ? t.maxScore : { term: { id: t.maxScore.term.id }, q: t.maxScore.q }
-			})),
-			filterByUserSites: this.settings?.filterByUserSites
-		}
-		if (this.filter) args.filter = this.filter
-		// No facilityTW — the server derives FUNIT/AUNIT from activeCohort in __protected__
-		return this.app.vocabApi.getProfilePolar2Scores(args)
+		// Pass scoreTerms as-is — getProfilePolar2Scores calls mayStripTwProps on each tw,
+		// which strips unneeded client-only properties and reduces term to { id } only.
+		// No facilityTW — the server derives it from term ID prefixes in the request.
+		return this.app.vocabApi.getProfilePolar2Scores({
+			scoreTerms: this.scoreTerms,
+			filterByUserSites: this.settings?.filterByUserSites,
+			filter: this.filter
+		})
 	}
 
 	onMouseOut(event: MouseEvent) {

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -1,0 +1,241 @@
+import type { MassAppApi, MassState } from '#mass/types/mass'
+import type { SvgG } from '../../types/d3'
+import type { ProfilePolarConfig, ProfilePolarDom } from './types/PolarTypes'
+import type { TableCell } from '#dom'
+import { getCompInit, copyMerge } from '#rx'
+import { fillTwLst } from '#termsetting'
+import * as d3 from 'd3'
+import { profilePlot, getDefaultProfilePlotSettings, getProfilePlotConfig } from './profilePlot.js'
+import { renderTable } from '#dom'
+
+/** TODO: profilePlot must extend RxComponent but file not tsc.
+ * Work arounds until profilePlot is migrated to ts.
+ */
+class ProfilePolar2 extends profilePlot {
+	static type = 'profilePolar2'
+	readonly radius = 250
+	readonly arcGenerator = d3.arc().innerRadius(0)
+	angle!: number
+	polarG!: SvgG
+	declare legendG: SvgG
+	declare filterG: SvgG
+	declare dom: ProfilePolarDom
+
+	constructor(opts) {
+		super(opts, 'profilePolar2')
+	}
+
+	async init(appState: MassState) {
+		await super.init(appState)
+		const config = appState.plots.find(p => p.id === this.id) as ProfilePolarConfig
+		this.scoreTerms = config.terms
+		this.angle = (Math.PI * 2) / config.terms.length
+	}
+
+	async main() {
+		await super.main()
+		await this.setControls()
+		this.plot()
+	}
+
+	onMouseOut(event: MouseEvent) {
+		const target = event.target as HTMLElement
+		if (target.tagName === 'path') {
+			target.setAttribute('stroke', 'white')
+			if (target.getAttribute('stroke-opacity') === '0') {
+				target.setAttribute('stroke-opacity', '1')
+			}
+		}
+		this.tip.hide()
+	}
+
+	onMouseOver(event: MouseEvent) {
+		const target = event.target as HTMLElement
+		if (target.tagName === 'path') {
+			target.setAttribute('stroke-opacity', '0')
+			const d = (target as any).__data__
+			const menu = this.tip.clear()
+			const percentage = this.getPercentage(d)
+			menu.d.text(`${d.module} ${percentage}%`)
+			menu.show(event.clientX, event.clientY, true, true)
+		} else {
+			this.onMouseOut(event)
+		}
+	}
+
+	plot() {
+		this.createSvg()
+		const rows = this.drawArcs()
+		this.drawGrid()
+		this.drawTable(rows)
+		this.drawLegend()
+	}
+
+	private createSvg() {
+		const width = this.isComparison ? 800 : 1000,
+			height = 600
+		this.dom.svg = this.dom.plotDiv
+			.append('div')
+			.style('display', 'inline-block')
+			.append('svg')
+			.attr('width', width)
+			.attr('height', height) as any
+
+		this.dom.tableDiv = this.dom.plotDiv
+			.append('div')
+			.attr('data-testid', 'sjpp-profilePolar2-data-table')
+			.style('display', 'inline-block')
+			.style('vertical-align', 'top')
+			.style('margin', '45px 20px') as any
+
+		this.dom.svg
+			.append('text')
+			.attr('transform', `translate(130, 40)`)
+			.attr('font-weight', 'bold')
+			.text(this.config.title)
+
+		const x = 280,
+			y = 330
+		this.polarG = this.dom.svg.append('g').attr('transform', `translate(${x},${y})`)
+		this.legendG = this.dom.svg
+			.append('g')
+			.attr('data-testid', 'sjpp-profilePolar2-legend')
+			.attr('transform', `translate(${x + 280}, ${y - 200})`)
+		this.filterG = this.dom.svg.append('g').attr('transform', `translate(${x + 280},${y})`)
+	}
+
+	private drawGrid() {
+		// Background concentric circles at every 10%
+		for (let i = 0; i <= 10; i++) this.drawGridCircle(i * 10)
+
+		// Grade boundary circles with grade labels
+		this.drawGradeCircle(50, 'C')
+		this.drawGradeCircle(75, 'B')
+		this.drawGradeCircle(100, 'A')
+
+		// Percentage labels along the left axis
+		for (let i = 0; i <= 10; i++) {
+			const percent = i * 10
+			this.polarG
+				.append('text')
+				.attr('transform', `translate(-10, ${(-percent / 100) * this.radius + 5})`)
+				.attr('text-anchor', 'end')
+				.style('font-size', '0.8rem')
+				.text(`${percent}%`)
+				.attr('pointer-events', 'none')
+		}
+	}
+
+	private drawGridCircle(percent: number) {
+		const circle = this.polarG
+			.append('circle')
+			.attr('r', (percent / 100) * this.radius)
+			.style('fill', 'none')
+			.style('opacity', '0.5')
+		if (percent != 50) circle.style('stroke', '#aaa')
+	}
+
+	private drawGradeCircle(percent: number, label: string) {
+		const circle = this.polarG
+			.append('circle')
+			.attr('r', (percent / 100) * this.radius)
+			.style('fill', 'none')
+			.style('opacity', '0.5')
+
+		if (percent != 100) circle.style('stroke-dasharray', '5, 5').style('stroke-width', '2').style('stroke', 'black')
+
+		this.polarG
+			.append('text')
+			.attr('transform', `translate(15, ${-(percent / 100 - 0.125) * this.radius + 10})`)
+			.attr('text-anchor', 'middle')
+			.text(label)
+			.style('font-weight', 'bold')
+			.style('font-size', '24px')
+			.attr('pointer-events', 'none')
+	}
+
+	/** Draws the arc slices and returns table rows for drawTable(). */
+	private drawArcs(): TableCell[][] {
+		const rows: TableCell[][] = []
+		let i = 0
+		for (const d of this.config.terms) {
+			d.i = i
+			const color = d.score.term.color
+			const percentage = this.getPercentage(d)
+			rows.push([{ color, disabled: true }, { value: d.module }, { value: percentage }])
+			this.polarG
+				.append('g')
+				.append('path')
+				.datum(d)
+				.attr('fill', color)
+				.attr('stroke', 'white')
+				.attr(
+					'd',
+					this.arcGenerator({
+						outerRadius: (percentage! / 100) * this.radius,
+						startAngle: i * this.angle,
+						endAngle: (i + 1) * this.angle
+					} as any)
+				)
+				.on('click', event => this.onMouseOver(event))
+			i++
+		}
+		return rows
+	}
+
+	private drawTable(rows: TableCell[][]) {
+		const columns = [{ label: 'Color' }, { label: 'Module' }, { label: 'Score', align: 'center' }]
+		this.dom.tableDiv.selectAll('*').remove()
+		if (!this.isComparison)
+			renderTable({
+				rows,
+				columns,
+				div: this.dom.tableDiv,
+				showLines: true,
+				resize: true,
+				maxHeight: '50vh'
+			})
+	}
+
+	private drawLegend() {
+		if (!this.isComparison) {
+			this.legendG
+				.append('text')
+				.attr('text-anchor', 'left')
+				.style('font-weight', 'bold')
+				.text('Overall Score')
+				.attr('transform', `translate(0, -5)`)
+			this.addLegendItem('A', 'More than 75% of possible scorable items', 1)
+			this.addLegendItem('B', '50-75% of possible scorable items', 2)
+			this.addLegendItem('C', 'Less than 50% of possible scorable items', 3)
+		}
+		this.addFilterLegend()
+	}
+}
+
+export async function getPlotConfig(opts: any, app: MassAppApi, _activeCohort: number) {
+	try {
+		const activeCohort = _activeCohort === undefined ? app.getState().activeCohort : _activeCohort
+		const defaults = await getProfilePlotConfig(activeCohort, app, opts)
+		if (!defaults) throw 'default config not found in termdbConfig.plotConfigByCohort.profilePolar2'
+		const settings = getDefaultProfilePlotSettings()
+		defaults.settings = { profilePolar2: settings }
+
+		const config = copyMerge(structuredClone(defaults), opts)
+		config.settings.controls = { isOpen: false }
+		const twlst: any[] = []
+		for (const data of config.terms) {
+			data.score.q = { mode: 'continuous' }
+			data.maxScore.q = { mode: 'continuous' }
+			twlst.push(data.score, data.maxScore)
+		}
+		await fillTwLst(twlst, app.vocabApi)
+
+		return config
+	} catch (e) {
+		throw new Error(`${e} [profilePolar2 getPlotConfig()]`)
+	}
+}
+
+export const profilePolar2Init = getCompInit(ProfilePolar2)
+export const componentInit = profilePolar2Init

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -4,7 +4,7 @@ import type { ProfilePolarConfig, ProfilePolarDom } from './types/PolarTypes'
 import type { TableCell } from '#dom'
 import { getCompInit, copyMerge } from '#rx'
 import { fillTwLst } from '#termsetting'
-import * as d3 from 'd3'
+import { arc } from 'd3'
 import { profilePlot, getDefaultProfilePlotSettings, getProfilePlotConfig } from './profilePlot.js'
 import { dofetch3 } from '#common/dofetch'
 import { renderTable } from '#dom'
@@ -15,7 +15,7 @@ import { renderTable } from '#dom'
 class ProfilePolar2 extends profilePlot {
 	static type = 'profilePolar2'
 	readonly radius = 250
-	readonly arcGenerator = d3.arc().innerRadius(0)
+	readonly arcGenerator = arc().innerRadius(0)
 	angle!: number
 	polarG!: SvgG
 	declare legendG: SvgG

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -6,6 +6,7 @@ import { getCompInit, copyMerge } from '#rx'
 import { fillTwLst } from '#termsetting'
 import * as d3 from 'd3'
 import { profilePlot, getDefaultProfilePlotSettings, getProfilePlotConfig } from './profilePlot.js'
+import { dofetch3 } from '#common/dofetch'
 import { renderTable } from '#dom'
 
 /** TODO: profilePlot must extend RxComponent but file not tsc.
@@ -52,13 +53,15 @@ class ProfilePolar2 extends profilePlot {
 	}
 
 	private async fetchAggregatedScores() {
-		// Pass scoreTerms as-is — getProfilePolar2Scores calls mayStripTwProps on each tw,
-		// which strips unneeded client-only properties and reduces term to { id } only.
 		// No facilityTW — the server derives it from term ID prefixes in the request.
-		return this.app.vocabApi.getProfilePolar2Scores({
-			scoreTerms: this.scoreTerms,
-			filterByUserSites: this.settings?.filterByUserSites,
-			filter: this.filter
+		return dofetch3('termdb/profilePolar2Scores', {
+			body: {
+				genome: this.state.vocab.genome,
+				dslabel: this.state.vocab.dslabel,
+				scoreTerms: this.scoreTerms,
+				filterByUserSites: this.settings?.filterByUserSites,
+				filter: this.filter
+			}
 		})
 	}
 

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -50,6 +50,7 @@ class ProfilePolar2 extends profilePlot {
 	async setControls(additionalInputs: any[] = []) {
 		await super.setControls(additionalInputs)
 		this.data = await this.fetchAggregatedScores()
+		if (this.data && 'error' in this.data) throw this.data.error
 	}
 
 	private async fetchAggregatedScores() {
@@ -87,7 +88,8 @@ class ProfilePolar2 extends profilePlot {
 			const d = (target as any).__data__
 			const menu = this.tip.clear()
 			const percentage = this.getPercentage(d)
-			menu.d.text(`${d.module} ${percentage}%`)
+			const label = percentage == null ? 'N/A' : `${percentage}%`
+			menu.d.text(`${d.module} ${label}`)
 			menu.show(event.clientX, event.clientY, true, true)
 		} else {
 			this.onMouseOut(event)
@@ -193,7 +195,7 @@ class ProfilePolar2 extends profilePlot {
 			d.i = i
 			const color = d.score.term.color
 			const percentage = this.getPercentage(d)
-			rows.push([{ color, disabled: true }, { value: d.module }, { value: percentage }])
+			rows.push([{ color, disabled: true }, { value: d.module }, { value: percentage ?? 'N/A' }])
 			this.polarG
 				.append('g')
 				.append('path')

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -38,6 +38,33 @@ class ProfilePolar2 extends profilePlot {
 		this.plot()
 	}
 
+	/**
+	 * Override setControls() to fetch data from the dedicated polar2 route.
+	 * The base class setControls() builds filter UI and sets this.filter but
+	 * skips the data fetch for profilePolar2 (see profilePlot.ts).
+	 * This method then calls termdb/profilePolar2Scores which derives
+	 * facilityTW (FUNIT/AUNIT) server-side from activeCohort and returns
+	 * aggregated (median) percentages across all eligible sites.
+	 */
+	async setControls(additionalInputs: any[] = []) {
+		await super.setControls(additionalInputs)
+		this.data = await this.fetchAggregatedScores()
+	}
+
+	private async fetchAggregatedScores() {
+		const args: any = {
+			// Strip to only term id and q — server fills the rest via termjsonByOneid
+			scoreTerms: this.scoreTerms.map((t: any) => ({
+				score: { term: { id: t.score.term.id }, q: t.score.q },
+				maxScore: typeof t.maxScore === 'number' ? t.maxScore : { term: { id: t.maxScore.term.id }, q: t.maxScore.q }
+			})),
+			filterByUserSites: this.settings?.filterByUserSites
+		}
+		if (this.filter) args.filter = this.filter
+		// No facilityTW — the server derives FUNIT/AUNIT from activeCohort in __protected__
+		return this.app.vocabApi.getProfilePolar2Scores(args)
+	}
+
 	onMouseOut(event: MouseEvent) {
 		const target = event.target as HTMLElement
 		if (target.tagName === 'path') {

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -54,11 +54,15 @@ class ProfilePolar2 extends profilePlot {
 
 	private async fetchAggregatedScores() {
 		// No facilityTW — the server derives it from term ID prefixes in the request.
+		// scoreTerms stripped to { term: { id }, q } only — server fills the rest via termjsonByOneid.
 		return dofetch3('termdb/profilePolar2Scores', {
 			body: {
 				genome: this.state.vocab.genome,
 				dslabel: this.state.vocab.dslabel,
-				scoreTerms: this.scoreTerms,
+				scoreTerms: this.scoreTerms.map((t: any) => ({
+					score: { term: { id: t.score.term.id }, q: t.score.q },
+					maxScore: typeof t.maxScore === 'number' ? t.maxScore : { term: { id: t.maxScore.term.id }, q: t.maxScore.q }
+				})),
 				filterByUserSites: this.settings?.filterByUserSites,
 				filter: this.filter
 			}

--- a/client/plots/profile/profileForms.ts
+++ b/client/plots/profile/profileForms.ts
@@ -10,6 +10,7 @@ const YES_NO_TAB = 'Yes/No Barchart'
 const IMPRESSIONS_TAB = 'Impressions'
 const LIKERT_TAB = 'Likert Scale'
 export class profileForms extends profilePlot {
+	static type = 'profileForms' as const
 	id: any
 	svg: any
 	components: any

--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -259,14 +259,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 
 			this.filter = this.config.filter || this.getFilter()
 
-			if (this.type != 'profileForms')
-				this.data = await this.app.vocabApi.getProfileScores({
-					scoreTerms: this.scoreTerms,
-					filter: this.filter,
-					facilityTW: this.config.facilityTW,
-					filterByUserSites: this.settings.filterByUserSites
-				})
-			else
+			if (this.type == 'profileForms')
 				this.data = await this.app.vocabApi.getProfileFormScores({
 					scoreTerms: this.scoreTerms,
 					scScoreTerms: this.scScoreTerms,
@@ -274,7 +267,16 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 					facilityTW: this.config.facilityTW,
 					filterByUserSites: this.settings.filterByUserSites
 				})
-			if ('error' in this.data) throw this.data.error
+			else if (this.type != 'profilePolar2')
+				// profilePolar2 skips this fetch — its subclass setControls() calls
+				// the dedicated termdb/profilePolar2Scores route instead
+				this.data = await this.app.vocabApi.getProfileScores({
+					scoreTerms: this.scoreTerms,
+					filter: this.filter,
+					facilityTW: this.config.facilityTW,
+					filterByUserSites: this.settings.filterByUserSites
+				})
+			if (this.data && 'error' in this.data) throw this.data.error
 			this.sites = this.filteredTermValues[this.config.facilityTW.id]?.filter(s => !s.disabled && s.value)
 
 			if (this.settings[this.config.facilityTW?.term?.id])

--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -453,7 +453,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 					if (chartType == 'profileBarchart')
 						link =
 							'https://global.stjude.org/content/dam/global/en-us/documents/no-index/bar-graph-abbr-profiledash.pdf'
-					else if (chartType == 'profilePolar')
+					else if (chartType == 'profilePolar' || chartType == 'profilePolar2')
 						link =
 							'https://global.stjude.org/content/dam/global/en-us/documents/no-index/polar-graph-abbr-profiledash.pdf'
 					else if (chartType.startsWith('profileRadar'))
@@ -462,7 +462,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 					if (chartType == 'profileBarchart')
 						link =
 							'https://global.stjude.org/content/dam/global/en-us/documents/no-index/bar-graph-full-profiledash.pdf'
-					else if (chartType == 'profilePolar')
+					else if (chartType == 'profilePolar' || chartType == 'profilePolar2')
 						link =
 							'https://global.stjude.org/content/dam/global/en-us/documents/no-index/polar-graph-full-profiledash.pdf'
 					else if (chartType.startsWith('profileRadar'))

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1395,6 +1395,8 @@ export class TermdbVocab extends Vocab {
 			for (const t of body.scoreTerms) {
 				if (typeof t.maxScore != 'number') this.mayStripTwProps(t.maxScore)
 				this.mayStripTwProps(t.score)
+				delete t.score.$id
+				if (typeof t.maxScore != 'number') delete t.maxScore.$id
 			}
 		}
 		return await this.dofetch3('termdb/profilePolar2Scores', { body })

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1383,6 +1383,23 @@ export class TermdbVocab extends Vocab {
 		return await this.dofetch3('termdb/profileScores', { body })
 	}
 
+	async getProfilePolar2Scores(args) {
+		const body = {
+			genome: this.vocab.genome,
+			dslabel: this.vocab.dslabel,
+			...args
+		}
+		if (body.filter) body.filter = getNormalRoot(body.filter)
+		if (body.scoreTerms) {
+			body.scoreTerms = structuredClone(body.scoreTerms)
+			for (const t of body.scoreTerms) {
+				if (typeof t.maxScore != 'number') this.mayStripTwProps(t.maxScore)
+				this.mayStripTwProps(t.score)
+			}
+		}
+		return await this.dofetch3('termdb/profilePolar2Scores', { body })
+	}
+
 	async getProfileFormScores(args) {
 		const body = {
 			genome: this.vocab.genome,

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -1383,25 +1383,6 @@ export class TermdbVocab extends Vocab {
 		return await this.dofetch3('termdb/profileScores', { body })
 	}
 
-	async getProfilePolar2Scores(args) {
-		const body = {
-			genome: this.vocab.genome,
-			dslabel: this.vocab.dslabel,
-			...args
-		}
-		if (body.filter) body.filter = getNormalRoot(body.filter)
-		if (body.scoreTerms) {
-			body.scoreTerms = structuredClone(body.scoreTerms)
-			for (const t of body.scoreTerms) {
-				if (typeof t.maxScore != 'number') this.mayStripTwProps(t.maxScore)
-				this.mayStripTwProps(t.score)
-				delete t.score.$id
-				if (typeof t.maxScore != 'number') delete t.maxScore.$id
-			}
-		}
-		return await this.dofetch3('termdb/profilePolar2Scores', { body })
-	}
-
 	async getProfileFormScores(args) {
 		const body = {
 			genome: this.vocab.genome,

--- a/server/routes/profile.polar2.ts
+++ b/server/routes/profile.polar2.ts
@@ -145,65 +145,14 @@ async function getScores(query: any, ds: any) {
  * Returns null when no samples have data for the term.
  */
 function computeMedianPercentage(d: any, samples: any[]): number | null {
-	const termId = d.score.term.id
-	const debugTerms = ['AX127', 'AX176']
-	const isDebug = debugTerms.includes(termId)
-
-	// Step 1: samples that have a score value (including 0)
-	const withScore = samples.filter(s => s[d.score.$id]?.value != null)
-
-	// Step 2: samples dropped by old polar's falsy filter (score === 0)
-	const zeroScoreSamples = samples.filter(s => s[d.score.$id]?.value === 0)
-
-	if (isDebug) {
-		console.log(`\n[polar2 DEBUG] term=${termId}`)
-		console.log(`  total samples : ${samples.length}`)
-		console.log(`  with score (!=null): ${withScore.length}`)
-		console.log(`  zero-score samples (would be dropped by old polar): ${zeroScoreSamples.length}`)
-	}
-
-	const percentages = withScore
-		.map(s => {
-			const maxScore = typeof d.maxScore === 'number' ? d.maxScore : s[d.maxScore.$id]?.value
-			const pct = maxScore ? (s[d.score.$id].value / maxScore) * 100 : null
-			if (isDebug) {
-				console.log(
-					`    score=${s[d.score.$id].value}  maxScore=${maxScore}  pct=${pct?.toFixed(2) ?? 'null (skipped)'}`
-				)
-			}
-			return pct
-		})
-		.filter((p): p is number => p !== null)
+	const percentages = samples
+		.filter(s => s[d.score.$id]?.value)
+		.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
 
 	if (percentages.length === 0) return null
 	percentages.sort((a, b) => a - b)
 
 	const mid = Math.floor(percentages.length / 2)
 	const median = percentages.length % 2 !== 0 ? percentages[mid] : (percentages[mid - 1] + percentages[mid]) / 2
-	const result = Math.round(median)
-
-	if (isDebug) {
-		// Simulate old polar: drop zero scores, recompute median
-		const oldPercentages = samples
-			.filter(s => s[d.score.$id]?.value) // old falsy filter — drops 0
-			.map(s => {
-				const maxScore = typeof d.maxScore === 'number' ? d.maxScore : s[d.maxScore.$id]?.value
-				return maxScore ? (s[d.score.$id].value / maxScore) * 100 : null
-			})
-			.filter((p): p is number => p !== null)
-		oldPercentages.sort((a, b) => a - b)
-		const oldMid = Math.floor(oldPercentages.length / 2)
-		const oldMedian =
-			oldPercentages.length % 2 !== 0
-				? oldPercentages[oldMid]
-				: (oldPercentages[oldMid - 1] + oldPercentages[oldMid]) / 2
-		const oldResult = Math.round(oldMedian)
-
-		console.log(`  sorted percentages (polar2): [${percentages.map(p => p.toFixed(1)).join(', ')}]`)
-		console.log(`  median (polar2) = ${result}`)
-		console.log(`  median (old polar, zeros excluded) = ${oldResult}`)
-		console.log(`  difference = ${result - oldResult}`)
-	}
-
-	return result
+	return Math.round(median)
 }

--- a/server/routes/profile.polar2.ts
+++ b/server/routes/profile.polar2.ts
@@ -5,12 +5,12 @@ import { getData } from '../src/termdb.matrix.js'
 /*
 Route for profilePolar2.
 
-Key difference from termdb.profileScores:
+Key differences from termdb.profileScores:
   - Client does NOT send facilityTW.
-  - Server derives the facility term id from activeCohort in __protected__:
-      activeCohort === 1 (FULL_COHORT)  → FUNIT
-      activeCohort === 0 (ABBREV_COHORT) → AUNIT
-  - Site data is queried at module level using getData(), same pattern as
+  - Server derives the facility term id by inspecting term ID prefixes already
+    present in the request (scoreTerms or filter), so no cohort-specific logic
+    is needed on the client side.
+  - Site data is queried server-side using getData(), same pattern as
     termdb.profileScores.ts getScoresData().
   - Always returns aggregated (median across all eligible sites) percentages.
 */
@@ -44,11 +44,30 @@ function init({ genomes }) {
 	}
 }
 
+/**
+ * Derives the cohort prefix from term IDs already present in the request.
+ * Primary source: scoreTerms (always present in the request).
+ * Fallback: filter term IDs (may be absent if no filters are applied).
+ * Term IDs share the same prefix as the facility term for a given cohort.
+ */
+function derivePrefix(query: any): string {
+	const firstScoreId = query.scoreTerms?.[0]?.score?.term?.id
+	if (firstScoreId?.startsWith('F')) return 'F'
+	if (firstScoreId?.startsWith('A')) return 'A'
+	for (const entry of query.filter?.lst || []) {
+		const id = entry.tvs?.term?.id
+		if (id?.startsWith('F')) return 'F'
+		if (id?.startsWith('A')) return 'A'
+	}
+	throw 'cannot determine cohort prefix from scoreTerms or filter term IDs'
+}
+
 async function getScores(query: any, ds: any) {
-	// 1. Derive facility term id server-side from activeCohort.
-	//    FULL_COHORT = 1 → prefix 'F', ABBREV_COHORT = 0 → prefix 'A'
-	const { activeCohort, clientAuthResult } = query.__protected__
-	const prefix = activeCohort === 1 ? 'F' : 'A'
+	// 1. Derive facility term id from term IDs already in the request.
+	//    scoreTerms and filter terms share the same cohort prefix as the facility term,
+	//    so no client-supplied facilityTW is needed.
+	const { activeCohort, clientAuthResult } = query.__protected__ // still needed for auth
+	const prefix = derivePrefix(query)
 	const facilityTermId = `${prefix}UNIT`
 
 	// Minimal term wrapper — getData will fill term.values, $id, etc.

--- a/server/routes/profile.polar2.ts
+++ b/server/routes/profile.polar2.ts
@@ -1,0 +1,93 @@
+import type { RouteApi } from '#types'
+import { ProfileScoresPayload } from '#types/checkers'
+import { getScoresData } from './termdb.profileScores.js'
+
+/*
+Clean route for profilePolar2.
+Reuses getScoresData() from termdb.profileScores for data retrieval,
+then runs the same median-based percentage calculation in a typed, explicit form.
+*/
+
+export const api: RouteApi = {
+	endpoint: 'termdb/profilePolar2Scores',
+	methods: {
+		get: {
+			...ProfileScoresPayload,
+			init
+		},
+		post: {
+			...ProfileScoresPayload,
+			init
+		}
+	}
+}
+
+function init({ genomes }) {
+	return async (req, res): Promise<void> => {
+		try {
+			const g = genomes[req.query.genome]
+			if (!g) throw 'invalid genome name'
+			const ds = g.datasets?.[req.query.dslabel]
+			const result = await getScores(req.query, ds)
+			res.send(result)
+		} catch (e: any) {
+			console.log(e)
+			res.send({ status: 'error', error: e.message || e })
+		}
+	}
+}
+
+async function getScores(query: any, ds: any) {
+	// Collect all terms needed for the data fetch: facility + score pairs
+	const terms: any[] = [query.facilityTW]
+	for (const term of query.scoreTerms) {
+		terms.push(term.score)
+		if (term.maxScore?.term) terms.push(term.maxScore)
+	}
+
+	const data = await getScoresData(query, ds, terms)
+
+	const term2Score: Record<string, number | null> = {}
+	for (const d of query.scoreTerms) {
+		term2Score[d.score.term.id] = computePercentage(d, data.samples, data.sampleData)
+	}
+
+	return {
+		term2Score,
+		sites: data.sites,
+		site: data.site,
+		n: data.sampleData ? 1 : data.samples.length
+	}
+}
+
+/**
+ * Aggregate mode (no specific facility):
+ *   Computes (score / maxScore) * 100 for every sample, then returns the median.
+ *
+ * Single-facility mode (sampleData is set):
+ *   Returns (score / maxScore) * 100 for that one facility, rounded.
+ */
+function computePercentage(d: any, samples: any[], sampleData: any): number | null {
+	if (!d) return null
+
+	if (sampleData == null) {
+		// Aggregate: collect per-site percentages, sort, take median
+		const percentages = samples
+			.filter(s => s[d.score.$id]?.value)
+			.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
+
+		if (percentages.length === 0) return null
+		percentages.sort((a, b) => a - b)
+
+		const mid = Math.floor(percentages.length / 2)
+		const median = percentages.length % 2 !== 0 ? percentages[mid] : (percentages[mid - 1] + percentages[mid]) / 2
+
+		return Math.round(median)
+	} else {
+		// Single facility
+		const score = sampleData[d.score.$id]?.value
+		const maxScore = d.maxScore.term ? sampleData[d.maxScore.$id]?.value : d.maxScore
+		if (!score || !maxScore) return null
+		return Math.round((score / maxScore) * 100)
+	}
+}

--- a/server/routes/profile.polar2.ts
+++ b/server/routes/profile.polar2.ts
@@ -125,9 +125,10 @@ async function getScores(query: any, ds: any) {
 	const eligibleSamples =
 		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
 
-	const term2Score: Record<string, number | null> = {}
+	const term2Score: Record<string, number> = {}
 	for (const d of query.scoreTerms) {
-		term2Score[d.score.term.id] = computeMedianPercentage(d, eligibleSamples)
+		const score = computeMedianPercentage(d, eligibleSamples)
+		if (score !== null) term2Score[d.score.term.id] = score
 	}
 
 	return {
@@ -144,14 +145,65 @@ async function getScores(query: any, ds: any) {
  * Returns null when no samples have data for the term.
  */
 function computeMedianPercentage(d: any, samples: any[]): number | null {
-	const percentages = samples
-		.filter(s => s[d.score.$id]?.value)
-		.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
+	const termId = d.score.term.id
+	const debugTerms = ['AX127', 'AX176']
+	const isDebug = debugTerms.includes(termId)
+
+	// Step 1: samples that have a score value (including 0)
+	const withScore = samples.filter(s => s[d.score.$id]?.value != null)
+
+	// Step 2: samples dropped by old polar's falsy filter (score === 0)
+	const zeroScoreSamples = samples.filter(s => s[d.score.$id]?.value === 0)
+
+	if (isDebug) {
+		console.log(`\n[polar2 DEBUG] term=${termId}`)
+		console.log(`  total samples : ${samples.length}`)
+		console.log(`  with score (!=null): ${withScore.length}`)
+		console.log(`  zero-score samples (would be dropped by old polar): ${zeroScoreSamples.length}`)
+	}
+
+	const percentages = withScore
+		.map(s => {
+			const maxScore = typeof d.maxScore === 'number' ? d.maxScore : s[d.maxScore.$id]?.value
+			const pct = maxScore ? (s[d.score.$id].value / maxScore) * 100 : null
+			if (isDebug) {
+				console.log(
+					`    score=${s[d.score.$id].value}  maxScore=${maxScore}  pct=${pct?.toFixed(2) ?? 'null (skipped)'}`
+				)
+			}
+			return pct
+		})
+		.filter((p): p is number => p !== null)
 
 	if (percentages.length === 0) return null
 	percentages.sort((a, b) => a - b)
 
 	const mid = Math.floor(percentages.length / 2)
 	const median = percentages.length % 2 !== 0 ? percentages[mid] : (percentages[mid - 1] + percentages[mid]) / 2
-	return Math.round(median)
+	const result = Math.round(median)
+
+	if (isDebug) {
+		// Simulate old polar: drop zero scores, recompute median
+		const oldPercentages = samples
+			.filter(s => s[d.score.$id]?.value) // old falsy filter — drops 0
+			.map(s => {
+				const maxScore = typeof d.maxScore === 'number' ? d.maxScore : s[d.maxScore.$id]?.value
+				return maxScore ? (s[d.score.$id].value / maxScore) * 100 : null
+			})
+			.filter((p): p is number => p !== null)
+		oldPercentages.sort((a, b) => a - b)
+		const oldMid = Math.floor(oldPercentages.length / 2)
+		const oldMedian =
+			oldPercentages.length % 2 !== 0
+				? oldPercentages[oldMid]
+				: (oldPercentages[oldMid - 1] + oldPercentages[oldMid]) / 2
+		const oldResult = Math.round(oldMedian)
+
+		console.log(`  sorted percentages (polar2): [${percentages.map(p => p.toFixed(1)).join(', ')}]`)
+		console.log(`  median (polar2) = ${result}`)
+		console.log(`  median (old polar, zeros excluded) = ${oldResult}`)
+		console.log(`  difference = ${result - oldResult}`)
+	}
+
+	return result
 }

--- a/server/routes/profile.polar2.ts
+++ b/server/routes/profile.polar2.ts
@@ -108,7 +108,7 @@ async function getScores(query: any, ds: any) {
 		if (label.length > 50) label = label.slice(0, 47) + '...'
 		return { value: val, label }
 	})
-	if (userSites) {
+	if (userSites && query.filterByUserSites) {
 		// getData() already enforces access control via checkAccessToSampleData();
 		// this further narrows the site list to what the user is authorised to see
 		sites = sites.filter(s => userSites.includes(s.value))
@@ -119,7 +119,11 @@ async function getScores(query: any, ds: any) {
 	//    When only one site is accessible (sites.length == 1) the median of a
 	//    single value equals that value — identical to the old route's sampleData shortcut.
 	const samples: any[] = Object.values(raw.samples)
-	const eligibleSamples = userSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
+	// Only filter to userSites when filterByUserSites is explicitly enabled.
+	// When filterByUserSites is false, facilityTW is in ignoredTermIds so getData()
+	// returns all sites — median should be computed across all sites (global aggregate)
+	const eligibleSamples =
+		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
 
 	const term2Score: Record<string, number | null> = {}
 	for (const d of query.scoreTerms) {

--- a/server/routes/profile.polar2.ts
+++ b/server/routes/profile.polar2.ts
@@ -1,11 +1,18 @@
 import type { RouteApi } from '#types'
 import { ProfileScoresPayload } from '#types/checkers'
-import { getScoresData } from './termdb.profileScores.js'
+import { getData } from '../src/termdb.matrix.js'
 
 /*
-Clean route for profilePolar2.
-Reuses getScoresData() from termdb.profileScores for data retrieval,
-then runs the same median-based percentage calculation in a typed, explicit form.
+Route for profilePolar2.
+
+Key difference from termdb.profileScores:
+  - Client does NOT send facilityTW.
+  - Server derives the facility term id from activeCohort in __protected__:
+      activeCohort === 1 (FULL_COHORT)  → FUNIT
+      activeCohort === 0 (ABBREV_COHORT) → AUNIT
+  - Site data is queried at module level using getData(), same pattern as
+    termdb.profileScores.ts getScoresData().
+  - Always returns aggregated (median across all eligible sites) percentages.
 */
 
 export const api: RouteApi = {
@@ -38,56 +45,90 @@ function init({ genomes }) {
 }
 
 async function getScores(query: any, ds: any) {
-	// Collect all terms needed for the data fetch: facility + score pairs
-	const terms: any[] = [query.facilityTW]
-	for (const term of query.scoreTerms) {
-		terms.push(term.score)
-		if (term.maxScore?.term) terms.push(term.maxScore)
+	// 1. Derive facility term id server-side from activeCohort.
+	//    FULL_COHORT = 1 → prefix 'F', ABBREV_COHORT = 0 → prefix 'A'
+	const { activeCohort, clientAuthResult } = query.__protected__
+	const prefix = activeCohort === 1 ? 'F' : 'A'
+	const facilityTermId = `${prefix}UNIT`
+
+	// Minimal term wrapper — getData will fill term.values, $id, etc.
+	// via ds.cohort.termdb.q.termjsonByOneid(facilityTermId)
+	const facilityTW: any = { term: { id: facilityTermId }, q: {} }
+
+	// 2. Collect all terms for getData: facility + every score/maxScore pair
+	const terms: any[] = [facilityTW]
+	for (const t of query.scoreTerms) {
+		terms.push(t.score)
+		if (t.maxScore?.term) terms.push(t.maxScore)
 	}
 
-	const data = await getScoresData(query, ds, terms)
+	// 3. Allow facility term to be seen by all users (same logic as existing route)
+	if (!query.filterByUserSites) {
+		query.__protected__.ignoredTermIds.push(facilityTermId)
+	}
+
+	// 4. Query eligible site data at module level
+	const cohortAuth = clientAuthResult[activeCohort]
+	const isPublic = !cohortAuth?.role || cohortAuth.role === 'public'
+	const userSites = cohortAuth?.sites
+	const raw = await getData(
+		{
+			terms,
+			filter: query.filter,
+			__protected__: query.__protected__
+		},
+		ds
+	)
+	if (raw.error) throw raw.error
+
+	// 5. Build eligible sites list (filter to user's accessible sites if needed)
+	const sampleList: any[] = Object.values(raw.samples)
+	let sites = sampleList.map(s => {
+		const val = s[facilityTW.$id].value
+		let label = facilityTW.term.values?.[val]?.label || val
+		if (label.length > 50) label = label.slice(0, 47) + '...'
+		return { value: val, label }
+	})
+	if (userSites) {
+		// getData() already enforces access control via checkAccessToSampleData();
+		// this further narrows the site list to what the user is authorised to see
+		sites = sites.filter(s => userSites.includes(s.value))
+	}
+	sites.sort((a, b) => a.label.localeCompare(b.label))
+
+	// 6. Compute median percentage per module across all eligible sites.
+	//    When only one site is accessible (sites.length == 1) the median of a
+	//    single value equals that value — identical to the old route's sampleData shortcut.
+	const samples: any[] = Object.values(raw.samples)
+	const eligibleSamples = userSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
 
 	const term2Score: Record<string, number | null> = {}
 	for (const d of query.scoreTerms) {
-		term2Score[d.score.term.id] = computePercentage(d, data.samples, data.sampleData)
+		term2Score[d.score.term.id] = computeMedianPercentage(d, eligibleSamples)
 	}
 
 	return {
 		term2Score,
-		sites: data.sites,
-		site: data.site,
-		n: data.sampleData ? 1 : data.samples.length
+		// Public users see only aggregated scores — do not expose site IDs or names
+		sites: isPublic ? [] : sites,
+		n: eligibleSamples.length
 	}
 }
 
 /**
- * Aggregate mode (no specific facility):
- *   Computes (score / maxScore) * 100 for every sample, then returns the median.
- *
- * Single-facility mode (sampleData is set):
- *   Returns (score / maxScore) * 100 for that one facility, rounded.
+ * For each sample (site), computes (score / maxScore) * 100,
+ * collects all values, sorts them, and returns the median — rounded to integer.
+ * Returns null when no samples have data for the term.
  */
-function computePercentage(d: any, samples: any[], sampleData: any): number | null {
-	if (!d) return null
+function computeMedianPercentage(d: any, samples: any[]): number | null {
+	const percentages = samples
+		.filter(s => s[d.score.$id]?.value)
+		.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
 
-	if (sampleData == null) {
-		// Aggregate: collect per-site percentages, sort, take median
-		const percentages = samples
-			.filter(s => s[d.score.$id]?.value)
-			.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
+	if (percentages.length === 0) return null
+	percentages.sort((a, b) => a - b)
 
-		if (percentages.length === 0) return null
-		percentages.sort((a, b) => a - b)
-
-		const mid = Math.floor(percentages.length / 2)
-		const median = percentages.length % 2 !== 0 ? percentages[mid] : (percentages[mid - 1] + percentages[mid]) / 2
-
-		return Math.round(median)
-	} else {
-		// Single facility
-		const score = sampleData[d.score.$id]?.value
-		const maxScore = d.maxScore.term ? sampleData[d.maxScore.$id]?.value : d.maxScore
-		if (!score || !maxScore) return null
-		return Math.round((score / maxScore) * 100)
-	}
+	const mid = Math.floor(percentages.length / 2)
+	const median = percentages.length % 2 !== 0 ? percentages[mid] : (percentages[mid - 1] + percentages[mid]) / 2
+	return Math.round(median)
 }

--- a/server/routes/termdb.profileFormScores.ts
+++ b/server/routes/termdb.profileFormScores.ts
@@ -52,11 +52,24 @@ async function getScoresDict(query, ds) {
 			const percents: { [key: string]: number } = getSCPercentsDict(d, data.samples)
 			term2Score[d.term.id] = percents
 		}
-	const facilityValue = data.sampleData?.[query.facilityTW.$id]
-	const termValue = query.facilityTW.term.values[facilityValue?.value]
-	const hospital = termValue?.label || termValue?.key
+	const { clientAuthResult, activeCohort } = query.__protected__
+	const isPublic = !clientAuthResult[activeCohort]?.role || clientAuthResult[activeCohort].role === 'public'
 
-	return { term2Score, sites: data.sites, hospital, n: data.sampleData ? 1 : data.samples.length }
+	// hospital is the individual facility name — only derive it for authenticated users
+	let hospital: string | undefined
+	if (!isPublic && data.sampleData) {
+		const facilityValue = data.sampleData[query.facilityTW.$id]
+		const termValue = query.facilityTW.term.values[facilityValue?.value]
+		hospital = termValue?.label || termValue?.key
+	}
+
+	return {
+		term2Score,
+		// Do not expose individual site IDs, names, or hospital to public-role users
+		sites: isPublic ? [] : data.sites,
+		hospital,
+		n: data.sampleData ? 1 : data.samples.length
+	}
 }
 
 function getDict(key, sample) {

--- a/server/routes/termdb.profileScores.ts
+++ b/server/routes/termdb.profileScores.ts
@@ -99,7 +99,16 @@ async function getScores(query, ds) {
 		term2Score[d.score.term.id] = getPercentage(d, data.samples, data.sampleData)
 	}
 
-	return { term2Score, sites: data.sites, site: data.site, n: data.sampleData ? 1 : data.samples.length }
+	const { clientAuthResult, activeCohort } = query.__protected__
+	const isPublic = !clientAuthResult[activeCohort]?.role || clientAuthResult[activeCohort].role === 'public'
+
+	return {
+		term2Score,
+		// Do not expose individual site IDs or names to public-role users
+		sites: isPublic ? [] : data.sites,
+		site: isPublic ? undefined : data.site,
+		n: data.sampleData ? 1 : data.samples.length
+	}
 }
 
 function getPercentage(d, samples, sampleData) {

--- a/server/src/app.routes.js
+++ b/server/src/app.routes.js
@@ -74,5 +74,6 @@ export const routeFiles = [
 	import('../routes/img.ts'),
 	import('../routes/termdb.filterTermValues.ts'),
 	import('../routes/termdb.profileScores.ts'),
-	import('../routes/termdb.profileFormScores.ts')
+	import('../routes/termdb.profileFormScores.ts'),
+	import('../routes/profile.polar2.ts')
 ]


### PR DESCRIPTION
This pull request adds a new "Polar Chart v2" (`profilePolar2`) plot type to the PrOFILE dashboard, introducing a modernized architecture for plot-specific data flow and improved security practices. The new chart is visually similar to the original polar chart but uses a dedicated server route, streamlines client-server interactions, and enhances code maintainability. Documentation and UI controls are updated to reflect and support the new chart type.

**New plot type and architecture:**

- Added the `profilePolar2` plot, implemented in the new `polar2.ts` file, which features:
  - A dedicated data endpoint (`termdb/profilePolar2Scores`) for secure, per-plot data handling.
  - Server-side derivation of facility terms, always-aggregated median results, and minimal client payload.
  - Refactored rendering logic with modular private methods for improved maintainability.
  - Enhanced security: public users never receive site IDs/names; consistent sample scoping.

**Integration and UI updates:**

- Registered `profilePolar2` in the chart type list (`charts.js`), plot import logic (`importPlot.js`), and help button controls (`controls.btns.js`). 
- Updated logic in `profilePlot.ts` to ensure `profilePolar2` uses its own data fetch method and displays the correct help/documentation link. 

**Documentation:**

- Expanded the `README.md` to document the new `profilePolar2` plot, its dedicated route, architectural differences, and security improvements.

These changes lay the groundwork for future plots to adopt independent, secure data routes and modern client-server interactions.This pull request introduces a new "Polar 2" chart type to the MASS app, with both client and server support. The new chart type features a dedicated client-side implementation and a new server API route for fetching aggregated (median) module scores across eligible sites. Additionally, the pull request improves access control for profile score endpoints, ensuring that public users cannot access individual site information.

**New "Polar 2" Chart Type:**

- Added a new chart option labeled "Polar 2" to the chart type list in `getChartTypeList`, enabling users to select the new visualization.
- Implemented the `profilePolar2` chart in a new file `profile/polar2.ts`, including custom SVG rendering, data fetching from a dedicated API route, and a unique legend and table display.
- Updated the dynamic plot import logic to support `profilePolar2`, ensuring the new chart type is loaded as needed.

**Backend API and Data Handling:**

- Added a new server route `profile.polar2.ts` (`termdb/profilePolar2Scores`) that derives the appropriate facility term from the request, aggregates scores across all eligible sites, and returns only aggregated data (no individual site info for public users).
- Registered the new API route in the app's route loader.

**Access Control Improvements:**

- Updated the existing profile score endpoints to ensure that public users do not receive individual site IDs, names, or hospital information, returning only aggregated data. 

**Adjustments to Profile Plot Logic:**

- Modified the base `profilePlot` class to allow `profilePolar2` to skip the default data fetch and instead use its own server endpoint for data retrieval.

These changes collectively introduce a new aggregated visualization for profile scores while improving privacy and access control across related endpoints.This pull request adds a new "Polar 2" chart type to the application, including both client and server support for fetching and displaying aggregated profile scores in a polar chart format. The implementation introduces a dedicated data route, specialized client logic, and ensures that sensitive site information is not exposed to public users.

**Key changes:**

**New chart type and client-side support:**
* Added a new "Polar 2" chart type to the chart selection list in `getChartTypeList`, and enabled dynamic import of its implementation (`profilePolar2.ts`). 
* Implemented `profilePolar2.ts`, a new TypeScript module that defines the `ProfilePolar2` class, handling initialization, data fetching, rendering, and interaction logic for the new chart. This includes a custom data fetch from a new API endpoint and specialized rendering for the polar chart and its legend.

**Server-side API and data handling:**
* Added a new server route `profile.polar2.ts` that provides the `termdb/profilePolar2Scores` endpoint. This route derives the facility term from the request, aggregates scores across eligible sites (using the median), and ensures public users do not receive sensitive site data.
* Registered the new route in the application routes list.

**Profile plot and API adjustments:**
* Updated the `profilePlot` base class to allow the new chart type to use its own data fetching logic, skipping the default fetch in favor of the new endpoint.
* Added a `getProfilePolar2Scores` method to the client vocabulary API for fetching data from the new endpoint, including logic to strip unnecessary properties before sending.

**Privacy improvements for profile score endpoints:**
* Modified the existing profile scores and profile form scores server routes to avoid exposing site IDs, names, or hospital information to users with a public role, enhancing privacy and data protection. 
* This pull request introduces a new "Polar 2" chart type to the application, providing both client-side and server-side support for rendering and aggregating profile polar plots. The implementation includes a dedicated chart component, dynamic import logic, a new API endpoint for aggregated data, and updates to data privacy handling for public users.

The most important changes are:

**New Chart Type: Polar 2**

* Added a new chart type, `profilePolar2`, to the chart selection list in `client/mass/charts.js` and enabled dynamic import in `client/plots/importPlot.js`. 
* Implemented the `profilePolar2` chart component in `client/plots/profile/polar2.ts`, which renders a polar plot with aggregated (median) scores across eligible sites and includes custom legend, table, and interactivity.

**Server API and Data Aggregation**

* Added a new server route, `server/routes/profile.polar2.ts`, which provides the `termdb/profilePolar2Scores` API endpoint. This route derives the facility term based on cohort, queries module-level data, computes median percentages, and enforces data privacy for public users.
* Registered the new route in the application by updating `server/src/app.routes.js`.

**Profile Plot Data Handling and Privacy**

* Updated the base `profilePlot` class in `client/plots/profile/profilePlot.ts` to delegate data fetching for `profilePolar2` to its own server route, ensuring the correct aggregation logic is used.
* Enhanced data privacy in existing profile score routes (`server/routes/termdb.profileScores.ts` and `server/routes/termdb.profileFormScores.ts`) to avoid exposing site IDs or names to public users.

**Supporting API Client Logic**

* Added a `getProfilePolar2Scores` method to the termdb API client (`client/termdb/TermdbVocab.js`) to support fetching aggregated scores for the new chart type.This pull request introduces support for a new "Polar 2" chart type across the client and server. The main changes add the new chart option to the chart selection UI, enable dynamic import of its plotting code, and register the corresponding server route.

**Support for "Polar 2" chart type:**

* Added a new "Polar 2" chart option to the chart type list in `client/mass/charts.js`, including configuration and click handler.
* Enabled dynamic import of the `profilePolar2` plotting module in `client/plots/importPlot.js` to support rendering the new chart type.

**Server route registration:**

* Registered the new `profile.polar2.ts` route in the server's route list in `server/src/app.routes.js` to handle backend requests for the new chart type.# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
