### PR TITLE
Handle missing samples in data files

### DIFF
--- a/server/routes/termdb.cluster.ts
+++ b/server/routes/termdb.cluster.ts
@@ -353,20 +353,27 @@ async function validateNative(q: GeneExpressionQuery, ds: any) {
 
 		if (vr.status !== 'success') throw vr.message
 		if (!vr.samples?.length) throw 'HDF5 file has no samples, please check file.'
+		const unknownSamples = new Set() // samples present in gene expression file but missing from db
 		for (const sn of vr.samples) {
 			const si = ds.cohort.termdb.q.sampleName2id(sn)
-			if (si == undefined) {
+			if (si === undefined) {
 				if (ds.cohort.db) {
 					// sqlite-based db, samples in hdf5 file should be in sync with db
 					throw `unknown sample ${sn} from HDF5 ${q.file}`
 				} else {
 					// api-based db, samples in hdf5 file may not be in sync with api
+					unknownSamples.add(sn)
 					continue
 				}
 			}
 			q.samples.push(si)
 		}
 		console.log(`${ds.label}: geneExpression HDF5 file validated. Format: ${vr.format}, Samples:`, q.samples.length)
+		if (unknownSamples.size) {
+			// report unknown samples in server log
+			const arr = [...unknownSamples]
+			console.log(`unknown samples from geneExpression HDF5 file (${arr.length}): ${arr.join(', ')}`)
+		}
 	} catch (error) {
 		throw `${ds.label}: Failed to validate geneExpression HDF5 file: ${error}`
 	}

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -823,22 +823,22 @@ function mayValidateSampleHeader(ds, samples, where) {
 function validateSampleHeader2(ds, samples, where) {
 	const sampleIds = []
 	// ds?.cohort?.termdb.q.sampleName2id must be present
-	const unknownSamples = [] // samples present in big file header but missing from db
+	const unknownSamples = new Set() // samples present in big file header but missing from db
 	if (ds.cohort?.termdb?.q?.sampleName2id) {
 		// has id mapper and is official ds
 		for (const s of samples) {
 			const id = ds.cohort.termdb.q.sampleName2id(s.name)
-			if (id == undefined) {
+			if (id === undefined) {
 				if (ds.cohort.db) {
 					// sqlite-based db, samples in file should be in sync with db
-					unknownSamples.push(s.name)
-					continue
+					throw new Error(`unknown sample ${s.name} from ${where} file`)
 				} else {
 					// api-based db, samples in file may not be in sync with api
 					// file should still be used, so insert a mock element in
-					// sampleIds to preserve sample order
-					// downstream query should be able to ignore it
+					// sampleIds to preserve sample order, downstream query should
+					// be able to ignore it
 					sampleIds.push({})
+					unknownSamples.add(s.name)
 					continue
 				}
 			}
@@ -846,11 +846,10 @@ function validateSampleHeader2(ds, samples, where) {
 			sampleIds.push(s)
 		}
 		console.log(samples.length, 'samples from ' + where + ' of ' + ds.label)
-		if (unknownSamples.length) {
+		if (unknownSamples.size) {
 			// unknown samples can be safely reported to server log
-			console.log('unknown samples: ' + unknownSamples.join(', '))
-			// later attach a sanitized err msg to ds to report to client
-			throw 'unknown samples in big file'
+			const arr = [...unknownSamples]
+			console.log(`unknown samples from ${where} (${arr.length}): ${arr.join(', ')}`)
 		}
 	} else {
 		// no mapper, should be custom ds from custom bcf file
@@ -2780,6 +2779,11 @@ async function addCnvGetter(ds, genome) {
 
 					if (j.sample) {
 						j.sample = ds.cohort.termdb.q.sampleName2id(j.sample)
+						if (j.sample === undefined) {
+							// skip unmapped samples here as there are already
+							// handled during validation (see validateSampleHeader2())
+							return
+						}
 						if (limitSamples) {
 							// to filter sample
 							if (!limitSamples.has(j.sample)) return


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1319

When a data file has a sample(s) missing from the db:
- When db is sql-based, throw error because samples in data files should be in sync with db
- When db is api-based, report missing samples in server log, but still allow file to load because samples in files may be out of sync with api.

All unit and integration tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
