### PR TITLE
use a unique plot-level vocabApi to cancel fetch requests 

### DIFF
--- a/client/common/dofetch.js
+++ b/client/common/dofetch.js
@@ -230,12 +230,14 @@ export function dofetch3(path, init = {}, opts = {}) {
 	// init.signal option, or for a vocabApi method to supply a default
 	// init.signal.
 	//
-	// 'this' is a Vocab or TermdbVocab instance, where the Vocab constructor
-	// sets a this.dofetch3 method that has access to this.app.getAbortSignal.
+	// 'this' is a Vocab or TermdbVocab instance, where the Vocab constructor sets a
+	// this.dofetch3 method that has access to a plot-level or app-level getAbortSignal.
 	// In Javascript, a function that's attached to an object and called as
 	// object.method() will have its `this` context set to the object that it's
 	// attached to.
-	if (!init.signal && typeof this?.app?.getAbortSignal == 'function') init.signal = this.app.getAbortSignal()
+	if (!init.signal && this) {
+		init.signal = this.getAbortSignal?.() || this.app?.getAbortSignal?.()
+	}
 
 	opts.serverData = defaultServerDataCache
 	return dofetch2(path, init, opts)

--- a/client/plots/PlotBase.ts
+++ b/client/plots/PlotBase.ts
@@ -1,4 +1,5 @@
 import type { AppApi, ComponentApi } from '#rx'
+import type { TermdbVocab } from '../termdb/TermdbVocab.js'
 import { TwRouter, routedTermTypes } from '#tw'
 
 export class PlotBase {
@@ -22,6 +23,7 @@ export class PlotBase {
 	// dom: any
 	// config: any
 	configTermKeys?: string[]
+	vocabApi: TermdbVocab
 
 	constructor(opts, plotApi?: ComponentApi) {
 		if (plotApi) this.api = plotApi
@@ -29,6 +31,28 @@ export class PlotBase {
 		this.id = opts?.id
 		this.app = opts?.app
 		this.parentId = opts?.parentId
+		// Below creates a vocabApi instance that is unique to the plot instance,
+		// but inherits all the methods and properties of an "active" instance that
+		// is updated on every app dispatch. This prototypal inheritance makes up-to-date
+		// state.termfilter available inside every vocabApi method call.
+		//
+		// In contrast, classical inheritance (using the "new" keyword) would require calling
+		// vocabApi.main() on all plot-related instance on every componentApi.update().
+		// In this current use case, the tradeoff is between faster property/method lookup
+		// in classical inheritance versus being able to inherit dynamically updated state
+		// of the prototype.
+		this.vocabApi = Object.create(this.app?.vocabApi || {}, {
+			// Below makes a plot-level abort signal easily accessible inside all vocabApi methods,
+			// usage example: `const signal = this.getAbortSignal?.()` inside TermdbVocab.getCategories()
+			// This overrides the TermdbVocab.getAbortSignal() that is not plot-level, where the app-wide
+			// cancellation may affect fetch requests that shouldn't be cancelled.
+			// Details at https://docs.google.com/drawings/d/1fQUq6icJORgJncwW-Fh3npq1vt9-3GvaVPLgXptTGWU/edit.
+			getAbortSignal: {
+				value: () => {
+					return this.api?.getAbortSignal?.()
+				}
+			}
+		})
 	}
 
 	async getMutableConfig() {

--- a/client/plots/PlotBase.ts
+++ b/client/plots/PlotBase.ts
@@ -46,7 +46,7 @@ export class PlotBase {
 			// usage example: `const signal = this.getAbortSignal?.()` inside TermdbVocab.getCategories()
 			// This overrides the TermdbVocab.getAbortSignal() that is not plot-level, where the app-wide
 			// cancellation may affect fetch requests that shouldn't be cancelled.
-			// Details at https://docs.google.com/drawings/d/1fQUq6icJORgJncwW-Fh3npq1vt9-3GvaVPLgXptTGWU/edit.
+			// Details at https://github.com/stjude/proteinpaint/wiki/Using-AbortController-to-prevent-race-condition
 			getAbortSignal: {
 				value: () => {
 					return this.api?.getAbortSignal?.()
@@ -61,7 +61,7 @@ export class PlotBase {
 		if (!config || !this.configTermKeys?.length) return structuredClone(config)
 
 		const opts = {
-			vocabApi: this.app.vocabApi
+			vocabApi: this.vocabApi
 		}
 
 		for (const key of this.configTermKeys) {

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -17,6 +17,7 @@ export class InputTerm {
 		this.section = opts.section
 		this.term = opts.term // term wrapper {id, term, q}; will be missing for a blank input
 		this.parent = opts.parent // the inputs instance
+		this.vocabApi = this.parent.parent.vocabApi || this.parent.app.vocabApi
 	}
 
 	async init(holder) {
@@ -150,7 +151,7 @@ export class InputTerm {
 		try {
 			if (tw && this.setQ) {
 				const { app, state } = this.parent
-				await this.setQ[tw.term.type](tw, app.vocabApi, this.parent.parent.filter, state)
+				await this.setQ[tw.term.type](tw, this.vocabApi, this.parent.parent.filter, state)
 			}
 
 			try {
@@ -210,7 +211,7 @@ export class InputTerm {
 		const wait = this.dom.holder.append('div').style('padding', '5px').text('Loading...') // getCategories may wait long time e.g. gdc. adding this to indicate its loading to avoid just showing a nopill prompt
 		let data
 		try {
-			data = await this.parent.app.vocabApi.getCategories(tw.term, this.parent.parent.filter, body)
+			data = await this.vocabApi.getCategories(tw.term, this.parent.parent.filter, body)
 			if (!data) throw `no data for term.id='${tw.term.id}'`
 			if (data.error) throw data.error
 		} finally {

--- a/client/plots/regression.inputs.term.js
+++ b/client/plots/regression.inputs.term.js
@@ -50,7 +50,7 @@ export class InputTerm {
 				placeholder: this.section.selectPrompt,
 				placeholderIcon: this.section.placeholderIcon,
 				holder: this.dom.pillDiv,
-				vocabApi: app.vocabApi,
+				vocabApi: this.vocabApi,
 				noTermPromptOptions: this.opts.noTermPromptOptions,
 				activeCohort: state.activeCohort,
 				debug: app.opts.debug,
@@ -167,7 +167,7 @@ export class InputTerm {
 			// $id needs to be filled in here for non-dictionary terms
 			// TODO: should have a centralized location for filling in
 			// $id for non-dictionary terms
-			if (tw && !tw.$id) tw.$id = await get$id(this.parent.app.vocabApi.getTwMinCopy(tw))
+			if (tw && !tw.$id) tw.$id = await get$id(this.vocabApi.getTwMinCopy(tw))
 			const e = (tw && tw.error) || this.pill.error
 			if (e) errors.push(e)
 			if (errors.length) throw errors
@@ -296,7 +296,7 @@ export class InputTerm {
 				}
 				if (this.section.configKey == 'outcome' && this.parent.opts.regressionType == 'cox') {
 					if (!['age', 'time'].includes(tw.q.timeScale)) throw 'invalid q.timeScale'
-					const tdb = this.parent.app.vocabApi.termdbConfig
+					const tdb = this.vocabApi.termdbConfig
 
 					this.termStatus.topInfoStatus.push(`Time axis: ${tw.q.timeScale == 'time' ? tdb.timeUnit : 'age'}`)
 
@@ -424,7 +424,7 @@ export class InputTerm {
 		if (!this.term) return // missing term
 		if (this.section.configKey != 'independent') return
 		if (this.term.q.mode == 'spline') return // not on a spline term
-		if (this.parent.app.vocabApi.termdbConfig.regression?.settings?.disableInteractions) return
+		if (this.vocabApi.termdbConfig.regression?.settings?.disableInteractions) return
 		{
 			// require minimum of 2 independent terms eligible for interaction
 			let count = 0

--- a/client/rx/src/ComponentApi.ts
+++ b/client/rx/src/ComponentApi.ts
@@ -190,6 +190,9 @@ export class ComponentApi {
 	// }
 	//
 
+	// !!! detectStale() has been deprecated !!!
+	// TODO: Replace all detectStale() usage with vocabApi.getAbortSignal()
+	//
 	// When an async function takes a while to resolve, such as for server requests,
 	// a subsequent action may trigger another request before the first one resolves,
 	// in that case should ignore the stale response/result from the async function.

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -16,7 +16,7 @@ export class TermdbVocab extends Vocab {
 	//
 	// A more targeted, plot-level cancellation may override this and should be preferred,
 	// which is done in PlotBase constructor using prototypal inheritance. See details at
-	// https://docs.google.com/drawings/d/1fQUq6icJORgJncwW-Fh3npq1vt9-3GvaVPLgXptTGWU/edit.
+	// https://github.com/stjude/proteinpaint/wiki/Using-AbortController-to-prevent-race-condition
 	getAbortSignal() {
 		return this.app?.getAbortSignal?.()
 	}

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -5,6 +5,22 @@ import { throwMsgWithFilePathAndFnName } from '../dom/sayerror'
 import { isDictionaryType } from '#shared/terms.js'
 
 export class TermdbVocab extends Vocab {
+	// getAbortSignal() will be used to cancel async fetch requests or canvas rendering that may
+	// lead to a mismatch between cohort label and rendered data due to race condition.
+	// Assume that the rarely used FrontendVocab will not require fetch/rendering cancellation,
+	// so there is no need to have this on the parent Vocab class as an inherited method.
+	// (May revisit this assumption as needed.)
+	//
+	// The default is to trigger cancellation at the beginning of every app.dispatch(),
+	// if the signal option is provided to fetch().
+	//
+	// A more targeted, plot-level cancellation may override this and should be preferred,
+	// which is done in PlotBase constructor using prototypal inheritance. See details at
+	// https://docs.google.com/drawings/d/1fQUq6icJORgJncwW-Fh3npq1vt9-3GvaVPLgXptTGWU/edit.
+	getAbortSignal() {
+		return this.app?.getAbortSignal?.()
+	}
+
 	// migrated from termdb/store
 	async getTermdbConfig() {
 		if (this.opts.getDatasetAccessToken) {
@@ -510,7 +526,7 @@ export class TermdbVocab extends Vocab {
 			if (termfilter.filter) body.filter = getNormalRoot(termfilter.filter)
 			if (termfilter.filter0) body.filter0 = termfilter.filter0
 		}
-		const signal = this.app?.getAbortSignal?.() // ok to be undefined
+		const signal = this.getAbortSignal() // ok to be undefined
 		return await this.dofetch3('termdb/getpercentile', { body, signal })
 	}
 
@@ -582,7 +598,7 @@ export class TermdbVocab extends Vocab {
 	optionally, caller can supply a {term1_q: {...}} key-object value in _body to customize categories
 	*/
 	async getCategories(term, filter, _body = {}) {
-		const signal = this.app?.getAbortSignal?.()
+		const signal = this.getAbortSignal()
 		const headers = await this.mayGetAuthHeaders()
 		if (term.type == 'snplst' || term.type == 'snplocus') {
 			const body = Object.assign(
@@ -790,7 +806,7 @@ export class TermdbVocab extends Vocab {
 
 		const warnings = []
 		const frozenEmptyObj = Object.freeze({})
-		const signal = opts.signal || this.app?.getAbortSignal?.()
+		const signal = opts.signal || this.getAbortSignal()
 
 		while (true) {
 			const copies = getTerms2update(allTerms2update, maxNumTerms) // list of unique terms to update in this round
@@ -1076,7 +1092,7 @@ export class TermdbVocab extends Vocab {
 			if (tf.filter) body.filter = getNormalRoot(tf.filter)
 			if (tf.filter0) body.filter0 = tf.filter0
 		}
-		const signal = opts.signal || this.app?.getAbortSignal?.()
+		const signal = opts.signal || this.getAbortSignal()
 		return await this.dofetch3('termdb', { headers, body, signal })
 	}
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- implement a unique plot-level vocabApi to cancel fetch requests only for affected charts and child components


### PR DESCRIPTION
# Description

... only for affected charts and child components.

Tested with all unit and integration tests. Also tested manually
1. open  [link](http://localhost:3000/?noheader=1&gdccorrelation=1&filter0={%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.primary_site%22,%22value%22:[%22brain%22,%22breast%22]}})
2. open Cox and select outcome
3. while outcome is loading, close off existing Correlation Input sandbox and Cox sandbox should not get `stale sequenceId` error

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
