### PR TITLE
GSEA: Reworked GSEA to use cache id

### DIFF
--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -1,5 +1,5 @@
 import * as d3axis from 'd3-axis'
-import { Menu, renderTable, table2col, axisstyle } from '#dom'
+import { Menu, renderTable, table2col, axisstyle, sayerror } from '#dom'
 import { dofetch3 } from '#common/dofetch'
 import { controlsInit } from './controls'
 import { getCompInit, copyMerge } from '#rx'
@@ -368,33 +368,43 @@ add:
 
 	//Ensure the image renders when toggling between tabs
 	if (self.config.gsea_params.geneset_name != null) {
-		if (self.settings.gsea_method == 'blitzgsea') {
-			self.config.gsea_params.method = self.settings.gsea_method
-			const image = await rungsea(self.config.gsea_params, self.dom)
-			// //render_gsea_plot(self, plot_data)
-			if (image.error) throw image.error
-			self.imageUrl = URL.createObjectURL(image)
-			const png_width = 600
-			const png_height = 400
-			self.dom.holder.append('img').attr('width', png_width).attr('height', png_height).attr('src', self.imageUrl)
-		} else if (self.settings.gsea_method == 'cerno') {
-			if (!self.rankedDE && self.config.gsea_params.cacheId) {
-				const deResp = await dofetch3('genesetEnrichment', {
-					body: {
-						genome: self.config.gsea_params.genome,
-						cacheId: self.config.gsea_params.cacheId,
-						fetchDE: true,
-						geneSetGroup: '-',
-						filter_non_coding_genes: false,
-						method: 'cerno'
-					}
-				})
-				if (deResp.error) throw deResp.error
-				self.rankedDE = deResp.data
+		try {
+			if (self.settings.gsea_method == 'blitzgsea') {
+				self.config.gsea_params.method = self.settings.gsea_method
+				const image = await rungsea(self.config.gsea_params, self.dom)
+				// //render_gsea_plot(self, plot_data)
+				if (image.error) throw image.error
+				self.imageUrl = URL.createObjectURL(image)
+				const png_width = 600
+				const png_height = 400
+				self.dom.holder.append('img').attr('width', png_width).attr('height', png_height).attr('src', self.imageUrl)
+			} else if (self.settings.gsea_method == 'cerno') {
+				if (!self.rankedDE && self.config.gsea_params.cacheId) {
+					const deResp = await dofetch3('genesetEnrichment', {
+						body: {
+							genome: self.config.gsea_params.genome,
+							cacheId: self.config.gsea_params.cacheId,
+							fetchDE: true,
+							geneSetGroup: '-',
+							filter_non_coding_genes: false,
+							method: 'cerno'
+						}
+					})
+					if (deResp.error) throw deResp.error
+					self.rankedDE = deResp.data
+				}
+				render_cerno_plot(self, output)
+			} else {
+				throw 'Unknown method:' + self.settings.gsea_method
 			}
-			render_cerno_plot(self, output)
-		} else {
-			throw 'Unknown method:' + self.settings.gsea_method
+		} catch (e) {
+			self.dom.holder.selectAll('*').remove()
+			const msg = String(e?.message || e)
+			const userMsg = /ENOENT|no such file/i.test(msg)
+				? 'The differential-analysis cache for this GSEA has expired. Reopen the volcano plot to regenerate it.'
+				: msg
+			sayerror(self.dom.holder, userMsg)
+			return
 		}
 	}
 

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -248,11 +248,12 @@ class gsea extends PlotBase {
 
 		this.imageUrl = null // Reset the image URL
 		await this.setControls()
-		if (this.dom.header)
+		if (this.dom.header) {
+			const geneCount = this.config.gsea_params.genes_length ?? this.config.gsea_params.genes?.length ?? 0
 			this.dom.header.html(
-				this.config.gsea_params.genes_length +
-					' genes <span style="font-size:.8em;opacity:.7">GENE SET ENRICHMENT ANALYSIS</span>'
+				geneCount + ' genes <span style="font-size:.8em;opacity:.7">GENE SET ENRICHMENT ANALYSIS</span>'
 			)
+		}
 		render_gsea(this)
 	}
 }
@@ -346,12 +347,18 @@ add:
 
 	let output
 	try {
+		const p = self.config.gsea_params
 		const body = {
-			genome: self.config.gsea_params.genome,
-			cacheId: self.config.gsea_params.cacheId,
+			genome: p.genome,
 			geneSetGroup: self.settings.pathway,
 			filter_non_coding_genes: self.settings.filter_non_coding_genes,
 			method: self.settings.gsea_method
+		}
+		if (p.cacheId) {
+			body.cacheId = p.cacheId
+		} else {
+			body.genes = p.genes
+			body.fold_change = p.fold_change
 		}
 
 		if (self.settings.gsea_method == 'blitzgsea') {

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -207,19 +207,17 @@ class gsea extends PlotBase {
 					config.settings?.volcano || getDefaultVolcanoSettings({}, { termType: 'geneExpression' })
 				const model = new VolcanoModel(this.app, config.termType)
 				const response = await model.getData(config, volcanoSettings)
-				if (!response || !response.data || response.error) {
-					throw response.error || 'No data returned from volcano model'
+				if (!response?.data?.cacheId || response.error) {
+					throw response.error || 'No DE cacheId returned from volcano model'
 				}
-				const inputGenes = response.data.map(g => g.gene_name)
 				await this.app.save({
 					type: 'plot_edit',
 					id: this.id,
 					config: {
 						gsea_params: {
-							genes: inputGenes,
-							fold_change: response.data.map(g => g.fold_change),
-							genome: this.app.vocabApi.opts.state.vocab.genome,
-							genes_length: inputGenes.length
+							cacheId: response.data.cacheId,
+							genes_length: response.data.totalRows,
+							genome: this.app.vocabApi.opts.state.vocab.genome
 						}
 					}
 				})
@@ -252,7 +250,7 @@ class gsea extends PlotBase {
 		await this.setControls()
 		if (this.dom.header)
 			this.dom.header.html(
-				this.config.gsea_params.genes.length +
+				this.config.gsea_params.genes_length +
 					' genes <span style="font-size:.8em;opacity:.7">GENE SET ENRICHMENT ANALYSIS</span>'
 			)
 		render_gsea(this)
@@ -350,8 +348,7 @@ add:
 	try {
 		const body = {
 			genome: self.config.gsea_params.genome,
-			genes: self.config.gsea_params.genes,
-			fold_change: self.config.gsea_params.fold_change,
+			cacheId: self.config.gsea_params.cacheId,
 			geneSetGroup: self.settings.pathway,
 			filter_non_coding_genes: self.settings.filter_non_coding_genes,
 			method: self.settings.gsea_method
@@ -381,6 +378,20 @@ add:
 			const png_height = 400
 			self.dom.holder.append('img').attr('width', png_width).attr('height', png_height).attr('src', self.imageUrl)
 		} else if (self.settings.gsea_method == 'cerno') {
+			if (!self.rankedDE && self.config.gsea_params.cacheId) {
+				const deResp = await dofetch3('genesetEnrichment', {
+					body: {
+						genome: self.config.gsea_params.genome,
+						cacheId: self.config.gsea_params.cacheId,
+						fetchDE: true,
+						geneSetGroup: '-',
+						filter_non_coding_genes: false,
+						method: 'cerno'
+					}
+				})
+				if (deResp.error) throw deResp.error
+				self.rankedDE = deResp.data
+			}
 			render_cerno_plot(self, output)
 		} else {
 			throw 'Unknown method:' + self.settings.gsea_method
@@ -607,9 +618,10 @@ function render_cerno_plot(self, cerno_output) {
 	const xpad = 50
 	const ypad = 100
 
+	const rankedDE = self.rankedDE || self.config.gsea_params
 	const DE_output = []
-	for (let i = 0; i < self.config.gsea_params.genes.length; i++) {
-		const item = { gene: self.config.gsea_params.genes[i], fold_change: self.config.gsea_params.fold_change[i] }
+	for (let i = 0; i < rankedDE.genes.length; i++) {
+		const item = { gene: rankedDE.genes[i], fold_change: rankedDE.fold_change[i] }
 		DE_output.push(item)
 	}
 	DE_output.sort((i, j) => j.fold_change - i.fold_change) // Sorting genes in descending order of fold change

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Added cache id for GSEA analysis. Allows it to work with new DA Volcano

--- a/server/routes/genesetEnrichment.ts
+++ b/server/routes/genesetEnrichment.ts
@@ -68,9 +68,27 @@ async function run_genesetEnrichment_analysis(
 ): Promise<GenesetEnrichmentResponse | string> {
 	if (!genomes[q.genome].termdbs) throw 'termdb database is not available for ' + q.genome
 
+	let genes = q.genes
+	let fold_change = q.fold_change
+	if (q.cacheId) {
+		// cacheId enters path.join; constrain to the exact format writeDaCache produces
+		if (!/^da_[0-9a-f]{32}$/.test(q.cacheId)) throw 'invalid cacheId'
+		const file = path.join(serverconfig.cachedir, 'daAnalysis', `${q.cacheId}.tsv`)
+		const text = await fs.promises.readFile(file, 'utf8')
+		const rows = text.split('\n').slice(1).filter(Boolean)
+		genes = rows.map(r => r.split('\t')[0])
+		fold_change = rows.map(r => Number(r.split('\t')[1]))
+	}
+
+	if (q.fetchDE) {
+		// Client requested the ranked DE list only (used by the cerno detail plot).
+		if (!genes || !fold_change) throw 'fetchDE requires cacheId'
+		return { data: { genes, fold_change } } as unknown as GenesetEnrichmentResponse
+	}
+
 	const genesetenrichment_input: any = {
-		genes: q.genes,
-		fold_change: q.fold_change,
+		genes,
+		fold_change,
 		db: genomes[q.genome].termdbs.msigdb.cohort.db.connection.name, // For now msigdb has been added, but later databases other than msigdb may be used
 		geneset_group: q.geneSetGroup,
 		genedb: path.join(serverconfig.tpmasterdir, genomes[q.genome].genedb.dbfile),

--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import type { DERequest, DEFullResponse, ExpressionInput, GeneDEEntry, RouteApi } from '#types'
@@ -12,6 +13,15 @@ import { imageSize } from 'image-size'
 import { get_header_txt } from '#src/utils.js'
 import { formatElapsedTime } from '#shared'
 import { renderVolcano } from '../src/renderVolcano.ts'
+
+async function writeDaCache(geneData: GeneDEEntry[]): Promise<string> {
+	const cacheId = `da_${crypto.randomBytes(16).toString('hex')}`
+	const file = path.join(serverconfig.cachedir, 'daAnalysis', `${cacheId}.tsv`)
+	const lines = ['gene_name\tfold_change']
+	for (const g of geneData) lines.push(`${g.gene_name}\t${g.fold_change}`)
+	await fs.promises.writeFile(file, lines.join('\n'))
+	return cacheId
+}
 
 export const api: RouteApi = {
 	endpoint: 'termdb/DE',
@@ -299,6 +309,7 @@ values[] // using integer sample id
 		const images = [result.ql_image]
 		if (result.mds_image) images.push(result.mds_image)
 		const rendered = await renderVolcano<GeneDEEntry>(result.gene_data, param.volcanoRender)
+		rendered.cacheId = await writeDaCache(result.gene_data)
 		const output: DEFullResponse = {
 			data: rendered,
 			sample_size2: result.num_cases[0],
@@ -318,6 +329,7 @@ values[] // using integer sample id
 	mayLog('Time taken to run rust DE pipeline:', formatElapsedTime(Date.now() - time1))
 	param.method = 'wilcoxon'
 	const rendered = await renderVolcano<GeneDEEntry>(result, param.volcanoRender)
+	rendered.cacheId = await writeDaCache(result)
 	return {
 		data: rendered,
 		sample_size1,

--- a/server/src/CacheManager.ts
+++ b/server/src/CacheManager.ts
@@ -89,6 +89,11 @@ const defaultOpts = {
 			...subdirOptsDefaults,
 			maxAge: day * 60,
 			skipMs: halfDay
+		},
+		daAnalysis: {
+			...subdirOptsDefaults,
+			maxAge: day * 60,
+			skipMs: halfDay
 		}
 		// bam: {
 		//  ...subdirOptsDefaults,

--- a/server/src/CacheManager.ts
+++ b/server/src/CacheManager.ts
@@ -71,6 +71,7 @@ const defaultOpts = {
 	cachedir: path.join(process.cwd(), '.cache'),
 	interval: minute,
 	subdirs: {
+		// TODO: What is generating .pkl files?
 		gsea: {
 			...subdirOptsDefaults,
 			fileExtensions: new Set(['.pkl'])

--- a/server/src/test/CacheManager.unit.spec.ts
+++ b/server/src/test/CacheManager.unit.spec.ts
@@ -67,6 +67,13 @@ tape('defaults', function (test) {
 							skipMs: 43200000,
 							absPath: `${m.cachedir}/grin2`,
 							skipUntil: 0
+						},
+						daAnalysis: {
+							maxAge: 5184000000,
+							maxSize: 5000000000,
+							skipMs: 43200000,
+							absPath: `${m.cachedir}/daAnalysis`,
+							skipUntil: 0
 						}
 					},
 					`should set default subdir properties`
@@ -81,7 +88,8 @@ tape('defaults', function (test) {
 							gsea: { deletedCount: 0, totalCount: 0 },
 							massSession: { deletedCount: 0, totalCount: 0 },
 							massSessionTrash: { deletedCount: 0, totalCount: 0 },
-							grin2: { deletedCount: 0, totalCount: 0 }
+							grin2: { deletedCount: 0, totalCount: 0 },
+							daAnalysis: { deletedCount: 0, totalCount: 0 }
 						},
 						`should detect no cache files to delete`
 					)
@@ -133,6 +141,7 @@ tape('move or delete by maxAge', test => {
 			massSession: undefined,
 			massSessionTrash: undefined,
 			grin2: undefined,
+			daAnalysis: undefined,
 			test0: {
 				maxAge,
 				moveTo: 'trash'
@@ -256,6 +265,7 @@ tape('limit deletion by file extension', test => {
 			massSession: undefined,
 			massSessionTrash: undefined,
 			grin2: undefined,
+			daAnalysis: undefined,
 			test0: {
 				maxAge: -10, // force deletion of all files (with matching extension) by maxAge
 				fileExtensions: new Set(['.txt'])

--- a/shared/types/src/routes/genesetEnrichment.ts
+++ b/shared/types/src/routes/genesetEnrichment.ts
@@ -1,10 +1,20 @@
 import type { RoutePayload } from './routeApi.js'
 
 export type GenesetEnrichmentRequest = {
-	/** Sample genes to be queried */
-	genes: string[]
-	/** Background genes against which the sample genes will be queried */
-	fold_change: number[]
+	/** Sample genes to be queried. Optional when `cacheId` is given — the
+	 * server loads genes from the DE cache file in that case. */
+	genes?: string[]
+	/** Fold changes aligned to `genes`. Optional when `cacheId` is given. */
+	fold_change?: number[]
+	/** DE cache ID (returned by the volcano/DE route). If set, the server
+	 * reads genes + fold_change from the cache file and ignores any
+	 * `genes`/`fold_change` fields sent in this request. */
+	cacheId?: string
+	/** When true and `cacheId` is set, the server skips enrichment and
+	 * returns the ranked `{ genes, fold_change }` from the cache. Used by
+	 * the client-side cerno detail plot to lazily load the full ranked
+	 * gene list without keeping it in plot state. */
+	fetchDE?: boolean
 	/** Filter non-coding genes */
 	filter_non_coding_genes: boolean
 	/** Genome build */

--- a/shared/types/src/routes/genesetEnrichment.ts
+++ b/shared/types/src/routes/genesetEnrichment.ts
@@ -25,8 +25,9 @@ export type GenesetEnrichmentRequest = {
 	geneset_name?: string
 	/** Pickle file to be queried for generating gsea image of a particular geneset */
 	pickle_file?: string
-	/** Number of permutations to be carried out for GSEA analysis */
-	num_permutations: number
+	/** Number of permutations to be carried out for GSEA analysis.
+	 * Only read by the blitzgsea path; cerno and fetchDE requests omit it. */
+	num_permutations?: number
 	/** Method used for GSEA blitzgsea/cerno */
 	method: 'blitzgsea' | 'cerno'
 }

--- a/shared/types/src/routes/termdb.DE.ts
+++ b/shared/types/src/routes/termdb.DE.ts
@@ -85,6 +85,10 @@ export type VolcanoData<T extends DataEntry> = {
 	/** Rows that passed significance thresholds, before any maxInteractiveDots
 	 * truncation. Use this (not dots.length) for "% significant" stats. */
 	totalSignificantRows: number
+	/** Server-side cache ID for the full DE result (all rows, not just dots).
+	 * Downstream tools (e.g. GSEA) pass this back to the server instead of
+	 * re-transmitting the gene + fold_change arrays. */
+	cacheId?: string
 }
 
 /** Coordinate metadata returned by the `volcano` renderer, used by the client to overlay


### PR DESCRIPTION
# Description
Fix GSEA after recent volcano changes by introducing a server-side DA cache.

The volcano plot was changed to server-render the scatter PNG and return only the top-significant interactive dots (capped at `maxInteractiveDots`). GSEA, which runs downstream of the DE analysis, was still expecting the full gene list on the client — so it either crashed (`response.data` is no longer an array) or silently ran on a truncated subset.

This PR mirrors the GRIN2 cache pattern: the DE route now writes the full `{gene_name, fold_change}` table to disk and returns a `cacheId`; GSEA consumes the cacheId instead of re-transmitting gene arrays.

## Changes

- **New `daAnalysis` cache subdir** registered in `CacheManager` (60-day TTL, `.tsv`). Named "da" rather than "de" because we now differential analysis on more than just gene expression
- **DE route** ([server/routes/termdb.DE.ts](proteinpaint/server/routes/termdb.DE.ts)) writes a TSV cache file (`da_<32hex>.tsv`) after edgeR, wilcoxon, and limma runs, and attaches `cacheId` to `VolcanoData`.
- **GSEA route** ([server/routes/genesetEnrichment.ts](proteinpaint/server/routes/genesetEnrichment.ts)) reads genes + fold_change from the cache when `cacheId` is present. CacheId is regex-gated (`/^da_[0-9a-f]{32}$/`) before it enters `path.join` to block traversal. Also adds a `fetchDE: true` short-circuit so the client can lazy-load the ranked gene list for the cerno detail plot.
- **GSEA client** ([client/plots/gsea.js](proteinpaint/client/plots/gsea.js)) stores `cacheId` + `genes_length` in `gsea_params` instead of raw arrays; POST body sends only `cacheId`. The cerno enrichment-curve detail plot lazy-fetches the ranked list once and caches it in memory (not plot state).
- **Types** ([shared/types/src/routes/termdb.DE.ts](proteinpaint/shared/types/src/routes/termdb.DE.ts), [shared/types/src/routes/genesetEnrichment.ts](proteinpaint/shared/types/src/routes/genesetEnrichment.ts)) updated: `VolcanoData.cacheId?`, `GenesetEnrichmentRequest.{cacheId?, fetchDE?}`, and `genes`/`fold_change` are now optional.

## Backward compatibility

The GSEA request still accepts inline `genes` + `fold_change` when `cacheId` is absent, so older mass-session files continue to work — they'll just re-run DE on load (same behavior as before). Sessions saved after this change carry a `cacheId` that may expire after 60 days; if so, the user reopens the plot to regenerate. Matches GRIN2 behavior.

## Test plan

- [x] Open a gene-expression volcano, launch GSEA with **blitzgsea** — table populates, header shows the full gene count (not `maxInteractiveDots`).
- [x] Same flow with **cerno** — click a pathway row, confirm the enrichment-curve detail plot renders.
- [x] `ls <cachedir>/daAnalysis/` shows a `da_<32hex>.tsv` with one row per DE gene; row count equals `totalRows` in the volcano response.
- [x] Delete the TSV then click a pathway — produces a clear error, not a silent empty result.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
