### PR TITLE
centralize the logic for generating component-level vocabApi inside a…

### DIFF
--- a/client/plots/PlotBase.ts
+++ b/client/plots/PlotBase.ts
@@ -23,7 +23,7 @@ export class PlotBase {
 	// dom: any
 	// config: any
 	configTermKeys?: string[]
-	vocabApi: TermdbVocab
+	vocabApi?: TermdbVocab
 
 	constructor(opts, plotApi?: ComponentApi) {
 		if (plotApi) this.api = plotApi
@@ -32,27 +32,9 @@ export class PlotBase {
 		this.app = opts?.app
 		this.parentId = opts?.parentId
 		// Below creates a vocabApi instance that is unique to the plot instance,
-		// but inherits all the methods and properties of an "active" instance that
-		// is updated on every app dispatch. This prototypal inheritance makes up-to-date
-		// state.termfilter available inside every vocabApi method call.
-		//
-		// In contrast, classical inheritance (using the "new" keyword) would require calling
-		// vocabApi.main() on all plot-related instance on every componentApi.update().
-		// In this current use case, the tradeoff is between faster property/method lookup
-		// in classical inheritance versus being able to inherit dynamically updated state
-		// of the prototype.
-		this.vocabApi = Object.create(this.app?.vocabApi || {}, {
-			// Below makes a plot-level abort signal easily accessible inside all vocabApi methods,
-			// usage example: `const signal = this.getAbortSignal?.()` inside TermdbVocab.getCategories()
-			// This overrides the TermdbVocab.getAbortSignal() that is not plot-level, where the app-wide
-			// cancellation may affect fetch requests that shouldn't be cancelled.
-			// Details at https://github.com/stjude/proteinpaint/wiki/Using-AbortController-to-prevent-race-condition
-			getAbortSignal: {
-				value: () => {
-					return this.api?.getAbortSignal?.()
-				}
-			}
-		})
+		// so that there'd be a plot-level request cancellation using
+		// plotApi.getAbortContoller()
+		if (this.app) this.vocabApi = this.app.vocabApi.create(() => this.api?.getAbortSignal())
 	}
 
 	async getMutableConfig() {

--- a/client/plots/PlotBase.ts
+++ b/client/plots/PlotBase.ts
@@ -32,9 +32,8 @@ export class PlotBase {
 		this.app = opts?.app
 		this.parentId = opts?.parentId
 		// Below creates a vocabApi instance that is unique to the plot instance,
-		// so that there'd be a plot-level request cancellation using
-		// plotApi.getAbortContoller()
-		if (this.app) this.vocabApi = this.app.vocabApi.create(() => this.api?.getAbortSignal())
+		// so that there'd be a plot-level request cancellation using plotApi.getAbortSignal()
+		if (this.app?.vocabApi) this.vocabApi = this.app.vocabApi.create(() => this.api?.getAbortSignal())
 	}
 
 	async getMutableConfig() {

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -32,6 +32,41 @@ export class Vocab {
 		this.dofetch3 = dofetch3
 	}
 
+	create(componentGetAbortSignal) {
+		// This creates a vocabApi instance that is unique to a component instance,
+		// but inherits all the methods and properties of this "active" current instance,
+		// which is updated on every app dispatch. This prototypal inheritance makes
+		// up-to-date state.termfilter available inside every vocabApi method call.
+		//
+		// In contrast, classical inheritance (using the "new" keyword) would require calling
+		// vocabApi.main() on all plot-related instance on every componentApi.update().
+		// In this current use case, the tradeoff is between faster property/method lookup
+		// in classical inheritance versus being able to inherit dynamically updated state
+		// of the prototype.
+		//
+		return Object.create(this, {
+			// Make a component-level abort signal easily accessible inside all vocabApi methods,
+			// usage example: `init.signal = this.getAbortSignal?.() || this.app?.getAbortSignal?.()` in dofetch3()
+			// This overrides the TermdbVocab.getAbortSignal() that is not plot-level, where the app-wide
+			// cancellation may affect fetch requests that shouldn't be cancelled.
+			// Details at https://github.com/stjude/proteinpaint/wiki/Using-AbortController-to-prevent-race-condition
+			getAbortSignal: {
+				value: () => componentGetAbortSignal()
+			}
+		})
+
+		// NOTE: May easily switch to classical inheritance approach if the prototypal
+		// inheritance leads to confusing behavior or debugging. For example:
+		//
+		// const vocabApi = new TermdbVocab(this.state.vocab)
+		// this.trackedApis.add(vocabApi)
+		// return vocabApi
+		//
+		// then inside vocabApi.main() when it is called by app.main(),
+		// for(const api of trackedApis) api.main()
+		//
+	}
+
 	async main(stateOverride = null) {
 		if (stateOverride) Object.assign(this.state, stateOverride)
 		else this.state = structuredClone(this.app?.getState?.() || this.opts.state)

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -47,8 +47,9 @@ export class Vocab {
 		return Object.create(this, {
 			// Make a component-level abort signal easily accessible inside all vocabApi methods,
 			// usage example: `init.signal = this.getAbortSignal?.() || this.app?.getAbortSignal?.()` in dofetch3()
-			// This overrides the TermdbVocab.getAbortSignal() that is not plot-level, where the app-wide
-			// cancellation may affect fetch requests that shouldn't be cancelled.
+			// This overrides the default app-level cancellation fallback with a component/plot-level
+			// signal, so app-wide state changes do not cancel fetch requests that should remain scoped
+			// to the current component instance.
 			// Details at https://github.com/stjude/proteinpaint/wiki/Using-AbortController-to-prevent-race-condition
 			getAbortSignal: {
 				value: () => componentGetAbortSignal()


### PR DESCRIPTION
… vocabApi.create() method

# Description

Same tests as https://github.com/stjude/proteinpaint/pull/4548.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
