### PR TITLE
Fix the at-risk legend label update

### DIFF
--- a/client/dom/renderAtRisk.js
+++ b/client/dom/renderAtRisk.js
@@ -16,9 +16,8 @@ input parameter:
 */
 
 export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }) {
-	// key: a visible seriesId
-	// value: {seriedId, seriesLabel, counts}
-	const bySeriesId = {}
+	// {seriedId: string, seriesLabel: string, counts: number}[]
+	const atRiskGroups = []
 
 	// do not compute at-risk counts of tick values that are
 	// smaller than the first timepoint of the chart
@@ -59,7 +58,7 @@ export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }
 			}
 		}
 		const { seriesId, seriesLabel } = series
-		bySeriesId[seriesId] = { seriesId, seriesLabel, counts }
+		atRiskGroups.push({ seriesId, seriesLabel, counts })
 	}
 
 	const y = s.svgh - s.svgPadding.top - s.svgPadding.bottom + 60 // make y-offset option???
@@ -68,12 +67,11 @@ export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }
 
 	const seriesOrder = order || chart.serieses.map(s => s.seriesId)
 
-	let data
 	g.selectAll('.sjpp-atrisk-title').remove()
 	if (s.atRiskVisible) {
 		// at-risk counts are visible
 		// sort the data
-		data = Object.values(bySeriesId).sort((a, b) => seriesOrder.indexOf(a.seriesId) - seriesOrder.indexOf(b.seriesId))
+		atRiskGroups.sort((a, b) => seriesOrder.indexOf(a.seriesId) - seriesOrder.indexOf(b.seriesId))
 		// render the title
 		// add a y offset to title if there is no series id
 		const addYoffset = chart.serieses.length == 1 && !chart.serieses[0].seriesId
@@ -95,32 +93,35 @@ export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }
 	} else {
 		// at-risk counts are not visible
 		// empty the data
-		data = []
+		atRiskGroups.length = 0
 	}
 
 	// render at-risk counts
 	const sg = g
 		.attr('transform', `translate(0,${y})`)
 		.selectAll(':scope > g')
-		.data(data, s => s.seriesLabel || s.seriesId)
+		.data(atRiskGroups, s => s.seriesLabel || s.seriesId)
 
-	sg.exit().remove()
+	sg.exit().each(function (d) {
+		this.remove()
+	})
 
-	sg.each(function (series, i) {
-		const { seriesId, seriesLabel, counts } = series
+	sg.each(function (atRiskGroup, i) {
+		const { seriesId, seriesLabel, counts } = atRiskGroup
 		const y = (i + 1) * (2 * s.axisTitleFontSize)
 		const g = select(this)
 			.attr('transform', `translate(0,${y})`)
 			.attr('fill', term2toColor[''] ? s.defaultColor : term2toColor[seriesId].adjusted) // TODO: attached series color to the data of 'sg'
-			.text(seriesId && seriesId !== '*' ? seriesLabel || seriesId : '')
 
-		renderAtRiskTick(g.select(':scope>g'), chart, xTickValues, s, seriesId, counts)
+		g.select(':scope>text').text(seriesId && seriesId !== '*' ? seriesLabel || seriesId : '')
+
+		renderAtRiskTick(g.select(':scope>g'), chart, xTickValues, s, atRiskGroup, counts)
 	})
 
 	sg.enter()
 		.append('g')
-		.each(function (series, i) {
-			const { seriesId, seriesLabel, counts } = series
+		.each(function (atRiskGroup, i) {
+			const { seriesId, seriesLabel, counts } = atRiskGroup
 			const y = (i + 1) * (2 * s.axisTitleFontSize)
 			const g = select(this)
 				.attr('transform', `translate(0,${y})`)
@@ -136,11 +137,13 @@ export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }
 				.datum({ seriesId })
 				.text(seriesId && seriesId !== '*' ? seriesLabel || seriesId : '')
 
-			renderAtRiskTick(g.append('g'), chart, xTickValues, s, seriesId, counts)
+			renderAtRiskTick(g.append('g'), chart, xTickValues, s, atRiskGroup, counts)
 		})
 }
 
-function renderAtRiskTick(g, chart, xTickValues, s, seriesId, series) {
+function renderAtRiskTick(g, chart, xTickValues, s, atRiskGroup, series) {
+	if (!g.size()) return
+	const { seriesId } = atRiskGroup
 	const reversed = series.slice().reverse()
 	const data = xTickValues.map(tickVal => {
 		if (tickVal === 0) return { seriesId, tickVal, atRisk: series[0][1], nCensored: series[0][2] }

--- a/client/dom/renderAtRisk.js
+++ b/client/dom/renderAtRisk.js
@@ -16,7 +16,7 @@ input parameter:
 */
 
 export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }) {
-	// {seriedId: string, seriesLabel: string, counts: number}[]
+	// {seriesId: string, seriesLabel: string, counts: [number, number, number][]}[]
 	const atRiskGroups = []
 
 	// do not compute at-risk counts of tick values that are
@@ -102,9 +102,7 @@ export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }
 		.selectAll(':scope > g')
 		.data(atRiskGroups, s => s.seriesLabel || s.seriesId)
 
-	sg.exit().each(function (d) {
-		this.remove()
-	})
+	sg.exit().remove()
 
 	sg.each(function (atRiskGroup, i) {
 		const { seriesId, seriesLabel, counts } = atRiskGroup
@@ -113,9 +111,14 @@ export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }
 			.attr('transform', `translate(0,${y})`)
 			.attr('fill', term2toColor[''] ? s.defaultColor : term2toColor[seriesId].adjusted) // TODO: attached series color to the data of 'sg'
 
-		g.select(':scope>text').text(seriesId && seriesId !== '*' ? seriesLabel || seriesId : '')
+		let legendText = g.select(':scope>text')
+		if (!legendText.size()) legendText = g.append('text')
+		legendText.text(seriesId && seriesId !== '*' ? seriesLabel || seriesId : '')
 
-		renderAtRiskTick(g.select(':scope>g'), chart, xTickValues, s, atRiskGroup, counts)
+		let ticksG = g.select(':scope>g')
+		if (!ticksG.size()) ticksG = g.append('g')
+
+		renderAtRiskTick(ticksG, chart, xTickValues, s, atRiskGroup)
 	})
 
 	sg.enter()
@@ -137,16 +140,15 @@ export function renderAtRiskG({ g, s, chart, order, term2toColor, onSerieClick }
 				.datum({ seriesId })
 				.text(seriesId && seriesId !== '*' ? seriesLabel || seriesId : '')
 
-			renderAtRiskTick(g.append('g'), chart, xTickValues, s, atRiskGroup, counts)
+			renderAtRiskTick(g.append('g'), chart, xTickValues, s, atRiskGroup)
 		})
 }
 
-function renderAtRiskTick(g, chart, xTickValues, s, atRiskGroup, series) {
-	if (!g.size()) return
-	const { seriesId } = atRiskGroup
-	const reversed = series.slice().reverse()
+function renderAtRiskTick(g, chart, xTickValues, s, atRiskGroup) {
+	const { seriesId, counts } = atRiskGroup
+	const reversed = counts.slice().reverse()
 	const data = xTickValues.map(tickVal => {
-		if (tickVal === 0) return { seriesId, tickVal, atRisk: series[0][1], nCensored: series[0][2] }
+		if (tickVal === 0) return { seriesId, tickVal, atRisk: counts[0][1], nCensored: counts[0][2] }
 		const d = reversed.find(d => d[0] <= tickVal)
 		return { seriesId, tickVal, atRisk: d[1], nCensored: d[2] }
 	})

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -1074,7 +1074,7 @@ function setInteractivity(self) {
 		const hidden = self.settings.hidden.slice()
 		const i = hidden.indexOf(d.seriesId)
 		if (i == -1) {
-			hidden.push(d.seriesId)
+			hidden.push(d.seriesId) // this setting data will be dispatched after clicking on the Hide menu option
 			self.showLegendItemMenu(d, hidden, x, y)
 		} else {
 			hidden.splice(i, 1)

--- a/client/plots/survival/test/survival.integration.spec.js
+++ b/client/plots/survival/test/survival.integration.spec.js
@@ -800,7 +800,8 @@ tape('survival term as term1, term0 = agedx, custom bins', function (test) {
 })
 
 tape('survival term as term1, term2 = geneVariant', function (test) {
-	test.timeoutAfter(10000)
+	test.timeoutAfter(5000)
+	test.plan(4)
 	runpp({
 		state: {
 			plots: [
@@ -838,8 +839,27 @@ tape('survival term as term1, term2 = geneVariant', function (test) {
 		const colorInput = await Locator.init(legendTip.d).shows('input[type="color"]').get(0)
 		colorInput.value = '#0000ff'
 		colorInput.dispatchEvent(new Event('change', { cancelable: true }))
+		legendTip.hide()
 		await sleep(100) // todo: use improved Locator methods to avoid using sleep()
 		test.equal(atRiskLegend0?.parentNode?.getAttribute('fill'), 'rgb(0, 0, 255)', 'should change the series color')
+
+		await survival.Inner.app.dispatch({
+			type: 'plot_edit',
+			id: survival.id,
+			config: {
+				settings: {
+					survival: {
+						atRiskVisible: false
+					}
+				}
+			}
+		})
+
+		test.equal(
+			survivalDiv.selectAll('.sjpp-atrisk-title').size(),
+			0,
+			'should hide at-risk legend when settings.survival.atRiskVisible is false'
+		)
 		if (test._ok) {
 			survival.Inner.app.destroy()
 			legendTip.hide()

--- a/client/plots/survival/test/survival.integration.spec.js
+++ b/client/plots/survival/test/survival.integration.spec.js
@@ -855,6 +855,7 @@ tape('survival term as term1, term2 = geneVariant', function (test) {
 			}
 		})
 
+		await sleep(100) // todo: use improved Locator methods to avoid using sleep()
 		test.equal(
 			survivalDiv.selectAll('.sjpp-atrisk-title').size(),
 			0,
@@ -869,7 +870,7 @@ tape('survival term as term1, term2 = geneVariant', function (test) {
 })
 
 tape('survival term as term1, term2 = geneExpression', function (test) {
-	test.timeoutAfter(10000)
+	test.timeoutAfter(8000)
 	runpp({
 		state: {
 			plots: [


### PR DESCRIPTION
# Description

This branch fixes the [failing tests in the integration CI](https://github.com/stjude/proteinpaint/actions/runs/25905322481/job/76137835752#step:3:3139), as related to the survival plot at-risk legend. 

- select the `svg:text` element when updating an at-risk legend label, previously this replaced both the label and the g-child element
- add a test for survival at-risk legend visibility

Tested with:
- https://github.com/stjude/proteinpaint/actions/runs/25930320336
- http://localhost:3000/testrun.html?dir=plots/survival&name=survival.integration

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
