### PR TITLE
deprecate serverconfig.dsCredentials.secrets 

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -39,10 +39,6 @@ export const authApi = Object.assign({}, defaultApiMethods)
 // serverconfig.dsCredentials
 //
 // DsCredentials = {
-// 	/** optional filepath of a secrets json file
-//   *  the default is to use the secrets object if provided
-//   */
-// 	secrets: string
 
 // 	// NOTES:
 // 	// 1. list keys in the desired matching order, for example, the catch-all '*' pattern should be entered last
@@ -61,7 +57,11 @@ export const authApi = Object.assign({}, defaultApiMethods)
 //            secret: string,
 //            // optional list of cohort(s) that a user must have access to,
 //            // to be matched against the jwt payload as signed by the embedder
-//            dsnames: [{id, label}]
+//            dsnames?: [{id, label}],
+//            demoToken?: {
+//              roles: string[],
+//              referers: string[]
+//            }
 //         } |
 //         // TODO: support other credential types
 // 		}
@@ -71,10 +71,16 @@ export const authApi = Object.assign({}, defaultApiMethods)
 // Examples:
 
 // dsCredentials: {
-// 	secrets: 'secrets', // pragma: allowlist secret
 // 	SJLife: {
 // 		termdb: {
-// 			'viz.stjude.cloud': 'vizcomJwt',
+// 			'viz.stjude.cloud': {
+//         type: 'jwt',
+//         secret: "something",  // pragma: allowlist secret
+//         demoToken: {
+//           roles: ['user', 'admin'],
+//           referers: ['/some-path?param=value', 'obscure=randomString']
+//         }
+//      }
 // 		},
 // 		burden: {
 // 			'*: 'burdenDemo'
@@ -99,22 +105,11 @@ export const authApi = Object.assign({}, defaultApiMethods)
 // 	}
 // }
 
-// secrets: {
-// 	vizcomJwt: {
-// 		type: "jwt"
-// 	},
-// 	burdenDemo: {
-// 		type: 'basic',
-//    password: '...'
-// 	}
-// }
-
 async function validateDsCredentials(creds, serverconfig) {
 	mayReshapeDsCredentials(creds)
 	const key = 'secrets' // to prevent a detect-secrets hook issue
 	if (typeof creds[key] == 'string') {
-		const json = await fs.readFile(creds[key], 'utf8')
-		creds[key] = JSON.parse(json)
+		throw `serverconfig {dsCredentials: {${key}: <string>}} has been deprecated. Use {dsCredentials: <abs filepath string>} instead.`
 	}
 
 	// track which domains are allowed to embed proteinpaint with credentials,
@@ -139,8 +134,12 @@ async function validateDsCredentials(creds, serverconfig) {
 				// create a copy from the original in case it's shared across different dslabels/routes/embedders,
 				// since additional properties may be added to the object that is specific to a dslabel/route/embedder
 				route[embedderHost] = JSON.parse(JSON.stringify(route[embedderHost]))
-				const c = route[embedderHost]
-				const cred = typeof c == 'string' ? creds.secrets[c] : c
+				const cred = route[embedderHost]
+				if (typeof cred == 'string')
+					throw (
+						`serverconfig {dsCredentials[dslabel][route][embedderHost]: <string>} has been deprecated. ` +
+						`Instead, use {dsCredentials: <abs filepath string>} where the filepath points to a pre-built json file.`
+					)
 				// copy the server route pattern to easily obtain it from within the cred
 				if (cred.type == 'basic') {
 					if (!cred.secret) cred.secret = cred.password

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -50,7 +50,6 @@ export const authApi = Object.assign({}, defaultApiMethods)
 // 		[serverRoute: string]: {
 // 			// serverRoute can be a glob pattern, to find any matching server route name/path
 // 			[hostName: string]:
-//         'secrets-object-key' |
 //         { type: 'basic', password: '...'} |
 //         {
 //            type: 'jwt',
@@ -83,7 +82,7 @@ export const authApi = Object.assign({}, defaultApiMethods)
 //      }
 // 		},
 // 		burden: {
-// 			'*: 'burdenDemo'
+// 			'*': 'burdenDemo'
 // 		}
 // 	},
 // 	PNET: {
@@ -137,7 +136,7 @@ async function validateDsCredentials(creds, serverconfig) {
 				const cred = route[embedderHost]
 				if (typeof cred == 'string')
 					throw (
-						`serverconfig {dsCredentials[dslabel][route][embedderHost]: <string>} has been deprecated. ` +
+						`serverconfig {dsCredentials[dslabel][serverRoute][embedderHost]: <string>} has been deprecated. ` +
 						`Instead, use {dsCredentials: <abs filepath string>} where the filepath points to a pre-built json file.`
 					)
 				// copy the server route pattern to easily obtain it from within the cred

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -163,11 +163,12 @@ if (serverconfig.debugmode && !serverconfig.binpath.includes('sjcrh/')) {
 }
 
 if (typeof serverconfig.dsCredentials == 'string') {
-	const json = fs.readFileSync(serverconfig.dsCredentials, { encoding: 'utf8' })
+	const dsCredentialsFile = serverconfig.dsCredentials
 	try {
+		const json = fs.readFileSync(dsCredentialsFile, { encoding: 'utf8' })
 		serverconfig.dsCredentials = JSON.parse(json)
 	} catch (e) {
-		throw `invalid json file, serverconfig.dsCredentials='${json}'`
+		throw `invalid json file, serverconfig.dsCredentials='${dsCredentialsFile}': ${e}`
 	}
 }
 

--- a/server/src/serverconfig.js
+++ b/server/src/serverconfig.js
@@ -162,6 +162,15 @@ if (serverconfig.debugmode && !serverconfig.binpath.includes('sjcrh/')) {
 	serverconfig.routeSetters = routeSetters
 }
 
+if (typeof serverconfig.dsCredentials == 'string') {
+	const json = fs.readFileSync(serverconfig.dsCredentials, { encoding: 'utf8' })
+	try {
+		serverconfig.dsCredentials = JSON.parse(json)
+	} catch (e) {
+		throw `invalid json file, serverconfig.dsCredentials='${json}'`
+	}
+}
+
 if (serverconfig.debugmode) {
 	// should be able to run this in local dev and test environments that use containers
 	const hg38test = serverconfig.genomes.find(g => g.name == 'hg38-test')


### PR DESCRIPTION
# Description

... in favor of `dsCredentials: <filepath>`. 

To test manually, extract the  `serverconfig.dsCredentials` object into a separate json file, and assign the absolute saved file path as a string value for `serverconfig.dsCredentials`. All protected features should work as before.

Also tested with all unit and integration tests.

@aacic This helps with the ability to save non-sensitive `serverconfig.json` entries, since the sensitive `dsCredentials` entry could be saved in a separate json file. The build step for serverconfig will also likely be simpler.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
