### PR TITLE
Toggle for gene set edit UI input for hierarchical clustering

### DIFF
--- a/client/gdc/geneExpClustering.js
+++ b/client/gdc/geneExpClustering.js
@@ -124,7 +124,7 @@ export async function init(arg, holder, genomes) {
 				mode: 'geneExpression', // consistent with GeneSetEdit
 				genome,
 				genes: arg.genes,
-				showEditUI: arg.opts.geneset.showEditUI,
+				showEditUI: arg.opts?.geneset?.showEditUI,
 				reactsTo(action) {
 					if (action.type.startsWith('plot_')) return action.id === this.id
 					if (action.type.startsWith('filter')) return true

--- a/client/gdc/geneExpClustering.js
+++ b/client/gdc/geneExpClustering.js
@@ -124,7 +124,7 @@ export async function init(arg, holder, genomes) {
 				mode: 'geneExpression', // consistent with GeneSetEdit
 				genome,
 				genes: arg.genes,
-				showEditUI: arg.showEditUI,
+				showEditUI: arg.opts.geneset.showEditUI,
 				reactsTo(action) {
 					if (action.type.startsWith('plot_')) return action.id === this.id
 					if (action.type.startsWith('filter')) return true

--- a/client/gdc/geneExpClustering.js
+++ b/client/gdc/geneExpClustering.js
@@ -124,6 +124,7 @@ export async function init(arg, holder, genomes) {
 				mode: 'geneExpression', // consistent with GeneSetEdit
 				genome,
 				genes: arg.genes,
+				showEditUI: arg.showEditUI,
 				reactsTo(action) {
 					if (action.type.startsWith('plot_')) return action.id === this.id
 					if (action.type.startsWith('filter')) return true

--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -172,9 +172,7 @@ class GenesetComp {
 
 	async render() {
 		if (!this.dom?.holder) return
-		this.dom.body
-			.append('p')
-			.text(`No default genes. Please change the cohort or define a gene set to launch ${this.state.config.toolName}.`)
+		this.dom.body.append('p').text(`Define a gene set to launch ${this.state.config.toolName.toLowerCase()}.`)
 		new GeneSetEditUI(
 			{
 				holder: this.dom.body.append('div'),

--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -106,15 +106,16 @@ class GenesetComp {
 
 	async getGenes({ signal }) {
 		const genes = this.opts.genes
-		if (this.opts.showEditUI) {
-			// must show edit UI, do not automatically get genes
-			return []
-		}
 		const settings = this.state.config.settings
 		if (this.opts.genes) {
 			// genes are predefined
 			if (!Array.isArray(this.opts.genes) || this.opts.genes.length == 0) throw '.genes[] is not non-empty array'
 			return await this.getTwLst(this.opts.genes)
+		}
+
+		if (this.opts.showEditUI) {
+			// must show edit UI, do not automatically get genes
+			return []
 		}
 
 		let waitDiv

--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -106,6 +106,10 @@ class GenesetComp {
 
 	async getGenes({ signal }) {
 		const genes = this.opts.genes
+		if (this.opts.showEditUI) {
+			// must show edit UI, do not automatically get genes
+			return []
+		}
 		const settings = this.state.config.settings
 		if (this.opts.genes) {
 			// genes are predefined

--- a/client/plots/geneset.js
+++ b/client/plots/geneset.js
@@ -45,7 +45,11 @@ class GenesetComp {
 		this.type = GenesetComp.type
 
 		this.dom = {
-			holder: opts.holder.style('position', 'relative').style('min-height', '300px'),
+			holder: opts.holder
+				.style('position', 'relative')
+				.style('min-height', '300px')
+				.style('margin', '0px 20px')
+				.style('max-width', '1000px'),
 			body: opts.holder.append('div'),
 			loadingOverlay: opts.holder
 				.append('div')

--- a/server/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/routes/termdb.topVariablyExpressedGenes.ts
@@ -2,7 +2,7 @@ import type { TermdbTopVariablyExpressedGenesRequest, TermdbTopVariablyExpressed
 import { termdbTopVariablyExpressedGenesPayload } from '#types/checkers'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
 import serverconfig from '#src/serverconfig.js'
-import { get_samples } from '#src/termdb.sql.js'
+import { mayLimitSamples } from '#src/mds3.filter.js'
 import { makeFilter } from '#src/mds3.gdc.js'
 import { cachedFetch } from '#src/utils.js'
 import { joinUrl } from '#shared/joinUrl.js'
@@ -70,18 +70,14 @@ function nativeValidateQuery(ds: any) {
 	ds.queries.topVariablyExpressedGenes.getGenes = async (q: TermdbTopVariablyExpressedGenesRequest) => {
 		// get list of samples that are used in current analysis; gE.samples[] contains all sample integer ids with exp data
 		const samples = [] as string[]
-		if (q.filter) {
-			// get all samples pasing pp filter, may contain those without exp data
-			const sidlst = await get_samples(q, ds)
-			// [{id:int}]
-			// filter for those with exp data from q.samples[]
-			for (const i of sidlst) {
-				if (gE.samples.includes(i.id)) {
-					// this sample passing filter also has exp data; convert to string name
-					const n: string = ds.cohort.termdb.q.id2sampleName(i.id)
-					if (!n) throw 'sample id cannot convert to string name'
-					samples.push(n)
-				}
+		const param = { filter: q.filter, filter0: q.filter0 }
+		const limitSamples = await mayLimitSamples(param, gE.samples, ds)
+		if (limitSamples) {
+			// get samples passing filter
+			for (const sid of limitSamples) {
+				const n: string = ds.cohort.termdb.q.id2sampleName(sid)
+				if (!n) throw 'sample id cannot convert to string name'
+				samples.push(n)
 			}
 		} else {
 			// no filter, use all samples with exp data

--- a/server/src/mds3.filter.js
+++ b/server/src/mds3.filter.js
@@ -34,9 +34,6 @@ export async function mayLimitSamples(param, _allSamples, ds) {
 	let filterSamples
 	if (ds.cohort?.db) {
 		// dataset has sqlite db
-		// get samples that match filter
-		if (typeof ds.cohort?.db?.connection?.prepare !== 'function')
-			throw new Error('db.connection.prepare() is not a function')
 		if (!filter) {
 			// no filtering, use all samples
 			return
@@ -45,17 +42,15 @@ export async function mayLimitSamples(param, _allSamples, ds) {
 		// get_samples() return [{id:int}] with possibly duplicated items, deduplicate and return list of integer ids
 		filterSamples = new Set((await get_samples({ filter }, ds)).map(i => i.id))
 	} else if (typeof ds.cohort?.termdb?.getSamples === 'function') {
-		// dataset is not sqlite-based, but supplies getSamples() function
-		// get samples that match filter/filter0
-		// TODO: currently only considering filter0, later will merge in filter
-		if (!filter0) {
+		// dataset supplies getSamples() function
+		if (!filter && !filter0) {
 			// no filtering, use all samples
 			return
 		}
-		// get samples that match filter0
-		filterSamples = await ds.cohort.termdb.getSamples({ filter0, ds })
+		// get samples that match filter/filter0
+		filterSamples = await ds.cohort.termdb.getSamples({ filter, filter0, ds })
 	} else {
-		throw new Error('no method available to filter samples')
+		throw new Error('no method available to get samples')
 	}
 
 	// filterSamples is the set of samples in dataset that match filter/filter0


### PR DESCRIPTION
# Description

Introduced the `.showEditUI` parameter to the `client/plots/geneset.js` component. When this parameter is true, the component will not automatically retrieve genes and instead display a geneset edit UI for user to select genes.

Also changed `server/routes/termdb.topVariablyExpressedGenes.ts` to use `mayLimitSamples()` to filter samples. This fixes the issue of editing top variably expressed genes for mmrf.

Verified that all unit and integration tests pass.

Can test by also pulling [sjpp PR](https://github.com/stjude/sjpp/pull/1285) and opening: http://localhost:3000/example.mmrf.exp.html


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
