### PR TITLE
Implement snvindel-only mds3 track using the `tk.snvIndelOnly` flag

### DIFF
--- a/client/gdc/lollipop.js
+++ b/client/gdc/lollipop.js
@@ -154,6 +154,9 @@ export async function init(arg, holder, genomes) {
 				delete pa.gmmode
 				first_genetrack_tolist(pa.genome, pa.tklst)
 			}
+			if (arg.geneSearch4GDCmds3.snvIndelOnly) {
+				tk.snvIndelOnly = 1
+			}
 		}
 
 		if (userSelection) {

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -530,6 +530,11 @@ function update_mclass(tk) {
 	const showlst = [],
 		hiddenlst = []
 	for (const [k, count] of tk.legend.mclass.currentData) {
+		if (tk.snvIndelOnly) {
+			// only show snvindel
+			// exclude non-snvindel classes from legend
+			if (tk.legend.mclass.nonSnvIndelClasses?.has(k)) continue
+		}
 		const v = { k, count }
 		if (tk.legend.mclass.hiddenvalues.has(k)) {
 			hiddenlst.push(v)
@@ -543,6 +548,11 @@ function update_mclass(tk) {
 	// items in hiddenvalues{} can still be absent in hiddenlst,
 	// e.g. if class filter is done at backend, and currentData is calculated just from visible data items
 	for (const k of tk.legend.mclass.hiddenvalues) {
+		if (tk.snvIndelOnly) {
+			// only show snvindel
+			// exclude non-snvindel classes from legend
+			if (tk.legend.mclass.nonSnvIndelClasses?.has(k)) continue
+		}
 		if (!hiddenlst.find(i => i.k == k)) {
 			hiddenlst.push({ k })
 		}
@@ -630,12 +640,6 @@ function update_mclass(tk) {
 
 	// hidden ones
 	for (const c of hiddenlst) {
-		if (tk.snvIndelOnly) {
-			// only showing snvindel data
-			// do not display non-snvindel classes in legend
-			if ([dtcnv, mclassfusionrna, mclasssv].includes(c.k)) continue
-		}
-
 		let loading = false
 
 		tk.legend.mclass.holder
@@ -904,8 +908,8 @@ function may_create_cnv(tk, block) {
 function may_update_cnv(tk) {
 	if (!tk.cnv) return
 	if (tk.snvIndelOnly) {
-		// only showing snvindel data
-		// do not show cnv legend
+		// only show snvindel
+		// clear cnv legend
 		tk.legend.cnv.row.selectAll('*').remove()
 		return
 	}

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -1,17 +1,6 @@
 import { legend_newrow } from '#src/block.legend'
 import { Menu, ColorScale, icons, shapes, renderCnvConfig } from '#dom'
-import {
-	mds3tkMclass,
-	mclass,
-	dt2label,
-	dtcnv,
-	dtloh,
-	dtitd,
-	dtsv,
-	dtfusionrna,
-	mclassitd,
-	bplen
-} from '#shared/common.js'
+import { mds3tkMclass, mclass, dt2label, dtcnv, mclassfusionrna, mclasssv, bplen } from '#shared/common.js'
 import { interpolateRgb } from 'd3-interpolate'
 import { showLDlegend } from '../plots/regression.results'
 import { rgb } from 'd3-color'
@@ -641,6 +630,12 @@ function update_mclass(tk) {
 
 	// hidden ones
 	for (const c of hiddenlst) {
+		if (tk.snvIndelOnly) {
+			// only showing snvindel data
+			// do not display non-snvindel classes in legend
+			if ([dtcnv, mclassfusionrna, mclasssv].includes(c.k)) continue
+		}
+
 		let loading = false
 
 		tk.legend.mclass.holder
@@ -908,6 +903,12 @@ function may_create_cnv(tk, block) {
 
 function may_update_cnv(tk) {
 	if (!tk.cnv) return
+	if (tk.snvIndelOnly) {
+		// only showing snvindel data
+		// do not show cnv legend
+		tk.legend.cnv.row.selectAll('*').remove()
+		return
+	}
 
 	// tk is equipped with cnv. determine if cnv data is actually shown
 	if (!tk.cnv.cnvLst || tk.cnv.cnvLst.length == 0) {

--- a/client/mds3/legend.js
+++ b/client/mds3/legend.js
@@ -907,12 +907,6 @@ function may_create_cnv(tk, block) {
 
 function may_update_cnv(tk) {
 	if (!tk.cnv) return
-	if (tk.snvIndelOnly) {
-		// only show snvindel
-		// clear cnv legend
-		tk.legend.cnv.row.selectAll('*').remove()
-		return
-	}
 
 	// tk is equipped with cnv. determine if cnv data is actually shown
 	if (!tk.cnv.cnvLst || tk.cnv.cnvLst.length == 0) {

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -468,7 +468,7 @@ function init_mclass(tk) {
 	if (tk.snvIndelOnly) {
 		// hide non-snvindel classes
 		const nonSnvIndelClasses = [mclassfusionrna, mclasssv]
-		const cnv = tk.mds.termdbConfig.queries.cnv
+		const cnv = tk.mds.termdbConfig?.queries?.cnv
 		if (cnv) {
 			const keys = Object.keys(cnv)
 			if (keys.includes('cnvGainCutoff') || keys.includes('cnvLossCutoff')) {

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -3,7 +3,7 @@ import { dofetch3 } from '#common/dofetch'
 import { initLegend, updateLegend } from './legend'
 import { loadTk, rangequery_rglst } from './tk'
 import urlmap from '#common/urlmap'
-import { mclass, dtsnvindel, dtsv, dtfusionrna, dtcnv, getColors } from '#shared/common.js'
+import { mclass, dtsnvindel, dtsv, dtfusionrna, dtcnv, mclassfusionrna, mclasssv, getColors } from '#shared/common.js'
 import { ssmIdFieldsSeparator } from '#shared/mds3tk.js'
 import { getFilterName } from './filterName'
 import { fillTermWrapper } from '#termsetting'
@@ -453,6 +453,10 @@ function init_mclass(tk) {
 	if (tk.mds.hiddenmclass) {
 		// port over default hidden mclass
 		for (const c of tk.mds.hiddenmclass) tk.legend.mclass.hiddenvalues.add(c)
+	}
+	if (tk.snvIndelOnly) {
+		// hide non-snvindel classes
+		for (const c of [dtcnv, mclassfusionrna, mclasssv]) tk.legend.mclass.hiddenvalues.add(c)
 	}
 }
 

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -257,6 +257,7 @@ export async function makeTk(tk, block) {
 			onClose: tk.onClose,
 			callbackOnRender: tk.callbackOnRender,
 			hardcodeCnvOnly: tk.hardcodeCnvOnly,
+			snvIndelOnly: tk.snvIndelOnly,
 			token: tk.token // for testing
 		}
 		if (tk.cnv?.presetMax) tkarg.cnv = { presetMax: tk.cnv.presetMax } // preset value is present, pass to subtk

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -3,7 +3,17 @@ import { dofetch3 } from '#common/dofetch'
 import { initLegend, updateLegend } from './legend'
 import { loadTk, rangequery_rglst } from './tk'
 import urlmap from '#common/urlmap'
-import { mclass, dtsnvindel, dtsv, dtfusionrna, dtcnv, mclassfusionrna, mclasssv, getColors } from '#shared/common.js'
+import {
+	mclass,
+	dtsnvindel,
+	dtsv,
+	dtfusionrna,
+	dtcnv,
+	mclassfusionrna,
+	mclasssv,
+	CNVClasses,
+	getColors
+} from '#shared/common.js'
 import { ssmIdFieldsSeparator } from '#shared/mds3tk.js'
 import { getFilterName } from './filterName'
 import { fillTermWrapper } from '#termsetting'
@@ -456,7 +466,23 @@ function init_mclass(tk) {
 	}
 	if (tk.snvIndelOnly) {
 		// hide non-snvindel classes
-		for (const c of [dtcnv, mclassfusionrna, mclasssv]) tk.legend.mclass.hiddenvalues.add(c)
+		const nonSnvIndelClasses = [mclassfusionrna, mclasssv]
+		const cnv = tk.mds.termdbConfig.queries.cnv
+		if (cnv) {
+			const keys = Object.keys(cnv)
+			if (keys.includes('cnvGainCutoff') || keys.includes('cnvLossCutoff')) {
+				// continuous cnv data
+				nonSnvIndelClasses.push(dtcnv)
+			} else {
+				// categorical cnv data
+				nonSnvIndelClasses.push(...CNVClasses)
+			}
+		}
+		tk.legend.mclass.nonSnvIndelClasses = new Set()
+		for (const c of nonSnvIndelClasses) {
+			tk.legend.mclass.hiddenvalues.add(c)
+			tk.legend.mclass.nonSnvIndelClasses.add(c) // keep track to hide legend items in client/mds3/legend.js
+		}
 	}
 }
 

--- a/client/mds3/makeTk.js
+++ b/client/mds3/makeTk.js
@@ -375,6 +375,7 @@ function mayInitSkewer(tk) {
 }
 
 export function mayInitCnv(tk) {
+	if (tk.snvIndelOnly) return
 	let cfg // cnv config obj
 	if (tk.mds.termdbConfig?.queries?.cnv) {
 		// cnv present

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -3,6 +3,7 @@ import * as d3s from 'd3-selection'
 import { detectOne, detectZero, detectGte, whenVisible, detectLst, sleep } from '../../test/test.helpers'
 import { runproteinpaint } from '../../test/front.helpers.js'
 import { unannotatedKey } from '../legend.js'
+import { dtsnvindel, mclass } from '#shared/common.js'
 
 /**************
  test sections
@@ -15,6 +16,7 @@ Official - allow2selectSamples
 Official - hidegenelegend
 Official - hardcodeCnvOnly hidegenelegend
 Official - hardcodeCnvOnly
+Official - snvIndelOnly
 Incorrect dslabel
 Custom cnv only, no sample
 
@@ -486,6 +488,40 @@ tape('Official - hardcodeCnvOnly', test => {
 		{
 			const t = tk.duplicateTk()
 			test.ok(t.hardcodeCnvOnly, 'duplicateTk() should attach hardcodeCnvOnly')
+		}
+
+		if (test._ok) holder.remove()
+		test.end()
+	}
+})
+
+tape('Official - snvIndelOnly', test => {
+	const holder = getHolder()
+	const gene = 'TP53'
+	runproteinpaint({
+		holder,
+		genome: 'hg38-test',
+		gene,
+		tracks: [{ type: 'mds3', dslabel: 'TermdbTest', snvIndelOnly: true, callbackOnRender }]
+	})
+	async function callbackOnRender(tk, bb) {
+		test.equal(bb.usegm.name, gene, 'block.usegm.name=' + gene)
+		test.equal(bb.tklst.length, 2, 'should have two tracks')
+		test.ok(tk.skewer.rawmlst.length > 0, 'rawmlst[] should be non-empty')
+		test.ok(
+			tk.skewer.rawmlst.every(m => m.dt === dtsnvindel),
+			'rawmlst[] should only contain snvindels'
+		)
+		test.ok(tk.cnv.cnvLst.length === 0, 'cnvLst[] should be empty')
+
+		test.ok(tk.leftlabels.doms.variants, 'tk.leftlabels.doms.variants is set')
+		test.ok(tk.leftlabels.doms.samples, 'tk.leftlabels.doms.samples is set')
+
+		testLegend(test, tk)
+
+		{
+			const t = tk.duplicateTk()
+			test.ok(t.snvIndelOnly, 'duplicateTk() should attach snvIndelOnly')
 		}
 
 		if (test._ok) holder.remove()
@@ -1273,6 +1309,24 @@ function testLegend_mclass(test, tk) {
 		return
 	}
 
+	if (tk.snvIndelOnly) {
+		// ensure all mutation classes in legend are snvindel classes
+		const items = tk.legend.mclass.row.selectAll('.sja_clb').nodes()
+		for (const item of items) {
+			const itemLabel = Array.from(item.childNodes)
+				.filter(n => !n.classList?.contains('sja_mcdot'))
+				.map(n => n.textContent || '')
+				.join('')
+				.trim()
+			const m = Object.values(mclass).find(m => m.label == itemLabel)
+			if (!m) {
+				test.fail('cannot find mutation by label')
+			} else {
+				test.equal(m.dt, dtsnvindel, 'variant in legend should be snvindel')
+			}
+		}
+	}
+
 	test.equal(
 		tk.legend.mclass.row.style('display'),
 		'table-row',
@@ -1381,6 +1435,13 @@ function testLegend_cnv(test, tk) {
 		return
 	}
 	test.ok(tk.legend.cnv, 'tk.legend.cnv is set when tk has cnv')
+
+	const cnvItems = tk.legend.cnv.row.selectAll('*').nodes()
+	if (tk.snvIndelOnly) {
+		test.ok(cnvItems.length === 0, 'should not have cnv items when tk.snvIndelOnly = true')
+	} else {
+		test.ok(cnvItems.length > 0, 'should have cnv items when tk.snvIndelOnly = false')
+	}
 
 	// test if color scale is shown based on type of cnv data
 	const colorS = tk.legend.cnv.holder.selectAll('[data-testid="sjpp-color-scale"]')._groups[0]

--- a/client/mds3/test/mds3.integration.spec.js
+++ b/client/mds3/test/mds3.integration.spec.js
@@ -512,8 +512,7 @@ tape('Official - snvIndelOnly', test => {
 			tk.skewer.rawmlst.every(m => m.dt === dtsnvindel),
 			'rawmlst[] should only contain snvindels'
 		)
-		test.ok(tk.cnv.cnvLst.length === 0, 'cnvLst[] should be empty')
-
+		test.notOk(tk.cnv, 'tk.cnv should not be defined')
 		test.ok(tk.leftlabels.doms.variants, 'tk.leftlabels.doms.variants is set')
 		test.ok(tk.leftlabels.doms.samples, 'tk.leftlabels.doms.samples is set')
 

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -677,7 +677,8 @@ export async function mayGetTkobj(key, value, urlp, genomeobj) {
 			}
 			if (urlp.has('token')) tk.token = urlp.get('token') // temporary
 			if (urlp.has('filterobj')) tk.filterObj = urlp.get('filterobj')
-			if (urlp.has('cnvonly')) tk.hardcodeCnvOnly = true // quick fix for testing cnv-only mode via url param; in actual use this flag should be set in runpp()
+			if (urlp.has('cnvonly')) tk.hardcodeCnvOnly = true // for testing cnv-only mode via url param; in actual use this flag should be set in runpp()
+			if (urlp.has('snvindelonly')) tk.snvIndelOnly = true // for testing snvindel-only mode
 			tks.push(tk)
 		}
 		return tks

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -973,6 +973,10 @@ export async function snvindelByRangeGetter_bcfMaf(ds, genome) {
 			{ <formatKey> : set of hidden values }
 	*/
 	return async param => {
+		if (param.hiddenmclass?.has(dtsnvindel)) {
+			// snvindel is skipped
+			return []
+		}
 		utils.validateRglst(param, genome)
 		const formatFilter = getFormatFilter(param)
 
@@ -1018,7 +1022,7 @@ export async function snvindelByRangeGetter_bcfMaf(ds, genome) {
 
 				// make a m{} for every alt allele
 				for (const m of m0.mlst) {
-					if (param.hiddenmclass && param.hiddenmclass.has(m.class)) continue
+					if (param.hiddenmclass?.has(m.class)) continue
 
 					// m should have .info{}
 					if (mayDropMbyInfoFilter(m, param)) continue // m is dropped due to info filter
@@ -1253,6 +1257,11 @@ export async function snvindelByRangeGetter_bcf(ds, genome) {
 			{ <formatKey> : set of hidden values }
 	*/
 	return async param => {
+		if (param.hiddenmclass?.has(dtsnvindel)) {
+			// snvindel is skipped. allows to avoid file read
+			return []
+		}
+
 		utils.validateRglst(param, genome)
 
 		const formatFilter = getFormatFilter(param)
@@ -1323,7 +1332,7 @@ export async function snvindelByRangeGetter_bcf(ds, genome) {
 
 				// make a m{} for every alt allele
 				for (const m of m0.mlst) {
-					if (param.hiddenmclass && param.hiddenmclass.has(m.class)) continue
+					if (param.hiddenmclass?.has(m.class)) continue
 
 					// m should have .info{}
 					if (mayDropMbyInfoFilter(m, param)) continue // m is dropped due to info filter
@@ -2308,6 +2317,10 @@ export async function svfusionByRangeGetter_file(ds, genome) {
 
 	// same parameter as snvindel.byrange.get()
 	return async param => {
+		if (param.hiddenmclass?.has(dtsv) && param.hiddenmclass.has(dtfusionrna)) {
+			// both sv & fusion are skipped (even if ds has only 1 type)
+			return []
+		}
 		utils.validateRglst(param, genome)
 
 		const formatFilter = getFormatFilter(param)
@@ -2353,7 +2366,7 @@ export async function svfusionByRangeGetter_file(ds, genome) {
 
 					j.class = j.dt == dtsv ? mclasssv : mclassfusionrna
 
-					if (param.hiddenmclass && param.hiddenmclass.has(j.class)) return
+					if (param.hiddenmclass?.has(j.class)) return
 
 					if (j.sample) {
 						j.sample = ds.cohort.termdb.q.sampleName2id(j.sample)
@@ -2484,6 +2497,10 @@ export async function svfusionByRangeGetter_file(ds, genome) {
 export async function svfusionByNameGetter_file(ds, genome) {
 	const q = ds.queries.svfusion.byname
 	return async param => {
+		if (param.hiddenmclass?.has(dtsv) && param.hiddenmclass.has(dtfusionrna)) {
+			// both sv & fusion are skipped (even if ds has only 1 type)
+			return []
+		}
 		utils.validateRglst(param, genome)
 
 		const formatFilter = getFormatFilter(param)
@@ -2541,7 +2558,7 @@ export async function svfusionByNameGetter_file(ds, genome) {
 					// FIXME file should use sample name but not integer id
 					j.sample = ds.cohort.termdb.q.sampleName2id(m['sample_name'])
 
-					if (param.hiddenmclass && param.hiddenmclass.has(j.class)) return
+					if (param.hiddenmclass?.has(j.class)) return
 
 					if (j.sample && limitSamples) {
 						// to filter sample
@@ -2685,6 +2702,10 @@ async function addCnvGetter(ds, genome) {
 	cnvLossCutoff: float
 	*/
 	return async param => {
+		if (param.hiddenmclass?.has(dtcnv)) {
+			// cnv is skipped
+			return { cnvs: [] }
+		}
 		utils.validateRglst(param, genome)
 		if (param.cnvMaxLength && !Number.isInteger(param.cnvMaxLength)) throw 'cnvMaxLength is not integer' // cutoff<=0 is ignored
 		if (param.cnvGainCutoff && !Number.isFinite(param.cnvGainCutoff)) throw 'cnvGainCutoff is not finite'
@@ -2754,7 +2775,7 @@ async function addCnvGetter(ds, genome) {
 						if (j.class != mclasscnvgain && j.class != mclasscnvloss) return // no valid class
 					}
 
-					if (param.hiddenmclass && param.hiddenmclass.has(j.class)) return
+					if (param.hiddenmclass?.has(j.class)) return
 
 					if (j.sample) {
 						j.sample = ds.cohort.termdb.q.sampleName2id(j.sample)


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1313

Implemented `tk.snvIndelOnly` flag in pp code. This flag will cause non-snvindel variant classes (e.g. fusion, sv, cnv) to be hidden from the track. Legend items for these non-snvindel variant classes are also removed from the legend (so as to not display crossed-out legend items for these classes).

Added integration tests for this new flag.

Can test by launching: http://localhost:3000/example.mmrf.lollipop.html

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
