### PR TITLE
Add mutation fraction filtering and improve legends

### DIFF
--- a/client/plots/disco/Disco.UI.ts
+++ b/client/plots/disco/Disco.UI.ts
@@ -128,10 +128,14 @@ function makeDataTypeTabs(dataTypeTabs_div: Selection<HTMLDivElement, any, any, 
 					<li>position</li>
 					<li>gene</li>
 					<li>aachange</li>
-					<li>class</li></ol>
+					<li>class</li>
+					<li>DNA total reads (optional)</li>
+					<li>DNA alt reads (optional)</li>
+					<li>RNA total reads (optional)</li>
+					<li>RNA alt reads (optional)</li></ol>
 					<p>Example:</p>
 <pre style="margin-left: 10px;">
-chr1	226252135	H3F3A	K28M	M
+chr1	226252135	H3F3A	K28M	M	100	25	80	16
 chr2	98765432	TestGene	TestMutation	F
 </pre>`
 				mainTabCallback(dataTypeTab, obj, listHTML)

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -125,6 +125,21 @@ export default class Disco {
 			configInputsOptions.push(...cnvConfigInputOptions)
 		}
 
+		if (viewModel.hasMutationFractionData) {
+			configInputsOptions.push({
+				boxLabel: '',
+				label: 'Minimum mutation fraction',
+				type: 'number',
+				chartType: 'Disco',
+				settingsKey: 'minMutationFraction',
+				title: 'Only show SNV/indel mutations with at least one DNA/RNA mutation fraction at or above this value.',
+				step: 0.01,
+				min: 0,
+				max: 1,
+				debounceInterval: 500
+			})
+		}
+
 		configInputsOptions.push({
 			boxLabel: '',
 			label: 'Show gene names',

--- a/client/plots/disco/Settings.ts
+++ b/client/plots/disco/Settings.ts
@@ -26,6 +26,8 @@ export default interface Settings {
 		showGeneNames: boolean
 		mutationWaterfallPlot: boolean
 		mutationWaterfallColor: string
+		/** Minimum DNA/RNA mutation fraction (0-1) required to render SNV/indel mutations. */
+		minMutationFraction: number
 	}
 
 	rings: {

--- a/client/plots/disco/data/Data.ts
+++ b/client/plots/disco/data/Data.ts
@@ -2,7 +2,10 @@ export type Vaf = {
 	readonly id?: string
 	readonly name?: string
 	readonly refCount?: string | number
+	readonly totalCount?: string | number
 	readonly altCount?: string | number
+	readonly fraction?: string | number
+	readonly mutationFraction?: string | number
 }
 
 export default interface Data {

--- a/client/plots/disco/data/DataHolder.ts
+++ b/client/plots/disco/data/DataHolder.ts
@@ -30,6 +30,7 @@ export interface DataHolder {
 
 	hasPrioritizedGenes: boolean
 	hasWaterfallEligibleChromosome: boolean
+	hasMutationFractionData: boolean
 
 	cnvGainMaxValue?: number
 	cnvLossMaxValue?: number

--- a/client/plots/disco/data/DataMapper.ts
+++ b/client/plots/disco/data/DataMapper.ts
@@ -7,6 +7,7 @@ import type { DataHolder } from '#plots/disco/data/DataHolder.ts'
 import { dtsnvindel, dtfusionrna, dtsv, dtcnv, dtloh } from '#shared/common.js'
 import { PercentileMapper } from '#plots/disco/data/PercentileMapper.ts'
 import type { MutationWaterfallDatum } from '#plots/disco/waterfall/MutationWaterfallDatum.ts'
+import { getMaxMutationFraction } from '#plots/disco/snv/vafTooltip.ts'
 
 export default class DataMapper {
 	// remove fields and extract filters to seperate classes
@@ -49,6 +50,7 @@ export default class DataMapper {
 	private cnvMaxPercentileAbs = 0
 
 	private mutationWaterfallData: Array<MutationWaterfallDatum> = []
+	private hasMutationFractionData = false
 	private mutationWaterfallInnerRadius = 0
 	private mutationWaterfallRangeMin = Infinity
 	private mutationWaterfallRangeMax = -Infinity
@@ -129,8 +131,12 @@ export default class DataMapper {
 		this.mutationWaterfallInnerRadius = 0
 		this.mutationWaterfallRangeMin = Infinity
 		this.mutationWaterfallRangeMax = -Infinity
+		this.hasMutationFractionData = false
 
 		data.forEach(dObject => {
+			if (dObject.dt == dtsnvindel && getMaxMutationFraction(dObject.vafs) != null) {
+				this.hasMutationFractionData = true
+			}
 			const index = this.reference.chromosomesOrder.indexOf(dObject.chr)
 			const indexA = this.reference.chromosomesOrder.indexOf(dObject.chrA)
 			const indexB = this.reference.chromosomesOrder.indexOf(dObject.chrB)
@@ -312,6 +318,8 @@ export default class DataMapper {
 			lohMaxValue: this.lohMaxValue,
 			lohMinValue: this.lohMinValue,
 
+			hasMutationFractionData: this.hasMutationFractionData,
+
 			mutationWaterfallData: this.mutationWaterfallData,
 			mutationWaterfallInnerRadius: this.mutationWaterfallInnerRadius,
 			mutationWaterfallLogRange: this.mutationWaterfallData.length
@@ -338,7 +346,7 @@ export default class DataMapper {
 	}
 
 	private filterNonExonicSnvData(data: Data) {
-		if (this.snvFilter(data)) {
+		if (this.snvFilter(data) && this.passesMutationFractionFilter(data)) {
 			if (this.settings.rings.nonExonicRingEnabled && this.nonExonicFilter(data)) {
 				this.nonExonicSnvData.push(data)
 			}
@@ -349,7 +357,7 @@ export default class DataMapper {
 		if (this.snvFilter(data)) {
 			this.snvData.push(data)
 
-			if (this.snvRingFilter(data)) {
+			if (this.passesMutationFractionFilter(data) && this.snvRingFilter(data)) {
 				if (this.snvInnerRadius == 0) {
 					this.snvInnerRadius = this.lastInnerRadious - this.settings.rings.snvRingWidth
 					this.lastInnerRadious = this.snvInnerRadius
@@ -375,6 +383,14 @@ export default class DataMapper {
 				this.snvRingDataMap.set(arcAngle, dataArray)
 			}
 		}
+	}
+
+	private passesMutationFractionFilter(data: Data): boolean {
+		const minMutationFraction = this.settings.Disco.minMutationFraction || 0
+		if (minMutationFraction <= 0) return true
+
+		const fraction = getMaxMutationFraction(data.vafs)
+		return fraction != null && fraction >= minMutationFraction
 	}
 
 	private filterFusion(data: Data) {

--- a/client/plots/disco/data/DataMapper.ts
+++ b/client/plots/disco/data/DataMapper.ts
@@ -386,6 +386,8 @@ export default class DataMapper {
 	}
 
 	private passesMutationFractionFilter(data: Data): boolean {
+		// If the dataset has no usable mutation-fraction info anywhere, don't apply the threshold.
+		if (!this.hasMutationFractionData) return true
 		const minMutationFraction = this.settings.Disco.minMutationFraction || 0
 		if (minMutationFraction <= 0) return true
 

--- a/client/plots/disco/data/test/DataMapper.unit.spec.ts
+++ b/client/plots/disco/data/test/DataMapper.unit.spec.ts
@@ -93,3 +93,43 @@ test('DataMapper.map() flags SNV positions outside chromosome size', t => {
 	t.equal(res.snvData.length, 0, 'Invalid SNV should be skipped')
 	t.end()
 })
+
+test('DataMapper.map() filters rendered SNVs by minimum DNA/RNA mutation fraction', t => {
+	const fractionSettings = discoDefaults({
+		Disco: {
+			cnvCapping: 2,
+			prioritizeGeneLabelsByGeneSets: false,
+			cnvPercentile: 0.8,
+			minMutationFraction: 0.2
+		},
+		rings: {}
+	})
+	const fractionReference = new Reference(fractionSettings, chromosomesOrder, chromosomes)
+	const mapper = new DataMapper(fractionSettings, fractionReference, 'SampleA', [])
+	const res = mapper.map([
+		{
+			dt: dtsnvindel,
+			chr: 'chr1',
+			position: 100,
+			gene: 'LOW',
+			class: 'M',
+			mname: 'low',
+			vafs: [{ id: 'DNA', totalCount: 100, altCount: 10 }]
+		},
+		{
+			dt: dtsnvindel,
+			chr: 'chr1',
+			position: 200,
+			gene: 'HIGH',
+			class: 'M',
+			mname: 'high',
+			vafs: [{ id: 'RNA', totalCount: 100, altCount: 25 }]
+		}
+	])
+
+	t.equal(res.snvData.length, 2, 'All valid SNVs are retained in unfiltered data')
+	t.equal(res.filteredSnvData.length, 1, 'Only SNVs meeting the fraction threshold are rendered')
+	t.equal(res.filteredSnvData[0].gene, 'HIGH', 'SNV with mutation fraction above threshold remains')
+	t.equal(res.hasMutationFractionData, true, 'Data holder reports available mutation fraction data')
+	t.end()
+})

--- a/client/plots/disco/defaults.ts
+++ b/client/plots/disco/defaults.ts
@@ -21,6 +21,7 @@ export default function discoDefaults(overrides: any = {}, app?: any): Settings 
 			showGeneNames: true,
 			mutationWaterfallPlot: false,
 			mutationWaterfallColor: '#4d4d4d',
+			minMutationFraction: 0,
 			cnvRenderingType: CnvRenderingType.heatmap,
 			cnvPercentile: 90, // 90th percentile for removing outliers
 			cnvCutoffMode: 'percentile',
@@ -76,7 +77,7 @@ export default function discoDefaults(overrides: any = {}, app?: any): Settings 
 			maxMutationCount: 10000
 		},
 		legend: {
-			snvTitle: 'SNV',
+			snvTitle: 'Mutations',
 			cnvTitle: 'CNV',
 			lohTitle: 'LOH',
 			fusionTitle: 'SV', // Structural Variants (color by co-location)

--- a/client/plots/disco/launch.adhoc.ts
+++ b/client/plots/disco/launch.adhoc.ts
@@ -218,13 +218,14 @@ function parseOptionalVafs(line: string[], errors: string[]) {
 		if (
 			!Number.isInteger(totalCount) ||
 			!Number.isInteger(altCount) ||
-			totalCount < 0 ||
+			totalCount <= 0 ||
 			altCount < 0 ||
 			altCount > totalCount
 		) {
-			errors.push(`${id} total/alt counts must be non-negative integers and alt cannot exceed total`)
+			errors.push(`${id} total/alt counts must be integers with total > 0, alt >= 0, and alt cannot exceed total`)
 			return
 		}
+
 		vafs.push({ id, totalCount, altCount })
 	}
 

--- a/client/plots/disco/launch.adhoc.ts
+++ b/client/plots/disco/launch.adhoc.ts
@@ -11,6 +11,7 @@ type SnvEntry = {
 	gene: string
 	mname: string
 	class: string
+	vafs?: Array<{ id: string; totalCount: number; altCount: number }>
 }
 type CnvEntry = {
 	dt: 4
@@ -52,6 +53,8 @@ export type DiscoPlotArgs = {
 	3. gene
 	4. aachange
 	5. class
+	Optionally, provide DNA total/alt read counts in columns 6-7 and RNA total/alt 
+	read counts in columns 8-9.
 	each line is parsed into an object:
 	{dt:1, chr:, position:, gene:, class:} */
 	snvText?: string
@@ -181,8 +184,8 @@ function parseSnvText(text: string, mlst: MutationListEntry[], errors: string[])
 	for (const line of text.trim().split('\n')) {
 		const l = line.trim().split('\t')
 
-		if (l.length != 5) {
-			errors.push('snv input not equal to 5 columns')
+		if (![5, 7, 9].includes(l.length)) {
+			errors.push('snv input not equal to 5, 7, or 9 columns')
 			continue
 		}
 
@@ -196,12 +199,38 @@ function parseSnvText(text: string, mlst: MutationListEntry[], errors: string[])
 				mname: l[3],
 				class: validateMutation(l[4], errors)
 			}
+			const vafs = parseOptionalVafs(l, errors)
+			if (vafs.length) m.vafs = vafs
 		} catch (e: any) {
 			errors.push(e)
 			continue
 		}
 		mlst.push(m)
 	}
+}
+
+function parseOptionalVafs(line: string[], errors: string[]) {
+	const vafs: Array<{ id: string; totalCount: number; altCount: number }> = []
+	const addVaf = (id: string, totalIndex: number, altIndex: number) => {
+		if (line.length <= altIndex) return
+		const totalCount = Number(line[totalIndex])
+		const altCount = Number(line[altIndex])
+		if (
+			!Number.isInteger(totalCount) ||
+			!Number.isInteger(altCount) ||
+			totalCount < 0 ||
+			altCount < 0 ||
+			altCount > totalCount
+		) {
+			errors.push(`${id} total/alt counts must be non-negative integers and alt cannot exceed total`)
+			return
+		}
+		vafs.push({ id, totalCount, altCount })
+	}
+
+	addVaf('DNA', 5, 6)
+	addVaf('RNA', 7, 8)
+	return vafs
 }
 
 function parseSvText(text: string, mlst: MutationListEntry[], errors: string[]) {

--- a/client/plots/disco/legend/Legend.ts
+++ b/client/plots/disco/legend/Legend.ts
@@ -9,6 +9,11 @@ export type MutationWaterfallLegend = {
 	onColorChange: (color: string) => void
 }
 
+export type FusionLegendCounts = {
+	interchromosomal: number
+	intrachromosomal: number
+}
+
 export default class Legend {
 	snvTitle: string
 	snvClassMap: Map<string, SnvLegendElement>
@@ -23,6 +28,7 @@ export default class Legend {
 
 	fusionTitle: string
 	fusionLegend: boolean
+	fusionLegendCounts: FusionLegendCounts
 	cnvRenderingType: string
 
 	discoInteractions: DiscoInteractions
@@ -42,7 +48,8 @@ export default class Legend {
 		fusionLegend: boolean,
 		discoInteractions: DiscoInteractions,
 		lohLegend?: LohLegend,
-		mutationWaterfallLegend?: MutationWaterfallLegend
+		mutationWaterfallLegend?: MutationWaterfallLegend,
+		fusionLegendCounts: FusionLegendCounts = { interchromosomal: 0, intrachromosomal: 0 }
 	) {
 		this.snvTitle = snvTitle
 		this.cnvTitle = cnvTitle
@@ -55,6 +62,7 @@ export default class Legend {
 		this.cnvRenderingType = cnvRenderingType
 		this.lohLegend = lohLegend
 		this.fusionLegend = fusionLegend
+		this.fusionLegendCounts = fusionLegendCounts
 		this.discoInteractions = discoInteractions
 		this.mutationWaterfallLegend = mutationWaterfallLegend
 	}

--- a/client/plots/disco/legend/LegendJSONMapper.ts
+++ b/client/plots/disco/legend/LegendJSONMapper.ts
@@ -53,8 +53,7 @@ export default class LegendJSONMapper {
 				key: snvKey,
 				text: `${snvLegendElement.snvType} (${snvLegendElement.count})`,
 				color: snvLegendElement.color,
-				order: snvOrder++,
-				border: '1px solid #ccc'
+				order: snvOrder++
 			})
 		}
 
@@ -80,8 +79,7 @@ export default class LegendJSONMapper {
 					key: CnvType.Gain,
 					text: `Max: ${gain.value}`,
 					color: gain.color,
-					order: cnvOrder++,
-					border: '1px solid #ccc'
+					order: cnvOrder++
 				})
 			}
 
@@ -91,8 +89,7 @@ export default class LegendJSONMapper {
 					key: CnvType.Loss,
 					text: `Min: ${loss.value}`,
 					color: loss.color,
-					order: cnvOrder++,
-					border: '1px solid #ccc'
+					order: cnvOrder++
 				})
 			}
 
@@ -101,8 +98,7 @@ export default class LegendJSONMapper {
 				key: CnvType.Cap,
 				text: `Capping: ${cap.value}`,
 				color: cap.color,
-				order: cnvOrder++,
-				border: '1px solid #ccc'
+				order: cnvOrder++
 				// ,
 				// onClickCallback: this.onClickCallback
 			})
@@ -201,8 +197,7 @@ export default class LegendJSONMapper {
 			key: 'min',
 			text: 'min',
 			color: legend.lohLegend.colorStartValue,
-			order: 0,
-			border: '1px solid #ccc'
+			order: 0
 		})
 
 		lohItems.push({
@@ -210,8 +205,7 @@ export default class LegendJSONMapper {
 			key: 'max',
 			text: 'max',
 			color: legend.lohLegend.colorEndValue,
-			order: 1,
-			border: '1px solid #ccc'
+			order: 1
 		})
 
 		legendJSON.push({
@@ -227,19 +221,17 @@ export default class LegendJSONMapper {
 		fusionItems.push({
 			termid: legend.fusionTitle,
 			key: FusionLegend.Interchromosomal,
-			text: 'Interchromosomal',
+			text: `Interchromosomal (${legend.fusionLegendCounts.interchromosomal})`,
 			color: FusionLegend.Interchromosomal.valueOf(),
-			order: 0,
-			border: '1px solid #ccc'
+			order: 0
 		})
 
 		fusionItems.push({
 			termid: legend.fusionTitle,
 			key: FusionLegend.Intrachromosomal,
-			text: 'Intrachromosomal',
+			text: `Intrachromosomal (${legend.fusionLegendCounts.intrachromosomal})`,
 			color: FusionLegend.Intrachromosomal.valueOf(),
-			order: 1,
-			border: '1px solid #ccc'
+			order: 1
 		})
 
 		legendJSON.push({

--- a/client/plots/disco/legend/test/LegendJSONMapper.waterfall.unit.spec.ts
+++ b/client/plots/disco/legend/test/LegendJSONMapper.waterfall.unit.spec.ts
@@ -40,7 +40,7 @@ test('LegendJSONMapper includes mutation waterfall entry with color picker and a
 	t.end()
 })
 
-test('LegendJSONMapper includes fusion event counts and omits square borders', t => {
+test('LegendJSONMapper includes fusion event counts', t => {
 	const legend = new Legend(
 		'Mutations',
 		'CNV',
@@ -62,6 +62,5 @@ test('LegendJSONMapper includes fusion event counts and omits square borders', t
 
 	t.equal(fusionEntry.items[0].text, 'Interchromosomal (2)', 'Interchromosomal count is shown')
 	t.equal(fusionEntry.items[1].text, 'Intrachromosomal (1)', 'Intrachromosomal count is shown')
-	t.notOk('border' in fusionEntry.items[0], 'Fusion color square does not define a gray border')
 	t.end()
 })

--- a/client/plots/disco/legend/test/LegendJSONMapper.waterfall.unit.spec.ts
+++ b/client/plots/disco/legend/test/LegendJSONMapper.waterfall.unit.spec.ts
@@ -39,3 +39,29 @@ test('LegendJSONMapper includes mutation waterfall entry with color picker and a
 	t.equal(waterfallEntry.items[1].text, 'Axis: log10 intermutation distance', 'axis note is appended')
 	t.end()
 })
+
+test('LegendJSONMapper includes fusion event counts and omits square borders', t => {
+	const legend = new Legend(
+		'Mutations',
+		'CNV',
+		'LOH',
+		'SV',
+		90,
+		'percentile',
+		emptyMap,
+		emptyMap,
+		'heatmap',
+		true,
+		{} as any,
+		undefined,
+		undefined,
+		{ interchromosomal: 2, intrachromosomal: 1 }
+	)
+	const mapped = legendJSONMapper.map(legend)
+	const fusionEntry = mapped.find(group => group.name === 'SV')
+
+	t.equal(fusionEntry.items[0].text, 'Interchromosomal (2)', 'Interchromosomal count is shown')
+	t.equal(fusionEntry.items[1].text, 'Intrachromosomal (1)', 'Intrachromosomal count is shown')
+	t.notOk('border' in fusionEntry.items[0], 'Fusion color square does not define a gray border')
+	t.end()
+})

--- a/client/plots/disco/snv/test/VafTooltip.unit.spec.ts
+++ b/client/plots/disco/snv/test/VafTooltip.unit.spec.ts
@@ -1,5 +1,5 @@
 import test from 'tape'
-import { getVafEntries, hasAnyValidVafEntry } from '#plots/disco/snv/vafTooltip.ts'
+import { getMaxMutationFraction, getVafEntries, hasAnyValidVafEntry } from '#plots/disco/snv/vafTooltip.ts'
 
 test('getVafEntries extracts labeled entries from vafs array', t => {
 	const entries = getVafEntries([
@@ -39,5 +39,31 @@ test('hasAnyValidVafEntry accepts mixed vaf input with at least one valid entry'
 	] as any)
 
 	t.equal(hasAny, true, 'Should detect at least one valid vaf entry')
+	t.end()
+})
+
+test('getVafEntries and hasAnyValidVafEntry support total/alt read counts', t => {
+	const entries = getVafEntries([{ id: 'DNA', totalCount: 20, altCount: 5 }] as any)
+
+	t.deepEqual(
+		entries,
+		[{ label: 'DNA', refCount: undefined, totalCount: 20, altCount: 5 }],
+		'Should keep total/alt VAF entries'
+	)
+	t.equal(
+		hasAnyValidVafEntry([{ id: 'DNA', totalCount: 20, altCount: 5 }] as any),
+		true,
+		'Should validate total/alt entries'
+	)
+	t.end()
+})
+
+test('getMaxMutationFraction supports explicit DNA/RNA mutation fractions', t => {
+	const maxFraction = getMaxMutationFraction([
+		{ id: 'DNA', fraction: 0.12 },
+		{ id: 'RNA', mutationFraction: '0.33' }
+	] as any)
+
+	t.equal(maxFraction, 0.33, 'Should use the highest explicit mutation fraction')
 	t.end()
 })

--- a/client/plots/disco/snv/test/VafTooltip.unit.spec.ts
+++ b/client/plots/disco/snv/test/VafTooltip.unit.spec.ts
@@ -45,11 +45,7 @@ test('hasAnyValidVafEntry accepts mixed vaf input with at least one valid entry'
 test('getVafEntries and hasAnyValidVafEntry support total/alt read counts', t => {
 	const entries = getVafEntries([{ id: 'DNA', totalCount: 20, altCount: 5 }] as any)
 
-	t.deepEqual(
-		entries,
-		[{ label: 'DNA', refCount: undefined, totalCount: 20, altCount: 5 }],
-		'Should keep total/alt VAF entries'
-	)
+	t.deepEqual(entries, [{ label: 'DNA', totalCount: 20, altCount: 5 }], 'Should keep total/alt VAF entries')
 	t.equal(
 		hasAnyValidVafEntry([{ id: 'DNA', totalCount: 20, altCount: 5 }] as any),
 		true,

--- a/client/plots/disco/snv/vafTooltip.ts
+++ b/client/plots/disco/snv/vafTooltip.ts
@@ -4,7 +4,8 @@ import type Data from '#plots/disco/data/Data.ts'
 export type ReadCountValue = string | number | undefined
 export type VafEntry = {
 	label: string
-	refCount: ReadCountValue
+	refCount?: ReadCountValue
+	totalCount?: ReadCountValue
 	altCount: ReadCountValue
 }
 
@@ -17,10 +18,31 @@ export function getIntegerCount(v: ReadCountValue): number | null {
 	return null
 }
 
-export function hasValidReadCounts(refCountValue: ReadCountValue, altCountValue: ReadCountValue): boolean {
-	const refCount = getIntegerCount(refCountValue)
+export function getReadCounts(
+	refCountValue: ReadCountValue,
+	altCountValue: ReadCountValue,
+	totalCountValue?: ReadCountValue
+) {
 	const altCount = getIntegerCount(altCountValue)
-	return refCount != null && altCount != null && refCount >= 0 && altCount >= 0 && refCount + altCount > 0
+	if (altCount == null || altCount < 0) return null
+
+	const totalCount = getIntegerCount(totalCountValue)
+	if (totalCount != null) {
+		if (totalCount <= 0 || totalCount < altCount) return null
+		return { altCount, refCount: totalCount - altCount, totalCount }
+	}
+
+	const refCount = getIntegerCount(refCountValue)
+	if (refCount == null || refCount < 0 || refCount + altCount <= 0) return null
+	return { altCount, refCount, totalCount: refCount + altCount }
+}
+
+export function hasValidReadCounts(
+	refCountValue: ReadCountValue,
+	altCountValue: ReadCountValue,
+	totalCountValue?: ReadCountValue
+): boolean {
+	return getReadCounts(refCountValue, altCountValue, totalCountValue) != null
 }
 
 export function getVafEntries(vafs: Data['vafs']): VafEntry[] {
@@ -29,25 +51,59 @@ export function getVafEntries(vafs: Data['vafs']): VafEntry[] {
 		for (const vaf of vafs) {
 			const label = vaf?.id || vaf?.name
 			const refCount = vaf?.refCount
+			const totalCount = vaf?.totalCount
 			const altCount = vaf?.altCount
-			if (!label || refCount == null || altCount == null) continue
-			entries.push({ label, refCount, altCount })
+			if (!label || altCount == null || (refCount == null && totalCount == null)) continue
+			entries.push({ label, refCount, totalCount, altCount })
 		}
 	}
 	return entries
 }
 
-export function hasAnyValidVafEntry(vafs: Data['vafs']): boolean {
-	return getVafEntries(vafs).some(vaf => hasValidReadCounts(vaf.refCount, vaf.altCount))
+export function getNumericFraction(v: ReadCountValue): number | null {
+	if (typeof v != 'number' && typeof v != 'string') return null
+	const n = Number(v)
+	return Number.isFinite(n) && n >= 0 && n <= 1 ? n : null
 }
 
-export function appendVafBar(td2: any, refCountValue: ReadCountValue, altCountValue: ReadCountValue, label = 'VAF') {
-	const refCount = getIntegerCount(refCountValue)
-	const altCount = getIntegerCount(altCountValue)
-	if (refCount == null || altCount == null) return
+export function getMutationFractions(vafs: Data['vafs']): number[] {
+	const fractions: number[] = []
+	if (!Array.isArray(vafs)) return fractions
 
-	const totalCount = refCount + altCount
-	const fraction = altCount / totalCount
+	for (const vaf of vafs) {
+		const explicitFraction = getNumericFraction(vaf?.fraction ?? vaf?.mutationFraction)
+		if (explicitFraction != null) {
+			fractions.push(explicitFraction)
+			continue
+		}
+
+		const counts = getReadCounts(vaf?.refCount, vaf?.altCount, vaf?.totalCount)
+		if (!counts) continue
+		fractions.push(counts.altCount / counts.totalCount)
+	}
+	return fractions
+}
+
+export function getMaxMutationFraction(vafs: Data['vafs']): number | null {
+	const fractions = getMutationFractions(vafs)
+	return fractions.length ? Math.max(...fractions) : null
+}
+
+export function hasAnyValidVafEntry(vafs: Data['vafs']): boolean {
+	return getVafEntries(vafs).some(vaf => hasValidReadCounts(vaf.refCount, vaf.altCount, vaf.totalCount))
+}
+
+export function appendVafBar(
+	td2: any,
+	refCountValue: ReadCountValue,
+	altCountValue: ReadCountValue,
+	label = 'VAF',
+	totalCountValue?: ReadCountValue
+) {
+	const counts = getReadCounts(refCountValue, altCountValue, totalCountValue)
+	if (!counts) return
+
+	const fraction = counts.altCount / counts.totalCount
 	const div = td2
 		.append('div')
 		.style('margin-left', '5px')
@@ -57,12 +113,12 @@ export function appendVafBar(td2: any, refCountValue: ReadCountValue, altCountVa
 		.style('gap', '6px')
 
 	div.append('span').style('font-size', '0.8em').style('color', '#555').text(label)
-	fillbar(div, { f: fraction, v1: altCount, v2: totalCount })
+	fillbar(div, { f: fraction, v1: counts.altCount, v2: counts.totalCount })
 }
 
 export function appendVafBars(td2: any, vafs: Data['vafs']) {
 	for (const vaf of getVafEntries(vafs)) {
-		if (!hasValidReadCounts(vaf.refCount, vaf.altCount)) continue
-		appendVafBar(td2, vaf.refCount, vaf.altCount, vaf.label)
+		if (!hasValidReadCounts(vaf.refCount, vaf.altCount, vaf.totalCount)) continue
+		appendVafBar(td2, vaf.refCount, vaf.altCount, vaf.label, vaf.totalCount)
 	}
 }

--- a/client/plots/disco/snv/vafTooltip.ts
+++ b/client/plots/disco/snv/vafTooltip.ts
@@ -54,7 +54,10 @@ export function getVafEntries(vafs: Data['vafs']): VafEntry[] {
 			const totalCount = vaf?.totalCount
 			const altCount = vaf?.altCount
 			if (!label || altCount == null || (refCount == null && totalCount == null)) continue
-			entries.push({ label, refCount, totalCount, altCount })
+			const entry: VafEntry = { label, altCount }
+			if (refCount != null) entry.refCount = refCount
+			if (totalCount != null) entry.totalCount = totalCount
+			entries.push(entry)
 		}
 	}
 	return entries

--- a/client/plots/disco/viewmodel/ViewModel.ts
+++ b/client/plots/disco/viewmodel/ViewModel.ts
@@ -34,6 +34,7 @@ export default class ViewModel {
 	positivePercentile?: number
 	invalidDataInfo?: InvalidDataInfo
 	canShowMutationWaterfallPlot: boolean
+	hasMutationFractionData: boolean
 
 	constructor(
 		settings: Settings,
@@ -84,6 +85,7 @@ export default class ViewModel {
 		this.positivePercentile = dataHolder.percentilePositive
 		this.invalidDataInfo = dataHolder.invalidDataInfo
 		this.canShowMutationWaterfallPlot = dataHolder.hasWaterfallEligibleChromosome
+		this.hasMutationFractionData = dataHolder.hasMutationFractionData
 	}
 
 	getElements(ringType: RingType): Array<Arc> {

--- a/client/plots/disco/viewmodel/ViewModelProvider.ts
+++ b/client/plots/disco/viewmodel/ViewModelProvider.ts
@@ -171,6 +171,19 @@ export default class ViewModelProvider {
 			lohLegend = new LohLegend(dataHolder.lohMinValue, dataHolder.lohMaxValue)
 		}
 
+		const fusionLegendCounts = fusions.reduce(
+			(counts, fusion) => {
+				if (
+					fusion.target &&
+					fusion.source.positionInChromosome.chromosome == fusion.target.positionInChromosome.chromosome
+				)
+					counts.intrachromosomal++
+				else counts.interchromosomal++
+				return counts
+			},
+			{ interchromosomal: 0, intrachromosomal: 0 }
+		)
+
 		const legend = new Legend(
 			this.settings.legend.snvTitle,
 			this.settings.legend.cnvTitle,
@@ -186,10 +199,11 @@ export default class ViewModelProvider {
 			lohLegend,
 			this.settings.Disco.mutationWaterfallPlot && this.mutationWaterfallRing
 				? {
-					color: this.settings.Disco.mutationWaterfallColor || '#4d4d4d',
-					onColorChange: this.discoInteractions.onMutationWaterfallColorChange
-				}
-				: undefined
+						color: this.settings.Disco.mutationWaterfallColor || '#4d4d4d',
+						onColorChange: this.discoInteractions.onMutationWaterfallColorChange
+				  }
+				: undefined,
+			fusionLegendCounts
 		)
 
 		const rings = new Rings(


### PR DESCRIPTION
# Description
Provided a way to filter SNV/indel rendering by minimum mutation fraction derived from DNA/RNA (either explicit fraction or total/alt read counts).

Made legend UI clearer by renaming the SNV heading to "Mutations"
Now shows SV/fusion event counts (n) for inter- vs intrachromosomal events, and removed the gray border on colored legend swatches.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
