### PR TITLE
Polarplot2 median percentage

### DIFF
--- a/server/routes/profile.polar2.ts
+++ b/server/routes/profile.polar2.ts
@@ -146,7 +146,7 @@ async function getScores(query: any, ds: any) {
  */
 function computeMedianPercentage(d: any, samples: any[]): number | null {
 	const percentages = samples
-		.filter(s => s[d.score.$id]?.value)
+		.filter(s => s[d.score.$id]?.value != null)
 		.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
 
 	if (percentages.length === 0) return null


### PR DESCRIPTION
This pull request makes a small improvement to the `computeMedianPercentage` function by updating the filter condition to explicitly check for `null` and `undefined` values, ensuring more robust handling of sample data.

- Improved data filtering:
  * [`server/routes/profile.polar2.ts`]
  *  Changed the filter in `computeMedianPercentage` to `.value != null` for more accurate exclusion of missing values.