### PR TITLE
Optimized plot grouping and added plot buttons to sample table

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -46,6 +46,7 @@ export function renderTable({
 	download = undefined,
 	noAutoScroll = false,
 	hoverEffects,
+	afterRender,
 	allowRestoreRowOrder = false,
 	restoreButtonInFooter = false,
 	pagination
@@ -434,6 +435,7 @@ export function renderTable({
 			//Allows for hover effects to remain consistent when the rows are updated.
 			if (hoverEffects) hoverEffects(tr, row)
 		}
+		if (afterRender) afterRender()
 	}
 
 	updateRows()

--- a/client/dom/types/table.ts
+++ b/client/dom/types/table.ts
@@ -159,6 +159,9 @@ export type TableArgs = {
 	allowRestoreRowOrder?: boolean
 	/** When true, places the restore button with footer buttons instead of separately */
 	restoreButtonInFooter?: boolean
+	/** Called after rows are rendered (e.g. after sort, pagination,
+	 * or restore). Use with __td references to apply custom html */
+	afterRender?: () => void
 	/** When set, render pagination controls below the table and only display
 	 * one page worth of rows at a time. Sort still operates on the full rows[] array. */
 	pagination?: {

--- a/client/plots/sc/README.md
+++ b/client/plots/sc/README.md
@@ -1,7 +1,5 @@
-_This document is a draft. App is in development_
-
-# Single Cell App
-The sc 'super' app is designed to showcase single cell data in multiple modalities. SC.ts is the parent component for the mass UI. The child components are launched based on the configuration in the dataset file from the parent. 
+# Single Cell (SC) App
+The SC 'super' app is designed to showcase single cell data in multiple modalities. SC.ts is the parent component for the mass UI. The child components are launched based on the configuration in the dataset file from the parent. 
 
 # Code architecture
 
@@ -12,7 +10,7 @@ The SC app makes two server requests via SCModel, each corresponding to a differ
 Called during `init()` to populate the sample selection table. The request sends the genome, dslabel, and an optional filter. The response returns an array of `SingleCellSample` objects along with `fields` and `columnNames` used to build the table columns. SCViewModel.getTableData() transforms the samples and column metadata into the table structure rendered by the view. This data drives the rest of the app: the user must select a sample from the table before any plots can be created.
 
 ### Plot Data (`termdb/singlecellData`)
-Called during `main()` once a sample is selected (`config.settings.sc.item`). The request sends the sample identifier, the list of plot names to fetch (e.g. `['umap', 'tsne']`), and optional gene/colorBy parameters. The response returns an array of plot objects, each containing cell coordinate arrays (`expCells`, `noExpCells`), color columns, and color mappings. `formatPlotData()` merges and sorts the cell arrays before the view renders them.
+Called during `main()` once a sample is selected (`config.settings.sc.item`). The request sends the sample identifier, the list of plot names to fetch (e.g. `['umap', 'tsne']`), and `checkPlotAvailability` (default true). When `checkPlotAvailability` is true, the response returns which plots are available for the sample but not the actual cell data. The available plot names drive the plot buttons rendered by `SCViewRenderer`. Individual subplot components fetch their own cell data independently.
 
 ## Subplots
 Subplot creation and rendering: 
@@ -23,11 +21,11 @@ Subplot creation and rendering:
 Once added as a component, the plot will update every time `app.dispatch` is called.
 
 ### Sections (`SectionRenderer`)
-`SectionRenderer` (in `view/SectionRenderer.ts`) groups subplots by sample into collapsible sections. It maintains a `sections` map keyed by sample id and a `plotId2Sample` map that links each subplot id back to its sample.
+`SectionRenderer` (in `view/SectionRenderer.ts`) groups subplots into collapsible sections based on the `groupBy` setting (`'none'`, `'sample'`, or `'plot'`). It maintains a `sections` map keyed by the grouping key (a fixed `'none'` string, a sample id, or a plot name) and a `plotId2Key` map that links each subplot id back to its section key.
 
-`update()` runs three passes on every render cycle:
+`update()` first checks whether `groupBy` has changed. If so, it delegates to `regroupSections()` which reparents existing sandboxes into new section containers without destroying or recreating plot components. Otherwise it runs three passes:
 1. **Remove stale subplots** — builds an active set from the current state and calls `removeSandbox()` for any component in `sc.components.plots` that is no longer active.
-2. **Initialize new subplots** — for each subplot in state, creates its section (via `initSection()`) if one does not exist for the sample, then creates a sandbox (via `initSandbox()`) if one does not exist for the subplot. `initSandbox()` calls `sc.initPlotComponent()` which dynamically imports the chart module and stores the component.
+2. **Initialize new subplots** — for each subplot in state, derives the section key via `getKey()`, creates its section (via `initSection()`) if one does not exist for that key, then creates a sandbox (via `initSandbox()`) if one does not exist for the subplot. `initSandbox()` calls `sc.initPlotComponent()` which dynamically imports the chart module and stores the component.
 3. **Remove empty sections** — deletes any section whose sandboxes map is empty.
 
 Users can also remove subplots and sections directly:

--- a/client/plots/sc/SCTypes.ts
+++ b/client/plots/sc/SCTypes.ts
@@ -69,6 +69,8 @@ export type SCTableData = {
 	rows: TableRow[]
 	columns: TableColumn[]
 	selectedRows: number[]
+	/** Column idx with sample IDs */
+	sampleColIdx: number
 }
 
 /** Slightly modified from termdbConfig.queries.singleCell.samples.sampleColumns */

--- a/client/plots/sc/test/SCViewModel.unit.spec.ts
+++ b/client/plots/sc/test/SCViewModel.unit.spec.ts
@@ -131,14 +131,14 @@ tape('getTabelData() should expand experiments into separate rows', test => {
 	test.equal(vm.tableData.rows.length, 2, 'Should create one row per experiment')
 	// Columns: Sample, Sample (experiment sample name), Experiment
 	test.equal(vm.tableData.columns.length, 4, 'Should have Sample + Shown plots + Sample + Experiment columns')
-	test.equal(vm.tableData.columns[2].label, 'Sample', 'Second column should be Sample for experiment sample name')
+	test.equal(vm.tableData.columns[1].label, 'Sample', 'Second column should be Sample for experiment sample name')
 	test.equal(vm.tableData.columns[3].label, 'Experiment', 'Third column should be Experiment')
 
 	const row0 = vm.tableData.rows[0] as any[]
 	test.equal(row0[0].value, 'Case1', 'Row should have case/sample name')
 	test.equal(row0[0].__experimentID, 'EXP1', 'Row should sneak in experimentID')
 	test.equal(row0[1].value, 'exp_sample_1', 'Row should have experiment sample name')
-	test.equal(row0[2].value, 'EXP1', 'Row should have experiment ID')
+	test.equal(row0[3].value, 'EXP1', 'Row should have experiment ID')
 	test.end()
 })
 
@@ -198,6 +198,6 @@ tape('getTabelData() should include sampleColumns with experiments', test => {
 	test.equal(vm.tableData.columns[3].label, 'Sex', 'Third column should be Sex')
 
 	const row0 = vm.tableData.rows[0] as any[]
-	test.equal(row0[2].value, 'Female', 'Row should include sample column value')
+	test.equal(row0[3].value, 'Female', 'Row should include sample column value')
 	test.end()
 })

--- a/client/plots/sc/test/SCViewModel.unit.spec.ts
+++ b/client/plots/sc/test/SCViewModel.unit.spec.ts
@@ -91,11 +91,11 @@ tape('getTabelData() should add sampleColumns when provided', test => {
 
 	const vm = new SCViewModel(app, config, items as any, sampleColumns)
 
-	test.equal(vm.tableData.columns.length, 2, 'Should have sample column + 1 extra column')
-	test.equal(vm.tableData.columns[1].label, 'Sex', 'Extra column label should match')
-	test.equal(vm.tableData.columns[1].sortable, true, 'Extra column should be sortable')
+	test.equal(vm.tableData.columns.length, 3, 'Should have sample column + 1 extra column')
+	test.equal(vm.tableData.columns[2].label, 'Sex', 'Extra column label should match')
+	test.equal(vm.tableData.columns[2].sortable, true, 'Extra column should be sortable')
 	const row = vm.tableData.rows[0] as any[]
-	test.equal(row[1].value, 'Male', 'Row should include sample column value')
+	test.equal(row[2].value, 'Male', 'Row should include sample column value')
 	test.end()
 })
 
@@ -106,7 +106,7 @@ tape('getTabelData() should handle samples without experiments', test => {
 
 	const vm = new SCViewModel(app, config, items as any)
 
-	test.equal(vm.tableData.columns.length, 1, 'Should only have the sample column')
+	test.equal(vm.tableData.columns.length, 2, 'Should only have the sample and shown plots columns')
 	test.equal(vm.tableData.rows.length, 2, 'Should have one row per sample')
 	const row0 = vm.tableData.rows[0] as any[]
 	test.equal(row0[0].value, 'S1', 'First row value should be sample name')
@@ -130,9 +130,9 @@ tape('getTabelData() should expand experiments into separate rows', test => {
 
 	test.equal(vm.tableData.rows.length, 2, 'Should create one row per experiment')
 	// Columns: Sample, Sample (experiment sample name), Experiment
-	test.equal(vm.tableData.columns.length, 3, 'Should have sample + Sample + Experiment columns')
-	test.equal(vm.tableData.columns[1].label, 'Sample', 'Second column should be Sample for experiment sample name')
-	test.equal(vm.tableData.columns[2].label, 'Experiment', 'Third column should be Experiment')
+	test.equal(vm.tableData.columns.length, 4, 'Should have Sample + Shown plots + Sample + Experiment columns')
+	test.equal(vm.tableData.columns[2].label, 'Sample', 'Second column should be Sample for experiment sample name')
+	test.equal(vm.tableData.columns[3].label, 'Experiment', 'Third column should be Experiment')
 
 	const row0 = vm.tableData.rows[0] as any[]
 	test.equal(row0[0].value, 'Case1', 'Row should have case/sample name')
@@ -194,8 +194,8 @@ tape('getTabelData() should include sampleColumns with experiments', test => {
 	const vm = new SCViewModel(app, config, items as any, sampleColumns)
 
 	// Columns: Sample, Sample (exp), Sex, Experiment
-	test.equal(vm.tableData.columns.length, 4, 'Should have 4 columns')
-	test.equal(vm.tableData.columns[2].label, 'Sex', 'Third column should be Sex')
+	test.equal(vm.tableData.columns.length, 5, 'Should have 5 columns')
+	test.equal(vm.tableData.columns[3].label, 'Sex', 'Third column should be Sex')
 
 	const row0 = vm.tableData.rows[0] as any[]
 	test.equal(row0[2].value, 'Female', 'Row should include sample column value')

--- a/client/plots/sc/test/SampleTableRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SampleTableRenderer.unit.spec.ts
@@ -1,0 +1,394 @@
+import tape from 'tape'
+import * as d3s from 'd3-selection'
+import { SampleTableRenderer } from '../view/SampleTableRenderer.ts'
+
+/**
+ * Tests
+ *   - constructor should set dom, interactions, tableData, and rowIndex
+ *   - renderSamplesTable() should render table headers from columns
+ *   - renderSamplesTable() should render correct number of rows
+ *   - renderSamplesTable() noButtonCallback should build item with sID from sample column
+ *   - renderSamplesTable() noButtonCallback should build item with eID from experiment column
+ *   - renderSamplesTable() noButtonCallback should map custom column labels to keys
+ *   - renderSamplesTable() noButtonCallback should throw when sID is missing
+ *   - renderSamplesTable() noButtonCallback should call interactions.updateItem
+ *   - renderSamplesTable() noButtonCallback should show plotsBtnsDiv
+ *   - updateTable() should return early when sampleId is undefined
+ *   - updateTable() should return early when row does not match sampleId
+ *   - updateTable() should clear previous plot buttons
+ *   - updateTable() should return early when no sandboxes exist for sample
+ *   - updateTable() should append plot buttons for each sandbox
+ *   - appendPlotBtn() should truncate long plot names
+ *   - appendPlotBtn() should not truncate short plot names
+ *   - appendPlotBtn() should scroll sandbox into view on click
+ */
+
+/*************************
+ reusable helper functions
+**************************/
+
+function getHolder() {
+	return d3s
+		.select('body')
+		.append('div')
+		.style('border', '1px solid #aaa')
+		.style('padding', '5px')
+		.style('margin', '5px')
+}
+
+function getTestTableData() {
+	return {
+		columns: [{ label: 'Sample', sortable: true }, { label: 'Shown plots' }, { label: 'Experiment', sortable: true }],
+		rows: [
+			[{ value: 'S1' }, { value: '' }, { value: 'EXP1' }],
+			[{ value: 'S2' }, { value: '' }, { value: 'EXP2' }],
+			[{ value: 'S3' }, { value: '' }, { value: 'EXP3' }]
+		],
+		selectedRows: []
+	}
+}
+
+function getMockDom(holder: any) {
+	return {
+		tableDiv: holder,
+		plotsBtnsDiv: holder.append('div').style('display', 'none')
+	} as any
+}
+
+function getMockInteractions(overrides: any = {}) {
+	return {
+		updateItem: overrides.updateItem || (() => {}),
+		...overrides
+	} as any
+}
+
+function getRenderer(overrides: any = {}) {
+	const holder = getHolder()
+	const dom = overrides.dom || getMockDom(holder)
+	const interactions = overrides.interactions || getMockInteractions(overrides)
+	const tableData = overrides.tableData || getTestTableData()
+	const renderer = new SampleTableRenderer(dom, interactions, tableData)
+	return { renderer, holder, dom, interactions, tableData }
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- plots/sc/view/SampleTableRenderer -***-')
+	test.end()
+})
+
+/* ---- constructor ---- */
+
+tape('constructor should set dom, interactions, tableData, and rowIndex', test => {
+	const { renderer, holder, dom, interactions, tableData } = getRenderer()
+
+	test.equal(renderer.dom, dom, 'Should set dom reference')
+	test.equal(renderer.interactions, interactions, 'Should set interactions reference')
+	test.equal(renderer.tableData, tableData, 'Should set tableData reference')
+	test.equal(renderer.rowIndex, -1, 'Should initialize rowIndex to -1')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+/* ---- renderSamplesTable() ---- */
+
+tape('renderSamplesTable() should render table headers from columns', test => {
+	const { holder } = getRenderer()
+
+	const headers = holder.selectAll('th').nodes() as HTMLElement[]
+	const headerTexts = headers.map(h => h.textContent?.replace(/[⇵↑↓]/g, '').trim())
+	test.ok(headerTexts.includes('Sample'), 'Should render Sample header')
+	test.ok(headerTexts.includes('Shown plots'), 'Should render Shown plots header')
+	test.ok(headerTexts.includes('Experiment'), 'Should render Experiment header')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('renderSamplesTable() should render correct number of rows', test => {
+	const { holder } = getRenderer()
+
+	const rows = holder.selectAll('tr.sjpp_row_wrapper').nodes()
+	test.equal(rows.length, 3, 'Should render 3 rows')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('renderSamplesTable() noButtonCallback should build item with sID from sample column', test => {
+	let capturedItem: any
+	const { holder } = getRenderer({
+		updateItem: (item: any) => {
+			capturedItem = item
+		}
+	})
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	test.equal(capturedItem.sID, 'S1', 'Should map sample column to sID')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('renderSamplesTable() noButtonCallback should build item with eID from experiment column', test => {
+	let capturedItem: any
+	const { holder } = getRenderer({
+		updateItem: (item: any) => {
+			capturedItem = item
+		}
+	})
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	test.equal(capturedItem.eID, 'EXP1', 'Should map experiment column to eID')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('renderSamplesTable() noButtonCallback should map custom column labels to keys', test => {
+	let capturedItem: any
+	const tableData = {
+		columns: [
+			{ label: 'Sample', sortable: true },
+			{ label: 'Shown plots' },
+			{ label: 'Experiment', sortable: true },
+			{ label: 'Project', sortable: true }
+		],
+		rows: [[{ value: 'S1' }, { value: '' }, { value: 'EXP1' }, { value: 'PROJ1' }]],
+		selectedRows: []
+	}
+
+	const holder = getHolder()
+	const dom = getMockDom(holder)
+	const interactions = getMockInteractions({
+		updateItem: (item: any) => {
+			capturedItem = item
+		}
+	})
+	new SampleTableRenderer(dom, interactions, tableData)
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	test.equal(capturedItem.project, 'PROJ1', 'Should use lowercase column label as key for custom columns')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape.skip('renderSamplesTable() noButtonCallback should throw when sID is missing', test => {
+	const tableData = {
+		columns: [{ label: 'Project', sortable: true }],
+		rows: [[{ value: 'PROJ1' }]],
+		selectedRows: []
+	}
+
+	const holder = getHolder()
+	const dom = getMockDom(holder)
+	const interactions = getMockInteractions()
+	new SampleTableRenderer(dom, interactions, tableData)
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	test.throws(
+		() => {
+			firstRow.click()
+		},
+		/sID/,
+		'Should throw error about missing sID'
+	)
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('renderSamplesTable() noButtonCallback should call interactions.updateItem', test => {
+	let called = false
+	const { holder } = getRenderer({
+		updateItem: () => {
+			called = true
+		}
+	})
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	test.ok(called, 'Should call interactions.updateItem')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('renderSamplesTable() noButtonCallback should show plotsBtnsDiv', test => {
+	const { holder, dom } = getRenderer()
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	test.equal(dom.plotsBtnsDiv.style('display'), 'block', 'Should set plotsBtnsDiv display to block')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+/* ---- updateTable() ---- */
+
+tape('updateTable() should return early when sampleId is undefined', test => {
+	const { renderer, holder } = getRenderer()
+
+	// Should not throw
+	renderer.updateTable(undefined, new Map())
+	test.pass('Should return early without error')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('updateTable() should return early when row does not match sampleId', test => {
+	const { renderer, holder } = getRenderer()
+
+	// rowIndex is -1, so no row matches
+	renderer.updateTable('S1', new Map())
+	test.pass('Should return early when rowIndex row does not match sampleId')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('updateTable() should clear previous plot buttons', test => {
+	const { renderer, holder } = getRenderer()
+
+	// Simulate selecting first row
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	// Get the cell and manually add a plot button
+	const row = renderer.tableData.rows[0] as any
+	const cell = row[1].__td
+	cell.append('span').attr('class', 'sjpp-sc-table-plot-btn').text('old btn')
+
+	// Call updateTable with empty sandboxes for this sample
+	const sandboxes = new Map<string, { plotId: string; div: any; plotName: string }[]>()
+	sandboxes.set('S1', [])
+	renderer.updateTable('S1', sandboxes)
+
+	const btns = cell.selectAll('.sjpp-sc-table-plot-btn').nodes()
+	test.equal(btns.length, 0, 'Should clear previous plot buttons')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('updateTable() should return early when no sandboxes exist for sample', test => {
+	const { renderer, holder } = getRenderer()
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	const sandboxes = new Map<string, { plotId: string; div: any; plotName: string }[]>()
+	renderer.updateTable('S1', sandboxes)
+
+	const row = renderer.tableData.rows[0] as any
+	const cell = row[1].__td
+	const btns = cell.selectAll('.sjpp-sc-table-plot-btn').nodes()
+	test.equal(btns.length, 0, 'Should not append buttons when no sandboxes')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('updateTable() should append plot buttons for each sandbox', test => {
+	const { renderer, holder } = getRenderer()
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	const mockDiv = { node: () => ({ scrollIntoView: () => {} }) }
+	const sandboxes = new Map<string, { plotId: string; div: any; plotName: string }[]>()
+	sandboxes.set('S1', [
+		{ plotId: 'p1', div: mockDiv, plotName: 'UMAP' },
+		{ plotId: 'p2', div: mockDiv, plotName: 'tSNE' }
+	])
+	renderer.updateTable('S1', sandboxes)
+
+	const row = renderer.tableData.rows[0] as any
+	const cell = row[1].__td
+	const btns = cell.selectAll('.sjpp-sc-table-plot-btn').nodes()
+	test.equal(btns.length, 2, 'Should append 2 plot buttons')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+/* ---- appendPlotBtn() ---- */
+
+tape('appendPlotBtn() should truncate long plot names', test => {
+	const { renderer, holder } = getRenderer()
+
+	// Click first row so __td is populated
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	const cell = (renderer.tableData.rows[0] as any)[1].__td
+	const mockDiv = { node: () => ({ scrollIntoView: () => {} }) }
+
+	const longName = 'This is a very long plot name that exceeds 25 chars'
+	renderer.appendPlotBtn(cell, mockDiv, longName)
+
+	const btn = cell.select('.sjpp-sc-table-plot-btn').node() as HTMLElement
+	test.equal(btn.textContent, 'This is a ve...', 'Should truncate to 12 chars + ...')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('appendPlotBtn() should not truncate short plot names', test => {
+	const { renderer, holder } = getRenderer()
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	const cell = (renderer.tableData.rows[0] as any)[1].__td
+	const mockDiv = { node: () => ({ scrollIntoView: () => {} }) }
+
+	renderer.appendPlotBtn(cell, mockDiv, 'UMAP')
+
+	const btn = cell.select('.sjpp-sc-table-plot-btn').node() as HTMLElement
+	test.equal(btn.textContent, 'UMAP', 'Should show full name for short plot names')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})
+
+tape('appendPlotBtn() should scroll sandbox into view on click', test => {
+	const { renderer, holder } = getRenderer()
+
+	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
+	firstRow.click()
+
+	const cell = (renderer.tableData.rows[0] as any)[1].__td
+	let scrollCalled = false
+	const mockDiv = {
+		node: () => ({
+			scrollIntoView: () => {
+				scrollCalled = true
+			}
+		})
+	}
+
+	renderer.appendPlotBtn(cell, mockDiv, 'UMAP')
+
+	const btn = cell.select('.sjpp-sc-table-plot-btn').node() as HTMLElement
+	btn.click()
+	test.ok(scrollCalled, 'Should call scrollIntoView on click')
+
+	if ((test as any)._ok) holder.remove()
+	test.end()
+})

--- a/client/plots/sc/test/SampleTableRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SampleTableRenderer.unit.spec.ts
@@ -14,7 +14,6 @@ import { SampleTableRenderer } from '../view/SampleTableRenderer.ts'
  *   - renderSamplesTable() noButtonCallback should call interactions.updateItem
  *   - renderSamplesTable() noButtonCallback should show plotsBtnsDiv
  *   - updateTable() should return early when sampleId is undefined
- *   - updateTable() should return early when row does not match sampleId
  *   - updateTable() should clear previous plot buttons
  *   - updateTable() should return early when no sandboxes exist for sample
  *   - updateTable() should append plot buttons for each sandbox
@@ -44,7 +43,8 @@ function getTestTableData() {
 			[{ value: 'S2' }, { value: '' }, { value: 'EXP2' }],
 			[{ value: 'S3' }, { value: '' }, { value: 'EXP3' }]
 		],
-		selectedRows: []
+		selectedRows: [],
+		sampleColIdx: 0
 	}
 }
 
@@ -88,7 +88,6 @@ tape('constructor should set dom, interactions, tableData, and rowIndex', test =
 	test.equal(renderer.dom, dom, 'Should set dom reference')
 	test.equal(renderer.interactions, interactions, 'Should set interactions reference')
 	test.equal(renderer.tableData, tableData, 'Should set tableData reference')
-	test.equal(renderer.rowIndex, -1, 'Should initialize rowIndex to -1')
 
 	if ((test as any)._ok) holder.remove()
 	test.end()
@@ -163,7 +162,8 @@ tape('renderSamplesTable() noButtonCallback should map custom column labels to k
 			{ label: 'Project', sortable: true }
 		],
 		rows: [[{ value: 'S1' }, { value: '' }, { value: 'EXP1' }, { value: 'PROJ1' }]],
-		selectedRows: []
+		selectedRows: [],
+		sampleColIdx: 0
 	}
 
 	const holder = getHolder()
@@ -184,24 +184,21 @@ tape('renderSamplesTable() noButtonCallback should map custom column labels to k
 	test.end()
 })
 
-tape.skip('renderSamplesTable() noButtonCallback should throw when sID is missing', test => {
+tape('renderSamplesTable() noButtonCallback should throw when sID is missing', test => {
 	const tableData = {
 		columns: [{ label: 'Project', sortable: true }],
 		rows: [[{ value: 'PROJ1' }]],
-		selectedRows: []
+		selectedRows: [],
+		sampleColIdx: 0
 	}
 
-	const holder = getHolder()
-	const dom = getMockDom(holder)
-	const interactions = getMockInteractions()
-	new SampleTableRenderer(dom, interactions, tableData)
+	const { renderer, holder } = getRenderer()
 
-	const firstRow = holder.select('tr.sjpp_row_wrapper').node() as HTMLElement
 	test.throws(
 		() => {
-			firstRow.click()
+			renderer.buildItemFromRow(tableData as any, 0)
 		},
-		/sID/,
+		/Selected item must have sID property/,
 		'Should throw error about missing sID'
 	)
 
@@ -241,22 +238,12 @@ tape('renderSamplesTable() noButtonCallback should show plotsBtnsDiv', test => {
 /* ---- updateTable() ---- */
 
 tape('updateTable() should return early when sampleId is undefined', test => {
+	test.plan(1)
 	const { renderer, holder } = getRenderer()
 
 	// Should not throw
 	renderer.updateTable(undefined, new Map())
 	test.pass('Should return early without error')
-
-	if ((test as any)._ok) holder.remove()
-	test.end()
-})
-
-tape('updateTable() should return early when row does not match sampleId', test => {
-	const { renderer, holder } = getRenderer()
-
-	// rowIndex is -1, so no row matches
-	renderer.updateTable('S1', new Map())
-	test.pass('Should return early when rowIndex row does not match sampleId')
 
 	if ((test as any)._ok) holder.remove()
 	test.end()
@@ -340,7 +327,7 @@ tape('appendPlotBtn() should truncate long plot names', test => {
 	const mockDiv = { node: () => ({ scrollIntoView: () => {} }) }
 
 	const longName = 'This is a very long plot name that exceeds 25 chars'
-	renderer.appendPlotBtn(cell, mockDiv, longName)
+	renderer.appendPlotBtn(cell, mockDiv, longName, 'S1')
 
 	const btn = cell.select('.sjpp-sc-table-plot-btn').node() as HTMLElement
 	test.equal(btn.textContent, 'This is a ve...', 'Should truncate to 12 chars + ...')
@@ -358,7 +345,7 @@ tape('appendPlotBtn() should not truncate short plot names', test => {
 	const cell = (renderer.tableData.rows[0] as any)[1].__td
 	const mockDiv = { node: () => ({ scrollIntoView: () => {} }) }
 
-	renderer.appendPlotBtn(cell, mockDiv, 'UMAP')
+	renderer.appendPlotBtn(cell, mockDiv, 'UMAP', 'S1')
 
 	const btn = cell.select('.sjpp-sc-table-plot-btn').node() as HTMLElement
 	test.equal(btn.textContent, 'UMAP', 'Should show full name for short plot names')
@@ -383,7 +370,7 @@ tape('appendPlotBtn() should scroll sandbox into view on click', test => {
 		})
 	}
 
-	renderer.appendPlotBtn(cell, mockDiv, 'UMAP')
+	renderer.appendPlotBtn(cell, mockDiv, 'UMAP', 'S1')
 
 	const btn = cell.select('.sjpp-sc-table-plot-btn').node() as HTMLElement
 	btn.click()

--- a/client/plots/sc/test/SampleTableRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SampleTableRenderer.unit.spec.ts
@@ -13,7 +13,6 @@ import { SampleTableRenderer } from '../view/SampleTableRenderer.ts'
  *   - renderSamplesTable() noButtonCallback should throw when sID is missing
  *   - renderSamplesTable() noButtonCallback should call interactions.updateItem
  *   - renderSamplesTable() noButtonCallback should show plotsBtnsDiv
- *   - updateTable() should return early when sampleId is undefined
  *   - updateTable() should clear previous plot buttons
  *   - updateTable() should return early when no sandboxes exist for sample
  *   - updateTable() should append plot buttons for each sandbox
@@ -236,18 +235,6 @@ tape('renderSamplesTable() noButtonCallback should show plotsBtnsDiv', test => {
 })
 
 /* ---- updateTable() ---- */
-
-tape('updateTable() should return early when sampleId is undefined', test => {
-	test.plan(1)
-	const { renderer, holder } = getRenderer()
-
-	// Should not throw
-	renderer.updateTable(undefined, new Map())
-	test.pass('Should return early without error')
-
-	if ((test as any)._ok) holder.remove()
-	test.end()
-})
 
 tape('updateTable() should clear previous plot buttons', test => {
 	const { renderer, holder } = getRenderer()

--- a/client/plots/sc/test/SectionRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SectionRenderer.unit.spec.ts
@@ -145,9 +145,9 @@ tape("getPlotName() should return 'Gene expression' for GeneExpInput chartType",
 
 /* ---- makeSectionTitleText ---- */
 
-tape("makeSectionTitleText() should return empty string when groupBy is 'none'", test => {
+tape("makeSectionTitleText() should return 'All plots' when groupBy is 'none'", test => {
 	const sr = new SectionRenderer(getMockDiv(), 'none')
-	test.equal(sr.makeSectionTitleText('anyKey'), '', 'Should return empty string for none groupBy')
+	test.equal(sr.makeSectionTitleText('anyKey'), 'All plots', 'Should return All plots for none groupBy')
 	test.end()
 })
 

--- a/client/plots/sc/test/SectionRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SectionRenderer.unit.spec.ts
@@ -30,7 +30,7 @@ import { SectionRenderer } from '../view/SectionRenderer.ts'
  *   - removeSandbox() should use provided key over plotId2Key lookup
  *   - removeSandbox() should return early when key is not found
  *   - removeSection() should remove all sandboxes and dispatch app_refresh
- *   - removeSection() should delete section from sections map and remove all elements from DOM
+ *   - removeSection() should delete section from sections map and remove all elements from dom
  *   - removeSection() should not dispatch when section has no sandboxes
  */
 
@@ -355,7 +355,7 @@ tape('removeSection() should remove all sandboxes and dispatch app_refresh', tes
 	test.end()
 })
 
-tape('removeSection() should delete section from sections map and remove all elements from DOM', test => {
+tape('removeSection() should delete section from sections map and remove all elements from dom', test => {
 	const sr = new SectionRenderer(getMockDiv(), 'sample')
 	let wrapperRemoved = false
 	const sc = getMockSCViewer()

--- a/client/plots/sc/test/SectionRenderer.unit.spec.ts
+++ b/client/plots/sc/test/SectionRenderer.unit.spec.ts
@@ -14,7 +14,11 @@ import { SectionRenderer } from '../view/SectionRenderer.ts'
  *   - getPlotName() should return 'Summary' for dictionary chartType
  *   - getPlotName() should return 'Summary' for summary chartType
  *   - getPlotName() should return 'Gene expression' for GeneExpInput chartType
- *   - makeSectionTitleText() should return empty string when groupBy is 'none'
+ *   - getKey() should return 'none' when groupBy is 'none'
+ *   - getKey() should return sampleId when groupBy is 'sample'
+ *   - getKey() should return plotName when groupBy is 'plot'
+ *   - getKey() should return undefined when no value can be determined
+ *   - makeSectionTitleText() should return 'All plots' when groupBy is 'none'
  *   - makeSectionTitleText() should return key when groupBy is 'plot'
  *   - makeSectionTitleText() should return sample info when groupBy is 'sample'
  *   - makeSectionTitleText() should include case and project info when available
@@ -25,6 +29,9 @@ import { SectionRenderer } from '../view/SectionRenderer.ts'
  *   - removeSandbox() should remove sandbox, clean up plotId2Key, and call sc.removeComponent
  *   - removeSandbox() should use provided key over plotId2Key lookup
  *   - removeSandbox() should return early when key is not found
+ *   - removeSection() should remove all sandboxes and dispatch app_refresh
+ *   - removeSection() should delete section from sections map and remove all elements from DOM
+ *   - removeSection() should not dispatch when section has no sandboxes
  */
 
 /**************
@@ -147,7 +154,7 @@ tape("getPlotName() should return 'Gene expression' for GeneExpInput chartType",
 
 tape("makeSectionTitleText() should return 'All plots' when groupBy is 'none'", test => {
 	const sr = new SectionRenderer(getMockDiv(), 'none')
-	test.equal(sr.makeSectionTitleText('anyKey'), 'All plots', 'Should return All plots for none groupBy')
+	test.equal(sr.makeSectionTitleText('anyKey'), 'All plots', "Should return 'All plots' for none groupBy")
 	test.end()
 })
 
@@ -269,5 +276,129 @@ tape('removeSandbox() should return early when key is not found', test => {
 
 	test.true(removedComponent, 'Should still call sc.removeComponent')
 	test.equal(sr.plotId2Key.size, 0, 'plotId2Key should remain empty')
+	test.end()
+})
+
+/* ---- getKey ---- */
+
+tape("getKey() should return 'none' when groupBy is 'none'", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'none')
+	test.equal(sr.getKey({ sample: { sID: 'S1' } }), 'none', "Should always return 'none' regardless of subplot")
+	test.equal(sr.getKey({}), 'none', "Should return 'none' even for empty subplot")
+	test.end()
+})
+
+tape("getKey() should return sampleId when groupBy is 'sample'", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	test.equal(sr.getKey({ sample: { sID: 'S1' } }), 'S1', 'Should return sID from subplot.sample')
+	test.equal(
+		sr.getKey({ singleCellPlot: { sample: { sID: 'S2' } } }),
+		'S2',
+		'Should return sID from singleCellPlot.sample'
+	)
+	test.equal(sr.getKey({ term: { term: { sample: { sID: 'S3' } } } }), 'S3', 'Should return sID from term.term.sample')
+	test.end()
+})
+
+tape("getKey() should return plotName when groupBy is 'plot'", test => {
+	const sr = new SectionRenderer(getMockDiv(), 'plot')
+	test.equal(sr.getKey({ plotName: 'UMAP' }), 'UMAP', 'Should return plotName')
+	test.equal(sr.getKey({ singleCellPlot: { name: 'tSNE' } }), 'tSNE', 'Should return singleCellPlot.name')
+	test.equal(sr.getKey({ chartType: 'dictionary' }), 'Summary', 'Should return Summary for dictionary chartType')
+	test.end()
+})
+
+tape('getKey() should return undefined when no value can be determined', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	test.equal(sr.getKey({}), undefined, 'Should return undefined when sample has no sID')
+	test.equal(sr.getKey({ sample: {} }), undefined, 'Should return undefined when sID is missing')
+	test.end()
+})
+
+/* ---- removeSection ---- */
+
+tape('removeSection() should remove all sandboxes and dispatch app_refresh', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	const removedComponents: string[] = []
+	let dispatched: any = null
+	const sc = getMockSCViewer({
+		removeComponent: (id: string) => {
+			removedComponents.push(id)
+		},
+		dispatch: (action: any) => {
+			dispatched = action
+		}
+	})
+	// Override app.dispatch since getMockSCViewer nests it
+	sc.app.dispatch = (action: any) => {
+		dispatched = action
+	}
+
+	const mockSandbox1 = { remove: () => {} }
+	const mockSandbox2 = { remove: () => {} }
+	sr.sections['S1'] = {
+		sectionWrapper: { remove: () => {} } as any,
+		title: {} as any,
+		subplots: {} as any,
+		sandboxes: { plot1: mockSandbox1, plot2: mockSandbox2 }
+	}
+	sr.plotId2Key.set('plot1', 'S1')
+	sr.plotId2Key.set('plot2', 'S1')
+
+	sr.removeSection('S1', sc)
+
+	test.deepEqual(removedComponents.sort(), ['plot1', 'plot2'], 'Should call removeComponent for each sandbox')
+	test.equal(dispatched.type, 'app_refresh', 'Should dispatch app_refresh')
+	test.equal(dispatched.subactions.length, 2, 'Should include a subaction for each sandbox')
+	test.equal(dispatched.subactions[0].type, 'plot_delete', 'Subaction type should be plot_delete')
+	test.equal(dispatched.subactions[0].parentId, 'sc1', 'Subaction parentId should be sc.id')
+	test.end()
+})
+
+tape('removeSection() should delete section from sections map and remove all elements from DOM', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	let wrapperRemoved = false
+	const sc = getMockSCViewer()
+
+	const mockSandbox = { remove: () => {} }
+	sr.sections['S1'] = {
+		sectionWrapper: {
+			remove: () => {
+				wrapperRemoved = true
+			}
+		} as any,
+		title: {} as any,
+		subplots: {} as any,
+		sandboxes: { plot1: mockSandbox }
+	}
+	sr.plotId2Key.set('plot1', 'S1')
+
+	sr.removeSection('S1', sc)
+
+	test.equal(sr.sections['S1'], undefined, 'Should delete the section from sections map')
+	test.true(wrapperRemoved, 'Should call remove() on sectionWrapper')
+	test.false(sr.plotId2Key.has('plot1'), 'Should clean up plotId2Key entries')
+	test.end()
+})
+
+tape('removeSection() should not dispatch when section has no sandboxes', test => {
+	const sr = new SectionRenderer(getMockDiv(), 'sample')
+	let dispatched = false
+	const sc = getMockSCViewer()
+	sc.app.dispatch = () => {
+		dispatched = true
+	}
+
+	sr.sections['S1'] = {
+		sectionWrapper: { remove: () => {} } as any,
+		title: {} as any,
+		subplots: {} as any,
+		sandboxes: {}
+	}
+
+	sr.removeSection('S1', sc)
+
+	test.false(dispatched, 'Should not dispatch when there are no sandboxes')
+	test.equal(sr.sections['S1'], undefined, 'Should still delete the section')
 	test.end()
 })

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -96,19 +96,7 @@ export class SCViewRenderer {
 		//Also handles when settings.sc.groupBy == 'none' to show all plots in one section
 		await this.sectionRenderer.update(this.sc, subplots, settings.sc.groupBy)
 
-		// Derive sample → sandbox divs from existing state to update the table
-		const sandboxes = new Map<string, { plotId: string; div: any; plotName: string }[]>()
-		for (const subplot of subplots) {
-			const sampleId = this.sectionRenderer.getSampleId(subplot)
-			const key = this.sectionRenderer.plotId2Key.get(subplot.id)
-			if (!sampleId || !key) continue
-			const div = this.sectionRenderer.sections[key]?.sandboxes[subplot.id]
-			if (!div) continue
-			const plotName = this.sectionRenderer.getPlotName(subplot) || subplot.id
-			if (!sandboxes.has(sampleId)) sandboxes.set(sampleId, [])
-			sandboxes.get(sampleId)!.push({ plotId: subplot.id, div, plotName })
-		}
-
+		const sandboxes = this.sectionRenderer.getSampleSandboxes(subplots)
 		this.sampleTableRenderer.updateTable(settings.sc.item?.sID, sandboxes)
 	}
 }

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -96,7 +96,8 @@ export class SCViewRenderer {
 		//Also handles when settings.sc.groupBy == 'none' to show all plots in one section
 		await this.sectionRenderer.update(this.sc, subplots, settings.sc.groupBy)
 
+		if (!settings.sc.item?.sID) return
 		const sandboxes = this.sectionRenderer.getSampleSandboxes(subplots)
-		this.sampleTableRenderer.updateTable(settings.sc.item?.sID, sandboxes)
+		this.sampleTableRenderer.updateTable(settings.sc.item!.sID, sandboxes)
 	}
 }

--- a/client/plots/sc/view/SCViewRenderer.ts
+++ b/client/plots/sc/view/SCViewRenderer.ts
@@ -20,6 +20,7 @@ export class SCViewRenderer {
 	//Eventually maybe an app dispatch and not a flag
 	static inUse: boolean = true
 	sectionRenderer: SectionRenderer
+	sampleTableRenderer!: SampleTableRenderer
 	sc: SCViewer
 
 	constructor(sc: SCViewer, state: any) {
@@ -33,7 +34,7 @@ export class SCViewRenderer {
 	render(tableData: SCTableData, settings: SCSettings) {
 		this.renderSelectBtn()
 		this.renderGroupByOptions(settings)
-		new SampleTableRenderer(this.dom, this.interactions, tableData)
+		this.sampleTableRenderer = new SampleTableRenderer(this.dom, this.interactions, tableData)
 		this.dom.plotsBtnsDiv.style('display', 'none')
 	}
 
@@ -94,5 +95,20 @@ export class SCViewRenderer {
 		this.plotBtns.update(settings, data)
 		//Also handles when settings.sc.groupBy == 'none' to show all plots in one section
 		await this.sectionRenderer.update(this.sc, subplots, settings.sc.groupBy)
+
+		// Derive sample → sandbox divs from existing state to update the table
+		const sandboxes = new Map<string, { plotId: string; div: any; plotName: string }[]>()
+		for (const subplot of subplots) {
+			const sampleId = this.sectionRenderer.getSampleId(subplot)
+			const key = this.sectionRenderer.plotId2Key.get(subplot.id)
+			if (!sampleId || !key) continue
+			const div = this.sectionRenderer.sections[key]?.sandboxes[subplot.id]
+			if (!div) continue
+			const plotName = this.sectionRenderer.getPlotName(subplot) || subplot.id
+			if (!sandboxes.has(sampleId)) sandboxes.set(sampleId, [])
+			sandboxes.get(sampleId)!.push({ plotId: subplot.id, div, plotName })
+		}
+
+		this.sampleTableRenderer.updateTable(settings.sc.item?.sID, sandboxes)
 	}
 }

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -9,14 +9,12 @@ import type { SCInteractions } from '../interactions/SCInteractions'
 export class SampleTableRenderer {
 	dom: SCDom
 	interactions: SCInteractions
-	rowIndex: number
 	tableData: SCTableData
 	lastSampleSandboxes: Map<string, { plotId: string; div: any; plotName: string }[]> | undefined
 
 	constructor(dom: SCDom, interactions: SCInteractions, tableData: SCTableData) {
 		this.dom = dom
 		this.interactions = interactions
-		this.rowIndex = -1
 		this.tableData = tableData
 		this.renderSamplesTable(tableData)
 	}
@@ -45,22 +43,29 @@ export class SampleTableRenderer {
 				}
 			},
 			noButtonCallback: index => {
-				const item = {} as { sID: string; eID: string; [key: string]: any }
-				tableData.rows[index].forEach((r: TableCell, idx: number) => {
-					if (!r.value) return
-					let key = tableData.columns[idx].label.toLowerCase()
-					/** Convert the column labels into the required sample structure keys.
-					 * Maintains the sample obj used throughout the app whilst allowing for
-					 * dynamic column labels based on the config. */
-					key = key === 'sample' ? 'sID' : key === 'experiment' ? 'eID' : key
-					item[key] = r.value
-				})
-				this.rowIndex = index
-				if (!item.sID) throw new Error('Selected item must have sID property')
+				const item = this.buildItemFromRow(tableData, index)
 				this.interactions.updateItem(item)
 				this.dom.plotsBtnsDiv.style('display', 'block')
 			}
 		})
+	}
+
+	/** Builds an item object from a table row, mapping column labels to keys.
+	 * Converts 'sample' -> 'sID' and 'experiment' -> 'eID'.
+	 * Extracted out from noButtonCallback for testing.  */
+	buildItemFromRow(tableData: SCTableData, index: number) {
+		const item = {} as { sID: string; eID: string; [key: string]: any }
+		tableData.rows[index].forEach((r: TableCell, idx: number) => {
+			if (!r.value) return
+			let key = tableData.columns[idx].label.toLowerCase()
+			/** Convert the column labels into the required sample structure keys.
+			 * Maintains the sample obj used throughout the app whilst allowing for
+			 * dynamic column labels based on the config. */
+			key = key === 'sample' ? 'sID' : key === 'experiment' ? 'eID' : key
+			item[key] = r.value
+		})
+		if (!item.sID) throw new Error('Selected item must have sID property')
+		return item
 	}
 
 	updateTable(

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -11,6 +11,7 @@ export class SampleTableRenderer {
 	interactions: SCInteractions
 	rowIndex: number
 	tableData: SCTableData
+	lastSampleSandboxes: Map<string, { plotId: string; div: any; plotName: string }[]> | undefined
 
 	constructor(dom: SCDom, interactions: SCInteractions, tableData: SCTableData) {
 		this.dom = dom
@@ -36,6 +37,13 @@ export class SampleTableRenderer {
 			},
 			striped: true,
 			selectedRows: tableData.selectedRows,
+			afterRender: () => {
+				/** Sort removes all custom html.
+				 * Re-apply the plot buttons after sort. */
+				if (this.lastSampleSandboxes) {
+					this.reapplyAllPlotButtons()
+				}
+			},
 			noButtonCallback: index => {
 				const item = {} as { sID: string; eID: string; [key: string]: any }
 				tableData.rows[index].forEach((r: TableCell, idx: number) => {
@@ -59,10 +67,28 @@ export class SampleTableRenderer {
 		sampleId: string | undefined,
 		sampleSandboxes: Map<string, { plotId: string; div: any; plotName: string }[]>
 	) {
-		const sampleIdx = this.tableData.sampleColIdx
+		this.lastSampleSandboxes = sampleSandboxes
 		if (!sampleId) return
-		const row = this.tableData.rows[this.rowIndex]
-		if (!row || row[sampleIdx].value !== sampleId) return
+		this.applyButtonsForSample(sampleId)
+	}
+
+	/** Called by afterRender to re-apply buttons for all samples with subplots. */
+	private reapplyAllPlotButtons() {
+		if (!this.lastSampleSandboxes) return
+		for (const sampleId of this.lastSampleSandboxes.keys()) {
+			this.applyButtonsForSample(sampleId)
+		}
+	}
+
+	/** Applies plot buttons to a single sample's row. */
+	private applyButtonsForSample(sampleId: string) {
+		const sampleSandboxes = this.lastSampleSandboxes
+		const sampleIdx = this.tableData.sampleColIdx
+		if (!sampleSandboxes) return
+
+		/** Rows array mutates on sort. Find the row by matching sampleId.*/
+		const row = this.tableData.rows.find(r => r[sampleIdx].value === sampleId)
+		if (!row) return
 
 		const cell = row[sampleIdx + 1].__td
 		// Clear previous plot buttons before re-rendering

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -10,7 +10,7 @@ export class SampleTableRenderer {
 	dom: SCDom
 	interactions: SCInteractions
 	tableData: SCTableData
-	lastSampleSandboxes: Map<string, { plotId: string; div: any; plotName: string }[]> | undefined
+	sandboxes: Map<string, { plotId: string; div: any; plotName: string }[]> = new Map()
 
 	constructor(dom: SCDom, interactions: SCInteractions, tableData: SCTableData) {
 		this.dom = dom
@@ -36,11 +36,7 @@ export class SampleTableRenderer {
 			striped: true,
 			selectedRows: tableData.selectedRows,
 			afterRender: () => {
-				/** Sort removes all custom html.
-				 * Re-apply the plot buttons after sort. */
-				if (this.lastSampleSandboxes) {
-					this.reapplyAllPlotButtons()
-				}
+				this.reapplyAllPlotButtons()
 			},
 			noButtonCallback: index => {
 				const item = this.buildItemFromRow(tableData, index)
@@ -68,28 +64,22 @@ export class SampleTableRenderer {
 		return item
 	}
 
-	updateTable(
-		sampleId: string | undefined,
-		sampleSandboxes: Map<string, { plotId: string; div: any; plotName: string }[]>
-	) {
-		this.lastSampleSandboxes = sampleSandboxes
-		if (!sampleId) return
+	updateTable(sampleId: string, sandboxes: Map<string, { plotId: string; div: any; plotName: string }[]>) {
+		this.sandboxes = sandboxes
 		this.applyButtonsForSample(sampleId)
 	}
 
 	/** Called by afterRender to re-apply buttons for all samples with subplots. */
-	private reapplyAllPlotButtons() {
-		if (!this.lastSampleSandboxes) return
-		for (const sampleId of this.lastSampleSandboxes.keys()) {
+	reapplyAllPlotButtons() {
+		for (const sampleId of this.sandboxes.keys()) {
 			this.applyButtonsForSample(sampleId)
 		}
 	}
 
-	/** Applies plot buttons to a single sample's row. */
-	private applyButtonsForSample(sampleId: string) {
-		const sampleSandboxes = this.lastSampleSandboxes
+	/** Applies buttons for a single sample after plot button click */
+	applyButtonsForSample(sampleId: string) {
 		const sampleIdx = this.tableData.sampleColIdx
-		if (!sampleSandboxes) return
+		if (!this.sandboxes) return
 
 		/** Rows array mutates on sort. Find the row by matching sampleId.*/
 		const row = this.tableData.rows.find(r => r[sampleIdx].value === sampleId)
@@ -98,10 +88,10 @@ export class SampleTableRenderer {
 		const cell = row[sampleIdx + 1].__td
 		// Clear previous plot buttons before re-rendering
 		cell.selectAll('.sjpp-sc-table-plot-btn').remove()
-		const sandboxes = sampleSandboxes.get(sampleId)
-		if (!sandboxes || sandboxes.length === 0) return
+		const sampleSandboxes = this.sandboxes.get(sampleId)
+		if (!sampleSandboxes || sampleSandboxes.length === 0) return
 
-		for (const { div, plotName } of sandboxes) {
+		for (const { div, plotName } of sampleSandboxes) {
 			this.appendPlotBtn(cell, div, plotName, sampleId)
 		}
 	}

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -59,14 +59,14 @@ export class SampleTableRenderer {
 		sampleId: string | undefined,
 		sampleSandboxes: Map<string, { plotId: string; div: any; plotName: string }[]>
 	) {
+		const sampleIdx = this.tableData.sampleColIdx
 		if (!sampleId) return
 		const row = this.tableData.rows[this.rowIndex]
-		if (!row || row[0].value !== sampleId) return
+		if (!row || row[sampleIdx].value !== sampleId) return
 
-		const cell = row[1].__td
+		const cell = row[sampleIdx + 1].__td
 		// Clear previous plot buttons before re-rendering
 		cell.selectAll('.sjpp-sc-table-plot-btn').remove()
-
 		const sandboxes = sampleSandboxes.get(sampleId)
 		if (!sandboxes || sandboxes.length === 0) return
 

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -9,10 +9,14 @@ import type { SCInteractions } from '../interactions/SCInteractions'
 export class SampleTableRenderer {
 	dom: SCDom
 	interactions: SCInteractions
+	rowIndex: number
+	tableData: SCTableData
 
 	constructor(dom: SCDom, interactions: SCInteractions, tableData: SCTableData) {
 		this.dom = dom
 		this.interactions = interactions
+		this.rowIndex = -1
+		this.tableData = tableData
 		this.renderSamplesTable(tableData)
 	}
 
@@ -24,7 +28,7 @@ export class SampleTableRenderer {
 			columns: tableData.columns,
 			div: this.dom.tableDiv,
 			singleMode: true,
-			maxWidth: tableData.columns.length > 3 ? '98vw' : '40vw',
+			maxWidth: tableData.columns.length > 3 ? '95vw' : 'auto',
 			maxHeight: '30vh',
 			header: {
 				allowSort: true,
@@ -43,10 +47,49 @@ export class SampleTableRenderer {
 					key = key === 'sample' ? 'sID' : key === 'experiment' ? 'eID' : key
 					item[key] = r.value
 				})
+				this.rowIndex = index
 				if (!item.sID) throw new Error('Selected item must have sID property')
 				this.interactions.updateItem(item)
 				this.dom.plotsBtnsDiv.style('display', 'block')
 			}
 		})
+	}
+
+	updateTable(
+		sampleId: string | undefined,
+		sampleSandboxes: Map<string, { plotId: string; div: any; plotName: string }[]>
+	) {
+		if (!sampleId) return
+		const row = this.tableData.rows[this.rowIndex]
+		if (!row || row[0].value !== sampleId) return
+
+		const cell = row[1].__td
+		// Clear previous plot buttons before re-rendering
+		cell.selectAll('.sjpp-sc-table-plot-btn').remove()
+
+		const sandboxes = sampleSandboxes.get(sampleId)
+		if (!sandboxes || sandboxes.length === 0) return
+
+		for (const { div, plotName } of sandboxes) {
+			this.appendPlotBtn(cell, div, plotName)
+		}
+	}
+
+	appendPlotBtn(cell: any, sandboxDiv: any, plotName: string) {
+		const text = plotName.length > 25 ? plotName.slice(0, 12) + '...' : plotName
+		cell
+			.append('span')
+			.attr('class', 'sjpp-sc-table-plot-btn')
+			.style('padding', '2px 5px')
+			.style('margin-left', '4px')
+			.style('font-size', '0.8em')
+			.style('border-radius', '20px')
+			.style('border', '0.5px solid black')
+			.style('cursor', 'pointer')
+			.text(text)
+			.attr('title', `Scroll to ${plotName}`)
+			.on('click', () => {
+				sandboxDiv.node().scrollIntoView({ behavior: 'smooth', block: 'start' })
+			})
 	}
 }

--- a/client/plots/sc/view/SampleTableRenderer.ts
+++ b/client/plots/sc/view/SampleTableRenderer.ts
@@ -71,15 +71,17 @@ export class SampleTableRenderer {
 		if (!sandboxes || sandboxes.length === 0) return
 
 		for (const { div, plotName } of sandboxes) {
-			this.appendPlotBtn(cell, div, plotName)
+			this.appendPlotBtn(cell, div, plotName, sampleId)
 		}
 	}
 
-	appendPlotBtn(cell: any, sandboxDiv: any, plotName: string) {
+	appendPlotBtn(cell: any, sandboxDiv: any, plotName: string, sampleId: string) {
 		const text = plotName.length > 25 ? plotName.slice(0, 12) + '...' : plotName
+		const label = `Scroll to ${plotName}`
 		cell
-			.append('span')
+			.append('button')
 			.attr('class', 'sjpp-sc-table-plot-btn')
+			.attr('data-testid', `sjpp-sc-table-${sampleId}-${plotName}-btn`)
 			.style('padding', '2px 5px')
 			.style('margin-left', '4px')
 			.style('font-size', '0.8em')
@@ -87,7 +89,9 @@ export class SampleTableRenderer {
 			.style('border', '0.5px solid black')
 			.style('cursor', 'pointer')
 			.text(text)
-			.attr('title', `Scroll to ${plotName}`)
+			.attr('aria-label', label)
+			.attr('title', label)
+			.attr('tabindex', 0)
 			.on('click', () => {
 				sandboxDiv.node().scrollIntoView({ behavior: 'smooth', block: 'start' })
 			})

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -34,16 +34,8 @@ export class SectionRenderer {
 	async update(sc: SCViewer, subplots: any, groupBy: (typeof GroupByOptions)[number]) {
 		if (groupBy !== this.groupBy) {
 			this.groupBy = groupBy
-			this.holder.selectAll('*').remove()
-			/** Reset sections and plotId2Key map when groupBy changes as the keys will be different
-			 *
-			 * TODO: evaluate if there's a more performant way to update sections when
-			 * groupBy changes without needing to re-render all the sections and sandboxes.*/
-			this.sections = {}
-			this.plotId2Key = new Map()
-			for (const subplotId of Object.keys(sc.components.plots)) {
-				sc.removeComponent(subplotId)
-			}
+			this.regroupSections(sc, subplots)
+			return
 		}
 		const activeSubplots = new Set(subplots.map(s => s.id))
 
@@ -56,8 +48,7 @@ export class SectionRenderer {
 		}
 
 		for (const subplot of subplots) {
-			const key =
-				groupBy == 'none' ? 'none' : groupBy == 'sample' ? this.getSampleId(subplot) : this.getPlotName(subplot)
+			const key = this.getKey(subplot)
 			if (!key) continue
 			if (!this.sections[key]) this.initSection(key, sc)
 			if (!this.sections[key].sandboxes[subplot.id]) {
@@ -73,6 +64,57 @@ export class SectionRenderer {
 				this.removeSection(key, sc)
 			}
 		}
+	}
+
+	/** Reparent existing sandboxes into new section containers
+	 * without destroying/recreating plot components. */
+	private regroupSections(sc: SCViewer, subplots: any[]) {
+		// Detach existing sandbox from their parents before clearing
+		const detached: Map<string, any> = new Map()
+		for (const [plotId, key] of this.plotId2Key) {
+			const sandboxNode = this.sections[key]?.sandboxes[plotId]
+			if (sandboxNode) {
+				// Remove from current parent without destroying
+				sandboxNode.remove()
+				detached.set(plotId, sandboxNode)
+			}
+		}
+
+		// Clear the section wrappers since sandboxes are already detached
+		this.holder.selectAll('*').remove()
+		this.sections = {}
+		this.plotId2Key = new Map()
+
+		const activeSubplots = new Set(subplots.map(s => s.id))
+
+		// Remove components that are no longer active
+		for (const plotId of Object.keys(sc.components.plots)) {
+			if (!activeSubplots.has(plotId)) {
+				sc.removeComponent(plotId)
+				detached.delete(plotId)
+			}
+		}
+
+		// Regroup into new sections, reparenting existing sandbox
+		for (const subplot of subplots) {
+			const key = this.getKey(subplot)
+			if (!key) continue
+			if (!this.sections[key]) this.initSection(key, sc)
+
+			this.plotId2Key.set(subplot.id, key)
+			const existing = detached.get(subplot.id)
+			if (existing) {
+				// Reparent the existing sandbox into the new section
+				this.sections[key].subplots.node()!.prepend(existing.node())
+				this.sections[key].sandboxes[subplot.id] = existing
+			}
+		}
+	}
+
+	getKey(subplot: any): string | undefined {
+		if (this.groupBy === 'none') return 'none'
+		if (this.groupBy === 'sample') return this.getSampleId(subplot)
+		return this.getPlotName(subplot)
 	}
 
 	/** Extract sID from a subplot's config.

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -82,14 +82,15 @@ export class SectionRenderer {
 	}
 
 	getPlotName(subplot: any): string {
-		let plotName = subplot?.plotName || subplot?.singleCellPlot?.name || subplot?.term?.term?.plot
+		let plotName = subplot?.plotName || subplot?.singleCellPlot?.name
 		if (!plotName) {
 			/** Harcoding logic for some transient and parent plots for now. May consider
 			 * adding to the config if this becomes more complex. Must weight against
 			 * adding unnecessary complexity to the config for edge cases though.*/
 			if (subplot.chartType === 'dictionary') plotName = 'Summary'
-			if (subplot.chartType === 'summary') plotName = 'Summary'
-			if (subplot.chartType === 'GeneExpInput') plotName = 'Gene expression'
+			else if (subplot.chartType === 'summary') plotName = 'Summary'
+			else if (subplot.chartType === 'GeneExpInput') plotName = 'Gene expression'
+			else if (subplot?.term?.term?.plot) plotName = subplot.term.term.plot
 		}
 		return plotName
 	}
@@ -157,7 +158,7 @@ export class SectionRenderer {
 	}
 
 	makeSectionTitleText(key: string, item?: SingleCellSample) {
-		if (this.groupBy === 'none') return ''
+		if (this.groupBy === 'none') return 'All plots'
 		if (this.groupBy === 'plot') return key
 		const caseText = item?.sample && item.sample !== key ? `Case: ${item.sample}` : ''
 		const itemText = `Sample: ${key}`

--- a/client/plots/sc/view/SectionRenderer.ts
+++ b/client/plots/sc/view/SectionRenderer.ts
@@ -276,4 +276,21 @@ export class SectionRenderer {
 		//Remove the reference to the plotId in plot2Sample map to avoid memory leak
 		this.plotId2Key.delete(plotId)
 	}
+
+	/** Derives a map of sampleId → sandbox info for all active subplots.
+	 * Used by SampleTableRenderer to render scroll-to buttons. */
+	getSampleSandboxes(subplots: any[]): Map<string, { plotId: string; div: any; plotName: string }[]> {
+		const sandboxes = new Map<string, { plotId: string; div: any; plotName: string }[]>()
+		for (const subplot of subplots) {
+			const sampleId = this.getSampleId(subplot)
+			const key = this.plotId2Key.get(subplot.id)
+			if (!sampleId || !key) continue
+			const div = this.sections[key]?.sandboxes[subplot.id]
+			if (!div) continue
+			const plotName = this.getPlotName(subplot) || subplot.id
+			if (!sandboxes.has(sampleId)) sandboxes.set(sampleId, [])
+			sandboxes.get(sampleId)!.push({ plotId: subplot.id, div, plotName })
+		}
+		return sandboxes
+	}
 }

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -43,7 +43,10 @@ export class SCViewModel {
 		const hasExperiments = items.some(i => i.experiments)
 
 		// first column is sample and is hardcoded
-		const columns: TableColumn[] = [{ label: plotConfig.settings.sc.columns.sample, sortable: true }]
+		const columns: TableColumn[] = [
+			{ label: plotConfig.settings.sc.columns.sample, sortable: true },
+			{ label: 'Shown plots' }
+		]
 		if (hasExperiments) columns.push({ label: 'Sample', sortable: true }) //add after the case column
 
 		// add in optional sample columns
@@ -84,6 +87,8 @@ export class SCViewModel {
 				const row: { [index: string]: any }[] = item.isMetaResult
 					? [{ html: item.sample.replace(/_/g, ' '), value: item.sample }]
 					: [{ value: item.sample }]
+				//Empty cell for shown plot buttons
+				row.push({ value: '' })
 				// optional sample columns
 				for (const col of sampleColumns || []) {
 					const value = item[col.termid]

--- a/client/plots/sc/viewModel/SCViewModel.ts
+++ b/client/plots/sc/viewModel/SCViewModel.ts
@@ -17,7 +17,7 @@ export class SCViewModel {
 		const items = _items.sort((a, b) => (b.isMetaResult === a.isMetaResult ? 0 : b.isMetaResult ? 1 : -1))
 
 		//Should only be called once
-		const [rows, columns] = this.getTabelData(config, items, sampleColumns)
+		const [rows, columns, sampleColIdx] = this.getTabelData(config, items, sampleColumns)
 		const selectedRows: number[] = []
 		const sID = config.settings.sc.item?.sID
 		const i = sID
@@ -30,7 +30,8 @@ export class SCViewModel {
 		this.tableData = {
 			rows: rows as any,
 			columns: columns as any,
-			selectedRows
+			selectedRows,
+			sampleColIdx
 		}
 	}
 
@@ -38,16 +39,18 @@ export class SCViewModel {
 		plotConfig: SCConfig,
 		items: SingleCellSample[],
 		sampleColumns?: SampleColumn[]
-	): [TableRow[], TableColumn[]] {
+	): [TableRow[], TableColumn[], number] {
 		const rows: TableRow[] = []
 		const hasExperiments = items.some(i => i.experiments)
+		let sampleColIdx = -1
 
 		// first column is sample and is hardcoded
-		const columns: TableColumn[] = [
-			{ label: plotConfig.settings.sc.columns.sample, sortable: true },
-			{ label: 'Shown plots' }
-		]
-		if (hasExperiments) columns.push({ label: 'Sample', sortable: true }) //add after the case column
+		const columns: TableColumn[] = [{ label: plotConfig.settings.sc.columns.sample, sortable: true }]
+		if (hasExperiments) {
+			columns.push({ label: 'Sample', sortable: true }) //add after the case column
+			sampleColIdx = 1
+		} else sampleColIdx = 0
+		columns.push({ label: 'Shown plots' }) //Empty column for plot buttons
 
 		// add in optional sample columns
 		for (const col of sampleColumns || []) {
@@ -70,6 +73,7 @@ export class SCViewModel {
 					const row: { [index: string]: any }[] = [{ value: item.sample, __experimentID: exp.experimentID }]
 					// hardcode to expect exp.sampleName and add this as a column
 					row.push({ value: exp.sampleName })
+					row.push({ value: '' }) //Empty cell for shown plot buttons
 					// optional sample and experiment columns
 					for (const col of sampleColumns || []) {
 						row.push({ value: item[col.termid] })
@@ -98,6 +102,6 @@ export class SCViewModel {
 				rows.push(row)
 			}
 		}
-		return [rows, columns]
+		return [rows, columns, sampleColIdx]
 	}
 }

--- a/client/plots/scatter/viewmodel/scatterInteractivity.ts
+++ b/client/plots/scatter/viewmodel/scatterInteractivity.ts
@@ -19,9 +19,12 @@ export class ScatterInteractivity {
 		this.scatter = scatter
 		this.view = scatter.view
 		document.addEventListener('scroll', () => {
+			//Quick fix. Fires after the plot has been destroyed.
+			if (!this.scatter.view.dom.tooltip) return
 			if (!this.scatter.vm?.scatterTooltip?.onClick) this.scatter.view.dom.tooltip.hide()
 		})
 		select('.sjpp-output-sandbox-content').on('scroll', () => {
+			if (!this.scatter.view.dom.tooltip) return
 			if (!this.scatter.vm?.scatterTooltip?.onClick) this.view.dom.tooltip.hide()
 		})
 	}

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,4 @@
-
+Features
+- Buttons for shown plots appear in the sample table of the SC app when a plot button is clicked. This allows users to see what plots are available. On click, the page scrolls to that plot.
+Fixes
+- Refactored the SC app SectionRenderer code to detach and reattach plots when groupBy changes. This optimization prevents unnecessary dispatches and state changes.


### PR DESCRIPTION
# Description

These are minor changes we discussed in team meeting some time ago. 
 
Changes:
- When a plot is visible, a button appears alongside the sample in the table, serving as a condensed, visual representation of plots shown. On button click, the page scrolls to that plot. 
- Instead of destroying and recreating plots when groupBy changes, the elements are detached from the parent and reattached to a new parent section. This avoids unnecessary app.dispatches, solves the issue of the half second flickering that would occur, and increases the page response time. 
- Updated `client/plots/sc/README.md` to clarify the SC app's grouping logic, especially for plot data fetching (`checkPlotAvailability`) and section grouping by `groupBy` setting. The documentation now accurately describes how plot buttons and subplots are managed and how sections are regrouped without destroying plot components. 
-  Updated `SCViewModel.unit.spec.ts` tests to reflect new columns in the sample table (such as the "Shown plots" column), adjusting expectations for the number and order of columns and the mapping of row values. 
- Improved `SectionRenderer.unit.spec.ts` test descriptions and coverage to include new grouping logic and section removal behavior, ensuring tests match the updated implementation. 
- Added a full unit test suite for `SampleTableRenderer` in `SampleTableRenderer.unit.spec.ts`, covering constructor behavior, table rendering, row selection, plot button rendering, and edge cases such as missing IDs and long plot names. This ensures robust coverage of table interactions and UI updates.

Test with any of the SC app examples from http://localhost:3000/url.html. 

This work supports efforts described in the [SC roadmap](https://github.com/stjude/sjpp/issues/658)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
