### PR TITLE
Update call to `dictionary.get()`

### DIFF
--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -35,6 +35,7 @@ export async function init(
 ): Promise<{ update: (updateArg: UpdateArg) => Promise<void> }> {
 	const useGenome = arg.genome || 'hg38'
 	const useDslabel = arg.dslabel || 'GDC'
+	if (!genomes[useGenome]) throw useGenome + ' missing'
 	const massApi = await appInit({
 		//debug: arg.debugmode, // is debug accepted?
 		genome: genomes[useGenome],

--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -12,6 +12,8 @@ todo
 
 interface InitArg {
 	debugmode?: true
+	genome?: string
+	dslabel?: string
 	filter0?: object
 	state?: {
 		plots?: Array<{ chartType: string; [key: string]: any }>
@@ -26,21 +28,20 @@ interface UpdateArg {
 	[key: string]: any
 }
 
-const gdcGenome = 'hg38'
-const gdcDslabel = 'GDC'
-
 export async function init(
 	arg: InitArg,
 	holder: HTMLElement,
 	genomes: any
 ): Promise<{ update: (updateArg: UpdateArg) => Promise<void> }> {
+	const useGenome = arg.genome || 'hg38'
+	const useDslabel = arg.dslabel || 'GDC'
 	const massApi = await appInit({
 		//debug: arg.debugmode, // is debug accepted?
-		genome: genomes[gdcGenome],
+		genome: genomes[useGenome],
 		holder,
 		state: {
-			genome: gdcGenome,
-			dslabel: gdcDslabel,
+			genome: useGenome,
+			dslabel: useDslabel,
 			termfilter: { filter0: arg.filter0 },
 			nav: { activeTab: 1, header_mode: 'only_buttons' },
 			plots: arg.state?.plots || [

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -24,6 +24,7 @@ const dsHelpers = {
 	isUsableTerm,
 	joinUrl,
 	ezFetch,
+	DEFAULT_SAMPLE_TYPE,
 	xfetch: utils.xfetch,
 	cachedFetch: utils.cachedFetch,
 	mayLog,

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -24,7 +24,6 @@ const dsHelpers = {
 	isUsableTerm,
 	joinUrl,
 	ezFetch,
-	DEFAULT_SAMPLE_TYPE,
 	xfetch: utils.xfetch,
 	cachedFetch: utils.cachedFetch,
 	mayLog,

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -513,7 +513,7 @@ async function mayValidateRestrictAcestries(tdb) {
 	}
 }
 
-async function call_barchart_data(twLst, q, combination, ds) {
+async function call_barchart_data(twLst, q, combination, ds, onlyChildren) {
 	// makes sense to call barchart function as it adds counting logic over getData output
 
 	const filter = combineFilterAndTid2value(q, ds) // optional filter, based on optional parameters
@@ -530,7 +530,7 @@ async function call_barchart_data(twLst, q, combination, ds) {
 				filter
 			}
 
-			const out = await barchart_data(_q, ds, ds.cohort.termdb)
+			const out = await barchart_data(_q, ds, ds.cohort.termdb, onlyChildren)
 
 			if (!out?.data?.charts?.[0]) {
 				// no data
@@ -3700,9 +3700,10 @@ function mayInitTermid2totalsize2(tdb, ds) {
 			a map, key is termid, value is array, each element: [category, total]
 		*/
 	tdb.termid2totalsize2.get = async (twLst, q = {}, combination = null) => {
+		const onlyChildren = true // only get sample-level data for mds3 track
 		if (tdb.termid2totalsize2.gdcapi) {
 			return await gdc.get_termlst2size(twLst, q, combination, ds)
 		}
-		return await call_barchart_data(twLst, q, combination, ds)
+		return await call_barchart_data(twLst, q, combination, ds, onlyChildren)
 	}
 }

--- a/server/src/termdb.barchart.js
+++ b/server/src/termdb.barchart.js
@@ -73,6 +73,8 @@ ds{}
 	server-side dataset obj
 tdb{}
 	ds.cohort.termdb
+onlyChildren: boolean
+	passed to getData()
 
 output an object:
 .charts=[]
@@ -83,7 +85,7 @@ output an object:
 			.dataId=str // key of term2 category, '' if no term2
 			.total=int // size of this term1-term2 combination
 */
-export async function barchart_data(q, ds, tdb) {
+export async function barchart_data(q, ds, tdb, onlyChildren) {
 	/* existing code to work with mds2 which only supports backend-termdb
 	as later mds2 will be deprecated and migrated to mds3,
 	there should be no need to check for isMds3 flag
@@ -110,7 +112,8 @@ export async function barchart_data(q, ds, tdb) {
 	const terms = [...map.values()]
 	const data = await getData(
 		{ filter: q.filter, filter0: q.filter0, terms, __protected__: q.__protected__, __abortSignal: q.__abortSignal },
-		q.ds
+		q.ds,
+		onlyChildren
 	)
 	if (data.error) throw data.error
 	const samplesMap = new Map()

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -700,8 +700,8 @@ async function mayQueryMutatedSamples(q) {
 // TODO: account for filter/filter0
 // TODO: use tw.$id instead of tw.term.id (will need to also change in flattenCaseByFields() in server/src/mds3.gdc.js)
 async function getSampleData_dictionaryTerms_api(q, termWrappers) {
-	const data = await q.ds.cohort.termdb.dictionary.get(termWrappers)
-	const samples = {} // data.samples[] converts into this
+	/*const data = */ return await q.ds.cohort.termdb.dictionary.get(termWrappers)
+	/*const samples = {} // data.samples[] converts into this
 	for (const s of data.samples) {
 		const sampleId = q.ds.cohort.termdb.q.sampleName2id(s.sample_id)
 		if (!sampleId && sampleId !== 0) throw new Error('cannot find sample')
@@ -727,7 +727,7 @@ async function getSampleData_dictionaryTerms_api(q, termWrappers) {
 		}
 		samples[sampleId] = s2
 	}
-	return [samples, data.byTermId || {}]
+	return [samples, data.byTermId || {}]*/
 }
 
 /*

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -501,8 +501,7 @@ async function getSampleData_dictionaryTerms(q, termWrappers, onlyChildren = fal
 	}
 	if (q.ds.cohort.termdb.dictionary?.get) {
 		// ds-supplied getter to retrieve dictionary term data
-		// TODO: account for filter/filter0
-		return await q.ds.cohort.termdb.dictionary.get(termWrappers)
+		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers)
 	}
 	/* gdc ds has no cohort.db. thus call v2s.get() to return sample annotations for its dictionary terms
 	 */

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -475,11 +475,14 @@ export function divideTerms(lst) {
 	return [dict, geneVariantTws, nonDict]
 }
 
-// set value of onlyChildren boolean
-// currently only perfomred if ds has necessary flag
+// function to set the onlyChildren flag, which controls whether
+// sample-level or parent-level data is retrieved
+// currently, this function is only performed if:
+// 	- ds has necessary flag and
+// 	- onlyChildren is false
 // TODO: apply to other datasets
 function maySetOnlyChildren(twLst, ds, onlyChildren) {
-	if (!ds.cohort.termdb.setOnlyChildren) return onlyChildren
+	if (!ds.cohort.termdb.setOnlyChildren || onlyChildren) return onlyChildren
 	const sampleTypeConfig = ds.cohort.termdb.sampleTypes
 	if (!sampleTypeConfig) 'sample type config missing'
 	if (Object.keys(sampleTypeConfig).length != 2) 'unexpected number of sample types in config'

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -125,6 +125,7 @@ let numActiveQueriesAcrossUsers = 0,
 async function getSampleData(q, ds, onlyChildren = false) {
 	// dictionary and non-dictionary terms require different methods for data query
 	const [dictTerms, geneVariantTws, nonDictTerms] = divideTerms(q.terms)
+	onlyChildren = maySetOnlyChildren(q.terms, ds, onlyChildren)
 	const [samples, byTermId] = await getSampleData_dictionaryTerms(q, dictTerms, onlyChildren)
 	/* samples={}
 	this object collects term annotation data on all samples; even if there's no dict term it still return blank {}
@@ -474,6 +475,30 @@ export function divideTerms(lst) {
 	return [dict, geneVariantTws, nonDict]
 }
 
+// set value of onlyChildren boolean
+// currently only perfomred if ds has necessary flag
+// TODO: apply to other datasets
+function maySetOnlyChildren(twLst, ds, onlyChildren) {
+	if (!ds.cohort.termdb.setOnlyChildren) return onlyChildren
+	const sampleTypeConfig = ds.cohort.termdb.sampleTypes
+	if (!sampleTypeConfig) 'sample type config missing'
+	if (Object.keys(sampleTypeConfig).length != 2) 'unexpected number of sample types in config'
+	const sampleTypes = getSampleTypes(twLst, ds)
+	const types = [...sampleTypes]
+	if (!types.length) {
+		throw 'no sample types found'
+	} else if (types.length > 1) {
+		// multiple sample types
+		// onlyChildren should be true
+		return true
+	} else {
+		// single sample type
+		// if sample type is child, then onlyChildren should be true
+		const type = types[0]
+		return Number.isInteger(sampleTypeConfig[type].parent_id)
+	}
+}
+
 /*
 input:
 
@@ -501,7 +526,7 @@ async function getSampleData_dictionaryTerms(q, termWrappers, onlyChildren = fal
 	}
 	if (q.ds.cohort.termdb.dictionary?.get) {
 		// ds-supplied getter to retrieve dictionary term data
-		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers)
+		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers, onlyChildren)
 	}
 	/* gdc ds has no cohort.db. thus call v2s.get() to return sample annotations for its dictionary terms
 	 */

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -501,7 +501,8 @@ async function getSampleData_dictionaryTerms(q, termWrappers, onlyChildren = fal
 	}
 	if (q.ds.cohort.termdb.dictionary?.get) {
 		// ds-supplied getter to retrieve dictionary term data
-		return await getSampleData_dictionaryTerms_api(q, termWrappers)
+		// TODO: account for filter/filter0
+		return await q.ds.cohort.termdb.dictionary.get(termWrappers)
 	}
 	/* gdc ds has no cohort.db. thus call v2s.get() to return sample annotations for its dictionary terms
 	 */
@@ -694,40 +695,6 @@ async function mayQueryMutatedSamples(q) {
 		}
 	}
 	return sampleSet
-}
-
-// query dictionary data for api-based datasets
-// TODO: account for filter/filter0
-// TODO: use tw.$id instead of tw.term.id (will need to also change in flattenCaseByFields() in server/src/mds3.gdc.js)
-async function getSampleData_dictionaryTerms_api(q, termWrappers) {
-	/*const data = */ return await q.ds.cohort.termdb.dictionary.get(termWrappers)
-	/*const samples = {} // data.samples[] converts into this
-	for (const s of data.samples) {
-		const sampleId = q.ds.cohort.termdb.q.sampleName2id(s.sample_id)
-		if (!sampleId && sampleId !== 0) throw new Error('cannot find sample')
-		const s2 = { sample: sampleId }
-		for (const tw of termWrappers) {
-			const id = tw.term.id || tw.term.name
-			const $id = tw.$id || id
-			if (!tw.$id) tw.$id = $id
-			const v = s[id]
-			if (!v && v !== 0) {
-				// skip undefined values
-				continue
-			} else if (Array.isArray(v)) {
-				// not handling it yet
-				throw new Error(`value '${v}' is an array`)
-			} else if (typeof v == 'object') {
-				// observed in gdc, but not handling it yet for mmrf
-				throw new Error(`value '${v}' is an object`)
-			} else {
-				// scalar value
-				s2[$id] = { key: v, value: v }
-			}
-		}
-		samples[sampleId] = s2
-	}
-	return [samples, data.byTermId || {}]*/
 }
 
 /*

--- a/server/src/xfetch.js
+++ b/server/src/xfetch.js
@@ -27,6 +27,13 @@ export async function xfetch(url, opts = {}) {
 		}
 		opts.body = JSON.stringify(opts.body)
 	}
+	if (!opts.headers) opts.headers = {}
+	if (
+		opts.method?.toUpperCase() == 'POST' &&
+		!Object.keys(opts.headers).find(k => k.toLowerCase() == 'content-type') &&
+		isJSON(opts.body)
+	)
+		opts.headers['Content-Type'] = 'application/json'
 
 	mayCollectTrackedInfo(url, opts)
 
@@ -140,4 +147,14 @@ function mayCollectTrackedInfo(url, opts) {
 	const key = '[' + url + ']' + (body || '')
 	if (!uniqueReqTracker.has(key)) uniqueReqTracker.set(key, 0)
 	uniqueReqTracker.set(key, uniqueReqTracker.get(key) + 1)
+}
+
+function isJSON(str) {
+	if (typeof str != 'string') return false
+	try {
+		JSON.parse(str)
+		return true
+	} catch (e) {
+		return false
+	}
 }

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -169,7 +169,7 @@ type DictApi = {
 	// helpers at ds.cohort.termdb.q{}
 	build?: (ds: any) => void
 	// gets dictionary term data
-	get?: (q: any, twLst: any, useCache?: boolean) => void
+	get?: (q: any, twLst: any, onlyChildren?: boolean, useCache?: boolean) => void
 }
 
 type SnvIndelFormat = {
@@ -1743,6 +1743,8 @@ keep this setting here for reason of:
 	getAdditionalFilter?: (__protected__: any, term: any) => Filter | undefined
 	/** collections of dictionary terms (numeric or categorical) that are related and can be used together in some plots */
 	termCollections?: TermCollection[]
+	/** whether to set onlyChildren in getData() */
+	setOnlyChildren: true
 }
 
 type TermCollectionBase = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1744,7 +1744,7 @@ keep this setting here for reason of:
 	/** collections of dictionary terms (numeric or categorical) that are related and can be used together in some plots */
 	termCollections?: TermCollection[]
 	/** whether to set onlyChildren in getData() */
-	setOnlyChildren: true
+	setOnlyChildren?: true
 }
 
 type TermCollectionBase = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -169,7 +169,7 @@ type DictApi = {
 	// helpers at ds.cohort.termdb.q{}
 	build?: (ds: any) => void
 	// gets dictionary term data
-	get?: (twLst: any) => void
+	get?: (q: any, twLst: any, useCache?: boolean) => void
 }
 
 type SnvIndelFormat = {


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1324

Allow correlation plot to be launched for different datasets/genomes. Update call to `dictionary.get()` to support updated dictionary getter code in MMRF.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
