### PR TITLE
Support `allow2selectSamples{}` in genomeBrowser plot

### DIFF
--- a/client/gdc/gb.ts
+++ b/client/gdc/gb.ts
@@ -14,6 +14,7 @@ interface InitArg {
 	}
 	opts?: {
 		app?: Record<string, any>
+		genomeBrowser?: any
 	}
 }
 
@@ -41,14 +42,7 @@ export async function init(
 			nav: { activeTab: 1, header_mode: 'hidden' },
 			plots: [{ chartType: 'genomeBrowser' }]
 		},
-		opts: Object.assign(
-			{
-				// todo additional customizations
-				// dictionary:{header:'Select a variable to build Correlation Plot'}
-				// some way to make gene exp violin/boxplot to use log scale by default, but numeric dict term should not
-			},
-			arg.opts || {}
-		),
+		genomeBrowser: arg.opts?.genomeBrowser || {},
 		app: arg.opts?.app || {}
 	})
 	const api = {

--- a/client/plots/gb/GB.ts
+++ b/client/plots/gb/GB.ts
@@ -96,7 +96,8 @@ class TdbGenomeBrowser extends PlotBase implements RxComponent {
 			vocabApi: this.app.vocabApi,
 			debug: this.app.opts.debug,
 			plotDiv: this.opts.plotDiv,
-			header: this.opts.header
+			header: this.opts.header,
+			allow2selectSamples: this.opts.allow2selectSamples
 		}
 		return opts
 	}

--- a/client/plots/gb/view/View.ts
+++ b/client/plots/gb/view/View.ts
@@ -216,7 +216,7 @@ export class View {
 
 	/* tricky logic */
 	async launchBlockWithTracks(tklst) {
-		if (this.state?.vocab?.dslabel != 'GDC' && this.blockInstance) {
+		if (!['GDC', 'MMRF'].includes(this.state?.vocab?.dslabel) && this.blockInstance) {
 			/* block instance is present
             this should be updating tracks in this block, by adding new ones listed in tklst[],
             and deleting old ones via a tricky method
@@ -268,7 +268,7 @@ export class View {
 			return
 		}
 
-		// is GDC and/or no block instance, create new block
+		// is GDC, MMRF, and/or no block instance, create new block
 
 		this.dom.blockHolder.selectAll('*').remove()
 		const arg: any = {

--- a/client/plots/gb/view/View.ts
+++ b/client/plots/gb/view/View.ts
@@ -59,6 +59,7 @@ export class View {
 				const tk: any = {
 					type: 'mds3',
 					dslabel: this.state.vocab.dslabel,
+					allow2selectSamples: this.opts.allow2selectSamples,
 					onClose: () => {
 						// on closing subtk, the filterObj corresponding to the subtk will be "removed" from subMds3Tks[], by regenerating the array
 						this.interactions.maySaveTrackUpdatesToState(this.blockInstance)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -333,7 +333,9 @@ export async function validate_termdb(ds) {
 	}
 
 	if (tdb.convertSampleId) {
-		if (tdb.convertSampleId.gdcapi) {
+		if (typeof tdb.convertSampleId.get === 'function') {
+			// ds-supplied getter
+		} else if (tdb.convertSampleId.gdcapi) {
 			gdc.convertSampleId_addGetter(tdb, ds)
 			// convertSampleId.get() added
 		} else {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -833,7 +833,7 @@ function validateSampleHeader2(ds, samples, where) {
 			if (id === undefined) {
 				if (ds.cohort.db) {
 					// sqlite-based db, samples in file should be in sync with db
-					throw new Error(`unknown sample ${s.name} from ${where} file`)
+					throw `unknown sample ${s.name} from ${where} file`
 				} else {
 					// api-based db, samples in file may not be in sync with api
 					// file should still be used, so insert a mock element in


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1319

Support `allow2selectSamples{}` in genomeBrowser plot code. Always create new block instance in genomeBrowser plot when ds is MMRF to allow usage of filter0.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
