### PR TITLE
avoid having a gene exp cluster width that is too narrow

### DIFF
--- a/client/plots/matrix/matrix.config.js
+++ b/client/plots/matrix/matrix.config.js
@@ -15,6 +15,7 @@ import { defaultUiLabels } from '#plots/PlotBase.js'
 
 export async function getPlotConfig(opts = {}, app) {
 	const controlLabels = structuredClone(defaultUiLabels)
+	const devicePixelRatio = opts.devicePixelRatio || window.devicePixelRatio
 	const config = {
 		// data configuration
 		termgroups: [],
@@ -85,7 +86,7 @@ export async function getPlotConfig(opts = {}, app) {
 				outlineStroke: '#ccc',
 				beamStroke: '#f00',
 				colw: 0,
-				colwMin: 0.1 / window.devicePixelRatio,
+				colwMin: 0.1 / devicePixelRatio,
 				colwMax: 16,
 				colspace: 1,
 				colgspace: 8,
@@ -128,7 +129,7 @@ export async function getPlotConfig(opts = {}, app) {
 				// renderedWMax should not be exposed as a user-input
 				// 60000 pixels is based on laptop and external monitor tests,
 				// when a canvas dataURL image in a zoomed-in matrix svg stops rendering
-				imgWMax: 60000 / window.devicePixelRatio,
+				imgWMax: 60000 / devicePixelRatio,
 				scrollHeight: 12,
 				controlLabels,
 				cnvUnit: 'log2ratio',

--- a/client/plots/matrix/matrix.dom.js
+++ b/client/plots/matrix/matrix.dom.js
@@ -15,6 +15,7 @@ export function setMatrixDom(opts) {
 	const warningDiv = holder.append('div').attr('class', 'sja_errorbar').style('display', 'none')
 	const svg = holder
 		.append('svg')
+		.attr('data-testid', 'sjpp-matrix-svg')
 		.style('margin', '20px')
 		.style('overflow', 'visible')
 		.on('mousemove.label', this.svgMousemove)

--- a/client/plots/matrix/matrix.layout.js
+++ b/client/plots/matrix/matrix.layout.js
@@ -41,25 +41,27 @@ export function setAutoDimensions(xOffset) {
 		this.availContentWidth = boundingWidth - padding - s.margin.right - xOffset - hcw // - 0.5 * labelOffset
 	}
 
+	let colwNoSpace
 	if (this.autoDimensions.has('colw')) {
 		const totalColgspace = s.colgspace * Math.max(0, this.visibleSampleGrps.size - 1)
 		const tentativeGaps = this.sampleOrder.length * s.colspace + totalColgspace
 		const spacedColw = (this.availContentWidth - tentativeGaps) / this.sampleOrder.length
+		const constrainedMINCOLWSPACED = Math.max(s.colwMin, Math.min(MINCOLWSPACED, s.colwMax))
 		// colwSpaced is the colw if the colspace is shown between columns, but note that
 		// its value does not include the colspace. It also requires MINCOLWSPACED column width
 		// for the colspace to not be too visually overwhelming.
-		const colwSpaced = Math.max(MINCOLWSPACED, Math.min(spacedColw, s.colwMax))
+		const colwSpaced = Math.max(constrainedMINCOLWSPACED, Math.min(spacedColw, s.colwMax))
 		// noSpacedColw is the colw if the colspace is not shown between columns, without taking into account colwMin and colwMax
 		const noSpacedColw = (this.availContentWidth - totalColgspace) / this.sampleOrder.length
 		// colwNoSpace is the colw if the colspace is not shown between columns, after taking into account colwMin and colwMax
-		const colwNoSpace = Math.max(s.colwMin, Math.min(noSpacedColw, s.colwMax))
+		colwNoSpace = Math.max(s.colwMin, Math.min(noSpacedColw, s.colwMax))
 
-		// detect if using colwSpaced + colspace + colgspace will cause the availContentWidth to be exceeded,
-		// to determine whether to use colwSpaced or colwNoSpace
-		this.computedSettings.colw =
-			colwSpaced * this.sampleOrder.length + tentativeGaps <= this.availContentWidth ? colwSpaced : colwNoSpace
+		// if the computed colwSpaced for (availContentWidth - gaps) / (numer of samples) is less than MINCOLWSPACED,
+		// then rendered gaps between columns will be visually overwhelming, use colwNoSpace in that case
+		this.computedSettings.colw = colwSpaced <= MINCOLWSPACED ? colwNoSpace : colwSpaced
 
-		// IMPORTANT: compute zoomMin and zoomMax here before computing settings.colw downstream, to avoid feedback loop
+		// IMPORTANT: compute zoomMin and zoomMax here before computing settings.colw downstream
+		// in setLayout(), to avoid feedback loop
 		this.computedSettings.zoomMin = s.colwMin / this.computedSettings.colw
 		this.computedSettings.zoomMax = s.colwMax / this.computedSettings.colw
 	} else {
@@ -72,7 +74,10 @@ export function setAutoDimensions(xOffset) {
 
 	// when cells have very small width, do not show colspace
 	// IMPORTANT: compute zoomMin and zoomMax before using s.zoomLevel for any computed settings
-	this.computedSettings.colspace = this.computedSettings.colw * s.zoomLevel < MINCOLWSPACED ? 0 : s.colspace
+	this.computedSettings.colspace =
+		this.computedSettings.colw === colwNoSpace || this.computedSettings.colw * s.zoomLevel < MINCOLWSPACED
+			? 0
+			: s.colspace
 
 	const hch = this.state.config.settings.hierCluster?.yDendrogramHeight || 0
 	const availHeight = s.availContentHeight || screen.availHeight - hch

--- a/client/plots/matrix/matrix.layout.js
+++ b/client/plots/matrix/matrix.layout.js
@@ -27,7 +27,10 @@ export function setAutoDimensions(xOffset) {
 		this.availContentWidth = s.availContentWidth
 	} else {
 		let boundingWidth = this.dom.contentNode.getBoundingClientRect().width
-		if (boundingWidth < 600) boundingWidth = window.document.body.clientWidth
+		if (boundingWidth < 600) {
+			// rely on div scroll to view a not-overly-narrow matrix
+			boundingWidth = window.document.body.clientWidth
+		}
 
 		// 65 is an mannually calibrated padding
 		const maxGrpLabelWidth = this.getMaxGrpLabelWidth()
@@ -41,7 +44,7 @@ export function setAutoDimensions(xOffset) {
 		this.availContentWidth = boundingWidth - padding - s.margin.right - xOffset - hcw // - 0.5 * labelOffset
 	}
 
-	let colwNoSpace
+	let colwSpaced, colwNoSpace
 	if (this.autoDimensions.has('colw')) {
 		const totalColgspace = s.colgspace * Math.max(0, this.visibleSampleGrps.size - 1)
 		const tentativeGaps = this.sampleOrder.length * s.colspace + totalColgspace
@@ -50,7 +53,7 @@ export function setAutoDimensions(xOffset) {
 		// colwSpaced is the colw if the colspace is shown between columns, but note that
 		// its value does not include the colspace. It also requires MINCOLWSPACED column width
 		// for the colspace to not be too visually overwhelming.
-		const colwSpaced = Math.max(constrainedMINCOLWSPACED, Math.min(spacedColw, s.colwMax))
+		colwSpaced = Math.max(constrainedMINCOLWSPACED, Math.min(spacedColw, s.colwMax))
 		// noSpacedColw is the colw if the colspace is not shown between columns, without taking into account colwMin and colwMax
 		const noSpacedColw = (this.availContentWidth - totalColgspace) / this.sampleOrder.length
 		// colwNoSpace is the colw if the colspace is not shown between columns, after taking into account colwMin and colwMax
@@ -65,6 +68,8 @@ export function setAutoDimensions(xOffset) {
 		this.computedSettings.zoomMin = s.colwMin / this.computedSettings.colw
 		this.computedSettings.zoomMax = s.colwMax / this.computedSettings.colw
 	} else {
+		colwSpaced = m.colw
+		colNoSpace = m.colw
 		// NOTE: There may be a hardcoded m.colw = 0 in matrix.config to force auto-sizing,
 		// handling this condition for future support.
 		this.computedSettings.colw = m.colw
@@ -72,12 +77,12 @@ export function setAutoDimensions(xOffset) {
 		this.computedSettings.zoomMax = s.colwMax / m.colw
 	}
 
-	// when cells have very small width, do not show colspace
+	const { colw } = this.computedSettings
+	// When cells have very small width, do not show colspace. If colwSpaced == colwNoSpace,
+	// that means max
 	// IMPORTANT: compute zoomMin and zoomMax before using s.zoomLevel for any computed settings
 	this.computedSettings.colspace =
-		this.computedSettings.colw === colwNoSpace || this.computedSettings.colw * s.zoomLevel < MINCOLWSPACED
-			? 0
-			: s.colspace
+		(colw === colwNoSpace && colwSpaced < colwNoSpace) || colw * s.zoomLevel < MINCOLWSPACED ? 0 : s.colspace
 
 	const hch = this.state.config.settings.hierCluster?.yDendrogramHeight || 0
 	const availHeight = s.availContentHeight || screen.availHeight - hch

--- a/client/plots/matrix/matrix.layout.js
+++ b/client/plots/matrix/matrix.layout.js
@@ -6,6 +6,8 @@ import { dtsnvindel, dtcnv, dtfusionrna, dtgeneexpression, dtsv } from '#shared/
 import { colorDelta, getInterpolatedDomainRange, removeInterpolatedOutliers, removeOutliers } from '#dom'
 import { roundValueAuto } from '#shared/roundValue.js'
 
+const MINCOLWSPACED = 7
+
 export function setAutoDimensions(xOffset) {
 	const m = this.state.config.settings.matrix
 	if (!this.autoDimensions) this.autoDimensions = new Set()
@@ -43,17 +45,19 @@ export function setAutoDimensions(xOffset) {
 		const totalColgspace = s.colgspace * Math.max(0, this.visibleSampleGrps.size - 1)
 		const tentativeGaps = this.sampleOrder.length * s.colspace + totalColgspace
 		const spacedColw = (this.availContentWidth - tentativeGaps) / this.sampleOrder.length
-		// tentativeColw is the colw if the colspace is shown between columns
-		const tentativeColw = Math.max(s.colwMin, Math.min(spacedColw, s.colwMax))
-
-		// noSpacedColw is the colw if the colspace is not shown between columns
+		// colwSpaced is the colw if the colspace is shown between columns, but note that
+		// its value does not include the colspace. It also requires MINCOLWSPACED column width
+		// for the colspace to not be too visually overwhelming.
+		const colwSpaced = Math.max(MINCOLWSPACED, Math.min(spacedColw, s.colwMax))
+		// noSpacedColw is the colw if the colspace is not shown between columns, without taking into account colwMin and colwMax
 		const noSpacedColw = (this.availContentWidth - totalColgspace) / this.sampleOrder.length
+		// colwNoSpace is the colw if the colspace is not shown between columns, after taking into account colwMin and colwMax
 		const colwNoSpace = Math.max(s.colwMin, Math.min(noSpacedColw, s.colwMax))
 
-		// detect if using colspace will cause the tentative computed widths to be exceeded
-		// to determine whether to use colw + colspace or colwNoSpace
+		// detect if using colwSpaced + colspace + colgspace will cause the availContentWidth to be exceeded,
+		// to determine whether to use colwSpaced or colwNoSpace
 		this.computedSettings.colw =
-			tentativeColw * this.sampleOrder.length + tentativeGaps <= this.availContentWidth ? tentativeColw : colwNoSpace
+			colwSpaced * this.sampleOrder.length + tentativeGaps <= this.availContentWidth ? colwSpaced : colwNoSpace
 
 		// IMPORTANT: compute zoomMin and zoomMax here before computing settings.colw downstream, to avoid feedback loop
 		this.computedSettings.zoomMin = s.colwMin / this.computedSettings.colw
@@ -66,12 +70,12 @@ export function setAutoDimensions(xOffset) {
 		this.computedSettings.zoomMax = s.colwMax / m.colw
 	}
 
-	// when cell has very small width, do not show colspace
+	// when cells have very small width, do not show colspace
 	// IMPORTANT: compute zoomMin and zoomMax before using s.zoomLevel for any computed settings
-	this.computedSettings.colspace = this.computedSettings.colw * s.zoomLevel < 7 ? 0 : s.colspace
+	this.computedSettings.colspace = this.computedSettings.colw * s.zoomLevel < MINCOLWSPACED ? 0 : s.colspace
 
 	const hch = this.state.config.settings.hierCluster?.yDendrogramHeight || 0
-	const availHeight = screen.availHeight - hch
+	const availHeight = s.availContentHeight || screen.availHeight - hch
 	this.computedSettings.clusterRowh = Math.min(
 		s.rowhMax,
 		Math.max(s.rowhMin, Math.floor(availHeight / this.numClusterTerms))

--- a/client/plots/matrix/test/matrix.integration.spec.js
+++ b/client/plots/matrix/test/matrix.integration.spec.js
@@ -2560,7 +2560,7 @@ tape('cell brush zoom in', function (test) {
 
 		matrix.on('postRender.test', () => {
 			matrix.on('postRender.test', null)
-			test.deepEqual(matrix.Inner.settings.matrix.zoomLevel, 4, 'should have the expected zoom level after zoom in')
+			test.deepEqual(matrix.Inner.settings.matrix.zoomLevel, 3.2, 'should have the expected zoom level after zoom in')
 			if (test._ok) matrix.Inner.app.destroy()
 			test.end()
 		})

--- a/client/plots/matrix/test/matrix.layout.unit.spec.ts
+++ b/client/plots/matrix/test/matrix.layout.unit.spec.ts
@@ -93,9 +93,9 @@ tape('100 samples', async test => {
 		obj.computedSettings,
 		{
 			useCanvas: false,
-			colw: 9.3,
-			zoomMin: 0.01075268817204301,
-			zoomMax: 1.7204301075268815,
+			colw: 8.3,
+			zoomMin: 0.012048192771084336,
+			zoomMax: 1.9277108433734937,
 			colspace: 1,
 			clusterRowh: 18
 		},

--- a/client/plots/matrix/test/matrix.layout.unit.spec.ts
+++ b/client/plots/matrix/test/matrix.layout.unit.spec.ts
@@ -1,0 +1,145 @@
+import tape from 'tape'
+import { copyMerge } from '#rx'
+import { getPlotConfig } from '../matrix.config'
+import * as matrixLayout from '../matrix.layout'
+
+/*************************
+ reusable helper functions
+**************************/
+
+async function getObj(opts: any = {}) {
+	const app = {
+		vocabApi: {
+			termdbConfig: {}
+		}
+	}
+
+	const config = copyMerge(
+		{
+			devicePixelRatio: 1,
+			settings: {
+				matrix: {
+					availContentHeight: 900
+				}
+			}
+		},
+		opts.config || {}
+	)
+
+	const obj: any = {
+		state: {
+			config: await getPlotConfig(config, app)
+		},
+		sampleOrder: opts.sampleOrder || new Array(5),
+		visibleSampleGrps: new Set([1]),
+		termOrder: [0, 1, 2, 3, 4, 5],
+		termGroups: [{ name: 'test-test' }],
+		numClusterTerms: opts.numClusterTerms || 50,
+		dom: {
+			contentNode: {
+				getBoundingClientRect: () => ({ width: opts.boundingWidth || 1000 })
+			},
+			svg: {
+				append: () => ({
+					attr() {
+						return this
+					},
+					append() {
+						return {
+							text() {
+								return {
+									attr() {
+										return this
+									},
+									node() {
+										return {
+											getBBox: () => ({ width: 50 })
+										}
+									}
+								}
+							}
+						}
+					},
+					remove() {}
+				})
+			}
+		}
+	}
+
+	// the functions from matrix.layout are attached directly as
+	// methods to an object instance that will become the `this`
+	// context within the method
+	for (const methodName in matrixLayout) {
+		obj[methodName] = matrixLayout[methodName]
+	}
+
+	obj.settings = structuredClone(obj.state.config.settings)
+	return obj
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- plots/matrix/matrix.layout -***-')
+	test.end()
+})
+
+tape('100 samples', async test => {
+	const obj = await getObj({ sampleOrder: new Array(100) })
+	obj.setAutoDimensions(0)
+	test.deepEqual(
+		obj.computedSettings,
+		{
+			useCanvas: false,
+			colw: 9.3,
+			zoomMin: 0.01075268817204301,
+			zoomMax: 1.7204301075268815,
+			colspace: 1,
+			clusterRowh: 18
+		},
+		`should give the expected computedSettings`
+	)
+	test.end()
+})
+
+tape('1000 cases (simulated GDC gliomas)', async test => {
+	// simulate GDC use case that previously led to incorrect imgW,
+	// where colWithSpace was incorrectly used with s.colspace = 0
+	const obj = await getObj({ sampleOrder: new Array(1000), boundingWidth: 1434 })
+	obj.setAutoDimensions(130)
+	test.deepEqual(
+		obj.computedSettings,
+		{
+			useCanvas: false,
+			colw: 1.234,
+			zoomMin: 0.08103727714748785,
+			zoomMax: 12.965964343598054,
+			colspace: 0,
+			clusterRowh: 18
+		},
+		`should give the expected computedSettings for simulated GDC gliomas hierCluster`
+	)
+	test.end()
+})
+
+tape('4873 cases (simulated ASH)', async test => {
+	// simulate GDC use case that previously led to incorrect imgW,
+	// where colWithSpace was incorrectly used with s.colspace = 0
+	const obj = await getObj({ sampleOrder: new Array(4873), boundingWidth: 1521.96875, numClusterTerms: 36 })
+	obj.setAutoDimensions(130)
+	test.deepEqual(
+		obj.computedSettings,
+		{
+			useCanvas: true,
+			colw: 0.2712843730761338,
+			zoomMin: 0.36861688296338324,
+			zoomMax: 58.978701274141315,
+			colspace: 0,
+			clusterRowh: 20
+		},
+		`should give the expected computedSettings for simulated ASH hierCluster`
+	)
+	test.end()
+})

--- a/client/plots/matrix/test/matrix.layout.unit.spec.ts
+++ b/client/plots/matrix/test/matrix.layout.unit.spec.ts
@@ -99,7 +99,39 @@ tape('100 samples', async test => {
 			colspace: 1,
 			clusterRowh: 18
 		},
-		`should give the expected computedSettings`
+		`should give the expected computedSettings for 100 samples and ${obj.availContentWidth}px width`
+	)
+	test.end()
+})
+
+tape('100 samples, narrow available width', async test => {
+	// narrow width > 600, since matrix.layout hardcodes limit that switches from
+	// using div width to document.body.contentWidth
+	const obj = await getObj({ sampleOrder: new Array(100), boundingWidth: 634 })
+	obj.setAutoDimensions(0)
+	test.deepEqual(
+		obj.computedSettings,
+		{
+			useCanvas: false,
+			colw: 5.64,
+			zoomMin: 0.01773049645390071,
+			zoomMax: 2.8368794326241136,
+			colspace: 0,
+			clusterRowh: 18
+		},
+		`should give the expected computedSettings for 100 samples and ${obj.availContentWidth}px width`
+	)
+	test.end()
+})
+
+tape('100 samples, content div wider than needed', async test => {
+	const obj = await getObj({ sampleOrder: new Array(100), boundingWidth: 2000 })
+	obj.setAutoDimensions(0)
+	test.deepEqual(
+		obj.computedSettings,
+		// test that colspace != 0,
+		{ useCanvas: false, colw: 16, zoomMin: 0.00625, zoomMax: 1, colspace: 1, clusterRowh: 18 },
+		`should give the expected computedSettings for 100 samples and ${obj.availContentWidth}px width, with colspace != 0`
 	)
 	test.end()
 })

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- avoid having a gene exp cluster width that is too small, by preventing the use of colwSpaced with s.colspace=0


### PR DESCRIPTION
# Description

... by preventing the use of `colwSpaced` with `s.colspace=0`.

Tests:
- all unit and integration tests
- new [matrix.layout.unit.spec.js](http://localhost:3000/testrun.html?dir=plots/matrix&name=matrix.layout.unit) test
- new e2e test in sjpp (in `master` branch): `npx playwright test test/geneExpCluster.e2e.spec.ts`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
