### PR TITLE
Incorporate meta analysis results in SC app

### DIFF
--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -120,7 +120,7 @@ export class PlotButtons {
 				label: 'Summary',
 				isVisible: () => true,
 				getPlotConfig: () => {
-					const sample = this.item!
+					const sample = Object.assign(this.item!, { plots: Array.from(this.availablePlots) })
 					return {
 						chartType: 'dictionary',
 						sample,

--- a/client/plots/sc/view/PlotButtons.ts
+++ b/client/plots/sc/view/PlotButtons.ts
@@ -120,7 +120,7 @@ export class PlotButtons {
 				label: 'Summary',
 				isVisible: () => true,
 				getPlotConfig: () => {
-					const sample = Object.assign(this.item!, { plots: Array.from(this.availablePlots) })
+					const sample = { ...this.item!, plots: Array.from(this.availablePlots) }
 					return {
 						chartType: 'dictionary',
 						sample,

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -78,11 +78,13 @@ export class SCViewModel {
 				// sample does not use experiment
 				// first cell is sample name
 				const row: { [index: string]: any }[] = item.isMetaResult
-					? [{ html: item.sample.replace(/_/g, ' '), value: item.sample, isMetaResult: true }]
+					? [{ html: item.sample.replace(/_/g, ' '), value: item.sample }]
 					: [{ value: item.sample }]
 				// optional sample columns
 				for (const col of sampleColumns || []) {
-					row.push({ value: item[col.termid] })
+					const value = item[col.termid]
+					if (!value && item.isMetaResult) row.push({ value: 'All' })
+					else row.push({ value: item[col.termid] })
 				}
 				if (item.isMetaResult) rows.unshift(row)
 				else rows.push(row)

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -8,9 +8,13 @@ export class SCViewModel {
 	state: SCFormattedState
 	tableData: SCTableData
 
-	constructor(app: AppApi, config: SCConfig, items: SingleCellSample[], sampleColumns?: SampleColumn[]) {
+	constructor(app: AppApi, config: SCConfig, _items: SingleCellSample[], sampleColumns?: SampleColumn[]) {
 		this.app = app
 		this.state = this.app.getState()
+
+		//Sort meta analysis results to show at the beginning of the table.
+		//Prevents breaking the logic for selected rows after formating the table data.
+		const items = _items.sort((a, b) => (b.isMetaResult === a.isMetaResult ? 0 : b.isMetaResult ? 1 : -1))
 
 		//Should only be called once
 		const [rows, columns] = this.getTabelData(config, items, sampleColumns)
@@ -86,8 +90,7 @@ export class SCViewModel {
 					if (!value && item.isMetaResult) row.push({ value: 'All' })
 					else row.push({ value: item[col.termid] })
 				}
-				if (item.isMetaResult) rows.unshift(row)
-				else rows.push(row)
+				rows.push(row)
 			}
 		}
 		return [rows, columns]

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -87,7 +87,7 @@ export class SCViewModel {
 				// optional sample columns
 				for (const col of sampleColumns || []) {
 					const value = item[col.termid]
-					if (!value && item.isMetaResult) row.push({ value: 'All' })
+					if (value == null && item.isMetaResult) row.push({ value: 'All' })
 					else row.push({ value: item[col.termid] })
 				}
 				rows.push(row)

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -77,12 +77,15 @@ export class SCViewModel {
 			else {
 				// sample does not use experiment
 				// first cell is sample name
-				const row: { [index: string]: any }[] = [{ value: item.sample }]
+				const row: { [index: string]: any }[] = item.isMetaResult
+					? [{ html: item.sample.replace(/_/g, ' '), value: item.sample, isMetaResult: true }]
+					: [{ value: item.sample }]
 				// optional sample columns
 				for (const col of sampleColumns || []) {
 					row.push({ value: item[col.termid] })
 				}
-				rows.push(row)
+				if (item.isMetaResult) rows.unshift(row)
+				else rows.push(row)
 			}
 		}
 		return [rows, columns]

--- a/client/termdb/handlers/singleCellCellType.ts
+++ b/client/termdb/handlers/singleCellCellType.ts
@@ -21,15 +21,22 @@ export class SearchHandler {
 			return
 		}
 		const usecaseConfig = opts.usecase?.specialCase?.config
-		const plotName = usecaseConfig?.name
-		let filteredTerms: any[] = []
-		if (plotName) {
-			filteredTerms = scctTerms.filter(t => t.plot == plotName)
-		} else {
-			filteredTerms = scctTerms.map(t => Object.assign(t, { label: `${t.name} (${t.plot})` }))
-		}
+		const plots = usecaseConfig?.sample?.plots
 
-		for (const t of filteredTerms) {
+		/** Use either the usecase.config.sample.plots:[] or usecase.config.name (i.e.
+		 * plot name) to filter the terms OR display all. If displaying all terms,
+		 * append the plot name to the label. Only display a term once. */
+		const filtered = plots
+			? scctTerms.filter(t => plots.includes(t.plot))
+			: usecaseConfig?.name
+			? scctTerms.filter(t => t.plot === usecaseConfig.name)
+			: scctTerms
+
+		const filteredTerms: Set<any> = new Set(
+			plots || !usecaseConfig?.name ? filtered.map(t => ({ ...t, label: `${t.name} (${t.plot})` })) : filtered
+		)
+
+		for (const t of Array.from(filteredTerms)) {
 			holder
 				/** The divs and styling duplicates the appearance of the
 				 * tree terms. The tree is NOT called for this handler. */

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features
+- Meta analysis results are incorporated into the SC app. The results appear in the first row(s) of the sample table.

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -146,8 +146,13 @@ async function validateSamples(q: SingleCellQuery, ds: any) {
 			 * in the db. */
 			const sampleName = plot?.sampleId || plot.name.replace(/\s/g, '_')
 			const tsvfile = path.join(serverconfig.tpmasterdir, plot.folder, sampleName + (plot.fileSuffix || ''))
-			if (!tsvfile) throw new Error('meta result plot.file missing')
-			samples.set(sampleName, { sample: sampleName, isMetaResult: true })
+			try {
+				/** Files should exist for each meta analysis result. */
+				await file_is_readable(tsvfile)
+				samples.set(sampleName, { sample: sampleName, isMetaResult: true })
+			} catch (e: any) {
+				throw new Error(`meta result data file missing or unreadable: ${sampleName} (${tsvfile}): ${e.message || e}`)
+			}
 			continue
 		}
 		for (const fn of await fs.promises.readdir(path.join(serverconfig.tpmasterdir, plot.folder))) {

--- a/server/routes/termdb.singlecellSamples.ts
+++ b/server/routes/termdb.singlecellSamples.ts
@@ -136,6 +136,20 @@ async function validateSamples(q: SingleCellQuery, ds: any) {
 	// v: { sample: string name, tid1:v1, ...} term ids are from S.sampleColumns[]. list of sample objects are returned in getter
 	const samples = new Map()
 	for (const plot of D.plots) {
+		if (plot.isMetaResult) {
+			/** Meta analysis results may not be separated into folders like the sample files
+			 * for other plots. Check the file exists with the appropriate "sample name". This
+			 * method ensure the file can be queried as intended later.
+			 *
+			 * Note: meta analysis results are treated as sample because the data structure and
+			 * getters are the same. The results or the sID used for querying will not appear
+			 * in the db. */
+			const sampleName = plot?.sampleId || plot.name.replace(/\s/g, '_')
+			const tsvfile = path.join(serverconfig.tpmasterdir, plot.folder, sampleName + (plot.fileSuffix || ''))
+			if (!tsvfile) throw new Error('meta result plot.file missing')
+			samples.set(sampleName, { sample: sampleName, isMetaResult: true })
+			continue
+		}
 		for (const fn of await fs.promises.readdir(path.join(serverconfig.tpmasterdir, plot.folder))) {
 			// fn: string file name.
 			let sampleName = fn

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -875,8 +875,7 @@ type GDCSingleCellPlot = {
 	colorColumns: ColorColumn[]
 	coordsColumns: { x: number; y: number }
 	/** if true the plot is shown by default. otherwise hidden
-	 * Will not be needed when the singleCellPlot is depreciated.
-	 */
+	 * Will not be needed when the singleCellPlot is deprecated.*/
 	selected?: boolean
 }
 
@@ -915,13 +914,12 @@ type SingleCellPlot = {
 	 */
 	colorColumns: ColorColumn[]
 	/** if true the plot is shown by default. otherwise hidden.
-	 * Old implementation. Maybe deleted when singleCellPlot is depreciated.
-	 */
+	 * Old implementation. Maybe deleted when singleCellPlot is deprecated.*/
 	selected?: boolean
 	/** Plot is a meta analysis result and treated differently in the UI */
 	isMetaResult?: boolean
-	/** optional for meta analysis result plots. Define the "sampleId" for the
-	 * server requests that should match the file name or the plot name with the
+	/** optional for meta analysis result plots. May define the "sampleId" for the
+	 * server requests. If not provided, the file name or the plot name with the
 	 * spaces replaced with '_' is used. */
 	sampleId?: string
 }
@@ -1111,7 +1109,7 @@ type Mds3Queries = {
 	singleCell?: SingleCellQuery
 	singleSampleGenomeQuantification?: SingleSampleGenomeQuantification
 	singleSampleGbtk?: SingleSampleGbtk
-	/** depreciated. replaced by WSImages */
+	/** deprecated. replaced by WSImages */
 	DZImages?: DZImages
 	WSImages?: WSImages
 	images?: Images
@@ -1143,7 +1141,7 @@ type Images = {
 	folder: string
 }
 
-/** Depreciated. deep zoom image shown via openseadragon, with precomputed tiles.
+/** Deprecated. deep zoom image shown via openseadragon, with precomputed tiles.
  * this is replaced by WSImages and should not be used anymore */
 export type DZImages = {
 	// type of the image, e.g. H&E

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -914,8 +914,16 @@ type SingleCellPlot = {
 	/** list of columns in tabular text file that define cell categories and can be used to color the cells in the plot. must have categorical values
 	 */
 	colorColumns: ColorColumn[]
-	/** if true the plot is shown by default. otherwise hidden */
+	/** if true the plot is shown by default. otherwise hidden.
+	 * Old implementation. Maybe deleted when singleCellPlot is depreciated.
+	 */
 	selected?: boolean
+	/** Plot is a meta analysis result and treated differently in the UI */
+	isMetaResult?: boolean
+	/** optional for meta analysis result plots. Define the "sampleId" for the
+	 * server requests that should match the file name or the plot name with the
+	 * spaces replaced with '_' is used. */
+	sampleId?: string
 }
 export type SingleCellDataNative = SingleCellDataBase & {
 	src: 'native'

--- a/shared/types/src/routes/termdb.singlecellSamples.ts
+++ b/shared/types/src/routes/termdb.singlecellSamples.ts
@@ -17,7 +17,7 @@ export type SingleCellSample = {
 		sampleName: any
 		experimentID?: string
 	}[]
-
+	isMetaResult?: boolean // whether this sample is a meta result. if so, sample name is from plot.sampleId or plot.name and experimentID is not used
 	// a sample may have additional fields that will be displayed in table, see singleCell.samples.sampleColumns[]
 }
 


### PR DESCRIPTION
# Description

Changes: 
If meta analysis results are present, the results will appear in the first row(s) of the sample table. All other columns are filled in with 'All'. The scct term handler now accounts for the available plots per term passed through `usecase.specialCase`.

Note: There are known bugs to work on in the next PR, before the 12th: 
1. scge terms inconsistently working for meta analysis results. 
2. Color scale for scge terms in single cell scatter plot not working
3. Local/plot filter not working in summary plot
4. No ability to overlay with cohort level terms. 

The goal is to allow others to implement meta analysis results for other datasets and find other bugs before the 12th. 

Test: 
1. Pull https://github.com/stjude/sjpp/pull/1301
2. Run `node utils/getDataset.js ballScrna`
3. Open http://localhost:3000/?mass={%22genome%22:%22hg38%22,%22dslabel%22:%22BALL-scrna%22,%22nav%22:{%22header_mode%22:%22hidden%22},%22plots%22:[{%22chartType%22:%22sc%22}]} 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
