### PR TITLE
Store sample ancestry in sample refs. Group samples by sample type in matrix

### DIFF
--- a/client/plots/matrix/matrix.groups.js
+++ b/client/plots/matrix/matrix.groups.js
@@ -1,6 +1,7 @@
 import { sample_match_termvaluesetting } from '#shared/filter.js'
 import { getSampleSorter, getTermSorter, getSampleGroupSorter, getMclassSorter } from './matrix.sort'
 import { dtsnvindel, dtcnv, dtfusionrna, dtgeneexpression, dtsv } from '#shared/common.js'
+import { ROOT_SAMPLE_TYPE } from '#shared/terms.js'
 
 export function getTermOrder(data) {
 	const s = this.settings.matrix
@@ -133,6 +134,37 @@ export function getSampleGroups(data) {
 				}
 				if (ref.bins && s.sortSampleGrpsBy == 'name') grp.order = ref.bins.findIndex(bin => bin.name == key)
 				else delete grp.order
+				sampleGroups.set(key, grp)
+			}
+			sampleGroups.get(key).lst.push(row)
+		} else if (this.state.termdbConfig.hasSampleAncestry) {
+			// has sample ancestry
+			// group samples by sample type (hardcoded to be root sample type)
+			let key, name
+			if (!row._ref_) continue
+			if (row._ref_.sampleType === ROOT_SAMPLE_TYPE) {
+				// sample is root sample
+				key = row.sample
+				name = row.label
+			} else {
+				// sample is not root sample
+				// check its ancestors
+				if (!row._ref_.ancestors?.length) continue
+				const ancestors = row._ref_.ancestors.filter(a => a.sample_type === ROOT_SAMPLE_TYPE)
+				if (!ancestors.length) continue
+				if (ancestors.length > 1) throw new Error('multiple root samples present')
+				const ancestor = ancestors[0]
+				key = ancestor.ancestor_id
+				name = ancestor.ancestor_name
+			}
+			if (!key) continue
+			if (!sampleGroups.has(key)) {
+				const grp = {
+					name,
+					id: key,
+					lst: [],
+					legendGroups: {}
+				}
 				sampleGroups.set(key, grp)
 			}
 			sampleGroups.get(key).lst.push(row)

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -126,16 +126,19 @@ export function server_init_db_queries(ds) {
 	}
 	if (tables.has('sampleidmap')) {
 		const i2s = new Map(),
-			s2i = new Map()
+			s2i = new Map(),
+			i2type = new Map()
 		const rows = cn.prepare('SELECT * FROM sampleidmap').all()
 		let totalCount = 0
-		for (const { id, name } of rows) {
+		for (const { id, name, sample_type } of rows) {
 			i2s.set(id, name)
 			s2i.set(name, id)
+			i2type.set(id, sample_type)
 			totalCount++ //for dbs without cohorts or types
 		}
 		q.id2sampleName = id => i2s.get(id)
 		q.sampleName2id = s => s2i.get(s)
+		q.id2sampleType = id => i2type.get(id)
 		if (tables.has('cohort_sample_types')) {
 			const rows = cn.prepare('SELECT * from cohort_sample_types').all()
 			q.getCohortSampleCount = cohortKey => {
@@ -568,6 +571,43 @@ export function server_init_db_queries(ds) {
 		const sql = cn.prepare(query)
 		const rows = sql.all()
 		return rows
+	}
+
+	if (ds.cohort.termdb.hasSampleAncestry) {
+		// ds has sample ancestry
+		// store sample ancestry in sample refs
+		const i2ancestors = new Map()
+		{
+			const rows = cn.prepare('SELECT * FROM sample_ancestry').all()
+			for (const row of rows) {
+				const id = row.sample_id
+				if (!i2ancestors.has(id)) i2ancestors.set(id, [])
+				const ancestors = i2ancestors.get(id)
+				const ancestor = {
+					ancestor_id: row.ancestor_id,
+					ancestor_name: q.id2sampleName(row.ancestor_id),
+					sample_type: q.id2sampleType(row.ancestor_id),
+					distance: row.distance
+				}
+				ancestors.push(ancestor)
+			}
+		}
+
+		const i2refs = new Map()
+		{
+			const rows = cn.prepare('SELECT * FROM sampleidmap').all()
+			for (const row of rows) {
+				const id = row.id
+				const name = row.name
+				const refs: any = { label: name, sample: id, sampleType: q.id2sampleType(id) }
+				const ancestors = i2ancestors.get(row.id)
+				if (ancestors) refs.ancestors = ancestors
+				Object.freeze(refs)
+				i2refs.set(id, refs)
+			}
+		}
+
+		q.id2sampleRefs = id => structuredClone(i2refs.get(id)) // returns sample refs to be used in bySampleId{} object, returning clone as some code (e.g. server/src/termdb.get_matrix.js) needs to modify the sample refs object
 	}
 }
 


### PR DESCRIPTION
# Description

When a dataset has sample ancestry (`ds.cohort.termdb.hasSampleAncestry=true`), the sample ancestry will get stored in the sample refs. In matrix, the sample ancestry can then be accessed in the sample refs to group samples by root sample type.

Can test by launching an [NB2012 matrix of a sample-level term](http://localhost:3000/?mass={%22dslabel%22:%22NB2012%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22id%22:%22Site%22}]}]}]}). The samples will be grouped by patient by default.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
