### PR TITLE
PrOFILE Bar chart2

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -185,6 +185,12 @@ function getChartTypeList(self, state) {
 			config: { chartType: 'profileBarchart' }
 		},
 		{
+			label: 'Barchart 2',
+			clickTo: self.prepPlot,
+			chartType: 'profileBarchart2',
+			config: { chartType: 'profileBarchart2' }
+		},
+		{
 			label: 'Facility Radar',
 			chartType: 'profileRadarFacility',
 			clickTo: self.loadChartSpecificMenu

--- a/client/plots/controls.btns.js
+++ b/client/plots/controls.btns.js
@@ -96,6 +96,7 @@ function helpBtnInit(opts) {
 			'profilePolar',
 			'profilePolar2',
 			'profileBarchart',
+			'profileBarchart2',
 			'profileRadar',
 			'profileRadarFacility',
 			'boxplot',

--- a/client/plots/importPlot.js
+++ b/client/plots/importPlot.js
@@ -101,6 +101,9 @@ export async function importPlot(chartType, notFoundMessage = '') {
 		case 'profileBarchart':
 			return await import('./profile/profileBarchart.ts')
 
+		case 'profileBarchart2':
+			return await import('./profile/barchart2.ts')
+
 		case 'profilePolar':
 			return await import('./profile/polar.ts')
 

--- a/client/plots/profile/README.md
+++ b/client/plots/profile/README.md
@@ -87,6 +87,37 @@ Here is a breakdown of the main plot types:
 Both Full (`FUNIT`) and Abbreviated (`AUNIT`) cohorts are handled automatically — `derivePrefix()` reads the `F`/`A` prefix from term IDs already present in the request, requiring no cohort-specific logic on the client.
 
 
+### Bar Chart v2 (profileBarchart2)
+**Class:** [barchart2.ts](./barchart2.ts)
+**Server route:** [`profile.barchart2.ts`](../../../../server/routes/profile.barchart2.ts) at endpoint `termdb/profileBarchart2Scores`
+**Title:** Score-based Results for the Component by Module and Domain (v2)
+**Description:** A redesigned bar chart that follows the per-plot dedicated route architecture established by `profilePolar2`. Visually identical to the original bar chart but with a cleaner, more secure data flow.
+
+**Key differences from the original Bar Chart:**
+
+- **Dedicated server route:** Uses `termdb/profileBarchart2Scores` instead of the shared `termdb/profileScores`. Same pattern as `profilePolar2` — each v2 plot owns its route and data logic independently.
+- **Server-side facility term derivation:** The client does not send `facilityTW`. The server derives the correct facility term (`FUNIT` for full cohort, `AUNIT` for abbreviated) by inspecting term ID prefixes already present in the request (`scoreTerms` or `filter`), eliminating any client influence over which facility term is used.
+- **Always aggregated:** Always returns the median percentage across all eligible sites. There is no single-site mode — when only one site is accessible, the median of a single value equals that value.
+- **Minimal client payload:** The client strips `scoreTerms` down to `{ term: { id }, q }` before sending via `dofetch3`. No `facilityTW`, no `$id`, no client-only term wrapper properties are sent.
+- **Consistent eligible sample scoping:** `eligibleSamples` is filtered to `userSites` only when `filterByUserSites` is explicitly `true`. When `filterByUserSites` is `false`, the median is computed across all sites (global aggregate).
+- **Public role security:** `sites` is always `[]` for public users — no site IDs or names are ever exposed to public-role users.
+- **Cleaner rendering structure:** The `plot()` method is split into focused private methods (`createSvg`, `drawTitleAndDefs`, `drawColumnHeaders`, `drawComponentRows`, `drawGuideLines`, `drawLegend`) instead of one large function.
+- **Documentation icon:** The help icon in the controls panel is enabled for `profileBarchart2` in [`controls.btns.js`](../../plots/controls.btns.js). Clicking it opens the same bar graph PDF as `profileBarchart` for the active cohort.
+
+**Calculation:** Identical to the original bar chart — for each score term, computes `(score / maxScore) * 100` per eligible site, then returns the median across all eligible sites, rounded to the nearest integer. Each row in the `plotByComponent` groups contributes `term1` (objective) and, when present, `term2` (subjective) into the flat `scoreTerms` list sent to the server.
+
+**Plot configuration:** Shares the same `plotByComponent` configuration as `profileBarchart` in [`sjglobal.profile.ts`](../../../../dataset/sjglobal.profile.ts) — the v2 difference is architectural (route + data flow), not config shape.
+
+**Role and cohort coverage:**
+
+| Role | `filterByUserSites` | Eligible samples | `sites` in response |
+|------|---------------------|-----------------|---------------------|
+| Public | false | All sites | `[]` (never exposed) |
+| Admin | false | All sites | Full sorted list |
+| Site user | false | All sites (global aggregate) | Full sorted list |
+| Site user | true | User's sites only | User's sites only |
+
+
 ### Facility Radar Chart
 **Class:** [profileRadarFacility.js](../profileRadarFacility.js)  
 **Title:** Comparison of Institutional and Aggregated Score-based Results by Module  

--- a/client/plots/profile/barchart2.ts
+++ b/client/plots/profile/barchart2.ts
@@ -1,0 +1,414 @@
+import { getCompInit, copyMerge } from '#rx'
+import { fillTwLst } from '#termsetting'
+import { scaleLinear as d3Linear } from 'd3-scale'
+import { axisTop } from 'd3-axis'
+import { dofetch3 } from '#common/dofetch'
+import {
+	profilePlot,
+	getDefaultProfilePlotSettings,
+	getProfilePlotConfig,
+	FULL_COHORT,
+	ABBREV_COHORT
+} from './profilePlot.js'
+
+/*
+profileBarchart2 — redesigned bar chart that establishes the per-plot dedicated
+route architecture for the bar chart (following profilePolar2's lead).
+
+Key differences from profileBarchart:
+  - Dedicated server route: termdb/profileBarchart2Scores.
+  - Server-side facility term derivation: client does not send facilityTW.
+  - Always aggregated: median percentage across eligible sites.
+  - Minimal client payload: scoreTerms stripped to { term: { id }, q }.
+  - Public role: sites is always [] in the response.
+  - Cleaner rendering structure: plot() split into focused private methods.
+*/
+
+const stepx = 500
+const barwidth = 400
+
+class ProfileBarchart2 extends profilePlot {
+	static type = 'profileBarchart2'
+	additionalInputs: any[]
+	componentNames!: { value: string; label: string }[]
+	configProfileComponent: any
+	rowCount: number = 0
+	profileComponent!: string
+
+	constructor(opts) {
+		super(opts, 'profileBarchart2')
+		this.additionalInputs = []
+	}
+
+	async init(appState) {
+		await super.init(appState)
+		const config = appState.plots.find(p => p.id === this.id)
+		this.componentNames = config.plotByComponent.map(elem => ({
+			value: elem.profileComponent.name,
+			label: elem.profileComponent.name
+		}))
+		const profileComponentInput = {
+			label: 'Component',
+			type: 'dropdown',
+			chartType: 'profileBarchart2',
+			options: this.componentNames,
+			settingsKey: 'profileComponent',
+			callback: value => this.setProfileComponent(value)
+		}
+		this.additionalInputs.push(profileComponentInput)
+	}
+
+	setProfileComponent(value) {
+		this.settings.profileComponent = value
+		this.app.dispatch({ type: 'plot_edit', id: this.id, config: this.config })
+	}
+
+	async main() {
+		try {
+			await super.main()
+			this.configProfileComponent =
+				this.config.plotByComponent.find(comp => comp.profileComponent.name == this.settings.profileComponent) ||
+				this.config.plotByComponent[0]
+			this.rowCount = 0
+			this.scoreTerms = []
+			for (const group of this.configProfileComponent.groups)
+				for (const row of group.rows) {
+					this.rowCount++
+					if (row.term1) this.scoreTerms.push(row.term1)
+					if (row.term2) this.scoreTerms.push(row.term2)
+				}
+			await this.setControls(this.additionalInputs)
+			this.profileComponent = this.settings.profileComponent || this.componentNames[0].value
+			this.plot()
+		} catch (e) {
+			console.error(e)
+			throw `${e} [profileBarchart2 main()]`
+		}
+	}
+
+	/**
+	 * Override setControls() to fetch data from the dedicated barchart2 route.
+	 * The base class setControls() builds filter UI and sets this.filter but
+	 * skips the data fetch for profileBarchart2 (see profilePlot.ts).
+	 * This method calls termdb/profileBarchart2Scores, which derives the facility
+	 * term server-side and returns aggregated (median) percentages.
+	 */
+	async setControls(additionalInputs: any[] = []) {
+		await super.setControls(additionalInputs)
+		this.data = await this.fetchAggregatedScores()
+		if (this.data && 'error' in this.data) throw this.data.error
+	}
+
+	private async fetchAggregatedScores() {
+		// No facilityTW — server derives it from term ID prefixes in the request.
+		// scoreTerms stripped to { term: { id }, q } only — server fills the rest via termjsonByOneid.
+		return dofetch3('termdb/profileBarchart2Scores', {
+			body: {
+				genome: this.state.vocab.genome,
+				dslabel: this.state.vocab.dslabel,
+				scoreTerms: this.scoreTerms.map((t: any) => ({
+					score: { term: { id: t.score.term.id }, q: t.score.q },
+					maxScore: typeof t.maxScore === 'number' ? t.maxScore : { term: { id: t.maxScore.term.id }, q: t.maxScore.q }
+				})),
+				filterByUserSites: this.settings?.filterByUserSites,
+				filter: this.filter
+			}
+		})
+	}
+
+	onMouseOut(event) {
+		if (event.target.tagName == 'rect' && event.target.getAttribute('fill-opacity') == 0.3) {
+			event.target.setAttribute('fill-opacity', 0)
+		}
+	}
+
+	onMouseOver(event) {
+		if (event.target.tagName == 'rect' && event.target.getAttribute('fill-opacity') == 0) {
+			event.target.setAttribute('fill-opacity', 0.3)
+		}
+	}
+
+	plot() {
+		const { hasSubjectiveData } = this.createSvg()
+		this.drawTitleAndDefs(hasSubjectiveData)
+		this.drawColumnHeaders(hasSubjectiveData)
+		const yEnd = this.drawComponentRows(hasSubjectiveData)
+		this.drawGuideLines(yEnd, hasSubjectiveData)
+		this.drawLegend(yEnd, hasSubjectiveData)
+	}
+
+	private createSvg() {
+		const hasSubjectiveData = this.configProfileComponent.hasSubjectiveData
+		const width = this.state.activeCohort == ABBREV_COHORT ? 1000 : 1300
+		const height = this.rowCount * 32 + 450
+		this.dom.svg = this.dom.plotDiv.append('svg').attr('width', width).attr('height', height)
+		return { width, height, hasSubjectiveData }
+	}
+
+	private drawTitleAndDefs(_hasSubjectiveData: boolean) {
+		const title =
+			this.state.activeCohort == ABBREV_COHORT
+				? `Score-based Results for the ${this.profileComponent} Component by Module and Domain Compared with End-User Impression`
+				: `Objective ${
+						this.profileComponent == 'Patients and Outcomes' ? '' : 'and Subjective '
+				  }Score-based Results for the ${this.profileComponent} Component by Module and Domain`
+		this.dom.svg.append('text').attr('transform', `translate(50, 30)`).attr('font-weight', 'bold').text(title)
+
+		const color = this.configProfileComponent.profileComponent.color
+		this.dom.svg
+			.append('defs')
+			.append('pattern')
+			.attr('id', `${this.id}_diagonalHatch`)
+			.attr('patternUnits', 'userSpaceOnUse')
+			.attr('width', 4)
+			.attr('height', 4)
+			.append('path')
+			.attr('d', 'M-1,1 l2,-2 M0,4 l4,-4 M3,5 l2,-2')
+			.attr('stroke-width', 1)
+			.attr('stroke', color)
+	}
+
+	private drawColumnHeaders(hasSubjectiveData: boolean) {
+		const svg = this.dom.svg
+		const config = this.config
+		for (const [i, c] of config.columnNames.entries()) {
+			if (i == 1 && !hasSubjectiveData) break
+			const x = (i % 2 == 0 ? 400 : 900) + 10
+			const y = 70
+			svg
+				.append('text')
+				.attr('transform', `translate(${x}, ${y})`)
+				.attr('text-anchor', 'start')
+				.style('font-weight', 'bold')
+				.text(c)
+			this.drawAxis(x, y + 30)
+		}
+	}
+
+	private drawAxis(x: number, y: number) {
+		const xAxisScale = d3Linear().domain([0, 100]).range([0, barwidth])
+		this.dom.svg.append('g').attr('transform', `translate(${x}, ${y})`).call(axisTop(xAxisScale))
+	}
+
+	private drawComponentRows(hasSubjectiveData: boolean): number {
+		const svg = this.dom.svg
+		const step = 30
+		let y = 70
+		for (const group of this.configProfileComponent.groups) {
+			svg
+				.append('text')
+				.attr('transform', `translate(${50}, ${y + 40})`)
+				.attr('text-anchor', 'start')
+				.text(`${group.label}`)
+				.style('font-weight', 'bold')
+
+			y += step + 20
+			for (const row of group.rows) {
+				const g = svg.append('g')
+				g.append('rect')
+					.attr('transform', `translate(${20}, ${y - 6})`)
+					.attr('x', 0)
+					.attr('y', 0)
+					.attr('width', hasSubjectiveData ? 1500 : 850)
+					.attr('height', 30)
+					.attr('fill', '#f8d335')
+					.attr('fill-opacity', 0)
+				const x = 400
+				if (row.term1) this.drawRect(x, y, row, 'term1', g)
+				if (row.term2) this.drawRect(x + stepx, y, row, 'term2', g)
+				y += step
+			}
+		}
+		return y
+	}
+
+	private drawRect(x: number, y: number, row: any, field: 'term1' | 'term2', g: any) {
+		const hasSubjectiveData = this.configProfileComponent.hasSubjectiveData
+		const d = row[field]
+		let subjectiveTerm = false
+		if ((row.name == 'Total Module' || row.name == 'End-user Impression*') && !row.term2) subjectiveTerm = true
+		const termColor = d.score.term.color
+		const value = this.getPercentage(d)
+		const isFirst = field == 'term1' || (field == 'term2' && !row.term1)
+		const pairValue = field == 'term1' ? this.getPercentage(row.term2) : this.getPercentage(row.term1)
+		const width = value ? (value / 100) * barwidth : 0
+		if (value) {
+			const isObjective =
+				this.state.activeCohort == FULL_COHORT && this.settings.profileComponent == 'Patients and Outcomes'
+					? true
+					: !subjectiveTerm && (pairValue || !hasSubjectiveData)
+			const rect = g
+				.append('rect')
+				.attr('transform', `translate(${x + 10}, ${y})`)
+				.attr('pointer-events', 'none')
+				.attr('x', 0)
+				.attr('y', 0)
+				.attr('width', width)
+				.attr('height', 20)
+			if (isObjective) rect.attr('fill', termColor)
+			else {
+				const termid = this.id + d.score.term.id
+				g.append('defs')
+					.append('pattern')
+					.attr('id', termid)
+					.attr('patternUnits', 'userSpaceOnUse')
+					.attr('width', 4)
+					.attr('height', 4)
+					.append('path')
+					.attr('d', 'M-1,1 l2,-2 M0,4 l4,-4 M3,5 l2,-2')
+					.attr('stroke-width', 1)
+					.attr('stroke', termColor)
+				rect.attr('fill', `url(#${termid})`)
+			}
+		}
+		const text = g
+			.append('text')
+			.attr('pointer-events', 'none')
+			.attr('text-anchor', 'end')
+			.text(`${value || 0}%`)
+		if (width > 0) text.attr('transform', `translate(${x + width + 55}, ${y + 15})`)
+		else if (!pairValue && field == 'term1') text.attr('transform', `translate(${x + 35}, ${y + 15})`)
+
+		if (isFirst)
+			g.append('text')
+				.attr('transform', `translate(${field == 'term1' ? x : x - stepx}, ${y + 15})`)
+				.attr('text-anchor', 'end')
+				.text(row.name)
+				.attr('pointer-events', 'none')
+	}
+
+	private drawGuideLines(yEnd: number, hasSubjectiveData: boolean) {
+		this.drawGuide(410, 120, 50, yEnd, 'B')
+		this.drawGuide(410, 120, 75, yEnd, 'A')
+		if (!hasSubjectiveData) return
+		this.drawGuide(910, 120, 50, yEnd, 'B')
+		this.drawGuide(910, 120, 75, yEnd, 'A')
+	}
+
+	private drawGuide(x: number, y: number, percent: number, y2: number, text: string) {
+		const svg = this.dom.svg
+		const x1 = x + (percent / 100) * barwidth
+		svg
+			.append('line')
+			.style('stroke', '#aaa')
+			.style('stroke-width', 1)
+			.style('stroke-dasharray', '5, 5')
+			.attr('x1', x1)
+			.attr('y1', y)
+			.attr('x2', x1)
+			.attr('y2', y2)
+		svg
+			.append('text')
+			.attr('transform', `translate(${x1 + 0.125 * barwidth}, ${y2 + 20})`)
+			.attr('text-anchor', 'middle')
+			.text(text)
+			.style('font-weight', 'bold')
+		if (percent == 50)
+			svg
+				.append('text')
+				.attr('transform', `translate(${x1 - 0.25 * barwidth}, ${y2 + 20})`)
+				.attr('text-anchor', 'middle')
+				.text('C')
+				.style('font-weight', 'bold')
+	}
+
+	private drawLegend(yEnd: number, hasSubjectiveData: boolean) {
+		this.legendG = this.dom.svg
+			.append('g')
+			.attr('data-testid', 'sjpp-profileBarchart2-legend')
+			.attr('transform', `translate(400,${yEnd + 90})`)
+		this.filterG = this.dom.svg.append('g').attr('transform', `translate(0,${yEnd + 90})`)
+
+		if (!this.isComparison) {
+			this.legendG
+				.append('text')
+				.attr('text-anchor', 'left')
+				.style('font-weight', 'bold')
+				.text('Overall Score')
+				.attr('transform', `translate(0, -5)`)
+
+			this.addLegendItem('A', 'More than 75% of possible scorable items', 1)
+			this.addLegendItem('B', '50-75% of possible scorable items', 2)
+			this.addLegendItem('C', 'Less than 50% of possible scorable items', 3)
+			if (this.state.activeCohort == ABBREV_COHORT) {
+				this.addEndUserImpressionNote(this.legendG.append('g'))
+			} else this.addPOCNote(this.legendG.append('g'))
+		}
+		this.addFilterLegend()
+
+		if (!hasSubjectiveData) return
+
+		const color = this.configProfileComponent.profileComponent.color
+		const svg = this.dom.svg
+		const y = yEnd + 40
+		let x = 600
+		const lineG = svg.append('g')
+		this.drawLegendRect(x, y, 'and', color, lineG)
+		x += 300
+		this.drawLegendRect(x, y, 'or', color, lineG)
+	}
+
+	drawLegendRect(x: number, y: number, operator: 'and' | 'or', color: string, lineG: any) {
+		const rect = lineG
+			.append('g')
+			.attr('transform', `translate(${x}, ${y})`)
+			.append('rect')
+			.attr('x', 0)
+			.attr('y', 0)
+			.attr('width', 20)
+			.attr('height', 20)
+		if (operator == 'and') rect.attr('fill', color)
+		else rect.attr('fill', `url(#${this.id}_diagonalHatch)`)
+
+		const text = this.dom.svg
+			.append('text')
+			.attr('transform', `translate(${x + 25}, ${y + 15})`)
+			.attr('text-anchor', 'start')
+			.text('Objective ')
+		text.append('tspan').attr('font-weight', 'bold').text(operator)
+		text.append('tspan').text(' Subjective data')
+	}
+}
+
+export async function getPlotConfig(opts, app, _activeCohort) {
+	try {
+		const activeCohort = _activeCohort === undefined ? app.getState().activeCohort : _activeCohort
+		const defaults = await getProfilePlotConfig(activeCohort, app, opts)
+		if (!defaults) throw 'default config not found in termdbConfig.plotConfigByCohort.profileBarchart2'
+		defaults.settings = { profileBarchart2: getDefaultProfilePlotSettings() }
+		let config = structuredClone(defaults)
+		config = copyMerge(config, opts)
+		config.settings.controls = { isOpen: false }
+		const twlst: any[] = []
+		for (const profileComponent of config.plotByComponent) {
+			profileComponent.hasSubjectiveData = false
+			for (const group of profileComponent.groups)
+				for (const row of group.rows) {
+					if (row.term1) {
+						row.term1.score.q = row.term1.maxScore.q = { mode: 'continuous' }
+						twlst.push(row.term1.score)
+						twlst.push(row.term1.maxScore)
+					}
+					if (row.term2) {
+						row.term2.score.q = row.term2.maxScore.q = { mode: 'continuous' }
+						twlst.push(row.term2.score)
+						twlst.push(row.term2.maxScore)
+					}
+					if (row.term1 && row.term2) profileComponent.hasSubjectiveData = true
+				}
+		}
+		await fillTwLst(twlst, app.vocabApi)
+
+		return config
+	} catch (e) {
+		throw `${e} [profileBarchart2 getPlotConfig()]`
+	}
+}
+
+export const profileBarchart2Init = getCompInit(ProfileBarchart2)
+// this alias will allow abstracted dynamic imports
+export const componentInit = profileBarchart2Init
+
+export function getDefaultProfileBarchart2Settings() {
+	return {}
+}

--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -267,9 +267,9 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 					facilityTW: this.config.facilityTW,
 					filterByUserSites: this.settings.filterByUserSites
 				})
-			else if (this.type != 'profilePolar2')
-				// profilePolar2 skips this fetch — its subclass setControls() calls
-				// the dedicated termdb/profilePolar2Scores route instead
+			else if (this.type != 'profilePolar2' && this.type != 'profileBarchart2')
+				// profilePolar2 and profileBarchart2 skip this fetch — their subclass setControls()
+				// calls their dedicated termdb/profilePolar2Scores / termdb/profileBarchart2Scores route instead
 				this.data = await this.app.vocabApi.getProfileScores({
 					scoreTerms: this.scoreTerms,
 					filter: this.filter,
@@ -450,7 +450,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 				const activeCohort = this.state.activeCohort
 				let link
 				if (activeCohort == ABBREV_COHORT) {
-					if (chartType == 'profileBarchart')
+					if (chartType == 'profileBarchart' || chartType == 'profileBarchart2')
 						link =
 							'https://global.stjude.org/content/dam/global/en-us/documents/no-index/bar-graph-abbr-profiledash.pdf'
 					else if (chartType == 'profilePolar' || chartType == 'profilePolar2')
@@ -459,7 +459,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 					else if (chartType.startsWith('profileRadar'))
 						link = 'https://global.stjude.org/content/dam/global/en-us/documents/no-index/radar-abbr-profiledash.pdf'
 				} else if (activeCohort == FULL_COHORT) {
-					if (chartType == 'profileBarchart')
+					if (chartType == 'profileBarchart' || chartType == 'profileBarchart2')
 						link =
 							'https://global.stjude.org/content/dam/global/en-us/documents/no-index/bar-graph-full-profiledash.pdf'
 					else if (chartType == 'profilePolar' || chartType == 'profilePolar2')

--- a/server/routes/profile.barchart2.ts
+++ b/server/routes/profile.barchart2.ts
@@ -136,12 +136,32 @@ async function getScores(query: any, ds: any) {
 /**
  * For each sample (site), computes (score / maxScore) * 100,
  * collects all values, sorts them, and returns the median — rounded to integer.
- * Returns null when no samples have data for the term.
+ * d.maxScore can be either a number or a term wrapper.
+ * Skips samples where score or maxScore are missing or maxScore is zero (to avoid NaN/Infinity).
+ * Returns null when no samples have valid data for the term.
  */
 function computeMedianPercentage(d: any, samples: any[]): number | null {
-	const percentages = samples
-		.filter(s => s[d.score.$id]?.value != null)
-		.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
+	const percentages: number[] = []
+
+	for (const s of samples) {
+		const scoreValue = s[d.score.$id]?.value
+		if (scoreValue == null) continue
+
+		// Resolve maxScore: either a number or a term wrapper
+		let maxScoreValue: number | null = null
+		if (typeof d.maxScore === 'number') {
+			maxScoreValue = d.maxScore
+		} else {
+			// d.maxScore is a term wrapper
+			maxScoreValue = s[d.maxScore.$id]?.value
+		}
+
+		// Skip if max score is null or zero (avoid NaN or Infinity)
+		if (maxScoreValue == null || maxScoreValue === 0) continue
+
+		const percentage = (scoreValue / maxScoreValue) * 100
+		percentages.push(percentage)
+	}
 
 	if (percentages.length === 0) return null
 	percentages.sort((a, b) => a - b)

--- a/server/routes/profile.barchart2.ts
+++ b/server/routes/profile.barchart2.ts
@@ -1,0 +1,152 @@
+import type { RouteApi } from '#types'
+import { ProfileScoresPayload } from '#types/checkers'
+import { getData } from '../src/termdb.matrix.js'
+
+/*
+Route for profileBarchart2.
+
+Key differences from termdb.profileScores:
+  - Client does NOT send facilityTW.
+  - Server derives the facility term id by inspecting term ID prefixes already
+    present in the request (scoreTerms or filter), so no cohort-specific logic
+    is needed on the client side.
+  - Site data is queried server-side using getData(), same pattern as
+    termdb.profileScores.ts getScoresData().
+  - Always returns aggregated (median across all eligible sites) percentages.
+
+Mirrors profile.polar2.ts. Each bar chart row contributes term1 (objective) and
+optionally term2 (subjective). The client flattens them into scoreTerms, so this
+route is shape-identical to polar2's request/response.
+*/
+
+export const api: RouteApi = {
+	endpoint: 'termdb/profileBarchart2Scores',
+	methods: {
+		get: {
+			...ProfileScoresPayload,
+			init
+		},
+		post: {
+			...ProfileScoresPayload,
+			init
+		}
+	}
+}
+
+function init({ genomes }) {
+	return async (req, res): Promise<void> => {
+		try {
+			const g = genomes[req.query.genome]
+			if (!g) throw 'invalid genome name'
+			const ds = g.datasets?.[req.query.dslabel]
+			const result = await getScores(req.query, ds)
+			res.send(result)
+		} catch (e: any) {
+			console.log(e)
+			res.send({ status: 'error', error: e.message || e })
+		}
+	}
+}
+
+/**
+ * Derives the cohort prefix from term IDs already present in the request.
+ * Primary source: scoreTerms (always present in the request).
+ * Fallback: filter term IDs (may be absent if no filters are applied).
+ * Term IDs share the same prefix as the facility term for a given cohort.
+ */
+function derivePrefix(query: any): string {
+	const firstScoreId = query.scoreTerms?.[0]?.score?.term?.id
+	if (firstScoreId?.startsWith('F')) return 'F'
+	if (firstScoreId?.startsWith('A')) return 'A'
+	for (const entry of query.filter?.lst || []) {
+		const id = entry.tvs?.term?.id
+		if (id?.startsWith('F')) return 'F'
+		if (id?.startsWith('A')) return 'A'
+	}
+	throw 'cannot determine cohort prefix from scoreTerms or filter term IDs'
+}
+
+async function getScores(query: any, ds: any) {
+	// 1. Derive facility term id from term IDs already in the request.
+	const { activeCohort, clientAuthResult } = query.__protected__
+	const prefix = derivePrefix(query)
+	const facilityTermId = `${prefix}UNIT`
+
+	// Minimal term wrapper — getData will fill term.values, $id, etc.
+	const facilityTW: any = { term: { id: facilityTermId }, q: {} }
+
+	// 2. Collect all terms for getData: facility + every score/maxScore pair
+	const terms: any[] = [facilityTW]
+	for (const t of query.scoreTerms) {
+		terms.push(t.score)
+		if (t.maxScore?.term) terms.push(t.maxScore)
+	}
+
+	// 3. Allow facility term to be seen by all users when not filtering by user sites
+	if (!query.filterByUserSites) {
+		query.__protected__.ignoredTermIds.push(facilityTermId)
+	}
+
+	// 4. Query eligible site data at module level
+	const cohortAuth = clientAuthResult[activeCohort]
+	const isPublic = !cohortAuth?.role || cohortAuth.role === 'public'
+	const userSites = cohortAuth?.sites
+	const raw = await getData(
+		{
+			terms,
+			filter: query.filter,
+			__protected__: query.__protected__
+		},
+		ds
+	)
+	if (raw.error) throw raw.error
+
+	// 5. Build eligible sites list (filter to user's accessible sites if needed)
+	const sampleList: any[] = Object.values(raw.samples)
+	let sites = sampleList.map(s => {
+		const val = s[facilityTW.$id].value
+		let label = facilityTW.term.values?.[val]?.label || val
+		if (label.length > 50) label = label.slice(0, 47) + '...'
+		return { value: val, label }
+	})
+	if (userSites && query.filterByUserSites) {
+		sites = sites.filter(s => userSites.includes(s.value))
+	}
+	sites.sort((a, b) => a.label.localeCompare(b.label))
+
+	// 6. Compute median percentage per score term across all eligible sites.
+	const samples: any[] = Object.values(raw.samples)
+	const eligibleSamples =
+		userSites && query.filterByUserSites ? samples.filter(s => userSites.includes(s[facilityTW.$id].value)) : samples
+
+	const term2Score: Record<string, number> = {}
+	for (const d of query.scoreTerms) {
+		const score = computeMedianPercentage(d, eligibleSamples)
+		if (score !== null) term2Score[d.score.term.id] = score
+	}
+
+	return {
+		term2Score,
+		// Public users see only aggregated scores — do not expose site IDs or names
+		sites: isPublic ? [] : sites,
+		n: eligibleSamples.length
+	}
+}
+
+/**
+ * For each sample (site), computes (score / maxScore) * 100,
+ * collects all values, sorts them, and returns the median — rounded to integer.
+ * Returns null when no samples have data for the term.
+ */
+function computeMedianPercentage(d: any, samples: any[]): number | null {
+	const percentages = samples
+		.filter(s => s[d.score.$id]?.value != null)
+		.map(s => (s[d.score.$id].value / (s[d.maxScore.$id]?.value || d.maxScore)) * 100)
+
+	if (percentages.length === 0) return null
+	percentages.sort((a, b) => a - b)
+
+	const mid = Math.floor(percentages.length / 2)
+	const median = percentages.length % 2 !== 0 ? percentages[mid] : (percentages[mid - 1] + percentages[mid]) / 2
+	return Math.round(median)
+}

--- a/server/src/app.routes.js
+++ b/server/src/app.routes.js
@@ -76,5 +76,6 @@ export const routeFiles = [
 	import('../routes/termdb.filterTermValues.ts'),
 	import('../routes/termdb.profileScores.ts'),
 	import('../routes/termdb.profileFormScores.ts'),
-	import('../routes/profile.polar2.ts')
+	import('../routes/profile.polar2.ts'),
+	import('../routes/profile.barchart2.ts')
 ]


### PR DESCRIPTION
This pull request introduces a new "Bar Chart v2" (`profileBarchart2`) plot type, following a more secure, modular, and maintainable architecture similar to `profilePolar2`. The changes include the addition of the new chart type to the UI, routing, and documentation, as well as significant internal improvements to the handling of bar chart series/row ordering and exclusion logic. There are also updates to integration tests to accommodate the new normalization and ordering behaviors.

**Bar Chart v2 introduction and documentation:**

- Added a new chart type, `profileBarchart2`, to the chart selection UI and dynamic import system, with dedicated documentation describing its architecture, server route, and differences from the original bar chart. 
- Updated the help/documentation button logic so that `profileBarchart2` displays the correct PDF for both full and abbreviated cohorts, matching the original bar chart. 
**Bar chart internal logic improvements:**

- Refactored the bar chart's settings and exclusion logic to robustly normalize series and row identifiers, ensuring consistent handling of key/label/value mappings for categorical and numeric terms, and improving the stability of hidden series/legend interactions. 
- Enhanced the ordering logic for bar chart series and overlays, so that bars and overlays are displayed in a consistent, declared, and predictable order, especially for numeric and condition-type terms.

**General codebase and error handling improvements:**

- Improved global error logging in `getPlotConfig` to avoid issues with unavailable `console` in some contexts.
- Updated the bar chart's DOM sizing logic to use a safer global reference for `window.innerWidth`.

**Integration test updates:**

- Adjusted barchart integration tests to account for new normalization logic, series ordering, and hidden legend label behaviors, making the tests more robust to changes in identifier semantics. 
**Profile plot architecture:**

- Modified the abstract `profilePlot` class to ensure that both `profilePolar2` and the new `profileBarchart2` use their dedicated server routes and do not use the shared profile scores fetch logic.

These changes collectively modernize the bar chart architecture, improve data flow security, and lay the groundwork for more maintainable and extensible chart implementations.# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
