### PR TITLE
use auto-generated plotId in summary, violin, and survival plots

### DIFF
--- a/client/mass/store.ts
+++ b/client/mass/store.ts
@@ -36,6 +36,10 @@ The state of each plot is added to the appState plots array, so that these plots
 const idPrefix = '_MASS_AUTOID_' + Math.random().toString().slice(-6)
 let id = 0 // Number((+new Date()).toString().slice(-8))
 
+// will be used to track plotId's that have already been used, so that plot_prep() and
+// plot_create() will avoid conflicts from having a plotId that's used by different plots
+const usedPlotIds = new Set()
+
 function getId() {
 	return idPrefix + '_' + id++
 }
@@ -317,11 +321,14 @@ MassStore.prototype.actions = {
 	// dispatch "plot_prep" action to produce a 'initiating' UI of this plot, for user to fill in additional details to launch the plot
 	// example: table, scatterplot which requires user to select two terms
 	async plot_prep(this: MassStore, action) {
+		if (usedPlotIds.has(action.id)) delete action.id // prevent potential conflicts
+
 		const plot = {
-			// rx.getComponents() relies on parsing dot-separate key names that breaks if a key has a dot,
+			// rx.getComponents() relies on parsing dot-separated key names that breaks if a key has a dot,
 			// the plot.id value should be assumed to be auto-generated and to not have any non-rx usage expectations
 			id: 'id' in action && !action.id.includes('.') ? action.id : getId()
 		}
+		usedPlotIds.add(plot.id)
 		if (!action.config) throw '.config{} missing for plot_prep'
 		if (action.config.chartType && Object.keys(action.config).length == 1) {
 			const _ = await importPlot(action.config.chartType)
@@ -333,12 +340,15 @@ MassStore.prototype.actions = {
 	},
 
 	async plot_create(this: MassStore, action) {
+		if (usedPlotIds.has(action.id)) delete action.id // prevent potential conflicts
+
 		const _ = await importPlot(action.config.chartType)
 		const plot = await _.getPlotConfig(action.config, this.app, this.state.activeCohort)
-		// rx.getComponents() relies on parsing dot-separate key names that breaks if a key has a dot,
+		// rx.getComponents() relies on parsing dot-separated key names that breaks if a key has a dot,
 		// the plot.id value should be assumed to be auto-generated and to not have any non-rx usage expectations
 		if (!('id' in action) || action.id.includes('.')) action.id = getId()
 		plot.id = action.id
+		usedPlotIds.add(plot.id)
 
 		if (plot.mayAdjustConfig) {
 			plot.mayAdjustConfig(plot)

--- a/client/mass/store.ts
+++ b/client/mass/store.ts
@@ -318,7 +318,9 @@ MassStore.prototype.actions = {
 	// example: table, scatterplot which requires user to select two terms
 	async plot_prep(this: MassStore, action) {
 		const plot = {
-			id: 'id' in action ? action.id : getId()
+			// rx.getComponents() relies on parsing dot-separate key names that breaks if a key has a dot,
+			// the plot.id value should be assumed to be auto-generated and to not have any non-rx usage expectations
+			id: 'id' in action && !action.id.includes('.') ? action.id : getId()
 		}
 		if (!action.config) throw '.config{} missing for plot_prep'
 		if (action.config.chartType && Object.keys(action.config).length == 1) {
@@ -333,8 +335,11 @@ MassStore.prototype.actions = {
 	async plot_create(this: MassStore, action) {
 		const _ = await importPlot(action.config.chartType)
 		const plot = await _.getPlotConfig(action.config, this.app, this.state.activeCohort)
-		if (!('id' in action)) action.id = getId()
+		// rx.getComponents() relies on parsing dot-separate key names that breaks if a key has a dot,
+		// the plot.id value should be assumed to be auto-generated and to not have any non-rx usage expectations
+		if (!('id' in action) || action.id.includes('.')) action.id = getId()
 		plot.id = action.id
+
 		if (plot.mayAdjustConfig) {
 			plot.mayAdjustConfig(plot)
 			this.plotAdjusters.set(plot, plot.mayAdjustConfig)

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -454,7 +454,6 @@ export async function getPlotConfig(opts, app) {
 	const config = {
 		chartType: 'summary',
 		childType: 'barchart',
-		//id: opts.term.term.id,
 		term: opts.term,
 		groups: [],
 		controlLabels: Object.assign({}, defaultUiLabels, app.vocabApi.termdbConfig.uiLabels || {}),

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -1280,7 +1280,6 @@ export async function getPlotConfig(opts, app) {
 	}
 
 	const config = {
-		id: opts.term.term.id,
 		controlLabels: Object.assign({}, defaultUiLabels, app.vocabApi.termdbConfig.uiLabels || {}),
 		settings: {
 			controls: {

--- a/client/plots/violin.js
+++ b/client/plots/violin.js
@@ -481,7 +481,6 @@ export async function getPlotConfig(opts, app) {
 	}
 
 	const config = {
-		id: opts.term.term.id,
 		controlLabels: Object.assign({}, defaultUiLabels, app.vocabApi.termdbConfig.uiLabels || {}),
 		settings: {
 			controls: {

--- a/client/termdb/app.ts
+++ b/client/termdb/app.ts
@@ -193,14 +193,14 @@ class TdbApp extends AppBase implements RxApp {
 		try {
 			this.store = await storeInit({ app: this.api, state: this.opts.state })
 			this.state = await this.store.copyState()
-			this.components = await this.getComponents()
+			this.components = await this.initComponents()
 			await this.api.dispatch()
 		} catch (e) {
 			this.printError(e)
 		}
 	}
 
-	async getComponents() {
+	async initComponents() {
 		const header_mode = this.state.nav?.header_mode
 		const compPromises: { [name: string]: Promise<ComponentApi> } = {
 			search: searchInit({


### PR DESCRIPTION
# Description

Also 
- replace an `action.id` that has a dot character to avoid conflicts with `rx getComponents()`
- avoid reusing a plotId across different plots

Only the `getPlotConfigs()` in `plots/summary`, `violin`, `survival` are affected. Plots are the only components that seem to be referenced by its ID in `app.plots{}`, which are object keys instead of `state.plots[]` array entry Ids. All other usage of `app.getComponents()` uses explicit string keys that relate to the component's role in the parent component such as `nav.filter`.

Tested with all unit and integration tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
