### PR TITLE
Volcano: quadtree hover, edge-dot padding, single/multi tooltip + click drilldown

### DIFF
--- a/client/plots/grin2/GRIN2Types.ts
+++ b/client/plots/grin2/GRIN2Types.ts
@@ -1,5 +1,4 @@
 import type { Menu } from '#dom'
-import type { ManhattanPoint } from '#plots/manhattan/manhattanTypes.ts'
 import type { Elem } from '../../types/d3'
 
 export interface GRIN2Dom {
@@ -98,37 +97,4 @@ export interface GRIN2Settings {
 	generalOptions?: {
 		[key: string]: any
 	}
-}
-/** A row from the top genes table where the first cell contains the gene name */
-export type GeneTableRow = Array<{ value?: string; [key: string]: any }>
-
-/** Data item for gene selection tracking - either a ManhattanPoint or a table row */
-export type GeneDataItem = ManhattanPoint | GeneTableRow
-
-/**
- * Options for showGrin2ResultTable
- */
-export interface ShowGrin2ResultTableOpts {
-	/** Div selection where the table will be rendered */
-	tableDiv: any
-	/** Array of ManhattanPoint gene results (used when columns/rows not provided) */
-	hits?: ManhattanPoint[]
-	/** Div where Matrix/Lollipop plots will be shown */
-	newPlotDiv?: any
-	/** App context for dispatching Matrix/Lollipop actions */
-	app?: any
-	/** Menu instance to hide on button actions */
-	clickMenu?: any
-	/** Pre-built columns (for top genes table). If not provided, builds from hits. */
-	columns?: any[]
-	/** Pre-built rows (for top genes table). If not provided, builds from hits. */
-	rows?: any[]
-	/** Original data items for button callbacks and selection tracking. Defaults to hits. */
-	dataItems?: any[]
-	/** Function to extract gene name from a data item. Defaults to (item) => item.gene */
-	getGene?: (item: any) => string
-	/** Format for matrix button text. Use {n} as placeholder for count. Defaults to "Matrix ({n})" */
-	matrixButtonFormat?: string
-	/** Additional options passed directly to renderTable */
-	[key: string]: any
 }

--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -1,119 +1,13 @@
 import { getCompInit, copyMerge, type RxComponent, type ComponentApi } from '#rx'
 import type { BasePlotConfig, MassAppApi, MassState } from '#mass/types/mass'
-import type { GRIN2Dom, GRIN2Opts, ShowGrin2ResultTableOpts } from './GRIN2Types'
+import type { GRIN2Dom, GRIN2Opts } from './GRIN2Types'
 import { getCombinedTermFilter, getNormalRoot, filterInit } from '#filter'
-import { Menu, renderTable, table2col, make_one_checkbox, sayerror } from '#dom'
+import { Menu, table2col, make_one_checkbox, sayerror } from '#dom'
 import { dtsnvindel, mclass, dtcnv, dtfusionrna, dtsv, proteinChangingMutations, dt2lesion } from '#shared/common.js'
 import { PlotBase } from '#plots/PlotBase.ts'
-import {
-	plotManhattan,
-	createLollipopFromGene,
-	createMatrixFromGenes,
-	updateSelectionTracking
-} from '#plots/manhattan/manhattan.ts'
+import { plotManhattan } from '#plots/manhattan/manhattan.ts'
+import { showResultsTable } from '../shared/resultsTable'
 import { controlsInit } from '#plots/controls.js'
-
-/**
- * Renders a GRIN2 result table for gene data.
- * Used by Manhattan plot for hover tooltips, click menus, and the top genes table.
- *
- * @param opts - Configuration options including tableDiv, hits, and optional settings
- */
-export function showGrin2ResultTable(opts: ShowGrin2ResultTableOpts): void {
-	const {
-		tableDiv,
-		hits,
-		app,
-		clickMenu,
-		columns: prebuiltColumns,
-		rows: prebuiltRows,
-		dataItems: prebuiltDataItems,
-		getGene = (item: any) => item.gene,
-		matrixButtonFormat = 'Matrix ({n})',
-		...renderTableOpts
-	} = opts
-
-	// Determine data source for button callbacks and selection tracking
-	const dataItems = prebuiltDataItems || hits
-
-	// Guard against empty data
-	if (!dataItems || dataItems.length === 0) return
-
-	// Use pre-built columns/rows if provided, otherwise build from hits
-	const columns = prebuiltColumns || [
-		{ label: 'Gene' },
-		{ label: `${hits![0].chrom.charAt(0).toUpperCase()}${hits![0].chrom.slice(1).toLowerCase()} pos` },
-		{ label: 'Type' },
-		{ label: 'Q-value', sortable: true },
-		{ label: 'Subject count', sortable: true }
-	]
-
-	const rows =
-		prebuiltRows ||
-		hits!.map(d => [
-			{ value: d.gene },
-			{ html: `<span style="font-size:.8em">${d.start}-${d.end}</span>` },
-			{ html: `<span style="color:${d.color}">●</span> ${d.type.charAt(0).toUpperCase() + d.type.slice(1)}` },
-			{ value: d.q_value.toPrecision(3) },
-			{ value: d.nsubj }
-		])
-	// Base table options
-	const tableOptions: any = {
-		div: tableDiv,
-		columns,
-		rows,
-		showLines: false,
-		showHeader: true,
-		striped: true,
-		resize: 'both',
-		header: { allowSort: true },
-		...renderTableOpts
-	}
-
-	// If app is provided, add Matrix/Lollipop buttons with selection tracking
-	if (app) {
-		let lastTouchedGene: string | null = null
-		let selectionOrder: number[] = []
-
-		tableOptions.buttonsToLeft = true
-		tableOptions.buttons = [
-			{
-				text: matrixButtonFormat.replace('{n}', '0'),
-				callback: (selectedIndices: number[], buttonNode: HTMLButtonElement) => {
-					if (selectedIndices.length > 0) {
-						buttonNode.disabled = true
-						const selectedGenes = selectedIndices.map(idx => getGene(dataItems[idx]))
-						clickMenu?.hide()
-						createMatrixFromGenes(selectedGenes, app)
-					}
-				},
-				onChange: (selectedIndices: number[], buttonNode: HTMLButtonElement) => {
-					buttonNode.textContent = matrixButtonFormat.replace('{n}', String(selectedIndices.length))
-					buttonNode.disabled = selectedIndices.length === 0
-				}
-			},
-			{
-				text: 'Lollipop',
-				callback: (_selectedIndices: number[], buttonNode: HTMLButtonElement) => {
-					if (lastTouchedGene) {
-						buttonNode.disabled = true
-						clickMenu?.hide()
-						createLollipopFromGene(lastTouchedGene, app)
-					}
-				},
-				onChange: (selectedIndices: number[], buttonNode: HTMLButtonElement) => {
-					const result = updateSelectionTracking(selectionOrder, selectedIndices, dataItems)
-					selectionOrder = result.selectionOrder
-					lastTouchedGene = result.lastTouchedGene
-					buttonNode.textContent = result.buttonText
-					buttonNode.disabled = result.buttonDisabled
-				}
-			}
-		]
-	}
-
-	renderTable(tableOptions)
-}
 
 class GRIN2 extends PlotBase implements RxComponent {
 	static type = 'grin2'
@@ -845,8 +739,8 @@ class GRIN2 extends PlotBase implements RxComponent {
 				return [{ value: '', html: circles.join('') }, ...row]
 			})
 
-			// Use showGrin2ResultTable for consistent table rendering
-			showGrin2ResultTable({
+			// Use showResultsTable for consistent table rendering
+			showResultsTable({
 				tableDiv,
 				app: this.app,
 				columns: modifiedColumns,

--- a/client/plots/manhattan/manhattan.ts
+++ b/client/plots/manhattan/manhattan.ts
@@ -1,116 +1,13 @@
 import { scaleLinear } from 'd3-scale'
 import * as d3axis from 'd3-axis'
 import { select } from 'd3-selection'
-import { Menu, icons, axisstyle, table2col, sayerror } from '#dom'
+import { Menu, icons, axisstyle, table2col } from '#dom'
 import { to_svg } from '#src/client'
-import { quadtree, type Quadtree } from 'd3-quadtree'
+import { quadtree } from 'd3-quadtree'
 import type { ManhattanPoint } from './manhattanTypes'
-import { get$id } from '#termsetting'
-import { showGrin2ResultTable } from '../grin2/grin2.ts'
-import type { GeneDataItem } from '../grin2/GRIN2Types.ts'
-
-/**
- * Searches a quadtree for all points within a specified radius of target coordinates.
- *
- * @param {Object} quadtree - D3 quadtree containing ManhattanPoint data
- * @param {number} mx - Target x coordinate (in pixels)
- * @param {number} my - Target y coordinate (in pixels)
- * @param {number} hitRadius - Search radius (in pixels)
- * @returns {Array<{point: ManhattanPoint, distance: number}>} Array of points within radius with their distances
- */
-function findPointsInRadius(
-	quadtree: Quadtree<ManhattanPoint>,
-	mx: number,
-	my: number,
-	hitRadius: number
-): Array<{ point: ManhattanPoint; distance: number }> {
-	const candidates: Array<{ point: ManhattanPoint; distance: number }> = []
-
-	quadtree.visit((node, x1, y1, x2, y2) => {
-		// Skip this node if it's outside the search radius
-		if (x1 > mx + hitRadius || x2 < mx - hitRadius || y1 > my + hitRadius || y2 < my - hitRadius) {
-			return true // Skip this branch
-		}
-
-		// If this is a leaf node, check ALL points (including coincident ones)
-		if (!node.length) {
-			// Traverse the linked list of coincident points
-			let current: any = node
-			while (current) {
-				const point = current.data
-				if (point) {
-					const px = point.pixel_x
-					const py = point.pixel_y
-					const distance = Math.sqrt((mx - px) ** 2 + (my - py) ** 2)
-
-					if (distance <= hitRadius) {
-						candidates.push({ point, distance })
-					}
-				}
-				current = current.next // Move to next coincident point
-			}
-		}
-
-		return false // Don't stop early - check all nodes in radius
-	})
-
-	return candidates
-}
-
-/**
- * Updates selection order tracking and determines the last touched gene.
- * This function is used by interactive selection buttons (Lollipop, Matrix) to track
- * which item was most recently selected, even when multiple items are selected.
- *
- * @param {number[]} currentSelectionOrder - Current array tracking selection order (indices in order of selection)
- * @param {number[]} selectedIndices - New array of selected indices from the selection UI
- * @param {GeneDataItem[]} dataSource - Array of data items containing gene information
- *   Can be either ManhattanPoints with `gene` property or table rows with `value` property
- * @returns {{selectionOrder: number[], lastTouchedGene: string | null, buttonText: string, buttonDisabled: boolean}}
- *   - selectionOrder: Updated array of indices in selection order
- *   - lastTouchedGene: Gene symbol of most recently selected item, or null if no selection
- *   - buttonText: Suggested button text including gene name if available
- *   - buttonDisabled: Whether the button should be disabled (true when no gene is selected)
- */
-export function updateSelectionTracking(
-	currentSelectionOrder: number[],
-	selectedIndices: number[],
-	dataSource: GeneDataItem[]
-): { selectionOrder: number[]; lastTouchedGene: string | null; buttonText: string; buttonDisabled: boolean } {
-	// Find newly selected items
-	const newlySelected = selectedIndices.filter(idx => !currentSelectionOrder.includes(idx))
-
-	// Update selection order: remove deselected items, add newly selected ones
-	const updatedSelectionOrder = currentSelectionOrder.filter(idx => selectedIndices.includes(idx))
-	updatedSelectionOrder.push(...newlySelected)
-
-	let lastTouchedGene: string | null = null
-	let buttonText = 'Lollipop'
-
-	if (updatedSelectionOrder.length > 0) {
-		// Get the most recently selected gene (last in selectionOrder)
-		const lastSelectedIdx = updatedSelectionOrder[updatedSelectionOrder.length - 1]
-		const dataItem = dataSource[lastSelectedIdx]
-
-		// Handle both ManhattanPoint objects (with 'gene' property) and table rows (arrays with value property)
-		if (Array.isArray(dataItem)) {
-			// Table row format: array of cells with value property
-			lastTouchedGene = dataItem[0]?.value || null
-		} else {
-			// ManhattanPoint format: object with gene property
-			lastTouchedGene = (dataItem as { gene: string }).gene
-		}
-
-		buttonText = `Lollipop (${lastTouchedGene})`
-	}
-
-	return {
-		selectionOrder: updatedSelectionOrder,
-		lastTouchedGene,
-		buttonText,
-		buttonDisabled: lastTouchedGene === null
-	}
-}
+import { showResultsTable } from '../shared/resultsTable'
+import { createLollipopFromGene } from '../shared/genePlotActions'
+import { findPointsInRadius } from '../shared/quadtreeHitTest'
 
 /**
  * Creates an interactive Manhattan plot on top of a PNG background plot image.
@@ -327,7 +224,7 @@ export function plotManhattan(div: any, data: any, settings: any, app?: any) {
 						// Multiple genes
 						const holder = geneTip.d.append('div').style('margin', '10px')
 
-						showGrin2ResultTable({ tableDiv: holder, hits: nearbyDots })
+						showResultsTable({ tableDiv: holder, hits: nearbyDots })
 
 						// Show message if there are more dots beyond the settings.maxTooltipGenes shown
 						// TODO: Make these settings abstracted out and can improve this later
@@ -394,7 +291,7 @@ export function plotManhattan(div: any, data: any, settings: any, app?: any) {
 
 					const holder = clickMenu.d.append('div').style('margin', '10px')
 
-					showGrin2ResultTable({ tableDiv: holder, hits: allNearbyDots, app, clickMenu })
+					showResultsTable({ tableDiv: holder, hits: allNearbyDots, app, clickMenu })
 				}
 			})
 	}
@@ -513,62 +410,5 @@ export function plotManhattan(div: any, data: any, settings: any, app?: any) {
 				.attr('font-size', `${settings.legendFontSize + 2}px`)
 				.text(item.type)
 		})
-	}
-}
-
-export function createLollipopFromGene(geneSymbol: string, app: any) {
-	const cfg: any = {
-		type: 'plot_create',
-		config: {
-			chartType: 'genomeBrowser',
-			snvindel: { shown: true }, // always set snvindel.shown=true so the mds3 tk is always shown; since grin2 works for this ds, it doesn't matter whether snvindel/cnv/svfusion any is present; all will be shown in mds3 tk
-			geneSearchResult: { geneSymbol }
-		}
-	}
-	if (app.vocabApi.termdbConfig.queries.trackLst?.activeTracks) {
-		cfg.config.trackLst = structuredClone(app.vocabApi.termdbConfig.queries.trackLst)
-		cfg.config.trackLst.activeTracks = [] // clear all active tracks as they are not related to grin2 analysis
-		// cannot do cfg.config.trackLst={activeTracks:[]}; breaks
-	}
-	app.dispatch(cfg)
-}
-
-export async function createMatrixFromGenes(geneSymbols: string[], app: any): Promise<void> {
-	// TODO: Improve this by maybe adding sayInfo that has a little div that shows a message letting the user know the matrix is being created with only the first N genes if they selected too many
-	const MAX_GENES = 100
-	const genesToUse = geneSymbols.slice(0, MAX_GENES)
-
-	try {
-		const termwrappers = await Promise.all(
-			genesToUse.map(async (gene: string) => {
-				const term = {
-					type: 'geneVariant',
-					gene: gene,
-					name: gene
-				}
-				const minTwCopy = app.vocabApi.getTwMinCopy({ term, q: {} })
-				return {
-					$id: await get$id(minTwCopy),
-					term,
-					q: {}
-				}
-			})
-		)
-
-		app.dispatch({
-			type: 'plot_create',
-			config: {
-				chartType: 'matrix',
-				dataType: 'geneVariant',
-				termgroups: [
-					{
-						name: 'Genomic Alterations',
-						lst: termwrappers
-					}
-				]
-			}
-		})
-	} catch (error) {
-		sayerror(app.dom.div, `Error creating matrix: ${error instanceof Error ? error.message : error}`)
 	}
 }

--- a/client/plots/shared/genePlotActions.ts
+++ b/client/plots/shared/genePlotActions.ts
@@ -1,0 +1,69 @@
+import { sayerror } from '#dom'
+import { get$id } from '#termsetting'
+
+/**
+ * Dispatches a plot_create action that opens a Lollipop / genome-browser view
+ * for a single gene. Used from gene-results tables (manhattan, grin2, volcano)
+ * when the user picks one gene to drill into.
+ */
+export function createLollipopFromGene(geneSymbol: string, app: any) {
+	const cfg: any = {
+		type: 'plot_create',
+		config: {
+			chartType: 'genomeBrowser',
+			snvindel: { shown: true }, // always set snvindel.shown=true so the mds3 tk is always shown; since grin2 works for this ds, it doesn't matter whether snvindel/cnv/svfusion any is present; all will be shown in mds3 tk
+			geneSearchResult: { geneSymbol }
+		}
+	}
+	if (app.vocabApi.termdbConfig.queries.trackLst?.activeTracks) {
+		cfg.config.trackLst = structuredClone(app.vocabApi.termdbConfig.queries.trackLst)
+		cfg.config.trackLst.activeTracks = [] // clear all active tracks as they are not related to grin2 analysis
+		// cannot do cfg.config.trackLst={activeTracks:[]}; breaks
+	}
+	app.dispatch(cfg)
+}
+
+/**
+ * Dispatches a plot_create action that opens a Matrix view for a set of genes.
+ * Capped at 100 genes — the table caller is expected to have already filtered
+ * to the user's selection.
+ */
+export async function createMatrixFromGenes(geneSymbols: string[], app: any): Promise<void> {
+	// TODO: Improve this by maybe adding sayInfo that has a little div that shows a message letting the user know the matrix is being created with only the first N genes if they selected too many
+	const MAX_GENES = 100
+	const genesToUse = geneSymbols.slice(0, MAX_GENES)
+
+	try {
+		const termwrappers = await Promise.all(
+			genesToUse.map(async (gene: string) => {
+				const term = {
+					type: 'geneVariant',
+					gene: gene,
+					name: gene
+				}
+				const minTwCopy = app.vocabApi.getTwMinCopy({ term, q: {} })
+				return {
+					$id: await get$id(minTwCopy),
+					term,
+					q: {}
+				}
+			})
+		)
+
+		app.dispatch({
+			type: 'plot_create',
+			config: {
+				chartType: 'matrix',
+				dataType: 'geneVariant',
+				termgroups: [
+					{
+						name: 'Genomic Alterations',
+						lst: termwrappers
+					}
+				]
+			}
+		})
+	} catch (error) {
+		sayerror(app.dom.div, `Error creating matrix: ${error instanceof Error ? error.message : error}`)
+	}
+}

--- a/client/plots/shared/quadtreeHitTest.ts
+++ b/client/plots/shared/quadtreeHitTest.ts
@@ -1,0 +1,57 @@
+import type { Quadtree } from 'd3-quadtree'
+
+/**
+ * Searches a quadtree for all points within a specified radius of target coordinates.
+ *
+ * Generic over the point type T. By default reads `pixel_x`/`pixel_y` from each
+ * datum (matching ManhattanPoint); pass `getX`/`getY` to use other coordinate
+ * fields (e.g. `x`/`y` for the volcano plot).
+ *
+ * @param qt - D3 quadtree containing T-typed point data
+ * @param mx - Target x coordinate (in pixels, in quadtree-local space)
+ * @param my - Target y coordinate (in pixels, in quadtree-local space)
+ * @param hitRadius - Search radius (in pixels)
+ * @param getX - Optional accessor for the point's x coord (default: d.pixel_x)
+ * @param getY - Optional accessor for the point's y coord (default: d.pixel_y)
+ * @returns Array of points within radius with their distances
+ */
+export function findPointsInRadius<T>(
+	qt: Quadtree<T>,
+	mx: number,
+	my: number,
+	hitRadius: number,
+	getX: (d: T) => number = (d: any) => d.pixel_x,
+	getY: (d: T) => number = (d: any) => d.pixel_y
+): Array<{ point: T; distance: number }> {
+	const candidates: Array<{ point: T; distance: number }> = []
+
+	qt.visit((node, x1, y1, x2, y2) => {
+		// Skip this node if it's outside the search radius
+		if (x1 > mx + hitRadius || x2 < mx - hitRadius || y1 > my + hitRadius || y2 < my - hitRadius) {
+			return true // Skip this branch
+		}
+
+		// If this is a leaf node, check ALL points (including coincident ones)
+		if (!node.length) {
+			// Traverse the linked list of coincident points
+			let current: any = node
+			while (current) {
+				const point = current.data as T | undefined
+				if (point) {
+					const px = getX(point)
+					const py = getY(point)
+					const distance = Math.sqrt((mx - px) ** 2 + (my - py) ** 2)
+
+					if (distance <= hitRadius) {
+						candidates.push({ point, distance })
+					}
+				}
+				current = current.next // Move to next coincident point
+			}
+		}
+
+		return false // Don't stop early - check all nodes in radius
+	})
+
+	return candidates
+}

--- a/client/plots/shared/resultsTable.ts
+++ b/client/plots/shared/resultsTable.ts
@@ -1,0 +1,143 @@
+import { renderTable } from '#dom'
+import { createLollipopFromGene, createMatrixFromGenes } from './genePlotActions'
+import type { ShowResultsTableOpts, ResultsDataItem } from './resultsTableTypes'
+
+/**
+ * Renders a results table for biological items (genes, promoters, etc.).
+ * Used by manhattan/volcano hover tooltips, click menus, and the grin2
+ * top-genes table. Data-agnostic — pass `columns`/`rows` for custom shapes.
+ *
+ * When `app` is provided, the gene-specific Matrix/Lollipop buttons are
+ * auto-injected; omit `app` for read-only or non-gene contexts.
+ */
+export function showResultsTable(opts: ShowResultsTableOpts): void {
+	const {
+		tableDiv,
+		hits,
+		app,
+		clickMenu,
+		columns: prebuiltColumns,
+		rows: prebuiltRows,
+		dataItems: prebuiltDataItems,
+		getGene = (item: any) => item.gene,
+		matrixButtonFormat = 'Matrix ({n})',
+		...renderTableOpts
+	} = opts
+
+	const dataItems = prebuiltDataItems || hits
+
+	if (!dataItems || dataItems.length === 0) return
+
+	const columns = prebuiltColumns || [
+		{ label: 'Gene' },
+		{ label: `${hits![0].chrom.charAt(0).toUpperCase()}${hits![0].chrom.slice(1).toLowerCase()} pos` },
+		{ label: 'Type' },
+		{ label: 'Q-value', sortable: true },
+		{ label: 'Subject count', sortable: true }
+	]
+
+	const rows =
+		prebuiltRows ||
+		hits!.map(d => [
+			{ value: d.gene },
+			{ html: `<span style="font-size:.8em">${d.start}-${d.end}</span>` },
+			{ html: `<span style="color:${d.color}">●</span> ${d.type.charAt(0).toUpperCase() + d.type.slice(1)}` },
+			{ value: d.q_value.toPrecision(3) },
+			{ value: d.nsubj }
+		])
+
+	const tableOptions: any = {
+		div: tableDiv,
+		columns,
+		rows,
+		showLines: false,
+		showHeader: true,
+		striped: true,
+		resize: 'both',
+		header: { allowSort: true },
+		...renderTableOpts
+	}
+
+	if (app) {
+		let lastTouchedGene: string | null = null
+		let selectionOrder: number[] = []
+
+		tableOptions.buttonsToLeft = true
+		tableOptions.buttons = [
+			{
+				text: matrixButtonFormat.replace('{n}', '0'),
+				callback: (selectedIndices: number[], buttonNode: HTMLButtonElement) => {
+					if (selectedIndices.length > 0) {
+						buttonNode.disabled = true
+						const selectedGenes = selectedIndices.map(idx => getGene(dataItems[idx]))
+						clickMenu?.hide()
+						createMatrixFromGenes(selectedGenes, app)
+					}
+				},
+				onChange: (selectedIndices: number[], buttonNode: HTMLButtonElement) => {
+					buttonNode.textContent = matrixButtonFormat.replace('{n}', String(selectedIndices.length))
+					buttonNode.disabled = selectedIndices.length === 0
+				}
+			},
+			{
+				text: 'Lollipop',
+				callback: (_selectedIndices: number[], buttonNode: HTMLButtonElement) => {
+					if (lastTouchedGene) {
+						buttonNode.disabled = true
+						clickMenu?.hide()
+						createLollipopFromGene(lastTouchedGene, app)
+					}
+				},
+				onChange: (selectedIndices: number[], buttonNode: HTMLButtonElement) => {
+					const result = updateSelectionTracking(selectionOrder, selectedIndices, dataItems)
+					selectionOrder = result.selectionOrder
+					lastTouchedGene = result.lastTouchedGene
+					buttonNode.textContent = result.buttonText
+					buttonNode.disabled = result.buttonDisabled
+				}
+			}
+		]
+	}
+
+	renderTable(tableOptions)
+}
+
+/**
+ * Updates selection-order tracking and determines the last-touched gene.
+ * Used by the Lollipop button to remember which gene the user touched most
+ * recently across multi-select changes. Lives next to showResultsTable since
+ * the button-state logic is its only caller.
+ */
+export function updateSelectionTracking(
+	currentSelectionOrder: number[],
+	selectedIndices: number[],
+	dataSource: ResultsDataItem[]
+): { selectionOrder: number[]; lastTouchedGene: string | null; buttonText: string; buttonDisabled: boolean } {
+	const newlySelected = selectedIndices.filter(idx => !currentSelectionOrder.includes(idx))
+
+	const updatedSelectionOrder = currentSelectionOrder.filter(idx => selectedIndices.includes(idx))
+	updatedSelectionOrder.push(...newlySelected)
+
+	let lastTouchedGene: string | null = null
+	let buttonText = 'Lollipop'
+
+	if (updatedSelectionOrder.length > 0) {
+		const lastSelectedIdx = updatedSelectionOrder[updatedSelectionOrder.length - 1]
+		const dataItem = dataSource[lastSelectedIdx]
+
+		if (Array.isArray(dataItem)) {
+			lastTouchedGene = dataItem[0]?.value || null
+		} else {
+			lastTouchedGene = (dataItem as { gene: string }).gene
+		}
+
+		buttonText = `Lollipop (${lastTouchedGene})`
+	}
+
+	return {
+		selectionOrder: updatedSelectionOrder,
+		lastTouchedGene,
+		buttonText,
+		buttonDisabled: lastTouchedGene === null
+	}
+}

--- a/client/plots/shared/resultsTable.ts
+++ b/client/plots/shared/resultsTable.ts
@@ -126,7 +126,10 @@ export function updateSelectionTracking(
 		const dataItem = dataSource[lastSelectedIdx]
 
 		if (Array.isArray(dataItem)) {
-			lastTouchedGene = dataItem[0]?.value || null
+			// First cell is by convention the gene/feature name; coerce to string
+			// since `value` is widened to string | number across the table API.
+			const v = dataItem[0]?.value
+			lastTouchedGene = v != null ? String(v) : null
 		} else {
 			lastTouchedGene = (dataItem as { gene: string }).gene
 		}

--- a/client/plots/shared/resultsTableTypes.ts
+++ b/client/plots/shared/resultsTableTypes.ts
@@ -1,0 +1,39 @@
+/** A row used by the results table where the first cell typically holds the
+ * gene/promoter/feature name. Generic — callers shape it however they like. */
+export type ResultsTableRow = Array<{ value?: string; [key: string]: any }>
+
+/** Data item passed to button callbacks for selection tracking. The table is
+ * data-agnostic — items can be points (manhattan), promoters (volcano DM),
+ * pre-built rows for the GRIN2 top-genes table, etc. */
+export type ResultsDataItem = ResultsTableRow | { gene?: string; [key: string]: any }
+
+/** Options for showResultsTable. Renderable via prebuilt columns/rows, or
+ * built from `hits` for the manhattan default shape. Pass `app` to opt into
+ * the built-in Matrix/Lollipop buttons (gene-data only). */
+export interface ShowResultsTableOpts {
+	/** Div selection where the table will be rendered */
+	tableDiv: any
+	/** Default-shape items used when `columns`/`rows` are not provided. Must
+	 * carry gene/chrom/start/end/color/type/q_value/nsubj fields (manhattan). */
+	hits?: any[]
+	/** App context for dispatching Matrix/Lollipop actions. When omitted, no
+	 * built-in buttons are rendered (volcano-style). */
+	app?: any
+	/** Menu instance to hide on button actions. */
+	clickMenu?: any
+	/** Pre-built columns. If not provided, builds default columns from `hits`. */
+	columns?: any[]
+	/** Pre-built rows. If not provided, builds from `hits`. */
+	rows?: any[]
+	/** Original data items for button callbacks and selection tracking.
+	 * Defaults to `hits`. */
+	dataItems?: any[]
+	/** Function to extract gene name from a data item. Defaults to
+	 * (item) => item.gene, which works for ManhattanPoint. */
+	getGene?: (item: any) => string
+	/** Format for matrix button text. Use {n} as placeholder for count.
+	 * Defaults to "Matrix ({n})". */
+	matrixButtonFormat?: string
+	/** Additional options passed directly to renderTable. */
+	[key: string]: any
+}

--- a/client/plots/shared/resultsTableTypes.ts
+++ b/client/plots/shared/resultsTableTypes.ts
@@ -1,6 +1,8 @@
 /** A row used by the results table where the first cell typically holds the
- * gene/promoter/feature name. Generic — callers shape it however they like. */
-export type ResultsTableRow = Array<{ value?: string; [key: string]: any }>
+ * gene/promoter/feature name. Generic — callers shape it however they like.
+ * `value` is `string | number` because numeric stats (q-values, fold-change,
+ * subject counts) are passed through unwrapped alongside string identifiers. */
+export type ResultsTableRow = Array<{ value?: string | number; [key: string]: any }>
 
 /** Data item passed to button callbacks for selection tracking. The table is
  * data-agnostic — items can be points (manhattan), promoters (volcano DM),

--- a/client/plots/volcano/VolcanoTypes.ts
+++ b/client/plots/volcano/VolcanoTypes.ts
@@ -11,9 +11,13 @@ export type DataPointEntry = (GeneDEEntry | DiffMethEntry | SingleCellDEEntry) &
 	color: string
 	/** If true, the fill opacity increases to show the highlight color */
 	highlighted: boolean
-	/** x coordinate */
+	/** Inner-plot pixel x coordinate (rust echoes plotters' rasterized center). */
+	pixel_x: number
+	/** Inner-plot pixel y coordinate (rust echoes plotters' rasterized center). */
+	pixel_y: number
+	/** SVG-absolute x = pixel_x + plotX */
 	x: number
-	/** y coordinate */
+	/** SVG-absolute y = pixel_y + topPad */
 	y: number
 	/** radius */
 	radius: number
@@ -68,9 +72,15 @@ export type VolcanoPlotDimensions = {
 	top: { x: number; y: number }
 	svg: { width: number; height: number }
 	xAxisLabel: { x: number; y: number }
+	/** Visible x-axis (unpadded data range) */
 	xScale: { x: number; y: number; scale: any }
 	yAxisLabel: { x: number; y: number; text: string }
+	/** Visible y-axis (unpadded data range) */
 	yScale: { x: number; y: number; scale: any }
+	/** Positioning scales: padded data range covering the full plot rect.
+	 * Use these for overlay dots, PNG image, and the fold-change=0 line. */
+	xPlotScale: any
+	yPlotScale: any
 }
 
 export type VolcanoOpts = {

--- a/client/plots/volcano/settings/Settings.ts
+++ b/client/plots/volcano/settings/Settings.ts
@@ -23,6 +23,9 @@ export type DefaultVolcanoSettings = {
 	 * PNG still shows every dot — this only caps the SVG overlay the client
 	 * renders on top. Capped to the most-significant rows. */
 	maxInteractiveDots: number
+	/** Max genes shown in the multi-gene hover tooltip when many dots overlap.
+	 * Beyond this an "and N more" footer appears. */
+	maxTooltipGenes: number
 }
 
 export type GEVolcanoSettings = DefaultVolcanoSettings & {

--- a/client/plots/volcano/settings/defaults.ts
+++ b/client/plots/volcano/settings/defaults.ts
@@ -26,7 +26,8 @@ export function getDefaultVolcanoSettings(overrides = {}, opts: any): ValidatedV
 		sampleNumCutoff: opts.termType == GENE_EXPRESSION ? maxGESampleCutoff : maxSampleCutoff,
 		showPValueTable: false,
 		width: 400,
-		maxInteractiveDots: 5000
+		maxInteractiveDots: 5000,
+		maxTooltipGenes: 5
 	} satisfies DefaultVolcanoSettings
 
 	addGEDefaults(opts.termType, defaults)

--- a/client/plots/volcano/test/volcano.unit.spec.ts
+++ b/client/plots/volcano/test/volcano.unit.spec.ts
@@ -71,21 +71,29 @@ const mockConfig = {
 // would emit for the old 10-row fixture; totalRows=10 lets numNonSignificant=9
 // fall out for the stats tests.
 const significantRow = testData.responseData.find((d: any) => d.gene_name === 'C1orf159')
+// Server now echoes pixel_x/pixel_y per dot (manhattan trick) so the SVG
+// overlay lands exactly on the rasterized PNG dot.
+const significantWithPixels = significantRow ? { ...significantRow, pixel_x: 350, pixel_y: 100 } : null
 const mockResponse = {
 	data: {
-		dots: significantRow ? [significantRow] : [],
+		dots: significantWithPixels ? [significantWithPixels] : [],
 		volcanoPng: '',
 		plotExtent: {
 			xMin: -0.1281,
 			xMax: 0.6196,
 			yMin: -0.192065410979292,
 			yMax: 2.677780705266081,
-			pixelWidth: 400,
-			pixelHeight: 400,
+			xMinUnpadded: -0.122,
+			xMaxUnpadded: 0.59,
+			yMinUnpadded: 0,
+			yMaxUnpadded: 2.55,
+			dotRadiusPx: 2,
+			pixelWidth: 404,
+			pixelHeight: 404,
 			plotLeft: 0,
 			plotTop: 0,
-			plotRight: 400,
-			plotBottom: 400,
+			plotRight: 404,
+			plotBottom: 404,
 			minNonZeroPValue: 1e-9
 		},
 		totalRows: testData.responseData.length,
@@ -152,17 +160,19 @@ tape('setPlotDimensions', function (test) {
 	const viewModel = new VolcanoViewModel(mockConfig as any, mockResponse, mockSettings as any)
 
 	const plotDim = viewModel.setPlotDimensions()
-	test.deepEqual(plotDim.svg, { height: 590, width: 540 }, 'Should properly set svg')
-	test.deepEqual(plotDim.xAxisLabel, { x: 280, y: 510 }, 'Should properly set xAxisLabel')
+	// Plot rect grows by 2*dotRadiusPx (= 4 px here) on each axis to match the
+	// server's PNG padding, so all dependent positions shift by 4.
+	test.deepEqual(plotDim.svg, { height: 594, width: 544 }, 'Should properly set svg')
+	test.deepEqual(plotDim.xAxisLabel, { x: 282, y: 514 }, 'Should properly set xAxisLabel')
 	test.deepEqual(
 		plotDim.yAxisLabel,
-		{ text: '-log10(adjusted P value)', x: 23.333333333333332, y: 240 },
+		{ text: '-log10(adjusted P value)', x: 23.333333333333332, y: 242 },
 		'Should properly set yAxisLabel'
 	)
-	test.deepEqual(plotDim.plot, { height: 400, width: 400, x: 90, y: 40 }, 'Should properly set plot')
+	test.deepEqual(plotDim.plot, { height: 404, width: 404, x: 90, y: 40 }, 'Should properly set plot')
 	test.deepEqual(
 		plotDim.logFoldChangeLine,
-		{ x: 158.5301591547412, y1: 40, y2: 440 },
+		{ x: 159.2154607462886, y1: 40, y2: 444 },
 		'Should properly set logFoldChangeLine'
 	)
 
@@ -189,7 +199,7 @@ tape('setPointData', function (test) {
 		1,
 		'Should properly set highlighted property for each data point'
 	)
-	test.equal(pointData.filter((d: any) => d.radius === 5).length, 1, 'Should properly set radius for each data point')
+	test.equal(pointData.filter((d: any) => d.radius === 2).length, 1, 'Should properly set radius for each data point')
 
 	test.end()
 })

--- a/client/plots/volcano/view/DataPointMouseEvents.ts
+++ b/client/plots/volcano/view/DataPointMouseEvents.ts
@@ -1,133 +1,76 @@
-import { table2col, type Menu } from '#dom'
 import { roundValueAuto } from '#shared/roundValue.js'
-import type { SvgCircle } from '../../../types/d3'
 import type { VolcanoInteractions } from '../interactions/VolcanoInteractions'
 import type { DataPointEntry } from '../VolcanoTypes'
 import { DNA_METHYLATION, GENE_EXPRESSION } from '#shared/terms.js'
 
-export class DataPointMouseEvents {
-	termType: string
+export type ActionMenuOpt = {
+	label: string
+	onClick: () => Promise<void> | void
+}
 
-	constructor(d: DataPointEntry, circle: SvgCircle, tip: Menu, interactions: VolcanoInteractions, termType: string) {
-		this.termType = termType
-
-		const menuOpts = [
-			{
-				label: 'Violin plot',
-				isVisible: () => {
-					const enabledTermTypes = new Set([DNA_METHYLATION, GENE_EXPRESSION])
-					return enabledTermTypes.has(termType)
-				},
-				onClick: async () => {
-					if (termType === DNA_METHYLATION) interactions.launchDNAMethViolin(d as any)
-					if (termType === GENE_EXPRESSION) interactions.launchViolinGeneExp(d.gene_name)
-				}
-			},
-			{
-				label: 'DMR analysis',
-				isVisible: () => termType === DNA_METHYLATION,
-				onClick: async () => {
-					const dm = d as DataPointEntry & {
-						chr: string
-						start: number
-						stop: number
-						promoter_id?: string
-						gene_name?: string
-					}
-					await interactions.launchDmr({
-						chr: dm.chr,
-						start: dm.start,
-						stop: dm.stop,
-						promoterId: dm.promoter_id
-					})
-				}
-			},
-			{
-				label: 'Box plot',
-				isVisible: () => termType === GENE_EXPRESSION,
-				onClick: async () => {
-					interactions.launchBoxPlot(d.gene_name)
-				}
+/** Returns the per-data-point action menu items (Violin / DMR / Box-plot). Used
+ * by both the single-gene click flow and the multi-gene click-menu rows so the
+ * launchers stay in lock-step. */
+export function getActionMenuOpts(
+	d: DataPointEntry,
+	termType: string,
+	interactions: VolcanoInteractions
+): ActionMenuOpt[] {
+	const all = [
+		{
+			label: 'Violin plot',
+			isVisible: () => termType === DNA_METHYLATION || termType === GENE_EXPRESSION,
+			onClick: async () => {
+				if (termType === DNA_METHYLATION) interactions.launchDNAMethViolin(d as any)
+				if (termType === GENE_EXPRESSION) interactions.launchViolinGeneExp(d.gene_name)
 			}
-		]
-
-		// Use a throwaway clone to visualize the hover highlight instead of mutating
-		// the original circle + raising it. Rearranging DOM mid-hover can leave the
-		// original stuck at full fill-opacity when rapid enter/leave events race
-		// against the DOM move. Same pattern as the p-value table hover preview.
-		let clone: SVGCircleElement | null = null
-		const showHighlight = () => {
-			if (clone) return
-			const node = circle.node() as SVGCircleElement | null
-			if (!node) return
-			const c = node.cloneNode(true) as SVGCircleElement
-			c.setAttribute('fill-opacity', '0.9')
-			// Don't intercept subsequent enter/leave events destined for siblings.
-			c.setAttribute('pointer-events', 'none')
-			node.parentNode?.appendChild(c)
-			clone = c
-		}
-		const hideHighlight = () => {
-			if (!clone) return
-			clone.remove()
-			clone = null
-		}
-
-		circle.on('mouseenter', () => {
-			// Skip the clone for already-highlighted points; their fill handles the visual.
-			if (!d.highlighted) showHighlight()
-			tip.clear().showunder(circle.node())
-			const table = table2col({ holder: tip.d.append('table') })
-			this.addTooltipRows(d, table)
-		})
-
-		let menuOpen = false
-		circle.on('mouseleave', () => {
-			if (menuOpen) return
-			tip.hide()
-			hideHighlight()
-		})
-
-		const visibleMenuOpts = menuOpts.filter(opt => opt.isVisible())
-		if (visibleMenuOpts.length === 0) return
-
-		circle.on('click', () => {
-			menuOpen = true
-			if (!d.highlighted) showHighlight()
-			tip.onHide = () => {
-				menuOpen = false
-				hideHighlight()
+		},
+		{
+			label: 'DMR analysis',
+			isVisible: () => termType === DNA_METHYLATION,
+			onClick: async () => {
+				const dm = d as DataPointEntry & {
+					chr: string
+					start: number
+					stop: number
+					promoter_id?: string
+					gene_name?: string
+				}
+				await interactions.launchDmr({
+					chr: dm.chr,
+					start: dm.start,
+					stop: dm.stop,
+					promoterId: dm.promoter_id
+				})
 			}
-			tip.clear().showunder(circle.node())
-			for (const opt of visibleMenuOpts) {
-				tip.d
-					.append('div')
-					.attr('class', 'sja_menuoption')
-					.text(opt.label)
-					.on('click', async () => {
-						tip.hide()
-						hideHighlight()
-						await opt.onClick()
-					})
+		},
+		{
+			label: 'Box plot',
+			isVisible: () => termType === GENE_EXPRESSION,
+			onClick: async () => {
+				interactions.launchBoxPlot(d.gene_name)
 			}
-		})
-	}
-
-	addTooltipRows(d: DataPointEntry, table: any) {
-		if (this.termType === DNA_METHYLATION) {
-			if ('promoter_id' in d) this.addTooltipRow(table, 'Promoter', d.promoter_id)
-			if (d.gene_name) this.addTooltipRow(table, 'Gene(s)', d.gene_name)
-		} else {
-			this.addTooltipRow(table, 'Gene name', d.gene_name)
 		}
-		this.addTooltipRow(table, 'log<sub>2</sub>(fold-change)', roundValueAuto(d.fold_change))
-		this.addTooltipRow(table, 'Original p-value', roundValueAuto(d.original_p_value))
-		this.addTooltipRow(table, 'Adjusted p-value', roundValueAuto(d.adjusted_p_value))
-	}
+	]
+	return all.filter(o => o.isVisible()).map(({ label, onClick }) => ({ label, onClick }))
+}
 
-	addTooltipRow(table: any, text: string, value: number | string) {
-		const [td1, td2] = table.addRow()
-		td1.html(text)
-		td2.text(value)
+/** Populates a `table2col` instance with the standard volcano hover rows
+ * (gene/promoter, fold-change, original + adjusted p-values). */
+export function addTooltipRows(d: DataPointEntry, table: any, termType: string) {
+	if (termType === DNA_METHYLATION) {
+		if ('promoter_id' in d) addTooltipRow(table, 'Promoter', (d as any).promoter_id)
+		if (d.gene_name) addTooltipRow(table, 'Gene(s)', d.gene_name)
+	} else {
+		addTooltipRow(table, 'Gene name', d.gene_name)
 	}
+	addTooltipRow(table, 'log<sub>2</sub>(fold-change)', roundValueAuto(d.fold_change))
+	addTooltipRow(table, 'Original p-value', roundValueAuto(d.original_p_value))
+	addTooltipRow(table, 'Adjusted p-value', roundValueAuto(d.adjusted_p_value))
+}
+
+function addTooltipRow(table: any, text: string, value: number | string) {
+	const [td1, td2] = table.addRow()
+	td1.html(text)
+	td2.text(value)
 }

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -1,11 +1,15 @@
 import { axisBottom, axisLeft } from 'd3-axis'
-import { axisstyle, table2col, renderTable } from '#dom'
-import { select, selectAll } from 'd3-selection'
+import { axisstyle, Menu, table2col, renderTable } from '#dom'
+import { selectAll } from 'd3-selection'
 import { rgb } from 'd3-color'
+import { quadtree } from 'd3-quadtree'
+import { roundValueAuto } from '#shared/roundValue.js'
 import type { DataPointEntry, VolcanoDom, VolcanoPlotDimensions, VolcanoViewData } from '../VolcanoTypes'
 import type { VolcanoPlotDom } from './VolcanoPlotDom'
 import type { VolcanoInteractions } from '../interactions/VolcanoInteractions'
-import { DataPointMouseEvents } from './DataPointMouseEvents'
+import { addTooltipRows, getActionMenuOpts } from './DataPointMouseEvents'
+import { findPointsInRadius } from '../../shared/quadtreeHitTest'
+import { showResultsTable } from '../../shared/resultsTable'
 import { DNA_METHYLATION, GENE_EXPRESSION, SINGLECELL_CELLTYPE } from '#shared/terms.js'
 import type { ValidatedVolcanoSettings } from '../settings/Settings'
 
@@ -56,6 +60,7 @@ export class VolcanoPlotView {
 		this.renderPlot(plotDim)
 		renderDataPoints(this)
 		this.renderFoldChangeLine(plotDim)
+		this.setupOverlayInteractions(plotDim)
 		if (this.settings.showPValueTable) this.renderPValueTable()
 	}
 
@@ -170,15 +175,6 @@ export class VolcanoPlotView {
 				.attr('height', plotDim.plot.height)
 				.attr('preserveAspectRatio', 'none')
 		}
-
-		this.volcanoDom.plot
-			.append('rect')
-			.attr('width', plotDim.plot.width)
-			.attr('height', plotDim.plot.height)
-			.attr('stroke', '#ededed')
-			.attr('fill', 'transparent')
-			.attr('shape-rendering', 'crispEdges')
-			.attr('transform', `translate(${plotDim.plot.x}, ${plotDim.plot.y})`)
 	}
 
 	renderTermInfo(plotDim) {
@@ -238,6 +234,164 @@ export class VolcanoPlotView {
 			.attr('x2', plotDim.logFoldChangeLine.x)
 			.attr('y1', plotDim.logFoldChangeLine.y1)
 			.attr('y2', plotDim.logFoldChangeLine.y2)
+	}
+
+	/** Quadtree-driven hover & click overlay. Mirrors the manhattan plot:
+	 *   - a transparent SVG rect (cover) sits over the plot rect and absorbs
+	 *     mouse events so coincident dots are all reachable;
+	 *   - hover finds every point within (dotRadiusPx + 3) px and shows a
+	 *     single-gene table2col tooltip OR a multi-gene sortable table;
+	 *   - click launches the per-gene action menu directly for one hit, or
+	 *     opens a click-menu with a row-clickable table for many hits. */
+	setupOverlayInteractions(plotDim: VolcanoPlotDimensions) {
+		// Skip for term types with no data point actions (e.g. SCCT) — preserves
+		// existing behavior where SCCT volcanoes have no per-dot interactions.
+		if (this.termType === SINGLECELL_CELLTYPE) return
+
+		const points = this.viewData.pointData as DataPointEntry[]
+		if (!points || points.length === 0) return
+
+		// PNG-aligned radius for hover fills + hit-radius. The SVG overlay rings
+		// (points[0].radius) are deliberately drawn smaller to keep their outer
+		// stroke from overhanging the PNG dot.
+		const dotRadiusPx = this.viewData.plotExtent.dotRadiusPx
+		const hitRadius = dotRadiusPx + 3
+		const maxTooltipGenes = this.settings.maxTooltipGenes
+
+		// Hover-ring layer — visual only, never intercepts mouse events so the
+		// cover keeps absorbing them.
+		const hoverLayer = this.volcanoDom.plot.append('g').attr('id', 'sjpp-volcano-hover').style('pointer-events', 'none')
+
+		// Cover rect — last child of plot group so it sits on top of dots,
+		// hover rings, and the fold-change line.
+		const cover = this.volcanoDom.plot
+			.append('rect')
+			.attr('id', 'sjpp-volcano-cover')
+			.attr('x', plotDim.plot.x)
+			.attr('y', plotDim.plot.y)
+			.attr('width', plotDim.plot.width)
+			.attr('height', plotDim.plot.height)
+			.attr('fill', 'transparent')
+			.style('pointer-events', 'all')
+			.style('cursor', 'default')
+
+		// Quadtree in cover-local space — d.x/d.y are SVG-absolute, so subtract
+		// the plot rect's origin once when building the tree.
+		const qt = quadtree<DataPointEntry>()
+			.x(d => d.x - plotDim.plot.x)
+			.y(d => d.y - plotDim.plot.y)
+			.addAll(points)
+
+		const hoverTip = this.dom.tip
+		const clickMenu = new Menu({
+			padding: '',
+			onHide: () => {
+				clickMenuIsShown = false
+				// Drop the persisted highlight once the user dismisses the menu.
+				drawHoverRings([])
+			}
+		})
+		let clickMenuIsShown = false
+
+		const highlightColor = this.settings.defaultHighlightColor
+		// Inset by stroke-width/2 (= 0.5 px for stroke=1) so the orange fill
+		// stops at the ring's inner edge — the colored stroke stays fully
+		// visible around the highlight instead of being painted over.
+		const highlightRadius = Math.max(0.5, dotRadiusPx - 0.5)
+		const drawHoverRings = (dots: DataPointEntry[]) => {
+			hoverLayer.selectAll('circle').remove()
+			for (const d of dots) {
+				hoverLayer
+					.append('circle')
+					.attr('cx', d.x)
+					.attr('cy', d.y)
+					.attr('r', highlightRadius)
+					.attr('fill', highlightColor)
+					.attr('fill-opacity', 0.9)
+			}
+		}
+
+		const findCandidates = (event: MouseEvent) => {
+			const rect = (cover.node() as SVGRectElement).getBoundingClientRect()
+			const mx = event.clientX - rect.left
+			const my = event.clientY - rect.top
+			const candidates = findPointsInRadius<DataPointEntry>(
+				qt,
+				mx,
+				my,
+				hitRadius,
+				d => d.x - plotDim.plot.x,
+				d => d.y - plotDim.plot.y
+			)
+			candidates.sort((a, b) => a.distance - b.distance)
+			return candidates.map(c => c.point)
+		}
+
+		cover.on('mousemove', (event: MouseEvent) => {
+			if (clickMenuIsShown) return
+			const all = findCandidates(event)
+			const shown = all.slice(0, maxTooltipGenes)
+			const additionalCount = all.length - maxTooltipGenes
+
+			if (shown.length === 0) {
+				drawHoverRings([])
+				hoverTip.hide()
+				return
+			}
+
+			drawHoverRings(shown)
+			hoverTip.clear().show(event.clientX, event.clientY)
+
+			if (shown.length === 1) {
+				const table = table2col({ holder: hoverTip.d.append('table') })
+				addTooltipRows(shown[0], table, this.termType)
+			} else {
+				const holder = hoverTip.d.append('div').style('margin', '10px')
+				renderVolcanoGeneTable(holder, shown, this.termType)
+				if (additionalCount > 0) {
+					holder
+						.append('div')
+						.style('font-size', '0.85em')
+						.style('color', '#666')
+						.style('font-style', 'italic')
+						.text(`and ${additionalCount} more gene${additionalCount > 1 ? 's' : ''}...`)
+				}
+			}
+		})
+
+		cover.on('mouseleave', () => {
+			// Don't clear rings while the click menu is showing — the highlight
+			// must stay on the picked dots until the user dismisses the menu.
+			if (!clickMenuIsShown) drawHoverRings([])
+			hoverTip.hide()
+		})
+
+		cover.on('click', (event: MouseEvent) => {
+			const candidates = findCandidates(event)
+			if (candidates.length === 0) return
+			hoverTip.hide()
+			// Persist highlight on the picked dots — clickMenu.onHide clears it.
+			drawHoverRings(candidates)
+			clickMenuIsShown = true
+
+			if (candidates.length === 1) {
+				// Use clickMenu (not hoverTip) so the cover's mouseleave handler
+				// doesn't dismiss this menu when the cursor moves up to a button.
+				openActionMenu(candidates[0], event, clickMenu, this.termType, this.interactions)
+				return
+			}
+
+			clickMenu.clear().show(event.clientX, event.clientY)
+			const holder = clickMenu.d.append('div').style('margin', '10px')
+			renderVolcanoGeneTable(holder, candidates, this.termType, {
+				// Radio buttons (not checkboxes) — volcano actions only target one gene.
+				singleMode: true,
+				noButtonCallback: (i: number) => {
+					const d = candidates[i]
+					openActionMenu(d, event, clickMenu, this.termType, this.interactions)
+				}
+			})
+		})
 	}
 
 	renderStatsMenu() {
@@ -346,6 +500,10 @@ export class VolcanoPlotView {
 }
 
 function renderDataPoints(self: any) {
+	// Visual-only circles. The cover rect added in setupOverlayInteractions
+	// drives all hover/click — we strip pointer-events here so events fall
+	// through to the cover. The p-value table hover-clone effect at
+	// renderPValueTable() still finds these via selectAll('circle').
 	self.volcanoDom.plot
 		.selectAll('circle')
 		.data(self.viewData.pointData)
@@ -353,14 +511,85 @@ function renderDataPoints(self: any) {
 		.append('circle')
 		.attr('stroke', (d: DataPointEntry) => rgb(d.color).formatHex())
 		.attr('stroke-opacity', (d: DataPointEntry) => (d.significant ? 0.35 : 0.2))
-		.attr('stroke-width', (d: DataPointEntry) => (d.significant ? 1.5 : 1))
+		// Match the rust PNG's stroke-width (1) so the overlay ring sits
+		// exactly on top of the rasterized dot.
+		.attr('stroke-width', 1)
 		.attr('fill', self.settings.defaultHighlightColor)
 		.attr('fill-opacity', (d: DataPointEntry) => (d.highlighted ? 0.9 : 0))
 		.attr('cx', (d: DataPointEntry) => d.x)
 		.attr('cy', (d: DataPointEntry) => d.y)
 		.attr('r', (d: DataPointEntry) => d.radius)
-		.each(function (this: any, d: DataPointEntry) {
-			const circle = select(this)
-			new DataPointMouseEvents(d, circle, self.dom.tip, self.interactions, self.termType)
-		})
+		.style('pointer-events', 'none')
+}
+
+/** Renders the multi-gene table used by both the hover tooltip (when >1 dot
+ * is in range) and the click menu. Reuses showResultsTable for sortable
+ * columns; volcano omits the `app` arg so manhattan-only Lollipop/Matrix
+ * buttons stay hidden. */
+function renderVolcanoGeneTable(
+	holder: any,
+	dots: DataPointEntry[],
+	termType: string,
+	extra: Record<string, any> = {}
+) {
+	const isDM = termType === DNA_METHYLATION
+	const columns = isDM
+		? [
+				{ label: 'Promoter' },
+				{ label: 'Gene(s)' },
+				{ label: 'log₂(FC)', sortable: true },
+				{ label: 'Adjusted p-value', sortable: true }
+		  ]
+		: [{ label: 'Gene' }, { label: 'log₂(FC)', sortable: true }, { label: 'Adjusted p-value', sortable: true }]
+	const rows = dots.map(d => {
+		const fc = { value: roundValueAuto(d.fold_change) }
+		const padj = { value: roundValueAuto(d.adjusted_p_value) }
+		if (isDM) {
+			return [{ value: (d as any).promoter_id || '' }, { value: d.gene_name || '' }, fc, padj]
+		}
+		return [{ value: d.gene_name || '' }, fc, padj]
+	})
+	showResultsTable({
+		tableDiv: holder,
+		dataItems: dots,
+		getGene: (d: any) => d.gene_name,
+		columns,
+		rows,
+		...extra
+	} as any)
+}
+
+/** Opens the per-gene action menu at the click point. Action buttons sit at
+ * the top of the menu; the same single-gene info shown on hover (gene name,
+ * fold-change, p-values) is rendered below so the user can confirm what
+ * they're acting on. Used for both the single-hit click flow and the
+ * row-drill-down from the multi-hit click menu. */
+function openActionMenu(
+	d: DataPointEntry,
+	event: MouseEvent,
+	hostMenu: any,
+	termType: string,
+	interactions: VolcanoInteractions
+) {
+	const opts = getActionMenuOpts(d, termType, interactions)
+	hostMenu.clear().show(event.clientX, event.clientY)
+	const container = hostMenu.d.append('div').style('margin', '10px')
+
+	if (opts.length > 0) {
+		const buttonRow = container.append('div').style('margin-bottom', '10px')
+		for (const opt of opts) {
+			buttonRow
+				.append('button')
+				.attr('class', 'sja_menuoption')
+				.style('margin-right', '5px')
+				.text(opt.label)
+				.on('click', async () => {
+					hostMenu.hide()
+					await opt.onClick()
+				})
+		}
+	}
+
+	const table = table2col({ holder: container.append('table') })
+	addTooltipRows(d, table, termType)
 }

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -347,7 +347,7 @@ export class VolcanoPlotView {
 				addTooltipRows(shown[0], table, this.termType)
 			} else {
 				const holder = hoverTip.d.append('div').style('margin', '10px')
-				renderVolcanoGeneTable(holder, shown, this.termType)
+				renderVolcanoGeneTable(holder, shown, this.termType, this.settings.pValueType)
 				if (additionalCount > 0) {
 					holder
 						.append('div')
@@ -383,7 +383,7 @@ export class VolcanoPlotView {
 
 			clickMenu.clear().show(event.clientX, event.clientY)
 			const holder = clickMenu.d.append('div').style('margin', '10px')
-			renderVolcanoGeneTable(holder, candidates, this.termType, {
+			renderVolcanoGeneTable(holder, candidates, this.termType, this.settings.pValueType, {
 				// Radio buttons (not checkboxes) — volcano actions only target one gene.
 				singleMode: true,
 				noButtonCallback: (i: number) => {
@@ -525,29 +525,33 @@ function renderDataPoints(self: any) {
 /** Renders the multi-gene table used by both the hover tooltip (when >1 dot
  * is in range) and the click menu. Reuses showResultsTable for sortable
  * columns; volcano omits the `app` arg so manhattan-only Lollipop/Matrix
- * buttons stay hidden. */
+ * buttons stay hidden. The p-value column matches `settings.pValueType` so
+ * the table aligns with the y-axis basis (original vs adjusted). */
 function renderVolcanoGeneTable(
 	holder: any,
 	dots: DataPointEntry[],
 	termType: string,
+	pValueType: 'original' | 'adjusted',
 	extra: Record<string, any> = {}
 ) {
 	const isDM = termType === DNA_METHYLATION
+	const pLabel = `${pValueType.charAt(0).toUpperCase()}${pValueType.slice(1)} p-value`
+	const pField = `${pValueType}_p_value` as 'original_p_value' | 'adjusted_p_value'
 	const columns = isDM
 		? [
 				{ label: 'Promoter' },
 				{ label: 'Gene(s)' },
 				{ label: 'log₂(FC)', sortable: true },
-				{ label: 'Adjusted p-value', sortable: true }
+				{ label: pLabel, sortable: true }
 		  ]
-		: [{ label: 'Gene' }, { label: 'log₂(FC)', sortable: true }, { label: 'Adjusted p-value', sortable: true }]
+		: [{ label: 'Gene' }, { label: 'log₂(FC)', sortable: true }, { label: pLabel, sortable: true }]
 	const rows = dots.map(d => {
 		const fc = { value: roundValueAuto(d.fold_change) }
-		const padj = { value: roundValueAuto(d.adjusted_p_value) }
+		const pval = { value: roundValueAuto(d[pField]) }
 		if (isDM) {
-			return [{ value: (d as any).promoter_id || '' }, { value: d.gene_name || '' }, fc, padj]
+			return [{ value: (d as any).promoter_id || '' }, { value: d.gene_name || '' }, fc, pval]
 		}
-		return [{ value: d.gene_name || '' }, fc, padj]
+		return [{ value: d.gene_name || '' }, fc, pval]
 	})
 	showResultsTable({
 		tableDiv: holder,

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -128,10 +128,14 @@ export class VolcanoViewModel {
 	}
 
 	setPlotDimensions() {
-		// Plot rect grows by 2*dotRadiusPx on each axis to accommodate the
-		// server-side PNG padding (so dots near the real-data edge stay whole).
-		const plotW = this.settings.width + 2 * this.dotRadiusPx
-		const plotH = this.settings.height + 2 * this.dotRadiusPx
+		// Trust the server's authoritative PNG dimensions for the plot rect.
+		// (Recomputing as `settings.width + 2*dotRadiusPx` is wrong when rust's
+		// `pad_px = ceil(2*dot_radius)` rounds up for non-integer dot_radius —
+		// the SVG plot rect would scale the PNG and break pixel_x/pixel_y
+		// alignment with the rasterized dots.)
+		const ext = this.response.data.plotExtent
+		const plotW = ext.pixelWidth
+		const plotH = ext.pixelHeight
 
 		// Positioning scales — padded data range covers the full plot rect.
 		// Used for overlay dot placement, the PNG image, and the fold-change line.

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -28,6 +28,13 @@ export class VolcanoViewModel {
 	//Used for the y axis domain
 	minLogPValue = 0
 	maxLogPValue = 0
+	//Unpadded extents — used for the visible axis labels/ticks (only span real data)
+	minLogFoldChangeAxis = 0
+	maxLogFoldChangeAxis = 0
+	minLogPValueAxis = 0
+	maxLogPValueAxis = 0
+	//Dot radius in pixels (from server) — overlay rings size to match the PNG
+	dotRadiusPx = 2
 	//Used in place of 0 p values that cannot be log transformed
 	minNonZeroPValue = 10e-10
 	//The x coord flush with the left side of the plot
@@ -105,40 +112,65 @@ export class VolcanoViewModel {
 		// server's minNonZeroPValue so p=0 rows are capped at the same y position
 		// the PNG used.
 		const ext = this.response.data.plotExtent
+		// Padded extents — used for positioning overlay dots & PNG (so dots near
+		// the real-data edge stay fully visible).
 		this.minLogFoldChange = ext.xMin
 		this.maxLogFoldChange = ext.xMax
 		this.minLogPValue = ext.yMin
 		this.maxLogPValue = ext.yMax
+		// Unpadded extents — used only for the visible axis ticks/labels.
+		this.minLogFoldChangeAxis = ext.xMinUnpadded
+		this.maxLogFoldChangeAxis = ext.xMaxUnpadded
+		this.minLogPValueAxis = ext.yMinUnpadded
+		this.maxLogPValueAxis = ext.yMaxUnpadded
+		this.dotRadiusPx = ext.dotRadiusPx
 		if (ext.minNonZeroPValue > 0) this.minNonZeroPValue = ext.minNonZeroPValue
 	}
 
 	setPlotDimensions() {
-		const xScale = scaleLinear().domain([this.minLogFoldChange, this.maxLogFoldChange]).range([0, this.settings.width])
-		const yScale = scaleLinear().domain([this.minLogPValue, this.maxLogPValue]).range([this.settings.height, 0])
+		// Plot rect grows by 2*dotRadiusPx on each axis to accommodate the
+		// server-side PNG padding (so dots near the real-data edge stay whole).
+		const plotW = this.settings.width + 2 * this.dotRadiusPx
+		const plotH = this.settings.height + 2 * this.dotRadiusPx
+
+		// Positioning scales — padded data range covers the full plot rect.
+		// Used for overlay dot placement, the PNG image, and the fold-change line.
+		const xPlotScale = scaleLinear().domain([this.minLogFoldChange, this.maxLogFoldChange]).range([0, plotW])
+		const yPlotScale = scaleLinear().domain([this.minLogPValue, this.maxLogPValue]).range([plotH, 0])
+
+		// Visible axis scales — unpadded domain mapped onto the matching pixel
+		// subrange of the padded plot, so axis ticks land exactly at their data
+		// values in the PNG (mirror of manhattan's yAxisScale).
+		const xScale = scaleLinear()
+			.domain([this.minLogFoldChangeAxis, this.maxLogFoldChangeAxis])
+			.range([xPlotScale(this.minLogFoldChangeAxis), xPlotScale(this.maxLogFoldChangeAxis)])
+		const yScale = scaleLinear()
+			.domain([this.minLogPValueAxis, this.maxLogPValueAxis])
+			.range([yPlotScale(this.minLogPValueAxis), yPlotScale(this.maxLogPValueAxis)])
 
 		return {
 			svg: {
 				//20 is for the term info above the plot
-				height: this.settings.height + this.topPad + this.bottomPad * 2 + this.offset * 3,
-				width: this.settings.width + this.horizPad * 2
+				height: plotH + this.topPad + this.bottomPad * 2 + this.offset * 3,
+				width: plotW + this.horizPad * 2
 			},
 			top: {
 				x: this.plotX,
 				y: 5
 			},
 			xAxisLabel: {
-				x: this.horizPad + this.settings.width / 2 + this.offset,
-				y: this.topPad + this.settings.height + this.bottomPad + this.offset
+				x: this.horizPad + plotW / 2 + this.offset,
+				y: this.topPad + plotH + this.bottomPad + this.offset
 			},
 			xScale: {
 				scale: xScale,
 				x: this.plotX,
-				y: this.settings.height + this.topPad + this.offset * 2
+				y: plotH + this.topPad + this.offset * 2
 			},
 			yAxisLabel: {
 				text: `-log10(${this.settings.pValueType} P value)`,
 				x: this.horizPad / 3,
-				y: this.topPad + this.settings.height / 2
+				y: this.topPad + plotH / 2
 			},
 			yScale: {
 				scale: yScale,
@@ -146,16 +178,18 @@ export class VolcanoViewModel {
 				y: this.topPad
 			},
 			plot: {
-				height: this.settings.height,
-				width: this.settings.width,
+				height: plotH,
+				width: plotW,
 				x: this.plotX,
 				y: this.topPad
 			},
 			logFoldChangeLine: {
-				x: xScale(0) + this.plotX,
+				x: xPlotScale(0) + this.plotX,
 				y1: this.topPad,
-				y2: this.settings.height + this.offset * 4
-			}
+				y2: plotH + this.offset * 4
+			},
+			xPlotScale,
+			yPlotScale
 		}
 	}
 
@@ -188,8 +222,11 @@ export class VolcanoViewModel {
 		}
 	}
 
-	setPointData(plotDim: VolcanoPlotDimensions, controlColor: string, caseColor: string) {
-		const radius = Math.max(this.settings.width, this.settings.height) / 80
+	setPointData(_plotDim: VolcanoPlotDimensions, controlColor: string, caseColor: string) {
+		// Use the server-supplied radius so SVG overlay rings sit exactly on top
+		// of the PNG rings. The view's renderDataPoints draws them at stroke-width
+		// 1 to match the rust PNG's stroke geometry.
+		const radius = this.dotRadiusPx
 		const dataCopy: any = structuredClone(this.dataRows)
 		for (const d of dataCopy) {
 			const highlightKey = this.termType === DNA_METHYLATION ? d.promoter_id : d.gene_name
@@ -214,10 +251,13 @@ export class VolcanoViewModel {
 			} else {
 				this.numNonSignificant++
 			}
-			d.x = plotDim.xScale.scale(d.fold_change) + this.plotX
-			const y =
-				d[`${this.settings.pValueType}_p_value`] == 0 ? this.minNonZeroPValue : d[`${this.settings.pValueType}_p_value`]
-			d.y = plotDim.yScale.scale(-Math.log10(y)) + this.topPad
+			// Use the exact pixel coords plotters used to rasterize this dot in
+			// the PNG (echoed back from rust per-point). Translating by plotX /
+			// topPad shifts from inner-plot pixel space to SVG-absolute coords.
+			// This is the manhattan trick — guarantees the SVG overlay ring lands
+			// on the rasterized PNG dot regardless of float-vs-int conventions.
+			d.x = d.pixel_x + this.plotX
+			d.y = d.pixel_y + this.topPad
 			d.radius = radius
 		}
 		// Use the server's pre-truncation count so stats are correct even when

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Now using common quadtree approach in volcano and manhattan plot

--- a/rust/src/volcano.rs
+++ b/rust/src/volcano.rs
@@ -40,10 +40,21 @@ struct Input {
 
 #[derive(Serialize)]
 struct PlotExtent {
+    /// Padded data extents — used to position overlay dots so points near the
+    /// real-data edge stay fully visible (mirror of manhattan's yPlot domain).
     x_min: f64,
     x_max: f64,
     y_min: f64,
     y_max: f64,
+    /// Unpadded data extents — used for the visible axis labels/ticks so the
+    /// axis only spans the real data region (mirror of manhattan's yAxisScale).
+    x_min_unpadded: f64,
+    x_max_unpadded: f64,
+    y_min_unpadded: f64,
+    y_max_unpadded: f64,
+    /// Dot radius in pixels (echoed back so the client can size overlay rings
+    /// to match the PNG without recomputing the heuristic).
+    dot_radius_px: f64,
     pixel_width: u32,
     pixel_height: u32,
     /// Inner drawing rect inside the PNG. Client overlay circles are
@@ -145,19 +156,43 @@ fn main() -> Result<(), Box<dyn Error>> {
         y_max_data = y_max_data.max(pt.y);
     }
 
-    // Axis extents — symmetric on x, padded 5%.
-    let x_span = if x_abs_max > 0.0 { x_abs_max * 1.05 } else { 1.0 };
-    let (x_min, x_max, y_min) = (-x_span, x_span, 0f64);
-    let y_max = if y_max_data > 0.0 { y_max_data * 1.05 } else { 1.0 };
+    // Unpadded axis extents — symmetric on x, raw data bounds. The dot-radius
+    // pad below provides pixel-level headroom so we don't need extra data-range
+    // breathing room (mirrors manhattan_plot.rs's tighter feel). Fallback to 1.0
+    // when the data has zero spread to keep the chart range valid.
+    let x_span = if x_abs_max > 0.0 { x_abs_max } else { 1.0 };
+    let (x_min_unpadded, x_max_unpadded) = (-x_span, x_span);
+    let y_min_unpadded = 0f64;
+    let y_max_unpadded = if y_max_data > 0.0 { y_max_data } else { 1.0 };
 
-    // Render — borderless scatter. No axes/labels/margins. The client owns
-    // axes and positions the PNG exactly over its plot rect, so the inner
-    // drawing area fills the whole canvas.
-    let (w, h) = (input.pixel_width, input.pixel_height);
+    // Pad PNG by 2*dot_radius on each axis so dots near the edges of the data
+    // region stay fully visible (matches manhattan_plot.rs:476-531).
+    // pad_px uses ceil() so dot_radius < 0.5 doesn't collapse to 0 under u32 cast.
+    let pad_px = (2.0 * input.dot_radius).ceil() as u32;
+    let (w, h) = (input.pixel_width + pad_px, input.pixel_height + pad_px);
     if w == 0 || h == 0 || w > 4000 || h > 4000 {
         return Err(format!("pixel dimensions {}x{} out of range (1–4000)", w, h).into());
     }
+
+    // Convert pixel padding to data units using the unpadded extents and the
+    // unpadded pixel dimensions. Use pad_px/2 (not dot_radius) so the data/pixel
+    // ratio stays exactly equal between padded and unpadded space — important
+    // when ceil() rounded pad_px above 2*dot_radius for sub-pixel radii.
+    let x_data_per_px = (x_max_unpadded - x_min_unpadded) / input.pixel_width as f64;
+    let y_data_per_px = (y_max_unpadded - y_min_unpadded) / input.pixel_height as f64;
+    let half_pad_px = pad_px as f64 / 2.0;
+    let x_pad_data = half_pad_px * x_data_per_px;
+    let y_pad_data = half_pad_px * y_data_per_px;
+    let x_min = x_min_unpadded - x_pad_data;
+    let x_max = x_max_unpadded + x_pad_data;
+    let y_min = y_min_unpadded - y_pad_data;
+    let y_max = y_max_unpadded + y_pad_data;
     let mut buffer = vec![0u8; (w as usize) * (h as usize) * 3];
+    // Per-point pixel coords as plotters actually rasterizes them. Returned to
+    // the client so the SVG overlay rings sit exactly on top of the PNG dots
+    // instead of being recomputed from data coords (which loses sub-pixel
+    // precision under plotters' integer truncation).
+    let mut all_pixel_coords: Vec<(f64, f64)> = Vec::with_capacity(points.len());
     {
         let backend = BitMapBackend::with_buffer(&mut buffer, (w, h));
         let root = backend.into_drawing_area();
@@ -205,6 +240,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             Circle::new((p.fc, p.y), radius, ring(c))
         }))?;
 
+        // Mirror manhattan_plot.rs: capture the exact pixel coords plotters
+        // used for each point so the client overlay can land on them precisely.
+        for p in points.iter() {
+            let (px, py) = chart.backend_coord(&(p.fc, p.y));
+            all_pixel_coords.push((px as f64, py as f64));
+        }
+
         root.present()?;
     }
 
@@ -216,7 +258,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     if let Some(cap) = input.max_interactive_dots {
         sig_points.truncate(cap);
     }
-    let dots: Vec<Value> = sig_points.iter().map(|p| input.rows[p.idx].clone()).collect();
+    let dots: Vec<Value> = sig_points
+        .iter()
+        .map(|p| {
+            let mut row = input.rows[p.idx].clone();
+            let (px, py) = all_pixel_coords[p.idx];
+            if let Value::Object(ref mut m) = row {
+                m.insert("pixel_x".to_string(), Value::from(px));
+                m.insert("pixel_y".to_string(), Value::from(py));
+            }
+            row
+        })
+        .collect();
 
     let output = Output {
         png: BASE64.encode(&encode_rgb_to_png(&buffer, w, h)?),
@@ -225,6 +278,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             x_max,
             y_min,
             y_max,
+            x_min_unpadded,
+            x_max_unpadded,
+            y_min_unpadded,
+            y_max_unpadded,
+            dot_radius_px: input.dot_radius,
             pixel_width: w,
             pixel_height: h,
             plot_left: 0,

--- a/rust/src/volcano.rs
+++ b/rust/src/volcano.rs
@@ -165,24 +165,26 @@ fn main() -> Result<(), Box<dyn Error>> {
     let y_min_unpadded = 0f64;
     let y_max_unpadded = if y_max_data > 0.0 { y_max_data } else { 1.0 };
 
-    // Pad PNG by 2*dot_radius on each axis so dots near the edges of the data
-    // region stay fully visible (matches manhattan_plot.rs:476-531).
-    // pad_px uses ceil() so dot_radius < 0.5 doesn't collapse to 0 under u32 cast.
-    let pad_px = (2.0 * input.dot_radius).ceil() as u32;
+    // Normalize the dot radius once into the integer pixel count plotters will
+    // actually draw, with a min of 1 so sub-pixel inputs don't collapse to a
+    // zero-radius dot. This single value drives both PNG padding and circle
+    // rendering, keeping the geometry self-consistent (matches manhattan).
+    let radius_px = (input.dot_radius as i32).max(1);
+    // Pad PNG by 2*radius_px so dots near the data edges stay fully visible.
+    let pad_px = (2 * radius_px) as u32;
     let (w, h) = (input.pixel_width + pad_px, input.pixel_height + pad_px);
     if w == 0 || h == 0 || w > 4000 || h > 4000 {
         return Err(format!("pixel dimensions {}x{} out of range (1–4000)", w, h).into());
     }
 
     // Convert pixel padding to data units using the unpadded extents and the
-    // unpadded pixel dimensions. Use pad_px/2 (not dot_radius) so the data/pixel
-    // ratio stays exactly equal between padded and unpadded space — important
-    // when ceil() rounded pad_px above 2*dot_radius for sub-pixel radii.
+    // unpadded pixel dimensions. Per-axis pad in data space = radius_px * (data
+    // range / pixel range) — keeps the data/pixel ratio identical between
+    // padded and unpadded space.
     let x_data_per_px = (x_max_unpadded - x_min_unpadded) / input.pixel_width as f64;
     let y_data_per_px = (y_max_unpadded - y_min_unpadded) / input.pixel_height as f64;
-    let half_pad_px = pad_px as f64 / 2.0;
-    let x_pad_data = half_pad_px * x_data_per_px;
-    let y_pad_data = half_pad_px * y_data_per_px;
+    let x_pad_data = radius_px as f64 * x_data_per_px;
+    let y_pad_data = radius_px as f64 * y_data_per_px;
     let x_min = x_min_unpadded - x_pad_data;
     let x_max = x_max_unpadded + x_pad_data;
     let y_min = y_min_unpadded - y_pad_data;
@@ -226,18 +228,17 @@ fn main() -> Result<(), Box<dyn Error>> {
             filled: false,
             stroke_width: 1,
         };
-        let radius = input.dot_radius as i32;
 
         // Draw non-significant first so significant rings overlay on top.
         chart.draw_series(
             points
                 .iter()
                 .filter(|p| !p.significant)
-                .map(|p| Circle::new((p.fc, p.y), radius, ring(color_non))),
+                .map(|p| Circle::new((p.fc, p.y), radius_px, ring(color_non))),
         )?;
         chart.draw_series(points.iter().filter(|p| p.significant).map(|p| {
             let c = if p.fc > 0.0 { color_up } else { color_down };
-            Circle::new((p.fc, p.y), radius, ring(c))
+            Circle::new((p.fc, p.y), radius_px, ring(c))
         }))?;
 
         // Mirror manhattan_plot.rs: capture the exact pixel coords plotters
@@ -282,7 +283,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             x_max_unpadded,
             y_min_unpadded,
             y_max_unpadded,
-            dot_radius_px: input.dot_radius,
+            // Echo the normalized integer radius plotters actually drew so the
+            // SVG overlay sizes its rings to match the rasterized PNG dots.
+            dot_radius_px: radius_px as f64,
             pixel_width: w,
             pixel_height: h,
             plot_left: 0,

--- a/server/routes/termdb.DE.ts
+++ b/server/routes/termdb.DE.ts
@@ -102,15 +102,15 @@ export async function validate_query_rnaseqGeneCount(ds) {
 		} else throw new Error('unknown storage type:' + ds.queries.rnaseqGeneCount.storage_type)
 
 		q.allSampleSet = new Set(samples)
-		//if(q.allSampleSet.size < samples.length) throw 'rnaseqGeneCount.file header contains duplicate samples'
+		//if(q.allSampleSet.size < samples.length) throw new Error('rnaseqGeneCount.file header contains duplicate samples')
 		const unknownSamples: string[] = []
 		for (const n of q.allSampleSet) {
 			if (!ds.cohort.termdb.q.sampleName2id(n)) unknownSamples.push(n)
 		}
 		//if (unknownSamples.length)
-		//	throw `${ds.label} rnaseqGeneCount: ${unknownSamples.length} out of ${
+		//	throw new Error(`${ds.label} rnaseqGeneCount: ${unknownSamples.length} out of ${
 		//		q.allSampleSet.size
-		//	} sample names are unknown: ${unknownSamples.join(',')}`
+		//	} sample names are unknown: ${unknownSamples.join(',')}`)
 		console.log(q.allSampleSet.size, `rnaseqGeneCount samples from ${ds.label}`)
 	}
 }

--- a/server/src/renderVolcano.ts
+++ b/server/src/renderVolcano.ts
@@ -70,6 +70,11 @@ export async function renderVolcano<T extends DataEntry>(
 			x_max: number
 			y_min: number
 			y_max: number
+			x_min_unpadded: number
+			x_max_unpadded: number
+			y_min_unpadded: number
+			y_max_unpadded: number
+			dot_radius_px: number
 			pixel_width: number
 			pixel_height: number
 			plot_left: number
@@ -90,6 +95,11 @@ export async function renderVolcano<T extends DataEntry>(
 			xMax: out.plot_extent.x_max,
 			yMin: out.plot_extent.y_min,
 			yMax: out.plot_extent.y_max,
+			xMinUnpadded: out.plot_extent.x_min_unpadded,
+			xMaxUnpadded: out.plot_extent.x_max_unpadded,
+			yMinUnpadded: out.plot_extent.y_min_unpadded,
+			yMaxUnpadded: out.plot_extent.y_max_unpadded,
+			dotRadiusPx: out.plot_extent.dot_radius_px,
 			pixelWidth: out.plot_extent.pixel_width,
 			pixelHeight: out.plot_extent.pixel_height,
 			plotLeft: out.plot_extent.plot_left,

--- a/shared/types/src/routes/termdb.DE.ts
+++ b/shared/types/src/routes/termdb.DE.ts
@@ -94,13 +94,23 @@ export type VolcanoData<T extends DataEntry> = {
 /** Coordinate metadata returned by the `volcano` renderer, used by the client to overlay
  * interactive top-significant circles on top of the server-drawn PNG. */
 export type PlotExtent = {
-	/** Data-space x domain used during rendering. */
+	/** Padded data-space x domain — used to position overlay dots so points near
+	 * the real-data edges stay fully visible (mirror of manhattan's yPlot domain). */
 	xMin: number
 	xMax: number
-	/** Data-space y domain used during rendering (on -log10 p-value scale). */
+	/** Padded data-space y domain (on -log10 p-value scale). */
 	yMin: number
 	yMax: number
-	/** PNG canvas dimensions. */
+	/** Unpadded data-space x domain — used for the visible axis labels/ticks
+	 * so the axis only spans the real data region. */
+	xMinUnpadded: number
+	xMaxUnpadded: number
+	/** Unpadded data-space y domain. */
+	yMinUnpadded: number
+	yMaxUnpadded: number
+	/** Dot radius in pixels (echoed back so overlay rings match the PNG). */
+	dotRadiusPx: number
+	/** PNG canvas dimensions (already include 2*dotRadiusPx of padding). */
 	pixelWidth: number
 	pixelHeight: number
 	/** Inner drawing rect inside the PNG (after axis margins). Client overlay circles


### PR DESCRIPTION
# Description
Brings the volcano plot to feature parity with the manhattan plot's interactive overlay, fixes pixel-clipping at the plot edges, and extracts the shared interaction primitives into reusable modules. **Rust will need to be recompiled because of this pr**

## What changed

### Volcano: quadtree hover, multi-gene tooltips, click-menu drilldown
- Replaced per-circle SVG event handlers with a transparent SVG cover rect over the plot area + d3-quadtree hit-test (mirrors manhattan). Coincident dots are now all reachable instead of just the topmost.
- Hover surfaces every dot within `dotRadiusPx + 3` px:
  - One hit → existing `table2col` single-gene tooltip
  - Multiple hits → sortable `showResultsTable` (Gene/log₂(FC)/p-value, plus Promoter/Gene(s) for DNA methylation), capped at `maxTooltipGenes` with an "and N more" footer
- Click on a dot opens an action menu (Violin / DMR / Box plot) with the gene info shown below the buttons. Multi-hit click opens a sortable table (radio buttons, single-select) whose row click drills into the same single-gene action view.
- Highlight (orange fill at `dotRadiusPx − 0.5`) persists on the picked dot(s) until the click menu is dismissed.
- The hover-only tooltip is suppressed while the click menu is open (`clickMenuIsShown` flag); the click menu uses its own `Menu` instance so leaving the plot rect to reach the buttons no longer dismisses it.
- Dropped the grey border rect and the always-visible action menu wrapper class (`DataPointMouseEvents`); `addTooltipRows` and `getActionMenuOpts` are now exported helpers.

### Volcano: PNG / SVG alignment
- Rust now pads the PNG by `2 × dot_radius` on each axis so dots near the real-data edge stay whole (was clipping at `y ≈ 0`).
- Rust echoes per-point `pixel_x` / `pixel_y` (via `chart.backend_coord`) so the SVG overlay lands exactly on plotters' rasterized centers — no more sub-pixel offsets between the colored ring and the PNG dot. (Same trick manhattan uses.)
- Dropped the 5% data-range buffer to match manhattan's tighter feel; the dot-radius pad alone keeps edge dots fully visible.
- Client uses dual scales: padded `xPlotScale` / `yPlotScale` for dot/PNG positioning, unpadded `xScale` / `yScale` for visible axis ticks (so the axis spans only the real data region).
- SVG ring `stroke-width` lowered from 1.5 → 1 to match plotters' stroke geometry.
- Replaced the old radius heuristic `max(width, height) / 80` with the server-supplied `dotRadiusPx`.

### Shared module extractions
New files under `proteinpaint/client/plots/shared/`:
- `quadtreeHitTest.ts` — generic `findPointsInRadius<T>(qt, mx, my, hitRadius, getX, getY)`. Imported by manhattan and volcano.
- `resultsTable.ts` — `showResultsTable` (renamed from `showGrin2ResultTable`), data-agnostic so it works for genes (manhattan/grin2) and promoters (volcano DM); type lives in `resultsTableTypes.ts` matching the codebase's `*Types.ts` convention.
- `genePlotActions.ts` — `createLollipopFromGene`, `createMatrixFromGenes` moved out of `manhattan.ts`. `updateSelectionTracking` moved into `resultsTable.ts` (its only caller).
- `manhattan.ts` and `grin2.ts` now both import from `shared/`. `GRIN2Types.ts` lost its now-orphan `ShowGrin2ResultTableOpts` / `GeneDataItem` / `GeneTableRow` / `ManhattanPoint` import.

### Type / setting updates
- `PlotExtent` (`shared/types/src/routes/termdb.DE.ts`) gains `xMinUnpadded`/`xMaxUnpadded`/`yMinUnpadded`/`yMaxUnpadded`/`dotRadiusPx`.
- `DataPointEntry` gains `pixel_x` / `pixel_y` from the server.
- `VolcanoPlotDimensions` gains `xPlotScale` / `yPlotScale`.
- Volcano settings: added `maxTooltipGenes: 5`. (Briefly added `interactiveDotStrokeWidth` then removed once hover went fill-only.)

## Test plan
- [x] `npx tsc --noEmit -p client/tsconfig.json` passes
- [x] `npx tsc --noEmit -p server/tsconfig.json` passes
- [x] `cargo build --release --bin volcano` passes
- [x] `npx tsx proteinpaint/client/plots/volcano/test/volcano.unit.spec.ts` — 24/24 tape tests pass
- [x] Open a gene-expression volcano (DUX4 Early vs DUX4 Committed): dots near `y ≈ 0` are no longer clipped; SVG overlay rings sit on the PNG dots
- [x] Hover a dense cluster: all overlapping dots highlight in orange; multi-gene table renders with sortable columns
- [x] Hover an isolated dot: single-gene `table2col` tooltip unchanged from before
- [x] Click an isolated dot: action menu shows Violin / Box plot at the top with gene info table below; menu persists when cursor moves to a button
- [x] Click a cluster: radio-select table appears; clicking a row drills into that gene's single-gene action view
- [x] Highlight rings stay on the picked dot(s) until the click menu closes
- [x] Open a DNA-methylation volcano: multi-gene table shows Promoter / Gene(s) / log₂(FC) / Adjusted p-value columns
- [x] Open a manhattan/GRIN2 plot: hover and click flows behave exactly as before (regression check on the shared util extraction)
- [x] Open the volcano p-value table and hover rows: clone-on-top + dim-others effect still works


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
