### PR TITLE
pass filter0 from scatter plot to disco plot as a component of the sa…

### DIFF
--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -41,11 +41,15 @@ export default class Disco {
 	private recreateViewModel = false
 	private errorDiv: any
 
+	args: any
+
 	constructor(opts: any) {
 		this.type = 'Disco'
 		this.opts = opts
 		this.isOpen = false
 		this.discoInteractions = new DiscoInteractions(this)
+		this.args = this.opts.args || this.opts.state?.args || this.opts?.app?.opts.args
+		console.log(51, this.args, this.opts)
 	}
 
 	async init() {
@@ -121,8 +125,7 @@ export default class Disco {
 			]
 			configInputsOptions.push(...cnvConfigInputOptions)
 		}
-
-		const genomeChr = this.app.opts.state.args.genome.majorchr
+		const genomeChr = this.args.genome.majorchr
 		const chromosomeConfigOption = {
 			label: 'Chromosomes',
 			title: 'Chromosomes shown in the plot',
@@ -215,12 +218,12 @@ export default class Disco {
 				this.features[name].update({ state: this.state, appState })
 			}
 
-			const legendRenderer = new LegendRenderer(this.viewModel.cappedCnvMaxAbsValue, settings.label.fontSize)
+			const legendRenderer = new LegendRenderer(this.viewModel.cappedCnvMaxAbsValue, settings.label.fontSize, this)
 
 			const discoRenderer = new DiscoRenderer(
 				this.getRingRenderers(this.viewModel.settings, this.viewModel, this.discoInteractions.geneClickListener),
 				legendRenderer,
-				this.app.opts.state.args.genome
+				this.args.genome
 			)
 
 			discoRenderer.render(svgDiv, this.viewModel, this.onCnvSourceSelect)
@@ -235,7 +238,7 @@ export default class Disco {
 		const config = appState.plots.find(p => p.id === this.id)
 		if (!config) return config
 		// include args.data so updates rerender when mutation list changes
-		return { ...config, mlst: appState.args.data }
+		return { ...config, mlst: this.args.data }
 	}
 
 	getRingRenderers(
@@ -276,8 +279,8 @@ export default class Disco {
 	}
 
 	private onCnvSourceSelect = (index: number) => {
-		const state = this.app.getState()
-		const args = state.args
+		//const state = this.app.getState()
+		const args = this.args
 		const alt = args.alternativeDataByDt?.[dtcnv]
 		if (!alt) return
 		const altClone = structuredClone(args.alternativeDataByDt)

--- a/client/plots/disco/interactions/DiscoInteractions.ts
+++ b/client/plots/disco/interactions/DiscoInteractions.ts
@@ -41,9 +41,10 @@ export class DiscoInteractions {
 
 		this.geneClickListener = async (gene: string, mnames: Array<string>) => {
 			const { filter, filter0 } = this.discoApp.app.getState().termfilter
+			console.log(43, filter0, filter)
 			const arg = {
 				holder: this.discoApp.app.opts.holder,
-				genome: this.discoApp.app.opts.state.args.genome,
+				genome: this.discoApp.args.genome || this.discoApp.app.opts.state.args.genome,
 				nobox: true,
 				query: gene,
 				tklst: [
@@ -56,6 +57,7 @@ export class DiscoInteractions {
 					}
 				]
 			}
+			console.log(58)
 			const _ = await import('#src/block.init')
 			await _.default(arg)
 		}

--- a/client/plots/disco/legend/LegendRenderer.ts
+++ b/client/plots/disco/legend/LegendRenderer.ts
@@ -1,4 +1,5 @@
 import type Legend from './Legend.ts'
+import type Disco from '../Disco.ts'
 import { svgLegend, getMaxLabelWidth } from '#dom'
 import LegendJSONMapper from './LegendJSONMapper.ts'
 import { dtcnv } from '#shared/common.js'
@@ -6,10 +7,12 @@ import { renderCnvSourceLegend, type AlternativeCnvSet } from '../cnv/renderCnvS
 import type ViewModel from '../viewmodel/ViewModel.ts'
 
 export default class LegendRenderer {
+	private discoApp: Disco
 	private legendJSONMapper: LegendJSONMapper
 	private fontSize: number
 
-	constructor(cappedCnvMaxAbsValue = 0, fontSize: number) {
+	constructor(cappedCnvMaxAbsValue = 0, fontSize: number, discoApp) {
+		this.discoApp = discoApp
 		this.fontSize = fontSize
 		this.legendJSONMapper = new LegendJSONMapper(cappedCnvMaxAbsValue)
 	}
@@ -48,7 +51,7 @@ export default class LegendRenderer {
 				}
 			)
 		})
-		const altCnv: AlternativeCnvSet[] = viewModel.appState.args.alternativeDataByDt?.[dtcnv]
+		const altCnv: AlternativeCnvSet[] = this.discoApp.args.alternativeDataByDt?.[dtcnv]
 
 		if (altCnv && altCnv.length > 0) {
 			const legendG = holder.select('g[data-testid="sjpp_disco_plot_legend"]')

--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -58,7 +58,8 @@ export class ViewModelMapper {
 	}
 
 	map(opts: any): ViewModel {
-		const chrSizes = opts.args.genome.majorchr
+		const args = this.discoInteractions.discoApp.args || opts.args
+		const chrSizes = args.genome.majorchr
 
 		/** Remove hidden chromosomes */
 		const chromosomesOverride = {}
@@ -68,15 +69,14 @@ export class ViewModelMapper {
 			}
 		}
 
-		const sampleName = opts.args.sampleName
-
-		const genome = opts.args.genome
+		const sampleName = args.sampleName
+		const genome = args.genome
 
 		const prioritizedGenes = genome?.geneset?.[0] ? genome.geneset[0].lst : []
 
 		const genesetName = genome?.geneset?.[0] ? genome.geneset[0].name : ''
 
-		const data: Array<any> = opts.args.data
+		const data: Array<any> = args.data
 
 		this.applyRadius()
 

--- a/client/plots/plot.disco.js
+++ b/client/plots/plot.disco.js
@@ -23,78 +23,18 @@ genomeObj={}
 _overrides={}
 	optional override parameters to pass to disco
 */
+
 export default async function (termdbConfig, dslabel, sample, holder, genomeObj, _overrides = {}, showError = true) {
 	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
-
 	try {
-		// must do this check to make sure this ds supports disco
-		if (typeof termdbConfig?.queries?.singleSampleMutation != 'object')
-			throw 'termdbConfig.queries.singleSampleMutation{} not object'
-		// TODO can delete following checks if written as ts
-		if (typeof sample != 'object') throw 'sample{} not object'
-		if (typeof genomeObj != 'object') throw 'genomeObj{} not object'
-
-		// request data
-		const body = {
-			genome: genomeObj.name,
-			dslabel,
-			sample: sample[termdbConfig.queries.singleSampleMutation.sample_id_key]
-		}
-		const data = await dofetch3('termdb/singleSampleMutation', { body })
-		if (data.error) throw data.error
-		if (!Array.isArray(data.mlst)) throw 'data.mlst is not array'
-
-		if (data.dt2total?.length) {
-			// array element: {dt:int, total:int}
-			// may pass this to disco argument to display it in legend
-			for (const o of data.dt2total) {
-				holder
-					.append('div')
-					.style('margin', '20px 20px 0px 40px')
-					.text(`(Displaying ${data.mlst.filter(i => i.dt == o.dt).length} out of total ${o.total} ${dt2label[o.dt]})`)
-			}
-		}
-
-		const mlst = data.mlst
-
-		for (const i of mlst) i.position = i.pos
-
-		const disco_arg = {
-			sampleName: sample[termdbConfig.queries.singleSampleMutation.sample_id_key],
-			data: mlst,
-			genome: genomeObj
-		}
-
-		if (data.alternativeDataByDt) {
-			disco_arg.alternativeDataByDt = data.alternativeDataByDt
-		}
-
-		if (termdbConfig.queries.singleSampleMutation.discoPlot?.skipChrM) {
-			// quick fix: exclude chrM from list of chromosomes
-			// assume the name of "chrM" but not chrMT. do case insensitive match
-			disco_arg.chromosomes = {}
-			for (const k in genomeObj.majorchr) {
-				if (k.toLowerCase() == 'chrm') continue
-				disco_arg.chromosomes[k] = genomeObj.majorchr[k]
-			}
-		}
-
+		const { disco_arg, plotConfig } = await getDiscoArgConfig(termdbConfig, dslabel, sample, genomeObj, _overrides)
 		const opts = {
 			holder: holder,
-
 			state: {
 				genome: genomeObj.name,
 				dslabel: dslabel,
 				args: disco_arg,
-
-				plots: [
-					{
-						chartType: 'Disco',
-						subfolder: 'disco',
-						extension: 'ts',
-						overrides: computeOverrides(_overrides, termdbConfig, genomeObj, sample)
-					}
-				]
+				plots: [plotConfig]
 			}
 		}
 		const plot = await import('#plots/plot.app.js')
@@ -105,6 +45,73 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj,
 		if (showError) loadingDiv.text('Error: ' + (e.message || e))
 		else loadingDiv.remove()
 		return false
+	}
+}
+
+export async function getDiscoArgConfig(termdbConfig, dslabel, sample, genomeObj, _overrides = {}) {
+	console.log(51, genomeObj)
+	// must do this check to make sure this ds supports disco
+	if (typeof termdbConfig?.queries?.singleSampleMutation != 'object')
+		throw 'termdbConfig.queries.singleSampleMutation{} not object'
+	// TODO can delete following checks if written as ts
+	if (typeof sample != 'object') throw 'sample{} not object'
+	if (typeof genomeObj != 'object') throw 'genomeObj{} not object'
+
+	// request data
+	const body = {
+		genome: genomeObj.name,
+		dslabel,
+		sample: sample[termdbConfig.queries.singleSampleMutation.sample_id_key]
+	}
+	console.log(64, body)
+	const data = await dofetch3('termdb/singleSampleMutation', { body })
+	console.log(65, data)
+	if (data.error) throw data.error
+	if (!Array.isArray(data.mlst)) throw 'data.mlst is not array'
+
+	if (data.dt2total?.length) {
+		// array element: {dt:int, total:int}
+		// may pass this to disco argument to display it in legend
+		for (const o of data.dt2total) {
+			holder
+				.append('div')
+				.style('margin', '20px 20px 0px 40px')
+				.text(`(Displaying ${data.mlst.filter(i => i.dt == o.dt).length} out of total ${o.total} ${dt2label[o.dt]})`)
+		}
+	}
+
+	const mlst = data.mlst
+
+	for (const i of mlst) i.position = i.pos
+
+	const disco_arg = {
+		sampleName: sample[termdbConfig.queries.singleSampleMutation.sample_id_key],
+		data: mlst,
+		genome: genomeObj
+	}
+
+	if (data.alternativeDataByDt) {
+		disco_arg.alternativeDataByDt = data.alternativeDataByDt
+	}
+
+	if (termdbConfig.queries.singleSampleMutation.discoPlot?.skipChrM) {
+		// quick fix: exclude chrM from list of chromosomes
+		// assume the name of "chrM" but not chrMT. do case insensitive match
+		disco_arg.chromosomes = {}
+		for (const k in genomeObj.majorchr) {
+			if (k.toLowerCase() == 'chrm') continue
+			disco_arg.chromosomes[k] = genomeObj.majorchr[k]
+		}
+	}
+
+	return {
+		disco_arg,
+		plotConfig: {
+			chartType: 'Disco',
+			subfolder: 'disco',
+			extension: 'ts',
+			overrides: computeOverrides(_overrides, termdbConfig, genomeObj, sample)
+		}
 	}
 }
 

--- a/client/plots/scatter/viewmodel/scatterInteractivity.ts
+++ b/client/plots/scatter/viewmodel/scatterInteractivity.ts
@@ -70,18 +70,34 @@ export class ScatterInteractivity {
 	async openDiscoPlot(sample) {
 		this.view.dom.tooltip.hide()
 		this.scatter.vm.scatterTooltip.onClick = false
-
 		sample.sample_id = sample.sample
-		const sandbox = newSandboxDiv(this.scatter.opts.plotDiv || select(this.scatter.opts.holder.node().parentNode))
-		sandbox.header.text(sample.sample_id)
-		const discoPlotImport = await import('../../plot.disco.js')
-		discoPlotImport.default(
+		const disco = await import('../../plot.disco.js')
+		const { disco_arg, plotConfig } = await disco.getDiscoArgConfig(
 			this.scatter.state.termdbConfig,
 			this.scatter.state.vocab.dslabel,
 			sample,
-			sandbox.body,
 			this.scatter.app.opts.genome
 		)
+		console.log(83, disco_arg, plotConfig)
+
+		// TODO: should not mutate app.opts directly,
+		this.scatter.app.opts.args = disco_arg
+
+		this.scatter.app.dispatch({
+			type: 'plot_create',
+			config: plotConfig
+		})
+
+		// const sandbox = newSandboxDiv(this.scatter.opts.plotDiv || select(this.scatter.opts.holder.node().parentNode))
+		// sandbox.header.text(sample.sample_id)
+		// const discoPlotImport = await import('../../plot.disco.js')
+		// discoPlotImport.default(
+		// 	this.scatter.state.termdbConfig,
+		// 	this.scatter.state.vocab.dslabel,
+		// 	sample,
+		// 	sandbox.body,
+		// 	this.scatter.app.opts.genome
+		// )
 	}
 
 	async openLollipop(label) {


### PR DESCRIPTION
…me app

# Description

Work-in-progress:

I'll disable the gene label click option to launch lollipop. In GDC, the lollipop that gets launched it's not reactive to cohort changes. The main issue is it doesn't request data on its own (no disco/model code), ideally it will follow the usual pattern where from its plot config, it requests its own server data instead of requiring data from the Disco constructor opts argument. It's current getState() also copies sample mutation data, so it can bloat saved sessions if that's ever used directly in the mass app (it uses plot.app currently). 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
