### PR TITLE
Support custom term collection filtering and fix single-position DNA methylation queries

### DIFF
--- a/client/dom/genesearch.ts
+++ b/client/dom/genesearch.ts
@@ -149,8 +149,10 @@ type Result = Partial<GeneOrSNPResult> &
 		chr?: string
 		searchbox?: any
 		genes?: { geneSymbol: string }[]
-		/** Original position before any expansion by string2pos(). Present when
-		 *  a single position or small range was expanded to a minimum span. */
+		/** Original position and length from string2pos(). Present for any
+		 *  coordinate input (position is the start, len is stop - start).
+		 *  Useful for recovering exact coordinates when string2pos() expands
+		 *  small ranges to a 400bp minimum span for the genome browser. */
 		actualposition?: { position: number; len: number }
 	}
 

--- a/client/dom/genesearch.ts
+++ b/client/dom/genesearch.ts
@@ -149,6 +149,9 @@ type Result = Partial<GeneOrSNPResult> &
 		chr?: string
 		searchbox?: any
 		genes?: { geneSymbol: string }[]
+		/** Original position before any expansion by string2pos(). Present when
+		 *  a single position or small range was expanded to a minimum span. */
+		actualposition?: { position: number; len: number }
 	}
 
 export const debounceDelay = 500
@@ -600,6 +603,7 @@ export function addGeneSearchbox(arg: GeneSearchBoxArg) {
 				result.chr = r.chr
 				result.start = r.start
 				result.stop = r.stop
+				if (r.actualposition) result.actualposition = r.actualposition
 				if (r.ref) result.ref = r.ref
 				if (r.alt) result.alt = r.alt
 			} else if (r.geneSymbol) {

--- a/client/filter/tvs.termCollection.ts
+++ b/client/filter/tvs.termCollection.ts
@@ -21,10 +21,21 @@ async function fillMenu(self, div, tvs: TermCollectionTvs) {
 	div.selectAll('*').remove()
 	div = div.append('div').style('font-size', '0.8em')
 
-	const rangeInput = renderRangeInput(div, tvs, applyRange)
-	const details = self.opts.vocabApi.termdbConfig.termCollections?.find(c => c.name === tvs.term.name)
-	if (!details) throw new Error(`No termCollection found for name=${tvs.term.name}`)
+	// Pre-configured collections are registered in termdbConfig.termCollections.
+	// Custom collections (e.g. isoform expression collections created dynamically
+	// via "Create Collection") are not registered there — they carry their own
+	// termlst and memberType directly on the term object.
+	let details = self.opts.vocabApi.termdbConfig.termCollections?.find(c => c.name === tvs.term.name)
+	if (!details) {
+		if (tvs.term.isCustom && tvs.term.termlst?.length) {
+			details = { termlst: tvs.term.termlst, type: tvs.term.memberType || 'numeric' }
+		} else {
+			throw new Error(`No termCollection found for name=${tvs.term.name}`)
+		}
+	}
 	if (details.type !== 'numeric') throw new Error('filter only supports numeric term collection')
+	// Render UI after details lookup succeeds so no orphaned input is left on error
+	const rangeInput = renderRangeInput(div, tvs, applyRange)
 	const getTableData = await addFilterTable({ holder: div, tvs, details, vocabApi: self.opts.vocabApi })
 
 	async function applyRange(tvs) {

--- a/client/termdb/handlers/dnaMethylation.ts
+++ b/client/termdb/handlers/dnaMethylation.ts
@@ -3,8 +3,24 @@ import { DNA_METHYLATION } from '#shared/terms.js'
 import { getDNAMethUnit } from '#tw/dnaMethylation'
 import { first_genetrack_tolist } from '#common/1stGenetk'
 
-// TODO: currently, when inputting a single position (e.g. chr17:7661778 or chr17:7661778-7661778), the output is a region 400bp long. Need to support single position input.
-// TODO: verify whether coordiante is 0-based or 1-based (need to do the same for other search handlers e.g. geneVariant.ts, snp.ts, etc.)
+/** Coordinate note: both the genome browser and the HDF5 beta file use 0-based
+ coordinates. Verified by cross-referencing 5 probes from the test H5 file
+ (dnaMeth.h5) against UCSC hg38 using the search API:
+   https://api.genome.ucsc.edu/search?search=<probeId>&genome=hg38
+
+ H5 positions were read with:
+   python3 -c "import h5py; h5=h5py.File('proteinpaint/server/test/tp/files/hg38/TermdbTest/dnaMeth.h5','r'); \
+     print(list(zip(h5['/meta/probe/probeID'].asstr()[:5], h5['/meta/start'][:5])))"
+
+ All matched the 0-based half-open (BED) position returned by UCSC:
+   cg22949073: H5=7669073, UCSC=chr17:7669073-7669074
+   cg16397722: H5=7673772, UCSC=chr17:7673772-7673773
+   cg04405586: H5=7675143, UCSC=chr17:7675143-7675144
+   cg15110538: H5=7675305, UCSC=chr17:7675305-7675306
+   cg10792831: H5=7675371, UCSC=chr17:7675371-7675372
+No conversion is needed. Single-position inputs (e.g. chr17:7661778) are
+recovered from actualposition to avoid the 400bp expansion that string2pos()
+applies for the genome browser. */
 
 export class SearchHandler {
 	opts: any
@@ -82,8 +98,15 @@ export class SearchHandler {
 				})
 		} else if (geneSearch.chr && Number.isInteger(geneSearch.start) && Number.isInteger(geneSearch.stop)) {
 			// coordinate input
-			// directly use coordinate to make term
-			const { chr, start, stop } = geneSearch
+			// string2pos() expands single positions to a 400bp window for the
+			// genome browser, but we need the exact position for CpG queries.
+			// Use actualposition when it indicates a single-position input.
+			const { chr } = geneSearch
+			let { start, stop } = geneSearch
+			if (geneSearch.actualposition?.len <= 1) {
+				start = geneSearch.actualposition.position
+				stop = start + 1
+			}
 			const term = this.makeTerm({ chr, start, stop })
 			await this.callback(term)
 		} else {

--- a/client/termdb/handlers/test/dnaMethylation.integration.spec.ts
+++ b/client/termdb/handlers/test/dnaMethylation.integration.spec.ts
@@ -65,6 +65,44 @@ tape('Coordinate search', async test => {
 	test.end()
 })
 
+tape('Single position search (chr:pos format)', async test => {
+	let term
+	const callback = _term => {
+		term = _term
+	}
+	const holder = getHolder()
+	await initializeSearchHandler({ holder, callback })
+	const geneSearchInput: any = holder.select('.sja_genesearchinput').node()
+	geneSearchInput.value = 'chr17:7669073'
+	geneSearchInput.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', bubbles: true }))
+	await sleep(100)
+	test.equal(term.chr, 'chr17', 'term.chr should equal input chr')
+	test.equal(term.start, 7669073, 'term.start should be exact position, not 400bp-expanded')
+	test.equal(term.stop, 7669074, 'term.stop should be start+1 for a single CpG site')
+	test.equal(term.type, TermTypes.DNA_METHYLATION, 'term.type should be dnaMethylation')
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('Single position search (chr:pos-pos format)', async test => {
+	let term
+	const callback = _term => {
+		term = _term
+	}
+	const holder = getHolder()
+	await initializeSearchHandler({ holder, callback })
+	const geneSearchInput: any = holder.select('.sja_genesearchinput').node()
+	geneSearchInput.value = 'chr17:7669073-7669073'
+	geneSearchInput.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', bubbles: true }))
+	await sleep(100)
+	test.equal(term.chr, 'chr17', 'term.chr should equal input chr')
+	test.equal(term.start, 7669073, 'term.start should be exact position, not 400bp-expanded')
+	test.equal(term.stop, 7669074, 'term.stop should be start+1 for a single CpG site')
+	test.equal(term.type, TermTypes.DNA_METHYLATION, 'term.type should be dnaMethylation')
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
 tape('Gene search', async test => {
 	let term
 	const callback = _term => {

--- a/client/tw/dnaMethylation.ts
+++ b/client/tw/dnaMethylation.ts
@@ -36,6 +36,10 @@ export class DnaMethylationBase {
 	}
 }
 
+/** Build the query string used by the server to look up CpG sites in the HDF5
+ *  file. Both the genome browser and the HDF5 file use 0-based coordinates
+ *  (verified against UCSC hg38 via api.genome.ucsc.edu/search for 5 probes;
+ *  see coordinate note in client/termdb/handlers/dnaMethylation.ts). */
 function makeDNAMethTermId(term: RawDnaMethylationTerm) {
 	return `${term.chr}:${term.start}-${term.stop}`
 }

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,5 @@
-
+Fixes:
+- restore option to replace survival series colors via legend click menu
+- darken wildtype gray color to pass Section 508 contrast requirement
+- Support custom numeric term collection filtering
+- Fix single-position DNA methylation queries using exact coordinates instead of 400bp window

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -319,13 +319,80 @@ async function get_termCollection_custom(tvs, CTEname, ds, onlyChildren) {
 	return numericSampleData2tvs(tvs, CTEname, values)
 }
 
+/** Percentage filter for custom (non-dictionary) termCollections, e.g. isoform
+ *  expression collections created dynamically via "Create Collection".
+ *
+ *  Cannot use getData() here because it requires req.query.__protected__ (auth
+ *  context set by Express middleware), which is not available inside the filter
+ *  evaluation path. Instead, call the underlying query handlers (e.g.
+ *  isoformExpression HDF5 handler) directly for each member term, then compute
+ *  the numerator/denominator percentage client-side and filter samples. */
+async function get_termCollection_custom_percentage(tvs, CTEname, ds, onlyChildren) {
+	const range = tvs.ranges?.[0]
+	if (!range) return emptyFilterResult(CTEname, onlyChildren, ds)
+	const termlst = tvs.term.termlst || []
+	const numerators = tvs.term.numerators || []
+	if (!termlst.length) return emptyFilterResult(CTEname, onlyChildren, ds)
+
+	// Fetch values for all member terms via query handlers directly
+	// sampleValues: { sampleId: { memberId: value, ... }, ... }
+	const sampleValues = {}
+	for (const mt of termlst) {
+		const dataType = mt.dataType || mt.type || 'isoformExpression'
+		const queryHandler = ds.queries?.[dataType]
+		if (!queryHandler) continue
+		const memberId = mt.id || mt.name
+		const tw = { $id: memberId, term: { type: dataType, isoform: mt.isoform, gene: mt.gene, name: mt.name } }
+		try {
+			const data = await queryHandler.get({ terms: [tw] }, ds)
+			const values = data.term2sample2value?.get(memberId)
+			if (!values) continue
+			for (const [sid, val] of Object.entries(values)) {
+				if (!sampleValues[sid]) sampleValues[sid] = {}
+				sampleValues[sid][memberId] = val
+			}
+		} catch (e) {
+			// skip members that have no data
+		}
+	}
+
+	// Calculate percentage and filter samples
+	const samplenames = []
+	for (const [sid, memberVals] of Object.entries(sampleValues)) {
+		let numeratorSum = 0
+		let totalSum = 0
+		for (const [mid, val] of Object.entries(memberVals)) {
+			totalSum += val
+			if (numerators.includes(mid)) numeratorSum += val
+		}
+		const percentage = totalSum == 0 ? 0 : (numeratorSum / totalSum) * 100
+		if (isInRange(percentage, range, tvs.isnot)) samplenames.push(sid)
+	}
+
+	if (!samplenames.length) return emptyFilterResult(CTEname, onlyChildren, ds)
+
+	let query = `SELECT id as sample
+				FROM sampleidmap
+				WHERE id IN (${samplenames.map(() => '?').join(', ')})`
+	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+
+	return {
+		CTEs: [`${CTEname} AS (${query})`],
+		values: [...samplenames],
+		CTEname
+	}
+}
+
 async function get_termCollection(tvs, CTEname, ds, onlyChildren) {
 	if (tvs.term.memberType === 'categorical') {
 		throw new Error('termcollection memberType=categorical not supported yet')
 	}
 	if (tvs.term.memberType !== 'numeric') throw new Error('termcollection memberType not categorical/numeric')
 	if (tvs.term.isCustom) {
-		return await get_termCollection_custom(tvs, CTEname, ds, onlyChildren)
+		// Custom collections bypass the getData() path below because getData()
+		// requires __protected__ auth context that is unavailable during filter
+		// CTE evaluation. Use direct query handler calls instead.
+		return await get_termCollection_custom_percentage(tvs, CTEname, ds, onlyChildren)
 	}
 	if (tvs.term.numerators) {
 		validateTermCollectionTvs(

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -333,26 +333,47 @@ async function get_termCollection_custom_percentage(tvs, CTEname, ds, onlyChildr
 	const termlst = tvs.term.termlst || []
 	const numerators = tvs.term.numerators || []
 	if (!termlst.length) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (numerators.length) {
+		validateTermCollectionTvs(
+			numerators,
+			termlst.map(i => i.id)
+		)
+	}
 
-	// Fetch values for all member terms via query handlers directly
+	// Fetch values for all member terms via query handlers directly.
+	// Group members by data type so each handler is called once with all its
+	// terms batched together (avoids sequential HDF5 reads).
 	// sampleValues: { sampleId: { memberId: value, ... }, ... }
 	const sampleValues = {}
+	const byDataType = new Map()
 	for (const mt of termlst) {
 		const dataType = mt.dataType || mt.type || 'isoformExpression'
-		const queryHandler = ds.queries?.[dataType]
-		if (!queryHandler) continue
+		if (!ds.queries?.[dataType]) continue
+		if (!byDataType.has(dataType)) byDataType.set(dataType, [])
 		const memberId = mt.id || mt.name
-		const tw = { $id: memberId, term: { type: dataType, isoform: mt.isoform, gene: mt.gene, name: mt.name } }
+		byDataType.get(dataType).push({
+			memberId,
+			tw: { $id: memberId, term: { type: dataType, isoform: mt.isoform, gene: mt.gene, name: mt.name } }
+		})
+	}
+	for (const [dataType, members] of byDataType) {
+		const queryHandler = ds.queries[dataType]
 		try {
-			const data = await queryHandler.get({ terms: [tw] }, ds)
-			const values = data.term2sample2value?.get(memberId)
-			if (!values) continue
-			for (const [sid, val] of Object.entries(values)) {
-				if (!sampleValues[sid]) sampleValues[sid] = {}
-				sampleValues[sid][memberId] = val
+			const data = await queryHandler.get({ terms: members.map(m => m.tw) }, ds)
+			for (const { memberId } of members) {
+				const values = data.term2sample2value?.get(memberId)
+				if (!values) continue
+				for (const [sid, val] of Object.entries(values)) {
+					if (!sampleValues[sid]) sampleValues[sid] = {}
+					sampleValues[sid][memberId] = val
+				}
 			}
 		} catch (e) {
-			// skip members that have no data
+			// The handler throws a string like "No data available for the input ..."
+			// when no expression data exists for the queried terms. This is expected
+			// and safe to skip. Rethrow unexpected errors (e.g. file read failures).
+			const msg = typeof e === 'string' ? e : e?.message || ''
+			if (!msg.startsWith('No data available')) throw e
 		}
 	}
 

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -320,7 +320,7 @@ async function get_termCollection_custom(tvs, CTEname, ds, onlyChildren) {
 }
 
 /** Percentage filter for custom (non-dictionary) termCollections, e.g. isoform
- *  expression collections created dynamically via "Create Collection".
+ *  expression collections created dynamically.
  *
  *  Cannot use getData() here because it requires req.query.__protected__ (auth
  *  context set by Express middleware), which is not available inside the filter

--- a/server/src/test/termdb.filter.unit.spec.js
+++ b/server/src/test/termdb.filter.unit.spec.js
@@ -9,6 +9,7 @@ import tape from 'tape'
 import { getFilterCTEs } from '../termdb.filter.js'
 import { init } from './load.testds.js'
 import { server_init_db_queries } from '../termdb.server.init.ts'
+import { validateQueryIsoformExpression } from '#routes/termdb.cluster.ts'
 
 tape('\n', function (test) {
 	test.comment('-***- src/termdb.filter specs -***-')
@@ -20,6 +21,7 @@ let tdb
 tape('simple filter', async function (test) {
 	tdb = await init('termdb.test.ts')
 	server_init_db_queries(tdb.ds)
+	await validateQueryIsoformExpression(tdb.ds, null)
 
 	const filter = await getFilterCTEs(
 		{
@@ -131,6 +133,100 @@ tape('nested filter', async function (test) {
 		'CTE string should have the same number of ? as values[]'
 	)
 	test.equal(filter.CTEs.length, 8, 'should return 8 CTE clauses for this complex filter')
+	test.end()
+})
+
+tape('custom termCollection percentage filter', async function (test) {
+	const filter = await getFilterCTEs(
+		{
+			type: 'tvslst',
+			in: true,
+			join: '',
+			lst: [
+				{
+					type: 'tvs',
+					tvs: {
+						term: {
+							type: 'termCollection',
+							isCustom: true,
+							memberType: 'numeric',
+							name: 'Test Isoforms (TPM)',
+							termlst: [
+								{
+									id: 'ENST00000256078',
+									name: 'ENST00000256078',
+									type: 'isoformExpression',
+									isoform: 'ENST00000256078'
+								},
+								{
+									id: 'ENST00000311936',
+									name: 'ENST00000311936',
+									type: 'isoformExpression',
+									isoform: 'ENST00000311936'
+								}
+							],
+							numerators: ['ENST00000256078'],
+							propsByTermId: {}
+						},
+						ranges: [{ start: 0, startinclusive: false, stopunbounded: true }]
+					}
+				}
+			]
+		},
+		tdb.ds
+	)
+
+	test.deepEqual(
+		Object.keys(filter).sort((a, b) => (a < b ? -1 : 1)),
+		['CTEname', 'CTEs', 'filters', 'sampleTypes', 'values'],
+		'should return an object with the five expected keys'
+	)
+	test.equal(filter.CTEname, 'f', 'should return the default CTE name')
+	test.ok(filter.values.length > 0, 'should return matching samples (percentage > 0)')
+	test.equal(filter.CTEs.length, 2, 'should return two CTE clauses')
+	test.end()
+})
+
+tape('custom termCollection filter validates numerators', async function (test) {
+	const message = 'Should throw when numerator is not in denominator'
+	try {
+		await getFilterCTEs(
+			{
+				type: 'tvslst',
+				in: true,
+				join: '',
+				lst: [
+					{
+						type: 'tvs',
+						tvs: {
+							term: {
+								type: 'termCollection',
+								isCustom: true,
+								memberType: 'numeric',
+								name: 'Test Isoforms (TPM)',
+								termlst: [
+									{
+										id: 'ENST00000256078',
+										name: 'ENST00000256078',
+										type: 'isoformExpression',
+										isoform: 'ENST00000256078'
+									}
+								],
+								// numerator not in termlst
+								numerators: ['ENST00000311936'],
+								propsByTermId: {}
+							},
+							ranges: [{ start: 0, startinclusive: false, stopunbounded: true }]
+						}
+					}
+				]
+			},
+			tdb.ds
+		)
+		test.fail(message)
+	} catch (e) {
+		test.pass(`${message}: ${e}`)
+	}
 	test.end()
 })
 

--- a/server/src/test/termdb.filter.unit.spec.js
+++ b/server/src/test/termdb.filter.unit.spec.js
@@ -9,7 +9,6 @@ import tape from 'tape'
 import { getFilterCTEs } from '../termdb.filter.js'
 import { init } from './load.testds.js'
 import { server_init_db_queries } from '../termdb.server.init.ts'
-import { validateQueryIsoformExpression } from '#routes/termdb.cluster.ts'
 
 tape('\n', function (test) {
 	test.comment('-***- src/termdb.filter specs -***-')
@@ -21,7 +20,22 @@ let tdb
 tape('simple filter', async function (test) {
 	tdb = await init('termdb.test.ts')
 	server_init_db_queries(tdb.ds)
-	await validateQueryIsoformExpression(tdb.ds, null)
+
+	// Mock isoformExpression handler for custom termCollection tests.
+	// The real handler requires Rust binaries not available in CI.
+	if (!tdb.ds.queries) tdb.ds.queries = {}
+	tdb.ds.queries.isoformExpression = {
+		get: async param => {
+			const term2sample2value = new Map()
+			for (const tw of param.terms) {
+				// Return mock TPM values for two samples per isoform.
+				// Sample IDs must exist in the test db's sampleidmap.
+				const s2v = { 1: 10, 2: 5 }
+				term2sample2value.set(tw.$id, s2v)
+			}
+			return { term2sample2value, byTermId: {}, bySampleId: {} }
+		}
+	}
 
 	const filter = await getFilterCTEs(
 		{


### PR DESCRIPTION
# Description
- Fix custom isoform collection local filter crashing with "No termCollection found" and "Cannot access getTableData before initialization" errors
- Fix single-position DNA methylation queries (e.g. `chr17:7669073`) returning a 400bp averaged window instead of the exact CpG site
- All tests pass on local

## Changes

### Term collection filter (client + server)
- **Client** (`tvs.termCollection.ts`): Custom collections created via "Create Collection" are not registered in `termdbConfig.termCollections`. Added fallback to use the term's own data. Moved UI rendering after validation to prevent orphaned inputs on error.
- **Server** (`termdb.filter.js`): Added `get_termCollection_custom_percentage()` which calls query handlers directly, bypassing `getData()` which requires `__protected__` auth context unavailable during filter CTE evaluation. Computes numerator/denominator percentage and filters samples.

### DNA methylation single-position fix (client)
- **`dnaMethylation.ts`**: When a single position is entered, use `actualposition` from `string2pos()` instead of the 400bp expanded window. Documented coordinate system verification (0-based, confirmed against UCSC hg38 API).
- **`genesearch.ts`**: Pass `actualposition` through the result object so handlers can recover the original position before expansion.
- **`tw/dnaMethylation.ts`**: Added coordinate system documentation.

## To Test

### Term collection filter
1. Go [here](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22Test%20Group%201%22,%22color%22:%22%23ff9100%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22diaggrp%22},%22values%22:[{%22key%22:%22Acute%20lymphoblastic%20leukemia%22}]}}]}},{%22name%22:%22Test%20Group%202%22,%22color%22:%22%230091ff%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22diaggrp%22},%22values%22:[{%22key%22:%22Non-Hodgkin%20lymphoma%22}]}}]}}]})
2. Select Isoform Expression → search KRAS → select all 4 isoforms → Create Collection
3. Click "+Add new filter" → select the collection
4. Verify: filter table with numerator/denominator checkboxes renders (no console errors)
5. Set percentage `x > 5` and apply
6. Keep only ENST00000256078 checked in numerator, leave all denominator checks → apply
7. Collection should filter appropriately

### DNA methylation single position
1. Go [here](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:2},%22groups%22:[{%22name%22:%22Test%20Group%201%22,%22color%22:%22%23ff9100%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22diaggrp%22},%22values%22:[{%22key%22:%22Acute%20lymphoblastic%20leukemia%22}]}}]}},{%22name%22:%22Test%20Group%202%22,%22color%22:%22%230091ff%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22diaggrp%22},%22values%22:[{%22key%22:%22Non-Hodgkin%20lymphoma%22}]}}]}}]})
2. Select DNA Methylation from Data variables → enter `chr17:7669073`
3. Verify: chart title shows `chr17:7669073-7669074` (not a 400bp range)
4. Enter `chr17:7686040` → verify single CpG site (wide bimodal distribution, not the narrow averaged shape from a 400bp window)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
