### PR TITLE
Do not reuse density data in numeric density handler

### DIFF
--- a/client/termsetting/handlers/NumericDensity.ts
+++ b/client/termsetting/handlers/NumericDensity.ts
@@ -67,7 +67,7 @@ export class NumericDensity {
 	}
 
 	async setData() {
-		if (this.density_data) return this.density_data
+		//if (this.density_data) return this.density_data
 		const self = this.termsetting
 		const d = await self.vocabApi.getViolinBox(
 			{


### PR DESCRIPTION
Issue on master: open [survival/TP53 geneExp](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22survival%22,%22term2%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22}},%22term%22:{%22id%22:%22efs%22}}]}) -> edit term2 -> correct TP53 violin plot is displayed -> replace gene with AKT1 -> edit term2 -> TP53 violin plot is displayed instead of AKT1 violin plot.

In this PR, the issue is fixed by commenting out the code to reuse `this.density_data` in `client/termsetting/handlers/NumericDensity.ts`. Please evaluate this code change.

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
