### PR TITLE
Concatenate buffer chunks of R output before string conversion

### DIFF
--- a/R/index.js
+++ b/R/index.js
@@ -45,8 +45,12 @@ export async function run_R(filename, data, args, subdir = 'src') {
 		sp.on('error', err => reject(err))
 		// return stdout and stderr when R process closes
 		sp.on('close', code => {
-			const stdout = _stdout.join('').trim()
-			const stderr = _stderr.join('').trim()
+			// concatenate buffer chunks and then convert to string
+			// important to do this because a multibyte UTF-8 character like ≥ (e2 89 a5)
+			// may be split across chunks and it needs to be concatenated before string
+			// conversion
+			const stdout = Buffer.concat(_stdout).toString('utf8').trim()
+			const stderr = Buffer.concat(_stderr).toString('utf8').trim()
 			if (code !== 0) {
 				// handle non-zero exit status
 				let errmsg = `R process exited with non-zero status code=${code}`

--- a/R/index.js
+++ b/R/index.js
@@ -34,7 +34,7 @@ export async function run_R(filename, data, args, subdir = 'src') {
 			} catch (e) {
 				sp.kill()
 				let errmsg = e
-				const stderr = _stderr.join('').trim()
+				const stderr = Buffer.concat(_stderr).toString('utf8').trim()
 				if (stderr) errmsg += `\nR stderr: ${stderr}`
 				reject(errmsg)
 			}


### PR DESCRIPTION
# Description

Fixes issue of unknown characters `??` showing up in legend of survival plot ([example](http://localhost:3000/?mass=%7B%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:%7B%22activeTab%22:1%7D,%22plots%22:%5B%7B%22chartType%22:%22survival%22,%22term%22:%7B%22id%22:%22Overall_Survival%22%7D,%22term2%22:%7B%22term%22:%7B%22type%22:%22geneExpression%22,%22gene%22:%22MYC%22%7D%7D%7D%5D%7D)). The `??` characters were replacing the `≥` symbol because the `≥` symbol is a multibyte UTF-8 character (e2 89 a5) and these bytes were split across buffer chunks outputted from R. When buffer chunks were then converted to string, the bytes representing the `≥` symbol were split and could not be decoded to a valid UTF-8 string.

To fix this issue, buffer chunks are now first concatenated to a single buffer, which is then converted to string.

All unit and integration pass, so other R-based features work fine with this change.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
