### PR TITLE
mds3 tk sample table cannot show annotations with patient-only terms

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- quick fix to hardcode to pull sample-level values for mds3 tk sample table to work with patient terms

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -304,8 +304,9 @@ export default function (): Mds3 {
 
 			// list of term ids as sample details
 			twLst: [
-				{ id: 'sex', q: {} }
-				//{ id: 'diaggrp', q: {} }, { id: 'agedx', q: {} } only for testing. REVERT before merging
+				{ id: 'sex', q: {} },
+				{ id: 'diaggrp', q: {} },
+				{ id: 'agedx', q: {} }
 			],
 
 			// small list of terms for sunburst rings

--- a/server/dataset/termdb.test.ts
+++ b/server/dataset/termdb.test.ts
@@ -304,9 +304,8 @@ export default function (): Mds3 {
 
 			// list of term ids as sample details
 			twLst: [
-				{ id: 'sex', q: {} },
-				{ id: 'diaggrp', q: {} },
-				{ id: 'agedx', q: {} }
+				{ id: 'sex', q: {} }
+				//{ id: 'diaggrp', q: {} }, { id: 'agedx', q: {} } only for testing. REVERT before merging
 			],
 
 			// small list of terms for sunburst rings

--- a/server/src/mds3.variant2samples.js
+++ b/server/src/mds3.variant2samples.js
@@ -424,8 +424,10 @@ export function combineSamplesById(inlst, samples, ssmid) {
 async function mayAddSampleAnnotationByTwLst(samples, twLst, ds) {
 	if (!twLst || twLst.length == 0) return
 
-	// Get data for all terms at once. fix is needed to handle sample hierarchy but inefficient as it pulls data for all samples.
-	const data = await getData({ terms: twLst }, ds)
+	// Get data for all terms at once.
+	// FIXME inefficient as it pulls data for all samples.
+	// FIXME hardcoded true as 3rd arg to obtain sample-level values for patient-level terms
+	const data = await getData({ terms: twLst }, ds, true)
 	if (data.error) throw data.error
 
 	// For every term, append term values to each sample

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -623,7 +623,10 @@ export async function getSamples(q, rows, termWrappers) {
 	// if q.currentGeneNames is in use, must restrict to these samples
 	const limitMutatedSamples = await mayQueryMutatedSamples(q)
 	for (const { sample, key, term_id, value } of rows) {
-		if (limitMutatedSamples && !limitMutatedSamples.has(sample)) return // this sample is not mutated for given genes
+		if (limitMutatedSamples && !limitMutatedSamples.has(sample)) {
+			// this sample is not mutated for given genes
+			continue
+		}
 		if (!samples[sample]) samples[sample] = { sample }
 		const v = tw$idsWithJson.has(term_id) && typeof value == 'string' ? JSON.parse(value) : value
 		// this assumes unique term key/value for a given sample
@@ -636,7 +639,7 @@ export async function getSamples(q, rows, termWrappers) {
 			// convert to .values[]
 			if (!samples[sample][term_id].values) {
 				const firstvalue = samples[sample][term_id] // first term value of the sample
-				if (firstvalue.key === key && firstvalue.value === v) return // duplicate
+				if (firstvalue.key === key && firstvalue.value === v) continue // duplicate
 				samples[sample][term_id] = { values: [firstvalue] } // convert to object with .values[]
 			}
 			// add next term value to .values[]


### PR DESCRIPTION
# Description
test with [propel](http://localhost:3000/?genome=hg38&gene=bcr&mds3=propel)
the problem of subtracking with patient-term e.g. Lineage doesn't work. it is due to problematic design of `get_samples()` and need to be looked at later


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
