### PR TITLE
Add credentials to jwt status call

### DIFF
--- a/.github/workflows/CI-unit.yml
+++ b/.github/workflows/CI-unit.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           cache: 'npm'
           node-version: '24'
-      
+
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,8 +91,8 @@ jobs:
       - name: 🔎 Run python test
         if: contains(env.WS_TO_TEST, 'python')
         run: npm test --workspace="python"
-        
-      # TODO: no need to run pack test once esbuild is used for package release 
+
+      # TODO: no need to run pack test once esbuild is used for package release
       - name: 🔎 Run client pack test
         if: contains(env.WS_TO_TEST, 'client')
         run: npm pack --workspace="client"

--- a/client/common/auth.js
+++ b/client/common/auth.js
@@ -127,6 +127,7 @@ export async function isInSession(dslabel, route) {
 		if (payload.exp && Math.ceil(Date.now() / 1000) > payload.exp) return false
 		const data = await dofetch3('/jwt-status', {
 			method: 'POST',
+			credentials: 'include',
 			headers: {
 				//authorization: `Bearer ${btoa(jwt)}`
 				[a.headerKey]: jwt


### PR DESCRIPTION
# Description

When ProteinPaint is imported through the embedder, the ds-/**-*-id cookie is not persisted on the client. As a result, some requests are sent without the required dataset identifier and fail authorization.

This PR fixes that issue. The fix has been tested, and requests are now authorized correctly when using the embedder.

The workflow file changes included in this PR are formatting-only and contain no functional changes.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
