### PR TITLE
Improvements in DA app and SC app

### DIFF
--- a/client/gdc/README.md
+++ b/client/gdc/README.md
@@ -16,8 +16,8 @@ oncomatrix.js
 	oncomatrix
 maf.js
 	cohort MAF
-(DEPRECIATED) singlecell.js 
-	single cell rnaseq (not released)
+(DEPRECATED) singlecell.js 
+	single cell rnaseq
 sc.ts
 	single cell app (not released)
 

--- a/client/gdc/README.md
+++ b/client/gdc/README.md
@@ -16,9 +16,10 @@ oncomatrix.js
 	oncomatrix
 maf.js
 	cohort MAF
-singlecell.js
+(DEPRECIATED) singlecell.js 
 	single cell rnaseq (not released)
-
+sc.ts
+	single cell app (not released)
 
 From a GFF card, it calls runpp({ purposeSpecificKey:{} })
 and such purpose-specific key will trigger client/src/app.js to load a script file from this folder,

--- a/client/plots/_README.md
+++ b/client/plots/_README.md
@@ -1,0 +1,86 @@
+_This document contains draft contents_
+
+# Plot Components
+
+## Creating a New Plot Component
+
+Every plot component in the mass UI must extend `PlotBase` and implement `RxComponent`:
+
+```ts
+import { PlotBase } from '../PlotBase.ts'
+import { getCompInit, type RxComponent } from '#rx'
+
+export class MyPlot extends PlotBase implements RxComponent {
+	static type = 'myPlot'
+
+	constructor(opts, api) {
+		super(opts, api)
+		// set up dom, components, etc.
+	}
+
+	getState(appState) { /* ... */ }
+	async init(appState) { /* ... */ }
+	async main() { /* ... */ }
+}
+
+export const MyPlotInit = getCompInit(MyPlot)
+export const componentInit = MyPlotInit
+```
+
+- **`extends PlotBase`** provides `this.app`, `this.id`, `this.state`, `this.opts`, `this.parentId`, `this.components`, `this.dom`, and `getMutableConfig()`. This avoids duplicating boilerplate across every plot.
+- **`implements RxComponent`** satisfies the rx reactive contract (`getState`, `init`, `main`).
+- **`static type`** is required by `getCompInit` to register the component in the rx store.
+- **`super(opts, api)`** in the constructor passes `opts` and the component API to `PlotBase`, which assigns `this.app`, `this.id`, and `this.parentId`.
+
+Additional sections describe special considerations for parent and transient plots. 
+
+# Parent Plots
+
+Parent plots manage child plot components (subplots). There are two strategies for managing children, depending on whether subplots are dynamic or persistent.
+
+## Dynamic Subplots
+
+Dynamic subplots are **separate entries** in `state.plots[]`, each with a `parentId` linking back to the parent. Multiple instances of the same chart type can exist simultaneously (e.g. several scatter plots for different samples/genes). Each subplot has its own unique id and its own rx lifecycle.
+
+### Init and Destroy
+
+mass/app.ts includes special considerations for initializing new plots with `.parentId`. mass/app.ts cannot remove components that live inside a parent plot. The parent must handle its own cleanup. 
+
+#### Phase 1 — Remove stale components
+Iterates over `sc.components.plots` (the locally tracked component map) and compares each plot id against the set of active subplot ids from state. Any component that no longer exists in state is removed via `removeSandbox()`, which destroys the component, removes the sandbox DOM element from its parent section, and cleans up the `plot2Sample` lookup.
+
+This step runs **first** because mass/app.ts does not destroy nested components (see note in previous section). Also, this step prevents `main()` from attempting to re-initialize a component that was already deleted by a state action (e.g. replacing a transient plot).
+
+#### Phase 2 — Initialize new subplots
+The parent plot is responsible for init'ing new plots with these : 
+
+1. Defined sandbox with it's own close method
+3. Importing the correct chartType componentInit
+4. Add plot to parent component `this.components.plots[plotKey] = await componentInit(opts)`
+
+Running this **after** cleanup in Phase 1 avoids stale id collisions.
+
+
+### Destroying subplots
+The parent must destroy the component **and** remove its DOM holder. mass/app.ts cannot remove components that live inside a parent plot. This must be done in phase 1 **and** the sandbox close() method. 
+
+Ex. In the SC app, `removeSandbox()` handles both: it calls `sc.removeComponent(plotId)` (which calls `destroy()` and deletes from `sc.components.plots`) and removes the sandbox DOM element from the section.
+
+## Persistent Child Plots (e.g. DifferentialAnalysis — `setComponent`)
+
+Persistent child plots **share the parent's `this.id`** and config; the active child is selected by `config.childType`. Only one instance per chart type exists. `setComponent()` is called lazily in `main()` only the first time a `childType` is needed, and the component persists for the lifetime of the parent.
+
+Switching between children (e.g. volcano ↔ GSEA) is done by **toggling visibility** (`display: none` / `''`) on the pre-existing DOM containers rather than creating or destroying components. There is no reconciliation loop—components are never removed, only hidden. The pattern is init-once, show/hide.
+
+## Dynamic vs. Persistent — Quick Comparison
+
+| | Dynamic (SC) | Persistent (DiffAnalysis) |
+|---|---|---|
+| State entries | Separate `state.plots[]` entry per subplot | Single parent entry; `childType` selects active child |
+| Instances | Multiple per chart type | One per chart type |
+| Lifecycle | Created/destroyed as user acts | Init once, persist forever |
+| Switching | Add/remove from state | Toggle DOM visibility |
+| Reconciliation | Three-phase (remove → init → prune) | None (lazy init on first use) |
+
+# Transient Plots
+Transient plots, such as: dictionary, summaryInput, and DEInput, are designed as forms for the user to spawn another plot.

--- a/client/plots/_README.md
+++ b/client/plots/_README.md
@@ -38,7 +38,7 @@ Plots are tracked in the MassApp as `app.components.plots{[plotId]: plot_instanc
 
 ## Local Filters
 
-Local filters are plot-specific filters that adhere to the same TermTypeSearch and tree.usecase{} declarations. These filters are enabled by **default** from `MassPlot`. Setting `config.hideLocalFilter: true` disables the filter. 
+Local filters are plot-specific filters that adhere to the same TermTypeSearch and tree.usecase{} declarations. These filters are enabled by **default** from `MassPlot`. Setting `config.hidePlotFilter: true` disables the filter. 
 
 # Transient Plots
 

--- a/client/plots/_README.md
+++ b/client/plots/_README.md
@@ -1,5 +1,3 @@
-_This document contains draft contents_
-
 # Plot Components
 
 ## Creating a New Plot Component
@@ -34,6 +32,32 @@ export const componentInit = MyPlotInit
 
 Additional sections describe special considerations for parent and transient plots. 
 
+## State Tracking and Implementation
+
+Plots are tracked in the MassApp as `app.components.plots{[plotId]: plot_instance}`. Each plot instance is wrapped in the `MassPlot` component defined in `mass/plots.ts`. `MassPlot` handles conveniences like local plot filtering (see section below).
+
+## Local Filters
+
+Local filters are plot-specific filters that adhere to the same TermTypeSearch and tree.usecase{} declarations. These filters are enabled by **default** from `MassPlot`. Setting `config.hideLocalFilter: true` disables the filter. 
+
+# Transient Plots
+
+Transient plots (e.g. dictionary, summaryInput, DEInput, etc.) serve as forms that spawn another plot. On submit, the form should dispatch a `plot_create` for the new plot and a `plot_delete` to destroy itself. Both may be submitted in one dispatch with: 
+```
+this.app.dispatch({
+    type: 'app_refresh',
+    subactions: [
+        {
+        type: 'plot_create',
+        config: configWithChanges
+    },
+    {
+        type: 'plot_delete',
+        id: this.id
+    }]
+})
+```
+
 # Parent Plots
 
 Parent plots manage child plot components (subplots). There are two strategies for managing children, depending on whether subplots are dynamic or persistent.
@@ -44,25 +68,27 @@ Dynamic subplots are **separate entries** in `state.plots[]`, each with a `paren
 
 ### Init and Destroy
 
-mass/app.ts includes special considerations for initializing new plots with `.parentId`. mass/app.ts cannot remove components that live inside a parent plot. The parent must handle its own cleanup. 
+`mass/app.ts` includes special considerations for initializing new plots with `.parentId`. mass/app.ts cannot remove components that live inside a parent plot. The parent must handle its own cleanup. 
 
 #### Phase 1 — Remove stale components
+
 Iterates over `sc.components.plots` (the locally tracked component map) and compares each plot id against the set of active subplot ids from state. Any component that no longer exists in state is removed via `removeSandbox()`, which destroys the component, removes the sandbox DOM element from its parent section, and cleans up the `plot2Sample` lookup.
 
 This step runs **first** because mass/app.ts does not destroy nested components (see note in previous section). Also, this step prevents `main()` from attempting to re-initialize a component that was already deleted by a state action (e.g. replacing a transient plot).
 
 #### Phase 2 — Initialize new subplots
-The parent plot is responsible for init'ing new plots with these : 
 
-1. Defined sandbox with it's own close method
-3. Importing the correct chartType componentInit
-4. Add plot to parent component `this.components.plots[plotKey] = await componentInit(opts)`
+The parent plot is responsible for initializing new plots with the following: 
+
+1. Defined sandbox with its own close method
+2. Importing the correct chartType componentInit
+3. Add plot to parent component `this.components.plots[plotKey] = await componentInit(opts)`
 
 Running this **after** cleanup in Phase 1 avoids stale id collisions.
 
-
 ### Destroying subplots
-The parent must destroy the component **and** remove its DOM holder. mass/app.ts cannot remove components that live inside a parent plot. This must be done in phase 1 **and** the sandbox close() method. 
+
+The parent must destroy the component **and** remove its DOM holder. mass/app.ts cannot remove components that live inside a parent plot. This is especially important when a subplot is replaced by another action (i.e. transient plots). This must be done in phase 1 **and** the sandbox close() method. 
 
 Ex. In the SC app, `removeSandbox()` handles both: it calls `sc.removeComponent(plotId)` (which calls `destroy()` and deletes from `sc.components.plots`) and removes the sandbox DOM element from the section.
 
@@ -81,6 +107,3 @@ Switching between children (e.g. volcano ↔ GSEA) is done by **toggling visibil
 | Lifecycle | Created/destroyed as user acts | Init once, persist forever |
 | Switching | Add/remove from state | Toggle DOM visibility |
 | Reconciliation | Three-phase (remove → init → prune) | None (lazy init on first use) |
-
-# Transient Plots
-Transient plots, such as: dictionary, summaryInput, and DEInput, are designed as forms for the user to spawn another plot.

--- a/client/plots/diffAnalysis/DiffAnalysisTypes.ts
+++ b/client/plots/diffAnalysis/DiffAnalysisTypes.ts
@@ -10,10 +10,10 @@ export type DiffAnalysisDom = {
 	div: Elem
 	/** Sandbox header, if provided */
 	header?: {
-		/** If tw.term.name is present, show in header */
-		terms: Elem
-		/** Updates plot titl per provided opts.termType */
+		/** If tw.term.name || headerText is present, show in header */
 		title: Elem
+		/** Updates plot title per provided opts.termType */
+		plot: Elem
 	}
 	/** Toggle between plots */
 	tabsDiv: Elem

--- a/client/plots/diffAnalysis/DifferentialAnalysis.ts
+++ b/client/plots/diffAnalysis/DifferentialAnalysis.ts
@@ -52,8 +52,8 @@ class DifferentialAnalysis extends PlotBase implements RxComponent {
 
 		if (opts.header) {
 			this.dom.header = {
-				terms: opts.header.append('span'),
-				title: opts.header.append('span').style('font-size', '0.8em').style('opacity', 0.7)
+				title: opts.header.append('span').style('margin-right', '5px').style('color', 'darkslategray'),
+				plot: opts.header.append('span').style('font-size', '0.7em').style('opacity', 0.6)
 			}
 		}
 	}
@@ -120,9 +120,10 @@ class DifferentialAnalysis extends PlotBase implements RxComponent {
 		this.plotsControlsDiv[config.childType].style('display', '')
 
 		if (this.dom.header) {
-			if (config.tw) this.dom.header.terms.text(config.tw.term.name)
+			if (config.tw) this.dom.header.title.text(config.tw.term.name)
+			if (config.headerText) this.dom.header.title.text(config.headerText)
 			const typeStr = termType2label(config.termType).toUpperCase()
-			this.dom.header.title.text(` DIFFERENTIAL ${typeStr} ANALYSIS`)
+			this.dom.header.plot.text(` DIFFERENTIAL ${typeStr} ANALYSIS`)
 		}
 
 		if (this.plotTabs) this.plotTabs.update(config)
@@ -148,6 +149,9 @@ export function getPlotConfig(opts: any) {
 		highlightedData: opts.highlightedData || [],
 		hidePlotFilter: true //TODO: Support filtering and reactivity in child plots
 	} as any
+
+	if (opts?.tw?.term?.name && opts.headerText)
+		throw new Error('Cannot provide both tw.term.name and headerText. Please choose one to use as the plot title.')
 
 	/** TODO: Fix this config. This only applies to the
 	 * gdc and won't work long term for terms */

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -205,8 +205,8 @@ class gsea extends PlotBase {
 			try {
 				const volcanoSettings =
 					config.settings?.volcano || getDefaultVolcanoSettings({}, { termType: 'geneExpression' })
-				const model = new VolcanoModel(this.app, config, volcanoSettings)
-				const response = await model.getData()
+				const model = new VolcanoModel(this.app, config.termType)
+				const response = await model.getData(config, volcanoSettings)
 				if (!response || !response.data || response.error) {
 					throw response.error || 'No data returned from volcano model'
 				}

--- a/client/plots/matrix/hierCluster.renderers.js
+++ b/client/plots/matrix/hierCluster.renderers.js
@@ -5,7 +5,7 @@ export function maySetSandboxHeader(appState) {
 	if (!this.dom.header) return // no header
 	switch (this.config.dataType) {
 		case TermTypes.GENE_EXPRESSION:
-			this.dom.header.text('Gene Expression Clustering')
+			this.dom.header.text(`${this.config?.headerText || ''} Gene Expression Clustering`)
 			break
 		case TermTypes.METABOLITE_INTENSITY:
 			this.dom.header.text('Metabolite Intensity Clustering')

--- a/client/plots/matrix/hierCluster.renderers.js
+++ b/client/plots/matrix/hierCluster.renderers.js
@@ -5,7 +5,8 @@ export function maySetSandboxHeader(appState) {
 	if (!this.dom.header) return // no header
 	switch (this.config.dataType) {
 		case TermTypes.GENE_EXPRESSION:
-			this.dom.header.text(`${this.config?.headerText || ''} Gene Expression Clustering`)
+			const headerText = this.config?.headerText ? `${this.config.headerText} ` : ''
+			this.dom.header.text(`${headerText}Gene Expression Clustering`)
 			break
 		case TermTypes.METABOLITE_INTENSITY:
 			this.dom.header.text('Metabolite Intensity Clustering')

--- a/client/plots/sc/SC.ts
+++ b/client/plots/sc/SC.ts
@@ -143,6 +143,7 @@ export class SCViewer extends PlotBase implements RxComponent {
 	}
 
 	removeComponent(subplotId) {
+		this.components.plots[subplotId].destroy()
 		delete this.components.plots[subplotId]
 	}
 }

--- a/client/plots/sc/SC.ts
+++ b/client/plots/sc/SC.ts
@@ -1,5 +1,5 @@
 import type { BasePlotConfig, MassAppApi, MassState } from '#mass/types/mass'
-import type { SCConfigOpts, SCDom, SCFormattedState, SCViewerOpts, SampleColumn, Segments } from './SCTypes'
+import type { SCConfigOpts, SCDom, SCFormattedState, SCViewerOpts, SampleColumn } from './SCTypes'
 import type { SingleCellSample } from '#types'
 import { PlotBase } from '../PlotBase.ts'
 import { getCompInit, copyMerge, type RxComponent } from '#rx'
@@ -9,22 +9,20 @@ import { SCInteractions } from './interactions/SCInteractions'
 import { SCViewRenderer } from './view/SCViewRenderer'
 import { getDefaultSCAppSettings } from './defaults'
 import { importPlot } from '#plots/importPlot.js'
-import { newSandboxDiv } from '#dom'
 import formatPlotData from './viewModel/plotData.ts'
 
-class SCViewer extends PlotBase implements RxComponent {
+export class SCViewer extends PlotBase implements RxComponent {
 	static type = 'sc'
 
 	type: string
 	components: { plots: { [key: string]: any } }
 	dom: SCDom
-	interactions?: SCInteractions
-	items?: SingleCellSample[]
-	itemColumns?: SampleColumn[]
-	model?: SCModel
-	segments: Segments
-	view?: SCViewRenderer
-	viewModel?: SCViewModel
+	interactions!: SCInteractions
+	items!: SingleCellSample[]
+	itemColumns!: SampleColumn[]
+	model!: SCModel
+	view!: SCViewRenderer
+	viewModel!: SCViewModel
 
 	constructor(opts: SCViewerOpts, api: any) {
 		super(opts, api)
@@ -54,10 +52,9 @@ class SCViewer extends PlotBase implements RxComponent {
 				.style('text-align', 'center'),
 			selectBtnDiv: div.append('div').attr('id', 'sjpp-sc-select-btn'),
 			tableDiv: div.append('div').attr('id', 'sjpp-sc-item-table'),
-			plotsBtnsDiv: div.append('div').attr('id', 'sjpp-sc-plot-buttons').style('display', 'none')
+			plotsBtnsDiv: div.append('div').attr('id', 'sjpp-sc-plot-buttons').style('display', 'none'),
+			sectionsDiv: div.append('div').attr('id', 'sjpp-sc-sections')
 		}
-
-		this.segments = {}
 
 		//opts.header is the sandbox header
 		if (opts.header) opts.header.html(`SINGLE CELL`).style('font-size', '0.9em')
@@ -100,110 +97,12 @@ class SCViewer extends PlotBase implements RxComponent {
 			throw new Error(e.message || e)
 		}
 		this.interactions = new SCInteractions(this.app, this.dom, this.id, () => this.getState(this.app.getState()))
-		//Init view model and view
 		this.viewModel = new SCViewModel(this.app, state.config, this.items!, this.itemColumns)
-		this.view = new SCViewRenderer(this.dom, this.interactions, this.segments)
+		this.view = new SCViewRenderer(this)
 
 		/** The item data and table rendering should only occur once
 		 * .update() in main() handles changes to the buttons and plots */
 		this.view.render(this.viewModel.tableData)
-	}
-
-	//TODO: .text() should be ds specific
-	async initSegment(item, sampleId) {
-		const caseText = item.case ? `Case: ${item.case}` : ''
-		const itemText = `Sample: ${sampleId}` //item.cell, etc.
-		const projectText = item['project id'] ? `Project: ${item['project id']}` : ''
-		const headerText = [itemText, caseText, projectText].join(' ')
-
-		this.segments[sampleId] = {
-			title: this.dom.div
-				.append('div')
-				.attr('data-testid', `sjpp-sc-segment-title-${sampleId}`)
-				.style('margin-left', '10px')
-				.style('padding', '10px')
-				.style('font-weight', 600)
-				.text(headerText),
-			subplots: this.dom.div
-				.append('div')
-				.attr('data-testid', `sjpp-sc-segment-subplots-${sampleId}`)
-				.style('margin-left', '10px'),
-			sandboxes: {}
-		}
-	}
-
-	/** The plot obj is already in state.plots[] but not rendered
-	 * (see SCInteractions). This creates the component and renders the plot */
-	async initSubplotComponent(subplot: any, sampleId) {
-		const sandbox = newSandboxDiv(this.segments[sampleId].subplots as any, {
-			close: () => {
-				//Delete the component before calling dispatch
-				//Prevents main attempting to re-init the component
-				delete this.components.plots[subplot.id]
-				delete this.segments[sampleId].sandboxes[subplot.id]
-				this.app.dispatch({
-					type: 'plot_delete',
-					id: subplot.id,
-					parentId: this.id
-				})
-				//Could do this in main() but this is more performant
-				this.view?.removeSegments()
-			},
-			plotId: subplot.id,
-			beforePlotId: subplot.insertBefore || null
-			// style: {
-			// 	width: '98.5%'
-			// }
-		})
-
-		const opts = Object.assign({}, subplot, {
-			app: this.app,
-			parentId: this.id,
-			id: subplot.id
-		})
-		/** Summary is expecting entire sandbox object. Most other plots
-		 * expect the header and the holder (i.e. body).*/
-		if (subplot.chartType == 'summary') {
-			opts.holder = sandbox
-		} else {
-			opts.holder = sandbox.body
-			opts.header = sandbox.header
-		}
-		const { componentInit } = await importPlot(opts.chartType)
-		this.components.plots[subplot.id] = await componentInit(opts)
-		this.segments[sampleId].sandboxes[subplot.id] = sandbox.app_div
-	}
-
-	private async reconcileSubplots(state: SCFormattedState) {
-		const subplotsById = new Map(state.subplots.map(subplot => [subplot.id, subplot]))
-		for (const [subplotId, subplot] of subplotsById) {
-			//TODO: Get rid of passing scItem
-			const item = subplot.scItem || subplot?.term?.term?.sample
-			if (!item) throw new Error('No item found for subplot. Expected subplot.scItem or config.settings.sc.item')
-			const sampleId = item.sample || item.sID
-			if (!this.segments[sampleId]) this.initSegment(item, sampleId)
-			if (!this.components.plots[subplotId]) await this.initSubplotComponent(subplot, sampleId)
-		}
-
-		/** Instances like init'ing another plot from a transient plot (e.g.
-		 * dictionary to summary) may not delete the sandbox DOM element immediately.
-		 * This is a clean up for those instances */
-		for (const subplotId of Object.keys(this.components.plots)) {
-			if (!subplotsById.has(subplotId)) {
-				// Find and remove the sandbox DOM element
-				for (const segment of Object.values(this.segments)) {
-					const sandbox = segment.sandboxes[subplotId]
-					if (sandbox) {
-						sandbox.remove()
-						delete segment.sandboxes[subplotId]
-						break
-					}
-				}
-				delete this.components.plots[subplotId]
-			}
-		}
-
-		this.view?.removeSegments()
 	}
 
 	async main() {
@@ -216,7 +115,6 @@ class SCViewer extends PlotBase implements RxComponent {
 		if (!this.interactions) throw new Error(`Interactions not initialized`)
 
 		this.interactions.toggleLoading(true)
-		await this.reconcileSubplots(state)
 
 		let data: any = null
 		if (config.settings.sc.item) {
@@ -235,8 +133,17 @@ class SCViewer extends PlotBase implements RxComponent {
 			}
 			data.plots = formatPlotData(data.plots)
 		}
-		this.view.update(config.settings, data)
+		await this.view.update(config.settings, data, state.subplots)
 		this.interactions.toggleLoading(false)
+	}
+
+	async initPlotComponent(subplotId, opts) {
+		const { componentInit } = await importPlot(opts.chartType)
+		this.components.plots[subplotId] = await componentInit(opts)
+	}
+
+	removeComponent(subplotId) {
+		delete this.components.plots[subplotId]
 	}
 }
 

--- a/client/plots/sc/SCTypes.ts
+++ b/client/plots/sc/SCTypes.ts
@@ -27,11 +27,15 @@ export type SCDom = {
 	tableDiv: Div
 	/** Holder for the dynamically generated plot buttons for each sample */
 	plotsBtnsDiv: Div
+	/** Holder for the sections that contain the plots */
+	sectionsDiv: Div
 	/** Sandbox header, if provided */
 	header?: Elem
 }
 
-export type Segments = { [key: string]: { title: any; subplots: any; sandboxes: { [key: string]: any } } }
+export type Sections = {
+	[key: string]: { sectionWrapper: Div; title: any; subplots: any; sandboxes: { [key: string]: any } }
+}
 
 export type SCSettings = {
 	sc: {

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -52,7 +52,7 @@ export class PlotButtons {
 		this.scTermdbConfig = state.termdbConfig.queries.singleCell
 	}
 
-	update(settings, data) {
+	update(settings: SCSettings, data) {
 		/** If the user has not selected a item yet but clicks
 		 * the select item/plots btn above the table, the prompt appears
 		 * unnecessarily */
@@ -221,6 +221,7 @@ export class PlotButtons {
 		const sample = this.makeSampleObj()
 		const config: any = {
 			chartType: 'sampleScatter',
+			name: `Sample: ${this.item!.sample}`,
 			singleCellPlot: {
 				name: plotName,
 				sample

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -18,10 +18,6 @@ import type { SCSettings } from '../SCTypes'
  * The matrix ** does not ** properly pull single cell data yet.
  * This implementation works as a placeholder for now.
  * Need to revisit before production.
- *
- * Questions:
- * - Limit to 100 genes or no?
- * - What settings to use for hier cluster?
  * */
 export class PlotButtons {
 	plotBtnsDom: {
@@ -126,6 +122,7 @@ export class PlotButtons {
 						spawnConfig: {
 							parentId: this.interactions.id,
 							hidePlotFilter: true,
+							headerText: `Sample: ${this.item!.sample}`,
 							sample
 						},
 						tree: {
@@ -165,6 +162,7 @@ export class PlotButtons {
 	}
 
 	//********** Btn Menus **********/
+	//TODO: Change gene expression menu to transient plot
 	geneExpMenu(plot: any, self: PlotButtons) {
 		const opts = {
 			termType: SINGLECELL_GENE_EXPRESSION as string,
@@ -172,6 +170,7 @@ export class PlotButtons {
 			spawnConfig: {
 				hidePlotFilter: true,
 				parentId: self.interactions.id,
+				headerText: `Sample: ${self.item!.sample}`,
 				scItem: self.makeSampleObj(),
 				/** It's not ideal to always pass the hierCluster settings here, but it's required for the current implementation */
 				settings: { hierCluster: self.settings.hierCluster }

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -154,6 +154,7 @@ export class PlotButtons {
 						chartType: 'differentialAnalysis',
 						termType: SINGLECELL_CELLTYPE,
 						categoryName: `${value}`,
+						headerText: `Sample: ${this.item!.sample} ${this.scTermdbConfig.DEgenes.termId} ${value}`,
 						termId: this.scTermdbConfig.DEgenes.termId,
 						sample: this.item!.experiment || this.item!.sample
 					}
@@ -186,12 +187,11 @@ export class PlotButtons {
 		const _plot = self.data.plots[0]
 
 		const wrapper = self.plotBtnsDom.tip.d.append('div').style('padding', '10px')
-
 		wrapper
 			.append('div')
 			.style('display', 'block')
 			.style('width', '300px')
-			.text(`View differentially expressed genes of a ${_plot.colorBy.toLowerCase()} versus rest of the cells:`)
+			.text(`View differentially expressed genes of a ${self.scTermdbConfig.DEgenes.termId} versus rest of the cells:`)
 
 		const select = wrapper
 			.append('select')
@@ -202,38 +202,39 @@ export class PlotButtons {
 				self.plotBtnsDom.tip.hide()
 				const value = select.node()!.value
 				if (value.indexOf('Select') == 0) return //ignore prompt option
-				const config = plot.getPlotConfig(value, _plot.colorBy)
+				const config = plot.getPlotConfig(value)
 				await self.interactions.createSubplot(config)
 			})
 
 		const regex = new RegExp(_plot.colorBy, 'g')
-		_plot.clusters.unshift(`Select ${_plot.colorBy}...`)
+		_plot.clusters.unshift(`Select ${self.scTermdbConfig.DEgenes.termId}...`)
 		for (const cluster of _plot.clusters) {
 			select.append('option').attr('value', cluster.replace(regex, '').trim()).text(cluster)
 		}
 	}
 
 	//********** Plot Config Helpers **********/
-	async getSingleCellConfig(plotName): Promise<object> {
+	async getSingleCellConfig(plotName: string): Promise<object> {
 		if (!this.item) throw new Error('No item selected')
 		const plot = this.scTermdbConfig.data.plots.find(p => p.name == plotName)
 		if (!plot) throw new Error(`No plot by name ${plotName} in data.plots.`)
+		const sample = this.makeSampleObj()
 		const config: any = {
 			chartType: 'sampleScatter',
 			singleCellPlot: {
 				name: plotName,
-				sample: this.makeSampleObj()
+				sample
 			}
 		}
 		if (plot.colorColumns?.[0]) {
 			// apply optional color term. hardcodes to 1st of the array
-			config.colorTW = await this.makeScctTW(this.item, plot)
+			config.colorTW = await this.makeScctTW(sample, plot)
 		}
 		return config
 	}
 
 	// Quick fix. Eventually use the handler to get the proper term from the termdbConfig
-	async makeScctTW(item, plot) {
+	async makeScctTW(item: { sID: string; eID: string }, plot: any) {
 		const colorColName = plot.colorColumns[0].name
 		const savedTerm = this.scctTerms?.find(t => t.name == colorColName && t.plot == plot.name)
 		if (!savedTerm)
@@ -243,14 +244,14 @@ export class PlotButtons {
 		const term = Object.assign(structuredClone(savedTerm), {
 			sample: this.makeSampleObj()
 		})
-		const id = await digestMessage(`${plot.name}-${item.sample}-${item.experiment}`)
+		const id = await digestMessage(`${plot.name}-${item.sID}-${item.eID}`)
 		return Object.assign({ $id: id }, { term })
 	}
 
 	/** Creates a sample object for the current item.
 	 * Part of the effort to normalize sample objects across
 	 * native and gdc datasets. */
-	makeSampleObj() {
+	makeSampleObj(): { sID: string; eID: string } {
 		return {
 			sID: this.item!.sample,
 			eID: this.item!.experiment

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -1,6 +1,6 @@
 import type { SCDom, Segments } from '../SCTypes'
 import type { SCInteractions } from '../interactions/SCInteractions'
-import { PlotSelectionRenderer } from './PlotSelectionRenderer'
+import { SampleTableRenderer } from './SampleTableRenderer'
 import { PlotButtons } from './PlotButtons'
 
 export class SCViewRenderer {
@@ -21,7 +21,7 @@ export class SCViewRenderer {
 
 	render(tableData) {
 		this.renderSelectBtn()
-		new PlotSelectionRenderer(this.dom, this.interactions, tableData)
+		new SampleTableRenderer(this.dom, this.interactions, tableData)
 		this.dom.plotsBtnsDiv.style('display', 'none')
 	}
 

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -1,7 +1,10 @@
-import type { SCDom, Segments } from '../SCTypes'
+import type { SCDom } from '../SCTypes'
 import type { SCInteractions } from '../interactions/SCInteractions'
 import { SampleTableRenderer } from './SampleTableRenderer'
 import { PlotButtons } from './PlotButtons'
+import type { TableData } from '../viewModel/SCViewModel'
+import { SectionRender } from './SectionRender'
+import type { SCViewer } from '../SC.ts'
 
 export class SCViewRenderer {
 	dom: SCDom
@@ -10,16 +13,20 @@ export class SCViewRenderer {
 	//On load, show table
 	//Eventually maybe an app dispatch and not a flag
 	static inUse = true
-	segments: Segments
+	sectionRender: SectionRender
+	sc: SCViewer
+	// sections: Sections
 
-	constructor(dom: SCDom, interactions: SCInteractions, segments: Segments) {
-		this.dom = dom
-		this.interactions = interactions
+	constructor(sc: SCViewer) {
+		this.sc = sc
+		this.dom = sc.dom
+		this.interactions = sc.interactions
 		this.plotBtns = new PlotButtons(this.interactions, this.dom.plotsBtnsDiv)
-		this.segments = segments
+		// this.sections = {}
+		this.sectionRender = new SectionRender(this.dom.sectionsDiv)
 	}
 
-	render(tableData) {
+	render(tableData: TableData) {
 		this.renderSelectBtn()
 		new SampleTableRenderer(this.dom, this.interactions, tableData)
 		this.dom.plotsBtnsDiv.style('display', 'none')
@@ -49,21 +56,8 @@ export class SCViewRenderer {
 		})
 	}
 
-	update(settings, data) {
+	async update(settings, data, subplots) {
 		this.plotBtns.update(settings, data)
-	}
-
-	removeSegments() {
-		if (!Object.keys(this.segments).length) return
-		for (const [key, segment] of Object.entries(this.segments)) {
-			//DO NOT use .sjpp-sandbox as the identifier.
-			//That div remains after user deletes the plot
-			const plots = segment.subplots.selectAll('.sjpp-output-sandbox-header').size()
-			if (!plots) {
-				segment.title.remove()
-				segment.subplots.remove()
-				delete this.segments[key]
-			}
-		}
+		await this.sectionRender.update(this.sc, subplots)
 	}
 }

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -3,7 +3,8 @@ import type { TableCell } from '#dom'
 import { renderTable } from '#dom'
 import type { SCInteractions } from '../interactions/SCInteractions'
 
-export class PlotSelectionRenderer {
+/** Renders the sample table for selection */
+export class SampleTableRenderer {
 	dom: SCDom
 	interactions: SCInteractions
 

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -29,7 +29,7 @@ export class SectionRender {
 		for (const subplot of subplots) {
 			const item = subplot.scItem || subplot?.term?.term?.sample
 			const sampleId = item.sample || item.sID
-			if (!this.sections[sampleId]) this.initSection(sampleId, item)
+			if (!this.sections[sampleId]) this.initSection(sampleId, item, sc)
 			if (!this.sections[sampleId].sandboxes[subplot.id]) {
 				this.plot2Sample.set(subplot.id, sampleId)
 				await this.initSandbox(sc, subplot, sampleId)
@@ -40,12 +40,12 @@ export class SectionRender {
 		 * deleting sections before they can be re-rendered with the correct plots */
 		for (const sampleId of Object.keys(this.sections)) {
 			if (Object.keys(this.sections[sampleId].sandboxes).length === 0) {
-				this.removeSection(sampleId)
+				this.removeSection(sampleId, sc)
 			}
 		}
 	}
 
-	initSection(sampleId: string, item: any) {
+	initSection(sampleId: string, item: any, sc: SCViewer) {
 		const sectionWrapper = this.holder
 			.insert('div', ':first-child')
 			.style('padding', '10px')
@@ -67,7 +67,7 @@ export class SectionRender {
                 </svg>`
 			)
 			.on('click', () => {
-				this.removeSection(sampleId)
+				this.removeSection(sampleId, sc)
 			})
 
 		const titleText = this.makeSectionTitleText(sampleId, item)
@@ -111,13 +111,7 @@ export class SectionRender {
 			close: () => {
 				//Delete the component before calling dispatch
 				//Prevents main attempting to re-init the component
-				//Remove the reference to the plotId in plot2Sample map to avoid memory leak
 				this.removeSandbox(subplot.id, sc)
-				sc.app.dispatch({
-					type: 'plot_delete',
-					id: subplot.id,
-					parentId: sc.id
-				})
 			},
 			plotId: subplot.id
 		})
@@ -141,18 +135,35 @@ export class SectionRender {
 		this.sections[sampleId].sandboxes[subplot.id] = sandbox.app_div
 	}
 
-	removeSection(sampleId: string) {
+	removeSection(sampleId: string, sc: SCViewer) {
+		const subactions: { type: string; id: string; parentId: string }[] = []
+		for (const plotId of Object.keys(this.sections[sampleId].sandboxes || {})) {
+			this.removeSandbox(plotId, sc, sampleId)
+			/** Need to remove plots from the state to prevent main from re-rendering
+			 * and memory leak from orphaned components after the section is deleted. */
+			subactions.push({
+				type: 'plot_delete',
+				id: plotId,
+				parentId: sc.id
+			})
+		}
+		if (subactions.length > 0) {
+			sc.app.dispatch({
+				type: 'app_refresh',
+				subactions
+			})
+		}
 		this.sections[sampleId].sectionWrapper.remove()
 		delete this.sections[sampleId]
 	}
 
-	removeSandbox(plotId: string, sc: SCViewer) {
+	removeSandbox(plotId: string, sc: SCViewer, _sampleId?: string) {
 		sc.removeComponent(plotId)
-		const sampleId = this.plot2Sample.get(plotId)
-		if (sampleId) {
-			this.sections[sampleId].sandboxes[plotId].remove()
-			delete this.sections[sampleId].sandboxes[plotId]
-			this.plot2Sample.delete(plotId)
-		}
+		const sampleId = _sampleId || this.plot2Sample.get(plotId)
+		if (!sampleId) return
+		this.sections[sampleId].sandboxes[plotId].remove()
+		delete this.sections[sampleId].sandboxes[plotId]
+		//Remove the reference to the plotId in plot2Sample map to avoid memory leak
+		this.plot2Sample.delete(plotId)
 	}
 }

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -1,0 +1,139 @@
+import type { Sections } from '../SCTypes'
+import type { Div } from '../../../types/d3'
+import { newSandboxDiv } from '#dom'
+
+export class SectionRender {
+	sections: Sections
+	holder: Div
+
+	constructor(sectionsDiv) {
+		this.sections = {}
+		this.holder = sectionsDiv
+	}
+
+	async update(sc, subplots: any) {
+		const activeSubplots = new Set(subplots.map(s => s.id))
+
+		/** Transient plots are deleted from the state but still plot components
+		 * until completely deleted from the app. */
+		for (const plotId of Object.keys(sc.components.plots)) {
+			if (!activeSubplots.has(plotId)) sc.removeComponent(plotId)
+		}
+
+		for (const subplot of subplots) {
+			const item = subplot.scItem || subplot?.term?.term?.sample
+			const sampleId = item.sample || item.sID
+			if (!this.sections[sampleId]) this.initSection(sampleId, item)
+			if (!this.sections[sampleId].sandboxes[subplot.id]) await this.initSandbox(sc, subplot, sampleId)
+		}
+
+		/** Remove sections after iterating through subplots to avoid
+		 * deleting sections before they can be re-rendered with the correct plots */
+		for (const sampleId of Object.keys(this.sections)) {
+			if (Object.keys(this.sections[sampleId].sandboxes).length === 0) {
+				this.removeSection(sampleId)
+			}
+		}
+	}
+
+	initSection(sampleId: string, item: any) {
+		const sectionWrapper = this.holder
+			.insert('div', ':first-child')
+			.style('padding', '10px')
+			.attr('data-testid', `sjpp-sc-section-wrapper-${sampleId}`)
+
+		//delete section btn
+		sectionWrapper
+			.append('span')
+			.attr('data-testid', `sjpp-sc-section-remove-btn-${sampleId}`)
+			.style('margin', '0px 5px')
+			.style('cursor', 'pointer')
+			.attr('title', 'Remove all plots for this sample')
+			.html(
+				`<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="#000" class="bi bi-x-lg" viewBox="0 0 12 12">
+                <path
+                    stroke="#000"
+                    transform="scale(0.75)"
+                    d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z"/>
+                </svg>`
+			)
+			.on('click', () => {
+				this.removeSection(sampleId)
+			})
+
+		const titleText = this.makeSectionTitleText(sampleId, item)
+		const titleWrapper = sectionWrapper.append('span').style('font-weight', 600).style('opacity', 0.7).text(titleText)
+
+		const arrow = titleWrapper
+			.append('span')
+			.style('font-size', '0.8em')
+			.style('padding-left', '3px')
+			.attr('title', 'Show or hide plots for this sample')
+			.text('▼')
+
+		titleWrapper.on('click', () => {
+			const isHidden = this.sections[sampleId].subplots.style('display') === 'none'
+			this.sections[sampleId].subplots.style('display', isHidden ? 'block' : 'none')
+			arrow.text(isHidden ? '▼' : '▲')
+		})
+
+		this.sections[sampleId] = {
+			sectionWrapper,
+			title: titleWrapper,
+			subplots: sectionWrapper.append('div').attr('data-testid', `sjpp-sc-subplots-${sampleId}`),
+			sandboxes: {}
+		}
+	}
+
+	//This needs to be ds specific. Placeholder for now
+	makeSectionTitleText(sampleId: string, item: any) {
+		const caseText = item.case ? `Case: ${item.case}` : ''
+		const itemText = `Sample: ${sampleId}` //item.cell, etc.
+		const projectText = item['project id'] ? `Project: ${item['project id']}` : ''
+		return [itemText, caseText, projectText].join(' ')
+	}
+
+	async initSandbox(sc: any, subplot: any, sampleId: string) {
+		const sandboxHolder = this.sections[sampleId].subplots
+			.insert('div', ':first-child')
+			.attr('data-testid', `sjpp-sc-sandbox-${subplot.id}`)
+
+		const sandbox = newSandboxDiv(sandboxHolder, {
+			close: () => {
+				//Delete the component before calling dispatch
+				//Prevents main attempting to re-init the component
+				sc.removeComponent(subplot.id)
+				delete this.sections[sampleId].sandboxes[subplot.id]
+				sc.app.dispatch({
+					type: 'plot_delete',
+					id: subplot.id,
+					parentId: sc.id
+				})
+			},
+			plotId: subplot.id
+		})
+
+		const opts = Object.assign({}, subplot, {
+			app: sc.app,
+			parentId: sc.id,
+			id: subplot.id
+		})
+
+		/** Summary is expecting entire sandbox object. Most other plots
+		 * expect the header and the holder (i.e. body).*/
+		if (subplot.chartType == 'summary') {
+			opts.holder = sandbox
+		} else {
+			opts.holder = sandbox.body
+			opts.header = sandbox.header
+		}
+
+		await sc.initPlotComponent(subplot.id, opts)
+		this.sections[sampleId].sandboxes[subplot.id] = sandbox.app_div
+	}
+
+	removeSection(sampleId: string) {
+		this.sections[sampleId].sectionWrapper.remove()
+		delete this.sections[sampleId]
+	}
+}

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -1,30 +1,39 @@
 import type { Sections } from '../SCTypes'
 import type { Div } from '../../../types/d3'
 import { newSandboxDiv } from '#dom'
+import type { SCViewer } from '../SC'
 
 export class SectionRender {
 	sections: Sections
 	holder: Div
+	plot2Sample: Map<string, string>
 
-	constructor(sectionsDiv) {
+	constructor(sectionsDiv: Div) {
 		this.sections = {}
 		this.holder = sectionsDiv
+		this.plot2Sample = new Map()
 	}
 
-	async update(sc, subplots: any) {
+	//Send the sc with the updated state
+	async update(sc: SCViewer, subplots: any) {
 		const activeSubplots = new Set(subplots.map(s => s.id))
 
-		/** Transient plots are deleted from the state but still plot components
-		 * until completely deleted from the app. */
+		/** Repeat the destory from the close button, as mass/app.ts
+		 * cannot remove components from within a parent plot */
 		for (const plotId of Object.keys(sc.components.plots)) {
-			if (!activeSubplots.has(plotId)) sc.removeComponent(plotId)
+			if (!activeSubplots.has(plotId)) {
+				this.removeSandbox(plotId, sc)
+			}
 		}
 
 		for (const subplot of subplots) {
 			const item = subplot.scItem || subplot?.term?.term?.sample
 			const sampleId = item.sample || item.sID
 			if (!this.sections[sampleId]) this.initSection(sampleId, item)
-			if (!this.sections[sampleId].sandboxes[subplot.id]) await this.initSandbox(sc, subplot, sampleId)
+			if (!this.sections[sampleId].sandboxes[subplot.id]) {
+				this.plot2Sample.set(subplot.id, sampleId)
+				await this.initSandbox(sc, subplot, sampleId)
+			}
 		}
 
 		/** Remove sections after iterating through subplots to avoid
@@ -102,8 +111,8 @@ export class SectionRender {
 			close: () => {
 				//Delete the component before calling dispatch
 				//Prevents main attempting to re-init the component
-				sc.removeComponent(subplot.id)
-				delete this.sections[sampleId].sandboxes[subplot.id]
+				//Remove the reference to the plotId in plot2Sample map to avoid memory leak
+				this.removeSandbox(subplot.id, sc)
 				sc.app.dispatch({
 					type: 'plot_delete',
 					id: subplot.id,
@@ -135,5 +144,15 @@ export class SectionRender {
 	removeSection(sampleId: string) {
 		this.sections[sampleId].sectionWrapper.remove()
 		delete this.sections[sampleId]
+	}
+
+	removeSandbox(plotId: string, sc: SCViewer) {
+		sc.removeComponent(plotId)
+		const sampleId = this.plot2Sample.get(plotId)
+		if (sampleId) {
+			this.sections[sampleId].sandboxes[plotId].remove()
+			delete this.sections[sampleId].sandboxes[plotId]
+			this.plot2Sample.delete(plotId)
+		}
 	}
 }

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -8,11 +8,7 @@ import type { SingleCellSample } from '#types'
  *  - Implement data mapper for plots in the dashboard
  */
 
-// export type SCViewModelData = {
-// 	//TODO
-// }
-
-type TableData = {
+export type TableData = {
 	rows: TableRow[]
 	columns: TableColumn[]
 	selectedRows: number[]
@@ -42,7 +38,11 @@ export class SCViewModel {
 		}
 	}
 
-	getTabelData(plotConfig: SCConfig, items: SingleCellSample[], sampleColumns?: SampleColumn[]) {
+	getTabelData(
+		plotConfig: SCConfig,
+		items: SingleCellSample[],
+		sampleColumns?: SampleColumn[]
+	): [TableRow[], TableColumn[]] {
 		const rows: TableRow[] = []
 		const hasExperiments = items.some(i => i.experiments)
 

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -317,15 +317,13 @@ class SummaryPlot extends PlotBase implements RxComponent {
 	}
 
 	maySetSandboxHeader() {
-		const { term, term2 } = this.config
+		const { term, term2, headerText } = this.config
 		const mainTerm = term.getTitleText?.() || term.term.name
+		const titleBase = mainTerm + (this.config.assayCohortTitle ? ` (${this.config.assayCohortTitle})` : '')
 		if (term2?.type) {
-			this.dom.paneTitleText.html(
-				`${term2.getTitleText?.() || term2.term.name} vs ${mainTerm}` +
-					(this.config.assayCohortTitle ? ` (${this.config.assayCohortTitle})` : '')
-			)
+			this.dom.paneTitleText.html(`${headerText || ''} ${term2.getTitleText?.() || term2.term.name} vs ${titleBase}`)
 		} else {
-			this.dom.paneTitleText.html(mainTerm + (this.config.assayCohortTitle ? ` (${this.config.assayCohortTitle})` : ''))
+			this.dom.paneTitleText.html(`${headerText || ''} ${titleBase}`)
 		}
 	}
 

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -324,7 +324,7 @@ class SummaryPlot extends PlotBase implements RxComponent {
 		const _headerSuffix = assayCohortTitle ? ` (${assayCohortTitle})` : ''
 		const titleBase = mainTerm + _headerSuffix
 		if (term2?.type) {
-			this.dom.paneTitleText.html(`${_headerPretext} ${term2.getTitleText?.() || term2.term.name} vs ${titleBase}`)
+			this.dom.paneTitleText.html(`${_headerPretext}${term2.getTitleText?.() || term2.term.name} vs ${titleBase}`)
 		} else {
 			this.dom.paneTitleText.html(`${_headerPretext}${titleBase}`)
 		}

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -317,13 +317,16 @@ class SummaryPlot extends PlotBase implements RxComponent {
 	}
 
 	maySetSandboxHeader() {
-		const { term, term2, headerText } = this.config
+		const { term, term2, headerText, assayCohortTitle } = this.config
 		const mainTerm = term.getTitleText?.() || term.term.name
-		const titleBase = mainTerm + (this.config.assayCohortTitle ? ` (${this.config.assayCohortTitle})` : '')
+		const _headerPretext = headerText ? `${headerText} ` : ''
+		//TODO: Should change .assayCohortTitle to headerSuffix, something more generic
+		const _headerSuffix = assayCohortTitle ? ` (${assayCohortTitle})` : ''
+		const titleBase = mainTerm + _headerSuffix
 		if (term2?.type) {
-			this.dom.paneTitleText.html(`${headerText || ''} ${term2.getTitleText?.() || term2.term.name} vs ${titleBase}`)
+			this.dom.paneTitleText.html(`${_headerPretext} ${term2.getTitleText?.() || term2.term.name} vs ${titleBase}`)
 		} else {
-			this.dom.paneTitleText.html(`${headerText || ''} ${titleBase}`)
+			this.dom.paneTitleText.html(`${_headerPretext}${titleBase}`)
 		}
 	}
 

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -33,17 +33,24 @@ class Volcano extends PlotBase implements RxComponent {
 		}
 
 		this.termType = opts.termType
-		const holder = opts.holder.classed('sjpp-diff-analysis-main', true)
+		const holder = opts.holder
+			.classed('sjpp-volcano-main', true)
+			.attr('data-testId', `sjpp-volcano-main-${opts.termType}`)
 		//Either allow a node to be passed or create a new div
 		const controls = typeof opts.controls == 'object' ? opts.controls : holder || (holder as any).append('div')
-		const error = opts.holder.append('div').attr('id', 'sjpp-diff-analysis-error').style('opacity', 0.75) as any
+		const error = opts.holder
+			.append('div')
+			.attr('id', 'sjpp-volcano-error')
+			.attr('data-testId', `sjpp-volcano-error-${opts.termType}`)
+			.style('opacity', 0.75) as any
 		this.dom = {
 			holder,
 			controls,
 			error,
 			wait: holder
 				.append('div')
-				.attr('id', 'sjpp-diff-analysis-wait')
+				.attr('id', 'sjpp-volcano-wait')
+				.attr('data-testId', `sjpp-volcano-wait-${opts.termType}`)
 				.style('opacity', 0.75)
 				.style('padding', '20px')
 				.text('Loading...') as any,
@@ -110,8 +117,6 @@ class Volcano extends PlotBase implements RxComponent {
 
 		const settings = config.settings.volcano
 		try {
-			if (!this.interactions) throw new Error('Interactions not initialized')
-
 			//Only show Loading for data requests that take longer than 500ms
 			const showWait = setTimeout(() => {
 				this.dom.wait.style('display', 'block')
@@ -126,18 +131,17 @@ class Volcano extends PlotBase implements RxComponent {
 				return
 			}
 
-			this.interactions.clearDom()
-
 			/** Format response into an object for rendering */
 			const viewModel = new VolcanoViewModel(config, response, settings)
 			//Pass table data for downloading
 			this.interactions.pValueTableData = viewModel.viewData.pValueTableData
 			this.interactions.data = response.data
 
-			clearTimeout(showWait)
-			this.dom.wait.style('display', 'none')
 			/** Render formatted data */
 			this.view.render(settings, viewModel.viewData)
+
+			clearTimeout(showWait)
+			this.dom.wait.style('display', 'none')
 		} catch (e: any) {
 			if (e instanceof Error) console.error(e.message || e)
 			else if (e.stack) console.log(e.stack)

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -20,6 +20,8 @@ class Volcano extends PlotBase implements RxComponent {
 	components: { controls: any }
 	dom: VolcanoDom
 	interactions?: VolcanoInteractions
+	model!: VolcanoModel
+	view!: VolcanoPlotView
 	termType: string
 
 	constructor(opts: VolcanoOpts, api) {
@@ -47,19 +49,6 @@ class Volcano extends PlotBase implements RxComponent {
 				.text('Loading...') as any,
 			tip: new Menu({ padding: '' }),
 			actionsTip: new Menu({ padding: '' })
-		}
-	}
-
-	reactsTo(action) {
-		if (action.type.includes('cache_termq')) return true
-		if (action.type.startsWith('filter')) return true
-		if (action.type.startsWith('cohort')) return true
-		if (action.type == 'app_refresh') return true
-		if (action.type.startsWith('plot_')) {
-			return (
-				(action.id === this.id || action.id == this.parentId) &&
-				(!action.config?.childType || action.config?.childType == this.type)
-			)
 		}
 	}
 
@@ -105,10 +94,16 @@ class Volcano extends PlotBase implements RxComponent {
 
 	async init() {
 		this.interactions = new VolcanoInteractions(this.app, this.id, this.dom)
+		this.model = new VolcanoModel(this.app, this.termType)
+		this.view = new VolcanoPlotView(this.dom, this.interactions, this.termType)
 		await this.setControls()
 	}
 
 	async main() {
+		if (!this.interactions) throw new Error('Volcano Interactions not initialized')
+		if (!this.model) throw new Error('Volcano Model not initialized')
+		if (!this.view) throw new Error('Volcano View not initialized')
+
 		const config = structuredClone(this.state.config)
 		//TODO: Fix this to use parentId instead
 		if (config.chartType != this.type && config.childType != this.type) return
@@ -123,8 +118,7 @@ class Volcano extends PlotBase implements RxComponent {
 			}, 500)
 
 			/** Fetch data */
-			const model = new VolcanoModel(this.app, config, settings)
-			const response = await model.getData()
+			const response = await this.model.getData(config, settings)
 			if (!response || response.error || !response.data || !response.data.length) {
 				sayerror(this.dom.error, response?.error || 'No data returned from server')
 				clearTimeout(showWait)
@@ -143,7 +137,7 @@ class Volcano extends PlotBase implements RxComponent {
 			clearTimeout(showWait)
 			this.dom.wait.style('display', 'none')
 			/** Render formatted data */
-			new VolcanoPlotView(this.dom, settings, viewModel.viewData, this.interactions, config.termType)
+			this.view.render(settings, viewModel.viewData)
 		} catch (e: any) {
 			if (e instanceof Error) console.error(e.message || e)
 			else if (e.stack) console.log(e.stack)

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -35,13 +35,13 @@ class Volcano extends PlotBase implements RxComponent {
 		this.termType = opts.termType
 		const holder = opts.holder
 			.classed('sjpp-volcano-main', true)
-			.attr('data-testId', `sjpp-volcano-main-${opts.termType}`)
+			.attr('data-testid', `sjpp-volcano-main-${opts.termType}`)
 		//Either allow a node to be passed or create a new div
 		const controls = typeof opts.controls == 'object' ? opts.controls : holder || (holder as any).append('div')
 		const error = opts.holder
 			.append('div')
 			.attr('id', 'sjpp-volcano-error')
-			.attr('data-testId', `sjpp-volcano-error-${opts.termType}`)
+			.attr('data-testid', `sjpp-volcano-error-${opts.termType}`)
 			.style('opacity', 0.75) as any
 		this.dom = {
 			holder,
@@ -50,7 +50,7 @@ class Volcano extends PlotBase implements RxComponent {
 			wait: holder
 				.append('div')
 				.attr('id', 'sjpp-volcano-wait')
-				.attr('data-testId', `sjpp-volcano-wait-${opts.termType}`)
+				.attr('data-testid', `sjpp-volcano-wait-${opts.termType}`)
 				.style('opacity', 0.75)
 				.style('padding', '20px')
 				.text('Loading...') as any,

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -45,8 +45,7 @@ class Volcano extends PlotBase implements RxComponent {
 				.style('opacity', 0.75)
 				.style('padding', '20px')
 				.text('Loading...') as any,
-			hoverTip: new Menu({ padding: '' }),
-			clickTip: new Menu({ padding: '' }),
+			tip: new Menu({ padding: '' }),
 			actionsTip: new Menu({ padding: '' })
 		}
 	}

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -1,4 +1,4 @@
-import type { Div, Elem, SvgG, SvgSvg, SvgText } from '../../types/d3'
+import type { Elem } from '../../types/d3'
 import type { PlotConfig } from '#mass/types/mass'
 import type { TableCell, TableColumn, Menu } from '#dom'
 import type { DataEntry, DiffMethDataEntry, DEImage, TermWrapper } from '#types'
@@ -105,27 +105,6 @@ export type VolcanoDom = {
 	tip: Menu
 	/** Menu for action buttons above the volcano plot */
 	actionsTip: Menu
-}
-
-/** this.volcanoDom in view */
-export type VolcanoPlotDom = {
-	/** Holder for action buttons above the images and plot */
-	actions: Div
-	/** Holder for data points, p value line, and fold change line */
-	plot: SvgG
-	pValueTable: Div
-	/** Holder for plot, axis labels, and title */
-	svg: SvgSvg
-	/** Term info */
-	top: SvgG
-	/** X axis */
-	xAxis: SvgG
-	/** X axis label */
-	xAxisLabel: SvgText
-	/** Y axis */
-	yAxis: SvgG
-	/** Y axis label */
-	yAxisLabel: SvgText
 }
 
 export type VolcanoPValueTableData = {

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -100,7 +100,8 @@ export type VolcanoDom = {
 	error: Elem
 	/** Loading message */
 	wait: Elem
-	/** Tooltip for data points */
+	/** Tooltip for data points. Displays information on hover
+	 * and, if enabled, a menu for launching other plots */
 	tip: Menu
 	/** Menu for action buttons above the volcano plot */
 	actionsTip: Menu

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -100,10 +100,8 @@ export type VolcanoDom = {
 	error: Elem
 	/** Loading message */
 	wait: Elem
-	/** Tooltip for data point hover */
-	hoverTip: Menu
-	/** Tooltip for data point click */
-	clickTip: Menu
+	/** Tooltip for data points */
+	tip: Menu
 	/** Menu for action buttons above the volcano plot */
 	actionsTip: Menu
 }

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -110,7 +110,6 @@ export class VolcanoInteractions {
 	 * For geneExpression, value == gene symbol */
 	async launchBoxPlot(value: string) {
 		const config = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
-		if (config.termType != GENE_EXPRESSION) return
 		const values = {}
 		for (const group of config.samplelst.groups) {
 			values[group.name] = {
@@ -151,7 +150,6 @@ export class VolcanoInteractions {
 	/** Launch a violin plot for a gene expression data point. */
 	async launchViolinGeneExp(value: string) {
 		const config = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
-		if (config.termType != GENE_EXPRESSION) return
 		this.app.dispatch({
 			type: 'plot_create',
 			config: {
@@ -217,7 +215,6 @@ export class VolcanoInteractions {
 	 * track. */
 	async launchDmr(d: { chr: string; start: number; stop: number; promoterId?: string }) {
 		const config = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
-		if (config.termType !== DNA_METHYLATION) return
 
 		const controlColor = config?.tw?.term?.values?.[config?.samplelst?.groups[0].name]?.color || '#ff0000'
 		const caseColor = config?.tw?.term?.values?.[config?.samplelst?.groups[1].name]?.color || '#0000ff'
@@ -291,8 +288,7 @@ export class VolcanoInteractions {
 			const unit = getGEunit(this.app.vocabApi)
 			const name = `${gene} ${unit}`
 			const term = { gene, name, type: GENE_EXPRESSION }
-			const tw = { term, q: {} }
-			return tw
+			return { term, q: {} }
 		})
 
 		const group = { lst: tws, type: 'hierCluster' }

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -108,7 +108,7 @@ export class VolcanoInteractions {
 
 	/** When clicking on a data point, launches the box plot in a separate sandbox
 	 * For geneExpression, value == gene symbol */
-	async launchBoxPlot(value: string) {
+	launchBoxPlot(value: string) {
 		const config = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
 		const values = {}
 		for (const group of config.samplelst.groups) {
@@ -148,7 +148,7 @@ export class VolcanoInteractions {
 	}
 
 	/** Launch a violin plot for a gene expression data point. */
-	async launchViolinGeneExp(value: string) {
+	launchViolinGeneExp(value: string) {
 		const config = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
 		this.app.dispatch({
 			type: 'plot_create',
@@ -242,7 +242,7 @@ export class VolcanoInteractions {
 	/** Launch a violin/box plot for a DNA methylation promoter.
 	 * Creates a methylation term using the promoter's chr/start/stop coordinates.
 	 * The tw handler fills in id and unit from termdbConfig. */
-	launchViolin(d: { chr: string; start: number; stop: number; gene_name?: string; promoter_id?: string }) {
+	launchDNAMethViolin(d: { chr: string; start: number; stop: number; gene_name?: string; promoter_id?: string }) {
 		const config = this.app.getState().plots.find((p: VolcanoPlotConfig) => p.id === this.id)
 		const genomicFeatureType = d.promoter_id ? 'promoter' : 'gene'
 		const featureName = genomicFeatureType === 'gene' ? d.gene_name?.split(',')[0]?.trim() || '' : ''

--- a/client/plots/volcano/interactions/VolcanoInteractions.ts
+++ b/client/plots/volcano/interactions/VolcanoInteractions.ts
@@ -11,6 +11,7 @@ export class VolcanoInteractions {
 	id: string
 	pValueTableData: any
 	data: any
+
 	constructor(app: MassAppApi, id: string, dom: VolcanoDom) {
 		this.app = app
 		this.dom = dom
@@ -61,15 +62,6 @@ export class VolcanoInteractions {
 			disable_terms
 		})
 		await ui.renderUI()
-	}
-
-	clearDom() {
-		this.dom.holder.selectAll('div[id="sjpp-volcano-actions"]').remove()
-		this.dom.holder.selectAll('svg[id="sjpp-volcano-svg"]').remove()
-		this.dom.holder.selectAll('div[id="sjpp-volcano-stats"]').remove()
-		this.dom.holder.selectAll('div[id="sjpp-volcano-pValueTable"]').remove()
-		this.dom.holder.selectAll('div[id="sjpp-volcano-images"]').remove()
-		this.dom.error.selectAll('*').remove()
 	}
 
 	download(termType: string) {

--- a/client/plots/volcano/model/VolcanoModel.ts
+++ b/client/plots/volcano/model/VolcanoModel.ts
@@ -1,25 +1,24 @@
 import type { MassAppApi } from '#mass/types/mass'
 import { dofetch3 } from '#common/dofetch'
-import type { VolcanoPlotConfig } from '../VolcanoTypes'
 import type { DERequest, DiffMethRequest, TermdbSingleCellDEgenesRequest } from '#types'
 import { DNA_METHYLATION, GENE_EXPRESSION, SINGLECELL_CELLTYPE } from '#shared/terms.js'
-import type { ValidatedVolcanoSettings } from '../settings/Settings'
 
 export class VolcanoModel {
 	app: MassAppApi
-	config: any
-	settings: any
+	config!: any
+	settings!: any
 	termType: string
 
-	constructor(app: MassAppApi, config: VolcanoPlotConfig, settings: ValidatedVolcanoSettings) {
+	constructor(app: MassAppApi, termType: string) {
 		this.app = app
-		this.config = config
-		this.settings = settings
-		this.termType = config.termType
+		this.termType = termType
 	}
 
 	/** May use mapper instead as more termTypes are added */
-	async getData() {
+	async getData(config: any, settings: any) {
+		this.config = config
+		this.settings = settings
+
 		if (this.termType === GENE_EXPRESSION) {
 			const body = await this.getGERequestBody()
 			return await dofetch3('termdb/DE', { body })
@@ -51,12 +50,8 @@ export class VolcanoModel {
 			filter0: state.termfilter.filter0,
 			cpm_cutoff: this.settings.cpmCutoff
 		} as Partial<DERequest> //remove Partial when storage_type is removed from DERequest
-		//This is a workaround until the server can accept an arr of confounder tws
-		const confounders = this.config?.confounderTws
-		if (confounders?.length) {
-			body.tw = this.config.confounderTws[0]
-			if (confounders.length > 1) body.tw2 = this.config.confounderTws[1]
-		}
+
+		this.addConfounderTw(body)
 
 		return body
 	}
@@ -73,12 +68,19 @@ export class VolcanoModel {
 			filter0: state.termfilter.filter0,
 			min_samples_per_group: this.settings.minSamplesPerGroup
 		} as Partial<DiffMethRequest>
+
+		this.addConfounderTw(body)
+
+		return body
+	}
+
+	//This is a workaround until the server can accept an arr of confounder tws
+	addConfounderTw(body) {
 		const confounders = this.config?.confounderTws
 		if (confounders?.length) {
 			body.tw = this.config.confounderTws[0]
 			if (confounders.length > 1) body.tw2 = this.config.confounderTws[1]
 		}
-		return body
 	}
 
 	//Single cell cell type

--- a/client/plots/volcano/settings/Settings.ts
+++ b/client/plots/volcano/settings/Settings.ts
@@ -15,6 +15,8 @@ export type DefaultVolcanoSettings = {
 	pValueType: 'original' | 'adjusted'
 	/** Maximum number of samples to include in the analysis per termType */
 	sampleNumCutoff: number
+	/** Show the p-value table */
+	showPValueTable: boolean
 	/** Width of the plot in pixels */
 	width: number
 }

--- a/client/plots/volcano/settings/defaults.ts
+++ b/client/plots/volcano/settings/defaults.ts
@@ -24,6 +24,7 @@ export function getDefaultVolcanoSettings(overrides = {}, opts: any): ValidatedV
 		pValueType: 'adjusted',
 		//Only declare this value in one place
 		sampleNumCutoff: opts.termType == GENE_EXPRESSION ? maxGESampleCutoff : maxSampleCutoff,
+		showPValueTable: false,
 		width: 400
 	} satisfies DefaultVolcanoSettings
 

--- a/client/plots/volcano/view/DataPointMouseEvents.ts
+++ b/client/plots/volcano/view/DataPointMouseEvents.ts
@@ -14,31 +14,39 @@ export class DataPointMouseEvents {
 		const menuOpts = [
 			{
 				label: 'Violin plot',
-				isVisible: () => termType === DNA_METHYLATION,
+				isVisible: () => {
+					const enabledTermTypes = new Set([DNA_METHYLATION, GENE_EXPRESSION])
+					return enabledTermTypes.has(termType)
+				},
 				onClick: async () => {
-					interactions.launchViolin(d as any)
+					if (termType === DNA_METHYLATION) interactions.launchDNAMethViolin(d as any)
+					if (termType === GENE_EXPRESSION) interactions.launchViolinGeneExp(d.gene_name)
 				}
 			},
 			{
 				label: 'DMR analysis',
 				isVisible: () => termType === DNA_METHYLATION,
 				onClick: async () => {
-					interactions.launchViolin(d as any)
-				}
-			},
-			{
-				label: 'Violin plot',
-				note: 'Gene expression only',
-				isVisible: () => termType === GENE_EXPRESSION,
-				onClick: async () => {
-					await interactions.launchViolinGeneExp(d.gene_name)
+					const dm = d as DataPointEntry & {
+						chr: string
+						start: number
+						stop: number
+						promoter_id?: string
+						gene_name?: string
+					}
+					await interactions.launchDmr({
+						chr: dm.chr,
+						start: dm.start,
+						stop: dm.stop,
+						promoterId: dm.promoter_id
+					})
 				}
 			},
 			{
 				label: 'Box plot',
 				isVisible: () => termType === GENE_EXPRESSION,
 				onClick: async () => {
-					await interactions.launchBoxPlot(d.gene_name)
+					interactions.launchBoxPlot(d.gene_name)
 				}
 			}
 		]
@@ -51,7 +59,9 @@ export class DataPointMouseEvents {
 			this.addTooltipRows(d, table)
 		})
 
+		let menuOpen = false
 		circle.on('mouseout', () => {
+			if (menuOpen) return
 			tip.hide()
 			if (d.highlighted) return
 			circle.attr('fill-opacity', 0)
@@ -61,7 +71,9 @@ export class DataPointMouseEvents {
 		if (visibleMenuOpts.length === 0) return
 
 		circle.on('click', () => {
+			menuOpen = true
 			tip.onHide = () => {
+				menuOpen = false
 				if (!d.highlighted) circle.attr('fill-opacity', 0)
 			}
 			tip.clear().showunder(circle.node())
@@ -72,6 +84,7 @@ export class DataPointMouseEvents {
 					.text(opt.label)
 					.on('click', async () => {
 						tip.hide()
+						if (!d.highlighted) circle.attr('fill-opacity', 0)
 						await opt.onClick()
 					})
 			}

--- a/client/plots/volcano/view/DataPointMouseEvents.ts
+++ b/client/plots/volcano/view/DataPointMouseEvents.ts
@@ -45,17 +45,14 @@ export class DataPointMouseEvents {
 
 		circle.on('mouseover', () => {
 			circle.attr('fill-opacity', 0.9)
-
-			hoverTip.clear().showunder(circle.node())
-			const table = table2col({ holder: hoverTip.d.append('table') })
+			tip.clear().showunder(circle.node())
+			const table = table2col({ holder: tip.d.append('table') })
 
 			this.addTooltipRows(d, table)
 		})
 
-		let menuOpen = false
-
 		circle.on('mouseout', () => {
-			hoverTip.hide()
+			tip.hide()
 			if (d.highlighted) return
 			circle.attr('fill-opacity', 0)
 		})
@@ -64,8 +61,7 @@ export class DataPointMouseEvents {
 		if (visibleMenuOpts.length === 0) return
 
 		circle.on('click', () => {
-			hoverTip.hide()
-			clickTip.onHide = () => {
+			tip.onHide = () => {
 				if (!d.highlighted) circle.attr('fill-opacity', 0)
 			}
 			tip.clear().showunder(circle.node())

--- a/client/plots/volcano/view/DataPointMouseEvents.ts
+++ b/client/plots/volcano/view/DataPointMouseEvents.ts
@@ -3,19 +3,46 @@ import { roundValueAuto } from '#shared/roundValue.js'
 import type { SvgCircle } from '../../../types/d3'
 import type { VolcanoInteractions } from '../interactions/VolcanoInteractions'
 import type { DataPointEntry } from '../VolcanoTypes'
-import { DNA_METHYLATION } from '#shared/terms.js'
+import { DNA_METHYLATION, GENE_EXPRESSION } from '#shared/terms.js'
 
 export class DataPointMouseEvents {
 	termType: string
-	constructor(
-		d: DataPointEntry,
-		circle: SvgCircle,
-		hoverTip: Menu,
-		clickTip: Menu,
-		interactions: VolcanoInteractions,
-		termType: string
-	) {
+
+	constructor(d: DataPointEntry, circle: SvgCircle, tip: Menu, interactions: VolcanoInteractions, termType: string) {
 		this.termType = termType
+
+		const menuOpts = [
+			{
+				label: 'Violin plot',
+				isVisible: () => termType === DNA_METHYLATION,
+				onClick: async () => {
+					interactions.launchViolin(d as any)
+				}
+			},
+			{
+				label: 'DMR analysis',
+				isVisible: () => termType === DNA_METHYLATION,
+				onClick: async () => {
+					interactions.launchViolin(d as any)
+				}
+			},
+			{
+				label: 'Violin plot',
+				note: 'Gene expression only',
+				isVisible: () => termType === GENE_EXPRESSION,
+				onClick: async () => {
+					await interactions.launchViolinGeneExp(d.gene_name)
+				}
+			},
+			{
+				label: 'Box plot',
+				isVisible: () => termType === GENE_EXPRESSION,
+				onClick: async () => {
+					await interactions.launchBoxPlot(d.gene_name)
+				}
+			}
+		]
+
 		circle.on('mouseover', () => {
 			circle.attr('fill-opacity', 0.9)
 
@@ -25,69 +52,34 @@ export class DataPointMouseEvents {
 			this.addTooltipRows(d, table)
 		})
 
+		let menuOpen = false
+
 		circle.on('mouseout', () => {
 			hoverTip.hide()
 			if (d.highlighted) return
 			circle.attr('fill-opacity', 0)
 		})
+
+		const visibleMenuOpts = menuOpts.filter(opt => opt.isVisible())
+		if (visibleMenuOpts.length === 0) return
+
 		circle.on('click', () => {
 			hoverTip.hide()
 			clickTip.onHide = () => {
 				if (!d.highlighted) circle.attr('fill-opacity', 0)
 			}
-			clickTip.clear().showunder(circle.node())
-			const table = table2col({ holder: clickTip.d.append('table') })
-			this.addTooltipRows(d, table)
-			const menuDiv = clickTip.d.append('div').style('padding', '5px')
-
-			if (termType === DNA_METHYLATION) {
-				const dm = d as any
-				menuDiv
+			tip.clear().showunder(circle.node())
+			for (const opt of visibleMenuOpts) {
+				tip.d
 					.append('div')
 					.attr('class', 'sja_menuoption')
-					.text('Violin plot')
-					.on('click', () => {
-						clickTip.hide()
-						interactions.launchViolin(dm)
-					})
-				menuDiv
-					.append('div')
-					.attr('class', 'sja_menuoption')
-					.text('DMR analysis')
+					.text(opt.label)
 					.on('click', async () => {
-						clickTip.hide()
-						await interactions.launchDmr({
-							chr: dm.chr,
-							start: dm.start,
-							stop: dm.stop,
-							promoterId: dm.promoter_id
-						})
-					})
-			} else {
-				menuDiv
-					.append('div')
-					.attr('class', 'sja_menuoption')
-					.text('Violin plot')
-					.on('click', async () => {
-						clickTip.hide()
-						await interactions.launchViolinGeneExp(d.gene_name)
-					})
-				menuDiv
-					.append('div')
-					.attr('class', 'sja_menuoption')
-					.text('Box plot')
-					.on('click', async () => {
-						clickTip.hide()
-						await interactions.launchBoxPlot(d.gene_name)
+						tip.hide()
+						await opt.onClick()
 					})
 			}
 		})
-	}
-
-	addTooltipRow(table: any, text: string, value: number | string) {
-		const [td1, td2] = table.addRow()
-		td1.html(text)
-		td2.text(value)
 	}
 
 	addTooltipRows(d: DataPointEntry, table: any) {
@@ -100,5 +92,11 @@ export class DataPointMouseEvents {
 		this.addTooltipRow(table, 'log<sub>2</sub>(fold-change)', roundValueAuto(d.fold_change))
 		this.addTooltipRow(table, 'Original p-value', roundValueAuto(d.original_p_value))
 		this.addTooltipRow(table, 'Adjusted p-value', roundValueAuto(d.adjusted_p_value))
+	}
+
+	addTooltipRow(table: any, text: string, value: number | string) {
+		const [td1, td2] = table.addRow()
+		td1.html(text)
+		td2.text(value)
 	}
 }

--- a/client/plots/volcano/view/VolcanoPlotDom.ts
+++ b/client/plots/volcano/view/VolcanoPlotDom.ts
@@ -1,0 +1,22 @@
+import type { Div, SvgG, SvgSvg, SvgText } from '../../../types/d3'
+
+export type VolcanoPlotDom = {
+	/** Holder for action buttons above the images and plot */
+	actions: Div
+	/** Holder for data points, p value line, and fold change line */
+	plot: SvgG
+	/** Div for the p-value table */
+	pValueTable: Div
+	/** Holder for plot, axis labels, and title */
+	svg: SvgSvg
+	/** Term info */
+	top: SvgG
+	/** X axis */
+	xAxis: SvgG
+	/** X axis label */
+	xAxisLabel: SvgText
+	/** Y axis */
+	yAxis: SvgG
+	/** Y axis label */
+	yAxisLabel: SvgText
+}

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -20,18 +20,11 @@ export class VolcanoPlotView {
 	settings: any
 	termType: string
 	volcanoDom: VolcanoPlotDom
-	viewData: VolcanoViewData
-	constructor(
-		dom: VolcanoDom,
-		settings: ValidatedVolcanoSettings,
-		viewData: VolcanoViewData,
-		interactions: VolcanoInteractions,
-		termType: string
-	) {
+	viewData!: VolcanoViewData
+	constructor(dom: VolcanoDom, interactions: VolcanoInteractions, termType: string) {
 		this.dom = dom
 		this.interactions = interactions
-		this.settings = settings
-		this.viewData = viewData
+		this.termType = termType
 		const actions = this.dom.holder
 			.append('div')
 			.attr('id', 'sjpp-volcano-actions')
@@ -54,7 +47,11 @@ export class VolcanoPlotView {
 			plot: svg.append('g').attr('id', 'sjpp-volcano-plot'),
 			pValueTable: this.dom.holder.append('div').attr('id', 'sjpp-volcano-pValueTable').style('display', 'none')
 		}
-		this.termType = termType
+	}
+
+	render(settings: ValidatedVolcanoSettings, viewData: VolcanoViewData) {
+		this.settings = settings
+		this.viewData = viewData
 		const plotDim = this.viewData.plotDim
 		this.renderUserActions()
 		this.renderPlot(plotDim)

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -16,6 +16,7 @@ export class VolcanoPlotView {
 	termType: string
 	volcanoDom: VolcanoPlotDom
 	viewData!: VolcanoViewData
+
 	constructor(dom: VolcanoDom, interactions: VolcanoInteractions, termType: string) {
 		this.dom = dom
 		this.interactions = interactions
@@ -34,11 +35,7 @@ export class VolcanoPlotView {
 		this.volcanoDom = {
 			actions,
 			svg,
-			pValueTable: this.dom.holder
-				.append('div')
-				.attr('id', 'sjpp-volcano-pValueTable')
-				.style('display', 'inline-block')
-				.style('vertical-align', 'top'),
+			pValueTable: undefined,
 			top: undefined,
 			xAxis: undefined,
 			xAxisLabel: undefined,
@@ -59,13 +56,12 @@ export class VolcanoPlotView {
 		this.renderPlot(plotDim)
 		renderDataPoints(this)
 		this.renderFoldChangeLine(plotDim)
-		this.renderPValueTable()
+		if (this.settings.showPValueTable) this.renderPValueTable()
 	}
 
 	initDom() {
 		this.volcanoDom.actions.selectAll('*').remove()
 		this.volcanoDom.svg.selectAll('*').remove()
-		this.volcanoDom.pValueTable.selectAll('*').remove()
 
 		const svg = this.volcanoDom.svg
 		this.volcanoDom.top = svg.append('g').attr('id', 'sjpp-volcano-top')
@@ -74,6 +70,14 @@ export class VolcanoPlotView {
 		this.volcanoDom.xAxisLabel = svg.append('text').attr('id', 'sjpp-volcano-xAxisLabel').attr('text-anchor', 'middle')
 		this.volcanoDom.yAxisLabel = svg.append('text').attr('id', 'sjpp-volcano-yAxisLabel').attr('text-anchor', 'middle')
 		this.volcanoDom.plot = svg.append('g').attr('id', 'sjpp-volcano-plot')
+
+		if (!this.settings.showPValueTable) return
+		this.volcanoDom.pValueTable = this.dom.holder
+			.append('div')
+			.attr('id', 'sjpp-volcano-pValueTable')
+			.attr('data-testid', 'sjpp-volcano-pValueTable')
+			.style('display', 'inline-block')
+			.style('vertical-align', 'top')
 	}
 
 	renderUserActions() {
@@ -97,6 +101,8 @@ export class VolcanoPlotView {
 			this.volcanoDom.actions.append('span').text(sigText).style('margin-left', '10px').style('font-weight', 'bold')
 
 			this.addActionButton('Show p-value table', [GENE_EXPRESSION, SINGLECELL_CELLTYPE, DNA_METHYLATION], async () => {
+				/** TODO: This is very slow to render. Need to optimize rendering
+				 * and server response to increase performance.*/
 				const showTable = !this.settings.showPValueTable
 				await this.interactions.app.dispatch({
 					type: 'plot_edit',

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -2,13 +2,8 @@ import { axisBottom, axisLeft } from 'd3-axis'
 import { axisstyle, table2col, renderTable } from '#dom'
 import { select, selectAll } from 'd3-selection'
 import { rgb } from 'd3-color'
-import type {
-	DataPointEntry,
-	VolcanoDom,
-	VolcanoPlotDimensions,
-	VolcanoPlotDom,
-	VolcanoViewData
-} from '../VolcanoTypes'
+import type { DataPointEntry, VolcanoDom, VolcanoPlotDimensions, VolcanoViewData } from '../VolcanoTypes'
+import type { VolcanoPlotDom } from './VolcanoPlotDom'
 import type { VolcanoInteractions } from '../interactions/VolcanoInteractions'
 import { DataPointMouseEvents } from './DataPointMouseEvents'
 import { DNA_METHYLATION, GENE_EXPRESSION, SINGLECELL_CELLTYPE } from '#shared/terms.js'
@@ -39,26 +34,46 @@ export class VolcanoPlotView {
 		this.volcanoDom = {
 			actions,
 			svg,
-			top: svg.append('g').attr('id', 'sjpp-volcano-top'),
-			xAxis: svg.append('g').attr('id', 'sjpp-volcano-xAxis'),
-			yAxis: svg.append('g').attr('id', 'sjpp-volcano-yAxis'),
-			xAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-xAxisLabel').attr('text-anchor', 'middle'),
-			yAxisLabel: svg.append('text').attr('id', 'sjpp-volcano-yAxisLabel').attr('text-anchor', 'middle'),
-			plot: svg.append('g').attr('id', 'sjpp-volcano-plot'),
-			pValueTable: this.dom.holder.append('div').attr('id', 'sjpp-volcano-pValueTable').style('display', 'none')
-		}
+			pValueTable: this.dom.holder
+				.append('div')
+				.attr('id', 'sjpp-volcano-pValueTable')
+				.style('display', 'inline-block')
+				.style('vertical-align', 'top'),
+			top: undefined,
+			xAxis: undefined,
+			xAxisLabel: undefined,
+			yAxis: undefined,
+			yAxisLabel: undefined,
+			plot: undefined
+		} as Partial<VolcanoPlotDom> as VolcanoPlotDom
 	}
 
 	render(settings: ValidatedVolcanoSettings, viewData: VolcanoViewData) {
 		this.settings = settings
 		this.viewData = viewData
 		const plotDim = this.viewData.plotDim
+
+		this.initDom()
+
 		this.renderUserActions()
 		this.renderPlot(plotDim)
 		renderDataPoints(this)
 		this.renderFoldChangeLine(plotDim)
-		this.renderStatsMenu()
 		this.renderPValueTable()
+	}
+
+	initDom() {
+		this.volcanoDom.actions.selectAll('*').remove()
+		this.volcanoDom.svg.selectAll('*').remove()
+		this.volcanoDom.pValueTable.selectAll('*').remove()
+
+		const svg = this.volcanoDom.svg
+		this.volcanoDom.top = svg.append('g').attr('id', 'sjpp-volcano-top')
+		this.volcanoDom.xAxis = svg.append('g').attr('id', 'sjpp-volcano-xAxis')
+		this.volcanoDom.yAxis = svg.append('g').attr('id', 'sjpp-volcano-yAxis')
+		this.volcanoDom.xAxisLabel = svg.append('text').attr('id', 'sjpp-volcano-xAxisLabel').attr('text-anchor', 'middle')
+		this.volcanoDom.yAxisLabel = svg.append('text').attr('id', 'sjpp-volcano-yAxisLabel').attr('text-anchor', 'middle')
+		this.volcanoDom.plot = svg.append('g').attr('id', 'sjpp-volcano-plot')
 	}
 
 	renderUserActions() {
@@ -81,11 +96,14 @@ export class VolcanoPlotView {
 			const sigText = this.termType == DNA_METHYLATION ? `${numSigGenes} DM promoters:` : `${numSigGenes} DE genes:`
 			this.volcanoDom.actions.append('span').text(sigText).style('margin-left', '10px').style('font-weight', 'bold')
 
-			this.addActionButton('Show p-value table', [GENE_EXPRESSION, SINGLECELL_CELLTYPE, DNA_METHYLATION], () => {
-				this.volcanoDom.pValueTable.style(
-					'display',
-					this.volcanoDom.pValueTable.style('display') == 'none' ? 'inline-block' : 'none'
-				)
+			this.addActionButton('Show p-value table', [GENE_EXPRESSION, SINGLECELL_CELLTYPE, DNA_METHYLATION], async () => {
+				const showTable = !this.settings.showPValueTable
+				await this.interactions.app.dispatch({
+					type: 'plot_edit',
+					id: this.interactions.id,
+					config: { settings: { volcano: { showPValueTable: showTable } } }
+				})
+				console.log('showTable', showTable)
 			})
 		}
 		if (numSigGenes && numSigGenes >= 3) {
@@ -110,9 +128,9 @@ export class VolcanoPlotView {
 			.style('margin', '3px')
 			.style('padding', '3px')
 			.text(text)
-			.on('click', () => {
+			.on('click', async () => {
 				this.dom.actionsTip.clear().showunder(button.node())
-				callback()
+				await callback()
 			})
 	}
 
@@ -232,6 +250,7 @@ export class VolcanoPlotView {
 	}
 
 	renderPValueTable() {
+		if (!this.settings.showPValueTable) return
 		// Cap rendered rows to prevent browser OOM with large datasets (e.g. 30k+ significant promoters).
 		// The full data is still available in pValueTableData.rows for export/search.
 		const maxTableRows = 5000

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -103,7 +103,6 @@ export class VolcanoPlotView {
 					id: this.interactions.id,
 					config: { settings: { volcano: { showPValueTable: showTable } } }
 				})
-				console.log('showTable', showTable)
 			})
 		}
 		if (numSigGenes && numSigGenes >= 3) {

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -325,6 +325,6 @@ function renderDataPoints(self: any) {
 		.attr('r', (d: DataPointEntry) => d.radius)
 		.each(function (this: any, d: DataPointEntry) {
 			const circle = select(this)
-			new DataPointMouseEvents(d, circle, self.dom.hoverTip, self.dom.clickTip, self.interactions, self.termType)
+			new DataPointMouseEvents(d, circle, self.dom.tip, self.interactions, self.termType)
 		})
 }

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -53,7 +53,8 @@ export class VolcanoViewModel {
 				{ label: 'Original p-value', sortable: true },
 				{ label: 'Adjusted p-value', sortable: true }
 			],
-			//Arr set in setPointData()
+			/** Arr set in setPointData() if settings.showPValueTable is true to
+			 * prevent unnecessary data processing when the table is not shown */
 			rows: [],
 			height: settings.height + this.topPad
 		}
@@ -66,9 +67,12 @@ export class VolcanoViewModel {
 		const plotDim = this.setPlotDimensions()
 		this.setPTableColumns()
 		const pointData = this.setPointData(plotDim, controlColor, caseColor)
-		//Get all rows data for the pValueTable in setPointsData, then sort by fold change
-		const foldChangeIdx = this.pValueTable.columns.findIndex(c => c.label.includes('log₂(fold-change)'))
-		this.pValueTable.rows.sort((a: any, b: any) => b[foldChangeIdx].value - a[foldChangeIdx].value)
+
+		if (this.settings.showPValueTable) {
+			//Get all rows data for the pValueTable in setPointsData, then sort by fold change
+			const foldChangeIdx = this.pValueTable.columns.findIndex(c => c.label.includes('log₂(fold-change)'))
+			this.pValueTable.rows.sort((a: any, b: any) => b[foldChangeIdx].value - a[foldChangeIdx].value)
+		}
 
 		this.viewData = {
 			images: response.images || [],
@@ -196,7 +200,8 @@ export class VolcanoViewModel {
 				} else {
 					row.splice(0, 0, { value: d.gene_name || '' })
 				}
-				this.pValueTable.rows.push(row)
+				//Do not create p-value table data unless user opts to show the table
+				if (this.settings.showPValueTable) this.pValueTable.rows.push(row)
 			} else {
 				this.numNonSignificant++
 			}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,7 @@
-
+Fixes
+- SC: Sample sections and subplots within sample sections are added to the DOM in descending order.
+- DA volcano: The click events in the volcano now show appropriately per termType and launch the appropriate plot. 
+- DA: Showing or hiding the p value table is tracked in the state; fixing the issue of the table disappearing on state change.
+Features
+- SC: Sample sections in the SC app include action buttons: 'X' to destroy the section and an arrow to show/hide the section.
+- SC: Header text is passed to the subplots to show the sample to avoid confusion. 


### PR DESCRIPTION
# Description

Changes: 
- SC: 
    - Child plots display sample ID (scatter, DA, summary)
    - Better implementation of the sections with fixes:
        - Sample sections appear in descending order of appearance. 
        - Same applied to sandboxes within sections.
        - Action buttons: destroy and hide/show
    - Allow users to group by sample or by plot?
    - Optimizing code 
- DA: 
    - Fixed volcano click events for all the term types
    - Showing the p-value table is saved in the state
    - Optimized code
- New _README.md for client/plots

Test: 
1. DA: Use any of the group examples from http://localhost:3000/url.html
2. SC: Use any of the examples from http://localhost:3000/url.html, this [GDC cohort example](http://localhost:3000/example.gdc.scApp.html?&cohort=All_GDC), and [MMRF example](http://localhost:3000/example.mmrf.sc.html)


Addresses issues noted in the [DA roadmap](https://github.com/stjude/sjpp/issues/669) and [SC roadmap](https://github.com/stjude/sjpp/issues/658). Outstanding issues that maybe seen in testing are also noted in the roadmaps. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
