### PR TITLE
do not load dsCredentials entry for a dslabel that was not loaded

### DIFF
--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -39,7 +39,7 @@ export async function getAuthApi(app, genomes, _serverconfig = null, assignShare
 	// !!! do not expose the loaded dsCredentials to other code that imports serverconfig.json !!!
 	delete serverconfig.dsCredentials
 
-	const credEmbedders = await validateDsCredentials(creds)
+	const credEmbedders = await validateDsCredentials(creds, genomes)
 	// no need to set up auth middleware and routes if there are no dsCredential entries
 	const _authApi = credEmbedders.size ? new AuthApi(creds, app, genomes, serverconfig) : AuthApiOpen
 	//console.log(44, credEmbedders, authApi === AuthApiProtected)

--- a/server/src/auth/auth.dsCredentials.ts
+++ b/server/src/auth/auth.dsCredentials.ts
@@ -105,7 +105,7 @@ export async function validateDsCredentials(creds: ServerConfigDsCredentials, ge
 	// to be used by app middleware to set CORS response headers
 	const credEmbedders: Set<string> = new Set()
 	// detect loaded datasets in order to filter out credentials that are not matched and do not need to be loaded
-	const loadedDslabels = Object.values(genomes || {}).reduce((loadedDs: string[], g?: any) => {
+	const loadedDslabels = Object.values(genomes || {}).reduce((loadedDs: string[], g: any) => {
 		if (typeof g.datasets === 'object') loadedDs.push(...Object.keys(g.datasets))
 		return loadedDs
 	}, [])
@@ -119,8 +119,9 @@ export async function validateDsCredentials(creds: ServerConfigDsCredentials, ge
 		// For dslabel exact strings or glob pattern, delete the credentials entry if:
 		// - there is a genomes argument, so support legacy validateDsCredentials() without a second argument.
 		// - that dslabel pattern is not detected as being loaded.
-		// This prevents healthcheck errors if there is a cred.processor.test() or cred.type == 'basic'.
-		if (genomes && !dslabel.includes('*') && !loadedDslabels.find(ds => isMatch(ds, dslabel))) {
+		// Preserve the catch-all '*' entry, but prune any other unmatched pattern to prevent
+		// the /healthcheck route handler from processing credential test/checks for non-existent datasets.
+		if (genomes && dslabel != '*' && !loadedDslabels.find(ds => isMatch(ds, dslabel))) {
 			delete creds[dslabel]
 			continue
 		}

--- a/server/src/auth/auth.dsCredentials.ts
+++ b/server/src/auth/auth.dsCredentials.ts
@@ -121,7 +121,7 @@ export async function validateDsCredentials(creds: ServerConfigDsCredentials, ge
 		// - that dslabel pattern is not detected as being loaded.
 		// Preserve the catch-all '*' entry, but prune any other unmatched pattern to prevent
 		// the /healthcheck route handler from processing credential test/checks for non-existent datasets.
-		if (genomes && dslabel != '*' && !loadedDslabels.find(ds => isMatch(ds, dslabel))) {
+		if (genomes && dslabel != '*' && !loadedDslabels.find(ds => ds === dslabel || isMatch(ds, dslabel))) {
 			delete creds[dslabel]
 			continue
 		}

--- a/server/src/auth/auth.dsCredentials.ts
+++ b/server/src/auth/auth.dsCredentials.ts
@@ -91,7 +91,10 @@ type JwtCredEntry = {
 // 	}
 // }
 
-export async function validateDsCredentials(creds: ServerConfigDsCredentials) {
+export async function validateDsCredentials(
+	creds: ServerConfigDsCredentials,
+	genomes: { [genomeName: string]: any } = {}
+) {
 	mayReshapeDsCredentials(creds)
 	const key = 'secrets' // to prevent a detect-secrets hook issue
 	if (typeof creds[key] == 'string') {
@@ -101,9 +104,21 @@ export async function validateDsCredentials(creds: ServerConfigDsCredentials) {
 	// track which domains are allowed to embed proteinpaint with credentials,
 	// to be used by app middleware to set CORS response headers
 	const credEmbedders: Set<string> = new Set()
+	// detect loaded datasets in order to filter out credentials that are not matched and does not need to be loaded
+	const loadedDslabels = Object.values(genomes).reduce((loadedDs: string[], g: any) => {
+		if (typeof g.datasets === 'object') loadedDs.push(...Object.keys(g.datasets))
+		return loadedDs
+	}, [])
 
 	for (const [dslabel, _ds] of Object.entries(creds)) {
 		if (dslabel[0] == '#') {
+			delete creds[dslabel]
+			continue
+		}
+		// For exact dslabels with no wildcard characters, delete the credentials entry
+		// if that exact dslabel is not detected as being loaded. This prevents healthcheck
+		// errors if there is a cred.processor.test() or cred.type == 'basic'.
+		if (!dslabel.includes('*') && !loadedDslabels.includes(dslabel)) {
 			delete creds[dslabel]
 			continue
 		}
@@ -115,7 +130,7 @@ export async function validateDsCredentials(creds: ServerConfigDsCredentials) {
 		const headerKey = ds.headerKey || 'x-ds-access-token'
 		delete ds.headerKey
 
-		for (const serverRoute in ds) {
+		for (const serverRoute of Object.keys(ds)) {
 			const route = ds[serverRoute]
 			for (const embedderHost in route) {
 				credEmbedders.add(embedderHost)

--- a/server/src/auth/auth.dsCredentials.ts
+++ b/server/src/auth/auth.dsCredentials.ts
@@ -1,4 +1,7 @@
 import { addDemoTokenCred } from './auth.demoToken.ts'
+import mm from 'micromatch'
+
+const { isMatch } = mm
 
 // NOTES:
 // 1. list keys in the desired matching order, for example, the catch-all '*' pattern should be entered last
@@ -91,10 +94,7 @@ type JwtCredEntry = {
 // 	}
 // }
 
-export async function validateDsCredentials(
-	creds: ServerConfigDsCredentials,
-	genomes: { [genomeName: string]: any } = {}
-) {
+export async function validateDsCredentials(creds: ServerConfigDsCredentials, genomes?: { [genomeName: string]: any }) {
 	mayReshapeDsCredentials(creds)
 	const key = 'secrets' // to prevent a detect-secrets hook issue
 	if (typeof creds[key] == 'string') {
@@ -104,21 +104,23 @@ export async function validateDsCredentials(
 	// track which domains are allowed to embed proteinpaint with credentials,
 	// to be used by app middleware to set CORS response headers
 	const credEmbedders: Set<string> = new Set()
-	// detect loaded datasets in order to filter out credentials that are not matched and does not need to be loaded
-	const loadedDslabels = Object.values(genomes).reduce((loadedDs: string[], g: any) => {
+	// detect loaded datasets in order to filter out credentials that are not matched and do not need to be loaded
+	const loadedDslabels = Object.values(genomes || {}).reduce((loadedDs: string[], g?: any) => {
 		if (typeof g.datasets === 'object') loadedDs.push(...Object.keys(g.datasets))
 		return loadedDs
 	}, [])
 
+	// dslabel may be exact or a pattern
 	for (const [dslabel, _ds] of Object.entries(creds)) {
 		if (dslabel[0] == '#') {
 			delete creds[dslabel]
 			continue
 		}
-		// For exact dslabels with no wildcard characters, delete the credentials entry
-		// if that exact dslabel is not detected as being loaded. This prevents healthcheck
-		// errors if there is a cred.processor.test() or cred.type == 'basic'.
-		if (!dslabel.includes('*') && !loadedDslabels.includes(dslabel)) {
+		// For dslabel exact strings or glob pattern, delete the credentials entry if:
+		// - there is a genomes argument, so support legacy validateDsCredentials() without a second argument.
+		// - that dslabel pattern is not detected as being loaded.
+		// This prevents healthcheck errors if there is a cred.processor.test() or cred.type == 'basic'.
+		if (genomes && !dslabel.includes('*') && !loadedDslabels.find(ds => isMatch(ds, dslabel))) {
 			delete creds[dslabel]
 			continue
 		}

--- a/server/src/auth/test/auth.dsCredentials.unit.spec.ts
+++ b/server/src/auth/test/auth.dsCredentials.unit.spec.ts
@@ -43,15 +43,28 @@ tape('validateDsCredentials: skips and removes comment keys starting with #', as
 
 tape('validateDsCredentials: removes entries for exact dslabels that were not loaded', async function (test) {
 	test.timeoutAfter(500)
-	test.plan(2)
+	test.plan(4)
 
-	const creds: any = {
-		someDs: { termdb: { '*': { type: 'basic', password: 'test' } } }, // pragma: allowlist secret
-		realDs: { termdb: { '*': { type: 'basic', password: 'test' } } } // pragma: allowlist secret
+	{
+		const creds: any = {
+			someDs: { termdb: { '*': { type: 'basic', password: 'test' } } }, // pragma: allowlist secret
+			realDs: { termdb: { '*': { type: 'basic', password: 'test' } } } // pragma: allowlist secret
+		}
+		await validateDsCredentials(creds, { hg38: { datasets: { realDs: {} } } })
+		test.equal(creds['someDs'], undefined, 'should remove cred entries for dslabels that were not loaded')
+		test.ok(creds['realDs'], 'should keep cred entries for dslabels that were loaded')
 	}
-	await validateDsCredentials(creds, { hg38: { datasets: { realDs: {} } } })
-	test.equal(creds['someDs'], undefined, 'should remove cred entries for dslabels that were not loaded')
-	test.ok(creds['realDs'], 'should keep cred entries for dslabels that were loaded')
+
+	{
+		const creds: any = {
+			someDs: { termdb: { '*': { type: 'basic', password: 'test' } } }, // pragma: allowlist secret
+			realDs: { termdb: { '*': { type: 'basic', password: 'test' } } } // pragma: allowlist secret
+		}
+		await validateDsCredentials(creds)
+		test.ok(creds['someDs'], 'should keep cred entries if the 2nd argument is not supplied')
+		test.ok(creds['realDs'], 'should keep cred entries for dslabels that were loaded')
+	}
+
 	test.end()
 })
 

--- a/server/src/auth/test/auth.dsCredentials.unit.spec.ts
+++ b/server/src/auth/test/auth.dsCredentials.unit.spec.ts
@@ -41,9 +41,9 @@ tape('validateDsCredentials: skips and removes comment keys starting with #', as
 	test.end()
 })
 
-tape('validateDsCredentials: removes entries for exact dslabels that were not loaded', async function (test) {
+tape('validateDsCredentials: removes entries for dslabel patterns that were not loaded', async function (test) {
 	test.timeoutAfter(500)
-	test.plan(4)
+	test.plan(6)
 
 	{
 		const creds: any = {
@@ -63,6 +63,16 @@ tape('validateDsCredentials: removes entries for exact dslabels that were not lo
 		await validateDsCredentials(creds)
 		test.ok(creds['someDs'], 'should keep cred entries if the 2nd argument is not supplied')
 		test.ok(creds['realDs'], 'should keep cred entries for dslabels that were loaded')
+	}
+
+	{
+		const creds: any = {
+			someDs: { termdb: { '*': { type: 'basic', password: 'test' } } }, // pragma: allowlist secret
+			'realD*': { termdb: { '*': { type: 'basic', password: 'test' } } } // pragma: allowlist secret
+		}
+		await validateDsCredentials(creds, { hg38: { datasets: { realDs: {}, someDs: {}, ds0: {} } } })
+		test.ok(creds['someDs'], 'should keep cred entries for an exact dslabel match')
+		test.ok(creds['realD*'], 'should keep cred entries for a dslabel pattern match')
 	}
 
 	test.end()

--- a/server/src/auth/test/auth.dsCredentials.unit.spec.ts
+++ b/server/src/auth/test/auth.dsCredentials.unit.spec.ts
@@ -35,9 +35,23 @@ tape('validateDsCredentials: skips and removes comment keys starting with #', as
 		'#comment': { termdb: { '*': { type: 'basic', password: 'test' } } }, // pragma: allowlist secret
 		realDs: { termdb: { '*': { type: 'basic', password: 'test' } } } // pragma: allowlist secret
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { realDs: {} } } })
 	test.equal(creds['#comment'], undefined, 'should remove comment keys starting with #')
 	test.ok(creds['realDs'], 'should keep non-comment keys')
+	test.end()
+})
+
+tape('validateDsCredentials: removes entries for exact dslabels that were not loaded', async function (test) {
+	test.timeoutAfter(500)
+	test.plan(2)
+
+	const creds: any = {
+		someDs: { termdb: { '*': { type: 'basic', password: 'test' } } }, // pragma: allowlist secret
+		realDs: { termdb: { '*': { type: 'basic', password: 'test' } } } // pragma: allowlist secret
+	}
+	await validateDsCredentials(creds, { hg38: { datasets: { realDs: {} } } })
+	test.equal(creds['someDs'], undefined, 'should remove cred entries for dslabels that were not loaded')
+	test.ok(creds['realDs'], 'should keep cred entries for dslabels that were loaded')
 	test.end()
 })
 
@@ -55,7 +69,7 @@ tape('validateDsCredentials: basic type gets expected defaults', async function 
 			}
 		}
 	}
-	const credEmbedders = await validateDsCredentials(creds)
+	const credEmbedders = await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 	const cred = creds.testDs.termdb['test.example.com']
 	test.equal(cred.secret, 'mypassword', 'should copy password to secret for basic type')
 	test.equal(cred.authRoute, '/dslogin', 'should set authRoute to /dslogin for basic type')
@@ -80,7 +94,7 @@ tape('validateDsCredentials: jwt type gets expected defaults', async function (t
 			}
 		}
 	}
-	const credEmbedders = await validateDsCredentials(creds)
+	const credEmbedders = await validateDsCredentials(creds, { hg38: { datasets: { jwtDs: {} } } })
 	const cred = creds.jwtDs.termdb['jwt.example.com']
 	test.equal(cred.authRoute, '/jwt-status', 'should set authRoute to /jwt-status for jwt type')
 	test.equal(cred.headerKey, 'x-ds-access-token', 'should set default headerKey for jwt type')
@@ -104,7 +118,7 @@ tape('validateDsCredentials: wildcard route is renamed from * to /**', async fun
 			}
 		}
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 	test.ok(creds.testDs['/**'], 'should rename * route to /**')
 	test.equal(creds.testDs['*'], undefined, 'should remove the original * route key')
 	test.end()
@@ -125,7 +139,7 @@ tape('validateDsCredentials: looseIpCheck is converted to ipCheck: loose', async
 			}
 		}
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 	const cred = creds.testDs.termdb['*']
 	test.equal(cred.ipCheck, 'loose', 'should convert looseIpCheck to ipCheck: loose')
 	test.equal(cred.looseIpCheck, undefined, 'should remove looseIpCheck property')
@@ -146,7 +160,7 @@ tape('validateDsCredentials: forbidden type is accepted without error', async fu
 		}
 	}
 	try {
-		await validateDsCredentials(creds)
+		await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 		test.pass('should not throw for forbidden type')
 	} catch (e) {
 		test.fail(`should not throw: ${e}`)
@@ -168,7 +182,7 @@ tape('validateDsCredentials: open type is accepted without error', async functio
 		}
 	}
 	try {
-		await validateDsCredentials(creds)
+		await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 		test.pass('should not throw for open type')
 	} catch (e) {
 		test.fail(`should not throw: ${e}`)
@@ -190,7 +204,7 @@ tape('validateDsCredentials: unknown type throws an error', async function (test
 		}
 	}
 	try {
-		await validateDsCredentials(creds)
+		await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 		test.fail('should throw for unknown credential type')
 	} catch (e) {
 		test.ok(String(e).includes('unknown cred.type'), 'should throw an error mentioning unknown cred.type')
@@ -213,7 +227,7 @@ tape('validateDsCredentials: cookieId is set from headerKey for termdb route', a
 			}
 		}
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 	const cred = creds.testDs.termdb['*']
 	test.equal(cred.cookieId, 'custom-header-key', 'should use headerKey as cookieId for termdb route')
 	test.end()
@@ -233,7 +247,7 @@ tape('validateDsCredentials: cookieId uses dslabel+route+embedder pattern for no
 			}
 		}
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { myDs: {} } } })
 	const cred = creds.myDs.burden['myEmbedder']
 	test.equal(
 		cred.cookieId,
@@ -253,7 +267,7 @@ tape('validateDsCredentials: legacy type=login is reshaped correctly', async fun
 			password: 'legacyPassword' // pragma: allowlist secret
 		}
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { legacyDs: {} } } })
 	test.equal(creds.legacyDs.type, undefined, 'should remove legacy type field')
 	test.ok(creds.legacyDs['/**'], 'should create /** route key from legacy login type')
 	const cred = creds.legacyDs['/**']['*']
@@ -277,7 +291,7 @@ tape('validateDsCredentials: legacy type=jwt with embedders is reshaped correctl
 			}
 		}
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { legacyJwtDs: {} } } })
 	test.equal(creds.legacyJwtDs.type, undefined, 'should remove legacy type field')
 	test.ok(creds.legacyJwtDs.termdb, 'should create termdb route key from legacy jwt type')
 	const cred = creds.legacyJwtDs.termdb['localhost']
@@ -293,7 +307,7 @@ tape('validateDsCredentials: deprecated secrets key throws an error', async func
 		secrets: 'deprecated-secrets-value' // pragma: allowlist secret
 	}
 	try {
-		await validateDsCredentials(creds)
+		await validateDsCredentials(creds, { hg38: { datasets: { termdb: {} } } })
 		test.fail('should throw for deprecated secrets key')
 	} catch (e) {
 		test.ok(String(e).includes('deprecated'), 'should throw an error mentioning deprecated')
@@ -316,7 +330,7 @@ tape('validateDsCredentials: ds-level headerKey overrides default for all routes
 			}
 		}
 	}
-	await validateDsCredentials(creds)
+	await validateDsCredentials(creds, { hg38: { datasets: { testDs: {} } } })
 	const cred = creds.testDs.termdb['*']
 	test.equal(
 		cred.headerKey,

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -9,7 +9,7 @@ const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, '../packag
 
 export async function getStat(genomes) {
 	if (!versionInfo.deps) setVersionInfoDeps() // set only once
-	const auth = (await authApi.getHealth()) as undefined | { errors?: string[] }
+	const auth = (await authApi.getHealth(genomes)) as undefined | { errors?: string[] }
 	const health = {
 		status: auth?.errors?.length ? 'error' : 'ok',
 		genomes: {},

--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -9,7 +9,7 @@ const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, '../packag
 
 export async function getStat(genomes) {
 	if (!versionInfo.deps) setVersionInfoDeps() // set only once
-	const auth = (await authApi.getHealth(genomes)) as undefined | { errors?: string[] }
+	const auth = (await authApi.getHealth()) as undefined | { errors?: string[] }
 	const health = {
 		status: auth?.errors?.length ? 'error' : 'ok',
 		genomes: {},

--- a/server/src/test/auth.unit.spec.js
+++ b/server/src/test/auth.unit.spec.js
@@ -155,7 +155,7 @@ tape(`initialization, non-empty credentials`, async test => {
 			}
 		}
 		const serverconfig = { debugmode, cachedir, dsCredentials, secrets }
-		const { app, authApi } = await appInit(serverconfig)
+		const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { testDs: {} } } })
 		const middlewares = Object.keys(app.middlewares)
 		test.deepEqual(middlewares, ['*'], 'should set a global middleware when dsCredentials is not empty')
 		const routes = Object.keys(app.routes)
@@ -169,7 +169,7 @@ tape(`initialization, non-empty credentials`, async test => {
 
 	{
 		const dsCredentials = {
-			testds: {
+			testDs: {
 				'*': {
 					'*': {
 						type: 'basic',
@@ -179,7 +179,7 @@ tape(`initialization, non-empty credentials`, async test => {
 			}
 		}
 		const serverconfig = { debugmode, cachedir, dsCredentials, secrets }
-		const { app, authApi } = await appInit(serverconfig)
+		const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { testDs: {} } } })
 		const middlewares = Object.keys(app.middlewares)
 		test.deepEqual(
 			middlewares,
@@ -290,7 +290,7 @@ tape('legacy reshape', async test => {
 		dsCredentials,
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {}, ds1: {} } } })
 
 	test.deepEqual(
 		JSON.parse(JSON.stringify(dsCredentials)),
@@ -435,7 +435,7 @@ tape(`a valid request`, async test => {
 		},
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 
 	{
 		const req = {
@@ -482,7 +482,7 @@ tape(`mismatched ip address in /jwt-status`, async test => {
 		},
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 	{
 		const req = {
 			query: { embedder: 'localhost', dslabel: 'ds0' },
@@ -538,7 +538,7 @@ tape(`invalid embedder`, async test => {
 		},
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 
 	{
 		const req = {
@@ -592,7 +592,7 @@ tape(`invalid dataset access`, async test => {
 		},
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 
 	{
 		const req = {
@@ -646,7 +646,7 @@ tape(`invalid jwt`, async test => {
 		},
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 
 	{
 		const req = {
@@ -758,7 +758,7 @@ tape(`session handling by the middleware`, async test => {
 		cachedir
 	}
 
-	const { app, authApi } = await appInit(serverconfig, {})
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 
 	{
 		const message = 'should call the next function on a non-protected route'
@@ -931,7 +931,7 @@ tape(`/dslogin`, async test => {
 		},
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 
 	let cookie
 	/*** valid /dslogin request ***/
@@ -1101,7 +1101,7 @@ tape(`req.query.filter, __protected__`, async test => {
 		},
 		cachedir
 	}
-	const { app, authApi } = await appInit(serverconfig)
+	const { app, authApi } = await appInit(serverconfig, { hg38: { datasets: { ds0: {} } } })
 
 	const tvslst = { type: 'tvslst', lst: [{ type: 'tvs', tvs: { term: {}, values: {} } }] }
 


### PR DESCRIPTION
# Description

This fixes an incorrect `/healtcheck` response error, caused by not ignoring `dsCredentials` entry for a dataset that was not loaded.

Test:
- `npm run test:unit` from the server dir
- all client side unit and integration tests
- Manually: Remove or disable a genome datasets entry (may use `"skip": true`), but keep the dsCredentials entry for it. Then open http://localhost:3000/healthcheck: should have `status: 'ok'`, but commenting out the fix in lines 121-123 of `auth.dsCredentials.ts` should have `status: "error"`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
