### PR TITLE
Added Toggle for gene label and dynamic radius to disco

### DIFF
--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -154,6 +154,15 @@ export default class Disco {
 
 		configInputsOptions.push(chromosomeConfigOption)
 
+		configInputsOptions.push({
+			boxLabel: '',
+			label: 'Auto radius',
+			type: 'checkbox',
+			chartType: 'Disco',
+			settingsKey: 'autoRadius',
+			title: 'Automatically set the radius based on the number of data rings'
+		})
+
 		const dimensionOptions = [
 			{
 				label: 'Radius',
@@ -164,7 +173,8 @@ export default class Disco {
 				debounceInterval: 500,
 				step: 25,
 				min: 200,
-				max: 1000
+				max: 1000,
+				getDisplayStyle: (plot: any) => (plot.settings.Disco.autoRadius ? 'none' : 'table-row')
 			},
 			{
 				label: 'Fusion opacity',

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -122,6 +122,15 @@ export default class Disco {
 			configInputsOptions.push(...cnvConfigInputOptions)
 		}
 
+		configInputsOptions.push({
+			boxLabel: '',
+			label: 'Show gene names',
+			type: 'checkbox',
+			chartType: 'Disco',
+			settingsKey: 'showGeneNames',
+			title: 'Show gene name labels on the outside of the plot'
+		})
+
 		const genomeChr = this.app.opts.state.args.genome.majorchr
 		const chromosomeConfigOption = {
 			label: 'Chromosomes',
@@ -148,13 +157,13 @@ export default class Disco {
 		const dimensionOptions = [
 			{
 				label: 'Radius',
-				title: 'Set the radius of the entire plot, between 300 and 1000 pixels.',
+				title: 'Set the radius of the entire plot, between 200 and 1000 pixels.',
 				type: 'number',
 				chartType: 'Disco',
 				settingsKey: 'radius',
 				debounceInterval: 500,
 				step: 25,
-				min: 300,
+				min: 200,
 				max: 1000
 			},
 			{

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -5,8 +5,10 @@ export default interface Settings {
 	downloadImgName: string // file name of downloaded svg
 
 	Disco: {
-		/** Global radius controlling ring size */
-		radius?: number
+		/** When true, radius is computed from the number of data-ring types */
+		autoRadius: boolean
+		/** Global radius controlling ring size (used when autoRadius is false to allow user-set radius) */
+		radius: number
 		/** Opacity of the fusion arcs */
 		fusionOpacity?: number
 		centerText: string

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -21,6 +21,7 @@ export default interface Settings {
 		cnvCutoffMode: string
 		/** Chromosomes not rendered */
 		hiddenChromosomes: string[]
+		showGeneNames: boolean
 		mutationWaterfallPlot: boolean
 		mutationWaterfallColor: string
 	}

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -18,12 +18,13 @@ export default function discoDefaults(overrides: any = {}, app?: any): Settings 
 			isOpen: false,
 			prioritizeGeneLabelsByGeneSets: false,
 			showPrioritizeGeneLabelsByGeneSets: false,
+			showGeneNames: true,
 			mutationWaterfallPlot: false,
 			mutationWaterfallColor: '#4d4d4d',
 			cnvRenderingType: CnvRenderingType.heatmap,
 			cnvPercentile: 90, // 90th percentile for removing outliers
 			cnvCutoffMode: 'percentile',
-			radius: 300,
+			radius: undefined as number | undefined,
 			fusionOpacity: 1,
 			hiddenChromosomes
 		},
@@ -88,7 +89,7 @@ export default function discoDefaults(overrides: any = {}, app?: any): Settings 
 		}
 	}
 
-	if (overrides?.Disco?.radius > 1000 || overrides?.Disco?.radius < 300) {
+	if (overrides?.Disco?.radius > 1000 || overrides?.Disco?.radius < 200) {
 		console.log(`${overrides?.Disco?.radius} is greater or lower than the min and max for the radius`)
 	}
 

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -24,7 +24,8 @@ export default function discoDefaults(overrides: any = {}, app?: any): Settings 
 			cnvRenderingType: CnvRenderingType.heatmap,
 			cnvPercentile: 90, // 90th percentile for removing outliers
 			cnvCutoffMode: 'percentile',
-			radius: undefined as number | undefined,
+			autoRadius: true,
+			radius: 300,
 			fusionOpacity: 1,
 			hiddenChromosomes
 		},
@@ -89,7 +90,7 @@ export default function discoDefaults(overrides: any = {}, app?: any): Settings 
 		}
 	}
 
-	if (overrides?.Disco?.radius > 1000 || overrides?.Disco?.radius < 200) {
+	if (overrides?.Disco?.radius != null && (overrides.Disco.radius > 1000 || overrides.Disco.radius < 200)) {
 		console.log(`${overrides?.Disco?.radius} is greater or lower than the min and max for the radius`)
 	}
 

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -4,6 +4,7 @@ import DataMapper from '#plots/disco/data/DataMapper.ts'
 import type Settings from '#plots/disco/Settings.ts'
 import ViewModelProvider from './ViewModelProvider.ts'
 import type { DiscoInteractions } from '../interactions/DiscoInteractions.ts'
+import { dtsnvindel, dtcnv, dtloh } from '#shared/common.js'
 
 export class ViewModelMapper {
 	static snvClassLayer = {
@@ -57,6 +58,17 @@ export class ViewModelMapper {
 		this.settings.legend.fontSize *= scale
 	}
 
+	private computeDynamicRadius(data: Array<any>): number {
+		let ringCount = 0
+		if (data.some(d => d.dt == dtsnvindel)) ringCount++
+		if (data.some(d => d.dt == dtcnv)) ringCount++
+		if (data.some(d => d.dt == dtloh)) ringCount++
+
+		if (ringCount <= 1) return 200
+		if (ringCount == 2) return 250
+		return 300
+	}
+
 	map(opts: any): ViewModel {
 		const chrSizes = opts.args.genome.majorchr
 
@@ -77,6 +89,10 @@ export class ViewModelMapper {
 		const genesetName = genome?.geneset?.[0] ? genome.geneset[0].name : ''
 
 		const data: Array<any> = opts.args.data
+
+		if (!this.settings.Disco.radius) {
+			this.settings.Disco.radius = this.computeDynamicRadius(data)
+		}
 
 		this.applyRadius()
 

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -58,7 +58,7 @@ export class ViewModelMapper {
 		this.settings.legend.fontSize *= scale
 	}
 
-	private computeDynamicRadius(data: Array<any>): number {
+	static computeDynamicRadius(data: Array<any>): number {
 		let ringCount = 0
 		if (data.some(d => d.dt == dtsnvindel)) ringCount++
 		if (data.some(d => d.dt == dtcnv)) ringCount++
@@ -90,8 +90,8 @@ export class ViewModelMapper {
 
 		const data: Array<any> = opts.args.data
 
-		if (!this.settings.Disco.radius) {
-			this.settings.Disco.radius = this.computeDynamicRadius(data)
+		if (this.settings.Disco.autoRadius) {
+			this.settings.Disco.radius = ViewModelMapper.computeDynamicRadius(data)
 		}
 
 		this.applyRadius()

--- a/client/plots/disco/viewmodel/ViewModelProvider.ts
+++ b/client/plots/disco/viewmodel/ViewModelProvider.ts
@@ -56,16 +56,20 @@ export default class ViewModelProvider {
 	map(data: Array<any>) {
 		const dataHolder = this.dataMapper.map(data)
 
-		const labelsMapper = new LabelsMapper(
-			this.settings,
-			this.sampleName,
-			this.reference,
-			dataHolder.cnvMaxPercentileAbs
-		)
+		let labelsRing: Labels
+		if (this.settings.Disco.showGeneNames) {
+			const labelsMapper = new LabelsMapper(
+				this.settings,
+				this.sampleName,
+				this.reference,
+				dataHolder.cnvMaxPercentileAbs
+			)
 
-		const labelsData = labelsMapper.map(dataHolder.labelData, dataHolder.cnvData)
-
-		const labelsRing = new Labels(this.settings, labelsData, dataHolder.hasPrioritizedGenes)
+			const labelsData = labelsMapper.map(dataHolder.labelData, dataHolder.cnvData)
+			labelsRing = new Labels(this.settings, labelsData, dataHolder.hasPrioritizedGenes)
+		} else {
+			labelsRing = new Labels(this.settings, [], false)
+		}
 
 		const chromosomesRing = new Ring(
 			this.settings.rings.chromosomeInnerRadius,
@@ -182,9 +186,9 @@ export default class ViewModelProvider {
 			lohLegend,
 			this.settings.Disco.mutationWaterfallPlot && this.mutationWaterfallRing
 				? {
-						color: this.settings.Disco.mutationWaterfallColor || '#4d4d4d',
-						onColorChange: this.discoInteractions.onMutationWaterfallColorChange
-				  }
+					color: this.settings.Disco.mutationWaterfallColor || '#4d4d4d',
+					onColorChange: this.discoInteractions.onMutationWaterfallColorChange
+				}
 				: undefined
 		)
 

--- a/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
@@ -7,7 +7,7 @@ Tests:
 ViewModelMapper scales rings and dimensions using the radius setting
 */
 
-const settings = discoDefaults({ Disco: { radius: 500 } })
+const settings = discoDefaults({ Disco: { autoRadius: false, radius: 500 } })
 const mapper = new ViewModelMapper(structuredClone(settings as any), {} as any)
 
 const opts = {

--- a/client/plots/disco/viewmodel/test/ViewModelMapperAutoRadius.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModelMapperAutoRadius.unit.spec.ts
@@ -1,0 +1,175 @@
+import test from 'tape'
+import { ViewModelMapper } from '../ViewModelMapper'
+import discoDefaults from '../../defaults'
+import { dtsnvindel, dtcnv, dtloh } from '#shared/common.js'
+
+/*
+Tests:
+	computeDynamicRadius returns correct radius for 1, 2, and 3 ring-type combinations
+	Auto-radius path computes radius and scales settings accordingly
+	Explicit radius is used when autoRadius is false
+*/
+
+// ───── computeDynamicRadius unit tests ─────
+
+test('\n', function (t) {
+	t.pass('-***- plots/disco/viewmodel/ViewModelMapper autoRadius -***-')
+	t.end()
+})
+
+test('computeDynamicRadius returns 200 for SNV-only data (1 ring type)', t => {
+	const data = [{ dt: dtsnvindel }]
+	t.equal(ViewModelMapper.computeDynamicRadius(data), 200)
+	t.end()
+})
+
+test('computeDynamicRadius returns 200 for CNV-only data (1 ring type)', t => {
+	const data = [{ dt: dtcnv }]
+	t.equal(ViewModelMapper.computeDynamicRadius(data), 200)
+	t.end()
+})
+
+test('computeDynamicRadius returns 200 for LOH-only data (1 ring type)', t => {
+	const data = [{ dt: dtloh }]
+	t.equal(ViewModelMapper.computeDynamicRadius(data), 200)
+	t.end()
+})
+
+test('computeDynamicRadius returns 200 for empty data', t => {
+	t.equal(ViewModelMapper.computeDynamicRadius([]), 200)
+	t.end()
+})
+
+test('computeDynamicRadius returns 250 for SNV + CNV data (2 ring types)', t => {
+	const data = [{ dt: dtsnvindel }, { dt: dtcnv }]
+	t.equal(ViewModelMapper.computeDynamicRadius(data), 250)
+	t.end()
+})
+
+test('computeDynamicRadius returns 250 for SNV + LOH data (2 ring types)', t => {
+	const data = [{ dt: dtsnvindel }, { dt: dtloh }]
+	t.equal(ViewModelMapper.computeDynamicRadius(data), 250)
+	t.end()
+})
+
+test('computeDynamicRadius returns 250 for CNV + LOH data (2 ring types)', t => {
+	const data = [{ dt: dtcnv }, { dt: dtloh }]
+	t.equal(ViewModelMapper.computeDynamicRadius(data), 250)
+	t.end()
+})
+
+test('computeDynamicRadius returns 300 for SNV + CNV + LOH data (3 ring types)', t => {
+	const data = [{ dt: dtsnvindel }, { dt: dtcnv }, { dt: dtloh }]
+	t.equal(ViewModelMapper.computeDynamicRadius(data), 300)
+	t.end()
+})
+
+// ───── Integration: auto-radius path through map() ─────
+
+test('Auto-radius path computes radius=200 and scales settings for SNV-only data', t => {
+	const settings = discoDefaults({ Disco: { autoRadius: true } })
+	const baseLabel = settings.rings.labelLinesInnerRadius
+	const mapper = new ViewModelMapper(structuredClone(settings as any), {} as any)
+
+	const opts = {
+		args: {
+			genome: { majorchr: { chr1: 1000 }, geneset: [] },
+			sampleName: 'Sample',
+			data: [{ dt: dtsnvindel, chr: 'chr1', pos: 100, gene: 'TP53', mClass: 'M' }]
+		}
+	}
+
+	const vm = mapper.map(opts)
+	const expectedScale = 200 / baseLabel
+
+	t.equal(
+		vm.settings.rings.labelLinesInnerRadius,
+		baseLabel * expectedScale,
+		'labelLinesInnerRadius should be scaled using auto-computed radius 200'
+	)
+	t.equal(
+		vm.settings.rings.labelsToLinesDistance,
+		settings.rings.labelsToLinesDistance * expectedScale,
+		'labelsToLinesDistance should be scaled using auto-computed radius 200'
+	)
+	t.end()
+})
+
+test('Auto-radius path computes radius=250 for two ring types', t => {
+	const settings = discoDefaults({ Disco: { autoRadius: true } })
+	const baseLabel = settings.rings.labelLinesInnerRadius
+	const mapper = new ViewModelMapper(structuredClone(settings as any), {} as any)
+
+	const opts = {
+		args: {
+			genome: { majorchr: { chr1: 1000 }, geneset: [] },
+			sampleName: 'Sample',
+			data: [
+				{ dt: dtsnvindel, chr: 'chr1', pos: 100, gene: 'TP53', mClass: 'M' },
+				{ dt: dtcnv, chr: 'chr1', start: 50, stop: 200, value: 2 }
+			]
+		}
+	}
+
+	const vm = mapper.map(opts)
+	const expectedScale = 250 / baseLabel
+
+	t.equal(
+		vm.settings.rings.labelLinesInnerRadius,
+		baseLabel * expectedScale,
+		'labelLinesInnerRadius should be scaled using auto-computed radius 250'
+	)
+	t.end()
+})
+
+test('Auto-radius path computes radius=300 for three ring types', t => {
+	const settings = discoDefaults({ Disco: { autoRadius: true } })
+	const baseLabel = settings.rings.labelLinesInnerRadius
+	const mapper = new ViewModelMapper(structuredClone(settings as any), {} as any)
+
+	const opts = {
+		args: {
+			genome: { majorchr: { chr1: 1000 }, geneset: [] },
+			sampleName: 'Sample',
+			data: [
+				{ dt: dtsnvindel, chr: 'chr1', pos: 100, gene: 'TP53', mClass: 'M' },
+				{ dt: dtcnv, chr: 'chr1', start: 50, stop: 200, value: 2 },
+				{ dt: dtloh, chr: 'chr1', start: 50, stop: 200, value: 0.5, segmean: 0.5 }
+			]
+		}
+	}
+
+	const vm = mapper.map(opts)
+	const expectedScale = 300 / baseLabel
+
+	t.equal(
+		vm.settings.rings.labelLinesInnerRadius,
+		baseLabel * expectedScale,
+		'labelLinesInnerRadius should be scaled using auto-computed radius 300'
+	)
+	t.end()
+})
+
+test('Explicit radius is used when autoRadius is false', t => {
+	const settings = discoDefaults({ Disco: { autoRadius: false, radius: 500 } })
+	const baseLabel = settings.rings.labelLinesInnerRadius
+	const mapper = new ViewModelMapper(structuredClone(settings as any), {} as any)
+
+	const opts = {
+		args: {
+			genome: { majorchr: { chr1: 1000 }, geneset: [] },
+			sampleName: 'Sample',
+			data: [{ dt: dtsnvindel, chr: 'chr1', pos: 100, gene: 'TP53', mClass: 'M' }]
+		}
+	}
+
+	const vm = mapper.map(opts)
+	const expectedScale = 500 / baseLabel
+
+	t.equal(
+		vm.settings.rings.labelLinesInnerRadius,
+		baseLabel * expectedScale,
+		'labelLinesInnerRadius should be scaled using explicit radius 500, not auto-computed 200'
+	)
+	t.end()
+})


### PR DESCRIPTION
# Description
**Control Improvements:**
- **Toggleable gene labels:**
Added `showGeneNames` setting (default: true) that allows users to control whether gene name labels appear on the plot. When disabled, an empty Labels ring is created instead of processing label data.
Modified `ViewModelProvider.map()` to only instantiate `LabelsMapper` and process label data when `showGeneNames` is enabled
- **Dynamic Radius Calculation:**
 Added `computeDynamicRadius()` method in `ViewModelMapper` that automatically sets the plot radius based on the number of data types present (SNV/indel, CNV, LOH)

- **Settings Updates:**
Changed default radius from fixed 300 to undefined to enable dynamic calculation
Updated radius validation range from 300-1000 to 200-1000 pixels
Added showGeneNames: boolean to Settings interface

Please use the [disco card](http://localhost:3000/?appcard=disco) examples for testing:
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
