### PR TITLE
Fix termcollection visibility

### DIFF
--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -468,7 +468,16 @@ export function divideTerms(q, ds) {
 		geneVariantTws = [],
 		nonDict = []
 	const isTermCollectionVisible = tw => {
-		const memberIds = tw.term?.termIds || tw.term?.termlst?.map(t => t?.id).filter(Boolean) || []
+		// Fail-closed against malformed input: a request that arrives with termIds or
+		// termlst as a non-array (string, object, etc.) is treated as having no resolvable
+		// members. Guarding here keeps a malformed payload from crashing the whole request
+		// with a TypeError when .every()/.map() is called on a non-array.
+		const raw = Array.isArray(tw.term?.termIds)
+			? tw.term.termIds
+			: Array.isArray(tw.term?.termlst)
+			? tw.term.termlst.map(t => t?.id)
+			: []
+		const memberIds = [...new Set(raw.filter(id => typeof id === 'string' && id))]
 		if (!memberIds.length) return false
 		return memberIds.every(id => ds.cohort.termdb.isTermVisible(q.__protected__, id))
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -458,10 +458,20 @@ export function divideTerms(q, ds) {
 	inline at every dict-push site: when the dataset declares an isTermVisible hook, dict terms
 	the requester cannot see are dropped before downstream queries are issued. Datasets without
 	the hook are unaffected — every dict term flows through.
+
+	A termCollection has no scalar `id` — it's identified by `name` + `termIds[]`. Calling
+	isTermVisible(undefined) returns false for any role consulting an allowlist, which would
+	silently drop the collection before SQL. Decide visibility from the members instead: the
+	collection is visible iff every member id is visible to the requesting role.
 	*/
 	const dict = [],
 		geneVariantTws = [],
 		nonDict = []
+	const isTermCollectionVisible = tw => {
+		const memberIds = tw.term?.termIds || tw.term?.termlst?.map(t => t?.id).filter(Boolean) || []
+		if (!memberIds.length) return false
+		return memberIds.every(id => ds.cohort.termdb.isTermVisible(q.__protected__, id))
+	}
 	for (const tw of q.terms) {
 		const type = tw.term?.type
 		// TODO FIXME should require valid term type, reject if not and remove assumptions and guesses
@@ -471,6 +481,12 @@ export function divideTerms(q, ds) {
 				geneVariantTws.push(tw) // collect into own list to process separately later
 			} else if (isNonDictionaryType(type)) {
 				nonDict.push(tw)
+			} else if (type == 'termCollection') {
+				if (ds.cohort.termdb.isTermVisible) {
+					if (isTermCollectionVisible(tw)) dict.push(tw)
+				} else {
+					dict.push(tw)
+				}
 			} else {
 				if (ds.cohort.termdb.isTermVisible) {
 					if (ds.cohort.termdb.isTermVisible(q.__protected__, tw.term.id)) {

--- a/server/src/test/termdb.matrix.unit.spec.js
+++ b/server/src/test/termdb.matrix.unit.spec.js
@@ -209,3 +209,54 @@ tape('divideTerms: termCollection flows through when dataset has no isTermVisibl
 	t.deepEqual(dict, [collection], 'termCollection passes through unconditionally when no hook is declared')
 	t.end()
 })
+
+tape('divideTerms: malformed termCollection (termIds is not an array) is dropped, not thrown', t => {
+	// A request that arrives with termIds as a string/object must not crash the whole request
+	// with a TypeError. Fail-closed: drop the collection instead.
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'Bad termIds',
+			termIds: 'EXCHEMYN' // not an array
+		}
+	}
+	const ds = buildRestrictedDs(['EXCHEMYN'])
+	const q = { terms: [collection], __protected__: { clientAuthResult: { role: 'public' } } }
+	t.doesNotThrow(() => divideTerms(q, ds), 'does not throw on non-array termIds')
+	const [dict] = divideTerms(q, ds)
+	t.deepEqual(dict, [], 'malformed termCollection is dropped under a restricted role')
+	t.end()
+})
+
+tape('divideTerms: malformed termCollection (termlst is not an array) is dropped, not thrown', t => {
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'Bad termlst',
+			termlst: { id: 'A' } // not an array
+		}
+	}
+	const ds = buildRestrictedDs(['A'])
+	const q = { terms: [collection], __protected__: { clientAuthResult: { role: 'public' } } }
+	t.doesNotThrow(() => divideTerms(q, ds), 'does not throw on non-array termlst')
+	const [dict] = divideTerms(q, ds)
+	t.deepEqual(dict, [], 'malformed termCollection is dropped under a restricted role')
+	t.end()
+})
+
+tape('divideTerms: termCollection ignores non-string and duplicate ids in termIds', t => {
+	// Numbers, objects, undefined, empty strings are filtered out; duplicates are deduped.
+	// The collection should still be authorized when every remaining (valid, unique) id is visible.
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'Mixed ids',
+			termIds: ['A', '', null, 42, { id: 'B' }, 'A', 'B', undefined]
+		}
+	}
+	const ds = buildRestrictedDs(['A', 'B'])
+	const q = { terms: [collection], __protected__: { clientAuthResult: { role: 'public' } } }
+	const [dict] = divideTerms(q, ds)
+	t.deepEqual(dict, [collection], 'collection passes when the deduped, valid id set is fully visible')
+	t.end()
+})

--- a/server/src/test/termdb.matrix.unit.spec.js
+++ b/server/src/test/termdb.matrix.unit.spec.js
@@ -10,6 +10,9 @@ divideTerms: sorts terms by type
 divideTerms: assigns $id if missing
 divideTerms: assigns $id from term.name if id missing
 divideTerms: drops role-restricted dict terms via isTermVisible
+divideTerms: shorthand dict terms (no type, just id) are also gated by isTermVisible
+divideTerms: q.__protected__ is forwarded to the isTermVisible hook
+divideTerms: termCollection visibility decided by member ids
 */
 
 tape('\n', function (test) {
@@ -112,5 +115,97 @@ tape('divideTerms: q.__protected__ is forwarded to the isTermVisible hook', t =>
 	const expectedAuth = { clientAuthResult: { role: 'public' }, activeCohort: 'full' }
 	divideTerms({ terms: [{ term: { type: 'categorical', id: 'x' } }], __protected__: expectedAuth }, ds)
 	t.equal(receivedAuth, expectedAuth, 'Hook called with q.__protected__ object by reference')
+	t.end()
+})
+
+/*
+termCollection terms have no scalar .id — they're identified by .name + .termIds[].
+Previous behavior called isTermVisible(undefined) and silently dropped the collection
+for any role consulting an allowlist. The fix decides visibility from the members
+instead: visible iff every member id is visible to the role.
+*/
+function buildRestrictedDs(allowlist) {
+	const allow = new Set(allowlist)
+	return {
+		cohort: {
+			termdb: {
+				isTermVisible(_auth, id) {
+					return allow.has(id)
+				}
+			}
+		}
+	}
+}
+
+tape('divideTerms: termCollection visible when every member id is visible', t => {
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'Yes/No flags',
+			termIds: ['A', 'B', 'C']
+		}
+	}
+	const ds = buildRestrictedDs(['A', 'B', 'C'])
+	const [dict] = divideTerms({ terms: [collection], __protected__: { clientAuthResult: { role: 'public' } } }, ds)
+	t.deepEqual(dict, [collection], 'termCollection passes through to dict when all members are visible')
+	t.end()
+})
+
+tape('divideTerms: termCollection dropped when any member id is not visible', t => {
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'Yes/No flags',
+			termIds: ['A', 'B', 'C']
+		}
+	}
+	// 'C' is missing from the allowlist
+	const ds = buildRestrictedDs(['A', 'B'])
+	const [dict] = divideTerms({ terms: [collection], __protected__: { clientAuthResult: { role: 'public' } } }, ds)
+	t.deepEqual(dict, [], 'termCollection is dropped when any member is not visible')
+	t.end()
+})
+
+tape('divideTerms: termCollection falls back to termlst[].id when termIds is absent', t => {
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'From termlst',
+			termlst: [{ id: 'A' }, { id: 'B' }]
+		}
+	}
+	const ds = buildRestrictedDs(['A', 'B'])
+	const [dict] = divideTerms({ terms: [collection], __protected__: { clientAuthResult: { role: 'public' } } }, ds)
+	t.deepEqual(dict, [collection], 'termCollection uses termlst[].id when termIds is missing')
+	t.end()
+})
+
+tape('divideTerms: empty-member termCollection is dropped (fail-closed)', t => {
+	// A collection with no resolvable member ids cannot be authorized for a restricted role.
+	// Better to drop it than to expose a query whose membership is unknown.
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'Empty',
+			termIds: []
+		}
+	}
+	const ds = buildRestrictedDs(['A', 'B'])
+	const [dict] = divideTerms({ terms: [collection], __protected__: { clientAuthResult: { role: 'public' } } }, ds)
+	t.deepEqual(dict, [], 'empty-member termCollection is dropped under a restricted role')
+	t.end()
+})
+
+tape('divideTerms: termCollection flows through when dataset has no isTermVisible hook', t => {
+	// Datasets that don't opt into role-based visibility are unaffected by the new branch.
+	const collection = {
+		term: {
+			type: 'termCollection',
+			name: 'No-hook collection',
+			termIds: ['A', 'B']
+		}
+	}
+	const [dict] = divideTerms({ terms: [collection] }, emptyDs)
+	t.deepEqual(dict, [collection], 'termCollection passes through unconditionally when no hook is declared')
 	t.end()
 })


### PR DESCRIPTION
This pull request improves the handling of `termCollection` visibility in the `divideTerms` function, ensuring that access control is enforced correctly for collections of terms. Previously, `termCollection` terms could be incorrectly dropped for users with restricted roles because they lack a scalar `id`. Now, visibility is determined by checking that all member term IDs are visible to the requesting role. Comprehensive unit tests are added to validate this behavior.

Enhancements to termCollection visibility logic:

* Updated `divideTerms` to determine visibility of `termCollection` terms by requiring all member IDs to be visible to the requesting role, rather than relying on a non-existent scalar `id`. If any member is not visible, the collection is dropped. 
* Added logic to fall back to `termlst[].id` when `termIds` is absent in a `termCollection`, and to drop collections with no resolvable member IDs ("fail-closed").

Unit test coverage:

* Added multiple tests to verify that `termCollection` terms are only visible when all member IDs are allowed, that the fallback to `termlst[].id` works, that empty collections are dropped, and that datasets without an `isTermVisible` hook are unaffected. 
* This pull request introduces significant improvements to the barchart plotting logic, especially around the normalization and ordering of categorical and numeric series, as well as enhancements to term visibility and error handling. The changes improve robustness in edge cases, ensure more predictable bar ordering, and update test coverage accordingly.

**Barchart Series Normalization and Ordering:**

* Added a `normalizeRefOrder` function in `barchart.js` to ensure that categorical and numeric series IDs and labels are consistently normalized, improving the stability and predictability of series ordering and hidden value handling. This normalization is now applied when updating chart settings and when determining which series are excluded or hidden. 
* Refined the logic for determining the order of bars and overlays in the chart by introducing declared and numeric value order detection, and by making the bar and overlay sorters more robust to key/label mismatches.

**Error Handling and Global Context:**

* Updated error logging in `getPlotConfig` to use a more robust global context detection (`Function('return this')()`) for environments where `window` may not be available, preventing runtime errors in non-browser contexts. 

**Test Suite Updates:**

* Revised integration tests to accommodate the new normalization logic, including more flexible assertions for bar counts and order, and avoiding legend click interactions that could be affected by normalization changes. Added a new test for series order when no hidden values are present. 

**Server-side Series Ordering:**

* Improved the `getOrderedLabels` function on the server to better handle terms with partial or missing `order` properties, ensuring that keys with explicit order are prioritized and sorted correctly.

**Term Collection Visibility:**

* Enhanced the `divideTerms` function to properly determine the visibility of term collections by checking the visibility of all member terms, rather than relying on the collection itself having an `id`. # Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
