### PR TITLE
sc: add checkPlotAvailability to efficiently get available plots

### DIFF
--- a/client/plots/sc/model/SCModel.ts
+++ b/client/plots/sc/model/SCModel.ts
@@ -75,6 +75,7 @@ export class SCModel {
 		return {
 			genome: this.state.vocab.genome,
 			dslabel: this.state.vocab.dslabel,
+			checkPlotAvailability: true, // only return available plot names, but not actual plot data
 			plots,
 			sample: {
 				eID: config.settings.sc.item.experiment,

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -7,7 +7,6 @@ import { run_rust } from '@sjcrh/proteinpaint-rust'
 import serverconfig from '#src/serverconfig.js'
 import type {
 	SingleCellQuery,
-	SingleCellSamples,
 	SingleCellDataNative,
 	SingleCellGeneExpressionNative,
 	SingleCellSample,
@@ -78,7 +77,7 @@ export async function validate_query_singleCell(ds: any, genome: any) {
 		// ds-supplied
 	} else {
 		// add q.samples.get() for native ds
-		await validateSamplesNative(q.samples, q.data as SingleCellDataNative, ds)
+		await validateSamplesNative(q, ds)
 	}
 
 	// validate required q.data{}
@@ -123,12 +122,12 @@ function validateImages(images) {
  * Adds ds.queries.singleCell.samples.get() for native ds (see route init() above).
  * Adds ds.queries.singleCell.terms which is list of all possible colorBy terms
  * defined in the ds file, for use in vocabApi methods later.
- * @param S ds.queries.singleCell.samples{}
- * @param D ds.queries.singleCell.data{}
  * @param ds Entire dataset configuration from the ds file
  */
-async function validateSamplesNative(S: SingleCellSamples, D: SingleCellDataNative, ds: any) {
+async function validateSamplesNative(q: SingleCellQuery, ds: any) {
 	// folder of every plot contains text files, one file per sample and named by sample names. each folder may contain variable number of samples. look into all folders to get union of samples as list of samples with sc data and return in this getter
+	const S: any = q.samples,
+		D: any = q.data
 
 	// k: sample integer id
 	// v: { sample: string name, tid1:v1, ...} term ids are from S.sampleColumns[]. list of sample objects are returned in getter
@@ -151,6 +150,8 @@ async function validateSamplesNative(S: SingleCellSamples, D: SingleCellDataNati
 
 		if (!plot.colorColumns || plot.colorColumns.length == 0) continue
 	}
+	if (samples.size == 0) throw new Error('no scrna samples found')
+	console.log(samples.size, 'singleCell samples loaded from ' + ds.label)
 
 	// samples map populated with samples with sc data
 	if (S.sampleColumns) {
@@ -167,9 +168,16 @@ async function validateSamplesNative(S: SingleCellSamples, D: SingleCellDataNati
 		}
 	}
 
-	// FIXME must get q.filter and apply filter to list!!
 	S.get = () => {
-		return { samples: [...samples.values()] as SingleCellSample[] }
+		// FIXME must get q.filter and apply filter to list!!
+		const re: any = { samples: [...samples.values()] as SingleCellSample[] }
+		if (q.metaResults) {
+			// meta analysis results exist. pass it along with samples
+			re.metaResults = q.metaResults.map(i => {
+				return { name: i.name }
+			})
+		}
+		return re
 	}
 }
 

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -73,19 +73,21 @@ export async function validate_query_singleCell(ds: any, genome: any) {
 
 	// validate required q.samples{}
 	if (typeof q.samples != 'object') throw new Error('singleCell.samples{} not object')
+	if (typeof q.data != 'object') throw new Error('singleCell.data{} not object')
+
 	if (typeof q.samples.get == 'function') {
 		// ds-supplied
 	} else {
-		// add q.samples.get() for native ds
-		await validateSamplesNative(q, ds)
+		await validateSamples(q, ds)
+		// added q.samples.get()
 	}
 
 	// validate required q.data{}
-	if (typeof q.data != 'object') throw new Error('singleCell.data{} not object')
 	if (q.data.src == 'gdcapi') {
 		gdc_validate_query_singleCell_data(ds, genome) // todo change to ds-supplied q.data.get()
 	} else if (q.data.src == 'native') {
 		validateDataNative(q.data as SingleCellDataNative, ds)
+		// added q.data.get()
 	} else {
 		throw new Error('unknown singleCell.data.src')
 	}
@@ -122,12 +124,13 @@ function validateImages(images) {
  * Adds ds.queries.singleCell.samples.get() for native ds (see route init() above).
  * Adds ds.queries.singleCell.terms which is list of all possible colorBy terms
  * defined in the ds file, for use in vocabApi methods later.
+ * @param q query
  * @param ds Entire dataset configuration from the ds file
  */
-async function validateSamplesNative(q: SingleCellQuery, ds: any) {
+async function validateSamples(q: SingleCellQuery, ds: any) {
 	// folder of every plot contains text files, one file per sample and named by sample names. each folder may contain variable number of samples. look into all folders to get union of samples as list of samples with sc data and return in this getter
-	const S: any = q.samples,
-		D: any = q.data
+	const S: SingleCellQuery['samples'] = q.samples,
+		D = q.data as SingleCellDataNative
 
 	// k: sample integer id
 	// v: { sample: string name, tid1:v1, ...} term ids are from S.sampleColumns[]. list of sample objects are returned in getter
@@ -197,6 +200,29 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 	const file2Lines = {} // key: file path, value: string[]
 
 	D.get = async (q: TermdbSingleCellDataRequest) => {
+		if (q.checkPlotAvailability) {
+			const plots: any = []
+			for (const plot of D.plots) {
+				if (!q.plots.includes(plot.name)) continue
+				const tsvfile = path.join(
+					serverconfig.tpmasterdir,
+					plot.folder,
+					(q.sample?.eID || q.sample?.sID) + (plot.fileSuffix || '')
+				)
+				try {
+					await file_is_readable(tsvfile)
+					// file exists for this sample
+					plots.push({
+						name: plot.name,
+						expCells: [], // FIXME avoid breaking client but shouldn't be needed
+						noExpCells: []
+					})
+				} catch (_) {
+					// file doesn't exist for this sample. this is allowed
+				}
+			}
+			return { plots }
+		}
 		// if sample is int, may convert to string
 		const plots: Plot[] = [] // given a sample name, collect every plot data for this sample and return
 		let geneExpMap
@@ -211,7 +237,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 			const tsvfile = path.join(
 				serverconfig.tpmasterdir,
 				plot.folder,
-				(q.sample?.eID || q.sample?.sID) + plot.fileSuffix
+				(q.sample?.eID || q.sample?.sID) + (plot.fileSuffix || '')
 			)
 			if (!file2Lines[tsvfile]) {
 				await file_is_readable(tsvfile)

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2369,6 +2369,13 @@ async function getSinglecellDEgenes(q, degFileId, ds) {
 export function gdc_validate_query_singleCell_data(ds, genome) {
 	// q{} TermdbSinglecellDataRequest
 	ds.queries.singleCell.data.get = async q => {
+		if (q.checkPlotAvailability) {
+			// hardcoded to assume every sample has all plots
+			return {
+				plots: q.plots.map(p => ({ expCells: [], noExpCells: [], name: p }))
+			}
+		}
+
 		const { host, headers } = ds.getHostHeaders(q)
 		const sample = q.sample || q.singleCellPlot.sample
 		// do not use headers here that has accept: 'application/json'

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -919,6 +919,7 @@ export type SingleCellQuery = {
 	/** defines tsne/umap type of clustering maps for each sample
 	 */
 	data: SingleCellDataGdc | SingleCellDataNative
+	metaResults?: SingleCellMetaResult[]
 	/** defines available gene-level expression values for each cell of each sample */
 	geneExpression?: SingleCellGeneExpressionGdc | SingleCellGeneExpressionNative
 	/** Precomputed top differentialy expressed genes for a cell cluster, against rest of cells */
@@ -927,6 +928,23 @@ export type SingleCellQuery = {
 	images?: SCImages
 	/** Created on mds.init() from colorMap and alias within each plot. */
 	terms?: object[]
+}
+
+export type SingleCellMetaResult = {
+	/** identifier */
+	name: string
+	/** tsv file
+	- 1st column is cell barcode
+	- x/y coordinate column number is defined in coordsColumns{x,y} below
+	- additional columns for cell annotations, corresponds to colorColumns
+	- must have a column for sample name, to identify which sample the cell is from
+	*/
+	file: string
+	/** gene exp h5 file */
+	geneExpFile?: string
+	/** 0-based column number for x/y coordinate for this plot */
+	coordsColumns: { x: number; y: number }
+	colorColumns: ColorColumn[]
 }
 
 type SCImages = {

--- a/shared/types/src/routes/termdb.singlecellData.ts
+++ b/shared/types/src/routes/termdb.singlecellData.ts
@@ -38,6 +38,8 @@ export type TermdbSingleCellDataRequest = {
 	sample: { eID?: string; sID: string }
 	/** List of plot names from this sample to request data for */
 	plots: string[]
+	/** check plot availability for this sample, will not return actual plot data and speed up */
+	checkPlotAvailability?: boolean
 	/** Gene name to retrieve expression data for all cells of the given sample, and to overlay on maps */
 	gene?: string
 	/** in each plot, what Column name to color by 

--- a/shared/types/src/routes/termdb.singlecellSamples.ts
+++ b/shared/types/src/routes/termdb.singlecellSamples.ts
@@ -31,9 +31,10 @@ export type TermdbSingleCellSamplesRequest = {
 type ValidResponse = {
 	/** List of sample names with singlecell data */
 	samples: SingleCellSample[]
-	fields: string[]
-	columnNames: string[]
-	sameLegend?: boolean
+	metaResults?: {
+		/** identifier of one result */
+		name: string
+	}[]
 }
 
 export type TermdbSingleCellSamplesResponse = ErrorResponse | ValidResponse


### PR DESCRIPTION
# Description
all integration tests pass
gdc legacy sc works

known issue is that sc still displays all plots rather than only those returned by {checkPlotAvailability:true}. [test link](http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22BALL-scrna%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22sc%22}]})

this branch also introduces `metaResults[]` to a singlecell ds, and will be supported by sc
it does not impact current features

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
