### PR TITLE
Show the correct error message in the volcano when no data is returned

### DIFF
--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -126,7 +126,7 @@ class Volcano extends PlotBase implements RxComponent {
 			/** Fetch data */
 			const model = new VolcanoModel(this.app, config, settings)
 			const response = await model.getData()
-			if (!response || response.error || !response.data.length) {
+			if (!response || response.error || !response.data || !response.data.length) {
 				sayerror(this.dom.error, response.error || 'No data returned from server')
 				clearTimeout(showWait)
 				this.dom.wait.style('display', 'none')

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -127,7 +127,7 @@ class Volcano extends PlotBase implements RxComponent {
 			const model = new VolcanoModel(this.app, config, settings)
 			const response = await model.getData()
 			if (!response || response.error || !response.data || !response.data.length) {
-				sayerror(this.dom.error, response.error || 'No data returned from server')
+				sayerror(this.dom.error, response?.error || 'No data returned from server')
 				clearTimeout(showWait)
 				this.dom.wait.style('display', 'none')
 				return


### PR DESCRIPTION
# Description

Will not see the same error in the MMRF portal if no data is returned from the server. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
