### PR TITLE
Changing tileserver base image

### DIFF
--- a/client/plots/wsiviewer/viewModel/ViewModelProvider.ts
+++ b/client/plots/wsiviewer/viewModel/ViewModelProvider.ts
@@ -161,7 +161,7 @@ export class ViewModelProvider {
 			}
 
 			const zoomifyUrl = `${host}/tileserver/layer/slide/${data.wsiSessionId}/zoomify/{TileGroup}/{z}-{x}-{y}@1x.jpg?${queryParams}`
-
+			// something wrong here get 401 error, is this just a test to see if the tileserver is working?
 			const source = new Zoomify({
 				url: zoomifyUrl,
 				size: [imgWidth, imgHeight],

--- a/container/tileserver/Dockerfile
+++ b/container/tileserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.0rc2-slim-bookworm
+FROM python:3.13-slim-bullseye
 
 
 LABEL org.opencontainers.image.source="https://github.com/stjude/proteinpaint" \

--- a/container/tileserver/app.py
+++ b/container/tileserver/app.py
@@ -1,8 +1,37 @@
 from flask_cors import CORS
+from pathlib import Path
 from tiatoolbox.wsicore.wsireader import WSIReader
 from tiatoolbox.visualization.tileserver import TileServer
 import glob
 import os
+
+
+# def remap_host_path(path: Path) -> Path:
+#     print(path)
+#     host_mount = os.environ.get('TILESERVER_HOST_MOUNT')
+#     container_mount = os.environ.get('TILESERVER_CONTAINER_MOUNT', '/home/root/tileserver/tp')
+
+#     if not host_mount:
+#         return path
+
+#     normalized_path = os.path.normpath(str(path))
+#     normalized_host_mount = os.path.normpath(host_mount)
+
+#     if normalized_path == normalized_host_mount:
+#         return Path(container_mount)
+
+#     relative_path = os.path.relpath(normalized_path, normalized_host_mount)
+#     if relative_path == os.pardir or relative_path.startswith(f'{os.pardir}{os.sep}'):
+#         return path
+
+#     return Path(container_mount) / relative_path
+
+
+# class ProteinPaintTileServer(TileServer):
+#     @staticmethod
+#     def decode_safe_name(name: str) -> Path:
+#         decoded_path = Path(os.path.normpath(os.path.expanduser(os.path.expandvars(name))))
+        # return remap_host_path(decoded_path)
 
 # Initialize and run the TileServer
 app = TileServer(

--- a/container/tileserver/run.sh
+++ b/container/tileserver/run.sh
@@ -27,14 +27,17 @@ set -e
 sh ../createPPNetwork.sh
 # theeres a problem that the container and the machine makes inquiries about aihisto data, but the container is looking in this "/home/root/tileserver/tp" path 
 # (side note I dont think you want tp bu actually aihisto data path) and the machine wants to look in the "/Users/jsimps98/data/aihisto" path, but both seem to be  using the mount path from serverconfig.
+#Theres also a problem that data and model are put up by symlnks so when the links are mounted they point to data thats not actually there, so the overlays dont show up
 # I think there are 3 solutions
 # 1. have two variables in serverconfig for host and container paths 
-# 2. mount the data path with the same path as the host files (probably the simplest)
+# 2. mount the data path with the same path as the host files including real ppaihal data (probably the simplest)
 # 3. use this translate path function in app.py from copilot (seems fragile)
 docker run -d \
 	--name $CONTAINER_NAME \
 	--network pp_network \
-	--mount type=bind,source=$TP,target=$CONTAINER_MOUNT,readonly \
+	--mount type=bind,source=$TP,target=$TP,readonly \
+	--mount type=bind,source=/Users/jsimps98/dev/sjpp/ppaihal/data,target=/Users/jsimps98/dev/sjpp/ppaihal/data,readonly \
+	--mount type=bind,source=/Users/jsimps98/dev/sjpp/ppaihal/model,target=/Users/jsimps98/dev/sjpp/ppaihal/model,readonly \
 	-e PORT=$PORT \
 	-e TILESERVER_HOST_MOUNT=$TP \
 	-e TILESERVER_CONTAINER_MOUNT=$CONTAINER_MOUNT \

--- a/container/tileserver/run.sh
+++ b/container/tileserver/run.sh
@@ -34,7 +34,7 @@ sh ../createPPNetwork.sh
 docker run -d \
 	--name $CONTAINER_NAME \
 	--network pp_network \
-	--mount type=bind,source=$TP,target=$TP,readonly \
+	--mount type=bind,source=$TP,target=$CONTAINER_MOUNT,readonly \
 	-e PORT=$PORT \
 	-e TILESERVER_HOST_MOUNT=$TP \
 	-e TILESERVER_CONTAINER_MOUNT=$CONTAINER_MOUNT \

--- a/container/tileserver/run.sh
+++ b/container/tileserver/run.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 #
-# Run from the command line like e.g.: sh run.sh "/path/to/tp/"
+# Run from the command line like e.g.: sh run.sh "/path/to/aihisto/"
+# I think it should be more clear about how to change your serverconfig and that symlinks wont work for this
 #
 
 
 if [ $# -eq 0 ]; then
-  echo "Error: No host tp argument supplied." >&2
+	echo "Error: No host data root argument supplied." >&2
   exit 1
 fi
 
@@ -14,22 +15,29 @@ TP=$1
 CONTAINER_NAME="tile-server"
 PORT=5000
 IMAGE_NAME="ghcr.io/stjude/tile-server"
+CONTAINER_MOUNT="/home/root/tileserver/tp"
 
 # temporarily ignore bash error
 set +e
-echo "finding any matching blat containers to stop and remove ..."
+echo "finding any matching tileserver containers to stop and remove ..."
   docker ps -aq --filter "name=$CONTAINER_NAME" | xargs -r docker rm -f
 # re-enable exit on errors
 set -e
 
-# common network is needed to communicate with the blat server
 sh ../createPPNetwork.sh
-
+# theeres a problem that the container and the machine makes inquiries about aihisto data, but the container is looking in this "/home/root/tileserver/tp" path 
+# (side note I dont think you want tp bu actually aihisto data path) and the machine wants to look in the "/Users/jsimps98/data/aihisto" path, but both seem to be  using the mount path from serverconfig.
+# I think there are 3 solutions
+# 1. have two variables in serverconfig for host and container paths 
+# 2. mount the data path with the same path as the host files (probably the simplest)
+# 3. use this translate path function in app.py from copilot (seems fragile)
 docker run -d \
 	--name $CONTAINER_NAME \
 	--network pp_network \
-	--mount type=bind,source=$TP,target=/home/root/tileserver/tp,readonly \
+	--mount type=bind,source=$TP,target=$TP,readonly \
 	-e PORT=$PORT \
+	-e TILESERVER_HOST_MOUNT=$TP \
+	-e TILESERVER_CONTAINER_MOUNT=$CONTAINER_MOUNT \
 	--memory="4g" \
 	 --cpus="1" \
 	--publish $PORT:$PORT \

--- a/server/routes/tileserver.ts
+++ b/server/routes/tileserver.ts
@@ -39,7 +39,7 @@ function init({ genomes }) {
 			const projectId = query.ai_project_id
 			if (!sampleId && !projectId) throw new Error('Either sample_id or project_id must be provided')
 
-			const mount = serverconfig.features?.tileserver?.mount
+			const mount = serverconfig.features?.tileserver?.hostMount
 			if (!mount) throw new Error('No mount available for TileServer')
 
 			let wsiImagePath: string

--- a/server/routes/wsimages.ts
+++ b/server/routes/wsimages.ts
@@ -78,7 +78,7 @@ function init({ genomes }) {
 }
 
 async function getWSImagePath(ds: any, wSImagesRequest: WSImagesRequest) {
-	const mount = serverconfig.features?.tileserver?.mount
+	const mount = serverconfig.features?.tileserver?.containerMount
 
 	if (!mount) throw new Error('No mount available for TileServer')
 

--- a/server/routes/wsimages.ts
+++ b/server/routes/wsimages.ts
@@ -79,7 +79,6 @@ function init({ genomes }) {
 
 async function getWSImagePath(ds: any, wSImagesRequest: WSImagesRequest) {
 	const mount = serverconfig.features?.tileserver?.containerMount
-
 	if (!mount) throw new Error('No mount available for TileServer')
 
 	if (wSImagesRequest.sampleId) {
@@ -152,7 +151,7 @@ async function getSessionId(
 	if (ds.queries.WSImages.getPredictionLayers) {
 		const predictionLayers: Map<string, string> | Record<string, string> | undefined =
 			await ds.queries.WSImages.getPredictionLayers(projectId, wsimage)
-
+		console.log('Retrieved prediction layers:', predictionLayers)
 		if (predictionLayers) {
 			const resolveFilename = (key: string): string | undefined => {
 				if (!predictionLayers) return undefined

--- a/server/src/adHocDictionary/buildAdHocDictionary.ts
+++ b/server/src/adHocDictionary/buildAdHocDictionary.ts
@@ -191,7 +191,7 @@ export async function makeAdHocDicTermdbQueries(ds: Mds3) {
 }
 
 async function readSourceFile(source: string) {
-	const sourceFilePath = path.join(serverconfig.features?.tileserver?.mount, source)
+	const sourceFilePath = path.join(serverconfig.features?.tileserver?.hostMount, source)
 	if (!fs.existsSync(sourceFilePath)) return
 	try {
 		return fs.readFileSync(sourceFilePath, 'utf8')

--- a/server/src/aiHistoDBConnection.ts
+++ b/server/src/aiHistoDBConnection.ts
@@ -7,7 +7,7 @@ let connection: Database.Database | null = null
 
 export function getDbConnection(ds: any): Database.Database | null {
 	// TODO introduce new mount property
-	const mount = serverconfig.features?.tileserver?.mount
+	const mount = serverconfig.features?.tileserver?.hostMount
 	if (!mount) throw new Error('No mount available for TileServer')
 
 	const dbFile = ds.queries.WSImages?.db?.file

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -190,7 +190,7 @@ function setHeaders(req, res, next) {
 	res.header('Vary', 'Origin')
 
 	// limit the allowed request methods for the PP server
-	res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS, HEAD')
+	res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS,PUT, HEAD')
 
 	const debugtest =
 		serverconfig.debugmode || serverconfig.defaultgenome == 'hg38-test' || serverconfig.features?.loosenCORS


### PR DESCRIPTION
changing base image of tileserver image to python:3.13-slim-bullseye to relieve security issues

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
