### PR TITLE
Survival colors

### DIFF
--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -444,6 +444,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 	setTerm2Color(charts) {
 		if (!charts) return
 		const config = this.state.config
+		// color override via legend clicks is saved in term2.values, not by directly editing term2.term.values
 		const t2values = copyMerge({}, config.term2?.term?.values || {}, config.term2?.values || {})
 		const values = (this.refs.bins[2] && [this.refs.bins[2]]) || Object.values(t2values)
 		let t2groups
@@ -461,6 +462,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 		for (const chart of charts) {
 			for (const series of chart.serieses) {
 				let color
+				// color override via legend clicks is saved in t2values, does not edit term.values or group.color directly
 				const v = values.find(
 					v =>
 						v.seriesId === series.seriesId ||
@@ -472,6 +474,12 @@ class TdbSurvival extends PlotBase implements RxComponent {
 				if (!color && t2groups?.length) {
 					const group = t2groups.find(g => g.name == series.seriesId)
 					color = group?.color
+					// quick fix to make WT gray darker to pass Section 508 contrast requirement;
+					// doing this in common.js makes this gray in all tools darker and conflicts
+					// with other mclass colors like in-frame insertion, also visually overwhelming
+					// in GDC oncomatrix
+					if (color === '#D3D3D3' && group?.filter?.lst?.find(f => f?.type === 'tvs' && f.tvs.genotype == 'wt'))
+						color = 'rgb(105,105,105)'
 				}
 				const orig = color || (series.seriesId == '' ? this.settings.defaultColor : this.colorScale(series.seriesId))
 				const _rgb = rgb(orig)

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -360,7 +360,9 @@ class TdbSurvival extends PlotBase implements RxComponent {
 			filter: this.state.termfilter.filter,
 			filter0: this.state.termfilter.filter0
 		}
-		if (c.term2) opts.term2 = c.term2
+		if (c.term2) {
+			opts.term2 = c.term2
+		}
 		if (c.term0) opts.term0 = c.term0
 		return opts
 	}
@@ -1195,7 +1197,6 @@ function setInteractivity(self) {
 		self.legendOrder.splice(oldIndex, 1)
 		// insert at new index
 		self.legendOrder.splice(newIndex, 0, d.seriesId)
-		console.log('self.legendOrder:', self.legendOrder)
 		self.app.dispatch({
 			type: 'app_refresh'
 		})
@@ -1212,11 +1213,14 @@ function setInteractivity(self) {
 				config: { settings: { survival: { defaultColor: color } } }
 			})
 		} else {
-			const values = structuredClone(t2?.term.values || self.legendValues)
+			// this is the overlay termwrapper
 			const term2 = structuredClone(t2)
-			term2.term.values = values
-			if (!values) term2.term.values = { [d.seriesId]: {} }
-			term2.term.values[d.seriesId].color = color
+			// do not replace term2.term.values directly, will set term2.values to use as overrides
+			if (!term2.values) term2.values = {}
+			const values = term2.values
+			if (!values[d.seriesId]) values[d.seriesId] = {}
+			if (!('key' in values[d.seriesId])) values[d.seriesId].key = d.seriesId
+			values[d.seriesId].color = color
 			self.app.dispatch({
 				type: 'plot_edit',
 				id: self.id,

--- a/client/tw/TwBase.ts
+++ b/client/tw/TwBase.ts
@@ -35,6 +35,7 @@ export class TwBase {
 	sortSamples?: any
 	minNumSamples?: number
 	valueFilter?: any
+	values?: { [key: string]: any }
 
 	constructor(tw: TermWrapper, opts: TwOpts) {
 		this.#tw = tw
@@ -44,6 +45,7 @@ export class TwBase {
 		if (tw.sortSamples) this.sortSamples = tw.sortSamples
 		if (tw.minNumSamples) this.minNumSamples = tw.minNumSamples
 		if (tw.valueFilter) this.valueFilter = tw.valueFilter
+		if (tw.values) this.values = tw.values
 
 		// By using Object.defineProperties(), addon methods are not enumerable
 		// and makes the xtw instance compatible with structuredClone(),

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Fixes:
 - restore option to replace survival series colors via legend click menu
+- darken willdtype gray color to pass Section 508 contrast requirement

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- restore option to replace survival series colors via legend click menu

--- a/shared/types/src/terms/tw.ts
+++ b/shared/types/src/terms/tw.ts
@@ -19,6 +19,7 @@ export type BaseTW = {
 	sortSamples?: any
 	minNumSamples?: number
 	valueFilter?: any
+	values?: { [key: string]: any }
 }
 
 export type TermWrapper = NumTW | GvTW | ConditionTW | SnpsTW | QualTW | TermCollectionTW

--- a/shared/utils/src/common.js
+++ b/shared/utils/src/common.js
@@ -208,7 +208,7 @@ export const mclass = {
 	// quick fix!! for showing genes that are not tested in samples (e.g. gene panels) in the heatmap
 	Blank: { label: 'Not tested', color: '#fff', dt: dtsnvindel, desc: 'This gene is not tested.', key: 'Blank' },
 
-	WT: { label: 'Wildtype', color: '#D3D3D3', dt: dtsnvindel, desc: 'Wildtype', key: 'WT' }
+	WT: { label: 'Wildtype', color: 'rgb(105,105,105)', dt: dtsnvindel, desc: 'Wildtype', key: 'WT' }
 }
 export const mclassitd = 'ITD'
 mclass[mclassitd] = {

--- a/shared/utils/src/common.js
+++ b/shared/utils/src/common.js
@@ -208,7 +208,7 @@ export const mclass = {
 	// quick fix!! for showing genes that are not tested in samples (e.g. gene panels) in the heatmap
 	Blank: { label: 'Not tested', color: '#fff', dt: dtsnvindel, desc: 'This gene is not tested.', key: 'Blank' },
 
-	WT: { label: 'Wildtype', color: 'rgb(105,105,105)', dt: dtsnvindel, desc: 'Wildtype', key: 'WT' }
+	WT: { label: 'Wildtype', color: '#D3D3D3', dt: dtsnvindel, desc: 'Wildtype', key: 'WT' }
 }
 export const mclassitd = 'ITD'
 mclass[mclassitd] = {


### PR DESCRIPTION
# Description

Partially addresses https://gdc-ctds.atlassian.net/browse/SV-2714, including being able to change survival series color via legend click menu.

Manual Test:
- open [a correlation plot](http://localhost:3000/example.gdc.correlation.html?noheader=1&cohort=TCGA-LUAD), Mutation/CNV vs Survival, then type a gene
-  open dev tools and run a full scan with Axe Devtools (rrequies Chrome plugin installation)
- The gray WT color should not be flagged, but the auto-assigned pink color is still flagged, but Sharon and Himanso are okay with this for now.
-  Also try changing the series colors from the legend click menu.

<img width="1010" height="472" alt="Screenshot 2026-04-14 at 11 14 45 PM" src="https://github.com/user-attachments/assets/21200c65-c2cf-4612-8ee5-f5fe08cf64bd" />

<img width="587" height="560" alt="Screenshot 2026-04-14 at 11 18 53 PM" src="https://github.com/user-attachments/assets/65adc05a-f8c3-4161-ae97-ce0c9ca674b0" />

This passed the contrast check:

<img width="710" height="469" alt="Screenshot 2026-04-14 at 11 20 21 PM" src="https://github.com/user-attachments/assets/88c6f59c-b6d4-4a20-84a8-de689e6e07e6" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
