### PR TITLE
Handling sample hierarchy of non-dictionary/dictionary terms

### DIFF
--- a/client/plots/test/barchart.integration.spec.js
+++ b/client/plots/test/barchart.integration.spec.js
@@ -21,16 +21,19 @@ term1=categorical (no values)
 term1=termCollection categorical
 term1=categorical, term2=defaultbins
 term0=defaultbins, term1=categorical
+term1=categorical, term2=categorical (patient-level)
 term1=geneVariant no group
 term1=geneVariant with groups
 term1=geneVariant, term2=geneVariant using region but not gene
 term1=geneVariant geneset with groups
 term1=categorical, term2=geneVariant
+term1=categorical (patient-level), term2=geneVariant
 term1=geneExp, term2=geneVariant SKIPPED
 term1=geneVariant, term2=geneExp
 term1=geneExp
 term1=numeric term2=geneExp with default bins
 term1=geneExp, term2=categorical
+term1=geneExp, term2=categorical (patient-level)
 term1=condition, term2=gene exp with default bins
 term1=TP53 gene exp, term2=BCR gene exp, both terms with default bins
 term1=categorical, term0=gene exp with default bins
@@ -39,6 +42,7 @@ series visibility - numeric
 series visibility - condition
 
 single barchart, categorical filter
+single barchart (patient-level), compound filter (patient-level + sample-level) SKIPPED
 genevariant barchart, compound filter
 single barchart, TP53 mutation dtTerm filter
 
@@ -355,6 +359,45 @@ tape('term0=defaultbins, term1=categorical', function (test) {
 	}
 })
 
+tape('term1=categorical, term2=categorical (patient-level)', function (test) {
+	test.timeoutAfter(5000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'barchart',
+					term: { id: 'diaggrp' },
+					term2: { id: 'sex' }
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	let barDiv
+	async function runTests(barchart) {
+		barchart.on('postRender.test', null)
+		barDiv = barchart.Inner.dom.barDiv
+		await detectOne({ elem: barDiv.node(), selector: '.pp-bars-svg' })
+		testBarCount()
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+
+	function testBarCount() {
+		// no need to await, the bar order will tested after the initial postRender event
+		const minBars = 5
+		const numBars = barDiv.selectAll('.bars-cell-grp').size()
+		const numOverlays = barDiv.selectAll('.bars-cell').size()
+		test.true(numBars > minBars, `should have more than ${minBars} Diagnosis Group bars`)
+		test.true(numOverlays > numBars, 'number of overlays should be greater than bars')
+	}
+})
+
 tape('term1=geneVariant with groups', function (test) {
 	test.timeoutAfter(3000)
 	runpp({
@@ -458,6 +501,45 @@ tape('term1=categorical, term2=geneVariant', function (test) {
 		test.true(numCharts == 1, 'Should have 1 chart from gene variant term')
 		if (test._ok) barchart.Inner.app.destroy()
 		test.end()
+	}
+})
+
+tape('term1=categorical (patient-level), term2=geneVariant', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'barchart',
+					term: { id: 'genetic_race' },
+					term2: { term: { type: 'geneVariant', gene: 'TP53' }, q: { type: 'predefined-groupset' } }
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	let barDiv
+	async function runTests(barchart) {
+		barchart.on('postRender.test', null)
+		barDiv = barchart.Inner.dom.barDiv
+		await detectOne({ elem: barDiv.node(), selector: '.pp-bars-svg' })
+		testBarCount()
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+
+	function testBarCount() {
+		// no need to await, the bar order will tested after the initial postRender event
+		const minBars = 2
+		const numBars = barDiv.selectAll('.bars-cell-grp').size()
+		const numOverlays = barDiv.selectAll('.bars-cell').size()
+		test.true(numBars > minBars, `should have more than ${minBars} bars`)
+		test.true(numOverlays > numBars, 'number of overlays should be greater than bars')
 	}
 })
 
@@ -630,6 +712,51 @@ tape('term1=geneExp, term2=categorical', function (test) {
 		)
 		if (test._ok) barchart.Inner.app.destroy()
 		test.end()
+	}
+})
+
+tape('term1=geneExp, term2=categorical (patient-level)', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			plots: [
+				{
+					chartType: 'summary',
+					childType: 'barchart',
+					term: {
+						term: { gene: 'TP53', type: 'geneExpression' },
+						q: { mode: 'discrete' }
+					},
+					term2: {
+						id: 'sex'
+					}
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	let barDiv
+	async function runTests(barchart) {
+		barchart.on('postRender.test', null)
+		barDiv = barchart.Inner.dom.barDiv
+		await detectOne({ elem: barDiv.node(), selector: '.pp-bars-svg' })
+		testBarCount()
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+
+	function testBarCount() {
+		// no need to await, the bar order will tested after the initial postRender event
+		const minBars = 5
+		const numBars = barDiv.selectAll('.bars-cell-grp').size()
+		const numOverlays = barDiv.selectAll('.bars-cell').size()
+		test.true(numBars > minBars, `should have more than ${minBars} bars`)
+		test.true(numOverlays > numBars, 'number of overlays should be greater than bars')
 	}
 })
 
@@ -956,6 +1083,61 @@ tape('single barchart, categorical filter', function (test) {
 				filter: {
 					type: 'tvslst',
 					in: 1,
+					join: '',
+					lst: [
+						{
+							type: 'tvs',
+							tvs: { term: { id: 'diaggrp' }, values: [{ key: 'Acute lymphoblastic leukemia' }] }
+						}
+					]
+				}
+			},
+			plots: [
+				{
+					chartType: 'barchart',
+					term: {
+						id: 'agedx'
+					}
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	let barDiv
+	async function runTests(barchart) {
+		barchart.on('postRender.test', null)
+		barDiv = barchart.Inner.dom.barDiv
+		await detectOne({ elem: barDiv.node(), selector: '.pp-bars-svg' })
+		testBarCount()
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+
+	function testBarCount() {
+		// no need to await, the bar order will tested after the initial postRender event
+		const minBars = 3
+		const numBars = barDiv.selectAll('.bars-cell-grp').size()
+		const numOverlays = barDiv.selectAll('.bars-cell').size()
+		test.true(numBars > minBars, `should have more than ${minBars} bars`)
+		test.true(numOverlays == numBars, 'number of overlays should equal number of bars')
+	}
+})
+
+// skipping until sample-level + patient-level terms can be
+// resupported in filter
+tape.skip('single barchart (patient-level), compound filter (patient-level + sample-level)', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			termfilter: {
+				filter: {
+					type: 'tvslst',
+					in: 1,
 					join: 'and',
 					lst: [
 						{
@@ -1001,6 +1183,7 @@ tape('single barchart, categorical filter', function (test) {
 		test.end()
 	}
 })
+
 tape('genevariant barchart, compound filter', function (test) {
 	test.timeoutAfter(3000)
 	runpp({

--- a/client/plots/test/barchart.integration.spec.js
+++ b/client/plots/test/barchart.integration.spec.js
@@ -42,8 +42,9 @@ series visibility - numeric
 series visibility - condition
 
 single barchart, categorical filter
-single barchart (patient-level), compound filter (patient-level + sample-level) SKIPPED
-genevariant barchart, compound filter
+single barchart, categorical filter (patient-level)
+single barchart (patient-level), compound filter (patient-level + sample-level)
+genevariant barchart, compound filter SKIPPED
 single barchart, TP53 mutation dtTerm filter
 
 click non-group bar to add filter
@@ -1128,9 +1129,60 @@ tape('single barchart, categorical filter', function (test) {
 	}
 })
 
-// skipping until sample-level + patient-level terms can be
-// resupported in filter
-tape.skip('single barchart (patient-level), compound filter (patient-level + sample-level)', function (test) {
+tape('single barchart, categorical filter (patient-level)', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			termfilter: {
+				filter: {
+					type: 'tvslst',
+					in: 1,
+					join: '',
+					lst: [
+						{
+							type: 'tvs',
+							tvs: { term: { id: 'sex' }, values: [{ key: '2' }] }
+						}
+					]
+				}
+			},
+			plots: [
+				{
+					chartType: 'barchart',
+					term: {
+						id: 'agedx'
+					}
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	let barDiv
+	async function runTests(barchart) {
+		barchart.on('postRender.test', null)
+		barDiv = barchart.Inner.dom.barDiv
+		await detectOne({ elem: barDiv.node(), selector: '.pp-bars-svg' })
+		testBarCount()
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+
+	function testBarCount() {
+		// no need to await, the bar order will tested after the initial postRender event
+		const minBars = 3
+		const numBars = barDiv.selectAll('.bars-cell-grp').size()
+		const numOverlays = barDiv.selectAll('.bars-cell').size()
+		test.true(numBars > minBars, `should have more than ${minBars} bars`)
+		test.true(numOverlays == numBars, 'number of overlays should equal number of bars')
+	}
+})
+
+tape('single barchart (patient-level), compound filter (patient-level + sample-level)', function (test) {
 	test.timeoutAfter(3000)
 	runpp({
 		state: {
@@ -1184,7 +1236,8 @@ tape.skip('single barchart (patient-level), compound filter (patient-level + sam
 	}
 })
 
-tape('genevariant barchart, compound filter', function (test) {
+// skipped until non-dictionary terms can be filtered by patient-level terms
+tape.skip('genevariant barchart, compound filter', function (test) {
 	test.timeoutAfter(3000)
 	runpp({
 		state: {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -525,8 +525,9 @@ function mayValidateSampleTypes(tdb) {
 	}
 	// dataset has sample ancestry, therefore must have
 	// two sample types: parent and child
+	// TODO: later will support other sample type hierarchies
 	const sampleTypeConfig = tdb.sampleTypes
-	if (!sampleTypeConfig) 'sample type config missing'
+	if (!sampleTypeConfig) throw 'sample type config missing'
 	if (Object.keys(sampleTypeConfig).length != 2) throw 'sample type config must have 2 sample types'
 	let parentSampleType, childSampleType
 	for (const [k, v] of Object.entries(sampleTypeConfig)) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -56,6 +56,7 @@ import {
 import { validate_query_getWSISamples } from '#routes/wsisamples.ts'
 import { mds3InitNonblocking } from './mds3.init.nonblocking.js'
 import { dtTermTypes, TermTypes } from '#shared/terms.js'
+import { isNumeric } from '#shared/helpers.js'
 import { makeAdHocDicTermdbQueries } from './adHocDictionary/buildAdHocDictionary.ts'
 import { validate_query_saveWSIAnnotation } from '#routes/saveWSIAnnotation.ts'
 import { validate_query_deleteWSIAnnotation } from '#routes/deleteWSITileSelection.ts'
@@ -323,6 +324,9 @@ export async function validate_termdb(ds) {
 	await mayInitiateNumericDictionaryTermplots(ds)
 	await validate_correlationVolcano(ds)
 
+	// validate sample types
+	mayValidateSampleTypes(tdb)
+
 	if ('minTimeSinceDx' in tdb) {
 		if (!Number.isFinite(tdb.minTimeSinceDx)) throw 'termdb.minTimeSinceDx not number'
 		if (tdb.minTimeSinceDx <= 0) throw 'termdb.minTimeSinceDx<=0'
@@ -511,6 +515,31 @@ async function mayValidateRestrictAcestries(tdb) {
 			throw 'unknown PC source and configuration for restrictAncestries'
 		}
 	}
+}
+
+function mayValidateSampleTypes(tdb) {
+	if (!tdb.hasSampleAncestry) {
+		// for now, only validating sample types if ds has sample ancestry
+		// TODO: validate sample types for all datasets
+		return
+	}
+	// dataset has sample ancestry, therefore must have
+	// two sample types: parent and child
+	const sampleTypeConfig = tdb.sampleTypes
+	if (!sampleTypeConfig) 'sample type config missing'
+	if (Object.keys(sampleTypeConfig).length != 2) throw 'sample type config must have 2 sample types'
+	let parentSampleType, childSampleType
+	for (const [k, v] of Object.entries(sampleTypeConfig)) {
+		if (!isNumeric(k)) throw 'sample type is non-numeric'
+		const sampleType = Number(k)
+		if (Number.isInteger(v.parent_id)) {
+			childSampleType = sampleType
+		} else {
+			parentSampleType = sampleType
+		}
+	}
+	if (!Number.isInteger(parentSampleType)) throw 'invalid parent sample type'
+	if (!Number.isInteger(childSampleType)) throw 'invalid child sample type'
 }
 
 async function call_barchart_data(twLst, q, combination, ds, onlyChildren) {

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -279,7 +279,7 @@ function isInRange(val, range, isnot) {
 
 function emptyFilterResult(CTEname, mapParent2Children, ds) {
 	let query = `SELECT id as sample FROM sampleidmap WHERE 0`
-	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
+	if (mapParent2Children) query = getChildren(query)
 	return { CTEs: [`${CTEname} AS (${query})`], values: [], CTEname }
 }
 

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -1,12 +1,4 @@
-import {
-	isDictionaryType,
-	TermTypes,
-	getBin,
-	annoNumericTypes,
-	getParentType,
-	getSampleType,
-	dtTermTypes
-} from '#shared/terms.js'
+import { TermTypes, getBin, annoNumericTypes, isParentType, getSampleType, dtTermTypes } from '#shared/terms.js'
 import { validateTermCollectionTvs } from '#shared/filter.js'
 import { getSnpData, getData } from './termdb.matrix.js'
 import { filterByItem } from './mds3.init.js'
@@ -27,7 +19,7 @@ A superCTE is made to cap this level, with name "CTEname"
 // dummy $id for making up tw from tvs ({$id,term:tvs:term}) as required by getters
 const $id = 'xx'
 
-export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname = 'f') {
+export async function getFilterCTEs(filter, ds, mapParent2Children, CTEname = 'f') {
 	if (!filter) return
 	if (filter.type != 'tvslst') throw 'filter.type is not "tvslst" but: ' + filter.type
 	if (!Array.isArray(filter.lst)) throw 'filter.lst must be an array'
@@ -56,11 +48,8 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 	const CTEs = []
 	// cumulative values
 	const values = []
-	sampleTypes = getFilterSampleTypes(filter, ds, sampleTypes) //add filter types to sampleTypes
 	for (const [i, item] of filter.lst.entries()) {
 		const sample_type = getSampleType(item.tvs?.term, ds)
-		const parentType = getParentType(sampleTypes, ds)
-		const onlyChildren = sampleTypes.size > 1 && sample_type == parentType
 
 		if (item.tvs?.term?.id && (!item.tvs.term.type || !item.tvs.term.name)) {
 			// handle stripped-down dictionary termwrapper
@@ -73,7 +62,7 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 		if (item.type == 'tvslst') {
 			if (item.lst.length == 0) continue // do not process blank list
 
-			f = await getFilterCTEs(item, ds, sampleTypes, CTEname_i)
+			f = await getFilterCTEs(item, ds, mapParent2Children, CTEname_i)
 			// .filters: str, the CTE cascade, not used here!
 			// .CTEs: [] list of individual CTE string
 			// .values: []
@@ -95,22 +84,22 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 		} else if (dtTermTypes.has(item.tvs.term.type)) {
 			f = await get_dtTerm(item.tvs, CTEname_i, ds)
 		} else if (item.tvs.term.type == 'categorical') {
-			f = get_categorical(item.tvs, CTEname_i, ds, onlyChildren)
+			f = get_categorical(item.tvs, CTEname_i, ds, mapParent2Children)
 			// .CTEs: []
 			// .values:[]
 			// .CTEname
 		} else if (item.tvs.term.type == 'survival') {
-			f = get_survival(item.tvs, CTEname_i, ds, onlyChildren)
+			f = get_survival(item.tvs, CTEname_i, ds, mapParent2Children)
 		} else if (item.tvs.term.type == 'samplelst') {
-			f = get_samplelst(item.tvs, CTEname_i, ds, sample_type, onlyChildren)
+			f = get_samplelst(item.tvs, CTEname_i, ds, sample_type, mapParent2Children)
 		} else if (annoNumericTypes.has(item.tvs.term.type)) {
-			f = get_numerical(item.tvs, CTEname_i, ds, onlyChildren)
+			f = get_numerical(item.tvs, CTEname_i, ds, mapParent2Children)
 		} else if (item.tvs.term.type == 'condition') {
 			f = get_condition(item.tvs, CTEname_i, ds)
 		} else if (item.tvs.term.type == 'geneVariant') {
-			f = await get_geneVariant(item.tvs, CTEname_i, ds, onlyChildren)
+			f = await get_geneVariant(item.tvs, CTEname_i, ds, mapParent2Children)
 		} else if (item.tvs.term.type == 'termCollection') {
-			f = await get_termCollection(item.tvs, CTEname_i, ds, onlyChildren)
+			f = await get_termCollection(item.tvs, CTEname_i, ds, mapParent2Children)
 		} else if (item.tvs.term.type == 'snp') {
 			f = await get_snp(item.tvs, CTEname_i, ds)
 		} else if (item.tvs.term.type == 'multivalue') {
@@ -145,8 +134,7 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 		filters: CTEs.join(',\n'),
 		CTEs,
 		values,
-		CTEname,
-		sampleTypes
+		CTEname
 	}
 }
 
@@ -154,12 +142,12 @@ export async function getFilterCTEs(filter, ds, sampleTypes = new Set(), CTEname
 // put here instead of inside makesql_by_tvsfilter
 // to parse function once at server start instead of
 // multiple times per server request
-function get_categorical(tvs, CTEname, ds, onlyChildren) {
+function get_categorical(tvs, CTEname, ds, mapParent2Children) {
 	let query = `SELECT sample
 	FROM anno_categorical 
 	WHERE term_id = ?
 	AND value ${tvs.isnot ? 'NOT' : ''} IN (${tvs.values.map(i => '?').join(', ')})`
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 	return {
 		CTEs: [` ${CTEname} AS (${query})`],
 		values: [tvs.term.id, ...tvs.values.map(i => i.key)],
@@ -167,14 +155,14 @@ function get_categorical(tvs, CTEname, ds, onlyChildren) {
 	}
 }
 
-function get_survival(tvs, CTEname, ds, onlyChildren) {
+function get_survival(tvs, CTEname, ds, mapParent2Children) {
 	let query = `SELECT sample
 	FROM survival
 	WHERE term_id = ?
 	${tvs.q?.cutoff ? 'AND tte >= ' + tvs.q?.cutoff : ''}
 	AND exit_code ${tvs.isnot ? 'NOT' : ''} IN (${tvs.values.map(i => '?').join(', ')})`
 
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 	return {
 		CTEs: [
 			`
@@ -187,7 +175,7 @@ function get_survival(tvs, CTEname, ds, onlyChildren) {
 	}
 }
 
-function get_samplelst(tvs, CTEname, ds, sample_type, onlyChildren) {
+function get_samplelst(tvs, CTEname, ds, sample_type, mapParent2Children) {
 	const samples = []
 	for (const field in tvs.term.values) {
 		const list = tvs.term.values[field].list
@@ -205,7 +193,7 @@ function get_samplelst(tvs, CTEname, ds, sample_type, onlyChildren) {
 		query += `and sample_type = ?` //later on need to cleanup the list handling in samplelst
 		values.push(sample_type)
 	}
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 	return {
 		CTEs: [
 			`
@@ -220,7 +208,7 @@ function get_samplelst(tvs, CTEname, ds, sample_type, onlyChildren) {
 
 // TODO: may retire get_geneVariant() as geneVariant filtering is now
 // performed by get_dtTerm()
-async function get_geneVariant(tvs, CTEname, ds, onlyChildren) {
+async function get_geneVariant(tvs, CTEname, ds, mapParent2Children) {
 	const tw = { $id, term: tvs.term, q: {} }
 	const data = await ds.mayGetGeneVariantData(tw, { genome: ds.genomename })
 	/*
@@ -266,7 +254,7 @@ async function get_geneVariant(tvs, CTEname, ds, onlyChildren) {
 	let query = `SELECT id as sample
 				FROM sampleidmap
 				WHERE id IN (${samplenames.map(i => '?').join(', ')})`
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 
 	return {
 		CTEs: [
@@ -289,22 +277,22 @@ function isInRange(val, range, isnot) {
 	return isnot ? !(left && right) : left && right
 }
 
-function emptyFilterResult(CTEname, onlyChildren, ds) {
+function emptyFilterResult(CTEname, mapParent2Children, ds) {
 	let query = `SELECT id as sample FROM sampleidmap WHERE 0`
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 	return { CTEs: [`${CTEname} AS (${query})`], values: [], CTEname }
 }
 
 /** Custom termCollection filter: call query handlers directly for each member term,
  *  then filter samples by value range on the selected member. */
-async function get_termCollection_custom(tvs, CTEname, ds, onlyChildren) {
+async function get_termCollection_custom(tvs, CTEname, ds, mapParent2Children) {
 	const memberKey = tvs.values?.[0]?.key
 	const range = tvs.ranges?.[0]
-	if (!memberKey || !range) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (!memberKey || !range) return emptyFilterResult(CTEname, mapParent2Children, ds)
 
 	// Find the member term being filtered on
 	const mt = tvs.term.termlst?.find(t => (t.id || t.name) === memberKey)
-	if (!mt) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (!mt) return emptyFilterResult(CTEname, mapParent2Children, ds)
 
 	// Call the existing query handler for this member's dataType
 	const dataType = mt.dataType || 'isoformExpression'
@@ -314,7 +302,7 @@ async function get_termCollection_custom(tvs, CTEname, ds, onlyChildren) {
 	const tw = { $id, term: { type: dataType, isoform: mt.isoform, gene: mt.gene, name: mt.name } }
 	const data = await queryHandler.get({ terms: [tw] }, ds)
 	const values = data.term2sample2value?.get($id)
-	if (!values) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (!values) return emptyFilterResult(CTEname, mapParent2Children, ds)
 
 	return numericSampleData2tvs(tvs, CTEname, values)
 }
@@ -327,12 +315,12 @@ async function get_termCollection_custom(tvs, CTEname, ds, onlyChildren) {
  *  evaluation path. Instead, call the underlying query handlers (e.g.
  *  isoformExpression HDF5 handler) directly for each member term, then compute
  *  the numerator/denominator percentage client-side and filter samples. */
-async function get_termCollection_custom_percentage(tvs, CTEname, ds, onlyChildren) {
+async function get_termCollection_custom_percentage(tvs, CTEname, ds, mapParent2Children) {
 	const range = tvs.ranges?.[0]
-	if (!range) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (!range) return emptyFilterResult(CTEname, mapParent2Children, ds)
 	const termlst = tvs.term.termlst || []
 	const numerators = tvs.term.numerators || []
-	if (!termlst.length) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (!termlst.length) return emptyFilterResult(CTEname, mapParent2Children, ds)
 	if (numerators.length) {
 		validateTermCollectionTvs(
 			numerators,
@@ -390,12 +378,12 @@ async function get_termCollection_custom_percentage(tvs, CTEname, ds, onlyChildr
 		if (isInRange(percentage, range, tvs.isnot)) samplenames.push(sid)
 	}
 
-	if (!samplenames.length) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (!samplenames.length) return emptyFilterResult(CTEname, mapParent2Children, ds)
 
 	let query = `SELECT id as sample
 				FROM sampleidmap
 				WHERE id IN (${samplenames.map(() => '?').join(', ')})`
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 
 	return {
 		CTEs: [`${CTEname} AS (${query})`],
@@ -404,7 +392,7 @@ async function get_termCollection_custom_percentage(tvs, CTEname, ds, onlyChildr
 	}
 }
 
-async function get_termCollection(tvs, CTEname, ds, onlyChildren) {
+async function get_termCollection(tvs, CTEname, ds, mapParent2Children) {
 	if (tvs.term.memberType === 'categorical') {
 		throw new Error('termcollection memberType=categorical not supported yet')
 	}
@@ -413,7 +401,7 @@ async function get_termCollection(tvs, CTEname, ds, onlyChildren) {
 		// Custom collections bypass the getData() path below because getData()
 		// requires __protected__ auth context that is unavailable during filter
 		// CTE evaluation. Use direct query handler calls instead.
-		return await get_termCollection_custom_percentage(tvs, CTEname, ds, onlyChildren)
+		return await get_termCollection_custom_percentage(tvs, CTEname, ds, mapParent2Children)
 	}
 	if (tvs.term.numerators) {
 		validateTermCollectionTvs(
@@ -424,7 +412,7 @@ async function get_termCollection(tvs, CTEname, ds, onlyChildren) {
 	const tw = { $id, term: tvs.term, q: {} }
 	const data = await getData({ terms: [tw] }, ds)
 	const samplenames = []
-	if (!data.samples) return emptyFilterResult(CTEname, onlyChildren, ds)
+	if (!data.samples) return emptyFilterResult(CTEname, mapParent2Children, ds)
 	for (const [key, value] of Object.entries(data.samples)) {
 		const sampleEntry = value[$id]
 		if (!sampleEntry) continue
@@ -460,7 +448,7 @@ async function get_termCollection(tvs, CTEname, ds, onlyChildren) {
 	let query = `SELECT id as sample
 				FROM sampleidmap
 				WHERE id IN (${samplenames.map(i => '?').join(', ')})`
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 
 	return {
 		CTEs: [
@@ -593,7 +581,7 @@ async function get_dtTerm(tvs, CTEname, ds) {
 	return result
 }
 
-function get_numerical(tvs, CTEname, ds, onlyChildren) {
+function get_numerical(tvs, CTEname, ds, mapParent2Children) {
 	/*
 for the case e.g. '0' is for "Not exposed", range.value can be either '0' or 0, string or number
 as it cannot be decided what client will provide
@@ -658,7 +646,7 @@ so here need to allow both string and number as range.value
 					${combinedClauses ? 'AND (' + combinedClauses + ')' : ''}
 					${excludevalues && excludevalues.length ? `AND value NOT IN (${excludevalues.map(d => '?').join(',')}) ` : ''}`
 
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 
 	return {
 		CTEs: [
@@ -733,7 +721,7 @@ function get_condition(tvs, CTEname) {
 
 const validTvsJoin = new Set(['and', 'or'])
 
-function get_multivalue(tvs, CTEname, ds, onlyChildren) {
+function get_multivalue(tvs, CTEname, ds, mapParent2Children) {
 	// default to join = 'or', more permissive/less likely to break,
 	// and also compatible with default join operator for categorical terms
 	if (!tvs.join) tvs.join = 'or'
@@ -750,23 +738,12 @@ function get_multivalue(tvs, CTEname, ds, onlyChildren) {
 	let query = `SELECT sample
 	FROM anno_multivalue
 	WHERE term_id = ? AND ${expectedValues}`
-	if (onlyChildren && ds.cohort.termdb.hasSampleAncestry) query = getChildren(query)
+	if (isParentType(tvs.term, ds) && mapParent2Children) query = getChildren(query)
 	return {
 		CTEs: [` ${CTEname} AS (${query})`],
 		values: [tvs.term.id],
 		CTEname
 	}
-}
-
-function getFilterSampleTypes(filter, ds, sampleTypes) {
-	for (const [i, item] of filter.lst.entries()) {
-		if (!item.tvs || item.tvs.term.id == 'subcohort') continue
-
-		const term_id = item.tvs.term
-		const sample_type = getSampleType(term_id, ds)
-		if (sample_type != null) sampleTypes.add(sample_type)
-	}
-	return sampleTypes
 }
 
 function getChildren(query) {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -8,8 +8,8 @@ import {
 	isDictionaryType,
 	isNonDictionaryType,
 	getBin,
-	getParentType,
 	getSampleType,
+	isParentType,
 	DNA_METHYLATION,
 	GENE_EXPRESSION,
 	GENE_VARIANT,
@@ -41,16 +41,15 @@ Inputs:
 		.terms[] array of tw
 	ds{}
 		server-side dataset object
-	onlyChildren: boolean
-		true: the term annotates parent samples, the query will return annotations for the children of the samples that have the term
-		false: the term annotates child samples, the query will return annotations for the samples that have the term
+	mapParent2Children: boolean
+		whether to map annotations of parent samples onto child samples
 
 Returns:
 	- see ValidGetDataResponse type in shared/types/src/termdb.matrix.ts for documentation
 	- please update types in shared/types/src/termdb.matrix.ts if the return object is changed
 */
 
-export async function getData(q, ds, onlyChildren = false) {
+export async function getData(q, ds, mapParent2Children) {
 	if (serverconfig.debugmode && !ds?.cohort?.db) trackXfetch(new Map())
 
 	try {
@@ -62,7 +61,7 @@ export async function getData(q, ds, onlyChildren = false) {
 
 		const { expandedTerms, tcMappings } = expandCustomTermCollection(q.terms)
 		q.terms = expandedTerms
-		const data = await getSampleData(q, ds, onlyChildren)
+		const data = await getSampleData(q, ds, mapParent2Children)
 		reconstituteCustomTermCollection(data, tcMappings)
 
 		checkAccessToSampleData(data, ds, q)
@@ -122,11 +121,15 @@ const maxPendingQueriesBeforeRejectingRequest = serverconfig.features?.maxPendin
 let numActiveQueriesAcrossUsers = 0,
 	numPendingQueriesAcrossUsers = 0
 
-async function getSampleData(q, ds, onlyChildren = false) {
+async function getSampleData(q, ds, mapParent2Children) {
 	// dictionary and non-dictionary terms require different methods for data query
 	const [dictTerms, geneVariantTws, nonDictTerms] = divideTerms(q.terms)
-	onlyChildren = maySetOnlyChildren(q.terms, ds, onlyChildren)
-	const [samples, byTermId] = await getSampleData_dictionaryTerms(q, dictTerms, onlyChildren)
+
+	// determine whether parent annotations should be mapped onto child samples
+	mapParent2Children = maySetMapParent2Children(q.terms, ds, mapParent2Children)
+
+	// query dictionary term data
+	const [samples, byTermId] = await getSampleData_dictionaryTerms(q, dictTerms, mapParent2Children)
 	/* samples={}
 	this object collects term annotation data on all samples; even if there's no dict term it still return blank {}
 	non-dict term data will be appended to it
@@ -475,30 +478,46 @@ export function divideTerms(lst) {
 	return [dict, geneVariantTws, nonDict]
 }
 
-// function to set the onlyChildren flag, which controls whether
-// sample-level or parent-level data is retrieved
-// currently, this function is only performed if:
-// 	- ds has necessary flag and
-// 	- onlyChildren is false
-// TODO: apply to other datasets
-function maySetOnlyChildren(twLst, ds, onlyChildren) {
-	if (!ds.cohort.termdb.setOnlyChildren || onlyChildren) return onlyChildren
+// function to set the mapParent2Children flag, which controls
+// whether to map parent-level data onto child samples
+function maySetMapParent2Children(twLst, ds, mapParent2Children) {
+	if (!ds.cohort.termdb.hasSampleAncestry) {
+		// no sample ancestry, so should not map parent to children
+		return false
+	}
+	if (typeof mapParent2Children === 'boolean') {
+		// flag already defined so return it
+		return mapParent2Children
+	}
+	// ds has sample ancestry and mapParent2Children is undefined
 	const sampleTypeConfig = ds.cohort.termdb.sampleTypes
-	if (!sampleTypeConfig) 'sample type config missing'
-	if (Object.keys(sampleTypeConfig).length != 2) 'unexpected number of sample types in config'
 	const sampleTypes = getSampleTypes(twLst, ds)
 	const types = [...sampleTypes]
 	if (!types.length) {
 		throw 'no sample types found'
+	} else if (types.length == 1) {
+		// single sample type, no need to map parent to children
+		const type = types[0]
+		if (!sampleTypeConfig[type]) throw 'invalid sample type'
+		return false
 	} else if (types.length > 1) {
 		// multiple sample types
-		// onlyChildren should be true
+		// validate that one is parent and one is child
+		if (types.length != 2) throw 'unexpected number of sample types'
+		let parentType, childType
+		for (const type of types) {
+			const config = sampleTypeConfig[type]
+			if (!config) throw 'invalid sample type'
+			if (Number.isInteger(config.parent_id)) {
+				childType = type
+			} else {
+				parentType = type
+			}
+		}
+		if (!Number.isInteger(parentType)) throw 'invalid parent sample type'
+		if (!Number.isInteger(childType)) throw 'invalid child sample type'
+		// set flag to true to map parent annotations onto child samples
 		return true
-	} else {
-		// single sample type
-		// if sample type is child, then onlyChildren should be true
-		const type = types[0]
-		return Number.isInteger(sampleTypeConfig[type].parent_id)
 	}
 }
 
@@ -521,11 +540,11 @@ output:
 		{ byTermId: {} }
 }
 */
-async function getSampleData_dictionaryTerms(q, termWrappers, onlyChildren = false) {
+async function getSampleData_dictionaryTerms(q, termWrappers, mapParent2Children) {
 	if (!termWrappers.length) return [{}, {}]
 	if (q.ds?.cohort?.db) {
 		// dataset uses server-side sqlite db, must use this method for dictionary terms
-		return await getSampleData_dictionaryTerms_termdb(q, termWrappers, onlyChildren)
+		return await getSampleData_dictionaryTerms_termdb(q, termWrappers, mapParent2Children)
 	}
 	if (q.ds.cohort.termdb.dictionary?.get) {
 		// ds-supplied getter to retrieve dictionary term data
@@ -544,7 +563,7 @@ async function getSampleData_dictionaryTerms(q, termWrappers, onlyChildren = fal
 	throw 'unknown method for dictionary terms'
 }
 
-export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, onlyChildren) {
+export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, mapParent2Children) {
 	const byTermId = {} // to return
 	// must copy filter.values as its copy may be used in separate SQL statements,
 	// for example get_rows or numeric min-max, and each CTE generator would
@@ -581,9 +600,9 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, only
 
 	// for "samplelst" term, term.id is missing and must use term.name
 	values.push(...termWrappers.map(tw => tw.$id || tw.term.id || tw.term.name))
-	const types = filter ? filter.sampleTypes : sampleTypes //the filter adds the types in the filter, that need to be considered
-	if (!onlyChildren) onlyChildren = types.size > 1
-	const rows = await getAnnotationRows(q, termWrappers, filter, CTEs, values, types, onlyChildren)
+	// TODO: handle sample types in filter
+	/*const types = filter ? filter.sampleTypes : sampleTypes //the filter adds the types in the filter, that need to be considered*/
+	const rows = await getAnnotationRows(q, termWrappers, filter, CTEs, values, mapParent2Children)
 	const samples = await getSamples(q, rows, termWrappers)
 	return [samples, byTermId]
 }
@@ -601,28 +620,28 @@ export function getSampleTypes(termWrappers, ds) {
 When querying sample annotations for dictionary terms, the query is split into two parts:
 1. CTEs are generated for each term, and the CTEs are combined into a single SQL query
 2. The SQL query is executed and the results are processed into a map of samples
-The query for a term needs to be generated based on the sample types present in the query and
-considering if the current term is a parent term or a child term.:
-- If `onlyChildren` is true  and the term annotates parent samples, the query will return annotations for the children of the samples that have the term
-- If `onlyChildren` is false or the term annotates child samples, the query will return annotations for the samples that have the term
- */
-export async function getAnnotationRows(q, termWrappers, filter, CTEs, values, types, onlyChildren) {
-	const parentType = getParentType(types, q.ds)
+
+Mapping parent annotations onto child samples: when a term annotates parent samples and mapParent2Children is true, then annotations will get mapped onto child samples
+*/
+export async function getAnnotationRows(q, termWrappers, filter, CTEs, values, mapParent2Children) {
 	const sql = `WITH
 		${filter ? filter.filters + ',' : ''}
 		${CTEs.map(t => t.sql).join(',\n')}
 		${CTEs.map((t, i) => {
 			const tw = termWrappers[i]
-			const sampleType = getSampleType(tw.term, q.ds)
 			let query
-			if (onlyChildren && parentType == sampleType && q.ds.cohort.termdb.hasSampleAncestry)
+			if (isParentType(tw.term, q.ds) && mapParent2Children) {
+				// term is parent-level term and need to map
+				// parent annotations onto child samples
 				query = ` select sa.sample_id as sample, key, value, ? as term_id
 				 from sample_ancestry sa join ${t.tablename} on sa.ancestor_id = sample
 				${filter ? ` WHERE sample_id IN ${filter.CTEname} ` : ''}`
-			else
+			} else {
+				// query annotations directly
 				query = ` SELECT sample, key, value, ? as term_id
 				FROM ${t.tablename}
 				${filter ? ` WHERE sample IN ${filter.CTEname} ` : ''}`
+			}
 			return query
 		}).join(`UNION ALL`)}`
 

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -624,6 +624,7 @@ function getTwSampleTypes(twLst, ds) {
 
 function getFilterSampleTypes(filter, ds) {
 	const types = new Set()
+	if (!filter) return types
 	for (const item of filter.lst) {
 		if (item.type == 'tvslst') {
 			for (const type of getFilterSampleTypes(item, ds)) types.add(type)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -126,7 +126,7 @@ async function getSampleData(q, ds, mapParent2Children) {
 	const [dictTerms, geneVariantTws, nonDictTerms] = divideTerms(q.terms)
 
 	// determine whether parent annotations should be mapped onto child samples
-	mapParent2Children = maySetMapParent2Children(q.terms, ds, mapParent2Children)
+	mapParent2Children = maySetMapParent2Children(q, ds, mapParent2Children)
 
 	// query dictionary term data
 	const [samples, byTermId] = await getSampleData_dictionaryTerms(q, dictTerms, mapParent2Children)
@@ -480,7 +480,7 @@ export function divideTerms(lst) {
 
 // function to set the mapParent2Children flag, which controls
 // whether to map parent-level data onto child samples
-function maySetMapParent2Children(twLst, ds, mapParent2Children) {
+function maySetMapParent2Children(q, ds, mapParent2Children) {
 	if (!ds.cohort.termdb.hasSampleAncestry) {
 		// no sample ancestry, so should not map parent to children
 		return false
@@ -491,7 +491,7 @@ function maySetMapParent2Children(twLst, ds, mapParent2Children) {
 	}
 	// ds has sample ancestry and mapParent2Children is undefined
 	const sampleTypeConfig = ds.cohort.termdb.sampleTypes
-	const sampleTypes = getSampleTypes(twLst, ds)
+	const sampleTypes = getSampleTypes(q, ds)
 	const types = [...sampleTypes]
 	if (!types.length) {
 		throw 'no sample types found'
@@ -568,8 +568,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, mapP
 	// must copy filter.values as its copy may be used in separate SQL statements,
 	// for example get_rows or numeric min-max, and each CTE generator would
 	// have to independently extend its copy of filter values
-	const sampleTypes = getSampleTypes(termWrappers, q.ds)
-	const filter = await getFilterCTEs(q.filter, q.ds, sampleTypes)
+	const filter = await getFilterCTEs(q.filter, q.ds, mapParent2Children)
 	const values = filter ? filter.values.slice() : []
 	const CTEs = await Promise.all(
 		termWrappers.map(async (tw, i) => {
@@ -600,18 +599,39 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, mapP
 
 	// for "samplelst" term, term.id is missing and must use term.name
 	values.push(...termWrappers.map(tw => tw.$id || tw.term.id || tw.term.name))
-	// TODO: handle sample types in filter
-	/*const types = filter ? filter.sampleTypes : sampleTypes //the filter adds the types in the filter, that need to be considered*/
 	const rows = await getAnnotationRows(q, termWrappers, filter, CTEs, values, mapParent2Children)
 	const samples = await getSamples(q, rows, termWrappers)
 	return [samples, byTermId]
 }
 
-export function getSampleTypes(termWrappers, ds) {
+function getSampleTypes(q, ds) {
+	const twLst = q.terms
+	const filter = q.filter
+	const twTypes = getTwSampleTypes(twLst, ds)
+	const filterTypes = getFilterSampleTypes(filter, ds)
+	const types = new Set([...twTypes, ...filterTypes])
+	return types
+}
+
+function getTwSampleTypes(twLst, ds) {
 	const types = new Set()
-	for (const tw of termWrappers) {
+	for (const tw of twLst) {
 		const type = getSampleType(tw.term, ds)
 		types.add(type)
+	}
+	return types
+}
+
+function getFilterSampleTypes(filter, ds) {
+	const types = new Set()
+	for (const item of filter.lst) {
+		if (item.type == 'tvslst') {
+			for (const type of getFilterSampleTypes(item, ds)) types.add(type)
+		} else {
+			if (item.tag == 'cohortFilter') continue
+			const type = getSampleType(item.tvs.term, ds)
+			if (Number.isInteger(type)) types.add(type)
+		}
 	}
 	return types
 }

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -548,7 +548,7 @@ async function getSampleData_dictionaryTerms(q, termWrappers, mapParent2Children
 	}
 	if (q.ds.cohort.termdb.dictionary?.get) {
 		// ds-supplied getter to retrieve dictionary term data
-		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers, onlyChildren)
+		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers, mapParent2Children)
 	}
 	/* gdc ds has no cohort.db. thus call v2s.get() to return sample annotations for its dictionary terms
 	 */

--- a/server/src/test/termdb.filter.unit.spec.js
+++ b/server/src/test/termdb.filter.unit.spec.js
@@ -59,8 +59,8 @@ tape('simple filter', async function (test) {
 	//console.log(filter.values)
 	test.deepEqual(
 		Object.keys(filter).sort((a, b) => (a < b ? -1 : 1)),
-		['CTEname', 'CTEs', 'filters', 'sampleTypes', 'values'],
-		'should return an object with the five expected keys'
+		['CTEname', 'CTEs', 'filters', 'values'],
+		'should return an object with the four expected keys'
 	)
 	test.equal(filter.CTEname, 'f', 'should return the default CTE name')
 	test.equal(
@@ -137,8 +137,8 @@ tape('nested filter', async function (test) {
 	//console.log(filter.values)
 	test.deepEqual(
 		Object.keys(filter).sort((a, b) => (a < b ? -1 : 1)),
-		['CTEname', 'CTEs', 'filters', 'sampleTypes', 'values'],
-		'should return an object with the five expected keys'
+		['CTEname', 'CTEs', 'filters', 'values'],
+		'should return an object with the four expected keys'
 	)
 	test.equal(filter.CTEname, 'f', 'should return the default CTE name')
 	test.equal(
@@ -192,8 +192,8 @@ tape('custom termCollection percentage filter', async function (test) {
 
 	test.deepEqual(
 		Object.keys(filter).sort((a, b) => (a < b ? -1 : 1)),
-		['CTEname', 'CTEs', 'filters', 'sampleTypes', 'values'],
-		'should return an object with the five expected keys'
+		['CTEname', 'CTEs', 'filters', 'values'],
+		'should return an object with the four expected keys'
 	)
 	test.equal(filter.CTEname, 'f', 'should return the default CTE name')
 	test.ok(filter.values.length > 0, 'should return matching samples (percentage > 0)')

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1754,8 +1754,6 @@ keep this setting here for reason of:
 	getAdditionalFilter?: (__protected__: any, term: any) => Filter | undefined
 	/** collections of dictionary terms (numeric or categorical) that are related and can be used together in some plots */
 	termCollections?: TermCollection[]
-	/** whether to set onlyChildren in getData() */
-	setOnlyChildren?: true
 }
 
 type TermCollectionBase = {

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -268,6 +268,22 @@ export function getParentType(types: Set<string>, ds: any) {
 	return null //no parent found
 }
 
+// whether the term annotates parent samples
+export function isParentType(term: any, ds: any) {
+	if (!ds.cohort.termdb.hasSampleAncestry) return false
+	const sampleType = getSampleType(term, ds)
+	if (!sampleType) throw 'sample type is not defined'
+	const sampleTypeObj = ds.cohort.termdb.sampleTypes[sampleType]
+	if (!sampleTypeObj) throw 'invalid sample type'
+	if (Number.isInteger(sampleTypeObj.parent_id)) {
+		// sample type has parent, so it is child sample type
+		return false
+	} else {
+		// sample type does not have parent, so it is parent sample type
+		return true
+	}
+}
+
 //Returns human readable label for each term type; label is just for printing and not computing
 const typeMap: { [key: string]: string } = {
 	categorical: 'Categorical',


### PR DESCRIPTION
# Description

This PR supports overlaying non-dictionary and dictionary terms when terms have different levels of sample hierarchy (parent vs. child). The PR also replaces the `onlyChildren` boolean with the `mapParent2Children` boolean.

Can test by launching [geneVariant (sample-level)/sex (patient-level) barchart](http://localhost:3000/?mass=%7B%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:%7B%22activeTab%22:-1%7D,%22plots%22:%5B%7B%22chartType%22:%22summary%22,%22term%22:%7B%22id%22:%22sex%22%7D,%22term2%22:%7B%22term%22:%7B%22type%22:%22geneVariant%22,%22gene%22:%22TP53%22%7D%7D%7D%5D%7D).

Sample hierarchy is handled as follows:
- When query reaches `getData()` in `server/src/termdb.matrix.js`, the `maySetMapParent2Children()` helper will get the sample types of all termwrapper terms and filter terms
- If only a single unique sample type, then `mapParent2Children` is set to `false`
- If multiple unique sample types, then `mapParent2Children` is set to `true`
- Then in `getAnnotationRows()`, if `mapParent2Children=true` and the term is a parent-level term, then map its annotations onto child samples
- Otherwise, query the term annotations directly

Sample hierarchy of filter terms is handled in a similar way in `getFilterCTEs()` in `server/src/termdb.filter.js`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
