### PR TITLE
support a serveronfig.features.requiredDslabels option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cd container/dev
 ## Develop
 ### Host Machine development
 
-These scripts require npm v10.2+ and are tested with Node v20+.
+These scripts require npm v11+ and are tested with Node v24+.
 
 ```bash
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ as listed in the [installation instructions](https://docs.google.com/document/d/
 ```bash
 cd proteinpaint
 npm run sethooks
-nvm use 20
+nvm use 24
 npm install
 # follow the instructions at https://docs.google.com/document/d/1tkEHG_vYtT-OifPV-tlPeWQUMsEd3aWAKf5ExOT8G34/edit
 ```

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -249,7 +249,7 @@ function processTrackedDs(trackedDatasets) {
 	let msg = '',
 		missingDslabelMsg = ''
 	const { requiredDslabels } = serverconfig.features
-	if (requiredDslabels) {
+	if (requiredDslabels !== undefined) {
 		if (!Array.isArray(requiredDslabels)) throw `serverconfig.features.requiredDslabels must be an array`
 		// NOTE: This option is separate from serverconfig.features.dslabelFilter since that is an option
 		// to limit the loaded datasets. Here, we detect required dslabels that were not loaded/processed
@@ -276,7 +276,7 @@ function processTrackedDs(trackedDatasets) {
 		// if no dataset loaded successfully, and only if there are genome + dataset entries,
 		// then assume that there may be something wrong with serverconfig and/or code,
 		// not with dataset js/ts files, and crash the server to trigger rollback
-		if (trackedDatasets.length)
+		if (trackedDatasets.length || missingDslabelMsg)
 			throw `${serverconfig.URL}: there were no datasets that loaded successfully` + missingDslabelMsg
 	} else {
 		if (done.length) {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -248,12 +248,14 @@ function processTrackedDs(trackedDatasets) {
 
 	let msg = '',
 		missingDslabelMsg = ''
-	if (serverconfig.features.requiredDslabels) {
+	const { requiredDslabels } = serverconfig.features
+	if (requiredDslabels) {
+		if (!Array.isArray(requiredDslabels)) throw `serverconfig.features.requiredDslabels must be an array`
 		// NOTE: This option is separate from serverconfig.features.dslabelFilter since that is an option
 		// to limit the loaded datasets. Here, we detect required dslabels that were not loaded/processed
 		// during server startup.
-		const requiredDslabels: Set<string> = new Set(serverconfig.features.requiredDslabels)
-		const missingDslabels = requiredDslabels.difference(new Set(trackedDatasets.map(ds => ds.label)))
+		const requiredDsSet: Set<string> = new Set(requiredDslabels)
+		const missingDslabels = requiredDsSet.difference(new Set(trackedDatasets.map(ds => ds.label)))
 		if (missingDslabels.size) {
 			missingDslabelMsg +=
 				`\n--- these required datasets were not processed ---\n` +
@@ -308,7 +310,7 @@ function processTrackedDs(trackedDatasets) {
 			msg += `\n--- failed dataset init ---\n${list}\n`
 		}
 
-		// we want this to be the
+		// add missingDslabelMsg to the bottom for readability, since it has extra lines of instructions
 		msg += missingDslabelMsg
 	}
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -270,6 +270,8 @@ function processTrackedDs(trackedDatasets) {
 		const failed = trackedDatasets.filter(
 			ds => !done.includes(ds) && !nonblocking.includes(ds) && !activeRetries.includes(ds)
 		)
+
+		let msg = ''
 		if (failed.length) {
 			const list = failed
 				.map(
@@ -278,11 +280,29 @@ function processTrackedDs(trackedDatasets) {
 						`: ${ds.init.fatalError || ds.init.recoverableError || ds.init.error || '(see startup logs)'}`
 				)
 				.join('\n')
-			const msg = `\n--- failed dataset init ---\n${list}\n`
+			msg += `\n--- failed dataset init ---\n${list}\n`
+		}
+
+		if (serverconfig.features.requiredDslabels) {
+			// NOTE: This option is separate from serverconfig.features.dslabelFilter since that is an option
+			// to limit the loaded datasets. Here, we detect required dslabels that were not loaded/processed
+			// during server startup.
+			const requiredDslabels: Set<string> = new Set(serverconfig.features.requiredDslabels)
+			const missingDslabels = requiredDslabels.difference(new Set(trackedDatasets.map(ds => ds.label)))
+			if (missingDslabels.size) {
+				msg += `\n--- these required datasets were not processed ---\n`
+				msg += [...missingDslabels].join(',') + '\n'
+				msg += `--- Check if the dslabel is not found as a serverconfig genome datasets entry,` + '\n'
+				msg += `or has 'skip: true', or is filtered out by dslabelFilter option. ---` + '\n'
+			}
+		}
+
+		if (msg.length) {
 			console.log(msg)
-			// not a fatal error for the server and will not trigger a deployment rollback notification,
-			// so must trigger a notification here
+
 			if (serverconfig.slackWebhookUrl) {
+				// not a fatal error for the server and will not trigger a deployment rollback notification,
+				// so must trigger a notification here
 				const hostname =
 					serverconfig.hostname || spawnSync('hostname', ['-s'], { encoding: 'utf-8' })?.stdout?.trim() || ''
 				sendMessageToSlack(

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -245,11 +245,37 @@ function processTrackedDs(trackedDatasets) {
 	const nonblocking = trackedDatasets.filter(
 		ds => ds.init.status === 'nonblocking' || ds.init.status == 'recoverableError'
 	)
+
+	let msg = '',
+		missingDslabelMsg = ''
+	if (serverconfig.features.requiredDslabels) {
+		// NOTE: This option is separate from serverconfig.features.dslabelFilter since that is an option
+		// to limit the loaded datasets. Here, we detect required dslabels that were not loaded/processed
+		// during server startup.
+		const requiredDslabels: Set<string> = new Set(serverconfig.features.requiredDslabels)
+		const missingDslabels = requiredDslabels.difference(new Set(trackedDatasets.map(ds => ds.label)))
+		if (missingDslabels.size) {
+			missingDslabelMsg +=
+				`\n--- these required datasets were not processed ---\n` +
+				[...missingDslabels].join(',') +
+				'\n\n' +
+				`Check if the missing dslabel(s) above: ` +
+				'\n' +
+				`- was not found as a serverconfig genome datasets entry` +
+				'\n' +
+				`- has 'skip: true'` +
+				'\n' +
+				`- was filtered out by dslabelFilter option. ---` +
+				'\n'
+		}
+	}
+
 	if (!done.length && !nonblocking.length) {
 		// if no dataset loaded successfully, and only if there are genome + dataset entries,
 		// then assume that there may be something wrong with serverconfig and/or code,
 		// not with dataset js/ts files, and crash the server to trigger rollback
-		if (trackedDatasets.length) throw `${serverconfig.URL}: there were no datasets that loaded successfully`
+		if (trackedDatasets.length)
+			throw `${serverconfig.URL}: there were no datasets that loaded successfully` + missingDslabelMsg
 	} else {
 		if (done.length) {
 			console.log(`\n--- these datasets finished loading ---`)
@@ -271,7 +297,6 @@ function processTrackedDs(trackedDatasets) {
 			ds => !done.includes(ds) && !nonblocking.includes(ds) && !activeRetries.includes(ds)
 		)
 
-		let msg = ''
 		if (failed.length) {
 			const list = failed
 				.map(
@@ -283,34 +308,22 @@ function processTrackedDs(trackedDatasets) {
 			msg += `\n--- failed dataset init ---\n${list}\n`
 		}
 
-		if (serverconfig.features.requiredDslabels) {
-			// NOTE: This option is separate from serverconfig.features.dslabelFilter since that is an option
-			// to limit the loaded datasets. Here, we detect required dslabels that were not loaded/processed
-			// during server startup.
-			const requiredDslabels: Set<string> = new Set(serverconfig.features.requiredDslabels)
-			const missingDslabels = requiredDslabels.difference(new Set(trackedDatasets.map(ds => ds.label)))
-			if (missingDslabels.size) {
-				msg += `\n--- these required datasets were not processed ---\n`
-				msg += [...missingDslabels].join(',') + '\n'
-				msg += `--- Check if the dslabel is not found as a serverconfig genome datasets entry,` + '\n'
-				msg += `or has 'skip: true', or is filtered out by dslabelFilter option. ---` + '\n'
-			}
-		}
+		// we want this to be the
+		msg += missingDslabelMsg
+	}
 
-		if (msg.length) {
-			console.log(msg)
-
-			if (serverconfig.slackWebhookUrl) {
-				// not a fatal error for the server and will not trigger a deployment rollback notification,
-				// so must trigger a notification here
-				const hostname =
-					serverconfig.hostname || spawnSync('hostname', ['-s'], { encoding: 'utf-8' })?.stdout?.trim() || ''
-				sendMessageToSlack(
-					serverconfig.slackWebhookUrl,
-					`\n${serverconfig.URL} ${hostname}: ${msg}`,
-					path.join(serverconfig.cachedir, '/slack/last_message_hash.txt')
-				).catch(console.log)
-			}
+	if (msg.length) {
+		console.log(msg)
+		if (serverconfig.slackWebhookUrl) {
+			// not a fatal error for the server and will not trigger a deployment rollback notification,
+			// so must trigger a notification here
+			const hostname =
+				serverconfig.hostname || spawnSync('hostname', ['-s'], { encoding: 'utf-8' })?.stdout?.trim() || ''
+			sendMessageToSlack(
+				serverconfig.slackWebhookUrl,
+				`\n${serverconfig.URL} ${hostname}: ${msg}`,
+				path.join(serverconfig.cachedir, '/slack/last_message_hash.txt')
+			).catch(console.log)
 		}
 	}
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "baseUrl": "./",
+    "target": "ESNext",
     "customConditions": ["sjpp/dev"]
   },
   "types": ["node"],


### PR DESCRIPTION
# Description

Support a `serveronfig.features.requiredDslabels` option to detect and alert when a required dataset is not processed during startup.

Test:
- Create this serverconfig.features option: `"requiredDslabels": ["xyz"]` :  you should see  these in the server startup logs
```
[2] --- these required datasets were not processed ---
[2] xyz
[2] 
[2] Check if the missing dslabel(s) above: 
[2] - was not found as a serverconfig genome datasets entry
[2] - has 'skip: true'
[2] - was filtered out by dslabelFilter option. ---
```

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
