### PR TITLE
Fix single-cell volcano: hover tooltips, group labels, GSEA tab, high res volcano render

### DIFF
--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -9,7 +9,7 @@ import { VolcanoModel } from '#plots/volcano/model/VolcanoModel.ts'
 import { getDefaultVolcanoSettings } from '#plots/volcano/settings/defaults.ts'
 import { PlotBase } from '#plots/PlotBase.js'
 import { getCombinedTermFilter } from '#filter'
-import { PROTEOME_DAP } from '#shared/terms.js'
+import { PROTEOME_DAP, SINGLECELL_CELLTYPE } from '#shared/terms.js'
 
 const tip = new Menu()
 
@@ -213,6 +213,40 @@ class gsea extends PlotBase {
 								dapParams: config.proteomeDetails,
 								genome: this.app.vocabApi.opts.state.vocab.genome,
 								dslabel: this.app.vocabApi.vocab.dslabel
+							}
+						}
+					})
+				} else if (config.termType === SINGLECELL_CELLTYPE) {
+					// SCCT has no DA cache — fetch the full DE gene list for the
+					// chosen cluster (omit volcanoRender so the route returns the
+					// raw gene array, not the threshold-passing `dots` subset)
+					// and pass genes + fold_change inline. `render_gsea` takes
+					// this path when neither cacheId nor dapParams is set.
+					const body = {
+						genome: this.app.vocabApi.vocab.genome,
+						dslabel: this.app.vocabApi.vocab.dslabel,
+						sample: config.sample,
+						termId: config.termId,
+						categoryName: config.categoryName
+					}
+					const response = await dofetch3('termdb/singlecellDEgenes', { body })
+					if (response.error) throw response.error
+					if (!Array.isArray(response.data) || response.data.length === 0) throw 'No DE genes returned for this cluster'
+					const genes = []
+					const fold_change = []
+					for (const g of response.data) {
+						genes.push(g.gene_name)
+						fold_change.push(g.fold_change)
+					}
+					await this.app.save({
+						type: 'plot_edit',
+						id: this.id,
+						config: {
+							gsea_params: {
+								genes,
+								fold_change,
+								genes_length: genes.length,
+								genome: this.app.vocabApi.opts.state.vocab.genome
 							}
 						}
 					})

--- a/client/plots/volcano/model/VolcanoModel.ts
+++ b/client/plots/volcano/model/VolcanoModel.ts
@@ -114,7 +114,17 @@ export class VolcanoModel {
 			colorSignificantDown: controlColor,
 			colorNonsignificant: toHex(this.settings.defaultNonSignColor, 'black'),
 			dotRadius,
-			maxInteractiveDots: this.settings.maxInteractiveDots
+			maxInteractiveDots: this.settings.maxInteractiveDots,
+			// Render the PNG at device-pixel resolution so it stays sharp on
+			// retina screens. The server reports the plot extent in CSS-space,
+			// so SVG overlay coords are unaffected.
+			//
+			// Oversample by 2× so the PNG also stays sharp when the user
+			// *zooms in after* the initial render (the captured DPR is frozen
+			// at fetch time — bigger headroom = more tolerable post-render
+			// zoom before pixelation appears). The server clamp keeps the
+			// bitmap memory bounded.
+			devicePixelRatio: (typeof window !== 'undefined' ? window.devicePixelRatio : 1) * 2
 		}
 	}
 

--- a/client/plots/volcano/view/VolcanoPlotView.ts
+++ b/client/plots/volcano/view/VolcanoPlotView.ts
@@ -342,9 +342,6 @@ export class VolcanoPlotView {
 	}
 
 	private attachInteractions(plotDim: VolcanoPlotDimensions) {
-		// SCCT volcanoes have no per-dot interactions — preserve that by no-op'ing.
-		if (this.termType === SINGLECELL_CELLTYPE) return
-
 		const points = this.viewData.pointData as DataPointEntry[]
 		if (!points || points.length === 0) return
 

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -230,17 +230,20 @@ export class VolcanoViewModel {
 		}
 
 		if (this.termType == SINGLECELL_CELLTYPE) {
-			// Positive fold-change = up in the selected cluster, so the cluster
+			// The "group name" prefix is the SC config's `DEgenes.termId`
+			// (e.g. "Cluster" for GDC) — it's the column whose value
+			// `categoryName` identifies, so the dataset already names it.
+			// Positive fold-change = up in the selected group, so the group
 			// label goes on the right and the complement on the left.
-			const clusterLabel = `Cluster ${this.config.categoryName}`
+			const groupLabel = `${this.config.termId} ${this.config.categoryName}`
 			return {
 				y: plotDim.top.y + 10,
 				first: {
-					label: getLabel(`Not in ${clusterLabel}`),
+					label: getLabel(`Not in ${groupLabel}`),
 					x: 0
 				},
 				second: {
-					label: getLabel(clusterLabel),
+					label: getLabel(groupLabel),
 					x: this.settings.width
 				}
 			}

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -203,7 +203,13 @@ export class VolcanoViewModel {
 		// caseColor: string,
 		// controlColor: string
 	) {
-		if (this.termType != GENE_EXPRESSION && this.termType != DNA_METHYLATION && this.termType != PROTEOME_DAP) return
+		if (
+			this.termType != GENE_EXPRESSION &&
+			this.termType != DNA_METHYLATION &&
+			this.termType != PROTEOME_DAP &&
+			this.termType != SINGLECELL_CELLTYPE
+		)
+			return
 		const getLabel = (name: string) => {
 			if (name.length >= 25) return name.substring(0, 20) + '...'
 			return name
@@ -218,6 +224,23 @@ export class VolcanoViewModel {
 				},
 				second: {
 					label: getLabel(`Case (${this.response.sample_size2})`),
+					x: this.settings.width
+				}
+			}
+		}
+
+		if (this.termType == SINGLECELL_CELLTYPE) {
+			// Positive fold-change = up in the selected cluster, so the cluster
+			// label goes on the right and the complement on the left.
+			const clusterLabel = `Cluster ${this.config.categoryName}`
+			return {
+				y: plotDim.top.y + 10,
+				first: {
+					label: getLabel(`Not in ${clusterLabel}`),
+					x: 0
+				},
+				second: {
+					label: getLabel(clusterLabel),
 					x: this.settings.width
 				}
 			}

--- a/client/plots/volcano/viewModel/VolcanoViewModel.ts
+++ b/client/plots/volcano/viewModel/VolcanoViewModel.ts
@@ -101,10 +101,10 @@ export class VolcanoViewModel {
 
 	setDataType() {
 		if (this.termType == GENE_EXPRESSION) return 'genes'
-		else if (this.termType == DNA_METHYLATION) return 'promoters'
-		else if (this.termType == SINGLECELL_CELLTYPE) return 'genes' //'cells'??
-		else if (this.termType == PROTEOME_DAP) return 'proteins'
-		else throw new Error(`Unknown termType: ${this.termType}`)
+		if (this.termType == DNA_METHYLATION) return 'promoters'
+		if (this.termType == SINGLECELL_CELLTYPE) return 'genes'
+		if (this.termType == PROTEOME_DAP) return 'proteins'
+		throw new Error(`Unknown termType: ${this.termType}`)
 	}
 
 	setMinMaxValues() {
@@ -216,6 +216,7 @@ export class VolcanoViewModel {
 		}
 
 		if (this.termType == PROTEOME_DAP) {
+			// FIXME this shouldn't be needed. there should be a way for caller to supply names for each group, and avoid this special logic and SINGLECELL_CELLTYPE
 			return {
 				y: plotDim.top.y + 10,
 				first: {
@@ -230,11 +231,12 @@ export class VolcanoViewModel {
 		}
 
 		if (this.termType == SINGLECELL_CELLTYPE) {
-			// The "group name" prefix is the SC config's `DEgenes.termId`
-			// (e.g. "Cluster" for GDC) — it's the column whose value
-			// `categoryName` identifies, so the dataset already names it.
-			// Positive fold-change = up in the selected group, so the group
-			// label goes on the right and the complement on the left.
+			/* quick fix - this only works for gdc's precomputed DE genes (selected cluster vs rest of cells)
+			this won't work for dynamic DE (user-selected cluster A vs cluster B)
+			thus not okay to hardcode `Not in` here
+			!! FIXME !!
+			sc should come up with actual names, and cell counts, for precompute/dynamic groups
+			*/
 			const groupLabel = `${this.config.termId} ${this.config.categoryName}`
 			return {
 				y: plotDim.top.y + 10,

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Enabled tooltip hover, GSEA support, and nicer group labels in GDC SCCT

--- a/rust/src/volcano.rs
+++ b/rust/src/volcano.rs
@@ -8,11 +8,11 @@
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use plotters::prelude::*;
-use plotters::style::ShapeStyle;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::error::Error;
 use std::io::{self, Read};
+use tiny_skia::{Paint, PathBuilder, Pixmap, Stroke, Transform};
 
 #[derive(Deserialize)]
 struct Input {
@@ -36,6 +36,14 @@ struct Input {
     /// only the overlay list is truncated to the most-significant N.
     #[serde(default)]
     max_interactive_dots: Option<usize>,
+    /// Hi-DPI scale factor (e.g. 2.0 on retina). Defaults to 1.0 when absent
+    /// so existing callers don't change behavior. The PNG is rasterized at
+    /// `(pixel_* + pad) * dpr` device pixels and is rendered at the CSS-space
+    /// dimensions reported in `plot_extent.pixel_*` — the browser uses the
+    /// extra resolution for sharpness on hi-DPI displays. Mirror of
+    /// manhattan_plot.rs's `device_pixel_ratio` handling.
+    #[serde(default)]
+    device_pixel_ratio: Option<f64>,
 }
 
 #[derive(Serialize)]
@@ -189,14 +197,23 @@ fn main() -> Result<(), Box<dyn Error>> {
     let x_max = x_max_unpadded + x_pad_data;
     let y_min = y_min_unpadded - y_pad_data;
     let y_max = y_max_unpadded + y_pad_data;
-    let mut buffer = vec![0u8; (w as usize) * (h as usize) * 3];
-    // Per-point pixel coords as plotters actually rasterizes them. Returned to
-    // the client so the SVG overlay rings sit exactly on top of the PNG dots
-    // instead of being recomputed from data coords (which loses sub-pixel
-    // precision under plotters' integer truncation).
-    let mut all_pixel_coords: Vec<(f64, f64)> = Vec::with_capacity(points.len());
+
+    // Hi-DPR scaling. The buffer/chart are sized in device pixels (CSS * dpr)
+    // and the drawn radius/stroke are scaled the same way, so the PNG is
+    // sharper on retina. backend_coord returns device-pixel coords; we divide
+    // by dpr below to keep `pixel_x/pixel_y` in CSS-space (which is what the
+    // SVG overlay coordinate system uses). Mirror of manhattan_plot.rs.
+    let dpr = input.device_pixel_ratio.unwrap_or(1.0).max(1.0);
+    let w_hd = ((w as f64) * dpr) as u32;
+    let h_hd = ((h as f64) * dpr) as u32;
+
+    let mut buffer = vec![0u8; (w_hd as usize) * (h_hd as usize) * 3];
+    // Per-point pixel coords as plotters' chart maps them. Captured in device
+    // pixels so tiny-skia can draw the AA rings exactly at those positions;
+    // we keep a CSS-space copy below for the SVG overlay.
+    let mut pixel_coords_hd: Vec<(f64, f64)> = Vec::with_capacity(points.len());
     {
-        let backend = BitMapBackend::with_buffer(&mut buffer, (w, h));
+        let backend = BitMapBackend::with_buffer(&mut buffer, (w_hd, h_hd));
         let root = backend.into_drawing_area();
         root.fill(&WHITE)?;
 
@@ -213,43 +230,76 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Threshold guide lines are drawn by the SVG overlay on the client, not
         // here — double-drawing them would add stray lines offset by axis padding.
+        // The dots themselves are drawn below with tiny-skia for true AA; here
+        // plotters just gives us a white-background buffer and the data-to-pixel
+        // mapping. Mirror of manhattan_plot.rs.
 
-        // Resolve colors once. Up/down fall back to `color_sig` when absent.
-        let color_sig = rgb(&input.color_significant, (214, 39, 40));
-        let color_non = rgb(&input.color_nonsignificant, (0, 0, 0));
-        let resolve = |o: &Option<String>| o.as_deref().map(|s| rgb(s, (214, 39, 40))).unwrap_or(color_sig);
-        let color_up = resolve(&input.color_significant_up);
-        let color_down = resolve(&input.color_significant_down);
-
-        // Stroke-only rings at full opacity so each ring is the exact configured
-        // group color — matching the hue the SVG overlay uses.
-        let ring = |c: RGBColor| ShapeStyle {
-            color: c.into(),
-            filled: false,
-            stroke_width: 1,
-        };
-
-        // Draw non-significant first so significant rings overlay on top.
-        chart.draw_series(
-            points
-                .iter()
-                .filter(|p| !p.significant)
-                .map(|p| Circle::new((p.fc, p.y), radius_px, ring(color_non))),
-        )?;
-        chart.draw_series(points.iter().filter(|p| p.significant).map(|p| {
-            let c = if p.fc > 0.0 { color_up } else { color_down };
-            Circle::new((p.fc, p.y), radius_px, ring(c))
-        }))?;
-
-        // Mirror manhattan_plot.rs: capture the exact pixel coords plotters
-        // used for each point so the client overlay can land on them precisely.
         for p in points.iter() {
             let (px, py) = chart.backend_coord(&(p.fc, p.y));
-            all_pixel_coords.push((px as f64, py as f64));
+            pixel_coords_hd.push((px as f64, py as f64));
         }
 
         root.present()?;
     }
+
+    // Convert plotters' RGB buffer to a tiny-skia RGBA pixmap, then stroke the
+    // dots on top with anti-aliasing — gives crisp rings even when the user
+    // zooms in past native DPR. Plotters' BitMapBackend has no AA on shapes,
+    // which is why ring edges looked chunky before this rewrite.
+    let mut pixmap = Pixmap::new(w_hd, h_hd).ok_or("failed to create pixmap")?;
+    {
+        let data = pixmap.data_mut();
+        for (src, dst) in buffer.chunks_exact(3).zip(data.chunks_exact_mut(4)) {
+            dst[..3].copy_from_slice(src);
+            dst[3] = 255;
+        }
+    }
+
+    // Resolve colors once. Up/down fall back to `color_sig` when absent.
+    let color_sig = rgb(&input.color_significant, (214, 39, 40));
+    let color_non = rgb(&input.color_nonsignificant, (0, 0, 0));
+    let resolve = |o: &Option<String>| o.as_deref().map(|s| rgb(s, (214, 39, 40))).unwrap_or(color_sig);
+    let color_up = resolve(&input.color_significant_up);
+    let color_down = resolve(&input.color_significant_down);
+
+    let radius_hd_f = radius_px as f32 * dpr as f32;
+    // 1 CSS-pixel-wide stroke at hi-DPR. The stroke straddles the path, so the
+    // visible ring thickness is `stroke_width` device px ≈ 1 CSS px.
+    let mut stroke = Stroke::default();
+    stroke.width = dpr as f32;
+    let mut paint = Paint::default();
+    paint.anti_alias = true;
+
+    let stroke_ring = |pixmap: &mut Pixmap, paint: &mut Paint, color: RGBColor, px: f32, py: f32| {
+        paint.set_color_rgba8(color.0, color.1, color.2, 255);
+        let mut pb = PathBuilder::new();
+        pb.push_circle(px, py, radius_hd_f);
+        if let Some(path) = pb.finish() {
+            pixmap.stroke_path(&path, paint, &stroke, Transform::identity(), None);
+        }
+    };
+
+    // Draw non-significant first so significant rings overlay on top.
+    for (i, p) in points.iter().enumerate() {
+        if p.significant {
+            continue;
+        }
+        let (px, py) = pixel_coords_hd[i];
+        stroke_ring(&mut pixmap, &mut paint, color_non, px as f32, py as f32);
+    }
+    for (i, p) in points.iter().enumerate() {
+        if !p.significant {
+            continue;
+        }
+        let (px, py) = pixel_coords_hd[i];
+        let c = if p.fc > 0.0 { color_up } else { color_down };
+        stroke_ring(&mut pixmap, &mut paint, c, px as f32, py as f32);
+    }
+
+    // CSS-space coords for the SVG overlay — divide the device-pixel positions
+    // by dpr. The overlay does not know about hi-DPR; the PNG sizing handles
+    // sharpness for us.
+    let all_pixel_coords: Vec<(f64, f64)> = pixel_coords_hd.iter().map(|(x, y)| (x / dpr, y / dpr)).collect();
 
     // Build the interactive `dots` list: threshold-passers sorted asc by the
     // chosen p-value column, optionally capped at `max_interactive_dots`.
@@ -273,7 +323,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .collect();
 
     let output = Output {
-        png: BASE64.encode(&encode_rgb_to_png(&buffer, w, h)?),
+        png: BASE64.encode(&pixmap.encode_png()?),
         plot_extent: PlotExtent {
             x_min,
             x_max,
@@ -301,14 +351,4 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("{}", serde_json::to_string(&output)?);
     Ok(())
-}
-
-/// Convert a plotters RGB buffer (3 bytes/px) to a PNG via tiny-skia (4 bytes/px).
-fn encode_rgb_to_png(rgb: &[u8], w: u32, h: u32) -> Result<Vec<u8>, Box<dyn Error>> {
-    let mut pixmap = tiny_skia::Pixmap::new(w, h).ok_or("failed to create pixmap")?;
-    for (src, dst) in rgb.chunks_exact(3).zip(pixmap.data_mut().chunks_exact_mut(4)) {
-        dst[..3].copy_from_slice(src);
-        dst[3] = 255;
-    }
-    Ok(pixmap.encode_png()?)
 }

--- a/server/src/renderVolcano.ts
+++ b/server/src/renderVolcano.ts
@@ -46,6 +46,14 @@ export async function renderVolcano<T extends DataEntry>(
 			? null
 			: clampedInt(req.maxInteractiveDots, 0, MAX_INTERACTIVE_DOTS, 'maxInteractiveDots')
 
+	// Clamp to a sane band. The client oversamples by 2× to keep post-render
+	// browser zoom sharp, so retina (DPR 2) sends 4 at base zoom and up to ~10
+	// at 250% zoom. Cap at 6 so the bitmap memory stays bounded (a 400px plot
+	// at DPR 6 is a 2400×2400 pixmap ≈ 23MB) while still oversampling the
+	// common cases. Without the upper bound, a malformed client value would
+	// blow up bitmap memory quadratically.
+	const devicePixelRatio = clampedFloat(req.devicePixelRatio ?? 1.0, 1.0, 6.0, 'devicePixelRatio')
+
 	const input = {
 		rows,
 		p_value_type: req.significanceThresholds.pValueType,
@@ -58,7 +66,8 @@ export async function renderVolcano<T extends DataEntry>(
 		color_significant_down: req.colorSignificantDown ?? null,
 		color_nonsignificant: req.colorNonsignificant ?? '#000000',
 		dot_radius: dotRadius,
-		max_interactive_dots: maxInteractiveDots
+		max_interactive_dots: maxInteractiveDots,
+		device_pixel_ratio: devicePixelRatio
 	}
 	const t0 = Date.now()
 	const raw = await run_rust('volcano', JSON.stringify(input))

--- a/shared/types/src/routes/termdb.DE.ts
+++ b/shared/types/src/routes/termdb.DE.ts
@@ -62,6 +62,12 @@ export type VolcanoRenderRequest = {
 	 * The server still renders every row into `volcanoPng`; this only caps the
 	 * interactive list. Capped to the most-significant rows (smallest p-value). */
 	maxInteractiveDots?: number
+	/** Hi-DPI scale factor from `window.devicePixelRatio` (e.g. 2.0 on retina).
+	 * The PNG is rasterized at `pixelWidth*dpr × pixelHeight*dpr` device pixels
+	 * but reported (and rendered in the SVG) at the CSS-space dimensions, so
+	 * the browser uses the extra resolution for sharpness. Defaults to 1.0
+	 * server-side. */
+	devicePixelRatio?: number
 }
 
 /** Everything the client needs to draw one volcano: the pre-rendered PNG of


### PR DESCRIPTION
# Description

Four fixes total. Three to the single-cell cell-type (SCCT) tab of differential analysis:

- **Hover tooltips on significant dots.** `attachInteractions` was short-circuiting for `SINGLECELL_CELLTYPE`, so the cover-rect / quadtree / tooltip pipeline never bound. Dropped the early-return; the existing GE tooltip path renders correctly for SCCT data (uses `gene_name`, `fold_change`, `original_p_value`, `adjusted_p_value`) and `getActionMenuOpts` already returns `[]` for SCCT so the single-hit action menu shows just the info panel with no buttons.
- **Group labels at the top of the plot.** `setTermInfo` ignored SCCT and returned `undefined`. Added an SCCT branch: `Cluster {categoryName}` on the right (positive fold-change = up in cluster) and `Not in Cluster {categoryName}` on the left. No `sample_size1/2` exists for SCCT, so the labels intentionally omit the trailing `(n)`.
- **GSEA tab now runs.** GSEA `init()` only knew the `cacheId` path (DE/DM) and the `dapParams` path (proteome); SCCT has neither, so init threw "No DE cacheId returned from volcano model" and the tab silently died. Added an SCCT branch that fetches `termdb/singlecellDEgenes` **without** `volcanoRender` (so the route returns the full ranked gene array, not the threshold-passing `dots` subset) and stores `{ genes, fold_change, genes_length, genome }` inline on `gsea_params`. `render_gsea`'s existing inline-genes path (previously only reached by the legacy `singleCellPlot.renderGSEA`) handles it.
- **High-resolution volcano render** Previously the render would be pixelated on higher dpi displays. Now uses device pixel ratio in a manner like manhattan plot to render the plot in a high res way


## Test plan

- [x] In GDC, open a single-cell sample → Differential expression → pick a cluster:
  - [x] Hovering a significant dot shows the gene tooltip with fold-change + p-values
  - [x] Plot header shows `Not in Cluster N` (left) and `Cluster N` (right)
  - [x] Clicking the **Gene Set Enrichment Analysis** tab fires `termdb/singlecellDEgenes` and renders the pathway dropdown (no console error)
  - [x] Picking a pathway returns enrichment results
- [x] Confirm the GE volcano is unchanged: hover, term-info labels with sample sizes, and GSEA via the cacheId path all still work.
- [ ] Confirm the DAP volcano is unchanged.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
