### PR TITLE
support a dataset requiresAuthCred option 

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,7 +12,7 @@ import serverconfig from './serverconfig.js'
 import { genomes, initGenomesDs } from './initGenomesDs.js'
 import { setAppMiddlewares } from './app.middlewares.js'
 import * as oldApp from './app.unorg.js'
-import { getAuthApi } from './auth.ts'
+import { getAuthApi, extractValidatedCreds } from './auth.ts'
 import * as phewas from './termdb.phewas.js'
 import { sendMessageToSlack } from './postOnSlack.ts'
 import { routeFiles } from './app.routes.js'
@@ -32,7 +32,11 @@ export async function launch() {
 			})
 		)
 
-		const trackedDatasets = await initGenomesDs(serverconfig)
+		// extract creds early so it is not unnecessarily exposed to other code that imports serverconfig.json,
+		// and so that the validated creds can be passed into getAuthApi() for maySetAuthRoutes() to use in
+		// setting up auth routes before any other routes are set up
+		const validatedCreds = await extractValidatedCreds(serverconfig)
+		const trackedDatasets = await initGenomesDs(serverconfig, { credDslabels: Object.keys(validatedCreds) })
 		const doneLoading = processTrackedDs(trackedDatasets)
 
 		// no error from server initiation
@@ -51,7 +55,7 @@ export async function launch() {
 			- so that a request will be inspected by auth before allowing 
 			to proceed to any *protected* route handler
 		*/
-		const authApi = await getAuthApi(app, genomes, serverconfig, true)
+		const authApi = await getAuthApi(app, genomes, { validatedCreds }, true)
 		await authApi.maySetAuthRoutes(app, genomes, basepath, serverconfig)
 
 		const routes = await Promise.all(routeFiles)

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -1,4 +1,4 @@
-import { validateDsCredentials } from './auth/auth.dsCredentials.ts'
+import { validateDsCredentials, type ServerConfigDsCredentials } from './auth/auth.dsCredentials.ts'
 import { AuthApiOpen } from './auth/AuthApiOpen.ts'
 import { AuthApi } from './auth/AuthApi.ts'
 
@@ -18,6 +18,15 @@ export interface AuthInterface {
 	mayAdjustFilter: (q, ds, routeTwLst) => void
 }
 
+// app should call this as early as possible to avoid unnecessarily exposing to other code
+export async function extractValidatedCreds(_serverconfig) {
+	const serverconfig = _serverconfig || (await import('./serverconfig.js')).default
+	const creds = serverconfig.dsCredentials || {}
+	// !!! do not expose the loaded dsCredentials to other code that imports serverconfig.json !!!
+	delete serverconfig.dsCredentials
+	return creds
+}
+
 // The authApi variable will be filled when the server/app.ts calls getAuthApi().
 // This is exported as a read-only live-binding where the importer sees the latest value.
 export let authApi
@@ -27,15 +36,24 @@ export let authApi
 const authApiByApp = new WeakMap()
 
 // these may be overriden within maySetAuthRoutes()
-export async function getAuthApi(app, genomes, _serverconfig = null, assignSharedApi = false) {
+// config: one of the following
+// - a loaded serverconfig with raw dsCredentials
+// - an object with validatedCreds that has been extracted from a serverconfig
+export async function getAuthApi(
+	app,
+	genomes,
+	config: null | { dsCredentials?: any; validatedCreds?: ServerConfigDsCredentials } = null,
+	assignSharedApi = false
+) {
 	if (assignSharedApi && authApi) {
 		throw `The shared authApi reference has already been assigned.`
 	}
 	// reuse an existing authApi if it already exists for an app
 	if (authApiByApp.has(app)) return authApiByApp.get(app)
 
-	const serverconfig = _serverconfig || (await import('./serverconfig.js')).default
-	const creds = serverconfig.dsCredentials || {}
+	const serverconfig = config || (await import('./serverconfig.js')).default
+	const creds =
+		config?.validatedCreds || (await extractValidatedCreds(config || (await import('./serverconfig.js')).default)) //serverconfig.dsCredentials || {}
 	// !!! do not expose the loaded dsCredentials to other code that imports serverconfig.json !!!
 	delete serverconfig.dsCredentials
 

--- a/server/src/auth/auth.dsCredentials.ts
+++ b/server/src/auth/auth.dsCredentials.ts
@@ -7,7 +7,7 @@ const { isMatch } = mm
 // 1. list keys in the desired matching order, for example, the catch-all '*' pattern should be entered last
 // 2. glob pattern: '*', '!', etc
 
-type ServerConfigDsCredentials = {
+export type ServerConfigDsCredentials = {
 	[dslabelPattern: string]: {
 		/** 
 		routePattern could be one of the following: 
@@ -70,17 +70,17 @@ type JwtCredEntry = {
 // 		},
 // 		burden: {
 // 			'*': {
-//         type: 'basic',
-//         password: '...'
-//      }
+//         		type: 'basic',
+//         		password: '...'
+//      	}
 // 		}
 // 	},
 // 	PNET: {
 // 		'*': { // equivalent to /** for a route path, all routes will be protected
 // 			'*': { // any embedder
-//         type: 'basic',
-//         password: '...'
-//      }
+//         	type: 'basic',
+//        	 password: '...'
+//      	}
 // 		}
 // 	},
 //
@@ -113,6 +113,7 @@ export async function validateDsCredentials(creds: ServerConfigDsCredentials, ge
 	// dslabel may be exact or a pattern
 	for (const [dslabel, _ds] of Object.entries(creds)) {
 		if (dslabel[0] == '#') {
+			// '#' is treated as a comment, no dslabel should start with this character in order to be loaded
 			delete creds[dslabel]
 			continue
 		}

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -36,7 +36,7 @@ export const genomes = {} // { hg19: {...}, ... }
 
 const features = serverconfig.features
 
-export async function initGenomesDs(serverconfig) {
+export async function initGenomesDs(serverconfig, opts = {}) {
 	// verify if tp directory is readable
 	// ppr has this situation where its tp/ is from a nfs mount and can go down...
 	try {
@@ -452,6 +452,15 @@ export async function initGenomesDs(serverconfig) {
 			}
 
 			trackedDatasets.push(ds)
+			// do this check after trackedDatasets.push so that datasets with auth requirement
+			// but no provided creds can still be tracked with fatalError status, to be emitted
+			// in app.ts processTrackedDs() and inform user about missing creds via log and optional slack notification
+			if (ds.requiresAuthCred && !opts.credDslabels?.includes(ds.label)) {
+				ds.init.status = 'fatalError'
+				ds.init.fatalError = `${ds.label} ds.requiresAuthCred is true but no credential provided`
+				delete g.datasets[ds.label] // do not keep reference to this dataset since it will not be loaded
+				continue
+			}
 
 			// wrap ds init execution in a try-catch, to not crash when at least 1 dataset loaded successfully
 			try {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -572,7 +572,7 @@ export async function validate_cumburden(ds) {
 	if (dir.includes('..') && !serverconfig.debugmode) throw `'..' path segment is not allowed in ds.cohort.cumburden.dir`
 	if (!fs.existsSync(path.join(serverconfig.tpmasterdir, dir))) `ds.cohort.cumburden.dir='${dir}' not found`
 
-	if (!ds.cohort.cumburden.files) `missing ds.cohort.cumburden.files`
+	if (!ds.cohort.cumburden.files) throw `missing ds.cohort.cumburden.files`
 	const inputFiles = ds.cohort.cumburden.files
 	for (const name of ['fit', 'surv', 'sample']) {
 		const fname = inputFiles[name]

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -2158,6 +2158,8 @@ export type Mds3 = BaseMds & {
 		data during post-processing */
 		postProcessDtFilter?: boolean
 	}
+	/** option to require an auth dsCredentials entry for this dataset in serverconfig, in order to load this dataset during server startup */
+	requiresAuthCred?: boolean
 	demoJwtInput?: {
 		[role: string]: {
 			datasets?: string[]


### PR DESCRIPTION
# Description

The `requiresAuthCred` dataset option will not load a dataset that has no corresponding `dsCredentials` entry.

Test with https://github.com/stjude/sjpp/pull/1338.

Tests:
- `npm run test:unit` from the server dir
- in `sjpp/serverconfig.json`, make sure that the SJLife entry is active. The error below should be logged during server startup
```sh
--- failed dataset init ---
hg38/SJLife: SJLife ds.requiresAuthCred is true but no credential provided
```
- To address this issue in local dev, put  `"updateAttr": [["requiresAuthCred", false]]` in the `serverconfig.genomes[].datasets` entry for `sjlife`.
- http://localhost:3000/sjlife/ and http://localhost:3000/demo-token?dslabel=SJLife should both show `invalid dslabel` and an enabled `Data Download` chart when `requiresAuthCred` is set to true and false, respectively.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
