### PR TITLE
Re-enable DE and add ssGSEA option to the GeneExpInput

### DIFF
--- a/client/plots/DEinput.ts
+++ b/client/plots/DEinput.ts
@@ -92,7 +92,9 @@ class DEinputPlot extends PlotBase implements RxComponent {
 				holder: this.dom.addGroup,
 				vocabApi: this.app.vocabApi,
 				emptyLabel: 'Add group',
-				header_mode: 'hide_search',
+				/** 'hide_search' by default expands all terms. Passing the
+				 * header_mode in opts gives the caller the flexibility to choose. */
+				header_mode: this.opts?.header_mode || 'hide_search',
 				callback: async f => {
 					const filter = getNormalRoot(f)
 					this.addNewGroup(filter, this.groups)

--- a/client/plots/GeneExpInput.ts
+++ b/client/plots/GeneExpInput.ts
@@ -1,6 +1,6 @@
 import { PlotBase } from './PlotBase.ts'
 import { getCompInit, copyMerge, type ComponentApi, type RxComponent } from '#rx'
-import { GENE_EXPRESSION, SINGLECELL_GENE_EXPRESSION, typeGroup } from '#shared/terms.js'
+import { GENE_EXPRESSION, SINGLECELL_GENE_EXPRESSION, SSGSEA, typeGroup } from '#shared/terms.js'
 import { getGEunit } from '../tw/geneExpression'
 import { getSCGEunit } from '../tw/singleCellGeneExpression'
 import { addGeneSearchbox, GeneSetEditUI, Menu, sayerror, Tabs } from '#dom'
@@ -121,6 +121,15 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 					})
 					delete tab.callback
 				}
+			},
+			{
+				label: typeGroup[SSGSEA],
+				active: true,
+				isVisible: () => this.termType === GENE_EXPRESSION,
+				callback: async (event, tab) => {
+					this.renderSSGEA(tab)
+					delete tab.callback
+				}
 			}
 		]
 
@@ -140,7 +149,11 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 		const headerText = this.opts.headerText ? `${this.opts.headerText} ` : ''
 		const dom: { [index: string]: any } = {
 			header: {
-				title: this.opts.header.append('span').text(headerText).attr('data-testid', 'sjpp-gene-exp-input-headerText'),
+				title: this.opts.header
+					.append('span')
+					.style('padding-right', '5px')
+					.text(headerText)
+					.attr('data-testid', 'sjpp-gene-exp-input-headerText'),
 				plot: this.opts.header
 					.append('span')
 					.text(typeGroup[this.termType].toUpperCase())
@@ -306,6 +319,24 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 					dataType: GENE_EXPRESSION
 				})
 
+				await this.dispatchEdits(config)
+			}
+		})
+	}
+
+	async renderSSGEA(tab) {
+		const holder = tab.contentHolder.style('padding', '10px')
+		const _ = await import('../termdb/handlers/ssGSEA.ts')
+		const searchHandler = new _.SearchHandler()
+		searchHandler.init({
+			holder,
+			app: this.app,
+			genomeObj: this.genome,
+			callback: async term => {
+				const config = this.makeConfig({
+					chartType: 'summary',
+					term: { term: term }
+				})
 				await this.dispatchEdits(config)
 			}
 		})

--- a/client/plots/GeneExpInput.ts
+++ b/client/plots/GeneExpInput.ts
@@ -124,10 +124,9 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 			},
 			{
 				label: typeGroup[SSGSEA],
-				active: true,
 				isVisible: () => this.termType === GENE_EXPRESSION,
 				callback: async (event, tab) => {
-					this.renderSSGEA(tab)
+					await this.renderSSGSEA(tab)
 					delete tab.callback
 				}
 			}
@@ -324,11 +323,11 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 		})
 	}
 
-	async renderSSGEA(tab) {
+	async renderSSGSEA(tab) {
 		const holder = tab.contentHolder.style('padding', '10px')
 		const _ = await import('../termdb/handlers/ssGSEA.ts')
 		const searchHandler = new _.SearchHandler()
-		searchHandler.init({
+		await searchHandler.init({
 			holder,
 			app: this.app,
 			genomeObj: this.genome,

--- a/client/plots/GeneExpInput.ts
+++ b/client/plots/GeneExpInput.ts
@@ -116,7 +116,10 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 						parentId: this.id,
 						config: {
 							chartType: 'DEinput',
-							parentId: this.id
+							parentId: this.id,
+							/** ' ' overrides the default 'hide_search' mode in DEInput.
+							 * 'hide_search' by default expands all terms. */
+							header_mode: ' '
 						}
 					})
 					delete tab.callback
@@ -124,7 +127,6 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 			},
 			{
 				label: typeGroup[SSGSEA],
-				active: true,
 				isVisible: () => {
 					return this.termType === GENE_EXPRESSION && state.termdbConfig?.allowedTermTypes?.includes(SSGSEA)
 				},

--- a/client/plots/GeneExpInput.ts
+++ b/client/plots/GeneExpInput.ts
@@ -124,7 +124,10 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 			},
 			{
 				label: typeGroup[SSGSEA],
-				isVisible: () => this.termType === GENE_EXPRESSION,
+				active: true,
+				isVisible: () => {
+					return this.termType === GENE_EXPRESSION && state.termdbConfig?.allowedTermTypes?.includes(SSGSEA)
+				},
 				callback: async (event, tab) => {
 					await this.renderSSGSEA(tab)
 					delete tab.callback

--- a/client/plots/GeneExpInput.ts
+++ b/client/plots/GeneExpInput.ts
@@ -109,10 +109,7 @@ export class GeneExpInput extends PlotBase implements RxComponent {
 				label: `Differential ${typeGroup[this.termType].toLowerCase()} analysis`,
 				//Only enabling for gene expression for now
 				chartType: 'DEinput',
-				isVisible: () => false,
-				// TODO: Sorting out server response error in another PR.
-				// Will enable when fixed. For now hiding from UI to avoid confusion.
-				// isVisible: () => chartTypes.has('DA') && this.termType === GENE_EXPRESSION,
+				isVisible: () => chartTypes.has('DA') && this.termType === GENE_EXPRESSION,
 				callback: async (event, tab) => {
 					await this.app.dispatch({
 						type: 'plot_create',

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
 Features
-- The differential expression option is re-enabled in the GeneExpInput plot. A new tab for gene set expression available as well. Selecting a gene set launches the summary chart. 
+- The differential expression option is re-enabled in the GeneExpInput plot. A new tab for gene set expression is available as well. Selecting a gene set launches the summary chart.

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- The differential expression option is re-enabled in the GeneExpInput plot. A new tab for gene set expression available as well. Selecting a gene set launches the summary chart. 


### PR DESCRIPTION
# Description

This PR supports the ongoing efforts with the AI chat bot. The differential expression option is re-enabled in the GeneExpInput plot. Please note the server response will be fixed in a separate PR. A new ssGSEA option is available as well. This allows users to launch the violin from the one gene tab, scatter (UMAP) from the two gene tab, raw count via the embedded DEInput from the Differential expression tab, and the ssGSEA from the aptly named tab.  See `client/plots/test/GeneExpInput.integration.spec.ts` for the config. 

Test with this [TermdbTest example](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:-1%7D,%22plots%22:%5B%7B%22chartType%22:%22GeneExpInput%22,%22termType%22:%22geneExpression%22%7D%5D%7D)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
