### PR TITLE
Support demo token login for datasets with custom jwt processor

### DIFF
--- a/client/common/auth.js
+++ b/client/common/auth.js
@@ -1,4 +1,5 @@
 import { select } from 'd3-selection'
+import { dofetch3 } from './dofetch'
 
 const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
 const jwtByDsRoute = JSON.parse(jwtByDsRouteStr)
@@ -72,7 +73,7 @@ export let includeEmbedder = false
 	.authUi: optional, a custom login UI function to launch as needed
 	.holder: optional, a d3-wrapped selection to hold the auth UI
 */
-export async function setDsAuthOk(opts, dofetch3) {
+export async function setDsAuthOk(opts) {
 	dsAuth = opts.dsAuth
 	authUi = opts.ui || defaultAuthUi
 	authUiHolder = opts.holder || select('body')
@@ -80,31 +81,10 @@ export async function setDsAuthOk(opts, dofetch3) {
 		// fillin all the dslabels that has an active session
 		// so that an unnecessary login form will not be shown
 		if (auth.insession) dsAuthOk.add(auth)
-		else {
-			// check if there is a PP-server generated session token that has been saved from a previous login
-			const { dslabel, route } = auth
-			const jwt = getSavedToken(dslabel, route)
-			if (jwt) {
-				const payload = JSON.parse(atob(jwt.split('.')[1]))
-				if (payload.exp && Math.ceil(Date.now() / 1000) > payload.exp) continue
-				const data = await dofetch3('/jwt-status', {
-					method: 'POST',
-					headers: {
-						//authorization: `Bearer ${btoa(jwt)}`
-						[auth.headerKey]: jwt
-					},
-					body: {
-						dslabel,
-						route,
-						embedder: location.hostname
-					}
-				})
-				if (data.ok || data.status == 'ok') {
-					dsAuthOk.add(auth)
-					auth.insession = true
-				}
-			}
-		}
+		// defer the check for saved jwtByDsRoute to isInSession(),
+		// so that there are no confusing multiple /jwt-status requests
+		// in the Network requests tab in simulated demoToken usage
+		// which is only one dslabel at a time
 	}
 	includeEmbedder = opts.dsAuth?.length > 0 || false
 }
@@ -120,10 +100,44 @@ export function getRequiredAuth(dslabel, route) {
 
 // check if a user is logged in, usually checked together with requiredAuth in termdb/config,
 // so access to unprotected ds/routes should not be affected by this check
-export function isInSession(dslabel, route) {
+export async function isInSession(dslabel, route) {
 	if (!dslabel) return false
-	for (const a of dsAuthOk) {
-		if (a.dslabel == dslabel && (a.route == route || a.route == '/**')) return true
+	for (const a of dsAuth) {
+		if (a.dslabel == dslabel && (a.route == route || a.route == '/**')) {
+			if (dsAuthOk.has(a)) return true
+			// for auth.type == 'jwt', migrate to always using getDatasetAccessToken()
+			// instead of saving a session jwt in localStorage
+			if (a.checked || a.type == 'jwt') return false
+			// for other auth types like basic (password login), recover related saved jwt that
+			// allows one-time sign-in throughout a user's browser session;
+			const { dslabel, route } = a
+			// check if there is a PP-server generated session token that has been saved from a previous login
+			const jwt = getSavedToken(dslabel, route)
+			if (jwt) {
+				const payload = JSON.parse(atob(jwt.split('.')[1]))
+				if (payload.exp && Math.ceil(Date.now() / 1000) > payload.exp) return false
+				const data = await dofetch3('/jwt-status', {
+					method: 'POST',
+					headers: {
+						//authorization: `Bearer ${btoa(jwt)}`
+						[a.headerKey]: jwt
+					},
+					body: {
+						dslabel,
+						route,
+						embedder: location.hostname
+					}
+				})
+				if (data.ok || data.status == 'ok') {
+					dsAuthOk.add(a)
+					a.insession = true
+					return true
+				} else {
+					a.checked = false
+					return false
+				}
+			}
+		}
 	}
 	// no matching sessions found for this dslabel and route
 	return false

--- a/client/common/auth.js
+++ b/client/common/auth.js
@@ -1,5 +1,5 @@
 import { select } from 'd3-selection'
-import { dofetch3 } from './dofetch'
+//import { dofetch3 } from './dofetch'
 
 const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
 const jwtByDsRoute = JSON.parse(jwtByDsRouteStr)
@@ -102,41 +102,38 @@ export function getRequiredAuth(dslabel, route) {
 // so access to unprotected ds/routes should not be affected by this check
 export async function isInSession(dslabel, route) {
 	if (!dslabel) return false
+	if (!Array.isArray(dsAuth)) return false
 	for (const a of dsAuth) {
-		if (a.dslabel == dslabel && (a.route == route || a.route == '/**')) {
-			if (dsAuthOk.has(a)) return true
-			// for auth.type == 'jwt', migrate to always using getDatasetAccessToken()
-			// instead of saving a session jwt in localStorage
-			if (a.checked || a.type == 'jwt') return false
-			// for other auth types like basic (password login), recover related saved jwt that
-			// allows one-time sign-in throughout a user's browser session;
-			const { dslabel, route } = a
-			// check if there is a PP-server generated session token that has been saved from a previous login
-			const jwt = getSavedToken(dslabel, route)
-			if (jwt) {
-				const payload = JSON.parse(atob(jwt.split('.')[1]))
-				if (payload.exp && Math.ceil(Date.now() / 1000) > payload.exp) return false
-				const data = await dofetch3('/jwt-status', {
-					method: 'POST',
-					headers: {
-						//authorization: `Bearer ${btoa(jwt)}`
-						[a.headerKey]: jwt
-					},
-					body: {
-						dslabel,
-						route,
-						embedder: location.hostname
-					}
-				})
-				if (data.ok || data.status == 'ok') {
-					dsAuthOk.add(a)
-					a.insession = true
-					return true
-				} else {
-					a.checked = false
-					return false
-				}
+		if (a.dslabel != dslabel || (a.route != route && a.route != '/**')) continue
+		if (dsAuthOk.has(a)) return true
+		// for auth.type == 'jwt', migrate to always using getDatasetAccessToken()
+		// instead of saving a session jwt in localStorage
+		if (a.checked || a.type == 'jwt') return false
+		// for other auth types like basic (password login), recover related saved jwt that
+		// allows one-time sign-in throughout a user's browser session;
+		// check if there is a PP-server generated session token that has been saved from a previous login
+		const jwt = getSavedToken(dslabel, a.route)
+		if (!jwt) return false
+		const { dofetch3 } = await import('./dofetch')
+		const payload = JSON.parse(atob(jwt.split('.')[1]))
+		if (payload.exp && Math.ceil(Date.now() / 1000) > payload.exp) return false
+		const data = await dofetch3('/jwt-status', {
+			method: 'POST',
+			headers: {
+				//authorization: `Bearer ${btoa(jwt)}`
+				[a.headerKey]: jwt
+			},
+			body: {
+				dslabel,
+				route,
+				embedder: location.hostname
 			}
+		})
+		a.checked = true
+		if (data.ok || data.status == 'ok') {
+			dsAuthOk.add(a)
+			a.insession = true
+			return true
 		}
 	}
 	// no matching sessions found for this dslabel and route
@@ -246,4 +243,18 @@ async function defaultAuthUi(dslabel, auth, opts = {}) {
 				authUiHolder
 			})
 	})
+}
+
+function decodeJwtPayload(token) {
+	// 1. Split the token into its 3 parts (header, payload, signature)
+	const base64Url = token.split('.')[1]
+	// 2. Convert Base64Url to standard Base64
+	const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+	// 3. Decode the Base64 string and parse it as JSON
+	const jsonPayload = decodeURIComponent(window.atob(base64).split('').map(convertAtoBresult).join(''))
+	return JSON.parse(jsonPayload)
+}
+
+function convertAtoBresult(c) {
+	return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
 }

--- a/client/common/auth.js
+++ b/client/common/auth.js
@@ -115,7 +115,7 @@ export async function isInSession(dslabel, route) {
 		const jwt = getSavedToken(dslabel, a.route)
 		if (!jwt) return false
 		const { dofetch3 } = await import('./dofetch')
-		const payload = JSON.parse(atob(jwt.split('.')[1]))
+		const payload = decodeJwtPayload(jwt)
 		if (payload.exp && Math.ceil(Date.now() / 1000) > payload.exp) return false
 		const data = await dofetch3('/jwt-status', {
 			method: 'POST',
@@ -250,8 +250,9 @@ function decodeJwtPayload(token) {
 	const base64Url = token.split('.')[1]
 	// 2. Convert Base64Url to standard Base64
 	const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+	const paddedBase64 = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
 	// 3. Decode the Base64 string and parse it as JSON
-	const jsonPayload = decodeURIComponent(window.atob(base64).split('').map(convertAtoBresult).join(''))
+	const jsonPayload = decodeURIComponent(window.atob(paddedBase64).split('').map(convertAtoBresult).join(''))
 	return JSON.parse(jsonPayload)
 }
 

--- a/client/common/auth.js
+++ b/client/common/auth.js
@@ -106,9 +106,9 @@ export async function isInSession(dslabel, route) {
 	for (const a of dsAuth) {
 		if (a.dslabel != dslabel || (a.route != route && a.route != '/**')) continue
 		if (dsAuthOk.has(a)) return true
-		// for auth.type == 'jwt', migrate to always using getDatasetAccessToken()
+		// TODO: for auth.type == 'jwt', consider migrating to always using getDatasetAccessToken()
 		// instead of saving a session jwt in localStorage
-		if (a.checked || a.type == 'jwt') return false
+		if (a.checked /*|| a.type == 'jwt'*/) return false
 		// for other auth types like basic (password login), recover related saved jwt that
 		// allows one-time sign-in throughout a user's browser session;
 		// check if there is a PP-server generated session token that has been saved from a previous login

--- a/client/common/test/auth.unit.spec.js
+++ b/client/common/test/auth.unit.spec.js
@@ -30,8 +30,8 @@ tape('setDsAuthOk()', async test => {
 	}
 	//const fakeDofetch3 = () => ({ status: 'ok' }) // uncomment only if there is a saved token for one of the test dslabels
 	await auth.setDsAuthOk(opts /*, fakeDofetch3 */)
-	test.equal(auth.isInSession('abc', 'termdb'), false, 'should detect a dslabel that is not in session')
-	test.equal(auth.isInSession('xyz', 'fake-route'), true, 'should detect a dslabel that is in session')
+	test.equal(await auth.isInSession('abc', 'termdb'), false, 'should detect a dslabel that is not in session')
+	test.equal(await auth.isInSession('xyz', 'fake-route'), true, 'should detect a dslabel that is in session')
 	await auth.setTokenByDsRoute(opts.dsAuth[0].dslabel, opts.dsAuth[0].route) // clear jwtByDsRoute[dslabel][route]
 	await auth.setTokenByDsRoute(opts.dsAuth[1].dslabel, opts.dsAuth[1].route) // clear jwtByDsRoute[dslabel][route]
 	test.end()

--- a/client/common/test/dofetch.unit.spec.js
+++ b/client/common/test/dofetch.unit.spec.js
@@ -78,8 +78,8 @@ tape('setAuth()', async test => {
 			{ dslabel: 'xyz', type: 'basic', insession: true }
 		]
 	}
-	df.setAuth(opts, df.dofetch3)
-	test.equal(df.isInSession('abc'), false, 'should detect a dslabel that is not in session')
-	test.equal(df.isInSession('xyz'), true, 'should detect a dslabel that is in session')
+	df.setAuth(opts)
+	test.equal(await df.isInSession('abc'), false, 'should detect a dslabel that is not in session')
+	test.equal(await df.isInSession('xyz'), true, 'should detect a dslabel that is in session')
 	test.end()
 })

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -40,7 +40,7 @@ export class Vocab {
 		if (this.state.vocab) this.vocab = this.state.vocab
 		// may or may not need a verified token for a dslabel, based on genome response.dsAuth
 		const dslabel = this.state.dslabel || this.state.vocab.dslabel
-		this.verifiedToken = !this.state.termdbConfig?.requiredAuth?.length || isInSession(dslabel, 'termdb')
+		this.verifiedToken = !this.state.termdbConfig?.requiredAuth?.length || (await isInSession(dslabel, 'termdb'))
 		// secured plots need to confirm that a verified token exists
 		if (dslabel) await this.maySetVerifiedToken(dslabel)
 	}
@@ -137,7 +137,7 @@ export class Vocab {
 
 		if (!auth) return {}
 		if (!this.verifiedToken) {
-			if (isInSession(dslabel, 'termdb')) {
+			if (await isInSession(dslabel, 'termdb')) {
 				const jwt = getSavedToken(this.state.vocab.dslabel, route)
 				if (jwt) this.verifiedToken = jwt
 			} else {

--- a/public/static/js/login.js
+++ b/public/static/js/login.js
@@ -31,8 +31,6 @@ function getJwtByDsRoute(dslabel) {
 	return dslabel ? jwtByDsRoute[dslabel] : jwtByDsRoute
 }
 
-const fakeTokensByDsRole = {}
-
 // this is meant for 1 time use throughout a browser session,
 // and not meant for repeated calls within getDatasetAccessToken()
 async function login(dslabel, role = '') {
@@ -66,8 +64,7 @@ function demoGetDatasetAccessToken(dslabel, defaultRole) {
 		const payloadEncoded = jwt?.split('.')[1]
 		if (payloadEncoded) {
 			try {
-				const payloadStr = atob(payloadEncoded)
-				const payload = JSON.parse(payloadStr)
+				const payload = decodeJwtPayload(jwt)
 				fakeTokensByRole[role] = { jwt, exp: payload.exp }
 			} catch (e) {
 				console.log(e)
@@ -116,4 +113,18 @@ function getParams() {
 			params[key] = value
 		})
 	return params
+}
+
+function decodeJwtPayload(token) {
+	// 1. Split the token into its 3 parts (header, payload, signature)
+	const base64Url = token.split('.')[1]
+	// 2. Convert Base64Url to standard Base64
+	const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+	// 3. Decode the Base64 string and parse it as JSON
+	const jsonPayload = decodeURIComponent(window.atob(base64).split('').map(convertAtoBresult).join(''))
+	return JSON.parse(jsonPayload)
+}
+
+function convertAtoBresult(c) {
+	return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
 }

--- a/public/static/js/login.js
+++ b/public/static/js/login.js
@@ -33,6 +33,8 @@ function getJwtByDsRoute(dslabel) {
 
 const fakeTokensByDsRole = {}
 
+// this is meant for 1 time use throughout a browser session,
+// and not meant for repeated calls within getDatasetAccessToken()
 async function login(dslabel, role = '') {
 	if (window.location.hash.includes('dslogout')) {
 		logout(dslabel)
@@ -42,27 +44,42 @@ async function login(dslabel, role = '') {
 	return jwt || undefined
 }
 
-async function getJwt(dslabel, _role = 'public') {
+// the returned function below can be used for the `getDatasetAccessToken()`
+// callback option in runproteinpaint() argument, which may be called
+// multiple times within a browser session
+function demoGetDatasetAccessToken(dslabel, defaultRole) {
+	// track jwt by role for possible reuse if not expired,
+	// to lessen /demoToken requests
+	const fakeTokensByRole = {}
+	// url param can specify a role to simulate a logged-in user
 	const params = getParams()
-	if (!params.role) params.role = _role
-	const role = params.role
+	// only one role per login/browser session, will require user logout
+	// to change the user role
+	const role = params.role || defaultRole
 
-	if (!fakeTokensByDsRole[dslabel]) {
-		fakeTokensByDsRole[dslabel] = {}
-	} else if (fakeTokensByDsRole[dslabel][role]) {
-		const jwt = fakeTokensByDsRole[dslabel][role]
-		const payloadEncoded = jwt.split('.')[1]
+	return async function getDatasetAccesToken() {
+		if (fakeTokensByRole[role]) {
+			const { jwt, exp } = fakeTokensByRole[role]
+			if (exp && Math.floor(Date.now() / 1000) < exp - 5) return jwt // reuse an unexpired demo token
+		}
+		const jwt = role ? await getJwt(dslabel, role) : await getJwt(dslabel)
+		const payloadEncoded = jwt?.split('.')[1]
 		if (payloadEncoded) {
 			try {
 				const payloadStr = atob(payloadEncoded)
 				const payload = JSON.parse(payloadStr)
-				return jwt
+				fakeTokensByRole[role] = { jwt, exp: payload.exp }
 			} catch (e) {
 				console.log(e)
 			}
 		}
+		return jwt
 	}
+}
 
+// this makes a server request to get a jwt by role,
+// and is called by other helper functions above
+async function getJwt(dslabel, role = 'public') {
 	// The fakeTokens allows simulating valid, signed jwt by dslabel and role.
 	// It assumes there is only one protected route entry for each dataset.demoJwtInput{[role]: {...}} entry,
 	// and there can be 1 or more entries by role.
@@ -84,11 +101,7 @@ async function getJwt(dslabel, _role = 'public') {
 		console.error(res.error)
 		return null
 	}
-	if (!res.fakeTokensByRole) return null
-	for (const [role, jwt] of Object.entries(res.fakeTokensByRole)) {
-		fakeTokensByDsRole[dslabel][role] = jwt
-	}
-	return res.fakeTokensByRole[role]
+	return res.fakeTokensByRole?.[role]
 }
 
 // URL search params can be used to trigger user roles or other behaviour

--- a/public/static/js/login.js
+++ b/public/static/js/login.js
@@ -14,10 +14,11 @@ async function logout(dslabel, route = 'termdb') {
 		.then(console.log)
 		.catch(console.error)
 
+	if (window.location.hash.includes('dslogout')) return
 	window.location.reload()
 }
 
-function getJwtByDsRoute() {
+function getJwtByDsRoute(dslabel) {
 	// jwtByDsRoute is a nested object that's saved to localStorage,
 	// so that a user can stay logged-in when opening new tabs.
 	// jwtByDsRoute{}
@@ -26,36 +27,66 @@ function getJwtByDsRoute() {
 	//     value = jwt
 	//
 	const jwtByDsRouteStr = localStorage.getItem('jwtByDsRoute') || `{}`
-	return JSON.parse(jwtByDsRouteStr)
+	const jwtByDsRoute = JSON.parse(jwtByDsRouteStr)
+	return dslabel ? jwtByDsRoute[dslabel] : jwtByDsRoute
 }
 
-async function login(dslabel, role = 'public') {
+const fakeTokensByDsRole = {}
+
+async function login(dslabel, role = '') {
+	if (window.location.hash.includes('dslogout')) {
+		logout(dslabel)
+		return null
+	}
 	const jwt = await getJwt(dslabel, role)
-	if (!jwt) return
-	return jwt
+	return jwt || undefined
 }
 
-async function getJwt(dslabel, role) {
+async function getJwt(dslabel, _role = 'public') {
 	const params = getParams()
-	if (!params.role) params.role = role
+	if (!params.role) params.role = _role
+	const role = params.role
+
+	if (!fakeTokensByDsRole[dslabel]) {
+		fakeTokensByDsRole[dslabel] = {}
+	} else if (fakeTokensByDsRole[dslabel][role]) {
+		const jwt = fakeTokensByDsRole[dslabel][role]
+		const payloadEncoded = jwt.split('.')[1]
+		if (payloadEncoded) {
+			try {
+				const payloadStr = atob(payloadEncoded)
+				const payload = JSON.parse(payloadStr)
+				return jwt
+			} catch (e) {
+				console.log(e)
+			}
+		}
+	}
 
 	// The fakeTokens allows simulating valid, signed jwt by dslabel and role.
-	// It assumes there is only one protected route entry for serverconfig.features.fakeTokens[<dslabel>],
-	// and there can be 1 or more role:jwt key-values nested under it.
+	// It assumes there is only one protected route entry for each dataset.demoJwtInput{[role]: {...}} entry,
+	// and there can be 1 or more entries by role.
+	//
+	// see https://github.com/stjude/sjpp/wiki/Demo-token-and-auth-testing-for-datasets-with-access-control
 	//
 	// NOTE: Verified fake tokens will be passed to `setTokenByDsRoute()` in `dofetch()`, to be
 	// saved in localStorage 'jwtByDsCredentials' and returned by getJwtByDsRoute() above.
 	//
 
-	// !!! NOTE: to clear/refresh the stored fake jwt's, use the dslogout() function above or force the condition below to true !!!
+	// !!! NOTE: to clear/refresh the stored fake jwt's, use the logout(dslabel) function above or force the condition below to true !!!
 	// otherwise, should reuse saved fake tokens that have not changed in serverconfig.features
-	const body = JSON.stringify({ genome: 'hg38', dslabel, role })
+	const genome = dslabel === 'ProtectedTest' ? 'hg38-test' : 'hg38'
+	const body = JSON.stringify({ genome, dslabel, role })
 	const res = await fetch('/demoToken', { method: 'POST', body })
 		.then(r => r.json())
 		.catch(console.error)
 	if (res.error) {
 		console.error(res.error)
 		return null
+	}
+	if (!res.fakeTokensByRole) return null
+	for (const [role, jwt] of Object.entries(res.fakeTokensByRole)) {
+		fakeTokensByDsRole[dslabel][role] = jwt
 	}
 	return res.fakeTokensByRole[role]
 }

--- a/server/dataset/protected.test.ts
+++ b/server/dataset/protected.test.ts
@@ -18,5 +18,11 @@ export default function (): Mds3 {
 			canAccess: data.count >= minSize
 		}
 	}
+
+	ds.demoJwtInput = {
+		user: {
+			datasets: ['abc', 'xyz']
+		}
+	}
 	return ds
 }

--- a/server/dataset/protected.test.ts
+++ b/server/dataset/protected.test.ts
@@ -21,7 +21,7 @@ export default function (): Mds3 {
 
 	ds.demoJwtInput = {
 		user: {
-			datasets: ['abc', 'xyz']
+			datasets: ['ABC', 'XYZ']
 		}
 	}
 	return ds

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -581,7 +581,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 			checkIPaddress(req, ip, cred)
 			let jwt = rawToken
 			if (!dslabel) {
-				// NOTE: A login jwt payload is expeted to not have dslabel, while session jwt is expected to have it
+				// NOTE: A login jwt payload is expected to not have dslabel, while session jwt is expected to have it
 				// No need to get another session jwt if the current jwt is already a session jwt (not from initial login)
 				code = 401 // in case of jwt processing error
 				jwt = await getSignedJwt(req, res, q, cred, clientAuthResult, maxSessionAge, email, sessions)
@@ -589,7 +589,6 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 			// difficult to setup CORS cookie, will deprecate support
 			res.send({ status: 'ok', jwt, route: cred.route, clientAuthResult })
 		} catch (e) {
-			//console.log(e)
 			res.status(code)
 			res.header('Set-Cookie', `${cred.cookieId}=; HttpOnly; SameSite=None; Secure; Max-Age=0`)
 			res.send(e instanceof Error || typeof e != 'object' ? { error: e } : e)
@@ -643,7 +642,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 				}
 			}
 
-			const computed = cred.demoToken.computedByRole[q.role] //; console.log(626, computed.exp, Date.now() + 60000, computed.exp - Date.now() + 60000)
+			const computed = cred.demoToken.computedByRole[q.role]
 			if (computed && computed.exp > Date.now() + 60000) {
 				// reuse a previously computed jwt that is not close to expiring;
 				// both computed.exp and time buffer (60000) are in milliseconds
@@ -660,7 +659,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 			}
 			const fullPayload = Object.assign({}, defaultToken, ds.demoJwtInput[q.role])
 			const jwt = cred.processor
-				? cred.processor.generatePayload(fullPayload, cred)
+				? cred.processor.generatePayload(fullPayload, { secret: cred.demoToken.secret })
 				: jsonwebtoken.sign(fullPayload, cred.demoToken.secret)
 			console.log(`~~ Faketoken computed for ds=${q.dslabel}, role=${q.role}`)
 			cred.demoToken.computedByRole[q.role] = { jwt, exp: fullPayload.exp * 1000 } // track expiration in milliseconds
@@ -676,10 +675,17 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 		will return a list of all dslabels that require credentials
 	*/
 	authApi.getDsAuth = function (req) {
+		const activeDslabels = []
+		for (const g of Object.values(genomes)) {
+			for (const dslabel of Object.keys(g.datasets)) {
+				activeDslabels.push(dslabel)
+			}
+		}
 		const dsAuth = []
 		const embedder = req.query.embedder || req.get('host')?.split(':')[0] // do not include port number
 		for (const [dslabelPattern, ds] of Object.entries(creds)) {
-			if (dslabelPattern.startsWith('__')) continue
+			if (dslabelPattern.startsWith('__') || dslabelPattern.startsWith('#') || !activeDslabels.includes(dslabelPattern))
+				continue
 			for (const [routePattern, route] of Object.entries(ds)) {
 				for (const [embedderHostPattern, cred] of Object.entries(route)) {
 					if (embedderHostPattern != '*' && !isMatch(embedder, embedderHostPattern)) continue
@@ -700,13 +706,16 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 
 					// if session is valid, extend the session expiration by resetting the start time
 					if (insession) activeSession.time = currTime
-
+					const demoTokenRoles = cred.demoToken?.referers.find(r => req.headers.referer.includes(r))
+						? cred.demoToken?.roles
+						: undefined
 					dsAuth.push({
 						dslabel: dslabelPattern,
 						route: routePattern,
 						type: cred.type || 'basic',
 						headerKey: cred.headerKey,
-						insession
+						insession,
+						demoTokenRoles
 					})
 				}
 			}
@@ -1078,7 +1087,7 @@ function getJwtPayload(q, headers, cred, session = null) {
 	// optionally transform, translate, reformat the payload
 	if (processor.handlePayload) {
 		try {
-			processor.handlePayload(cred, payload, time)
+			processor.handlePayload({ secret: cred.demoToken.secret }, payload, time)
 		} catch (e) {
 			//console.log(e)
 			if (e.reason == 'bad decrypt') throw `Please login again to access this feature. (${e.reason})`

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -1078,7 +1078,15 @@ function getJwtPayload(q, headers, cred, session = null) {
 	const token = processor.handleToken?.(rawToken) || rawToken
 	// this verification will throw if the token is invalid in any way
 	const secret = cred.demoToken?.referers.find(r => headers.referer.includes(r)) ? cred.demoToken.secret : cred.secret
-	const payload = jsonwebtoken.verify(token, secret)
+	let payload
+	try {
+		payload = jsonwebtoken.verify(token, secret) // change the secret with a suffix or to some other string to trigger and test the error below
+	} catch (e) {
+		// may include info on whether a demoToken secret was used, to help with embedder troubleshooting
+		if (typeof e == 'object' && cred.demoToken) e.usedDemoTokenSecret = secret === cred.demoToken.secret
+		throw e
+	}
+
 	// if there is a session, handle the expiration outside of this function
 	if (session)
 		return { iat: payload.iat, email: payload.email, ip: payload.ip, clientAuthResult: payload.clientAuthResult }
@@ -1087,9 +1095,9 @@ function getJwtPayload(q, headers, cred, session = null) {
 	// optionally transform, translate, reformat the payload
 	if (processor.handlePayload) {
 		try {
-			processor.handlePayload({ secret: cred.demoToken.secret }, payload, time)
+			processor.handlePayload({ secret }, payload, time)
 		} catch (e) {
-			//console.log(e)
+			console.log(e)
 			if (e.reason == 'bad decrypt') throw `Please login again to access this feature. (${e.reason})`
 			throw e
 		}

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -658,8 +658,9 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 				ip: req.ip || null
 			}
 			const fullPayload = Object.assign({}, defaultToken, ds.demoJwtInput[q.role])
+			const credCopy = Object.assign({}, cred, { secret: cred.demoToken.secret })
 			const jwt = cred.processor
-				? cred.processor.generatePayload(fullPayload, { secret: cred.demoToken.secret })
+				? cred.processor.generatePayload(fullPayload, credCopy)
 				: jsonwebtoken.sign(fullPayload, cred.demoToken.secret)
 			console.log(`~~ Faketoken computed for ds=${q.dslabel}, role=${q.role}`)
 			cred.demoToken.computedByRole[q.role] = { jwt, exp: fullPayload.exp * 1000 } // track expiration in milliseconds
@@ -684,7 +685,11 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 		const dsAuth = []
 		const embedder = req.query.embedder || req.get('host')?.split(':')[0] // do not include port number
 		for (const [dslabelPattern, ds] of Object.entries(creds)) {
-			if (dslabelPattern.startsWith('__') || dslabelPattern.startsWith('#') || !activeDslabels.includes(dslabelPattern))
+			if (
+				dslabelPattern.startsWith('__') ||
+				dslabelPattern.startsWith('#') ||
+				!activeDslabels.find(dslabel => dslabel === dslabelPattern || isMatch(dslabel, dslabelPattern))
+			)
 				continue
 			for (const [routePattern, route] of Object.entries(ds)) {
 				for (const [embedderHostPattern, cred] of Object.entries(route)) {
@@ -706,7 +711,8 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 
 					// if session is valid, extend the session expiration by resetting the start time
 					if (insession) activeSession.time = currTime
-					const demoTokenRoles = cred.demoToken?.referers.find(r => req.headers.referer.includes(r))
+					const referer = req.headers.referer || ''
+					const demoTokenRoles = cred.demoToken?.referers.find(r => referer.includes(r))
 						? cred.demoToken?.roles
 						: undefined
 					dsAuth.push({
@@ -1077,7 +1083,8 @@ function getJwtPayload(q, headers, cred, session = null) {
 	// use a handleToken() if available for an embedder, for example to decrypt a fully encrypted jwt
 	const token = processor.handleToken?.(rawToken) || rawToken
 	// this verification will throw if the token is invalid in any way
-	const secret = cred.demoToken?.referers.find(r => headers.referer.includes(r)) ? cred.demoToken.secret : cred.secret
+	const referer = headers.referer || ''
+	const secret = cred.demoToken?.referers.find(r => referer.includes(r)) ? cred.demoToken.secret : cred.secret
 	let payload
 	try {
 		payload = jsonwebtoken.verify(token, secret) // change the secret with a suffix or to some other string to trigger and test the error below
@@ -1095,9 +1102,10 @@ function getJwtPayload(q, headers, cred, session = null) {
 	// optionally transform, translate, reformat the payload
 	if (processor.handlePayload) {
 		try {
-			processor.handlePayload({ secret }, payload, time)
+			processor.handlePayload({ ...cred, secret }, payload, time)
 		} catch (e) {
-			console.log(e)
+			const errorMessage = typeof e == 'object' && e?.message ? e.message : String(e)
+			console.log(`JWT payload processing failed: ${errorMessage}`)
 			if (e.reason == 'bad decrypt') throw `Please login again to access this feature. (${e.reason})`
 			throw e
 		}

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -677,7 +677,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 	authApi.getDsAuth = function (req) {
 		const activeDslabels = []
 		for (const g of Object.values(genomes)) {
-			for (const dslabel of Object.keys(g.datasets)) {
+			for (const dslabel of Object.keys(g.datasets || {})) {
 				activeDslabels.push(dslabel)
 			}
 		}

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -178,15 +178,18 @@ async function validateDsCredentials(creds, serverconfig) {
 						delete cred.demoToken
 						console.warn(`(!) ${dslabel} cred.demoToken must be an object`)
 					} else {
-						// the demoToken secret must be different from the embedder's signing secret,
+						// The demoToken secret should be different from the embedder's signing secret,
 						// to make it simpler to invalidate demoToken and derived session tokens without
-						// having to coordinate with the embedder portal maintainers
+						// having to coordinate with the embedder portal maintainers. However, for now,
+						// support reusing the embedder's secret for the demo token to minimize testing
+						// issues in internal test sites.
 						// prettier-ignore
 						if (typeof cred.demoToken.secret != 'string') { // pragma: allowlist secret
-							delete cred.demoToken.secret
+							cred.demoToken.secret = cred.secret
+							// delete cred.demoToken.secret
 							// demoToken.secret cannot be randomly generated per server instance, 
 							// since this PP server may be in a server farm that has to accept each other's issued jwt
-							console.warn(`(!) invalid ${dslabel} demoToken.secret, will not issue`)
+							// console.warn(`(!) invalid ${dslabel} demoToken.secret, will not issue`)
 						}
 						if (!Array.isArray(cred.demoToken.roles)) {
 							cred.demoToken.roles = [] // an empty roles array means no matching demoJwtInput role will be found
@@ -637,8 +640,9 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 				if (!cred.demoToken.roles.includes(q.role) || !ds.demoJwtInput[q.role]) {
 					throw `${q.dslabel} demoToken is not supported for role=${q.role}`
 				}
-				if (!cred.demoToken.referers.find(r => req.headers.referer.includes(r))) {
-					throw `${q.dslabel} demoToken requests are not accepted from ${req.headers.referer}`
+				const referer = req.headers.referer || ''
+				if (!cred.demoToken.referers.find(r => referer.includes(r))) {
+					throw `${q.dslabel} demoToken requests are not accepted from referer='${referer}'`
 				}
 			}
 
@@ -1018,7 +1022,7 @@ function mayAddSessionFromJwt(sessions, req, cred) {
 	const token = Buffer.from(b64token, 'base64').toString()
 	const id = getSessionIdFromJwt(token)
 	try {
-		const { secret } = getApplicableSecret(req.headers, cred)
+		const { secret } = getApplicableSecret(req.headers, cred, token)
 		const payload = sessions[dslabel]?.[id] || jsonwebtoken.verify(token, secret)
 		// signed payload dataset must match the requested dataset
 		if (payload.dslabel) {

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -658,8 +658,8 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 				ip: req.ip || null
 			}
 			const fullPayload = Object.assign({}, defaultToken, ds.demoJwtInput[q.role])
-			const credCopy = Object.assign({}, cred, { secret: cred.demoToken.secret })
-			const jwt = cred.processor
+			const credCopy = { ...cred, secret: cred.demoToken.secret }
+			const jwt = cred.processor // also test any applicable cred.processor in demo mode
 				? cred.processor.generatePayload(fullPayload, credCopy)
 				: jsonwebtoken.sign(fullPayload, cred.demoToken.secret)
 			console.log(`~~ Faketoken computed for ds=${q.dslabel}, role=${q.role}`)
@@ -802,9 +802,7 @@ async function maySetAuthRoutes(app, genomes, basepath = '', _serverconfig = nul
 		const [type, b64token] = req.headers.authorization.split(' ')
 		if (type.toLowerCase() != 'bearer') throw `unsupported authorization type='${type}', allowed: 'Bearer'`
 		const token = Buffer.from(b64token, 'base64').toString()
-		const secret = cred.demoToken?.referers.find(r => r.includes(req.headers.referer))
-			? cred.demoToken.secret
-			: cred.secret
+		const { secret } = getApplicableSecret(req.headers, cred, token)
 		const payload = jsonwebtoken.verify(token, secret)
 		return payload || {}
 	}
@@ -975,7 +973,8 @@ async function getSignedJwt(req, res, q, cred, clientAuthResult, maxSessionAge, 
 			email
 		}
 		if (cred.dsnames) payload.datasets = cred.dsnames.map(d => d.id)
-		const jwt = jsonwebtoken.sign(payload, cred.secret)
+		const { secret } = getApplicableSecret(req.headers, cred, payload)
+		const jwt = jsonwebtoken.sign(payload, secret)
 		const id = getSessionIdFromJwt(jwt)
 		const ip = req.ip // may use req.ips?
 		if (!sessions[q.dslabel]) sessions[q.dslabel] = {}
@@ -1019,9 +1018,7 @@ function mayAddSessionFromJwt(sessions, req, cred) {
 	const token = Buffer.from(b64token, 'base64').toString()
 	const id = getSessionIdFromJwt(token)
 	try {
-		const secret = cred.demoToken?.referers.find(r => r.includes(req.headers.referer))
-			? cred.demoToken.secret
-			: cred.secret
+		const { secret } = getApplicableSecret(req.headers, cred)
 		const payload = sessions[dslabel]?.[id] || jsonwebtoken.verify(token, secret)
 		// signed payload dataset must match the requested dataset
 		if (payload.dslabel) {
@@ -1077,16 +1074,14 @@ function getJwtPayload(q, headers, cred, session = null) {
 	const rawToken = headers[cred.headerKey]
 	if (!rawToken) throw `missing header['${cred.headerKey}']`
 
-	// the embedder may supply a processor function
-	const processor = cred.processor || {}
-
-	// use a handleToken() if available for an embedder, for example to decrypt a fully encrypted jwt
-	const token = processor.handleToken?.(rawToken) || rawToken
-	// this verification will throw if the token is invalid in any way
-	const referer = headers.referer || ''
-	const secret = cred.demoToken?.referers.find(r => referer.includes(r)) ? cred.demoToken.secret : cred.secret
+	const { secret, processor } = getApplicableSecret(headers, cred, rawToken)
+	// use handleToken() if available for an embedder, for example to decrypt a fully encrypted jwt
+	const token =
+		// the embedder may supply a processor function
+		secret === cred.secret && processor.handleToken ? processor.handleToken(rawToken) : rawToken
 	let payload
 	try {
+		// this verification will throw if the token is invalid in any way
 		payload = jsonwebtoken.verify(token, secret) // change the secret with a suffix or to some other string to trigger and test the error below
 	} catch (e) {
 		// may include info on whether a demoToken secret was used, to help with embedder troubleshooting
@@ -1099,7 +1094,10 @@ function getJwtPayload(q, headers, cred, session = null) {
 		return { iat: payload.iat, email: payload.email, ip: payload.ip, clientAuthResult: payload.clientAuthResult }
 
 	// the embedder may use a post-processor function to
-	// optionally transform, translate, reformat the payload
+	// optionally transform, translate, reformat the payload,
+	// but this only applies to non-session jwt that was issued
+	// directly from getDatasetAccessToken() on the client-side
+	// and doesn't have a dslabel property
 	if (processor.handlePayload) {
 		try {
 			processor.handlePayload({ ...cred, secret }, payload, time)
@@ -1128,6 +1126,18 @@ function getJwtPayload(q, headers, cred, session = null) {
 		clientAuthResult: payload.clientAuthResult,
 		rawToken
 	}
+}
+
+function getApplicableSecret(headers, cred, rawToken) {
+	if (rawToken) {
+		const unverifiedPayload = typeof rawToken == 'object' ? rawToken : jsonwebtoken.decode(rawToken)
+		if (!unverifiedPayload) return { secret: cred.secret, processor: {} }
+		const { dslabel, embedder, route } = unverifiedPayload || {}
+		if (dslabel && embedder && route) return { secret: cred.secret, processor: {} }
+	}
+	const referer = headers.referer || ''
+	const secret = cred.demoToken?.referers.find(str => referer.includes(str)) ? cred.demoToken.secret : cred.secret
+	return { secret, processor: cred.processor || {} }
 }
 
 // cred.ipCheck: undefined | 'none' | 'loose'

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -322,7 +322,12 @@ function mayUpdateTestDatasets(datasets, serverconfig) {
 						id: 'XYZ',
 						label: 'XYZ cohort'
 					}
-				]
+				],
+				demoToken: {
+					secret: '...', // pragma: allowlist secret
+					roles: ['user'],
+					referers: ['/demo-login.html']
+				}
 			}
 		}
 	}

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -205,7 +205,8 @@ tape(`initialization, non-empty credentials`, async test => {
 				}
 			}
 		}
-		await authApi.maySetAuthRoutes(app, {}, '', { debugmode, dsCredentials, cachedir })
+		const genomes = { hg38: { datasets: { testds: {} } } }
+		await authApi.maySetAuthRoutes(app, genomes, '', { debugmode, dsCredentials, cachedir })
 		test.deepEqual(
 			Object.keys(authApi).sort(),
 			[
@@ -225,7 +226,16 @@ tape(`initialization, non-empty credentials`, async test => {
 		)
 		test.deepEqual(
 			authApi.getDsAuth({ query: { embedder: 'localhost' } }),
-			[{ dslabel: 'testds', route: '/**', type: 'basic', headerKey: 'x-ds-access-token', insession: false }],
+			[
+				{
+					dslabel: 'testds',
+					route: '/**',
+					type: 'basic',
+					headerKey: 'x-ds-access-token',
+					insession: false,
+					demoTokenRoles: undefined
+				}
+			],
 			'should return all dslabels that require authorization for a given embedder'
 		)
 
@@ -343,14 +353,29 @@ tape(`auth methods`, async test => {
 		cachedir
 	}
 
-	await authApi.maySetAuthRoutes(app, {}, '', serverconfig)
+	const genomes = { hg38: { datasets: { ds100: {} } } }
+	await authApi.maySetAuthRoutes(app, genomes, '', serverconfig)
 
 	const req0 = { query: { embedder: 'localhost', dslabel: 'ds100' }, get: () => 'localhost' }
 	test.deepEqual(
 		authApi.getDsAuth(req0),
 		[
-			{ dslabel: 'ds100', route: 'termdb', type: 'jwt', headerKey: 'x-ds-access-token', insession: undefined },
-			{ dslabel: 'ds100', route: 'burden', type: 'forbidden', headerKey: undefined, insession: false }
+			{
+				dslabel: 'ds100',
+				route: 'termdb',
+				type: 'jwt',
+				headerKey: 'x-ds-access-token',
+				insession: undefined,
+				demoTokenRoles: undefined
+			},
+			{
+				dslabel: 'ds100',
+				route: 'burden',
+				type: 'forbidden',
+				headerKey: undefined,
+				insession: false,
+				demoTokenRoles: undefined
+			}
 		],
 		`should return the expected dsAuth array for a termdb-specified embedder`
 	)
@@ -358,7 +383,16 @@ tape(`auth methods`, async test => {
 	const req1 = { query: { embedder: 'some.domain', dslabel: 'ds100' }, get: () => 'localhost' }
 	test.deepEqual(
 		authApi.getDsAuth(req1),
-		[{ dslabel: 'ds100', route: 'burden', type: 'forbidden', headerKey: undefined, insession: false }],
+		[
+			{
+				dslabel: 'ds100',
+				route: 'burden',
+				type: 'forbidden',
+				headerKey: undefined,
+				insession: false,
+				demoTokenRoles: undefined
+			}
+		],
 		`should return the expected dsAuth array for a specified embedder`
 	)
 	test.deepEqual(

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -225,7 +225,7 @@ tape(`initialization, non-empty credentials`, async test => {
 			'should set the expected methods with a non-empty dsCredentials'
 		)
 		test.deepEqual(
-			authApi.getDsAuth({ query: { embedder: 'localhost' } }),
+			authApi.getDsAuth({ query: { embedder: 'localhost' }, headers: {} }),
 			[
 				{
 					dslabel: 'testds',
@@ -239,7 +239,7 @@ tape(`initialization, non-empty credentials`, async test => {
 			'should return all dslabels that require authorization for a given embedder'
 		)
 
-		const req = { query: { dslabel: 'no-cred-entry', embedder: 'localhost' } }
+		const req = { query: { dslabel: 'no-cred-entry', embedder: 'localhost' }, headers: {} }
 		test.deepEqual(
 			authApi.getNonsensitiveInfo(req),
 			{ forbiddenRoutes: [], clientAuthResult: {} },
@@ -356,7 +356,7 @@ tape(`auth methods`, async test => {
 	const genomes = { hg38: { datasets: { ds100: {} } } }
 	await authApi.maySetAuthRoutes(app, genomes, '', serverconfig)
 
-	const req0 = { query: { embedder: 'localhost', dslabel: 'ds100' }, get: () => 'localhost' }
+	const req0 = { query: { embedder: 'localhost', dslabel: 'ds100' }, headers: {}, get: () => 'localhost' }
 	test.deepEqual(
 		authApi.getDsAuth(req0),
 		[
@@ -380,7 +380,7 @@ tape(`auth methods`, async test => {
 		`should return the expected dsAuth array for a termdb-specified embedder`
 	)
 
-	const req1 = { query: { embedder: 'some.domain', dslabel: 'ds100' }, get: () => 'localhost' }
+	const req1 = { query: { embedder: 'some.domain', dslabel: 'ds100' }, headers: {}, get: () => 'localhost' }
 	test.deepEqual(
 		authApi.getDsAuth(req1),
 		[
@@ -401,14 +401,14 @@ tape(`auth methods`, async test => {
 		`should return the expected forbidden routes for a wildcard embedder with cred.type='forbidden'`
 	)
 
-	const req2 = { query: { embedder: 'notlocalhost', dslabel: 'ds100' }, get: () => 'localhost' }
+	const req2 = { query: { embedder: 'notlocalhost', dslabel: 'ds100' }, headers: {}, get: () => 'localhost' }
 	test.deepEqual(
 		authApi.getNonsensitiveInfo(req2),
 		{ forbiddenRoutes: [], clientAuthResult: {} },
 		`should return the expected forbidden routes for a non-wildcard embedder`
 	)
 	test.deepEqual(
-		authApi.isUserLoggedIn({ query: { embedder: 'localhost' } }, { label: 'ds100' }),
+		authApi.isUserLoggedIn({ query: { embedder: 'localhost' }, headers: {} }, { label: 'ds100' }),
 		true,
 		`should return false for isUserLoggedIn() for a non-logged in user`
 	)


### PR DESCRIPTION
# Description

Test with sjpp/demoToken branch, https://github.com/stjude/sjpp/pull/1305.

This branch:
- supports demo token login for datasets with custom jwt processor
- indicates if a demoToken secret was used in a jwt verification error
- defers the check of dsAuthOk to when its checked for being in-session, to minimize confusing jwt-status requests

Tested with

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
