### PR TITLE
Introduce `tk.snvIndelOnly` flag

### DIFF
--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -145,7 +145,8 @@ export async function init(arg, holder, genomes) {
 				type: 'mds3',
 				dslabel: useDslabel,
 				allow2selectSamples: arg.allow2selectSamples,
-				filter0: arg.filter0
+				filter0: arg.filter0,
+				snvIndelOnly: arg.geneSearch4GDCmds3.snvIndelOnly
 			}
 			pa.tklst = [tk]
 			if (arg.geneSearch4GDCmds3.hardcodeCnvOnly) {

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -247,6 +247,7 @@ export async function makeTk(tk, block) {
 			onClose: tk.onClose,
 			callbackOnRender: tk.callbackOnRender,
 			hardcodeCnvOnly: tk.hardcodeCnvOnly,
+			snvIndelOnly: tk.snvIndelOnly,
 			token: tk.token // for testing
 		}
 		if (tk.cnv?.presetMax) tkarg.cnv = { presetMax: tk.cnv.presetMax } // preset value is present, pass to subtk

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -554,6 +554,11 @@ async function mayInitTermdb(tk, block) {
 
 	tk.mds.termdbConfig = await tdb.vocabApi.getTermdbConfig()
 
+	if (tk.hardcodeCnvOnly) {
+		if (tk.snvIndelOnly) throw 'hardcodeCnvOnly and tk.snvIndelOnly cannot both be true'
+		if (!tk.mds.termdbConfig.queries.cnv) throw 'hardcodeCnvOnly is set but cnv is missing'
+	}
+
 	if (tk.mds.termdb.allowCaseDetails) {
 		tk.mds.termdb.allowCaseDetails.get = async acase => {}
 	}

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -364,6 +364,7 @@ function mayInitSkewer(tk) {
 }
 
 export function mayInitCnv(tk) {
+	if (tk.snvIndelOnly) return // only show snvindel
 	let cfg // cnv config obj
 	if (tk.mds.termdbConfig?.queries?.cnv) {
 		// cnv present

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -3,6 +3,7 @@ import * as d3s from 'd3-selection'
 import { detectOne, detectZero, detectGte, whenVisible, detectLst, sleep } from '../../test/test.helpers'
 import { runproteinpaint } from '../../test/front.helpers.js'
 import { unannotatedKey } from '../legend.js'
+import { dtsnvindel } from '#shared/common.js'
 
 /**************
  test sections
@@ -508,7 +509,7 @@ tape('Official - snvIndelOnly', test => {
 		test.equal(bb.tklst.length, 2, 'should have two tracks')
 		test.ok(tk.skewer.rawmlst.length > 0, 'rawmlst[] should be non-empty')
 		test.ok(
-			tk.skewer.rawmlst.every(m => m.dt === 1),
+			tk.skewer.rawmlst.every(m => m.dt === dtsnvindel),
 			'rawmlst[] should only contain snvindels'
 		)
 		test.notOk(tk.cnv, 'tk.cnv should not be defined')

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -15,6 +15,7 @@ Official - allow2selectSamples
 Official - hidegenelegend
 Official - hardcodeCnvOnly hidegenelegend
 Official - hardcodeCnvOnly
+Official - snvIndelOnly
 Incorrect dslabel
 Custom cnv only, no sample
 
@@ -486,6 +487,39 @@ tape('Official - hardcodeCnvOnly', test => {
 		{
 			const t = tk.duplicateTk()
 			test.ok(t.hardcodeCnvOnly, 'duplicateTk() should attach hardcodeCnvOnly')
+		}
+
+		if (test._ok) holder.remove()
+		test.end()
+	}
+})
+
+tape('Official - snvIndelOnly', test => {
+	const holder = getHolder()
+	const gene = 'TP53'
+	runproteinpaint({
+		holder,
+		genome: 'hg38-test',
+		gene,
+		tracks: [{ type: 'mds3', dslabel: 'TermdbTest', snvIndelOnly: true, callbackOnRender }]
+	})
+	async function callbackOnRender(tk, bb) {
+		test.equal(bb.usegm.name, gene, 'block.usegm.name=' + gene)
+		test.equal(bb.tklst.length, 2, 'should have two tracks')
+		test.ok(tk.skewer.rawmlst.length > 0, 'rawmlst[] should be non-empty')
+		test.ok(
+			tk.skewer.rawmlst.every(m => m.dt === 1),
+			'rawmlst[] should only contain snvindels'
+		)
+		test.notOk(tk.cnv, 'tk.cnv should not be defined')
+		test.ok(tk.leftlabels.doms.variants, 'tk.leftlabels.doms.variants is set')
+		test.ok(tk.leftlabels.doms.samples, 'tk.leftlabels.doms.samples is set')
+
+		testLegend(test, tk)
+
+		{
+			const t = tk.duplicateTk()
+			test.ok(t.snvIndelOnly, 'duplicateTk() should attach snvIndelOnly')
 		}
 
 		if (test._ok) holder.remove()

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -82,7 +82,8 @@ function getParameter(tk, block) {
 		forTrack: 1,
 		// may not pass skewerRim if it is not in use (turn off)
 		skewerRim: tk.mds.queries?.snvindel?.skewerRim, // instructions for counting rim counts per variant
-		hardcodeCnvOnly: tk.hardcodeCnvOnly
+		hardcodeCnvOnly: tk.hardcodeCnvOnly,
+		snvIndelOnly: tk.snvIndelOnly // if true, will only query for snvindel data
 	}
 
 	const headers = { 'Content-Type': 'application/json', Accept: 'application/json' }

--- a/client/mds3/tk.js
+++ b/client/mds3/tk.js
@@ -27,6 +27,9 @@ rangequery_add_variantfilters
       this flag shouldn't be set in gdc ds, that will permanently disable skewer (lollipop and cnv tool are based on same ds)
 	  this mode will not allow reenabling snvindel, and will hide skewer-specific menu options
 	  this is similar to user "show only" cnv via legend option on a regular tk, but is reversible
+- snvIndelOnly=boolean:
+	  Whether to only show snvindel. If true, only snvindel data will be retrieved from server. Mutually exclusive
+	  with hardcodeCnvOnly (i.e. tk.snvIndelOnly and tk.hardcodeCnvOnly cannot both be true)
 */
 
 export async function loadTk(tk, block) {
@@ -74,6 +77,9 @@ export async function loadTk(tk, block) {
 
 function getParameter(tk, block) {
 	// to get data for current view range
+
+	if (tk.hardcodeCnvOnly && tk.snvIndelOnly)
+		throw new Error('tk.hardcodeCnvOnly and tk.snvIndelOnly cannot both be true')
 
 	const par = {
 		genome: block.genome.name,

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -678,6 +678,7 @@ export async function mayGetTkobj(key, value, urlp, genomeobj) {
 			if (urlp.has('token')) tk.token = urlp.get('token') // temporary
 			if (urlp.has('filterobj')) tk.filterObj = urlp.get('filterobj')
 			if (urlp.has('cnvonly')) tk.hardcodeCnvOnly = true // quick fix for testing cnv-only mode via url param; in actual use this flag should be set in runpp()
+			if (urlp.has('snvindelonly')) tk.snvIndelOnly = true // another quick fix
 			tks.push(tk)
 		}
 		return tks

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -256,6 +256,8 @@ export async function load_driver(q, ds) {
 	// various bits of data to be appended as keys to result{}
 	// what other loaders can be if not in ds.queries?
 
+	if (q.hardcodeCnvOnly && q.snvIndelOnly) throw new Error('q.hardcodeCnvOnly and q.snvIndelOnly cannot both be true')
+
 	if (q.singleSampleGenomeQuantification) {
 		if (!ds.queries.singleSampleGenomeQuantification) throw 'not supported on this dataset'
 		const p = ds.queries.singleSampleGenomeQuantification[q.singleSampleGenomeQuantification.dataType]

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -312,7 +312,7 @@ export async function load_driver(q, ds) {
 				result.skewer.push(...mlst)
 			}
 
-			if (ds.queries.svfusion && !q.hardcodeCnvOnly) {
+			if (ds.queries.svfusion && !q.hardcodeCnvOnly && !q.snvIndelOnly) {
 				const d = await query_svfusion(q, ds)
 				if (d) result.skewer.push(...d)
 			}
@@ -322,6 +322,8 @@ export async function load_driver(q, ds) {
 					// cnv is hidden, do not load
 				} else if (ds.queries.cnv.requiresHardcodeCnvOnlyFlag && !q.hardcodeCnvOnly) {
 					// the required flag is missing. do not load
+				} else if (q.snvIndelOnly) {
+					// only show snvindel, do not load
 				} else {
 					result.cnv = await ds.queries.cnv.get(q)
 					if (!Array.isArray(result.cnv?.cnvs)) throw 'result.cnv.cnvs[] not array'


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1308

Introduced the `tk.snvIndelOnly` flag to only retrieve SNV/indel data for mds3 track. This flag is used if an mds3 track should only display SNV/indels.

Can test with [MMRF lollipop example](http://localhost:3000/example.mmrf.lollipop.html), which should only display SNV/indel data.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
