### PR TITLE
Support non-PMIDs or DOIs in `sampletable.js`

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -571,11 +571,14 @@ export function value2urlsOrText(v, tw) {
 	if (tw.pmidOrDoi) {
 		const h = []
 		for (const i of Array.isArray(v) ? v : [v]) {
-			if (i.startsWith('doi: ')) {
+			if (typeof i === 'string' && i.startsWith('doi: ')) {
 				h.push(`<a href=https://doi.org/${i.slice(5)} target=_blank>${i}</a>`)
-			} else {
-				// must be pmid
+			} else if (/^\d+$/.test(String(i))) {
+				// numeric -> pmid
 				h.push(`<a href=https://pubmed.ncbi.nlm.nih.gov/${i} target=_blank>${i}</a>`)
+			} else {
+				// not a citation (e.g. "unpublished") -- render as plain text
+				h.push(i)
 			}
 		}
 		return h.join('<br>')

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -575,17 +575,23 @@ export function value2urlsOrText(v, tw) {
 	if (tw.pmidOrDoi) {
 		const h = []
 		for (const i of Array.isArray(v) ? v : [v]) {
-			if (typeof i === 'string' && i.startsWith('doi: ')) {
-				// preserve the visual "/" separators inside a DOI but URL-encode each segment
-				const safeDoi = i.slice(5).split('/').map(encodeURIComponent).join('/')
-				h.push(`<a href=https://doi.org/${safeDoi} target=_blank>${escapeHtml(i)}</a>`)
-			} else if (/^\d+$/.test(String(i))) {
-				// numeric -> pmid (regex above guarantees i is safe to interpolate)
+			if (Number.isFinite(i)) {
+				// numeric value -> pmid
 				h.push(`<a href=https://pubmed.ncbi.nlm.nih.gov/${i} target=_blank>${i}</a>`)
-			} else {
-				// not a citation (e.g. "unpublished") -- render as plain text, escaped
-				h.push(escapeHtml(String(i)))
+			} else if (typeof i === 'string') {
+				if (i.startsWith('doi: ')) {
+					// preserve the visual "/" separators inside a DOI but URL-encode each segment
+					const safeDoi = i.slice(5).split('/').map(encodeURIComponent).join('/')
+					h.push(`<a href=https://doi.org/${safeDoi} target=_blank>${escapeHtml(i)}</a>`)
+				} else if (/^\d+$/.test(i)) {
+					// numeric string -> pmid (regex guarantees i is safe to interpolate)
+					h.push(`<a href=https://pubmed.ncbi.nlm.nih.gov/${i} target=_blank>${i}</a>`)
+				} else {
+					// not a citation (e.g. "unpublished") -- render as plain text, escaped
+					h.push(escapeHtml(i))
+				}
 			}
+			// other types (null, undefined, object) are skipped
 		}
 		return h.join('<br>')
 	}

--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -553,6 +553,10 @@ export async function samples2columnsRows(samples, tk) {
 	}
 	return [columns, rows]
 }
+// TODO: Apply same html escaping to other places (e.g. baseURL)
+function escapeHtml(s) {
+	return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]))
+}
 
 /*
 v can be:
@@ -572,13 +576,15 @@ export function value2urlsOrText(v, tw) {
 		const h = []
 		for (const i of Array.isArray(v) ? v : [v]) {
 			if (typeof i === 'string' && i.startsWith('doi: ')) {
-				h.push(`<a href=https://doi.org/${i.slice(5)} target=_blank>${i}</a>`)
+				// preserve the visual "/" separators inside a DOI but URL-encode each segment
+				const safeDoi = i.slice(5).split('/').map(encodeURIComponent).join('/')
+				h.push(`<a href=https://doi.org/${safeDoi} target=_blank>${escapeHtml(i)}</a>`)
 			} else if (/^\d+$/.test(String(i))) {
-				// numeric -> pmid
+				// numeric -> pmid (regex above guarantees i is safe to interpolate)
 				h.push(`<a href=https://pubmed.ncbi.nlm.nih.gov/${i} target=_blank>${i}</a>`)
 			} else {
-				// not a citation (e.g. "unpublished") -- render as plain text
-				h.push(i)
+				// not a citation (e.g. "unpublished") -- render as plain text, escaped
+				h.push(escapeHtml(String(i)))
 			}
 		}
 		return h.join('<br>')

--- a/client/mds3/test/sampletable.unit.spec.ts
+++ b/client/mds3/test/sampletable.unit.spec.ts
@@ -49,5 +49,17 @@ tape('value2urlsOrText()', test => {
 		'<a href=https://doi.org/10.1/abc target=_blank>doi: 10.1/abc</a><br><a href=https://pubmed.ncbi.nlm.nih.gov/87654321 target=_blank>87654321</a>',
 		'should handle mixed array of DOI and PMID'
 	)
+	// non-citation string (e.g. "unpublished") -- plain text, no link
+	test.equal(
+		value2urlsOrText('unpublished', { pmidOrDoi: true }),
+		'unpublished',
+		'should render non-citation string as plain text'
+	)
+	// mixed pmid and "unpublished"
+	test.equal(
+		value2urlsOrText(['12345678', 'unpublished'], { pmidOrDoi: true }),
+		'<a href=https://pubmed.ncbi.nlm.nih.gov/12345678 target=_blank>12345678</a><br>unpublished',
+		'should mix PMID link with plain-text non-citation value'
+	)
 	test.end()
 })

--- a/client/mds3/test/sampletable.unit.spec.ts
+++ b/client/mds3/test/sampletable.unit.spec.ts
@@ -61,5 +61,17 @@ tape('value2urlsOrText()', test => {
 		'<a href=https://pubmed.ncbi.nlm.nih.gov/12345678 target=_blank>12345678</a><br>unpublished',
 		'should mix PMID link with plain-text non-citation value'
 	)
+	// HTML-injection attempt in a non-citation value -- must be escaped
+	test.equal(
+		value2urlsOrText('<script>alert(1)</script>', { pmidOrDoi: true }),
+		'&lt;script&gt;alert(1)&lt;/script&gt;',
+		'should HTML-escape non-citation values to prevent injection'
+	)
+	// DOI with characters that need URL-encoding in href and HTML-escaping in link text
+	test.equal(
+		value2urlsOrText('doi: 10.1/<bad>&"', { pmidOrDoi: true }),
+		'<a href=https://doi.org/10.1/%3Cbad%3E%26%22 target=_blank>doi: 10.1/&lt;bad&gt;&amp;&quot;</a>',
+		'should URL-encode DOI path segments and HTML-escape the link text'
+	)
 	test.end()
 })

--- a/client/mds3/test/sampletable.unit.spec.ts
+++ b/client/mds3/test/sampletable.unit.spec.ts
@@ -37,11 +37,17 @@ tape('value2urlsOrText()', test => {
 		'<a href=https://doi.org/10.1000/xyz target=_blank>doi: 10.1000/xyz</a>',
 		'should generate DOI link'
 	)
-	// single pmid
+	// single pmid as string
 	test.equal(
 		value2urlsOrText('12345678', { pmidOrDoi: true }),
 		'<a href=https://pubmed.ncbi.nlm.nih.gov/12345678 target=_blank>12345678</a>',
-		'should generate PubMed link'
+		'should generate PubMed link from numeric string'
+	)
+	// single pmid as number (TSV/JSON parsers commonly hand us integers)
+	test.equal(
+		value2urlsOrText(12345678, { pmidOrDoi: true }),
+		'<a href=https://pubmed.ncbi.nlm.nih.gov/12345678 target=_blank>12345678</a>',
+		'should generate PubMed link from number value'
 	)
 	// mixed pmid and doi
 	test.equal(

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Now properly display non PMIDs or DOIs in sampletable.js

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
 Fixes:
-- Now properly display non PMIDs or DOIs in sampletable.js
+- Now properly display non-PMIDs or non-DOIs in sampletable.js

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1844,7 +1844,8 @@ type Tw = {
 	cannot use ds-defined callback to compute the link as the links are only generated on client
 	thus this work around for client code to apply the url-building logic
 	a doi value must be defined as "doi: 10.1038/s41408-025-01309-6", beginning with "doi: ", this allows client code to recognize it is doi;
-	otherwise it is treated as pmid and joined to pubmed link as-is
+	a numeric value is treated as a pmid and joined to the pubmed link;
+	any other value (e.g. "unpublished") is rendered as plain text with no hyperlink
 	*/
 	pmidOrDoi?: true
 }


### PR DESCRIPTION
# Description
Added support for non-PMID/non-DOI strings (e.g. "unpublished") in `tw.pmidOrDoi`. Attached are screenshots of what the behavior is on current master and what the behavior is on this branch
## Current master
<img width="3437" height="1353" alt="current_master" src="https://github.com/user-attachments/assets/30d95476-f882-4a42-9deb-d83dbee3536b" />

## This branch
<img width="3439" height="1356" alt="sampletable_fix" src="https://github.com/user-attachments/assets/a3eafc28-f71f-41fe-9575-e530dc1a1c63" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
