### PR TITLE
Compute the currBin.label and stopunbounded when the bin entries exceeds maxNumBins

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- compute the currBin.label and stopunbounded when the bin entries exceeds the maxNumBins

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
 Fixes:
-- compute the currBin.label and stopunbounded when the bin entries exceeds the maxNumBins
+- compute the currBin.label and stopunbounded when the number of bin entries exceeds the maxNumBins

--- a/shared/utils/src/termdb.bins.ts
+++ b/shared/utils/src/termdb.bins.ts
@@ -106,7 +106,7 @@ export default function validate_bins(binconfig) {
 	}
 }
 
-const maxNumBins = 100 // harcoded limit for now to not stress sqlite
+const maxNumBins = 100 // hardcoded limit for now to not stress sqlite
 
 export function compute_bins(binconfig, summaryfxn, valueConversion) {
 	/*
@@ -131,6 +131,8 @@ export function compute_bins(binconfig, summaryfxn, valueConversion) {
 
 	validate_bins(bc)
 	if (bc.lst) {
+		if (!Array.isArray(bc.lst)) throw `bc.lst is not an array`
+		if (bc.lst.length > maxNumBins) throw `bc.lst exceed the maximum of ${maxNumBins} allowed entries`
 		const k2c = getColors(bc.lst.length) //to color bins
 		for (const bin of bc.lst) bin.color = k2c(bin.label)
 	}
@@ -250,10 +252,7 @@ export function compute_bins(binconfig, summaryfxn, valueConversion) {
 			currBin.stopunbounded = true
 			currBin.label = get_bin_label(currBin, bc, valueConversion)
 			if (!bins.includes(currBin)) bins.push(currBin)
-			const hint =
-				bc.type == 'regular-bin'
-					? 'Please increase the bin_size or first bin stop, or have a lower last bin start.'
-					: `Please have less than ${maxNumBins} bins.`
+			const hint = 'Please increase the bin_size or first bin stop, or have a lower last bin start.'
 			bc.error = hint + ' (max_num_bins_reached)'
 			break
 		}

--- a/shared/utils/src/termdb.bins.ts
+++ b/shared/utils/src/termdb.bins.ts
@@ -106,6 +106,8 @@ export default function validate_bins(binconfig) {
 	}
 }
 
+const maxNumBins = 100 // harcoded limit for now to not stress sqlite
+
 export function compute_bins(binconfig, summaryfxn, valueConversion) {
 	/*
 	  Bins generator
@@ -203,7 +205,6 @@ export function compute_bins(binconfig, summaryfxn, valueConversion) {
 	}
 
 	if (!isStrictNumeric(currBin.stop)) throw 'the computed first_bin.stop is non-numeric' + currBin.stop
-	const maxNumBins = 100 // harcoded limit for now to not stress sqlite
 
 	while ((numericMax && currBin.stop <= max) || (currBin.startunbounded && !bins.length) || currBin.stopunbounded) {
 		bins.push(currBin)
@@ -245,7 +246,15 @@ export function compute_bins(binconfig, summaryfxn, valueConversion) {
 			else break
 		}
 		if (bins.length + 1 >= maxNumBins) {
-			bc.error = 'max_num_bins_reached'
+			delete currBin.stop
+			currBin.stopunbounded = true
+			currBin.label = get_bin_label(currBin, bc, valueConversion)
+			if (!bins.includes(currBin)) bins.push(currBin)
+			const hint =
+				bc.type == 'regular-bin'
+					? 'Please increase the bin_size or first bin stop, or have a lower last bin start.'
+					: `Please have less than ${maxNumBins} bins.`
+			bc.error = hint + ' (max_num_bins_reached)'
 			break
 		}
 	}


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2773.

Tested using the example in the linked jira ticket, also locally with all unit and integration tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
