### PR TITLE
Support `.survMsg` property to render message in survival plot

### DIFF
--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -62,6 +62,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 	colorScale: any
 
 	refs: any
+	msg?: string
 	symbol: any
 	serverData?: any
 	currData?: any
@@ -420,6 +421,17 @@ class TdbSurvival extends PlotBase implements RxComponent {
 			}
 		}
 
+		// process refs
+		if (data.refs.byTermId) {
+			const byTermId = data.refs.byTermId
+			const msg = byTermId[this.state.config.term.term.id]?.survMsg
+			if (msg) {
+				// message to be displayed in survival plot
+				// will be rendered in .pp-survival-chartLegends of each chart
+				this.msg = msg
+			}
+		}
+
 		return rows
 	}
 
@@ -649,7 +661,11 @@ function setRenderers(self) {
 
 			// p-values legend
 			if (self.tests && chart.rawChartId in self.tests) {
-				const holder = div.select('.pp-survival-chartLegends').style('display', 'inline-block').append('div')
+				const holder = div
+					.select('.pp-survival-chartLegends')
+					.style('display', 'inline-block')
+					.append('div')
+					.style('margin-bottom', '30px')
 				renderPvalues({
 					title: 'Group comparisons (log-rank test)',
 					holder,
@@ -661,6 +677,16 @@ function setRenderers(self) {
 					setActiveMenu,
 					updateHiddenPvalues
 				})
+			}
+
+			// message
+			if (self.msg) {
+				const fontSize = s.axisTitleFontSize ? s.axisTitleFontSize - 2 : 15
+				const holder = div.select('.pp-survival-chartLegends').style('display', 'inline-block').append('div')
+				holder
+					.style('font-size', fontSize + 'px')
+					.style('font-style', 'italic')
+					.text(self.msg)
 			}
 		}
 	}
@@ -705,7 +731,11 @@ function setRenderers(self) {
 
 		// p-values legend
 		if (self.tests && chart.rawChartId in self.tests) {
-			const holder = div.select('.pp-survival-chartLegends').style('display', 'inline-block').append('div')
+			const holder = div
+				.select('.pp-survival-chartLegends')
+				.style('display', 'inline-block')
+				.append('div')
+				.style('margin-bottom', '30px')
 			renderPvalues({
 				title: 'Group comparisons (log-rank test)',
 				holder,
@@ -717,6 +747,16 @@ function setRenderers(self) {
 				setActiveMenu,
 				updateHiddenPvalues
 			})
+		}
+
+		// message
+		if (self.msg) {
+			const fontSize = s.axisTitleFontSize ? s.axisTitleFontSize - 2 : 15
+			const holder = div.select('.pp-survival-chartLegends').style('display', 'inline-block').append('div')
+			holder
+				.style('font-size', fontSize + 'px')
+				.style('font-style', 'italic')
+				.text(self.msg)
 		}
 	}
 

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -391,6 +391,8 @@ class TdbSurvival extends PlotBase implements RxComponent {
 
 	processData(data) {
 		this.uniqueSeriesIds = new Set()
+		this.msg = ''
+
 		const rows: any[] = []
 		const estKeys = ['survival', 'lower', 'upper']
 		for (const d of data.case) {
@@ -727,7 +729,7 @@ function setRenderers(self) {
 		renderSVG(div.select('svg'), chart, s, s.duration)
 
 		// div for chart-specific legends
-		div.select('.pp-survival-chartLegends').selectAll('*').remove()
+		div.select('.pp-survival-chartLegends').style('display', 'none').selectAll('*').remove()
 
 		// p-values legend
 		if (self.tests && chart.rawChartId in self.tests) {

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -102,11 +102,16 @@ export async function get_survival(q, ds) {
 			byChartSeries[chart].push({ time, status, series })
 		}
 
+		// FIXME: data.refs.byTermId[q.term2.id] should be queried instead of
+		// data.refs[q.term2.id]
 		const bins = (q.term2_id && data.refs[q.term2.id]?.bins) || []
 		const final_data = {
 			keys: ['chartId', 'seriesId', 'time', 'survival', 'lower', 'upper', 'nevent', 'ncensor', 'nrisk'],
 			case: [],
-			refs: { bins }
+			refs: {
+				bins,
+				byTermId: data.refs.byTermId
+			}
 		}
 
 		// perform survival analysis for each chart

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -2190,6 +2190,8 @@ export type Mds3 = BaseMds & {
 			email?: string
 		}
 	}
+	/** mmrf-specific helpers */
+	__mmrf?: any
 	// !!! TODO: improve these type definitions below !!!
 	serverconfigFeatures?: any
 	/** a dataset may supply custom URL host and headers to use when making external API requests, such as for GDC */


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1351

This PR supports a `.survMsg` property in `byTermId{}` that will allow a message to be displayed in survival plot.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
