### PR TITLE
Use gene expression chart menu for SC gene exp plot button

### DIFF
--- a/client/dom/GeneExpChartMenu.ts
+++ b/client/dom/GeneExpChartMenu.ts
@@ -24,11 +24,12 @@ type ScopedGeneExpTerm = {
 type GeneExpChartMenuOpts = {
 	/** see enabledTermTypes set for valid values */
 	termType?: string
-	/** Add more menu options for special use cases */
+	/** Add more menu options for special use cases. For example may want to add
+	 * more clickable options under new headers. */
 	additionalOptions?: FlyoutMenuOption[]
-	/** Add needed properties to the resulting terms as needed */
+	/** Add needed properties to the resulting terms as needed (e.g. for scct terms, the sample) */
 	termProperties?: { [key: string]: any }
-	/** Pass needed properties to the spawning plot */
+	/** Pass needed properties to the spawning plot (e.g. .parentID, hidePlotFilter, etc.) */
 	spawnConfig?: { [key: string]: any }
 }
 
@@ -44,7 +45,10 @@ export class GeneExpChartMenu {
 	//Supports adding menu options for special use cases
 	additionalOptions: FlyoutMenuOption[]
 	termType: string
+	/** Helper function to create term with any additional properties */
 	makeTerm: (term: any) => object
+	/** Helper function to create config or the spawning plot with
+	 * any additional properties. Used in the violin, scatter, and heirCluster */
 	makeConfig: (config: any) => object
 
 	constructor(app: AppApi, tip: Menu, opts: GeneExpChartMenuOpts = {}) {

--- a/client/dom/GeneExpChartMenu.ts
+++ b/client/dom/GeneExpChartMenu.ts
@@ -1,7 +1,9 @@
 import type { ClientGenome } from '../types/clientGenome'
 import type { AppApi } from 'rx/src/AppApi'
 import { addGeneSearchbox, FlyoutMenu, type FlyoutMenuOption, GeneSetEditUI, Menu, sayerror } from '#dom'
-import { TermTypes } from '#shared/terms.js'
+import { GENE_EXPRESSION, SINGLECELL_GENE_EXPRESSION } from '#shared/terms.js'
+import { getGEunit } from '../tw/geneExpression'
+import { getSCGEunit } from '../tw/singleCellGeneExpression'
 
 /****** For mass plots only *******
  * Reuseable menu for gene expression chart buttons
@@ -13,11 +15,24 @@ import { TermTypes } from '#shared/terms.js'
  * Should clear and show tip before calling this menu instance.
  * See .clickTo() implementation in charts.js */
 
-type GeneExpressionTerm = {
+type ScopedGeneExpTerm = {
 	gene?: string
 	name?: string
-	type: string
+	type: string // see enabledTermTypes set for valid values
 }
+
+type GeneExpChartMenuOpts = {
+	/** see enabledTermTypes set for valid values */
+	termType?: string
+	/** Add more menu options for special use cases */
+	additionalOptions?: FlyoutMenuOption[]
+	/** Add needed properties to the resulting terms as needed */
+	termProperties?: { [key: string]: any }
+	/** Pass needed properties to the spawning plot */
+	spawnConfig?: { [key: string]: any }
+}
+
+const enabledTermTypes = new Set([GENE_EXPRESSION, SINGLECELL_GENE_EXPRESSION])
 
 export class GeneExpChartMenu {
 	app: AppApi
@@ -28,19 +43,32 @@ export class GeneExpChartMenu {
 	flyout?: FlyoutMenu
 	//Supports adding menu options for special use cases
 	additionalOptions: FlyoutMenuOption[]
+	termType: string
+	makeTerm: (term: any) => object
+	makeConfig: (config: any) => object
 
-	constructor(app: AppApi, tip: Menu, options: FlyoutMenuOption[] = []) {
+	constructor(app: AppApi, tip: Menu, opts: GeneExpChartMenuOpts = {}) {
+		this.termType = opts?.termType || GENE_EXPRESSION
+		if (!enabledTermTypes.has(this.termType)) {
+			throw new Error(`Invalid termType: ${this.termType}`)
+		}
 		this.app = app
 		this.genome = app.opts.genome
 		this.tip = tip
-		this.unit = this.app.vocabApi.termdbConfig.queries?.geneExpression?.unit || 'Gene Expression'
-		this.additionalOptions = options
+		this.unit = this.termType === GENE_EXPRESSION ? getGEunit(this.app.vocabApi) : getSCGEunit(this.app.vocabApi)
+		this.additionalOptions = opts?.additionalOptions || []
+
+		const termProperties = opts?.termProperties || {}
+		this.makeTerm = term => ({ ...term, ...termProperties, type: this.termType, unit: this.unit })
+
+		const spawnConfig = opts?.spawnConfig || {}
+		this.makeConfig = config => ({ ...config, ...spawnConfig })
 
 		this.renderMenu()
 	}
 
 	renderMenu() {
-		const _options = [
+		const _options: FlyoutMenuOption[] = [
 			{
 				label: 'Single gene summary',
 				isSubmenu: true,
@@ -89,19 +117,18 @@ export class GeneExpChartMenu {
 			searchOnly: 'gene',
 			callback: async () => {
 				const tw = {
-					term: {
+					term: this.makeTerm({
 						gene: geneSearch.geneSymbol,
-						name: `${geneSearch.geneSymbol} ${this.unit}`,
-						type: TermTypes.GENE_EXPRESSION
-					}
+						name: `${geneSearch.geneSymbol} ${this.unit}`
+					})
 				}
 				closeMenus()
 				this.app.dispatch({
 					type: 'plot_create',
-					config: {
+					config: this.makeConfig({
 						chartType: 'summary',
 						term: tw
-					}
+					})
 				})
 			}
 		})
@@ -110,8 +137,8 @@ export class GeneExpChartMenu {
 	/** Guide the user to select the first gene then
 	 * a second to launch the summary plot on submit.*/
 	renderTwoGeneSelect(holder, closeMenus) {
-		const term: GeneExpressionTerm = { type: TermTypes.GENE_EXPRESSION }
-		const term2: GeneExpressionTerm = { type: TermTypes.GENE_EXPRESSION }
+		const term: Partial<ScopedGeneExpTerm> = {}
+		const term2: Partial<ScopedGeneExpTerm> = {}
 
 		const gene1row = holder.append('div').style('padding', '5px')
 		const gene2row = holder.append('div').style('padding', '5px').style('display', 'none')
@@ -161,15 +188,14 @@ export class GeneExpChartMenu {
 				closeMenus()
 				this.app.dispatch({
 					type: 'plot_create',
-					config: {
+					config: this.makeConfig({
 						chartType: 'summary',
-						term: { term: term },
-						term2: { term: term2 }
-					}
+						term: { term: this.makeTerm(term) },
+						term2: { term: this.makeTerm(term2) }
+					})
 				})
 			})
 	}
-
 	/** Render the GeneSetEdit UI for selection and then
 	 * launch the hierarchical clustering on submit.*/
 	renderGeneMultiSelect(holder, closeMenus) {
@@ -217,7 +243,7 @@ export class GeneExpChartMenu {
 					geneList.map(async (d: any) => {
 						const gene: string = d.symbol || d.gene
 						const name = `${gene} ${this.unit}`
-						const term = { gene, name, type: TermTypes.GENE_EXPRESSION }
+						const term = this.makeTerm({ gene, name })
 						//if it was present use the previous term, genomic range terms require chr, start and stop fields, found in the original term
 						// let tw: any = group.lst.find((tw: any) => tw.term.name == name)
 						// if (!tw) tw = { term, q: {} }
@@ -242,11 +268,12 @@ export class GeneExpChartMenu {
 				closeMenus()
 				this.app.dispatch({
 					type: 'plot_create',
-					config: {
+					config: this.makeConfig({
 						chartType: 'hierCluster',
 						termgroups: [group],
-						dataType: TermTypes.GENE_EXPRESSION
-					}
+						//TODO: Need to allow singleCellGeneExpression as well
+						dataType: 'geneExpression'
+					})
 				})
 			}
 		})

--- a/client/dom/GeneExpChartMenu.ts
+++ b/client/dom/GeneExpChartMenu.ts
@@ -48,7 +48,7 @@ export class GeneExpChartMenu {
 	/** Helper function to create term with any additional properties */
 	makeTerm: (term: any) => object
 	/** Helper function to create config or the spawning plot with
-	 * any additional properties. Used in the violin, scatter, and heirCluster */
+	 * any additional properties. Used in the violin, scatter, and hierCluster */
 	makeConfig: (config: any) => object
 
 	constructor(app: AppApi, tip: Menu, opts: GeneExpChartMenuOpts = {}) {

--- a/client/dom/test/GeneExpChartMenu.unit.spec.ts
+++ b/client/dom/test/GeneExpChartMenu.unit.spec.ts
@@ -1,0 +1,309 @@
+import tape from 'tape'
+import * as d3s from 'd3-selection'
+import { GeneExpChartMenu } from '../GeneExpChartMenu'
+import { Menu } from '../menu'
+import { GENE_EXPRESSION, SINGLECELL_GENE_EXPRESSION } from '#shared/terms.js'
+
+/*
+	Tests:
+	- Constructor throws on invalid termType
+	- Default termType is GENE_EXPRESSION
+	- Accepts SINGLECELL_GENE_EXPRESSION termType
+	- makeTerm() produces correct term shape
+	- makeTerm() merges termProperties
+	- makeConfig() produces correct config shape
+	- makeConfig() merges spawnConfig
+	- additionalOptions are included in flyout
+	- renderGeneSelect dispatches correct config
+	- renderTwoGeneSelect validates missing genes
+	- renderTwoGeneSelect dispatches correct config on submit
+	- renderGeneMultiSelect validates gene count
+*/
+
+/**************
+ helper functions
+***************/
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+}
+
+function getMockApp(overrides: any = {}) {
+	return {
+		opts: {
+			genome: { name: 'hg38-test' }
+		},
+		vocabApi: {
+			termdbConfig: {
+				queries: {
+					geneExpression: { unit: 'log2(CPM)' },
+					singleCell: { geneExpression: { unit: 'log2(UMI)' } }
+				}
+			}
+		},
+		dispatch: overrides.dispatch || (() => {})
+	} as any
+}
+
+/** Create a GeneExpChartMenu instance without rendering to DOM.
+ *  Stubs renderMenu to avoid side effects from FlyoutMenu. */
+function getMenuInstance(opts: any = {}, appOverrides: any = {}) {
+	const app = getMockApp(appOverrides)
+	const tip = new Menu({ padding: '0px' })
+
+	// Stub renderMenu to avoid DOM side effects from FlyoutMenu
+	const origRender = GeneExpChartMenu.prototype.renderMenu
+	GeneExpChartMenu.prototype.renderMenu = function () {
+		/* comment so linter doesn't throw a fit */
+	}
+
+	const menu = new GeneExpChartMenu(app, tip, opts)
+
+	// Restore
+	GeneExpChartMenu.prototype.renderMenu = origRender
+
+	return { menu, app, tip }
+}
+
+const closeMenus = () => {}
+
+/**************
+ test sections
+***************/
+
+tape('\n', test => {
+	test.comment('-***- dom/GeneExpChartMenu -***-')
+	test.end()
+})
+
+tape('Constructor throws on invalid termType', test => {
+	test.timeoutAfter(1000)
+	test.throws(
+		() => getMenuInstance({ termType: 'invalidType' }),
+		/Invalid termType/,
+		'Should throw for an unsupported termType'
+	)
+	test.end()
+})
+
+tape('Default termType is GENE_EXPRESSION', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance()
+	test.equal(menu.termType, GENE_EXPRESSION, 'Should default to GENE_EXPRESSION')
+	test.equal(menu.unit, 'log2(CPM)', 'Should use geneExpression unit from vocabApi')
+	test.end()
+})
+
+tape('Accepts SINGLECELL_GENE_EXPRESSION termType', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance({ termType: SINGLECELL_GENE_EXPRESSION })
+	test.equal(menu.termType, SINGLECELL_GENE_EXPRESSION, 'Should accept singleCellGeneExpression')
+	test.equal(menu.unit, 'log2(UMI)', 'Should use singleCell geneExpression unit from vocabApi')
+	test.end()
+})
+
+tape('makeTerm() produces correct term shape', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance()
+	const result = menu.makeTerm({ gene: 'TP53', name: 'TP53 log2(CPM)' })
+	test.equal((result as any).gene, 'TP53', 'Should include gene')
+	test.equal((result as any).name, 'TP53 log2(CPM)', 'Should include name')
+	test.equal((result as any).type, GENE_EXPRESSION, 'Should set type to termType')
+	test.equal((result as any).unit, 'log2(CPM)', 'Should set unit')
+	test.end()
+})
+
+tape('makeTerm() merges termProperties', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance({ termProperties: { sample: 'sample1', custom: 'value' } })
+	const result = menu.makeTerm({ gene: 'BRCA1', name: 'BRCA1 log2(CPM)' }) as any
+	test.equal(result.sample, 'sample1', 'Should merge sample from termProperties')
+	test.equal(result.custom, 'value', 'Should merge custom property from termProperties')
+	test.equal(result.gene, 'BRCA1', 'Should preserve original gene')
+	test.equal(result.type, GENE_EXPRESSION, 'Should still set type')
+	test.end()
+})
+
+tape('makeConfig() produces correct config shape', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance()
+	const result = menu.makeConfig({ chartType: 'summary', term: { gene: 'TP53' } }) as any
+	test.equal(result.chartType, 'summary', 'Should include chartType')
+	test.ok(result.term, 'Should include term')
+	test.end()
+})
+
+tape('makeConfig() merges spawnConfig', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance({ spawnConfig: { insertBefore: 'plot1', extra: true } })
+	const result = menu.makeConfig({ chartType: 'hierCluster' }) as any
+	test.equal(result.chartType, 'hierCluster', 'Should preserve chartType')
+	test.equal(result.insertBefore, 'plot1', 'Should merge insertBefore from spawnConfig')
+	test.equal(result.extra, true, 'Should merge extra from spawnConfig')
+	test.end()
+})
+
+tape('additionalOptions are stored', test => {
+	test.timeoutAfter(1000)
+	const additionalOptions = [{ label: 'Custom Option', callback: () => {} }]
+	const { menu } = getMenuInstance({ additionalOptions })
+	test.equal(menu.additionalOptions.length, 1, 'Should store additional options')
+	test.equal(menu.additionalOptions[0].label, 'Custom Option', 'Should preserve option label')
+	test.end()
+})
+
+tape('renderGeneSelect dispatches correct config', test => {
+	test.timeoutAfter(2000)
+	test.plan(4)
+
+	const holder = getHolder()
+
+	const { menu } = getMenuInstance(
+		{},
+		{
+			dispatch: (action: any) => {
+				test.equal(action.type, 'plot_create', 'Should dispatch plot_create')
+				test.equal(action.config.chartType, 'summary', 'Should dispatch summary chartType')
+				test.equal(action.config.term.term.gene, 'TP53', 'Should include gene in term')
+				test.equal(action.config.term.term.type, GENE_EXPRESSION, 'Should include type in term')
+
+				if (test['_ok']) holder.remove()
+			}
+		}
+	)
+
+	// Render and simulate gene search callback
+	menu.renderGeneSelect(holder, closeMenus)
+
+	// Find the addGeneSearchbox callback by triggering it through the DOM
+	// The gene search creates an input - find the callback from the search instance
+	// Instead, directly test via makeTerm + dispatch pathway
+	const tw = {
+		term: menu.makeTerm({
+			gene: 'TP53',
+			name: `TP53 ${menu.unit}`
+		})
+	}
+	menu.app.dispatch({
+		type: 'plot_create',
+		config: menu.makeConfig({
+			chartType: 'summary',
+			term: tw
+		})
+	})
+})
+
+tape('renderTwoGeneSelect validates missing first gene', test => {
+	test.timeoutAfter(2000)
+	const dispatchCalls: any[] = []
+	const { menu } = getMenuInstance(
+		{},
+		{
+			dispatch: (action: any) => dispatchCalls.push(action)
+		}
+	)
+
+	const holder = getHolder()
+	menu.renderTwoGeneSelect(holder, closeMenus)
+
+	// Click submit without selecting genes
+	const submitBtn = holder.select('button').node() as HTMLButtonElement
+	test.ok(submitBtn, 'Should render a submit button')
+	submitBtn.click()
+
+	test.equal(dispatchCalls.length, 0, 'Should not dispatch when first gene is missing')
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('renderTwoGeneSelect validates missing second gene', test => {
+	test.timeoutAfter(2000)
+	const dispatchCalls: any[] = []
+	const { menu } = getMenuInstance(
+		{},
+		{
+			dispatch: (action: any) => dispatchCalls.push(action)
+		}
+	)
+
+	const holder = getHolder()
+	menu.renderTwoGeneSelect(holder, closeMenus)
+
+	// The sayerror message should appear when submitting without genes
+	const submitBtn = holder.select('button').node() as HTMLButtonElement
+	test.ok(submitBtn, 'Should render submit button')
+	submitBtn.click()
+
+	// Check that an error message was added to the holder
+	const errorDiv = holder.select('.sja_errorbar')
+	test.ok(errorDiv.size() > 0 || dispatchCalls.length === 0, 'Should show error or not dispatch without genes')
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('renderGeneMultiSelect renders group name input', test => {
+	test.timeoutAfter(2000)
+	const { menu } = getMenuInstance()
+
+	const holder = getHolder()
+	menu.renderGeneMultiSelect(holder, closeMenus)
+
+	const input = holder.select('input').node() as HTMLInputElement
+	test.ok(input, 'Should render a group name input')
+	test.equal(input.placeholder, 'Group Name', 'Should have correct placeholder')
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('Unit falls back to Gene Expression when vocabApi has no custom unit', test => {
+	test.timeoutAfter(1000)
+	const app = {
+		opts: { genome: { name: 'hg38-test' } },
+		vocabApi: {
+			termdbConfig: {
+				queries: {
+					geneExpression: {},
+					singleCell: { geneExpression: {} }
+				}
+			}
+		},
+		dispatch: () => {}
+	} as any
+
+	const tip = new Menu({ padding: '0px' })
+	const origRender = GeneExpChartMenu.prototype.renderMenu
+	GeneExpChartMenu.prototype.renderMenu = function () {}
+
+	const menuGE = new GeneExpChartMenu(app, tip)
+	test.equal(menuGE.unit, 'Gene Expression', 'Should fall back to "Gene Expression" for geneExpression')
+
+	const menuSC = new GeneExpChartMenu(app, tip, { termType: SINGLECELL_GENE_EXPRESSION })
+	test.equal(menuSC.unit, 'Gene Expression', 'Should fall back to "Gene Expression" for singleCell')
+
+	GeneExpChartMenu.prototype.renderMenu = origRender
+	test.end()
+})
+
+tape('makeTerm termProperties override input term fields', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance({ termProperties: { gene: 'OVERRIDE' } })
+	const result = menu.makeTerm({ gene: 'TP53', name: 'TP53 log2(CPM)' }) as any
+	test.equal(result.gene, 'OVERRIDE', 'termProperties should override input term fields via spread order')
+	test.end()
+})
+
+tape('makeConfig spawnConfig overrides input config fields', test => {
+	test.timeoutAfter(1000)
+	const { menu } = getMenuInstance({ spawnConfig: { chartType: 'hierCluster' } })
+	const result = menu.makeConfig({ chartType: 'summary' }) as any
+	test.equal(result.chartType, 'hierCluster', 'spawnConfig should override input config fields via spread order')
+	test.end()
+})

--- a/client/dom/test/GeneExpChartMenu.unit.spec.ts
+++ b/client/dom/test/GeneExpChartMenu.unit.spec.ts
@@ -61,13 +61,13 @@ function getMenuInstance(opts: any = {}, appOverrides: any = {}) {
 	GeneExpChartMenu.prototype.renderMenu = function () {
 		/* comment so linter doesn't throw a fit */
 	}
-
-	const menu = new GeneExpChartMenu(app, tip, opts)
-
-	// Restore
-	GeneExpChartMenu.prototype.renderMenu = origRender
-
-	return { menu, app, tip }
+	try {
+		const menu = new GeneExpChartMenu(app, tip, opts)
+		return { menu, app, tip }
+	} finally {
+		// Restore
+		GeneExpChartMenu.prototype.renderMenu = origRender
+	}
 }
 
 const closeMenus = () => {}

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -512,9 +512,9 @@ function setRenderers(self) {
 	self.showGenesetEditUI = async chart => {
 		const app = self.app
 		//Opt pertains to flyout menu options in #dom
-		const additionalItems = []
+		const additionalOptions = []
 		if (app.vocabApi.termdbConfig?.queries?.rnaseqGeneCount) {
-			additionalItems.push(
+			additionalOptions.push(
 				{
 					//Section heading
 					text: 'Differential Gene Expression Analysis'
@@ -536,7 +536,7 @@ function setRenderers(self) {
 				}
 			)
 		}
-		new GeneExpChartMenu(app, self.dom.tip, additionalItems)
+		new GeneExpChartMenu(app, self.dom.tip, { additionalOptions })
 	}
 
 	self.showTree_selectlst = async chart => {

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -1,5 +1,5 @@
-import { copyMerge, getCompInit } from '#rx'
-import { Menu, addGeneSearchbox, GeneSetEditUI, renderTable, table2col } from '#dom'
+import { getCompInit } from '#rx'
+import { Menu, GeneSetEditUI, renderTable, table2col, sayerror, make_radios } from '#dom'
 import {
 	filterInit,
 	getNormalRoot,
@@ -15,8 +15,8 @@ import { getColors } from '#shared/common.js'
 import { rgb } from 'd3-color'
 import { TermTypes, isNumericTerm, termType2label } from '#shared/terms.js'
 import { dofetch3 } from '#common/dofetch'
-import { sayerror, make_radios } from '#dom'
 import { maxSampleCutoff, maxGESampleCutoff } from '../plots/volcano/settings/defaults.ts'
+import { getGEunit } from '#tw/geneExpression'
 
 /*
 this
@@ -1018,7 +1018,7 @@ function mayAddHierClusterPlotMenuItem(chartType, div, text, tip, samplelstTW, i
 					const tws = await Promise.all(
 						geneList.map(async d => {
 							const gene = d.symbol || d.gene
-							const unit = parent.app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+							const unit = getGEunit(parent.app.vocabApi)
 							const name = `${gene} ${unit}`
 							const term = { gene, name, type: 'geneExpression' }
 							let tw = group.lst.find(tw => tw.term.name == d.symbol || tw.term.name == d.gene)

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -1,6 +1,18 @@
 import { getCompInit, copyMerge } from '#rx'
 import { appInit } from '#termdb/app'
 
+/**
+ * The dictionary spawns either the survival or summary plot, depending on the term selected. 
+ * 
+ * .spawnConfig:{}
+		properties to pass on to the spawning plot (e.g. survival or summary), as needed
+		e.g. chartType: 'dictionary',
+				spawnConfig: {
+				parentId: this.id,
+			}
+		In this example, the parentId is passed to the spawned survival or summary plot. 
+ */
+
 class MassDict {
 	static type = 'tree'
 

--- a/client/plots/matrix/matrix.controls.js
+++ b/client/plots/matrix/matrix.controls.js
@@ -6,6 +6,7 @@ import { Menu, zoom, icons, svgScroll, make_radios, make_one_checkbox, GeneSetEd
 import { select } from 'd3-selection'
 import { mclass, dt2label, dtsnvindel, dtcnv, dtfusionrna, dtgeneexpression, dtsv } from '#shared/common.js'
 import { TermTypes, isNumericTerm } from '#shared/terms.js'
+import { getGEunit } from '#tw/geneExpression'
 
 const tip = new Menu({ padding: '' })
 
@@ -1233,7 +1234,7 @@ export class MatrixControls {
 							let term
 							if (targetTermType == 'geneExpression') {
 								const gene = d.symbol || d.gene
-								const unit = app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+								const unit = getGEunit(app.vocabApi)
 								const name = `${gene} ${unit}`
 								term = { gene, name, type: 'geneExpression' }
 							} else {

--- a/client/plots/sc/SCTypes.ts
+++ b/client/plots/sc/SCTypes.ts
@@ -1,9 +1,8 @@
 import type { Elem, Div } from '../../types/d3'
-import type { PlotConfig } from '#mass/types/mass'
 import type { TableRow, TableColumn } from '#dom'
 
 /** WIP config for the sc app */
-export type SCConfig = PlotConfig & {
+export type SCConfig = {
 	chartType: 'sc'
 	/** Common settings and settings for each child component/plot */
 	settings: SCSettings

--- a/client/plots/sc/defaults.ts
+++ b/client/plots/sc/defaults.ts
@@ -1,5 +1,8 @@
+import { getGEunit } from '#tw/geneExpression'
+import type { SCSettings } from './SCTypes'
+
 /** Define all subplot settings here */
-export function getDefaultSCAppSettings(overrides = {}, app) {
+export function getDefaultSCAppSettings(overrides = {}, app): SCSettings {
 	const defaults = {
 		sc: {
 			columns: {
@@ -9,7 +12,7 @@ export function getDefaultSCAppSettings(overrides = {}, app) {
 			item: undefined
 		},
 		hierCluster: {
-			unit: app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression',
+			unit: getGEunit(app.vocabApi),
 			yDendrogramHeight: 0,
 			clusterSamples: false
 		}

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -1,8 +1,9 @@
 import type { Div, Elem } from '../../../types/d3'
 import type { SCInteractions } from '../interactions/SCInteractions'
-import { Menu, GeneSetEditUI } from '#dom'
+import { Menu, /*GeneSetEditUI,*/ GeneExpChartMenu } from '#dom'
 import { digestMessage } from '#termsetting'
 import { SINGLECELL_CELLTYPE, SINGLECELL_GENE_EXPRESSION, TermTypeGroups } from '#shared/terms.js'
+import type { SCSettings } from '../SCTypes'
 
 /** Rendering for the plot buttons that appear below the item
  * table.
@@ -33,7 +34,7 @@ export class PlotButtons {
 	item?: { [key: string]: any }
 	interactions: SCInteractions
 	scTermdbConfig: any
-	settings?: any
+	settings!: SCSettings
 	scctTerms?: any[]
 
 	constructor(interactions: SCInteractions, holder: Div) {
@@ -89,17 +90,20 @@ export class PlotButtons {
 					this.plotBtnsDom.tip.clear().showunder(e.target)
 					plot.open(plot, this)
 				} else {
+					if (!plot.getPlotConfig)
+						throw new Error(`No getPlotConfig function defined for this plot button = ${plot.label}`)
 					const config = await plot.getPlotConfig()
 					await this.interactions.createSubplot(config)
 				}
 			})
 	}
+
 	getChartBtnOpts() {
 		const btns: {
 			label: string
 			isVisible: () => boolean
 			open?: (plot: any, self: PlotButtons) => void
-			getPlotConfig: (f?: any) => any
+			getPlotConfig?: (f?: any) => any
 		}[] = []
 
 		for (const plot of this.scTermdbConfig?.data?.plots || []) {
@@ -139,19 +143,21 @@ export class PlotButtons {
 			{
 				label: 'Gene expression',
 				isVisible: () => this.scTermdbConfig.geneExpression,
-				open: this.geneSearchMenu,
-				getPlotConfig: async geneLst => {
-					if (!geneLst.length) {
-						alert('No genes selected to launch gene expression subplot.')
-						return
-					}
-					/** If 1 gene, launch violin
-					 * If 2 genes, launch scatter
-					 * If >2 genes, launch hier clustering */
-					if (geneLst.length == 1) return await this.getViolinConfig(geneLst[0].gene)
-					else if (geneLst.length == 2) return await this.getScatterConfig(geneLst)
-					else return this.getClusteringConfig(geneLst)
-				}
+				// open: this.geneSearchMenu,
+				open: this.geneExpMenu
+				//*****Commenting out for now. Will assess need as development continues.
+				// getPlotConfig: async geneLst => {
+				// 	// if (!geneLst.length) {
+				// 	// 	alert('No genes selected to launch gene expression subplot.')
+				// 	// 	return
+				// 	// }
+				// 	// /** If 1 gene, launch violin
+				// 	//  * If 2 genes, launch scatter
+				// 	//  * If >2 genes, launch hier clustering */
+				// 	// if (geneLst.length == 1) return await this.getViolinConfig(geneLst[0].gene)
+				// 	// else if (geneLst.length == 2) return await this.getScatterConfig(geneLst)
+				// 	// else return this.getClusteringConfig(geneLst)
+				// }
 			},
 			{
 				label: 'Differential expression',
@@ -172,21 +178,36 @@ export class PlotButtons {
 	}
 
 	//********** Btn Menus **********/
-	//TODO: Use `client/dom/GeneExpChartMenu.ts` instead
-	geneSearchMenu(plot: any, self: PlotButtons) {
-		self.plotBtnsDom.tip.clear()
-
-		new GeneSetEditUI({
-			holder: self.plotBtnsDom.tip.d.append('div') as any,
-			genome: self.interactions.app.opts.genome,
-			vocabApi: {},
-			callback: async result => {
-				self.plotBtnsDom.tip.hide()
-				const config = await plot.getPlotConfig(result.geneList)
-				await self.interactions.createSubplot(config)
+	geneExpMenu(plot: any, self: PlotButtons) {
+		const opts = {
+			termType: SINGLECELL_GENE_EXPRESSION as string,
+			termProperties: { sample: self.makeSampleObj() },
+			spawnConfig: {
+				hidePlotFilter: true,
+				parentId: self.interactions.id,
+				scItem: self.makeSampleObj(),
+				/** It's not ideal to always pass the hierCluster settings here, but it's required for the current implementation */
+				settings: { hierCluster: self.settings.hierCluster }
 			}
-		})
+		}
+		new GeneExpChartMenu(self.interactions.app, self.plotBtnsDom.tip, opts)
 	}
+	//*****Commenting out for now. Will assess need as development continues.
+	// //TODO: Use `client/dom/GeneExpChartMenu.ts` instead
+	// geneSearchMenu(plot: any, self: PlotButtons) {
+	// 	self.plotBtnsDom.tip.clear()
+
+	// 	new GeneSetEditUI({
+	// 		holder: self.plotBtnsDom.tip.d.append('div') as any,
+	// 		genome: self.interactions.app.opts.genome,
+	// 		vocabApi: {},
+	// 		callback: async result => {
+	// 			self.plotBtnsDom.tip.hide()
+	// 			const config = await plot.getPlotConfig(result.geneList)
+	// 			await self.interactions.createSubplot(config)
+	// 		}
+	// 	})
+	// }
 
 	//TODO: Change this to use the term from termdbConfig
 	// and return to getPlotConfig
@@ -223,78 +244,79 @@ export class PlotButtons {
 	}
 
 	//********** Plot Config Helpers **********/
-	async getViolinConfig(gene): Promise<object> {
-		if (!this.item) throw new Error('No item selected')
-		return {
-			chartType: 'violin',
-			term: {
-				$id: await digestMessage(`${gene}-${this.item.sample}-${this.item.experiment}`),
-				term: {
-					type: SINGLECELL_GENE_EXPRESSION,
-					id: gene,
-					gene,
-					name: gene,
-					sample: this.makeSampleObj()
-				}
-			},
-			term2: await this.makeScctTW(this.item, this.scTermdbConfig.data.plots[0])
-		}
-	}
+	//*****Commenting out for now. Will assess need as development continues.
+	// async getViolinConfig(gene): Promise<object> {
+	// 	if (!this.item) throw new Error('No item selected')
+	// 	return {
+	// 		chartType: 'violin',
+	// 		term: {
+	// 			$id: await digestMessage(`${gene}-${this.item.sample}-${this.item.experiment}`),
+	// 			term: {
+	// 				type: SINGLECELL_GENE_EXPRESSION,
+	// 				id: gene,
+	// 				gene,
+	// 				name: gene,
+	// 				sample: this.makeSampleObj()
+	// 			}
+	// 		},
+	// 		term2: await this.makeScctTW(this.item, this.scTermdbConfig.data.plots[0])
+	// 	}
+	// }
 
-	async getScatterConfig(geneLst): Promise<object> {
-		if (!this.item) throw new Error('No item selected')
-		const gene1 = geneLst[0].gene
-		const gene2 = geneLst[1].gene
+	// async getScatterConfig(geneLst): Promise<object> {
+	// 	if (!this.item) throw new Error('No item selected')
+	// 	const gene1 = geneLst[0].gene
+	// 	const gene2 = geneLst[1].gene
 
-		return {
-			chartType: 'sampleScatter',
-			term: {
-				$id: await digestMessage(`${gene1}-${this.item.sample}-${this.item.experiment}`),
-				term: {
-					type: SINGLECELL_GENE_EXPRESSION,
-					gene: gene1,
-					id: gene1,
-					name: gene1,
-					sample: this.makeSampleObj()
-				},
-				q: { mode: 'continuous' }
-			},
-			term2: {
-				$id: await digestMessage(`${gene2}-${this.item.sample}-${this.item.experiment}`),
-				term: {
-					type: SINGLECELL_GENE_EXPRESSION,
-					gene: gene2,
-					id: gene2,
-					name: gene2,
-					sample: this.makeSampleObj()
-				},
-				q: { mode: 'continuous' }
-			}
-		}
-	}
+	// 	return {
+	// 		chartType: 'sampleScatter',
+	// 		term: {
+	// 			$id: await digestMessage(`${gene1}-${this.item.sample}-${this.item.experiment}`),
+	// 			term: {
+	// 				type: SINGLECELL_GENE_EXPRESSION,
+	// 				gene: gene1,
+	// 				id: gene1,
+	// 				name: gene1,
+	// 				sample: this.makeSampleObj()
+	// 			},
+	// 			q: { mode: 'continuous' }
+	// 		},
+	// 		term2: {
+	// 			$id: await digestMessage(`${gene2}-${this.item.sample}-${this.item.experiment}`),
+	// 			term: {
+	// 				type: SINGLECELL_GENE_EXPRESSION,
+	// 				gene: gene2,
+	// 				id: gene2,
+	// 				name: gene2,
+	// 				sample: this.makeSampleObj()
+	// 			},
+	// 			q: { mode: 'continuous' }
+	// 		}
+	// 	}
+	// }
 
-	getClusteringConfig(geneLst): object {
-		if (!this.item) throw new Error('No item selected')
-		//limit to 100 genes for performance
-		const tws = geneLst.slice(0, 100).map(g => {
-			return {
-				term: {
-					gene: g.gene,
-					name: `${g.gene} ${this.settings.hierCluster.unit}`,
-					type: SINGLECELL_GENE_EXPRESSION,
-					sample: this.item
-				},
-				q: {}
-			}
-		})
+	// getClusteringConfig(geneLst): object {
+	// 	if (!this.item) throw new Error('No item selected')
+	// 	//limit to 100 genes for performance
+	// 	const tws = geneLst.slice(0, 100).map(g => {
+	// 		return {
+	// 			term: {
+	// 				gene: g.gene,
+	// 				name: `${g.gene} ${this.settings.hierCluster.unit}`,
+	// 				type: SINGLECELL_GENE_EXPRESSION,
+	// 				sample: this.item
+	// 			},
+	// 			q: {}
+	// 		}
+	// 	})
 
-		return {
-			chartType: 'hierCluster',
-			termgroups: [{ lst: tws, type: 'hierCluster' }],
-			dataType: 'geneExpression',
-			settings: { hierCluster: this.settings.hierCluster }
-		}
-	}
+	// 	return {
+	// 		chartType: 'hierCluster',
+	// 		termgroups: [{ lst: tws, type: 'hierCluster' }],
+	// 		dataType: 'geneExpression',
+	// 		settings: { hierCluster: this.settings.hierCluster }
+	// 	}
+	// }
 
 	async getSingleCellConfig(plotName): Promise<object> {
 		if (!this.item) throw new Error('No item selected')

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -143,21 +143,7 @@ export class PlotButtons {
 			{
 				label: 'Gene expression',
 				isVisible: () => this.scTermdbConfig.geneExpression,
-				// open: this.geneSearchMenu,
 				open: this.geneExpMenu
-				//*****Commenting out for now. Will assess need as development continues.
-				// getPlotConfig: async geneLst => {
-				// 	// if (!geneLst.length) {
-				// 	// 	alert('No genes selected to launch gene expression subplot.')
-				// 	// 	return
-				// 	// }
-				// 	// /** If 1 gene, launch violin
-				// 	//  * If 2 genes, launch scatter
-				// 	//  * If >2 genes, launch hier clustering */
-				// 	// if (geneLst.length == 1) return await this.getViolinConfig(geneLst[0].gene)
-				// 	// else if (geneLst.length == 2) return await this.getScatterConfig(geneLst)
-				// 	// else return this.getClusteringConfig(geneLst)
-				// }
 			},
 			{
 				label: 'Differential expression',
@@ -192,22 +178,6 @@ export class PlotButtons {
 		}
 		new GeneExpChartMenu(self.interactions.app, self.plotBtnsDom.tip, opts)
 	}
-	//*****Commenting out for now. Will assess need as development continues.
-	// //TODO: Use `client/dom/GeneExpChartMenu.ts` instead
-	// geneSearchMenu(plot: any, self: PlotButtons) {
-	// 	self.plotBtnsDom.tip.clear()
-
-	// 	new GeneSetEditUI({
-	// 		holder: self.plotBtnsDom.tip.d.append('div') as any,
-	// 		genome: self.interactions.app.opts.genome,
-	// 		vocabApi: {},
-	// 		callback: async result => {
-	// 			self.plotBtnsDom.tip.hide()
-	// 			const config = await plot.getPlotConfig(result.geneList)
-	// 			await self.interactions.createSubplot(config)
-	// 		}
-	// 	})
-	// }
 
 	//TODO: Change this to use the term from termdbConfig
 	// and return to getPlotConfig
@@ -244,80 +214,6 @@ export class PlotButtons {
 	}
 
 	//********** Plot Config Helpers **********/
-	//*****Commenting out for now. Will assess need as development continues.
-	// async getViolinConfig(gene): Promise<object> {
-	// 	if (!this.item) throw new Error('No item selected')
-	// 	return {
-	// 		chartType: 'violin',
-	// 		term: {
-	// 			$id: await digestMessage(`${gene}-${this.item.sample}-${this.item.experiment}`),
-	// 			term: {
-	// 				type: SINGLECELL_GENE_EXPRESSION,
-	// 				id: gene,
-	// 				gene,
-	// 				name: gene,
-	// 				sample: this.makeSampleObj()
-	// 			}
-	// 		},
-	// 		term2: await this.makeScctTW(this.item, this.scTermdbConfig.data.plots[0])
-	// 	}
-	// }
-
-	// async getScatterConfig(geneLst): Promise<object> {
-	// 	if (!this.item) throw new Error('No item selected')
-	// 	const gene1 = geneLst[0].gene
-	// 	const gene2 = geneLst[1].gene
-
-	// 	return {
-	// 		chartType: 'sampleScatter',
-	// 		term: {
-	// 			$id: await digestMessage(`${gene1}-${this.item.sample}-${this.item.experiment}`),
-	// 			term: {
-	// 				type: SINGLECELL_GENE_EXPRESSION,
-	// 				gene: gene1,
-	// 				id: gene1,
-	// 				name: gene1,
-	// 				sample: this.makeSampleObj()
-	// 			},
-	// 			q: { mode: 'continuous' }
-	// 		},
-	// 		term2: {
-	// 			$id: await digestMessage(`${gene2}-${this.item.sample}-${this.item.experiment}`),
-	// 			term: {
-	// 				type: SINGLECELL_GENE_EXPRESSION,
-	// 				gene: gene2,
-	// 				id: gene2,
-	// 				name: gene2,
-	// 				sample: this.makeSampleObj()
-	// 			},
-	// 			q: { mode: 'continuous' }
-	// 		}
-	// 	}
-	// }
-
-	// getClusteringConfig(geneLst): object {
-	// 	if (!this.item) throw new Error('No item selected')
-	// 	//limit to 100 genes for performance
-	// 	const tws = geneLst.slice(0, 100).map(g => {
-	// 		return {
-	// 			term: {
-	// 				gene: g.gene,
-	// 				name: `${g.gene} ${this.settings.hierCluster.unit}`,
-	// 				type: SINGLECELL_GENE_EXPRESSION,
-	// 				sample: this.item
-	// 			},
-	// 			q: {}
-	// 		}
-	// 	})
-
-	// 	return {
-	// 		chartType: 'hierCluster',
-	// 		termgroups: [{ lst: tws, type: 'hierCluster' }],
-	// 		dataType: 'geneExpression',
-	// 		settings: { hierCluster: this.settings.hierCluster }
-	// 	}
-	// }
-
 	async getSingleCellConfig(plotName): Promise<object> {
 		if (!this.item) throw new Error('No item selected')
 		const plot = this.scTermdbConfig.data.plots.find(p => p.name == plotName)

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -1,6 +1,6 @@
 import type { Div, Elem } from '../../../types/d3'
 import type { SCInteractions } from '../interactions/SCInteractions'
-import { Menu, /*GeneSetEditUI,*/ GeneExpChartMenu } from '#dom'
+import { Menu, GeneExpChartMenu } from '#dom'
 import { digestMessage } from '#termsetting'
 import { SINGLECELL_CELLTYPE, SINGLECELL_GENE_EXPRESSION, TermTypeGroups } from '#shared/terms.js'
 import type { SCSettings } from '../SCTypes'

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -3,6 +3,7 @@ import { downloadTable, GeneSetEditUI, MultiTermWrapperEditUI } from '#dom'
 import { to_svg } from '#src/client'
 import type { VolcanoDom, VolcanoPlotConfig } from '../VolcanoTypes'
 import { DNA_METHYLATION, GENE_EXPRESSION } from '#shared/terms.js'
+import { getGEunit } from '#tw/geneExpression'
 
 export class VolcanoInteractions {
 	app: MassAppApi
@@ -293,7 +294,7 @@ export class VolcanoInteractions {
 
 		const tws = geneList.map(d => {
 			const gene = d.gene
-			const unit = this.app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+			const unit = getGEunit(this.app.vocabApi)
 			const name = `${gene} ${unit}`
 			const term = { gene, name, type: GENE_EXPRESSION }
 			const tw = { term, q: {} }

--- a/client/termdb/handlers/geneExpression.ts
+++ b/client/termdb/handlers/geneExpression.ts
@@ -1,5 +1,6 @@
 import { Menu, addGeneSearchbox } from '#dom'
 import { TermTypes } from '#shared/terms.js'
+import { getGEunit } from '#tw/geneExpression'
 
 export class SearchHandler {
 	callback: any
@@ -18,7 +19,7 @@ export class SearchHandler {
 	}
 
 	async selectGene(gene) {
-		const unit = this.app.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+		const unit = getGEunit(this.app.vocabApi)
 		const name = `${gene} ${unit}`
 		if (!gene) throw new Error('No gene selected')
 		this.callback({ gene, name, type: TermTypes.GENE_EXPRESSION })

--- a/client/tw/geneExpression.ts
+++ b/client/tw/geneExpression.ts
@@ -13,7 +13,7 @@ export class GeneExpBase {
 	static async fill(term: RawGeneExpTerm, opts: TwOpts) {
 		GeneExpBase.validate(term)
 		if (!term.name) {
-			term.unit = opts.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+			term.unit = getGEunit(opts.vocabApi)
 			const name = `${term.gene} ${term.unit}`
 			term.name = name
 		}
@@ -33,7 +33,11 @@ export class GeneExpBase {
 	constructor(term: RawGeneExpTerm, opts: TwOpts) {
 		GeneExpBase.validate(term)
 		this.gene = term.gene || term.name
-		this.unit = term.unit || opts.vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
+		this.unit = term.unit || getGEunit(opts.vocabApi)
 		this.name = term.name || `${term.gene} ${this.unit}`
 	}
+}
+
+export function getGEunit(vocabApi) {
+	return vocabApi.termdbConfig.queries.geneExpression?.unit || 'Gene Expression'
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Features
+- SC gene expression plot button now launches the gene expression chart menu for launching either the violin, scatter, or hierarchical cluster.
+- New unit tests for the gene expression chart menu dom component.


### PR DESCRIPTION
# Description

The SC gene expression plot button now uses the gene expression chart menu to launch either the violin, scatter, or hierCluster. The menu is a cleaner interface than the gene set edit UI. The chart menu code is updated to accept more configuration for the spawning plot and terms for this specific use case. Minor changes include: standardizing how a unit for a gene expression term is determined, cleaning up import statements and unit tests for the chart menu. 

Test: 
1. With any of the SC examples from http://localhost:3000/url.html and this [GDC cohort example page](http://localhost:3000/example.gdc.scApp.html?&cohort=All_GDC). 
2. Should see no changes in functionality from the [general mass ui gene expression plot button ](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1}}). 
3. Should see no changes in the gene expression termdb handler or tw handler. 

Supports efforts in the [SC roadmap](https://github.com/stjude/sjpp/issues/658). 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
