### PR TITLE
Fix floating point error causing over a dozen unit tests to fail

### DIFF
--- a/client/dom/test/menu.unit.spec.js
+++ b/client/dom/test/menu.unit.spec.js
@@ -46,6 +46,18 @@ function getTestMenu() {
 	return menu
 }
 
+/** Parse a CSS pixel value like '70px' to a number, returns NaN for empty/invalid */
+function parsePx(val) {
+	if (!val || !val.endsWith('px')) return NaN
+	return parseFloat(val)
+}
+
+/** Assert that a CSS pixel value is close to the expected number (tolerance of 1px) */
+function assertPxClose(test, actual, expected, msg) {
+	const parsed = parsePx(actual)
+	test.ok(Math.abs(parsed - expected) <= 1, `${msg} (actual: ${actual}, expected: ~${expected}px)`)
+}
+
 /**************
  test sections
 ***************/
@@ -128,24 +140,25 @@ tape('show() with args', async test => {
 	{
 		//left (x) position
 		const posNum = 50
-		const y = /*testMenu.offsetY +*/ window.scrollY // when running many other tests, the screen would scroll vertically
 		testMenu.show(posNum)
-		test.deepEqual(
-			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum + testMenu.offsetX}px`, top: '' },
-			`Should show menu left, under header, shifted by .offsetX = ${testMenu.offsetX}px`
+		assertPxClose(
+			test,
+			testMenu.dnode.style.left,
+			posNum + testMenu.offsetX,
+			`Should show menu left, shifted by .offsetX = ${testMenu.offsetX}px`
 		)
 	}
 
 	{
 		//top (y) position
 		const posNum = 50
-		const y = posNum + testMenu.offsetY + window.scrollY // when running many other tests, the screen would scroll vertically
+		const y = posNum + testMenu.offsetY + window.scrollY
 		testMenu.show('', posNum)
-		test.deepEqual(
-			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: '20px', top: `${y}px` },
-			`Should show menu at the top, above header, shifted by .offsetY + window.scrollY = ${y}px`
+		assertPxClose(
+			test,
+			testMenu.dnode.style.top,
+			y,
+			`Should show menu at the top, shifted by .offsetY + window.scrollY`
 		)
 	}
 
@@ -154,21 +167,25 @@ tape('show() with args', async test => {
 		const posNum = 100
 		const y = posNum + testMenu.offsetY + window.scrollY
 		testMenu.show(posNum, posNum)
-		test.deepEqual(
-			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum + testMenu.offsetX}px`, top: `${y}px` },
-			`Should show menu top left corner, over header, shifted by .offsetX = ${testMenu.offsetX}px & .offsetY = ${y}px`
+		assertPxClose(
+			test,
+			testMenu.dnode.style.left,
+			posNum + testMenu.offsetX,
+			`Should show menu left, shifted by .offsetX = ${testMenu.offsetX}px`
 		)
+		assertPxClose(test, testMenu.dnode.style.top, y, `Should show menu top, shifted by .offsetY + window.scrollY`)
 	}
 
 	{
 		const posNum = 100
 		//No shift (i.e. additional 20px)
 		testMenu.show(posNum, posNum, false)
-		test.deepEqual(
-			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum}px`, top: `${posNum + window.scrollY}px` },
-			`Should show menu top left corner without .offsetX or .offsetY added to left or top, respectively.`
+		assertPxClose(test, testMenu.dnode.style.left, posNum, `Should show menu left without .offsetX`)
+		assertPxClose(
+			test,
+			testMenu.dnode.style.top,
+			posNum + window.scrollY,
+			`Should show menu top without .offsetY, only window.scrollY`
 		)
 	}
 
@@ -182,10 +199,17 @@ tape('show() with args', async test => {
 		const posNum = 200
 		testMenu.d.append('div').text(longText)
 		testMenu.show(posNum, posNum, false)
-		test.deepEqual(
-			{ left: testMenu.dnode.style.left, top: testMenu.dnode.style.top },
-			{ left: `${posNum + window.scrollX}px`, top: `${posNum + window.scrollY}px` },
-			`Should show menu position with window.scrollX = ${window.scrollX} & window.scrollY = ${window.scrollY}`
+		assertPxClose(
+			test,
+			testMenu.dnode.style.left,
+			posNum + window.scrollX,
+			`Should show menu left with window.scrollX = ${window.scrollX}`
+		)
+		assertPxClose(
+			test,
+			testMenu.dnode.style.top,
+			posNum + window.scrollY,
+			`Should show menu top with window.scrollY = ${window.scrollY}`
 		)
 	}
 	testMenu.destroy()

--- a/client/dom/test/sketchGm.unit.spec.ts
+++ b/client/dom/test/sketchGm.unit.spec.ts
@@ -121,7 +121,7 @@ tape('sketchSplicerna renders spliced RNA on canvas', test => {
 
 	// Verify devicePixelRatio is considered
 	const dpr = window.devicePixelRatio || 1
-	test.ok(canvas.width >= 400 * dpr, 'Canvas backing store should be scaled by devicePixelRatio')
+	test.ok(Math.abs(canvas.width - 400 * dpr) <= 1, 'Canvas backing store should be scaled by devicePixelRatio')
 
 	// Check that the canvas has been drawn on
 	const ctx = canvas.getContext('2d')!
@@ -160,7 +160,11 @@ tape('sketchGmsum renders gene model summary', test => {
 
 	const canvas = holder.select('canvas').node() as HTMLCanvasElement
 	test.ok(canvas, 'Canvas element should be created')
-	test.equal(canvas.height * (1 / (window.devicePixelRatio || 1)), 20, 'Canvas height should match specified height')
+	test.equal(
+		Math.round(canvas.height / (window.devicePixelRatio || 1)),
+		20,
+		'Canvas height should match specified height'
+	)
 
 	// Check for rendering
 	const ctx = canvas.getContext('2d')!
@@ -199,11 +203,11 @@ tape('sketchRna renders RNA structure', test => {
 
 	const canvas = holder.select('canvas').node() as HTMLCanvasElement
 	test.ok(canvas, 'Canvas element should be created')
-	test.equal(canvas.height * (1 / (window.devicePixelRatio || 1)), 20, 'Canvas height should be 20px')
+	test.equal(Math.round(canvas.height / (window.devicePixelRatio || 1)), 20, 'Canvas height should be 20px')
 
 	// Check devicePixelRatio scaling
 	const dpr = window.devicePixelRatio || 1
-	test.ok(canvas.width >= 400 * dpr, 'Canvas should be scaled by devicePixelRatio')
+	test.ok(Math.abs(canvas.width - 400 * dpr) <= 1, 'Canvas should be scaled by devicePixelRatio')
 
 	holder.remove()
 	test.end()
@@ -253,7 +257,7 @@ tape('sketchProtein2 renders protein domains', test => {
 
 	const canvas = holder.select('canvas').node() as HTMLCanvasElement
 	test.ok(canvas, 'Canvas element should be created')
-	test.equal(canvas.height * (1 / (window.devicePixelRatio || 1)), 20, 'Canvas height should be 20px')
+	test.equal(Math.round(canvas.height / (window.devicePixelRatio || 1)), 20, 'Canvas height should be 20px')
 
 	// Verify that domains are rendered (canvas has content)
 	const ctx = canvas.getContext('2d')!
@@ -276,11 +280,15 @@ tape('sketchGene renders gene structure', test => {
 
 	const canvas = holder.select('canvas').node() as HTMLCanvasElement
 	test.ok(canvas, 'Canvas element should be created')
-	test.equal(canvas.height * (1 / (window.devicePixelRatio || 1)), 30, 'Canvas height should match specified height')
+	test.equal(
+		Math.round(canvas.height / (window.devicePixelRatio || 1)),
+		30,
+		'Canvas height should match specified height'
+	)
 
 	// Check devicePixelRatio scaling
 	const dpr = window.devicePixelRatio || 1
-	test.ok(canvas.width >= 400 * dpr, 'Canvas should be scaled by devicePixelRatio')
+	test.ok(Math.abs(canvas.width - 400 * dpr) <= 1, 'Canvas should be scaled by devicePixelRatio')
 
 	// Verify rendering
 	const ctx = canvas.getContext('2d')!
@@ -403,31 +411,31 @@ tape('All canvas functions respect devicePixelRatio', test => {
 	// Test sketchSplicerna
 	sketchSplicerna(holder, gm, width, '#000')
 	let canvas = holder.select('canvas').node() as HTMLCanvasElement
-	test.ok(canvas.width >= width * dpr, 'sketchSplicerna respects DPR')
+	test.ok(Math.abs(canvas.width - width * dpr) <= 1, 'sketchSplicerna respects DPR')
 	holder.selectAll('canvas').remove()
 
 	// Test sketchGmsum
 	sketchGmsum(holder, rglst, gm, 1, 10, width, 20, '#000')
 	canvas = holder.select('canvas').node() as HTMLCanvasElement
-	test.ok(canvas.width >= width * dpr, 'sketchGmsum respects DPR')
+	test.ok(Math.abs(canvas.width - width * dpr) <= 1, 'sketchGmsum respects DPR')
 	holder.selectAll('canvas').remove()
 
 	// Test sketchRna
 	sketchRna(holder, gm, width, '#000')
 	canvas = holder.select('canvas').node() as HTMLCanvasElement
-	test.ok(canvas.width >= width * dpr, 'sketchRna respects DPR')
+	test.ok(Math.abs(canvas.width - width * dpr) <= 1, 'sketchRna respects DPR')
 	holder.selectAll('canvas').remove()
 
 	// Test sketchProtein2
 	sketchProtein2(holder, gm, width)
 	canvas = holder.select('canvas').node() as HTMLCanvasElement
-	test.ok(canvas.width >= width * dpr, 'sketchProtein2 respects DPR')
+	test.ok(Math.abs(canvas.width - width * dpr) <= 1, 'sketchProtein2 respects DPR')
 	holder.selectAll('canvas').remove()
 
 	// Test sketchGene
 	sketchGene(holder, gm, width, 30, 1000, 5000, '#000', false, false)
 	canvas = holder.select('canvas').node() as HTMLCanvasElement
-	test.ok(canvas.width >= width * dpr, 'sketchGene respects DPR')
+	test.ok(Math.abs(canvas.width - width * dpr) <= 1, 'sketchGene respects DPR')
 
 	holder.remove()
 	test.end()


### PR DESCRIPTION
# Description

Of late, not all of the unit test on my local pass and the number of test failures is growing. Sifting through 12, 16, 18 tests to ensure my changes didn't cause a problem _every time_ is wildly inefficient. Here I set a tolerance for the rendering elements being tested to 1px. That prevents the test from failing for floating point errors (e.g. expected = 20px, actual = 19.999999566511683px). The test still fails for unexpected sizing but not minuscule discrepancies. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
