### PR TITLE
Adding spinner during Save for AiHisto

### DIFF
--- a/client/plots/aiProjectAdmin/AIProjectAdmin.ts
+++ b/client/plots/aiProjectAdmin/AIProjectAdmin.ts
@@ -18,7 +18,6 @@ class AIProjectAdmin extends PlotBase implements RxComponent {
 	projects?: any[]
 	prjtAdminUI?: ProjectAdminRender
 	interactions?: AIProjectAdminInteractions
-
 	dom!: {
 		[name: string]: any
 	}

--- a/client/plots/wsiviewer/Settings.ts
+++ b/client/plots/wsiviewer/Settings.ts
@@ -18,8 +18,10 @@ export default interface Settings {
 	renderAnnotationTable: boolean
 	selectedPatchBorderColor: string
 	annotatedPatchBorderColor: string
+	isSavingAnnotation: boolean
 	tileSize: number
 	activeAnnotation: number
 	sessionsTileSelection: Array<TileSelection>
 	changeTrigger: number
+	isMoving: boolean
 }

--- a/client/plots/wsiviewer/Settings.ts
+++ b/client/plots/wsiviewer/Settings.ts
@@ -23,5 +23,4 @@ export default interface Settings {
 	activeAnnotation: number
 	sessionsTileSelection: Array<TileSelection>
 	changeTrigger: number
-	isMoving: boolean
 }

--- a/client/plots/wsiviewer/Settings.ts
+++ b/client/plots/wsiviewer/Settings.ts
@@ -23,4 +23,7 @@ export default interface Settings {
 	activeAnnotation: number
 	sessionsTileSelection: Array<TileSelection>
 	changeTrigger: number
+	animationTime: number
+	animationDelay: number
+	defaultZoom: number
 }

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -63,8 +63,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 				.append('div')
 				.attr('id', 'annotations-table-wrapper')
 				.style('padding', '20px')
-				.style('display', 'inline-block')
-				.style('z-index', '9998'),
+				.style('display', 'inline-block'),
 			legendHolder: opts.holder
 				.append('div')
 				.attr('id', 'sjpp-legendHolder')

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -45,7 +45,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 		this.opts = opts
 		this.wsiViewerInteractions = new WSIViewerInteractions(this, opts)
 		this.dom = {
-			holder: opts.holder.attr('data-testid', 'wsiViewer-holder'),
+			holder: opts.holder,
 			loadingDiv: opts.holder
 				.append('div')
 				.attr('class', 'wsiViewer-progress')
@@ -57,24 +57,14 @@ class WSIViewer extends PlotBase implements RxComponent {
 				.style('background-color', 'rgba(255, 255, 255, 0.95)')
 				.style('text-align', 'center')
 				.style('display', 'none'),
-			inactivationDiv: opts.holder
-				.append('div')
-				.attr('class', 'wsiViewer-inactivate')
-				.style('cursor', 'wait')
-				.style('background-color', 'transparent')
-				.style('position', 'absolute')
-				.style('z-index', '9999')
-				.style('height', '100%')
-				.style('pointer-events', 'auto')
-				.style('display', 'block')
-				.style('width', '100%'),
 			errorDiv: opts.holder.append('div').attr('class', 'wsiViewer-error').style('margin-left', '10px'),
 			mapHolder: opts.holder.append('div').attr('id', 'wsiviewer-mapHolder'),
 			annotationsHolder: opts.holder
 				.append('div')
 				.attr('id', 'annotations-table-wrapper')
 				.style('padding', '20px')
-				.style('display', 'inline-block'),
+				.style('display', 'inline-block')
+				.style('z-index', '9998'),
 			legendHolder: opts.holder
 				.append('div')
 				.attr('id', 'sjpp-legendHolder')
@@ -178,11 +168,11 @@ class WSIViewer extends PlotBase implements RxComponent {
 				this.map.getView().fit(activeImageExtent)
 			}
 		}
-		this.wsiViewerInteractions.toggleSpinner(settings.isSavingAnnotation || settings.isMoving)
-		this.wsiViewerInteractions.toggleClickability(!settings.isMoving)
+
 		this.metadataRenderer.renderMetadata(this.dom.holder, imageViewData)
 
 		if (settings.renderAnnotationTable && this.map) {
+			this.dom.holder.selectAll('*').style('cursor', 'default')
 			const modelTrainerRenderer = new ModelTrainerRenderer(this.wsiViewerInteractions)
 			const downloadCSVButtonRenderer = new DownloadCSVButtonRenderer()
 
@@ -195,7 +185,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 
 			const initialZoomInCoordinate = viewModel.getInitialZoomInCoordinate(settings)
 
-			if (initialZoomInCoordinate != undefined && !settings.isMoving) {
+			if (initialZoomInCoordinate != undefined) {
 				this.wsiViewerInteractions.zoomInEffectListener(
 					activeImageExtent,
 					initialZoomInCoordinate,
@@ -210,6 +200,10 @@ class WSIViewer extends PlotBase implements RxComponent {
 					imageViewData.shortcuts
 				)
 			}
+		}
+
+		if (settings.isSavingAnnotation) {
+			this.wsiViewerInteractions.createSpinner()
 		}
 		this.wsiViewerInteractions.toggleLoadingDiv(false)
 	}

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -40,11 +40,12 @@ class WSIViewer extends PlotBase implements RxComponent {
 
 	constructor(opts: any, api) {
 		super(opts, api)
+
 		this.type = WSIViewer.type
 		this.opts = opts
 		this.wsiViewerInteractions = new WSIViewerInteractions(this, opts)
 		this.dom = {
-			holder: opts.holder,
+			holder: opts.holder.attr('data-testid', 'wsiViewer-holder'),
 			loadingDiv: opts.holder
 				.append('div')
 				.attr('class', 'wsiViewer-progress')
@@ -56,7 +57,17 @@ class WSIViewer extends PlotBase implements RxComponent {
 				.style('background-color', 'rgba(255, 255, 255, 0.95)')
 				.style('text-align', 'center')
 				.style('display', 'none'),
-
+			inactivationDiv: opts.holder
+				.append('div')
+				.attr('class', 'wsiViewer-inactivate')
+				.style('cursor', 'wait')
+				.style('background-color', 'transparent')
+				.style('position', 'absolute')
+				.style('z-index', '9999')
+				.style('height', '100%')
+				.style('pointer-events', 'auto')
+				.style('display', 'block')
+				.style('width', '100%'),
 			errorDiv: opts.holder.append('div').attr('class', 'wsiViewer-error').style('margin-left', '10px'),
 			mapHolder: opts.holder.append('div').attr('id', 'wsiviewer-mapHolder'),
 			annotationsHolder: opts.holder
@@ -93,7 +104,6 @@ class WSIViewer extends PlotBase implements RxComponent {
 		const sample_id = state.sample_id
 		const aiProjectID = state.aiProjectID
 		const aiWSIMageFiles = state.aiWSIMageFiles as Array<string>
-
 		const viewModel: ViewModel = await this.viewModelProvider.provide(
 			genome,
 			dslabel,
@@ -107,7 +117,6 @@ class WSIViewer extends PlotBase implements RxComponent {
 
 		const wsimageLayers = viewModel.wsimageLayers
 		const wsimageLayersLoadError = viewModel.wsimageLayersLoadError
-
 		if (wsimages.length === 0) {
 			sayerror(this.dom.errorDiv, 'No WSI images found.')
 			this.wsiViewerInteractions.toggleLoadingDiv(false)
@@ -136,6 +145,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 		if (!this.mapRenderer) {
 			this.mapRenderer = new MapRenderer()
 		}
+
 		this.mapRenderer.setState(
 			activeLayerData,
 			this.wsiViewerInteractions.viewerClickListener,
@@ -168,7 +178,8 @@ class WSIViewer extends PlotBase implements RxComponent {
 				this.map.getView().fit(activeImageExtent)
 			}
 		}
-
+		this.wsiViewerInteractions.toggleSpinner(settings.isSavingAnnotation || settings.isMoving)
+		this.wsiViewerInteractions.toggleClickability(!settings.isMoving)
 		this.metadataRenderer.renderMetadata(this.dom.holder, imageViewData)
 
 		if (settings.renderAnnotationTable && this.map) {
@@ -184,7 +195,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 
 			const initialZoomInCoordinate = viewModel.getInitialZoomInCoordinate(settings)
 
-			if (initialZoomInCoordinate != undefined) {
+			if (initialZoomInCoordinate != undefined && !settings.isMoving) {
 				this.wsiViewerInteractions.zoomInEffectListener(
 					activeImageExtent,
 					initialZoomInCoordinate,

--- a/client/plots/wsiviewer/WSIViewer.ts
+++ b/client/plots/wsiviewer/WSIViewer.ts
@@ -11,6 +11,7 @@ import { ViewModelProvider } from '#plots/wsiviewer/viewModel/ViewModelProvider.
 import { ThumbnailRenderer } from '#plots/wsiviewer/view/ThumbnailRenderer.ts'
 import { MapRenderer } from '#plots/wsiviewer/view/MapRenderer.ts'
 import { MetadataRenderer } from '#plots/wsiviewer/view/MetadataRenderer.ts'
+import { SpinnerRenderer } from '#plots/wsiviewer/view/SpinnerRenderer.ts'
 import { LegendRenderer } from '#plots/wsiviewer/view/LegendRenderer.ts'
 import { ModelTrainerRenderer } from './view/ModelTrainerRenderer'
 import type OLMap from 'ol/Map'
@@ -37,6 +38,7 @@ class WSIViewer extends PlotBase implements RxComponent {
 
 	// New: persistent MapRenderer instance reused across main() calls
 	private mapRenderer: MapRenderer | undefined
+	private spinnerRenderer = new SpinnerRenderer()
 
 	constructor(opts: any, api) {
 		super(opts, api)
@@ -169,9 +171,10 @@ class WSIViewer extends PlotBase implements RxComponent {
 		}
 
 		this.metadataRenderer.renderMetadata(this.dom.holder, imageViewData)
-
+		if (!settings.isSavingAnnotation) {
+			this.spinnerRenderer.renderDefaultCursor(this.dom.holder)
+		}
 		if (settings.renderAnnotationTable && this.map) {
-			this.dom.holder.selectAll('*').style('cursor', 'default')
 			const modelTrainerRenderer = new ModelTrainerRenderer(this.wsiViewerInteractions)
 			const downloadCSVButtonRenderer = new DownloadCSVButtonRenderer()
 
@@ -200,9 +203,8 @@ class WSIViewer extends PlotBase implements RxComponent {
 				)
 			}
 		}
-
 		if (settings.isSavingAnnotation) {
-			this.wsiViewerInteractions.createSpinner()
+			this.spinnerRenderer.renderSpinner(this.dom.holder)
 		}
 		this.wsiViewerInteractions.toggleLoadingDiv(false)
 	}

--- a/client/plots/wsiviewer/defaults.ts
+++ b/client/plots/wsiviewer/defaults.ts
@@ -21,7 +21,9 @@ export default function wsiViewerDefaults(overrides = {}): Settings {
 		tileSize: 512, // 512px
 		activeAnnotation: 0,
 		sessionsTileSelection: [],
-		changeTrigger: 0
+		changeTrigger: 0,
+		isSavingAnnotation: false,
+		isMoving: false
 	}
 	return copyMerge(defaults, overrides)
 }

--- a/client/plots/wsiviewer/defaults.ts
+++ b/client/plots/wsiviewer/defaults.ts
@@ -22,7 +22,10 @@ export default function wsiViewerDefaults(overrides = {}): Settings {
 		activeAnnotation: 0,
 		sessionsTileSelection: [],
 		changeTrigger: 0,
-		isSavingAnnotation: false
+		isSavingAnnotation: false,
+		animationTime: 700,
+		animationDelay: 200,
+		defaultZoom: 5
 	}
 	return copyMerge(defaults, overrides)
 }

--- a/client/plots/wsiviewer/defaults.ts
+++ b/client/plots/wsiviewer/defaults.ts
@@ -22,8 +22,7 @@ export default function wsiViewerDefaults(overrides = {}): Settings {
 		activeAnnotation: 0,
 		sessionsTileSelection: [],
 		changeTrigger: 0,
-		isSavingAnnotation: false,
-		isMoving: false
+		isSavingAnnotation: false
 	}
 	return copyMerge(defaults, overrides)
 }

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -32,12 +32,11 @@ export class WSIViewerInteractions {
 
 	onRetrainModelClicked: (genome: string, dslabel: string, projectId: string) => void
 	toggleLoadingDiv: (show: boolean) => void
-	toggleSpinner: (spin: boolean) => void
+	createSpinner: (spin: boolean) => void
 	toggleThumbnails: (start: number) => void
 	animationTime: number = 700
 	animationDelay: number = 200
 	previousZoomInPoints: [number, number][] = []
-	toggleClickability: (clickable: boolean) => void
 	constructor(wsiApp: any, opts: any) {
 		this.thumbnailClickListener = (index: number) => {
 			wsiApp.app.dispatch({
@@ -64,34 +63,6 @@ export class WSIViewerInteractions {
 			const settings: Settings = state.plots.find(p => p.id === wsiApp.id).settings
 
 			if (!zoomInPoints || zoomInPoints.length == 0) return
-
-			const pointsAreSame = JSON.stringify(this.previousZoomInPoints) === JSON.stringify(zoomInPoints)
-			this.previousZoomInPoints = zoomInPoints
-			if (!pointsAreSame) {
-				wsiApp.app.dispatch({
-					type: 'plot_edit',
-					id: wsiApp.id,
-					config: {
-						settings: {
-							isMoving: true,
-							changeTrigger: Date.now()
-						}
-					}
-				})
-
-				setTimeout(() => {
-					wsiApp.app.dispatch({
-						type: 'plot_edit',
-						id: wsiApp.id,
-						config: {
-							settings: {
-								isMoving: false,
-								changeTrigger: Date.now()
-							}
-						}
-					})
-				}, this.animationTime + this.animationDelay)
-			}
 
 			setTimeout(() => {
 				if (!activeImageExtent) return
@@ -379,12 +350,9 @@ export class WSIViewerInteractions {
 				}
 			})
 		}
-		this.toggleSpinner = (spin: boolean) => {
-			wsiApp.dom.inactivationDiv.style('cursor', spin ? 'wait' : 'default')
-		}
-		this.toggleClickability = (clickable: boolean) => {
-			//Might toggle click on individual elements instead of whole div
-			wsiApp.dom.inactivationDiv.style('pointer-events', clickable ? 'auto' : 'all')
+		this.createSpinner = () => {
+			wsiApp.dom.holder.selectAll('*').style('cursor', 'wait')
+			console.log('Creating spinner')
 		}
 	}
 
@@ -644,7 +612,6 @@ export class WSIViewerInteractions {
 		} catch (e) {
 			console.error('Error in saveWSIAnnotation request:', e)
 		}
-		await new Promise(resolve => setTimeout(resolve, 500)) // Small delay to ensure server data is updated before fetching again
 		wsiApp.app.dispatch({
 			type: 'plot_edit',
 			id: wsiApp.id,

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -600,7 +600,6 @@ export class WSIViewerInteractions {
 		aiProjectID: number
 	) {
 		const state = wsiApp.app.getState()
-		const settings: Settings = state.plots.find(p => p.id === wsiApp.id).settings
 		const tileSelections: TileSelection[] = SessionWSImage.getTileSelections(sessionWSImage)
 		const body: SaveWSIAnnotationRequest = {
 			genome: state.vocab.genome,
@@ -610,7 +609,6 @@ export class WSIViewerInteractions {
 			projectId: aiProjectID,
 			wsimage: sessionWSImage.filename
 		}
-		if (settings.isSavingAnnotation) return
 
 		try {
 			// TODO add UI rollback

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -32,8 +32,12 @@ export class WSIViewerInteractions {
 
 	onRetrainModelClicked: (genome: string, dslabel: string, projectId: string) => void
 	toggleLoadingDiv: (show: boolean) => void
+	toggleSpinner: (spin: boolean) => void
 	toggleThumbnails: (start: number) => void
-
+	animationTime: number = 700
+	animationDelay: number = 200
+	previousZoomInPoints: [number, number][] = []
+	toggleClickability: (clickable: boolean) => void
 	constructor(wsiApp: any, opts: any) {
 		this.thumbnailClickListener = (index: number) => {
 			wsiApp.app.dispatch({
@@ -61,6 +65,34 @@ export class WSIViewerInteractions {
 
 			if (!zoomInPoints || zoomInPoints.length == 0) return
 
+			const pointsAreSame = JSON.stringify(this.previousZoomInPoints) === JSON.stringify(zoomInPoints)
+			this.previousZoomInPoints = zoomInPoints
+			if (!pointsAreSame) {
+				wsiApp.app.dispatch({
+					type: 'plot_edit',
+					id: wsiApp.id,
+					config: {
+						settings: {
+							isMoving: true,
+							changeTrigger: Date.now()
+						}
+					}
+				})
+
+				setTimeout(() => {
+					wsiApp.app.dispatch({
+						type: 'plot_edit',
+						id: wsiApp.id,
+						config: {
+							settings: {
+								isMoving: false,
+								changeTrigger: Date.now()
+							}
+						}
+					})
+				}, this.animationTime + this.animationDelay)
+			}
+
 			setTimeout(() => {
 				if (!activeImageExtent) return
 
@@ -85,7 +117,7 @@ export class WSIViewerInteractions {
 				view.animate({
 					center: xyAvg,
 					zoom: 5,
-					duration: 700
+					duration: this.animationTime
 				})
 
 				//On zooming to a new annotation, add a border around the annotation
@@ -96,7 +128,7 @@ export class WSIViewerInteractions {
 
 				const zoomCoordinates = [zoomInPoints[0][0], imageHeight - zoomInPoints[0][1]] as [number, number]
 				this.addActiveBorder(vectorLayer as VectorLayer, zoomCoordinates, activePatchColor, settings.tileSize)
-			}, 200)
+			}, this.animationDelay)
 		}
 
 		this.setKeyDownListener = (
@@ -189,8 +221,8 @@ export class WSIViewerInteractions {
 
 					return
 				}
-
-				if (shortcuts.includes(event.code)) {
+				if (shortcuts.includes(event.code) && !settings.isSavingAnnotation) {
+					// For debugging purposes, counts how many times shortcut keys are pressed
 					// Resolve class either by key_shortcut
 					const matchingClass = sessionWSImage?.classes?.find(c => c.key_shortcut === event.code)
 
@@ -346,6 +378,13 @@ export class WSIViewerInteractions {
 					settings: { thumbnailRangeStart: start, displayedImageIndex: start, renderWSIViewer: true }
 				}
 			})
+		}
+		this.toggleSpinner = (spin: boolean) => {
+			wsiApp.dom.inactivationDiv.style('cursor', spin ? 'wait' : 'default')
+		}
+		this.toggleClickability = (clickable: boolean) => {
+			//Might toggle click on individual elements instead of whole div
+			wsiApp.dom.inactivationDiv.style('pointer-events', clickable ? 'auto' : 'all')
 		}
 	}
 
@@ -575,6 +614,7 @@ export class WSIViewerInteractions {
 		aiProjectID: number
 	) {
 		const state = wsiApp.app.getState()
+		const settings: Settings = state.plots.find(p => p.id === wsiApp.id).settings
 		const tileSelections: TileSelection[] = SessionWSImage.getTileSelections(sessionWSImage)
 		const body: SaveWSIAnnotationRequest = {
 			genome: state.vocab.genome,
@@ -584,8 +624,19 @@ export class WSIViewerInteractions {
 			projectId: aiProjectID,
 			wsimage: sessionWSImage.filename
 		}
+		if (settings.isSavingAnnotation) return
 
 		try {
+			wsiApp.app.dispatch({
+				type: 'plot_edit',
+				id: wsiApp.id,
+				config: {
+					settings: {
+						isSavingAnnotation: true,
+						changeTrigger: Date.now()
+					}
+				}
+			})
 			// TODO add UI rollback
 			await dofetch3('saveWSIAnnotation', { method: 'POST', body })
 			// TODO find another way to clear server cache
@@ -593,7 +644,17 @@ export class WSIViewerInteractions {
 		} catch (e) {
 			console.error('Error in saveWSIAnnotation request:', e)
 		}
-
+		await new Promise(resolve => setTimeout(resolve, 500)) // Small delay to ensure server data is updated before fetching again
+		wsiApp.app.dispatch({
+			type: 'plot_edit',
+			id: wsiApp.id,
+			config: {
+				settings: {
+					isSavingAnnotation: false,
+					changeTrigger: Date.now()
+				}
+			}
+		})
 		if (SessionWSImage.isSessionTileSelection(currentIndex, sessionWSImage)) {
 			SessionWSImage.removeTileSelection(currentIndex, sessionWSImage)
 		}

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -32,7 +32,7 @@ export class WSIViewerInteractions {
 
 	onRetrainModelClicked: (genome: string, dslabel: string, projectId: string) => void
 	toggleLoadingDiv: (show: boolean) => void
-	createSpinner: (spin: boolean) => void
+	createSpinner: () => void
 	toggleThumbnails: (start: number) => void
 	animationTime: number = 700
 	animationDelay: number = 200
@@ -193,6 +193,16 @@ export class WSIViewerInteractions {
 					return
 				}
 				if (shortcuts.includes(event.code) && !settings.isSavingAnnotation) {
+					wsiApp.app.dispatch({
+						type: 'plot_edit',
+						id: wsiApp.id,
+						config: {
+							settings: {
+								isSavingAnnotation: true,
+								changeTrigger: Date.now()
+							}
+						}
+					})
 					// For debugging purposes, counts how many times shortcut keys are pressed
 					// Resolve class either by key_shortcut
 					const matchingClass = sessionWSImage?.classes?.find(c => c.key_shortcut === event.code)
@@ -206,7 +216,16 @@ export class WSIViewerInteractions {
 
 					// Persist and finalize via helper
 					await this.saveAndFinalizeAnnotation(wsiApp, sessionWSImage, currentIndex, selectedClassId, aiProjectID)
-
+					wsiApp.app.dispatch({
+						type: 'plot_edit',
+						id: wsiApp.id,
+						config: {
+							settings: {
+								isSavingAnnotation: false,
+								changeTrigger: Date.now()
+							}
+						}
+					})
 					return
 				}
 			})
@@ -352,7 +371,6 @@ export class WSIViewerInteractions {
 		}
 		this.createSpinner = () => {
 			wsiApp.dom.holder.selectAll('*').style('cursor', 'wait')
-			console.log('Creating spinner')
 		}
 	}
 
@@ -595,16 +613,6 @@ export class WSIViewerInteractions {
 		if (settings.isSavingAnnotation) return
 
 		try {
-			wsiApp.app.dispatch({
-				type: 'plot_edit',
-				id: wsiApp.id,
-				config: {
-					settings: {
-						isSavingAnnotation: true,
-						changeTrigger: Date.now()
-					}
-				}
-			})
 			// TODO add UI rollback
 			await dofetch3('saveWSIAnnotation', { method: 'POST', body })
 			// TODO find another way to clear server cache
@@ -612,16 +620,7 @@ export class WSIViewerInteractions {
 		} catch (e) {
 			console.error('Error in saveWSIAnnotation request:', e)
 		}
-		wsiApp.app.dispatch({
-			type: 'plot_edit',
-			id: wsiApp.id,
-			config: {
-				settings: {
-					isSavingAnnotation: false,
-					changeTrigger: Date.now()
-				}
-			}
-		})
+
 		if (SessionWSImage.isSessionTileSelection(currentIndex, sessionWSImage)) {
 			SessionWSImage.removeTileSelection(currentIndex, sessionWSImage)
 		}

--- a/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
+++ b/client/plots/wsiviewer/interactions/WSIViewerInteractions.ts
@@ -32,11 +32,7 @@ export class WSIViewerInteractions {
 
 	onRetrainModelClicked: (genome: string, dslabel: string, projectId: string) => void
 	toggleLoadingDiv: (show: boolean) => void
-	createSpinner: () => void
 	toggleThumbnails: (start: number) => void
-	animationTime: number = 700
-	animationDelay: number = 200
-	previousZoomInPoints: [number, number][] = []
 	constructor(wsiApp: any, opts: any) {
 		this.thumbnailClickListener = (index: number) => {
 			wsiApp.app.dispatch({
@@ -87,8 +83,8 @@ export class WSIViewerInteractions {
 				const view = map.getView()
 				view.animate({
 					center: xyAvg,
-					zoom: 5,
-					duration: this.animationTime
+					zoom: settings.defaultZoom,
+					duration: settings.animationTime
 				})
 
 				//On zooming to a new annotation, add a border around the annotation
@@ -99,7 +95,7 @@ export class WSIViewerInteractions {
 
 				const zoomCoordinates = [zoomInPoints[0][0], imageHeight - zoomInPoints[0][1]] as [number, number]
 				this.addActiveBorder(vectorLayer as VectorLayer, zoomCoordinates, activePatchColor, settings.tileSize)
-			}, this.animationDelay)
+			}, settings.animationDelay)
 		}
 
 		this.setKeyDownListener = (
@@ -203,7 +199,6 @@ export class WSIViewerInteractions {
 							}
 						}
 					})
-					// For debugging purposes, counts how many times shortcut keys are pressed
 					// Resolve class either by key_shortcut
 					const matchingClass = sessionWSImage?.classes?.find(c => c.key_shortcut === event.code)
 
@@ -368,9 +363,6 @@ export class WSIViewerInteractions {
 					settings: { thumbnailRangeStart: start, displayedImageIndex: start, renderWSIViewer: true }
 				}
 			})
-		}
-		this.createSpinner = () => {
-			wsiApp.dom.holder.selectAll('*').style('cursor', 'wait')
 		}
 	}
 

--- a/client/plots/wsiviewer/view/SpinnerRenderer.ts
+++ b/client/plots/wsiviewer/view/SpinnerRenderer.ts
@@ -1,0 +1,8 @@
+export class SpinnerRenderer {
+	renderSpinner(holder: any) {
+		holder.selectAll('*').style('cursor', 'wait')
+	}
+	renderDefaultCursor(holder: any) {
+		holder.selectAll('*').style('cursor', 'default')
+	}
+}

--- a/server/routes/saveWSIAnnotation.ts
+++ b/server/routes/saveWSIAnnotation.ts
@@ -35,7 +35,6 @@ function init({ genomes }) {
 					return res.status(500).send(result)
 				}
 			}
-
 			res.status(200).send({ status: 'ok' })
 		} catch (e: any) {
 			console.warn(e)


### PR DESCRIPTION
# Description
Enabling a spinner and disabling shortcuts to indicate an annotation is being saved and prevent additional saves during the current one.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
