### PR TITLE
retry the request for cases with gene exp data until the maxCase4gene…

### DIFF
--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -462,22 +462,29 @@ async function getCases4exp(q, ds, case_filters) {
 	}
 	try {
 		const { host, headers } = ds.getHostHeaders(q)
-		const re = await xfetch(joinUrl(host.rest, 'cases'), {
-			method: 'POST',
-			timeout: false,
-			headers,
-			body,
-			signal: q.__abortSignal
-		})
-		if (!Array.isArray(re.data.hits)) throw 're.data.hits[] not array'
-		for (const h of re.data.hits) {
-			if (h.id && ds.__gdc.casesWithExpData.has(h.id)) {
-				lst.push(h.id)
-				if (q.forClusteringAnalysis && lst.length == maxCase4geneExpCluster) {
-					// flag indicates it is for clustering. apply this limit to not to overload clustering app, stop collecting when max number of cases is reached
-					break
+		let currTotal = 0
+		while (lst.length < maxCase4geneExpCluster) {
+			const re = await xfetch(joinUrl(host.rest, 'cases'), {
+				method: 'POST',
+				timeout: false,
+				headers,
+				body: Object.assign({ from: currTotal + 1 }, body),
+				signal: q.__abortSignal
+			})
+			if (!Array.isArray(re.data.hits)) throw 're.data.hits[] not array'
+			for (const h of re.data.hits) {
+				if (h.id && ds.__gdc.casesWithExpData.has(h.id)) {
+					lst.push(h.id)
+					if (q.forClusteringAnalysis && lst.length == maxCase4geneExpCluster) {
+						// flag indicates it is for clustering. apply this limit to not to overload clustering app, stop collecting when max number of cases is reached
+						break
+					}
 				}
 			}
+			if (lst.length >= maxCase4geneExpCluster) break
+			const { page, pages, total, count } = re.data.pagination
+			currTotal += count
+			if (!page || page >= pages || currTotal >= total) break
 		}
 		return lst
 	} catch (e) {

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -457,18 +457,19 @@ async function getCases4exp(q, ds, case_filters) {
 	const body = {
 		fields: 'case_id',
 		case_filters,
-		// hiercluster app will limit max number of allowed cases by hardcoded value. times 10 is a generous guess to allow for cases without gene exp data, as is from current cohort
+		// hiercluster app will limit max number of allowed cases by hardcoded value.
+		// times 10 is a generous guess to allow for cases without gene exp data, as is from current cohort
 		size: maxCase4geneExpCluster * 10
 	}
 	try {
 		const { host, headers } = ds.getHostHeaders(q)
 		let currTotal = 0
-		while (lst.length < maxCase4geneExpCluster) {
+		while (!q.forClusteringAnalysis || lst.length < maxCase4geneExpCluster) {
 			const re = await xfetch(joinUrl(host.rest, 'cases'), {
 				method: 'POST',
 				timeout: false,
 				headers,
-				body: Object.assign({ from: currTotal + 1 }, body),
+				body: Object.assign({ from: currTotal }, body),
 				signal: q.__abortSignal
 			})
 			if (!Array.isArray(re.data.hits)) throw 're.data.hits[] not array'
@@ -481,7 +482,9 @@ async function getCases4exp(q, ds, case_filters) {
 					}
 				}
 			}
-			if (lst.length >= maxCase4geneExpCluster) break
+			// querying for additional data is limited for clustering use case,
+			// but is not limited by a max constant for non-cluster use case
+			if (q.forClusteringAnalysis && lst.length >= maxCase4geneExpCluster) break
 			const { page, pages, total, count } = re.data.pagination
 			currTotal += count
 			if (!page || page >= pages || currTotal >= total) break


### PR DESCRIPTION
…ExpCluster is reached or there are no more pages to request

# Description

Fixes the remaining issue in https://gdc-ctds.atlassian.net/browse/SV-2686. 

Test with http://localhost:3000/example.gdc.exp.html?maxGenes=5&cohort=TARGET-AML,FM-AD, there should be rendered data.

Also tested with all unit and integration tests, plus updated ppgdc e2e tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
