### PR TITLE
Improved message

### DIFF
--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -776,15 +776,14 @@ export async function listSamples(arg, seriesId, dataId, chartId) {
 		// TODO: do not hardcode, make this dataset specific
 		const barOrChart = self.config.term0?.term.id.startsWith('case.diagnoses') ? 'bar or chart' : 'bar'
 		const matchedLabels = []
-		console.log(778, term?.term.id, term2?.term.id, term0?.term.id)
-		if (term?.term.id.startsWith('case.diagnoses')) matchedLabels.push(seriesId)
-		if (term2?.term.id.startsWith('case.diagnoses')) matchedLabels.push(dataId)
-		if (term0?.term.id.startsWith('case.diagnoses')) matchedLabels.push(chartId)
-		const clickedLabel = matchedLabels.join(',')
+		if (term?.term?.id?.startsWith('case.diagnoses')) matchedLabels.push(seriesId)
+		if (term2?.term?.id?.startsWith('case.diagnoses')) matchedLabels.push(dataId)
+		if (term0?.term?.id?.startsWith('case.diagnoses')) matchedLabels.push(chartId)
+		const clickedLabel = matchedLabels.join(', ')
 
 		div.append('div').style('margin', '5px').style('padding', '5px').style('max-width', '600px')
 			.html(`<span>The ${uiLabels.samples} below have multiple diagnoses entries, where 1 or more entries match the value in 
-				the clicked ${barOrChart} (${clickedLabel}), but were not rendered in this bar. The entries corresponding to the 
+				the clicked ${barOrChart} (${clickedLabel}), but were not rendered here. The entries corresponding to the 
 				primary diagnosis for these cases were rendered and counted in a different ${barOrChart}.</span>
 			`)
 

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -775,11 +775,17 @@ export async function listSamples(arg, seriesId, dataId, chartId) {
 	if (notRenderedVals.size) {
 		// TODO: do not hardcode, make this dataset specific
 		const barOrChart = self.config.term0?.term.id.startsWith('case.diagnoses') ? 'bar or chart' : 'bar'
+		const matchedLabels = []
+		console.log(778, term?.term.id, term2?.term.id, term0?.term.id)
+		if (term?.term.id.startsWith('case.diagnoses')) matchedLabels.push(seriesId)
+		if (term2?.term.id.startsWith('case.diagnoses')) matchedLabels.push(dataId)
+		if (term0?.term.id.startsWith('case.diagnoses')) matchedLabels.push(chartId)
+		const clickedLabel = matchedLabels.join(',')
 
 		div.append('div').style('margin', '5px').style('padding', '5px').style('max-width', '600px')
-			.html(`<span>The ${uiLabels.samples} below have matching values that were not rendered in this ${barOrChart}, 
-				due to statistical processing that requires 1 value per ${uiLabels.sample}.
-				A different value was used and rendered in a different ${barOrChart}.</span>
+			.html(`<span>The ${uiLabels.samples} below have multiple diagnoses entries, where 1 or more entries match the value in 
+				the clicked ${barOrChart} (${clickedLabel}), but were not rendered in this bar. The entries corresponding to the 
+				primary diagnosis for these cases were rendered and counted in a different ${barOrChart}.</span>
 			`)
 
 		await renderTable({

--- a/client/plots/matrix/matrix.js
+++ b/client/plots/matrix/matrix.js
@@ -359,10 +359,7 @@ export class Matrix extends PlotBase {
 	}
 
 	mayDisplayCohortMessage() {
-		const msg =
-			!this.prevFilter0 || deepEqual(this.state.filter0, this.prevFilter0)
-				? ''
-				: 'The gene list is persisted across cohorts.'
+		const msg = deepEqual(this.state.filter0, this.prevFilter0) ? '' : 'The gene list is persisted across cohorts.'
 		if (msg) {
 			this.dom.loadingDiv.html('')
 			const div = this.dom.loadingDiv

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - show the persisted top mutated genes message in matrix plot when starting with no cohort filter and after switching cohorts
+- improve the message wording when non-primary diagnoses data is not rendered for a sample or case

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- show the persisted top mutated genes message in matrix plot when starting with no cohort filter and after switching cohorts


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2785 and https://gdc-ctds.atlassian.net/browse/SV-2770.

Manual tests:
- After the initial render of http://localhost:3000/example.gdc.matrix.html?maxGenes=5 (all GDC/no cohort filter) and changing the cohort to CPTAC in the dropdown, the message below should be shown. Previously, it was shown only when the tool loaded with a cohort filter (not All GDC).
<img width="595" height="198" alt="Screenshot 2026-04-13 at 2 34 48 PM" src="https://github.com/user-attachments/assets/8343fb60-f89e-4d2a-a158-ea5e04651704" />

- Follow the steps in SV-2770. The wording has been improved as approved by Sharon. 
<img width="647" height="225" alt="Screenshot 2026-04-13 at 2 30 28 PM" src="https://github.com/user-attachments/assets/939bc1c1-af0b-4e4b-8131-6640a22806aa" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
