### PR TITLE
SC Improvements

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -343,8 +343,7 @@ function getChartTypeList(self, state) {
 			clickTo: self.prepPlot,
 			config: {
 				chartType: 'GeneExpInput',
-				termType: TermTypes.GENE_EXPRESSION,
-				hidePlotFilter: true
+				termType: TermTypes.GENE_EXPRESSION
 			}
 		},
 		{

--- a/client/plots/GeneExpInput.ts
+++ b/client/plots/GeneExpInput.ts
@@ -82,7 +82,7 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 
 		this.tabs = [
 			{
-				label: 'Single gene summary',
+				label: 'One gene',
 				isVisible: () => true,
 				callback: (event, tab) => {
 					this.renderGeneSelect(tab)
@@ -90,7 +90,7 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 				}
 			},
 			{
-				label: 'Two gene comparison',
+				label: 'Two gene',
 				isVisible: () => true,
 				callback: (event, tab) => {
 					this.renderTwoGeneSelect(tab)
@@ -98,7 +98,7 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 				}
 			},
 			{
-				label: 'Multiple genes for hierarchical clustering',
+				label: 'Hierarchical clustering',
 				isVisible: () => chartTypes.has('matrix') && this.termType === GENE_EXPRESSION, // hierarchical clustering doesn't support scge
 				callback: (event, tab) => {
 					this.renderGeneMultiSelect(tab)

--- a/client/plots/GeneExpInput.ts
+++ b/client/plots/GeneExpInput.ts
@@ -13,8 +13,8 @@ type GeneExpInputOpts = {
 	 * Normally this is optional but there's no reason to launch this plot
 	 * sans sandbox. */
 	header: any
-	/** Override default text for sanbox header */
-	headerTextOverride?: string
+	/** Optional text to display in the header before the term type */
+	headerText?: string
 	termProperties?: { [key: string]: any }
 	spawnConfig?: { [key: string]: any }
 }
@@ -90,7 +90,7 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 				}
 			},
 			{
-				label: 'Two gene',
+				label: 'Two genes',
 				isVisible: () => true,
 				callback: (event, tab) => {
 					this.renderTwoGeneSelect(tab)
@@ -140,10 +140,17 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 	}
 
 	initDom() {
-		const headerText = this.opts?.headerTextOverride || `${typeGroup[this.termType]}`
-
+		const headerText = this.opts.headerText ? `${this.opts.headerText} ` : ''
 		const dom: { [index: string]: any } = {
-			header: this.opts.header.text(headerText).attr('data-testid', 'sjpp-gene-exp-input-header'),
+			header: {
+				title: this.opts.header.append('span').text(headerText).attr('data-testid', 'sjpp-gene-exp-input-headerText'),
+				plot: this.opts.header
+					.append('span')
+					.text(typeGroup[this.termType].toUpperCase())
+					.style('font-size', '0.7em')
+					.style('opacity', '0.6')
+					.attr('data-testid', 'sjpp-gene-exp-input-termType')
+			},
 			tabs: this.opts.holder
 				.append('div')
 				.style('margin', '10px')
@@ -197,7 +204,7 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 		const gene2row = holder.append('div').style('padding', '5px').style('display', 'none')
 		const submitButton = holder.append('button').attr('type', 'button').attr('disabled', true)
 
-		gene1row.append('span').text('Select 1st gene:')
+		gene1row.append('span').text('Select the first gene:')
 		const geneSearch1 = addGeneSearchbox({
 			row: gene1row,
 			genome: this.genome,
@@ -211,7 +218,7 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 			}
 		})
 
-		gene2row.append('span').text('Select 2nd gene:')
+		gene2row.append('span').text('Select the second gene:')
 		const geneSearch2 = addGeneSearchbox({
 			row: gene2row,
 			genome: this.genome,

--- a/client/plots/diffAnalysis/DifferentialAnalysis.ts
+++ b/client/plots/diffAnalysis/DifferentialAnalysis.ts
@@ -159,7 +159,7 @@ export function getPlotConfig(opts: any) {
 		Object.assign(config, {
 			categoryName: opts.categoryName || '',
 			termId: opts.termId || '',
-			sample: opts.sample || ''
+			sample: opts.sample || { sID: '', eID: '' }
 		})
 	}
 

--- a/client/plots/sc/README.md
+++ b/client/plots/sc/README.md
@@ -16,7 +16,7 @@ Called during `main()` once a sample is selected (`config.settings.sc.item`). Th
 
 ## Subplots
 Subplot creation and rendering: 
-1. `SCInteractions.createSubplot()` dispatches `plot_create` with `parentId` set to the SC id and `scItem` cloned from the current selection. This adds the subplot as an entry in `state.plots[]`.
+1. `SCInteractions.createSubplot()` dispatches `plot_create` with `parentId` set to the SC id. Each subplot config carries its own `sample: {sID, eID}` (or `term.term.sample: {sID, eID}` for term-based plots). This adds the subplot as an entry in `state.plots[]`.
 2. `getState()` in SC.ts filters all plots with a `parentId` matching the SC id into `subplots[]`.
 3. `main()` passes `subplots[]` to `SCViewRenderer.update()`, which delegates to `SectionRender.update()` for reconciliation and rendering.
 

--- a/client/plots/sc/README.md
+++ b/client/plots/sc/README.md
@@ -16,14 +16,20 @@ Called during `main()` once a sample is selected (`config.settings.sc.item`). Th
 
 ## Subplots
 Subplot creation and rendering: 
-1. Subplots are first added as a plot to `state.plots[]` via `app.dispatch(...'plot_create')`.
+1. `SCInteractions.createSubplot()` dispatches `plot_create` with `parentId` set to the SC id and `scItem` cloned from the current selection. This adds the subplot as an entry in `state.plots[]`.
 2. `getState()` in SC.ts filters all plots with a `parentId` matching the SC id into `subplots[]`.
-3. `main()` calls `reconcileSubplots()` which iterates through all subplots to check for a matching component.
-
-### Segments
-Each sample has a segment in `this.segments[sampleId]` that holds the title DOM element, a container div for subplots, and a map of sandbox DOM elements keyed by subplot id. When a subplot is encountered for a sample that has no segment yet, `initSegment()` creates the segment. Then `initSubplotComponent()` creates a sandbox within that segment, imports and initializes the plot component, and stores references in both `this.components.plots[subplotId]` and `this.segments[sampleId].sandboxes[subplotId]`.
-
-### Reconciling Deleted Subplots
-After initializing new subplots, `reconcileSubplots()` cleans up stale components. It compares the subplot ids present in state against `this.components.plots`. Any component that exists locally but is no longer in state (e.g. deleted by another action such as replacing a transient plot) has its sandbox DOM element removed from the segment and its entry deleted from `this.components.plots`. Finally, `view.removeSegments()` removes any segment whose subplots container has no remaining sandbox headers.
+3. `main()` passes `subplots[]` to `SCViewRenderer.update()`, which delegates to `SectionRender.update()` for reconciliation and rendering.
 
 Once added as a component, the plot will update every time `app.dispatch` is called.
+
+### Sections (`SectionRender`)
+`SectionRender` (in `view/SectionRender.ts`) groups subplots by sample into collapsible sections. It maintains a `sections` map keyed by sample id and a `plotId2Sample` map that links each subplot id back to its sample.
+
+`update()` runs three passes on every render cycle:
+1. **Remove stale subplots** — builds an active set from the current state and calls `removeSandbox()` for any component in `sc.components.plots` that is no longer active.
+2. **Initialize new subplots** — for each subplot in state, creates its section (via `initSection()`) if one does not exist for the sample, then creates a sandbox (via `initSandbox()`) if one does not exist for the subplot. `initSandbox()` calls `sc.initPlotComponent()` which dynamically imports the chart module and stores the component.
+3. **Remove empty sections** — deletes any section whose sandboxes map is empty.
+
+Users can also remove subplots and sections directly:
+- **Sandbox close button** — calls `removeSandbox()` then dispatches `plot_delete`.
+- **Section close button** — calls `removeSection()`, which removes every sandbox in the section, batches the corresponding `plot_delete` actions into a single `app_refresh` dispatch, and removes the section wrapper from the DOM.

--- a/client/plots/sc/README.md
+++ b/client/plots/sc/README.md
@@ -18,12 +18,12 @@ Called during `main()` once a sample is selected (`config.settings.sc.item`). Th
 Subplot creation and rendering: 
 1. `SCInteractions.createSubplot()` dispatches `plot_create` with `parentId` set to the SC id. Each subplot config carries its own `sample: {sID, eID}` (or `term.term.sample: {sID, eID}` for term-based plots). This adds the subplot as an entry in `state.plots[]`.
 2. `getState()` in SC.ts filters all plots with a `parentId` matching the SC id into `subplots[]`.
-3. `main()` passes `subplots[]` to `SCViewRenderer.update()`, which delegates to `SectionRender.update()` for reconciliation and rendering.
+3. `main()` passes `subplots[]` to `SCViewRenderer.update()`, which delegates to `SectionRenderer.update()` for reconciliation and rendering.
 
 Once added as a component, the plot will update every time `app.dispatch` is called.
 
-### Sections (`SectionRender`)
-`SectionRender` (in `view/SectionRender.ts`) groups subplots by sample into collapsible sections. It maintains a `sections` map keyed by sample id and a `plotId2Sample` map that links each subplot id back to its sample.
+### Sections (`SectionRenderer`)
+`SectionRenderer` (in `view/SectionRenderer.ts`) groups subplots by sample into collapsible sections. It maintains a `sections` map keyed by sample id and a `plotId2Sample` map that links each subplot id back to its sample.
 
 `update()` runs three passes on every render cycle:
 1. **Remove stale subplots** — builds an active set from the current state and calls `removeSandbox()` for any component in `sc.components.plots` that is no longer active.

--- a/client/plots/sc/SC.ts
+++ b/client/plots/sc/SC.ts
@@ -50,7 +50,7 @@ export class SCViewer extends PlotBase implements RxComponent {
 				.style('height', '100%')
 				.style('background-color', 'rgba(255, 255, 255, 0.95)')
 				.style('text-align', 'center'),
-			selectBtnDiv: div.append('div').attr('id', 'sjpp-sc-select-btn'),
+			controlsDiv: div.append('div').attr('id', 'sjpp-sc-controls-btn'),
 			tableDiv: div.append('div').attr('id', 'sjpp-sc-item-table'),
 			plotsBtnsDiv: div.append('div').attr('id', 'sjpp-sc-plot-buttons').style('display', 'none'),
 			sectionsDiv: div.append('div').attr('id', 'sjpp-sc-sections')
@@ -102,7 +102,7 @@ export class SCViewer extends PlotBase implements RxComponent {
 
 		/** The item data and table rendering should only occur once
 		 * .update() in main() handles changes to the buttons and plots */
-		this.view.render(this.viewModel.tableData)
+		this.view.render(this.viewModel.tableData, state.config.settings.sc)
 	}
 
 	async main() {

--- a/client/plots/sc/SC.ts
+++ b/client/plots/sc/SC.ts
@@ -7,7 +7,7 @@ import { SCModel } from './model/SCModel'
 import { SCViewModel } from './viewModel/SCViewModel'
 import { SCInteractions } from './interactions/SCInteractions'
 import { SCViewRenderer } from './view/SCViewRenderer'
-import { getDefaultSCAppSettings } from './defaults'
+import { getDefaultSCAppSettings } from './settings/defaults.ts'
 import { importPlot } from '#plots/importPlot.js'
 import formatPlotData from './viewModel/plotData.ts'
 

--- a/client/plots/sc/SC.ts
+++ b/client/plots/sc/SC.ts
@@ -98,7 +98,7 @@ export class SCViewer extends PlotBase implements RxComponent {
 		}
 		this.interactions = new SCInteractions(this.app, this.dom, this.id, () => this.getState(this.app.getState()))
 		this.viewModel = new SCViewModel(this.app, state.config, this.items!, this.itemColumns)
-		this.view = new SCViewRenderer(this)
+		this.view = new SCViewRenderer(this, state.config.settings.sc.groupBy)
 
 		/** The item data and table rendering should only occur once
 		 * .update() in main() handles changes to the buttons and plots */

--- a/client/plots/sc/SCTypes.ts
+++ b/client/plots/sc/SCTypes.ts
@@ -37,14 +37,17 @@ export type Sections = {
 	[key: string]: { sectionWrapper: Div; title: any; subplots: any; sandboxes: { [key: string]: any } }
 }
 
+/** Standardized sample identifier used throughout the SC app */
+export type SCSample = { sID: string; eID: string }
+
 export type SCSettings = {
 	sc: {
 		columns: {
 			/** Defined column name for 'sample' column*/
 			sample: string
 		}
-		/** Active item choosen by the user */
-		item: any
+		/** Active item chosen by the user */
+		item: SCSample | undefined
 	}
 	hierCluster: {
 		unit: string

--- a/client/plots/sc/SCTypes.ts
+++ b/client/plots/sc/SCTypes.ts
@@ -1,12 +1,12 @@
 import type { Elem, Div } from '../../types/d3'
 import type { TableRow, TableColumn } from '#dom'
-import type { SCSettings } from './settings/Settings'
+import type { Settings } from './settings/Settings'
 
 /** WIP config for the sc app */
 export type SCConfig = {
 	chartType: 'sc'
 	/** Common settings and settings for each child component/plot */
-	settings: SCSettings
+	settings: Settings
 }
 
 /** Opts defined in getPlotConfig() */

--- a/client/plots/sc/SCTypes.ts
+++ b/client/plots/sc/SCTypes.ts
@@ -1,5 +1,6 @@
 import type { Elem, Div } from '../../types/d3'
 import type { TableRow, TableColumn } from '#dom'
+import type { SCSettings } from './settings/Settings'
 
 /** WIP config for the sc app */
 export type SCConfig = {
@@ -33,28 +34,8 @@ export type SCDom = {
 	header?: Elem
 }
 
-export type Sections = {
-	[key: string]: { sectionWrapper: Div; title: any; subplots: any; sandboxes: { [key: string]: any } }
-}
-
 /** Standardized sample identifier used throughout the SC app */
 export type SCSample = { sID: string; eID: string }
-
-export type SCSettings = {
-	sc: {
-		columns: {
-			/** Defined column name for 'sample' column*/
-			sample: string
-		}
-		/** Active item chosen by the user */
-		item: SCSample | undefined
-	}
-	hierCluster: {
-		unit: string
-		yDendrogramHeight: number
-		clusterSamples: boolean
-	}
-}
 
 /** State retrieved from this.getState()
  * specific to SC chartType. ** NOT ** reflective

--- a/client/plots/sc/SCTypes.ts
+++ b/client/plots/sc/SCTypes.ts
@@ -22,8 +22,9 @@ export type SCDom = {
 	div: Div
 	/** When visible, shows a loading spinner */
 	loading: Div
-	/** Holder for the 'select' btn at the top page */
-	selectBtnDiv: Div
+	/** Holder for the manually created controls at the top page
+	 * This is **not** the same as mass controls.*/
+	controlsDiv: Div
 	/** Holder for the sample table */
 	tableDiv: Div
 	/** Holder for the dynamically generated plot buttons for each sample */

--- a/client/plots/sc/interactions/SCInteractions.ts
+++ b/client/plots/sc/interactions/SCInteractions.ts
@@ -22,9 +22,7 @@ export class SCInteractions {
 	 * SC.main() initializes the subplots as components in chartsDiv
 	 */
 	async createSubplot(config) {
-		const item = this.app.getState().plots.find(p => p.id === this.id)?.settings.sc.item
-		//'item' isFrozen. Pass the clone to avoid downstream issues.
-		const c = Object.assign({}, config, { parentId: this.id, scItem: structuredClone(item) })
+		const c = Object.assign({}, config, { parentId: this.id })
 		await this.app.dispatch({
 			type: 'plot_create',
 			parentId: this.id,

--- a/client/plots/sc/model/SCModel.ts
+++ b/client/plots/sc/model/SCModel.ts
@@ -78,8 +78,8 @@ export class SCModel {
 			checkPlotAvailability: true, // only return available plot names, but not actual plot data
 			plots,
 			sample: {
-				eID: config.settings.sc.item.experiment,
-				sID: config.settings.sc.item.sample
+				eID: config.settings.sc.item.eID,
+				sID: config.settings.sc.item.sID
 			}
 		}
 	}

--- a/client/plots/sc/settings/Settings.ts
+++ b/client/plots/sc/settings/Settings.ts
@@ -2,19 +2,21 @@ import type { SCSample } from '../SCTypes'
 
 export const GroupByOptions = ['none', 'sample', 'plot'] as const
 
-export type SCSettings = {
-	sc: {
-		columns: {
-			/** Defined column name for 'sample' column*/
-			sample: string
-		}
-		/** Active item chosen by the user */
-		item: SCSample | undefined
-		groupBy: (typeof GroupByOptions)[number]
-	}
+export type Settings = {
+	sc: SCSettings
 	hierCluster: {
 		unit: string
 		yDendrogramHeight: number
 		clusterSamples: boolean
 	}
+}
+
+export type SCSettings = {
+	columns: {
+		/** Defined column name for 'sample' column*/
+		sample: string
+	}
+	/** Active item chosen by the user */
+	item: SCSample | undefined
+	groupBy: (typeof GroupByOptions)[number]
 }

--- a/client/plots/sc/settings/Settings.ts
+++ b/client/plots/sc/settings/Settings.ts
@@ -1,0 +1,18 @@
+import type { SCSample } from '../SCTypes'
+
+export type SCSettings = {
+	sc: {
+		columns: {
+			/** Defined column name for 'sample' column*/
+			sample: string
+		}
+		/** Active item chosen by the user */
+		item: SCSample | undefined
+		groupBy: 'none' | 'sample' | 'plot'
+	}
+	hierCluster: {
+		unit: string
+		yDendrogramHeight: number
+		clusterSamples: boolean
+	}
+}

--- a/client/plots/sc/settings/Settings.ts
+++ b/client/plots/sc/settings/Settings.ts
@@ -1,5 +1,7 @@
 import type { SCSample } from '../SCTypes'
 
+export const GroupByOptions = ['none', 'sample', 'plot'] as const
+
 export type SCSettings = {
 	sc: {
 		columns: {
@@ -8,7 +10,7 @@ export type SCSettings = {
 		}
 		/** Active item chosen by the user */
 		item: SCSample | undefined
-		groupBy: 'none' | 'sample' | 'plot'
+		groupBy: (typeof GroupByOptions)[number]
 	}
 	hierCluster: {
 		unit: string

--- a/client/plots/sc/settings/defaults.ts
+++ b/client/plots/sc/settings/defaults.ts
@@ -1,9 +1,9 @@
 import { getGEunit } from '#tw/geneExpression'
-import type { SCSettings } from './Settings'
+import type { Settings } from './Settings'
 
 /** Define all subplot settings here */
-export function getDefaultSCAppSettings(overrides = {}, app): SCSettings {
-	const defaults: SCSettings = {
+export function getDefaultSCAppSettings(overrides = {}, app): Settings {
+	const defaults: Settings = {
 		sc: {
 			columns: {
 				// TODO: Implement ds specific column name

--- a/client/plots/sc/settings/defaults.ts
+++ b/client/plots/sc/settings/defaults.ts
@@ -1,15 +1,16 @@
 import { getGEunit } from '#tw/geneExpression'
-import type { SCSettings } from './SCTypes'
+import type { SCSettings } from './Settings'
 
 /** Define all subplot settings here */
 export function getDefaultSCAppSettings(overrides = {}, app): SCSettings {
-	const defaults = {
+	const defaults: SCSettings = {
 		sc: {
 			columns: {
 				// TODO: Implement ds specific column name
 				sample: 'Sample'
 			},
-			item: undefined
+			item: undefined,
+			groupBy: 'sample'
 		},
 		hierCluster: {
 			unit: getGEunit(app.vocabApi),

--- a/client/plots/sc/test/PlotButtons.unit.spec.ts
+++ b/client/plots/sc/test/PlotButtons.unit.spec.ts
@@ -1,0 +1,347 @@
+import tape from 'tape'
+import { PlotButtons } from '../view/PlotButtons.ts'
+import { getMockSCState } from './getMockSCApp.ts'
+
+/**
+ * Tests
+ *   - constructor should set interactions, scTermdbConfig, and plotBtnsDom
+ *   - update() should hide promptDiv when no item is selected
+ *   - update() should set data, settings, and item when item is selected
+ *   - update() should retain previous data when new data is null
+ *   - getChartBtnOpts() should return configured plot buttons
+ *   - getChartBtnOpts() Summary button should always be visible
+ *   - getChartBtnOpts() Gene expression button should be visible when geneExpression is configured
+ *   - getChartBtnOpts() Gene expression button should not be visible when geneExpression is not configured
+ *   - getChartBtnOpts() Differential expression button should be visible when DEgenes is configured
+ *   - getChartBtnOpts() plot button isVisible() should return false when plot is not in data
+ *   - getSingleCellConfig() should return sampleScatter config
+ *   - getSingleCellConfig() should throw when no item is selected
+ *   - getSingleCellConfig() should throw when plot name is not found
+ *   - getSingleCellConfig() should include colorTW when colorColumns are configured
+ *   - makeScctTW() should return term wrapper with sample and $id
+ */
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- plots/sc/view/PlotButtons -***-')
+	test.end()
+})
+
+/* ---- helpers ---- */
+
+/** Chainable d3-like mock for Div/Elem */
+function getMockDiv() {
+	const self: any = {}
+	for (const m of ['style', 'text', 'attr', 'on', 'classed']) {
+		self[m] = (..._args: any[]) => self
+	}
+	self.append = (_tag: string) => getMockDiv()
+	self.selectAll = (_sel: string) => getMockSelection()
+	self.node = () => ({ value: '' })
+	return self
+}
+
+function getMockSelection() {
+	const self: any = {}
+	self.data = (_d: any) => self
+	self.enter = () => self
+	self.remove = () => self
+	self.filter = (_fn: any) => self
+	for (const m of ['style', 'text', 'attr', 'on', 'append', 'classed']) {
+		self[m] = (..._args: any[]) => self
+	}
+	return self
+}
+
+function getMockInteractions(overrides: any = {}) {
+	const state = getMockSCState({
+		termdbConfig: {
+			queries: {
+				singleCell: {
+					data: {
+						plots: [{ name: 'umap' }, { name: 'tsne' }]
+					},
+					geneExpression: overrides.geneExpression,
+					DEgenes: overrides.DEgenes
+				}
+			},
+			...(overrides.termdbConfig || {})
+		}
+	})
+	return {
+		id: 'sc1',
+		getState: state,
+		createSubplot: overrides.createSubplot || (async () => {}),
+		...overrides
+	} as any
+}
+
+function getPlotButtons(overrides: any = {}) {
+	const interactions = getMockInteractions(overrides)
+	const holder = getMockDiv()
+	const pb = new PlotButtons(interactions, holder)
+	return pb
+}
+
+/* ---- constructor ---- */
+
+tape('constructor should set interactions, scTermdbConfig, and plotBtnsDom', test => {
+	const pb = getPlotButtons()
+
+	test.ok(pb.interactions, 'Should set interactions')
+	test.equal(pb.interactions.id, 'sc1', 'Should have interactions.id')
+	test.ok(pb.scTermdbConfig, 'Should set scTermdbConfig')
+	test.deepEqual(
+		pb.scTermdbConfig.data.plots.map((p: any) => p.name),
+		['umap', 'tsne'],
+		'Should have plots from termdbConfig'
+	)
+	test.ok(pb.plotBtnsDom, 'Should set plotBtnsDom')
+	test.ok(pb.plotBtnsDom.promptDiv, 'Should have promptDiv')
+	test.ok(pb.plotBtnsDom.selectPrompt, 'Should have selectPrompt')
+	test.ok(pb.plotBtnsDom.btnsDiv, 'Should have btnsDiv')
+	test.ok(pb.plotBtnsDom.tip, 'Should have tip (Menu)')
+	test.end()
+})
+
+/* ---- update() ---- */
+
+tape('update() should hide promptDiv when no item is selected', test => {
+	const pb = getPlotButtons()
+	let displayValue
+	;(pb.plotBtnsDom.promptDiv as any).style = (prop: string, val?: string) => {
+		if (prop === 'display' && typeof val === 'string' && val !== undefined) {
+			displayValue = val
+		}
+		return pb.plotBtnsDom.promptDiv
+	}
+	const settings = { sc: { item: undefined } } as any
+	pb.update(settings, null)
+
+	test.equal(displayValue, 'none', 'Should hide promptDiv when no item')
+	test.end()
+})
+
+tape('update() should set data, settings, and item when item is selected', test => {
+	const pb = getPlotButtons()
+	// Override renderChartBtns to avoid d3 data join in test
+	pb.renderChartBtns = () => {}
+	const item = { sID: 'S1', eID: 'EXP1' }
+	const settings = { sc: { item } } as any
+	const data = { plots: [{ name: 'umap' }] }
+	pb.update(settings, data)
+
+	test.deepEqual(pb.data, data, 'Should set data')
+	test.deepEqual(pb.settings, settings, 'Should set settings')
+	test.deepEqual(pb.item, item, 'Should set item')
+	test.end()
+})
+
+tape('update() should retain previous data when new data is null', test => {
+	const pb = getPlotButtons()
+	pb.renderChartBtns = () => {}
+	const item = { sID: 'S1', eID: 'EXP1' }
+	const settings = { sc: { item } } as any
+	const data = { plots: [{ name: 'umap' }] }
+
+	pb.update(settings, data)
+	pb.update(settings, null)
+
+	test.deepEqual(pb.data, data, 'Should retain previous data when new data is null')
+	test.end()
+})
+
+/* ---- getChartBtnOpts() ---- */
+
+tape('getChartBtnOpts() should return configured plot buttons', test => {
+	const pb = getPlotButtons()
+	pb.data = { plots: [{ name: 'umap' }, { name: 'tsne' }] }
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const btns = pb.getChartBtnOpts()
+	const labels = btns.map(b => b.label)
+
+	test.ok(labels.includes('umap'), 'Should include umap button')
+	test.ok(labels.includes('tsne'), 'Should include tsne button')
+	test.ok(labels.includes('Summary'), 'Should include Summary button')
+	test.ok(labels.includes('Gene expression'), 'Should include Gene expression button')
+	test.ok(labels.includes('Differential expression'), 'Should include Differential expression button')
+	test.end()
+})
+
+tape('getChartBtnOpts() Summary button should always be visible', test => {
+	const pb = getPlotButtons()
+	pb.data = { plots: [] }
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const btns = pb.getChartBtnOpts()
+	const summary = btns.find(b => b.label === 'Summary')
+
+	test.ok(summary, 'Should have Summary button')
+	test.ok(summary!.isVisible(), 'Summary should always be visible')
+	test.end()
+})
+
+tape('getChartBtnOpts() Gene expression button should be visible when geneExpression is configured', test => {
+	const pb = getPlotButtons({ geneExpression: true })
+	pb.data = { plots: [] }
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const btns = pb.getChartBtnOpts()
+	const geneExp = btns.find(b => b.label === 'Gene expression')
+
+	test.ok(geneExp!.isVisible(), 'Gene expression should be visible when geneExpression is configured')
+	test.end()
+})
+
+tape('getChartBtnOpts() Gene expression button should not be visible when geneExpression is not configured', test => {
+	const pb = getPlotButtons()
+	pb.data = { plots: [] }
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const btns = pb.getChartBtnOpts()
+	const geneExp = btns.find(b => b.label === 'Gene expression')
+
+	test.notOk(geneExp!.isVisible(), 'Gene expression should not be visible when geneExpression is not configured')
+	test.end()
+})
+
+tape('getChartBtnOpts() Differential expression button should be visible when DEgenes is configured', test => {
+	const pb = getPlotButtons({ DEgenes: { termId: 'cluster' } })
+	pb.data = { plots: [] }
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const btns = pb.getChartBtnOpts()
+	const de = btns.find(b => b.label === 'Differential expression')
+
+	test.ok(de!.isVisible(), 'Differential expression should be visible when DEgenes is configured')
+	test.end()
+})
+
+tape('getChartBtnOpts() plot button isVisible() should return false when plot is not in data', test => {
+	const pb = getPlotButtons()
+	pb.data = { plots: [{ name: 'umap' }] }
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const btns = pb.getChartBtnOpts()
+	const umap = btns.find(b => b.label === 'umap')
+	const tsne = btns.find(b => b.label === 'tsne')
+
+	test.ok(umap!.isVisible(), 'umap should be visible when in data.plots')
+	test.notOk(tsne!.isVisible(), 'tsne should not be visible when not in data.plots')
+	test.end()
+})
+
+/* ---- getSingleCellConfig() ---- */
+
+tape('getSingleCellConfig() should return sampleScatter config', async test => {
+	const pb = getPlotButtons()
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const config = (await pb.getSingleCellConfig('umap')) as any
+
+	test.equal(config.chartType, 'sampleScatter', 'Should set chartType to sampleScatter')
+	test.equal(config.name, 'Sample: S1', 'Should set name with sample sID')
+	test.deepEqual(config.sample, { sID: 'S1', eID: 'EXP1' }, 'Should include sample')
+	test.equal(config.singleCellPlot.name, 'umap', 'Should set singleCellPlot.name')
+	test.deepEqual(config.singleCellPlot.sample, { sID: 'S1', eID: 'EXP1' }, 'Should set singleCellPlot.sample')
+	test.end()
+})
+
+tape('getSingleCellConfig() should throw when no item is selected', async test => {
+	const pb = getPlotButtons()
+	pb.item = undefined
+
+	try {
+		await pb.getSingleCellConfig('umap')
+		test.fail('Should have thrown')
+	} catch (e: any) {
+		test.ok(e.message.includes('No item selected'), 'Should throw "No item selected"')
+	}
+	test.end()
+})
+
+tape('getSingleCellConfig() should throw when plot name is not found', async test => {
+	const pb = getPlotButtons()
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	try {
+		await pb.getSingleCellConfig('nonexistent')
+		test.fail('Should have thrown')
+	} catch (e: any) {
+		test.ok(e.message.includes('No plot by name nonexistent'), 'Should throw when plot name not found')
+	}
+	test.end()
+})
+
+tape('getSingleCellConfig() should include colorTW when colorColumns are configured', async test => {
+	const pb = getPlotButtons({
+		termdbConfig: {
+			queries: {
+				singleCell: {
+					data: {
+						plots: [{ name: 'umap', colorColumns: [{ name: 'cellType' }] }]
+					}
+				}
+			},
+			termType2terms: {
+				'Single-cell Cell Type': [{ name: 'cellType', plot: 'umap', id: 'ct1' }]
+			}
+		}
+	})
+	pb.item = { sID: 'S1', eID: 'EXP1' }
+
+	const config = (await pb.getSingleCellConfig('umap')) as any
+
+	test.ok(config.colorTW, 'Should include colorTW')
+	test.ok(config.colorTW.$id, 'Should have $id on colorTW')
+	test.deepEqual(config.colorTW.term.sample, { sID: 'S1', eID: 'EXP1' }, 'Should set sample on colorTW term')
+	test.end()
+})
+
+/* ---- makeScctTW() ---- */
+
+tape('makeScctTW() should return term wrapper with sample and $id', async test => {
+	const pb = getPlotButtons({
+		termdbConfig: {
+			queries: {
+				singleCell: {
+					data: {
+						plots: [{ name: 'umap', colorColumns: [{ name: 'cellType' }] }]
+					}
+				}
+			},
+			termType2terms: {
+				'Single-cell Cell Type': [{ name: 'cellType', plot: 'umap', id: 'ct1' }]
+			}
+		}
+	})
+	const item = { sID: 'S1', eID: 'EXP1' }
+	const plot = { name: 'umap', colorColumns: [{ name: 'cellType' }] }
+
+	const tw = await pb.makeScctTW(item, plot)
+
+	test.ok(tw.$id, 'Should have $id')
+	test.equal(typeof tw.$id, 'string', '$id should be a string')
+	test.deepEqual(tw.term.sample, item, 'Should set sample on term')
+	test.equal(tw.term.name, 'cellType', 'Should preserve term name')
+	test.equal(tw.term.plot, 'umap', 'Should preserve term plot')
+	test.end()
+})
+
+tape('makeScctTW() should throw when no matching term is found', async test => {
+	const pb = getPlotButtons()
+	const item = { sID: 'S1', eID: 'EXP1' }
+	const plot = { name: 'umap', colorColumns: [{ name: 'nonexistent' }] }
+
+	try {
+		await pb.makeScctTW(item, plot)
+		test.fail('Should have thrown')
+	} catch (e: any) {
+		test.ok(e.message.includes('No term found for colorColumn=nonexistent'), 'Should throw when term not found')
+	}
+	test.end()
+})

--- a/client/plots/sc/test/SCModel.unit.spec.ts
+++ b/client/plots/sc/test/SCModel.unit.spec.ts
@@ -17,7 +17,7 @@ import { SCModel } from '../model/SCModel.ts'
 ***************/
 
 tape('\n', function (test) {
-	test.comment('-***- plots/sc/SCModel -***-')
+	test.comment('-***- plots/sc/model/SCModel -***-')
 	test.end()
 })
 

--- a/client/plots/sc/test/SCViewModel.unit.spec.ts
+++ b/client/plots/sc/test/SCViewModel.unit.spec.ts
@@ -43,7 +43,7 @@ tape('constructor should set selectedRows when item matches a sample', test => {
 	const app = getMockSCApp()
 	const config = getMockSCConfig({
 		settings: {
-			sc: { columns: { sample: 'Sample' }, item: { sample: 'S2' } },
+			sc: { columns: { sample: 'Sample' }, item: { sID: 'S2', eID: '' } },
 			hierCluster: {}
 		}
 	})

--- a/client/plots/sc/test/SCViewModel.unit.spec.ts
+++ b/client/plots/sc/test/SCViewModel.unit.spec.ts
@@ -21,7 +21,7 @@ import { getMockSCApp, getMockSCConfig } from './getMockSCApp.ts'
 ***************/
 
 tape('\n', function (test) {
-	test.comment('-***- plots/sc/SCViewModel -***-')
+	test.comment('-***- plots/sc/viewModel/SCViewModel -***-')
 	test.end()
 })
 

--- a/client/plots/sc/test/SectionRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SectionRenderer.unit.spec.ts
@@ -1,0 +1,273 @@
+import tape from 'tape'
+import { SectionRenderer } from '../view/SectionRenderer.ts'
+
+/**
+ * Tests
+ *   - constructor should set sections, holder, plotId2Key, and groupBy
+ *   - getSampleId() should return sID from subplot.sample
+ *   - getSampleId() should return sID from subplot.singleCellPlot.sample
+ *   - getSampleId() should return sID from subplot.term.term.sample
+ *   - getSampleId() should return undefined when no sID is found
+ *   - getPlotName() should return plotName from subplot
+ *   - getPlotName() should return name from subplot.singleCellPlot
+ *   - getPlotName() should return plot from subplot.term.term
+ *   - getPlotName() should return 'Summary' for dictionary chartType
+ *   - getPlotName() should return 'Summary' for summary chartType
+ *   - getPlotName() should return 'Gene expression' for GeneExpInput chartType
+ *   - makeSectionTitleText() should return empty string when groupBy is 'none'
+ *   - makeSectionTitleText() should return key when groupBy is 'plot'
+ *   - makeSectionTitleText() should return sample info when groupBy is 'sample'
+ *   - makeSectionTitleText() should include case and project info when available
+ *   - findSampleMetadata() should find item by sample name
+ *   - findSampleMetadata() should find item by experiment sampleName
+ *   - findSampleMetadata() should return undefined when sc has no items
+ *   - findSampleMetadata() should return undefined when no match found
+ *   - removeSandbox() should remove sandbox, clean up plotId2Key, and call sc.removeComponent
+ *   - removeSandbox() should use provided key over plotId2Key lookup
+ *   - removeSandbox() should return early when key is not found
+ */
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- plots/sc/view/SectionRender -***-')
+	test.end()
+})
+
+/* ---- helpers ---- */
+
+function getMockDiv() {
+	return {} as any
+}
+
+function getMockSCViewer(overrides: any = {}) {
+	return {
+		id: 'sc1',
+		items: overrides.items || [],
+		components: { plots: overrides.plots || {} },
+		app: {
+			dispatch: overrides.dispatch || (() => {}),
+			...(overrides.app || {})
+		},
+		removeComponent: overrides.removeComponent || (() => {}),
+		initPlotComponent: overrides.initPlotComponent || (async () => {}),
+		...overrides
+	} as any
+}
+
+/* ---- constructor ---- */
+
+tape('constructor should set sections, holder, plotId2Key, and groupBy', test => {
+	const holder = getMockDiv()
+	const sr = new SectionRenderer(holder, 'sample')
+
+	test.deepEqual(sr.sections, {}, 'Should initialize sections as empty object')
+	test.equal(sr.holder, holder, 'Should set holder')
+	test.true(sr.plotId2Key instanceof Map, 'Should initialize plotId2Key as a Map')
+	test.equal(sr.plotId2Key.size, 0, 'plotId2Key should be empty')
+	test.equal(sr.groupBy, 'sample', 'Should set groupBy')
+	test.end()
+})
+
+/* ---- getSampleId ---- */
+
+tape('getSampleId() should return sID from subplot.sample', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const subplot = { sample: { sID: 'S1' } }
+	test.equal(sr.getSampleId(subplot), 'S1', 'Should extract sID from subplot.sample')
+	test.end()
+})
+
+tape('getSampleId() should return sID from subplot.singleCellPlot.sample', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const subplot = { singleCellPlot: { sample: { sID: 'S2' } } }
+	test.equal(sr.getSampleId(subplot), 'S2', 'Should extract sID from singleCellPlot.sample')
+	test.end()
+})
+
+tape('getSampleId() should return sID from subplot.term.term.sample', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const subplot = { term: { term: { sample: { sID: 'S3' } } } }
+	test.equal(sr.getSampleId(subplot), 'S3', 'Should extract sID from term.term.sample')
+	test.end()
+})
+
+tape('getSampleId() should return undefined when no sID is found', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	test.equal(sr.getSampleId({}), undefined, 'Should return undefined for empty subplot')
+	test.equal(sr.getSampleId({ sample: {} }), undefined, 'Should return undefined when sample has no sID')
+	test.end()
+})
+
+/* ---- getPlotName ---- */
+
+tape('getPlotName() should return plotName from subplot', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(sr.getPlotName({ plotName: 'UMAP' }), 'UMAP', 'Should return subplot.plotName')
+	test.end()
+})
+
+tape('getPlotName() should return name from subplot.singleCellPlot', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(sr.getPlotName({ singleCellPlot: { name: 'tSNE' } }), 'tSNE', 'Should return singleCellPlot.name')
+	test.end()
+})
+
+tape('getPlotName() should return plot from subplot.term.term', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(sr.getPlotName({ term: { term: { plot: 'Violin' } } }), 'Violin', 'Should return term.term.plot')
+	test.end()
+})
+
+tape("getPlotName() should return 'Summary' for dictionary chartType", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(sr.getPlotName({ chartType: 'dictionary' }), 'Summary', 'Should return Summary for dictionary')
+	test.end()
+})
+
+tape("getPlotName() should return 'Summary' for summary chartType", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(sr.getPlotName({ chartType: 'summary' }), 'Summary', 'Should return Summary for summary')
+	test.end()
+})
+
+tape("getPlotName() should return 'Gene expression' for GeneExpInput chartType", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(
+		sr.getPlotName({ chartType: 'GeneExpInput' }),
+		'Gene expression',
+		'Should return Gene expression for GeneExpInput'
+	)
+	test.end()
+})
+
+/* ---- makeSectionTitleText ---- */
+
+tape("makeSectionTitleText() should return empty string when groupBy is 'none'", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'none')
+	test.equal(sr.makeSectionTitleText('anyKey'), '', 'Should return empty string for none groupBy')
+	test.end()
+})
+
+tape("makeSectionTitleText() should return key when groupBy is 'plot'", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(sr.makeSectionTitleText('UMAP'), 'UMAP', 'Should return the key for plot groupBy')
+	test.end()
+})
+
+tape("makeSectionTitleText() should return sample info when groupBy is 'sample'", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const result = sr.makeSectionTitleText('S1')
+	test.true(result.includes('Sample: S1'), 'Should include sample id in title')
+	test.end()
+})
+
+tape('makeSectionTitleText() should include case and project info when available', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const item = { sample: 'CASE1', 'project id': 'PROJ1' } as any
+	const result = sr.makeSectionTitleText('S1', item)
+	test.true(result.includes('Sample: S1'), 'Should include sample id')
+	test.true(result.includes('Case: CASE1'), 'Should include case text')
+	test.true(result.includes('Project: PROJ1'), 'Should include project text')
+	test.end()
+})
+
+/* ---- findSampleMetadata ---- */
+
+tape('findSampleMetadata() should find item by sample name', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const items = [{ sample: 'S1' }, { sample: 'S2' }]
+	const sc = getMockSCViewer({ items })
+	const result = sr.findSampleMetadata('S2', sc)
+	test.deepEqual(result, { sample: 'S2' }, 'Should find matching item by sample')
+	test.end()
+})
+
+tape('findSampleMetadata() should find item by experiment sampleName', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const items = [{ sample: 'CASE1', experiments: [{ sampleName: 'EXP1' }, { sampleName: 'EXP2' }] }]
+	const sc = getMockSCViewer({ items })
+	const result = sr.findSampleMetadata('EXP2', sc)
+	test.equal(result!.sample, 'CASE1', 'Should find item by experiment sampleName')
+	test.end()
+})
+
+tape('findSampleMetadata() should return undefined when sc has no items', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const sc = getMockSCViewer({ items: undefined })
+	test.equal(sr.findSampleMetadata('S1', sc), undefined, 'Should return undefined when items is undefined')
+	test.end()
+})
+
+tape('findSampleMetadata() should return undefined when no match found', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const sc = getMockSCViewer({ items: [{ sample: 'S1' }] })
+	test.equal(sr.findSampleMetadata('MISSING', sc), undefined, 'Should return undefined for unmatched sampleId')
+	test.end()
+})
+
+/* ---- removeSandbox ---- */
+
+tape('removeSandbox() should remove sandbox, clean up plotId2Key, and call sc.removeComponent', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	let removedComponent = ''
+	const sc = getMockSCViewer({
+		removeComponent: (id: string) => {
+			removedComponent = id
+		}
+	})
+
+	const mockSandboxDiv = { remove: () => {} }
+	sr.sections['S1'] = {
+		sectionWrapper: {} as any,
+		title: {} as any,
+		subplots: {} as any,
+		sandboxes: { plot1: mockSandboxDiv }
+	}
+	sr.plotId2Key.set('plot1', 'S1')
+
+	sr.removeSandbox('plot1', sc)
+
+	test.equal(removedComponent, 'plot1', 'Should call sc.removeComponent with plotId')
+	test.equal(sr.sections['S1'].sandboxes['plot1'], undefined, 'Should delete sandbox from sections')
+	test.false(sr.plotId2Key.has('plot1'), 'Should delete plotId from plotId2Key')
+	test.end()
+})
+
+tape('removeSandbox() should use provided key over plotId2Key lookup', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const sc = getMockSCViewer()
+
+	const mockSandboxDiv = { remove: () => {} }
+	sr.sections['PROVIDED'] = {
+		sectionWrapper: {} as any,
+		title: {} as any,
+		subplots: {} as any,
+		sandboxes: { plot1: mockSandboxDiv }
+	}
+	sr.plotId2Key.set('plot1', 'LOOKUP')
+
+	sr.removeSandbox('plot1', sc, 'PROVIDED')
+
+	test.equal(sr.sections['PROVIDED'].sandboxes['plot1'], undefined, 'Should use provided key')
+	test.end()
+})
+
+tape('removeSandbox() should return early when key is not found', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	let removedComponent = false
+	const sc = getMockSCViewer({
+		removeComponent: () => {
+			removedComponent = true
+		}
+	})
+
+	// No sections or plotId2Key entries set up
+	sr.removeSandbox('plot1', sc)
+
+	test.true(removedComponent, 'Should still call sc.removeComponent')
+	test.equal(sr.plotId2Key.size, 0, 'plotId2Key should remain empty')
+	test.end()
+})

--- a/client/plots/sc/test/SectionRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SectionRenderer.unit.spec.ts
@@ -32,7 +32,7 @@ import { SectionRenderer } from '../view/SectionRenderer.ts'
 ***************/
 
 tape('\n', function (test) {
-	test.comment('-***- plots/sc/view/SectionRender -***-')
+	test.comment('-***- plots/sc/view/SectionRenderer -***-')
 	test.end()
 })
 

--- a/client/plots/sc/test/getMockSCApp.ts
+++ b/client/plots/sc/test/getMockSCApp.ts
@@ -27,7 +27,7 @@ export function getMockSCState(overrides: any = {}) {
 				id: 'plot1',
 				settings: {
 					sc: {
-						item: { experiment: 'EXP1', sample: 'S1' }
+						item: { sID: 'S1', eID: 'EXP1' }
 					}
 				}
 			}

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -1,6 +1,6 @@
 import type { Div, Elem } from '../../../types/d3'
 import type { SCInteractions } from '../interactions/SCInteractions'
-import { Menu, GeneExpChartMenu } from '#dom'
+import { Menu } from '#dom'
 import { digestMessage } from '#termsetting'
 import { SINGLECELL_CELLTYPE, SINGLECELL_GENE_EXPRESSION, TermTypeGroups } from '#shared/terms.js'
 import type { SCSettings } from '../SCTypes'
@@ -140,7 +140,21 @@ export class PlotButtons {
 			{
 				label: 'Gene expression',
 				isVisible: () => this.scTermdbConfig.geneExpression,
-				open: this.geneExpMenu
+				getPlotConfig: () => {
+					const sample = this.makeSampleObj()
+					const headerText = `Sample: ${this.item!.sample}`
+					return {
+						chartType: 'GeneExpInput',
+						termType: SINGLECELL_GENE_EXPRESSION,
+						headerText,
+						termProperties: { sample },
+						spawnConfig: {
+							parentId: this.interactions.id,
+							hidePlotFilter: true,
+							headerText
+						}
+					}
+				}
 			},
 			{
 				label: 'Differential expression',
@@ -162,23 +176,6 @@ export class PlotButtons {
 	}
 
 	//********** Btn Menus **********/
-	//TODO: Change gene expression menu to transient plot
-	geneExpMenu(plot: any, self: PlotButtons) {
-		const opts = {
-			termType: SINGLECELL_GENE_EXPRESSION as string,
-			termProperties: { sample: self.makeSampleObj() },
-			spawnConfig: {
-				hidePlotFilter: true,
-				parentId: self.interactions.id,
-				headerText: `Sample: ${self.item!.sample}`,
-				scItem: self.makeSampleObj(),
-				/** It's not ideal to always pass the hierCluster settings here, but it's required for the current implementation */
-				settings: { hierCluster: self.settings.hierCluster }
-			}
-		}
-		new GeneExpChartMenu(self.interactions.app, self.plotBtnsDom.tip, opts)
-	}
-
 	//TODO: Change this to use the term from termdbConfig
 	// and return to getPlotConfig
 	termDropdownMenu(plot: any, self: PlotButtons) {

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -4,7 +4,7 @@ import { Menu } from '#dom'
 import { digestMessage } from '#termsetting'
 import { SINGLECELL_CELLTYPE, SINGLECELL_GENE_EXPRESSION, TermTypeGroups } from '#shared/terms.js'
 import type { SCSample } from '../SCTypes'
-import type { SCSettings } from '../settings/Settings'
+import type { Settings } from '../settings/Settings'
 
 /** Rendering for the plot buttons that appear below the item
  * table. Plot buttons are rendered based on the available plots
@@ -29,7 +29,7 @@ export class PlotButtons {
 	item?: SCSample
 	interactions: SCInteractions
 	scTermdbConfig: any
-	settings!: SCSettings
+	settings!: Settings
 	scctTerms?: any[]
 
 	constructor(interactions: SCInteractions, holder: Div) {
@@ -47,7 +47,7 @@ export class PlotButtons {
 		this.scTermdbConfig = state.termdbConfig.queries.singleCell
 	}
 
-	update(settings: SCSettings, data) {
+	update(settings: Settings, data) {
 		/** If the user has not selected a item yet but clicks
 		 * the select item/plots btn above the table, the prompt appears
 		 * unnecessarily */

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -42,6 +42,8 @@ export class PlotButtons {
 			tip: new Menu({ padding: '' })
 		}
 		this.interactions = interactions
+		/** This is the initial state. scctTerms and the termdbConfig are created on
+		 * server init and will not change. */
 		const state = this.interactions.getState as any
 		this.scctTerms = state.termdbConfig?.termType2terms?.[TermTypeGroups.SINGLECELL_CELLTYPE]
 		this.scTermdbConfig = state.termdbConfig.queries.singleCell

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -3,7 +3,8 @@ import type { SCInteractions } from '../interactions/SCInteractions'
 import { Menu } from '#dom'
 import { digestMessage } from '#termsetting'
 import { SINGLECELL_CELLTYPE, SINGLECELL_GENE_EXPRESSION, TermTypeGroups } from '#shared/terms.js'
-import type { SCSettings, SCSample } from '../SCTypes'
+import type { SCSample } from '../SCTypes'
+import type { SCSettings } from '../settings/Settings'
 
 /** Rendering for the plot buttons that appear below the item
  * table.
@@ -140,7 +141,7 @@ export class PlotButtons {
 			},
 			{
 				label: 'Gene expression',
-				isVisible: () => this.scTermdbConfig.geneExpression,
+				isVisible: () => this.scTermdbConfig?.geneExpression,
 				getPlotConfig: () => {
 					const sample = this.item!
 					const headerText = `Sample: ${this.item!.sID}`
@@ -160,7 +161,7 @@ export class PlotButtons {
 			},
 			{
 				label: 'Differential expression',
-				isVisible: () => this.scTermdbConfig.DEgenes,
+				isVisible: () => this.scTermdbConfig?.DEgenes,
 				open: this.termDropdownMenu,
 				getPlotConfig: value => {
 					return {

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -7,18 +7,16 @@ import type { SCSample } from '../SCTypes'
 import type { SCSettings } from '../settings/Settings'
 
 /** Rendering for the plot buttons that appear below the item
- * table.
+ * table. Plot buttons are rendered based on the available plots
+ * for the selected sample, and the config defined in
+ * termdbConfig.queries.singleCell.data.plots. Each plot config
+ * in termdbConfig should define a name that matches the plot
+ * names returned from the server, and can optionally define
+ * colorColumns which will be used to apply color to the plot
+ * if those columns are present in the data.
  *
  * Notes:
  *  - The hierarchical clustering limits to the first 100 genes.
- *
- ******* TODOs:
- * - Disable all plot btns until plot loads for performance??
- *
- ******* Hier clustering implenentation TODOs and questions:
- * The matrix ** does not ** properly pull single cell data yet.
- * This implementation works as a placeholder for now.
- * Need to revisit before production.
  * */
 export class PlotButtons {
 	plotBtnsDom: {
@@ -65,7 +63,7 @@ export class PlotButtons {
 	}
 
 	renderChartBtns() {
-		this.plotBtnsDom.btnsDiv.selectAll('*').remove()
+		// this.plotBtnsDom.btnsDiv.selectAll('*').remove()
 		const btns = this.getChartBtnOpts()
 
 		this.plotBtnsDom.btnsDiv
@@ -103,10 +101,13 @@ export class PlotButtons {
 			getPlotConfig?: (f?: any) => any
 		}[] = []
 
+		//Show buttons for plots with found data files (see note above).
+		const availablePlots = new Set(this.data?.plots?.map((p: any) => p.name))
+
 		for (const plot of this.scTermdbConfig?.data?.plots || []) {
 			btns.push({
 				label: plot.name,
-				isVisible: () => true,
+				isVisible: () => availablePlots.has(plot.name),
 				getPlotConfig: async () => {
 					return await this.getSingleCellConfig(plot.name)
 				}
@@ -179,10 +180,12 @@ export class PlotButtons {
 	}
 
 	//********** Btn Menus **********/
-	//TODO: Change this to use the term from termdbConfig
-	// and return to getPlotConfig
 	termDropdownMenu(plot: any, self: PlotButtons) {
 		self.plotBtnsDom.tip.clear()
+		//TODO: Planned server request here to get the available
+		// clusters/termIds for the selected sample,
+		// instead of using the clusters returned for the
+		// plot which is currently hardcoded to a few options for testing.
 		const _plot = self.data.plots[0]
 
 		const wrapper = self.plotBtnsDom.tip.d.append('div').style('padding', '10px')
@@ -205,6 +208,7 @@ export class PlotButtons {
 				await self.interactions.createSubplot(config)
 			})
 
+		//TODO: Replace this with planned server response for the clusters/termId.
 		const regex = new RegExp(_plot.colorBy, 'g')
 		_plot.clusters.unshift(`Select ${self.scTermdbConfig.DEgenes.termId}...`)
 		for (const cluster of _plot.clusters) {

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -3,7 +3,7 @@ import type { SCInteractions } from '../interactions/SCInteractions'
 import { Menu } from '#dom'
 import { digestMessage } from '#termsetting'
 import { SINGLECELL_CELLTYPE, SINGLECELL_GENE_EXPRESSION, TermTypeGroups } from '#shared/terms.js'
-import type { SCSettings } from '../SCTypes'
+import type { SCSettings, SCSample } from '../SCTypes'
 
 /** Rendering for the plot buttons that appear below the item
  * table.
@@ -27,7 +27,7 @@ export class PlotButtons {
 		tip: Menu
 	}
 	data?: any
-	item?: { [key: string]: any }
+	item?: SCSample
 	interactions: SCInteractions
 	scTermdbConfig: any
 	settings!: SCSettings
@@ -58,7 +58,7 @@ export class PlotButtons {
 		if (data != null && data.plots) this.data = data
 		this.settings = settings
 		this.item = item
-		const name = item.sample // add ds specific keys/logic here
+		const name = item.sID
 		this.plotBtnsDom.selectPrompt.text(` ${name}:`)
 		this.renderChartBtns()
 	}
@@ -116,13 +116,14 @@ export class PlotButtons {
 				label: 'Summary',
 				isVisible: () => true,
 				getPlotConfig: () => {
-					const sample = this.makeSampleObj()
+					const sample = this.item!
 					return {
 						chartType: 'dictionary',
+						sample,
 						spawnConfig: {
 							parentId: this.interactions.id,
 							hidePlotFilter: true,
-							headerText: `Sample: ${this.item!.sample}`,
+							headerText: `Sample: ${this.item!.sID}`,
 							sample
 						},
 						tree: {
@@ -141,13 +142,14 @@ export class PlotButtons {
 				label: 'Gene expression',
 				isVisible: () => this.scTermdbConfig.geneExpression,
 				getPlotConfig: () => {
-					const sample = this.makeSampleObj()
-					const headerText = `Sample: ${this.item!.sample}`
+					const sample = this.item!
+					const headerText = `Sample: ${this.item!.sID}`
 					return {
 						chartType: 'GeneExpInput',
 						termType: SINGLECELL_GENE_EXPRESSION,
 						headerText,
 						termProperties: { sample },
+						sample,
 						spawnConfig: {
 							parentId: this.interactions.id,
 							hidePlotFilter: true,
@@ -165,9 +167,9 @@ export class PlotButtons {
 						chartType: 'differentialAnalysis',
 						termType: SINGLECELL_CELLTYPE,
 						categoryName: `${value}`,
-						headerText: `Sample: ${this.item!.sample} ${this.scTermdbConfig.DEgenes.termId} ${value}`,
+						headerText: `Sample: ${this.item!.sID} ${this.scTermdbConfig.DEgenes.termId} ${value}`,
 						termId: this.scTermdbConfig.DEgenes.termId,
-						sample: this.item!.experiment || this.item!.sample
+						sample: this.item!
 					}
 				}
 			}
@@ -214,10 +216,11 @@ export class PlotButtons {
 		if (!this.item) throw new Error('No item selected')
 		const plot = this.scTermdbConfig.data.plots.find(p => p.name == plotName)
 		if (!plot) throw new Error(`No plot by name ${plotName} in data.plots.`)
-		const sample = this.makeSampleObj()
+		const sample = this.item
 		const config: any = {
 			chartType: 'sampleScatter',
-			name: `Sample: ${this.item!.sample}`,
+			name: `Sample: ${this.item.sID}`,
+			sample,
 			singleCellPlot: {
 				name: plotName,
 				sample
@@ -239,19 +242,9 @@ export class PlotButtons {
 				`No term found for colorColumn=${colorColName} in .termType2terms.[TermTypeGroups.SINGLECELL_CELLTYPE] for plot ${plot.name}`
 			)
 		const term = Object.assign(structuredClone(savedTerm), {
-			sample: this.makeSampleObj()
+			sample: item
 		})
 		const id = await digestMessage(`${plot.name}-${item.sID}-${item.eID}`)
 		return Object.assign({ $id: id }, { term })
-	}
-
-	/** Creates a sample object for the current item.
-	 * Part of the effort to normalize sample objects across
-	 * native and gdc datasets. */
-	makeSampleObj(): { sID: string; eID: string } {
-		return {
-			sID: this.item!.sample,
-			eID: this.item!.experiment
-		}
 	}
 }

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -65,7 +65,7 @@ export class PlotButtons {
 	}
 
 	renderChartBtns() {
-		// this.plotBtnsDom.btnsDiv.selectAll('*').remove()
+		this.plotBtnsDom.btnsDiv.selectAll('*').remove()
 		const btns = this.getChartBtnOpts()
 
 		this.plotBtnsDom.btnsDiv

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -1,12 +1,13 @@
-import type { SCDom } from '../SCTypes'
+import type { SCDom, SCTableData } from '../SCTypes'
 import type { SCInteractions } from '../interactions/SCInteractions'
 import { SampleTableRenderer } from './SampleTableRenderer'
 import { PlotButtons } from './PlotButtons'
-import type { TableData } from '../viewModel/SCViewModel'
 import { SectionRender } from './SectionRender'
 import type { SCViewer } from '../SC.ts'
-import { GroupByOptions } from '../settings/Settings'
+import { GroupByOptions, type SCSettings, type Settings } from '../settings/Settings'
 import { make_radios } from '#dom'
+import type { SingleCellDataGdc, SingleCellDataNative } from '#types'
+import type { PlotBase } from '#plots/PlotBase.ts'
 
 export class SCViewRenderer {
 	dom: SCDom
@@ -18,7 +19,7 @@ export class SCViewRenderer {
 	sectionRender: SectionRender
 	sc: SCViewer
 
-	constructor(sc: SCViewer, groupBy: string) {
+	constructor(sc: SCViewer, groupBy: (typeof GroupByOptions)[number]) {
 		this.sc = sc
 		this.dom = sc.dom
 		this.interactions = sc.interactions
@@ -26,7 +27,7 @@ export class SCViewRenderer {
 		this.sectionRender = new SectionRender(this.dom.sectionsDiv, groupBy)
 	}
 
-	render(tableData: TableData, settings) {
+	render(tableData: SCTableData, settings: SCSettings) {
 		this.renderSelectBtn()
 		this.renderGroupByOptions(settings)
 		new SampleTableRenderer(this.dom, this.interactions, tableData)
@@ -58,7 +59,7 @@ export class SCViewRenderer {
 		})
 	}
 
-	renderGroupByOptions(settings) {
+	renderGroupByOptions(settings: SCSettings) {
 		this.dom.controlsDiv
 			.append('span')
 			.style('padding', '3px 0px 3px 20px')
@@ -86,7 +87,7 @@ export class SCViewRenderer {
 		})
 	}
 
-	async update(settings, data, subplots) {
+	async update(settings: Settings, data: SingleCellDataNative | SingleCellDataGdc, subplots: PlotBase[]) {
 		this.plotBtns.update(settings, data)
 		//Also handles when settings.sc.groupBy == 'none' to show all plots in one section
 		await this.sectionRender.update(this.sc, subplots, settings.sc.groupBy)

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -58,6 +58,9 @@ export class SCViewRenderer {
 
 	async update(settings, data, subplots) {
 		this.plotBtns.update(settings, data)
-		await this.sectionRender.update(this.sc, subplots)
+		if (settings.sc.groupBy !== 'none') await this.sectionRender.update(this.sc, subplots, settings.sc.groupBy)
+		else {
+			//TODO, need to init sandboxes for ungrouped view as well
+		}
 	}
 }

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -5,6 +5,8 @@ import { PlotButtons } from './PlotButtons'
 import type { TableData } from '../viewModel/SCViewModel'
 import { SectionRender } from './SectionRender'
 import type { SCViewer } from '../SC.ts'
+import { GroupByOptions } from '../settings/Settings'
+import { make_radios } from '#dom'
 
 export class SCViewRenderer {
 	dom: SCDom
@@ -15,19 +17,18 @@ export class SCViewRenderer {
 	static inUse = true
 	sectionRender: SectionRender
 	sc: SCViewer
-	// sections: Sections
 
 	constructor(sc: SCViewer) {
 		this.sc = sc
 		this.dom = sc.dom
 		this.interactions = sc.interactions
 		this.plotBtns = new PlotButtons(this.interactions, this.dom.plotsBtnsDiv)
-		// this.sections = {}
-		this.sectionRender = new SectionRender(this.dom.sectionsDiv)
+		this.sectionRender = new SectionRender(this.dom.sectionsDiv, sc.state.config.settings.sc.groupBy)
 	}
 
-	render(tableData: TableData) {
+	render(tableData: TableData, settings) {
 		this.renderSelectBtn()
+		this.renderGroupByOptions(settings)
 		new SampleTableRenderer(this.dom, this.interactions, tableData)
 		this.dom.plotsBtnsDiv.style('display', 'none')
 	}
@@ -35,9 +36,9 @@ export class SCViewRenderer {
 	/** Renders the select btn at the top of the page that
 	 * show/hides the item table and plot buttons */
 	renderSelectBtn() {
-		this.dom.selectBtnDiv.style('padding', '10px')
+		this.dom.controlsDiv.style('padding', '10px')
 
-		const btn = this.dom.selectBtnDiv
+		const btn = this.dom.controlsDiv
 			.append('button')
 			.attr('data-testid', 'sjpp-sc-item-table-select-btn')
 			.style('border-radius', '20px')
@@ -56,11 +57,33 @@ export class SCViewRenderer {
 		})
 	}
 
+	renderGroupByOptions(settings) {
+		this.dom.controlsDiv.append('span').style('margin-left', '20px').style('opacity', 0.7).text('Group plots by:')
+		const optionsDiv = this.dom.controlsDiv.append('div').style('display', 'inline-block').style('margin-left', '10px')
+		const options = GroupByOptions.map(option => {
+			return {
+				label: `${option.charAt(0).toUpperCase() + option.slice(1)}`,
+				value: option,
+				checked: settings.groupBy === option
+			}
+		})
+		make_radios({
+			holder: optionsDiv,
+			styles: { display: 'inline-block' },
+			options,
+			callback: async value => {
+				await this.sc.app.dispatch({
+					type: 'plot_edit',
+					id: this.sc.id,
+					config: { settings: { sc: { ...settings, groupBy: value } } }
+				})
+			}
+		})
+	}
+
 	async update(settings, data, subplots) {
 		this.plotBtns.update(settings, data)
-		if (settings.sc.groupBy !== 'none') await this.sectionRender.update(this.sc, subplots, settings.sc.groupBy)
-		else {
-			//TODO, need to init sandboxes for ungrouped view as well
-		}
+		//Also handles when settings.sc.groupBy == 'none' to show all plots in one section
+		await this.sectionRender.update(this.sc, subplots, settings.sc.groupBy)
 	}
 }

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -2,7 +2,7 @@ import type { SCDom, SCTableData } from '../SCTypes'
 import type { SCInteractions } from '../interactions/SCInteractions'
 import { SampleTableRenderer } from './SampleTableRenderer'
 import { PlotButtons } from './PlotButtons'
-import { SectionRender } from './SectionRender'
+import { SectionRenderer } from './SectionRenderer'
 import type { SCViewer } from '../SC.ts'
 import { GroupByOptions, type SCSettings, type Settings } from '../settings/Settings'
 import { make_radios } from '#dom'
@@ -15,8 +15,8 @@ export class SCViewRenderer {
 	plotBtns: PlotButtons
 	//On load, show table
 	//Eventually maybe an app dispatch and not a flag
-	static inUse = true
-	sectionRender: SectionRender
+	static inUse: boolean = true
+	sectionRender: SectionRenderer
 	sc: SCViewer
 
 	constructor(sc: SCViewer, groupBy: (typeof GroupByOptions)[number]) {
@@ -24,7 +24,7 @@ export class SCViewRenderer {
 		this.dom = sc.dom
 		this.interactions = sc.interactions
 		this.plotBtns = new PlotButtons(this.interactions, this.dom.plotsBtnsDiv)
-		this.sectionRender = new SectionRender(this.dom.sectionsDiv, groupBy)
+		this.sectionRender = new SectionRenderer(this.dom.sectionsDiv, groupBy)
 	}
 
 	render(tableData: SCTableData, settings: SCSettings) {

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -18,12 +18,12 @@ export class SCViewRenderer {
 	sectionRender: SectionRender
 	sc: SCViewer
 
-	constructor(sc: SCViewer) {
+	constructor(sc: SCViewer, groupBy: string) {
 		this.sc = sc
 		this.dom = sc.dom
 		this.interactions = sc.interactions
 		this.plotBtns = new PlotButtons(this.interactions, this.dom.plotsBtnsDiv)
-		this.sectionRender = new SectionRender(this.dom.sectionsDiv, sc.state.config.settings.sc.groupBy)
+		this.sectionRender = new SectionRender(this.dom.sectionsDiv, groupBy)
 	}
 
 	render(tableData: TableData, settings) {
@@ -41,6 +41,7 @@ export class SCViewRenderer {
 		const btn = this.dom.controlsDiv
 			.append('button')
 			.attr('data-testid', 'sjpp-sc-item-table-select-btn')
+			.attr('title', 'Show/hide sample table and plot buttons')
 			.style('border-radius', '20px')
 			.style('padding', '5px 10px')
 			.style('background-color', 'transparent')
@@ -58,8 +59,12 @@ export class SCViewRenderer {
 	}
 
 	renderGroupByOptions(settings) {
-		this.dom.controlsDiv.append('span').style('margin-left', '20px').style('opacity', 0.7).text('Group plots by:')
-		const optionsDiv = this.dom.controlsDiv.append('div').style('display', 'inline-block').style('margin-left', '10px')
+		this.dom.controlsDiv
+			.append('span')
+			.style('padding', '3px 0px 3px 20px')
+			.style('opacity', 0.7)
+			.text('Group plots by:')
+		const optionsDiv = this.dom.controlsDiv.append('span').style('display', 'inline-block')
 		const options = GroupByOptions.map(option => {
 			return {
 				label: `${option.charAt(0).toUpperCase() + option.slice(1)}`,

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -9,6 +9,9 @@ import { make_radios } from '#dom'
 import type { SingleCellDataGdc, SingleCellDataNative } from '#types'
 import type { PlotBase } from '#plots/PlotBase.ts'
 
+/** Manages the initial rendering of the sample table and the dynamic
+ * rendering of the plot buttons and sections based on the selected sample and plots.
+ * .update() from sc.main() updates the plot buttons and sections. */
 export class SCViewRenderer {
 	dom: SCDom
 	interactions: SCInteractions

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -19,7 +19,7 @@ export class SCViewRenderer {
 	//On load, show table
 	//Eventually maybe an app dispatch and not a flag
 	static inUse: boolean = true
-	sectionRender: SectionRenderer
+	sectionRenderer: SectionRenderer
 	sc: SCViewer
 
 	constructor(sc: SCViewer, groupBy: (typeof GroupByOptions)[number]) {
@@ -27,7 +27,7 @@ export class SCViewRenderer {
 		this.dom = sc.dom
 		this.interactions = sc.interactions
 		this.plotBtns = new PlotButtons(this.interactions, this.dom.plotsBtnsDiv)
-		this.sectionRender = new SectionRenderer(this.dom.sectionsDiv, groupBy)
+		this.sectionRenderer = new SectionRenderer(this.dom.sectionsDiv, groupBy)
 	}
 
 	render(tableData: SCTableData, settings: SCSettings) {
@@ -93,6 +93,6 @@ export class SCViewRenderer {
 	async update(settings: Settings, data: SingleCellDataNative | SingleCellDataGdc, subplots: PlotBase[]) {
 		this.plotBtns.update(settings, data)
 		//Also handles when settings.sc.groupBy == 'none' to show all plots in one section
-		await this.sectionRender.update(this.sc, subplots, settings.sc.groupBy)
+		await this.sectionRenderer.update(this.sc, subplots, settings.sc.groupBy)
 	}
 }

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -3,7 +3,9 @@ import type { TableCell } from '#dom'
 import { renderTable } from '#dom'
 import type { SCInteractions } from '../interactions/SCInteractions'
 
-/** Renders the sample table for selection */
+/** Renders the sample table for selection on SC app init()
+ * On selecting a sample, the plot buttons will appear and
+ * the user can select a plot to render in the dashboard. */
 export class SampleTableRenderer {
 	dom: SCDom
 	interactions: SCInteractions

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -31,11 +31,15 @@ export class SampleTableRenderer {
 			striped: true,
 			selectedRows: tableData.selectedRows,
 			noButtonCallback: index => {
-				const item = {}
+				const row = {} as { [key: string]: any }
 				tableData.rows[index].forEach((r: TableCell, idx: number) => {
 					if (!r.value) return
-					item[tableData.columns[idx].label.toLowerCase()] = r.value
+					row[tableData.columns[idx].label.toLowerCase()] = r.value
 				})
+				const item = {
+					sID: row.sample || '',
+					eID: row.experiment || ''
+				}
 				this.interactions.updateItem(item)
 				this.dom.plotsBtnsDiv.style('display', 'block')
 			}

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -33,15 +33,17 @@ export class SampleTableRenderer {
 			striped: true,
 			selectedRows: tableData.selectedRows,
 			noButtonCallback: index => {
-				const row = {} as { [key: string]: any }
+				const item = {} as { sID: string; eID: string; [key: string]: any }
 				tableData.rows[index].forEach((r: TableCell, idx: number) => {
 					if (!r.value) return
-					row[tableData.columns[idx].label.toLowerCase()] = r.value
+					let key = tableData.columns[idx].label.toLowerCase()
+					/** Convert the column labels into the required sample structure keys.
+					 * Maintains the sample obj used throughout the app whilst allowing for
+					 * dynamic column labels based on the config. */
+					key = key === 'sample' ? 'sID' : key === 'experiment' ? 'eID' : key
+					item[key] = r.value
 				})
-				const item = {
-					sID: row.sample || '',
-					eID: row.experiment || ''
-				}
+				if (!item.sID) throw new Error('Selected item must have sID property')
 				this.interactions.updateItem(item)
 				this.dom.plotsBtnsDiv.style('display', 'block')
 			}

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -6,12 +6,12 @@ import type { SCViewer } from '../SC'
 export class SectionRender {
 	sections: Sections
 	holder: Div
-	plot2Sample: Map<string, string>
+	plotId2Sample: Map<string, string>
 
 	constructor(sectionsDiv: Div) {
 		this.sections = {}
 		this.holder = sectionsDiv
-		this.plot2Sample = new Map()
+		this.plotId2Sample = new Map()
 	}
 
 	//Send the sc with the updated state
@@ -31,7 +31,7 @@ export class SectionRender {
 			const sampleId = item.sample || item.sID
 			if (!this.sections[sampleId]) this.initSection(sampleId, item, sc)
 			if (!this.sections[sampleId].sandboxes[subplot.id]) {
-				this.plot2Sample.set(subplot.id, sampleId)
+				this.plotId2Sample.set(subplot.id, sampleId)
 				await this.initSandbox(sc, subplot, sampleId)
 			}
 		}
@@ -112,6 +112,11 @@ export class SectionRender {
 				//Delete the component before calling dispatch
 				//Prevents main attempting to re-init the component
 				this.removeSandbox(subplot.id, sc)
+				sc.app.dispatch({
+					type: 'plot_delete',
+					id: subplot.id,
+					parentId: sc.id
+				})
 			},
 			plotId: subplot.id
 		})
@@ -159,11 +164,11 @@ export class SectionRender {
 
 	removeSandbox(plotId: string, sc: SCViewer, _sampleId?: string) {
 		sc.removeComponent(plotId)
-		const sampleId = _sampleId || this.plot2Sample.get(plotId)
+		const sampleId = _sampleId || this.plotId2Sample.get(plotId)
 		if (!sampleId) return
 		this.sections[sampleId].sandboxes[plotId].remove()
 		delete this.sections[sampleId].sandboxes[plotId]
 		//Remove the reference to the plotId in plot2Sample map to avoid memory leak
-		this.plot2Sample.delete(plotId)
+		this.plotId2Sample.delete(plotId)
 	}
 }

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -1,4 +1,4 @@
-import type { Sections } from '../SCTypes'
+import type { Sections } from './Sections'
 import type { Div } from '../../../types/d3'
 import { newSandboxDiv } from '#dom'
 import type { SCViewer } from '../SC'
@@ -7,16 +7,21 @@ import type { SingleCellSample } from '#types'
 export class SectionRender {
 	sections: Sections
 	holder: Div
-	plotId2Sample: Map<string, string>
+	/** Maps the plotId to either the sampleId or plotName (i.e. key in secions map)
+	 * as a reverse lookup. */
+	plotId2Key: Map<string, string>
+	groupBy: string | undefined
 
 	constructor(sectionsDiv: Div) {
 		this.sections = {}
 		this.holder = sectionsDiv
-		this.plotId2Sample = new Map()
+		//Key may be either sampleId or plotName
+		this.plotId2Key = new Map()
+		this.groupBy = undefined
 	}
 
 	//Send the sc with the updated state
-	async update(sc: SCViewer, subplots: any) {
+	async update(sc: SCViewer, subplots: any, groupBy: 'none' | 'sample' | 'plot') {
 		const activeSubplots = new Set(subplots.map(s => s.id))
 
 		/** Repeat the destory from the close button, as mass/app.ts
@@ -28,20 +33,20 @@ export class SectionRender {
 		}
 
 		for (const subplot of subplots) {
-			const sampleId = this.getSampleId(subplot)
-			if (!sampleId) continue
-			if (!this.sections[sampleId]) this.initSection(sampleId, sc)
-			if (!this.sections[sampleId].sandboxes[subplot.id]) {
-				this.plotId2Sample.set(subplot.id, sampleId)
-				await this.initSandbox(sc, subplot, sampleId)
+			const key = groupBy == 'sample' ? this.getSampleId(subplot) : undefined
+			if (!key) continue
+			if (!this.sections[key]) this.initSection(key, sc)
+			if (!this.sections[key].sandboxes[subplot.id]) {
+				this.plotId2Key.set(subplot.id, key)
+				await this.initSandbox(sc, subplot, key)
 			}
 		}
 
 		/** Remove sections after iterating through subplots to avoid
 		 * deleting sections before they can be re-rendered with the correct plots */
-		for (const sampleId of Object.keys(this.sections)) {
-			if (Object.keys(this.sections[sampleId].sandboxes).length === 0) {
-				this.removeSection(sampleId, sc)
+		for (const key of Object.keys(this.sections)) {
+			if (Object.keys(this.sections[key].sandboxes).length === 0) {
+				this.removeSection(key, sc)
 			}
 		}
 	}
@@ -52,17 +57,25 @@ export class SectionRender {
 		return subplot.sample?.sID || subplot.singleCellPlot?.sample?.sID || subplot.term?.term?.sample?.sID
 	}
 
-	initSection(sampleId: string, sc: SCViewer) {
-		const item = this.findSampleMetadata(sampleId, sc)
+	getPlotName(subplot: any): string {
+		let plotName = subplot?.singleCellPlot?.name || subplot?.term?.term?.plot
+		if (!plotName) {
+			if (subplot.chartType === 'dictionary') plotName = 'Dictionary'
+		}
+		return plotName
+	}
+
+	initSection(key: string, sc: SCViewer) {
+		const item = this.findSampleMetadata(key, sc)
 		const sectionWrapper = this.holder
 			.insert('div', ':first-child')
 			.style('padding', '10px')
-			.attr('data-testid', `sjpp-sc-section-wrapper-${sampleId}`)
+			.attr('data-testid', `sjpp-sc-section-wrapper-${key}`)
 
 		//delete section btn
 		sectionWrapper
 			.append('span')
-			.attr('data-testid', `sjpp-sc-section-remove-btn-${sampleId}`)
+			.attr('data-testid', `sjpp-sc-section-remove-btn-${key}`)
 			.style('margin', '0px 5px')
 			.style('cursor', 'pointer')
 			.attr('title', 'Remove all plots for this sample')
@@ -75,10 +88,10 @@ export class SectionRender {
                 </svg>`
 			)
 			.on('click', () => {
-				this.removeSection(sampleId, sc)
+				this.removeSection(key, sc)
 			})
 
-		const titleText = this.makeSectionTitleText(sampleId, item)
+		const titleText = this.makeSectionTitleText(key, item)
 		const titleWrapper = sectionWrapper.append('span').style('font-weight', 600).style('opacity', 0.7).text(titleText)
 
 		const arrow = titleWrapper
@@ -89,15 +102,15 @@ export class SectionRender {
 			.text('▼')
 
 		titleWrapper.on('click', () => {
-			const isHidden = this.sections[sampleId].subplots.style('display') === 'none'
-			this.sections[sampleId].subplots.style('display', isHidden ? 'block' : 'none')
+			const isHidden = this.sections[key].subplots.style('display') === 'none'
+			this.sections[key].subplots.style('display', isHidden ? 'block' : 'none')
 			arrow.text(isHidden ? '▼' : '▲')
 		})
 
-		this.sections[sampleId] = {
+		this.sections[key] = {
 			sectionWrapper,
 			title: titleWrapper,
-			subplots: sectionWrapper.append('div').attr('data-testid', `sjpp-sc-subplots-${sampleId}`),
+			subplots: sectionWrapper.append('div').attr('data-testid', `sjpp-sc-subplots-${key}`),
 			sandboxes: {}
 		}
 	}
@@ -110,15 +123,15 @@ export class SectionRender {
 		return sc.items.find(item => item.sample === sampleId || item.experiments?.some(e => e.sampleName === sampleId))
 	}
 
-	makeSectionTitleText(sampleId: string, item?: SingleCellSample) {
-		const caseText = item?.sample && item.sample !== sampleId ? `Case: ${item.sample}` : ''
-		const itemText = `Sample: ${sampleId}`
+	makeSectionTitleText(key: string, item?: SingleCellSample) {
+		const caseText = item?.sample && item.sample !== key ? `Case: ${item.sample}` : ''
+		const itemText = `Sample: ${key}`
 		const projectText = item?.['project id'] ? `Project: ${item['project id']}` : ''
 		return [itemText, caseText, projectText].filter(Boolean).join(' ')
 	}
 
-	async initSandbox(sc: any, subplot: any, sampleId: string) {
-		const sandboxHolder = this.sections[sampleId].subplots
+	async initSandbox(sc: any, subplot: any, key: string) {
+		const sandboxHolder = this.sections[key].subplots
 			.insert('div', ':first-child')
 			.attr('data-testid', `sjpp-sc-sandbox-${subplot.id}`)
 
@@ -152,13 +165,13 @@ export class SectionRender {
 		}
 
 		await sc.initPlotComponent(subplot.id, opts)
-		this.sections[sampleId].sandboxes[subplot.id] = sandbox.app_div
+		this.sections[key].sandboxes[subplot.id] = sandbox.app_div
 	}
 
-	removeSection(sampleId: string, sc: SCViewer) {
+	removeSection(key: string, sc: SCViewer) {
 		const subactions: { type: string; id: string; parentId: string }[] = []
-		for (const plotId of Object.keys(this.sections[sampleId].sandboxes || {})) {
-			this.removeSandbox(plotId, sc, sampleId)
+		for (const plotId of Object.keys(this.sections[key].sandboxes || {})) {
+			this.removeSandbox(plotId, sc, key)
 			/** Need to remove plots from the state to prevent main from re-rendering
 			 * and memory leak from orphaned components after the section is deleted. */
 			subactions.push({
@@ -173,17 +186,17 @@ export class SectionRender {
 				subactions
 			})
 		}
-		this.sections[sampleId].sectionWrapper.remove()
-		delete this.sections[sampleId]
+		this.sections[key].sectionWrapper.remove()
+		delete this.sections[key]
 	}
 
-	removeSandbox(plotId: string, sc: SCViewer, _sampleId?: string) {
+	removeSandbox(plotId: string, sc: SCViewer, _key?: string) {
 		sc.removeComponent(plotId)
-		const sampleId = _sampleId || this.plotId2Sample.get(plotId)
-		if (!sampleId) return
-		this.sections[sampleId].sandboxes[plotId].remove()
-		delete this.sections[sampleId].sandboxes[plotId]
+		const key = _key || this.plotId2Key.get(plotId)
+		if (!key) return
+		this.sections[key].sandboxes[plotId].remove()
+		delete this.sections[key].sandboxes[plotId]
 		//Remove the reference to the plotId in plot2Sample map to avoid memory leak
-		this.plotId2Sample.delete(plotId)
+		this.plotId2Key.delete(plotId)
 	}
 }

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -22,6 +22,14 @@ export class SectionRender {
 
 	//Send the sc with the updated state
 	async update(sc: SCViewer, subplots: any, groupBy: 'none' | 'sample' | 'plot') {
+		if (groupBy !== this.groupBy) {
+			this.groupBy = groupBy
+			//Reset sections and plotId2Key map when groupBy changes as the keys will be different
+			//TODO: evaluate if there's a more performant way to update sections when
+			//groupBy changes without needing to re-render all the sections and sandboxes
+			this.sections = {}
+			this.plotId2Key = new Map()
+		}
 		const activeSubplots = new Set(subplots.map(s => s.id))
 
 		/** Repeat the destory from the close button, as mass/app.ts
@@ -33,7 +41,7 @@ export class SectionRender {
 		}
 
 		for (const subplot of subplots) {
-			const key = groupBy == 'sample' ? this.getSampleId(subplot) : undefined
+			const key = groupBy == 'sample' ? this.getSampleId(subplot) : this.getPlotName(subplot)
 			if (!key) continue
 			if (!this.sections[key]) this.initSection(key, sc)
 			if (!this.sections[key].sandboxes[subplot.id]) {
@@ -58,9 +66,14 @@ export class SectionRender {
 	}
 
 	getPlotName(subplot: any): string {
-		let plotName = subplot?.singleCellPlot?.name || subplot?.term?.term?.plot
+		let plotName = subplot?.plotName || subplot?.singleCellPlot?.name || subplot?.term?.term?.plot
 		if (!plotName) {
-			if (subplot.chartType === 'dictionary') plotName = 'Dictionary'
+			/** Harcoding logic for some transient and parent plots for now. May consider
+			 * adding to the config if this becomes more complex. Must weight against
+			 * adding unnecessary complexity to the config for edge cases though.*/
+			if (subplot.chartType === 'dictionary') plotName = 'Summary'
+			if (subplot.chartType === 'summary') plotName = 'Summary'
+			if (subplot.chartType === 'GeneExpInput') plotName = 'Gene expression'
 		}
 		return plotName
 	}
@@ -124,6 +137,7 @@ export class SectionRender {
 	}
 
 	makeSectionTitleText(key: string, item?: SingleCellSample) {
+		if (this.groupBy === 'plot') return key
 		const caseText = item?.sample && item.sample !== key ? `Case: ${item.sample}` : ''
 		const itemText = `Sample: ${key}`
 		const projectText = item?.['project id'] ? `Project: ${item['project id']}` : ''

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -1,8 +1,9 @@
 import type { Sections } from './Sections'
-import type { Div } from '../../../types/d3'
+import type { Div, Elem } from '../../../types/d3'
 import { newSandboxDiv } from '#dom'
 import type { SCViewer } from '../SC'
 import type { SingleCellSample } from '#types'
+import type { GroupByOptions } from '../settings/Settings'
 
 export class SectionRender {
 	sections: Sections
@@ -10,9 +11,9 @@ export class SectionRender {
 	/** Maps the plotId to either the sampleId or plotName (i.e. key in secions map)
 	 * as a reverse lookup. */
 	plotId2Key: Map<string, string>
-	groupBy: string
+	groupBy: (typeof GroupByOptions)[number]
 
-	constructor(sectionsDiv: Div, groupBy: string) {
+	constructor(sectionsDiv: Div, groupBy: (typeof GroupByOptions)[number]) {
 		this.sections = {}
 		this.holder = sectionsDiv
 		//Key may be either sampleId or plotName
@@ -21,7 +22,7 @@ export class SectionRender {
 	}
 
 	//Send the sc with the updated state
-	async update(sc: SCViewer, subplots: any, groupBy: string) {
+	async update(sc: SCViewer, subplots: any, groupBy: (typeof GroupByOptions)[number]) {
 		if (groupBy !== this.groupBy) {
 			this.groupBy = groupBy
 			this.holder.selectAll('*').remove()
@@ -84,7 +85,7 @@ export class SectionRender {
 		const item = this.findSampleMetadata(key, sc)
 
 		const titleAttrText =
-			this.groupBy == 'this sample section' ? 'sample' : this.groupBy == 'plot' ? 'this plot section' : 'all plots'
+			this.groupBy == 'sample' ? 'this sample section' : this.groupBy == 'plot' ? 'this plot section' : 'all plots'
 		const sectionWrapper = this.holder
 			.insert('div', ':first-child')
 			.style('padding', '10px')
@@ -154,7 +155,7 @@ export class SectionRender {
 	async initSandbox(sc: any, subplot: any, key: string) {
 		const sandboxHolder = this.sections[key].subplots
 			.insert('div', ':first-child')
-			.attr('data-testid', `sjpp-sc-sandbox-${subplot.id}`)
+			.attr('data-testid', `sjpp-sc-sandbox-${subplot.id}`) as any as Elem
 
 		const sandbox = newSandboxDiv(sandboxHolder, {
 			close: () => {

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -2,6 +2,7 @@ import type { Sections } from '../SCTypes'
 import type { Div } from '../../../types/d3'
 import { newSandboxDiv } from '#dom'
 import type { SCViewer } from '../SC'
+import type { SingleCellSample } from '#types'
 
 export class SectionRender {
 	sections: Sections
@@ -27,9 +28,9 @@ export class SectionRender {
 		}
 
 		for (const subplot of subplots) {
-			const item = subplot.scItem || subplot?.term?.term?.sample
-			const sampleId = item.sample || item.sID
-			if (!this.sections[sampleId]) this.initSection(sampleId, item, sc)
+			const sampleId = this.getSampleId(subplot)
+			if (!sampleId) continue
+			if (!this.sections[sampleId]) this.initSection(sampleId, sc)
 			if (!this.sections[sampleId].sandboxes[subplot.id]) {
 				this.plotId2Sample.set(subplot.id, sampleId)
 				await this.initSandbox(sc, subplot, sampleId)
@@ -45,7 +46,14 @@ export class SectionRender {
 		}
 	}
 
-	initSection(sampleId: string, item: any, sc: SCViewer) {
+	/** Extract sID from a subplot's config.
+	 * Actual subplots store sample as {sID, eID} at top level or on term.term.sample. */
+	getSampleId(subplot: any): string | undefined {
+		return subplot.sample?.sID || subplot.singleCellPlot?.sample?.sID || subplot.term?.term?.sample?.sID
+	}
+
+	initSection(sampleId: string, sc: SCViewer) {
+		const item = this.findSampleMetadata(sampleId, sc)
 		const sectionWrapper = this.holder
 			.insert('div', ':first-child')
 			.style('padding', '10px')
@@ -94,12 +102,19 @@ export class SectionRender {
 		}
 	}
 
-	//This needs to be ds specific. Placeholder for now
-	makeSectionTitleText(sampleId: string, item: any) {
-		const caseText = item.case ? `Case: ${item.case}` : ''
-		const itemText = `Sample: ${sampleId}` //item.cell, etc.
-		const projectText = item['project id'] ? `Project: ${item['project id']}` : ''
-		return [itemText, caseText, projectText].join(' ')
+	/** Look up sample metadata from the fetched items list.
+	 * For experiment datasets, matches sID against experiments[].sampleName.
+	 * For non-experiment datasets, matches sID against item.sample. */
+	findSampleMetadata(sampleId: string, sc: SCViewer): SingleCellSample | undefined {
+		if (!sc.items) return undefined
+		return sc.items.find(item => item.sample === sampleId || item.experiments?.some(e => e.sampleName === sampleId))
+	}
+
+	makeSectionTitleText(sampleId: string, item?: SingleCellSample) {
+		const caseText = item?.sample && item.sample !== sampleId ? `Case: ${item.sample}` : ''
+		const itemText = `Sample: ${sampleId}`
+		const projectText = item?.['project id'] ? `Project: ${item['project id']}` : ''
+		return [itemText, caseText, projectText].filter(Boolean).join(' ')
 	}
 
 	async initSandbox(sc: any, subplot: any, sampleId: string) {

--- a/client/plots/sc/view/SectionRender.ts
+++ b/client/plots/sc/view/SectionRender.ts
@@ -10,20 +10,21 @@ export class SectionRender {
 	/** Maps the plotId to either the sampleId or plotName (i.e. key in secions map)
 	 * as a reverse lookup. */
 	plotId2Key: Map<string, string>
-	groupBy: string | undefined
+	groupBy: string
 
-	constructor(sectionsDiv: Div) {
+	constructor(sectionsDiv: Div, groupBy: string) {
 		this.sections = {}
 		this.holder = sectionsDiv
 		//Key may be either sampleId or plotName
 		this.plotId2Key = new Map()
-		this.groupBy = undefined
+		this.groupBy = groupBy
 	}
 
 	//Send the sc with the updated state
-	async update(sc: SCViewer, subplots: any, groupBy: 'none' | 'sample' | 'plot') {
+	async update(sc: SCViewer, subplots: any, groupBy: string) {
 		if (groupBy !== this.groupBy) {
 			this.groupBy = groupBy
+			this.holder.selectAll('*').remove()
 			//Reset sections and plotId2Key map when groupBy changes as the keys will be different
 			//TODO: evaluate if there's a more performant way to update sections when
 			//groupBy changes without needing to re-render all the sections and sandboxes
@@ -41,7 +42,8 @@ export class SectionRender {
 		}
 
 		for (const subplot of subplots) {
-			const key = groupBy == 'sample' ? this.getSampleId(subplot) : this.getPlotName(subplot)
+			const key =
+				groupBy == 'none' ? 'none' : groupBy == 'sample' ? this.getSampleId(subplot) : this.getPlotName(subplot)
 			if (!key) continue
 			if (!this.sections[key]) this.initSection(key, sc)
 			if (!this.sections[key].sandboxes[subplot.id]) {
@@ -80,6 +82,9 @@ export class SectionRender {
 
 	initSection(key: string, sc: SCViewer) {
 		const item = this.findSampleMetadata(key, sc)
+
+		const titleAttrText =
+			this.groupBy == 'this sample section' ? 'sample' : this.groupBy == 'plot' ? 'this plot section' : 'all plots'
 		const sectionWrapper = this.holder
 			.insert('div', ':first-child')
 			.style('padding', '10px')
@@ -91,7 +96,7 @@ export class SectionRender {
 			.attr('data-testid', `sjpp-sc-section-remove-btn-${key}`)
 			.style('margin', '0px 5px')
 			.style('cursor', 'pointer')
-			.attr('title', 'Remove all plots for this sample')
+			.attr('title', `Remove ${titleAttrText}`)
 			.html(
 				`<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="#000" class="bi bi-x-lg" viewBox="0 0 12 12">
                 <path
@@ -106,19 +111,20 @@ export class SectionRender {
 
 		const titleText = this.makeSectionTitleText(key, item)
 		const titleWrapper = sectionWrapper.append('span').style('font-weight', 600).style('opacity', 0.7).text(titleText)
+		if (titleText.length) {
+			const arrow = titleWrapper
+				.append('span')
+				.style('font-size', '0.8em')
+				.style('padding-left', '3px')
+				.attr('title', `Show/hide plots in ${titleAttrText}`)
+				.text('▼')
 
-		const arrow = titleWrapper
-			.append('span')
-			.style('font-size', '0.8em')
-			.style('padding-left', '3px')
-			.attr('title', 'Show or hide plots for this sample')
-			.text('▼')
-
-		titleWrapper.on('click', () => {
-			const isHidden = this.sections[key].subplots.style('display') === 'none'
-			this.sections[key].subplots.style('display', isHidden ? 'block' : 'none')
-			arrow.text(isHidden ? '▼' : '▲')
-		})
+			titleWrapper.on('click', () => {
+				const isHidden = this.sections[key].subplots.style('display') === 'none'
+				this.sections[key].subplots.style('display', isHidden ? 'block' : 'none')
+				arrow.text(isHidden ? '▼' : '▲')
+			})
+		}
 
 		this.sections[key] = {
 			sectionWrapper,
@@ -137,6 +143,7 @@ export class SectionRender {
 	}
 
 	makeSectionTitleText(key: string, item?: SingleCellSample) {
+		if (this.groupBy === 'none') return ''
 		if (this.groupBy === 'plot') return key
 		const caseText = item?.sample && item.sample !== key ? `Case: ${item.sample}` : ''
 		const itemText = `Sample: ${key}`

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -5,18 +5,26 @@ import type { SCViewer } from '../SC'
 import type { SingleCellSample } from '#types'
 import type { GroupByOptions } from '../settings/Settings'
 
+/** Manages the mapping and rendering of the sections based on the groupBy option.
+ * sections{} maps the section key (i.e. sampleId, plotName, or none) to the section
+ * wrapper, title, subplots div, and the sandboxes in that section.
+ *
+ * Initializing and destorying the plot components is within SC.ts
+ * (i.e. sc.components.plots[plotId]). This ensures plots are responsive to state changes.
+ */
 export class SectionRenderer {
 	sections: Sections
 	holder: Div
-	/** Maps the plotId to either the sampleId or plotName (i.e. key in secions map)
-	 * as a reverse lookup. */
+	/** Maps the plotId to either the sampleId, plotName, or none (i.e. key in sections map)
+	 * as a reverse lookup. Used in tandem with sections{} to manage the sandboxes
+	 * within each section. */
 	plotId2Key: Map<string, string>
 	groupBy: (typeof GroupByOptions)[number]
 
 	constructor(sectionsDiv: Div, groupBy: (typeof GroupByOptions)[number]) {
 		this.sections = {}
 		this.holder = sectionsDiv
-		//Key may be either sampleId or plotName
+		//Key may be either sampleId, plotName, or none
 		this.plotId2Key = new Map()
 		this.groupBy = groupBy
 	}
@@ -159,8 +167,6 @@ export class SectionRenderer {
 
 		const sandbox = newSandboxDiv(sandboxHolder, {
 			close: () => {
-				//Delete the component before calling dispatch
-				//Prevents main attempting to re-init the component
 				this.removeSandbox(subplot.id, sc)
 				sc.app.dispatch({
 					type: 'plot_delete',
@@ -213,6 +219,8 @@ export class SectionRenderer {
 	}
 
 	removeSandbox(plotId: string, sc: SCViewer, _key?: string) {
+		//Delete the component before calling dispatch
+		//Prevents main attempting to re-init the component
 		sc.removeComponent(plotId)
 		const key = _key || this.plotId2Key.get(plotId)
 		if (!key) return

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -5,7 +5,7 @@ import type { SCViewer } from '../SC'
 import type { SingleCellSample } from '#types'
 import type { GroupByOptions } from '../settings/Settings'
 
-export class SectionRender {
+export class SectionRenderer {
 	sections: Sections
 	holder: Div
 	/** Maps the plotId to either the sampleId or plotName (i.e. key in secions map)

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -29,14 +29,18 @@ export class SectionRenderer {
 		this.groupBy = groupBy
 	}
 
-	//Send the sc with the updated state
+	/** Send the sc with the updated state. May not be necessary long term. If not,
+	 * remove and put in the constructor. */
 	async update(sc: SCViewer, subplots: any, groupBy: (typeof GroupByOptions)[number]) {
 		if (groupBy !== this.groupBy) {
 			this.groupBy = groupBy
 			this.holder.selectAll('*').remove()
-			//Reset sections and plotId2Key map when groupBy changes as the keys will be different
-			//TODO: evaluate if there's a more performant way to update sections when
-			//groupBy changes without needing to re-render all the sections and sandboxes
+			/** Reset sections and plotId2Key map when groupBy changes as the keys will be different
+			 *
+			 * TODO: evaluate if there's a more performant way to update sections when
+			 * groupBy changes without needing to re-render all the sections and sandboxes.
+			 *
+			 * Note: the plot component is only init'ed once under initSandbox() */
 			this.sections = {}
 			this.plotId2Key = new Map()
 		}
@@ -192,7 +196,10 @@ export class SectionRenderer {
 			opts.header = sandbox.header
 		}
 
-		await sc.initPlotComponent(subplot.id, opts)
+		/** Only initialize components once (i.e. do not re-initialize when the user has
+		 * changed the groupBy option, which triggers update and initSandbox for all
+		 * active subplots.) */
+		if (!sc.components.plots[subplot.id]) await sc.initPlotComponent(subplot.id, opts)
 		this.sections[key].sandboxes[subplot.id] = sandbox.app_div
 	}
 

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -38,11 +38,12 @@ export class SectionRenderer {
 			/** Reset sections and plotId2Key map when groupBy changes as the keys will be different
 			 *
 			 * TODO: evaluate if there's a more performant way to update sections when
-			 * groupBy changes without needing to re-render all the sections and sandboxes.
-			 *
-			 * Note: the plot component is only init'ed once under initSandbox() */
+			 * groupBy changes without needing to re-render all the sections and sandboxes.*/
 			this.sections = {}
 			this.plotId2Key = new Map()
+			for (const subplotId of Object.keys(sc.components.plots)) {
+				sc.removeComponent(subplotId)
+			}
 		}
 		const activeSubplots = new Set(subplots.map(s => s.id))
 
@@ -195,11 +196,7 @@ export class SectionRenderer {
 			opts.holder = sandbox.body
 			opts.header = sandbox.header
 		}
-
-		/** Only initialize components once (i.e. do not re-initialize when the user has
-		 * changed the groupBy option, which triggers update and initSandbox for all
-		 * active subplots.) */
-		if (!sc.components.plots[subplot.id]) await sc.initPlotComponent(subplot.id, opts)
+		await sc.initPlotComponent(subplot.id, opts)
 		this.sections[key].sandboxes[subplot.id] = sandbox.app_div
 	}
 

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -9,7 +9,7 @@ import type { GroupByOptions } from '../settings/Settings'
  * sections{} maps the section key (i.e. sampleId, plotName, or none) to the section
  * wrapper, title, subplots div, and the sandboxes in that section.
  *
- * Initializing and destorying the plot components is within SC.ts
+ * Initializing and destroying the plot components is within SC.ts
  * (i.e. sc.components.plots[plotId]). This ensures plots are responsive to state changes.
  */
 export class SectionRenderer {

--- a/client/plots/sc/view/Sections.ts
+++ b/client/plots/sc/view/Sections.ts
@@ -1,0 +1,18 @@
+import type { Div } from '../../../types/d3'
+
+export type Sections = {
+	//Key is either sampleId or plotName depending on the grouping method
+	[key: string]: {
+		/** Wrapper div for the entire section. Used to destroy the section when needed. */
+		sectionWrapper: Div
+		/** Title element for the section. */
+		title: any
+		/** Wrapper for the subplots within the section. */
+		subplots: any
+		/** Maps the plotId to the corresponding sandbox element. */
+		sandboxes: {
+			//Key is the plot.id and the value is sandbox.app_div
+			[key: string]: any
+		}
+	}
+}

--- a/client/plots/sc/view/Sections.ts
+++ b/client/plots/sc/view/Sections.ts
@@ -1,4 +1,4 @@
-import type { Div } from '../../../types/d3'
+import type { Div, Span } from '../../../types/d3'
 
 export type Sections = {
 	//Key is either sampleId or plotName depending on the grouping method
@@ -6,9 +6,9 @@ export type Sections = {
 		/** Wrapper div for the entire section. Used to destroy the section when needed. */
 		sectionWrapper: Div
 		/** Title element for the section. */
-		title: any
+		title: Span
 		/** Wrapper for the subplots within the section. */
-		subplots: any
+		subplots: Div
 		/** Maps the plotId to the corresponding sandbox element. */
 		sandboxes: {
 			//Key is the plot.id and the value is sandbox.app_div

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -3,11 +3,6 @@ import type { TableColumn, TableRow } from '#dom'
 import type { SCConfig, SCFormattedState, SampleColumn } from '../SCTypes'
 import type { SingleCellSample } from '#types'
 
-/** TODOs
- *  - ?Implement data mapper for buttons?
- *  - Implement data mapper for plots in the dashboard
- */
-
 export type TableData = {
 	rows: TableRow[]
 	columns: TableColumn[]
@@ -26,7 +21,10 @@ export class SCViewModel {
 		//Should only be called once
 		const [rows, columns] = this.getTabelData(config, items, sampleColumns)
 		const selectedRows: number[] = []
-		const i = items.findIndex(i => i.sample == config.settings.sc.item?.sample)
+		const sID = config.settings.sc.item?.sID
+		const i = sID
+			? items.findIndex(item => item.sample === sID || item.experiments?.some(e => e.sampleName === sID))
+			: -1
 		if (i != -1) selectedRows.push(i)
 
 		/** Returning this data separately from the eventual

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -1,18 +1,12 @@
 import type { AppApi } from '#rx'
 import type { TableColumn, TableRow } from '#dom'
-import type { SCConfig, SCFormattedState, SampleColumn } from '../SCTypes'
+import type { SCConfig, SCFormattedState, SampleColumn, SCTableData } from '../SCTypes'
 import type { SingleCellSample } from '#types'
-
-export type TableData = {
-	rows: TableRow[]
-	columns: TableColumn[]
-	selectedRows: number[]
-}
 
 export class SCViewModel {
 	app: AppApi
 	state: SCFormattedState
-	tableData: TableData
+	tableData: SCTableData
 
 	constructor(app: AppApi, config: SCConfig, items: SingleCellSample[], sampleColumns?: SampleColumn[]) {
 		this.app = app

--- a/client/plots/scatter/test/scatter.integration.spec.js
+++ b/client/plots/scatter/test/scatter.integration.spec.js
@@ -1295,7 +1295,7 @@ tape('singlecell map', function (test) {
 				{
 					chartType: 'sampleScatter',
 					colorTW: getScctTw(),
-					singleCellPlot: { name: 'scRNA', sample: { sID: '1_patient' } }
+					singleCellPlot: { name: 'UMAP', sample: { sID: '1_patient' } }
 				}
 			]
 		},

--- a/client/plots/test/GeneExpInput.integration.spec.ts
+++ b/client/plots/test/GeneExpInput.integration.spec.ts
@@ -50,12 +50,15 @@ tape('Test GeneExpInput rendering with GENE_EXPRESSION', test => {
 	})
 
 	async function runTests(GeneExpInput) {
-        const dom = GeneExpInput.Inner.dom
-        test.equal(dom.header.text(), 'Gene Expression', 'Header text should render with termtype.')
-        const visibleTabs = GeneExpInput.Inner.tabs.filter(tab => tab?.isVisible).map(tab => tab.label)
-        const tabs = dom.tabs.selectAll('button').nodes().map(n => n.textContent.trim())
-        test.deepEqual(tabs, visibleTabs, 'Should display the correct number of tabs with correct labels.')
-		
+		const dom = GeneExpInput.Inner.dom
+		test.equal(dom.header.plot.text(), 'GENE EXPRESSION', 'Header text should render with termtype.')
+		const visibleTabs = GeneExpInput.Inner.tabs.filter(tab => tab?.isVisible).map(tab => tab.label)
+		const tabs = dom.tabs
+			.selectAll('button')
+			.nodes()
+			.map(n => n.textContent.trim())
+		test.deepEqual(tabs, visibleTabs, 'Should display the correct number of tabs with correct labels.')
+
 		if (test['_ok']) GeneExpInput.Inner.app.destroy()
 		test.end()
 	}
@@ -81,11 +84,14 @@ tape('Test GeneExpInput rendering with SINGLECELL_GENE_EXPRESSION', test => {
 	})
 
 	async function runTests(GeneExpInput) {
-        const dom = GeneExpInput.Inner.dom
-        test.equal(dom.header.text(), 'Single-cell Gene Expression', 'Header text should render with termtype.')
+		const dom = GeneExpInput.Inner.dom
+		test.equal(dom.header.plot.text(), 'SINGLE-CELL GENE EXPRESSION', 'Header text should render with termtype.')
 		const visibleTabs = GeneExpInput.Inner.tabs.filter(tab => tab?.isVisible).map(tab => tab.label)
-        const tabs = dom.tabs.selectAll('button').nodes().map(n => n.textContent.trim())
-        test.deepEqual(tabs, visibleTabs, 'Should display the correct number of tabs with correct labels.')
+		const tabs = dom.tabs
+			.selectAll('button')
+			.nodes()
+			.map(n => n.textContent.trim())
+		test.deepEqual(tabs, visibleTabs, 'Should display the correct number of tabs with correct labels.')
 
 		if (test['_ok']) GeneExpInput.Inner.app.destroy()
 		test.end()

--- a/client/plots/test/violin.integration.spec.js
+++ b/client/plots/test/violin.integration.spec.js
@@ -1346,7 +1346,7 @@ tape('Load linear regression-violin UI', function (test) {
 	}
 })
 
-tape('term1=singleCellExpression, term2=singleCellCellType', function (test) {
+tape('Test violin render with term1=singleCellExpression, term2=singleCellCellType', function (test) {
 	test.timeoutAfter(3000)
 	runpp({
 		state: {

--- a/client/test/testdata/data.ts
+++ b/client/test/testdata/data.ts
@@ -623,7 +623,7 @@ export function getScctTw() {
 			sample: {
 				sID: '1_patient'
 			},
-			plot: 'scRNA',
+			plot: 'UMAP',
 			colorBy: 'CellType',
 			values: {
 				T_NK: {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- Several updates for the SC app: The flyout menu for the Gene expression button is replaced with the transient GeneExpInput plot. The blue plot buttons now correspond to plots with available data. Users may group plots by samples, plot type, or not at all. New units are available for the PlotButtons and SectionRenderer. 

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -450,7 +450,7 @@ export default function (): Mds3 {
 					src: 'native',
 					plots: [
 						{
-							name: 'scRNA',
+							name: 'UMAP',
 							folder: 'files/hg38/TermdbTest/scrna/umap',
 							fileSuffix: '_umap.txt',
 							colorColumns: [

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2235,9 +2235,10 @@ export function gdc_validate_query_singleCell_DEgenes(ds) {
 	q{} TermdbSinglecellDEgenesRequest
 	*/
 	ds.queries.singleCell.DEgenes.get = async q => {
-		const caseuuid = await getCaseidByFileid(q, q.sample, ds)
+		const fileId = typeof q.sample === 'string' ? q.sample : q.sample.eID
+		const caseuuid = await getCaseidByFileid(q, fileId, ds)
 
-		const degFileId = await getSinglecellDEfile(caseuuid, q, ds)
+		const degFileId = await getSinglecellDEfile(caseuuid, q, fileId, ds)
 
 		const genes = await getSinglecellDEgenes(q, degFileId, ds)
 		// Non-volcano callers (e.g. the singleCellPlot DE table) iterate data as
@@ -2267,8 +2268,8 @@ async function getCaseidByFileid(q, fileId, ds) {
 	return re.data?.cases[0].case_id
 }
 
-async function getSinglecellDEfile(caseuuid, q, ds) {
-	// find the seurat.deg.tsv file for the requested experient, and return file id. many cases have multiple sc experiments. to identify the correct experiment, use q.sample which is seurat.analysis.tsv file id. find the matching deg.tsv
+async function getSinglecellDEfile(caseuuid, q, fileId, ds) {
+	// find the seurat.deg.tsv file for the requested experient, and return file id. many cases have multiple sc experiments. to identify the correct experiment, use fileId which is seurat.analysis.tsv file id. find the matching deg.tsv
 
 	const body = {
 		filters: {
@@ -2324,7 +2325,7 @@ async function getSinglecellDEfile(caseuuid, q, ds) {
 		if (!Array.isArray(hit.downstream_analyses[0]?.output_files)) throw 'downstream_analyses[0].output_files[] missing'
 
 		// from output files of this experiment, find if the output_files[] array contains the requested analysis.tsv file
-		if (hit.downstream_analyses[0].output_files.find(f => f.file_id == q.sample)) {
+		if (hit.downstream_analyses[0].output_files.find(f => f.file_id == fileId)) {
 			// now find the deg.tsv file from output_files[] array
 			const f = hit.downstream_analyses[0].output_files.find(f => f.file_name == 'seurat.deg.tsv')
 			if (!f) throw 'a MEX downstream files has analysis.tsv but no deg.tsv'

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2269,7 +2269,7 @@ async function getCaseidByFileid(q, fileId, ds) {
 }
 
 async function getSinglecellDEfile(caseuuid, q, fileId, ds) {
-	// find the seurat.deg.tsv file for the requested experient, and return file id. many cases have multiple sc experiments. to identify the correct experiment, use fileId which is seurat.analysis.tsv file id. find the matching deg.tsv
+	// find the seurat.deg.tsv file for the requested experiment, and return file id. many cases have multiple sc experiments. to identify the correct experiment, use fileId which is seurat.analysis.tsv file id. find the matching deg.tsv
 
 	const body = {
 		filters: {

--- a/shared/types/src/routes/termdb.singlecellDEgenes.ts
+++ b/shared/types/src/routes/termdb.singlecellDEgenes.ts
@@ -7,7 +7,10 @@ export type TermdbSingleCellDEgenesRequest = {
 	genome: string
 	/** Dataset label */
 	dslabel: string
-	/** Sample identifier */
+	/** Sample identifier 
+	 * for GDC the value is "seurat.analysis.tsv" file UUID
+	rather than sample name, derived from the eID. The file 
+	contains the analysis results for an experiment */
 	sample: { sID: string; eID: string }
 	/** column name to provide cell groups/clustering,
 	 * for which DE genes are precomputed.  */

--- a/shared/types/src/routes/termdb.singlecellDEgenes.ts
+++ b/shared/types/src/routes/termdb.singlecellDEgenes.ts
@@ -7,11 +7,8 @@ export type TermdbSingleCellDEgenesRequest = {
 	genome: string
 	/** Dataset label */
 	dslabel: string
-	/** Sample name
-	for GDC the value is "seurat.analysis.tsv" file UUID
-	rather than sample name. the file contains the analysis
-	results for an experiment */
-	sample: string
+	/** Sample identifier */
+	sample: { sID: string; eID: string }
 	/** column name to provide cell groups/clustering,
 	 * for which DE genes are precomputed.  */
 	termId: string

--- a/shared/types/src/routes/termdb.singlecellDEgenes.ts
+++ b/shared/types/src/routes/termdb.singlecellDEgenes.ts
@@ -7,11 +7,14 @@ export type TermdbSingleCellDEgenesRequest = {
 	genome: string
 	/** Dataset label */
 	dslabel: string
-	/** Sample identifier 
+	/** Sample identifier
 	 * for GDC the value is "seurat.analysis.tsv" file UUID
-	rather than sample name, derived from the eID. The file 
-	contains the analysis results for an experiment */
-	sample: { sID: string; eID: string }
+	 * rather than sample name, derived from the eID. The file
+	 * contains the analysis results for an experiment.
+	 *
+	 * Eventually, all requests will use the object and
+	 * **not** the string format.*/
+	sample: string | { sID: string; eID: string }
 	/** column name to provide cell groups/clustering,
 	 * for which DE genes are precomputed.  */
 	termId: string


### PR DESCRIPTION
# Description

Addresses several tasks in the [roadmap](https://github.com/stjude/sjpp/issues/658)

Changes: 
1. The GeneExpChartMenu for the Gene expression button is replaced with the transient GeneExpInput plot. This depreciates the GeneExpChartMenu entirely and it maybe deleted from the repo. 
2. The labels for the GeneExpInput were updated, as requested. 
3. The sample object is now unified for all datasets. The sample unified object is passed to all subplots and implemented in server requests. This lowers the complexity of the app and increases maintainability. 
4. With the recent server response change, the plot buttons now correspond to plots with available data. In other words if no file is found, then the button should not appear. 
5. Users may group plots by samples, plot type, or not at all from radio buttons above the sample table.  
6. New units are available for the PlotButtons and SectionRenderer. 

Test with any of the SC examples from http://localhost:3000/url.html. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
