### PR TITLE
Support filtering non-dictionary terms and mds3 tk by patient-level terms

### DIFF
--- a/client/plots/test/barchart.integration.spec.js
+++ b/client/plots/test/barchart.integration.spec.js
@@ -43,6 +43,7 @@ series visibility - condition
 
 single barchart, categorical filter
 single barchart, categorical filter (patient-level)
+single geneExp barchart, categorical filter (patient-level)
 single barchart (patient-level), compound filter (patient-level + sample-level)
 genevariant barchart, compound filter SKIPPED
 single barchart, TP53 mutation dtTerm filter
@@ -1151,6 +1152,61 @@ tape('single barchart, categorical filter (patient-level)', function (test) {
 					chartType: 'barchart',
 					term: {
 						id: 'agedx'
+					}
+				}
+			]
+		},
+		barchart: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	let barDiv
+	async function runTests(barchart) {
+		barchart.on('postRender.test', null)
+		barDiv = barchart.Inner.dom.barDiv
+		await detectOne({ elem: barDiv.node(), selector: '.pp-bars-svg' })
+		testBarCount()
+		if (test._ok) barchart.Inner.app.destroy()
+		test.end()
+	}
+
+	function testBarCount() {
+		// no need to await, the bar order will tested after the initial postRender event
+		const minBars = 3
+		const numBars = barDiv.selectAll('.bars-cell-grp').size()
+		const numOverlays = barDiv.selectAll('.bars-cell').size()
+		test.true(numBars > minBars, `should have more than ${minBars} bars`)
+		test.true(numOverlays == numBars, 'number of overlays should equal number of bars')
+	}
+})
+
+tape('single geneExp barchart, categorical filter (patient-level)', function (test) {
+	test.timeoutAfter(3000)
+	runpp({
+		state: {
+			termfilter: {
+				filter: {
+					type: 'tvslst',
+					in: 1,
+					join: '',
+					lst: [
+						{
+							type: 'tvs',
+							tvs: { term: { id: 'sex' }, values: [{ key: '2' }] }
+						}
+					]
+				}
+			},
+			plots: [
+				{
+					chartType: 'summary',
+					childType: 'barchart',
+					term: {
+						term: { type: 'geneExpression', gene: 'TP53' },
+						q: { mode: 'discrete' }
 					}
 				}
 			]

--- a/server/src/mds3.filter.js
+++ b/server/src/mds3.filter.js
@@ -8,6 +8,7 @@ param={}
 	.filterObj = pp filter
 	.filter = pp filter
 	.filter0 = gdc/mmrf filter
+	.mapParent2Children = whether to map parent term annotations onto child samples
 _allSamples=[]
 	whole list of samples, each ele: {name: int}
 	presumably the set of samples from a bcf file or tabix file
@@ -40,7 +41,9 @@ export async function mayLimitSamples(param, _allSamples, ds) {
 		}
 		// get samples that match filter
 		// get_samples() return [{id:int}] with possibly duplicated items, deduplicate and return list of integer ids
-		filterSamples = new Set((await get_samples({ filter }, ds)).map(i => i.id))
+		filterSamples = new Set(
+			(await get_samples({ filter, mapParent2Children: param.mapParent2Children }, ds)).map(i => i.id)
+		)
 	} else if (typeof ds.cohort?.termdb?.getSamples === 'function') {
 		// dataset supplies getSamples() function
 		if (!filter && !filter0) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -3491,7 +3491,8 @@ async function getSnvindelByTerm(ds, term, genome, q) {
 			filter0: q.filter0, // hidden filter
 			filterObj: q.filter, // pp filter, must change key name to "filterObj" to be consistent with mds3 client
 			sessionid: q.sessionid,
-			__abortSignal: q.__abortSignal
+			__abortSignal: q.__abortSignal,
+			mapParent2Children: q.mapParent2Children
 		},
 		ds.mayGetGeneVariantDataParam || {}
 	)
@@ -3520,6 +3521,7 @@ async function getSvfusionByTerm(ds, term, genome, q) {
 		addFormatValues: true,
 		filter0: q.filter0, // hidden filter
 		filterObj: q.filter, // pp filter, must change key name to "filterObj" to be consistent with mds3 client
+		mapParent2Children: q.mapParent2Children,
 		sessionid: q.sessionid
 	}
 	if (ds.queries.svfusion.byrange && ds.queries.svfusion.byname) {
@@ -3559,6 +3561,7 @@ async function getCnvByTw(ds, tw, genome, q) {
 		addFormatValues: true,
 		filter0: q.filter0, // hidden filter
 		filterObj: q.filter, // pp filter, must change key name to "filterObj" to be consistent with mds3 client
+		mapParent2Children: q.mapParent2Children,
 		sessionid: q.sessionid,
 		...(tw?.q?.type === 'values' && {
 			cnvMaxLength: tw?.q?.cnvMaxLength,
@@ -3590,6 +3593,7 @@ async function getProbe2cnvByTw(ds, tw, genome, q) {
 async function getGenecnvByTerm(ds, term, genome, q) {
 	const arg = {
 		filter0: q.filter0,
+		mapParent2Children: q.mapParent2Children,
 		sessionid: q.sessionid,
 		__abortSignal: q.__abortSignal
 	}

--- a/server/src/mds3.load.js
+++ b/server/src/mds3.load.js
@@ -4,6 +4,7 @@ import { validate_variant2samples } from './mds3.variant2samples.js'
 import { dtcnv, mclasscnvgain, mclasscnvAmp, mclasscnvloss, mclasscnvHomozygousDel } from '#shared/common.js'
 import { summarize_mclass } from '#shared/mds3tk.js'
 import { plotWiggle } from './bw.js'
+import { maySetMapParent2Children } from './termdb.matrix.js'
 
 /*
 method good for somatic variants, in skewer and gp queries:
@@ -255,6 +256,11 @@ async function get_ds(q, genome) {
 export async function load_driver(q, ds) {
 	// various bits of data to be appended as keys to result{}
 	// what other loaders can be if not in ds.queries?
+
+	// assuming genomic data in mds3 tk is at sample-level, so setting
+	// mapParent2Children=true to allow parent-level term data to be mapped
+	// onto tk data (e.g. parent-level terms in variant2sample query or in tk filter)
+	maySetMapParent2Children(q, ds, true)
 
 	if (q.singleSampleGenomeQuantification) {
 		if (!ds.queries.singleSampleGenomeQuantification) throw 'not supported on this dataset'

--- a/server/src/termdb.getDefaultBins.js
+++ b/server/src/termdb.getDefaultBins.js
@@ -1,5 +1,6 @@
 import { SINGLECELL_GENE_EXPRESSION, PROTEOME_ABUNDANCE } from '#shared/terms.js'
 import initBinConfig from '#shared/termdb.initbinconfig.js'
+import { maySetMapParent2Children } from './termdb.matrix.js'
 
 // TODO convert to route
 
@@ -10,6 +11,11 @@ export async function trigger_getDefaultBins(q, ds, res) {
 		2. bin cache is indexed by term.name
 	CAUTION if a datatype naming in ds.queries{} cannot follow this pattern then it breaks!
 	*/
+
+	// determine if parent term annotations need to be mapped to child samples (e.g. if
+	// parent term(s) present in filter)
+	maySetMapParent2Children(q, ds)
+
 	const tw = q.tw
 	const lst = []
 	let min = Infinity
@@ -46,6 +52,7 @@ export async function trigger_getDefaultBins(q, ds, res) {
 				filter: q.filter,
 				filter0: q.filter0,
 				terms: [tw],
+				mapParent2Children: q.mapParent2Children,
 				__abortSignal: q.__abortSignal,
 				dataTypeDetails: tw.term.dataTypeDetails
 			}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -47,6 +47,8 @@ Inputs:
 Returns:
 	- see ValidGetDataResponse type in shared/types/src/termdb.matrix.ts for documentation
 	- please update types in shared/types/src/termdb.matrix.ts if the return object is changed
+
+// TODO: pass mapParent2Children in q{} when calling getData()
 */
 
 export async function getData(q, ds, mapParent2Children) {
@@ -63,8 +65,7 @@ export async function getData(q, ds, mapParent2Children) {
 		q.terms = expandedTerms
 
 		// set flag for mapping from parent to children
-		q.mapParent2Children = mapParent2Children // TODO: pass this flag in q{} when calling getData()
-		maySetMapParent2Children(q, ds)
+		maySetMapParent2Children(q, ds, mapParent2Children)
 
 		const data = await getSampleData(q, ds)
 		reconstituteCustomTermCollection(data, tcMappings)
@@ -526,14 +527,15 @@ export function divideTerms(q, ds) {
 
 // function to set the mapParent2Children flag, which controls
 // whether to map parent-level data onto child samples
-function maySetMapParent2Children(q, ds) {
+export function maySetMapParent2Children(q, ds, mapParent2Children) {
 	if (!ds.cohort.termdb.hasSampleAncestry) {
 		// no sample ancestry, so should not map parent to children
 		q.mapParent2Children = false
 		return
 	}
-	if (typeof q.mapParent2Children === 'boolean') {
-		// flag already defined, do not override it
+	if (typeof mapParent2Children === 'boolean') {
+		// flag supplied by caller
+		q.mapParent2Children = mapParent2Children
 		return
 	}
 	// ds has sample ancestry and mapParent2Children is undefined

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -654,7 +654,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 }
 
 function getSampleTypes(q, ds) {
-	const twLst = q.terms
+	const twLst = q.terms ? q.terms : q.tw ? [q.tw] : []
 	const filter = q.filter
 	const twTypes = getTwSampleTypes(twLst, ds)
 	const filterTypes = getFilterSampleTypes(filter, ds)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -62,9 +62,9 @@ export async function getData(q, ds, mapParent2Children) {
 		const { expandedTerms, tcMappings } = expandCustomTermCollection(q.terms)
 		q.terms = expandedTerms
 
-		// migrate the flag to q
-		// TODO: do the same when calling getData()
-		q.mapParent2Children = mapParent2Children
+		// set flag for mapping from parent to children
+		q.mapParent2Children = mapParent2Children // TODO: pass this flag in q{} when calling getData()
+		maySetMapParent2Children(q, ds)
 
 		const data = await getSampleData(q, ds)
 		reconstituteCustomTermCollection(data, tcMappings)
@@ -129,9 +129,6 @@ let numActiveQueriesAcrossUsers = 0,
 async function getSampleData(q, ds) {
 	// dictionary and non-dictionary terms require different methods for data query
 	const [dictTerms, geneVariantTws, nonDictTerms] = divideTerms(q, ds)
-
-	// determine whether parent annotations should be mapped onto child samples
-	maySetMapParent2Children(q, ds)
 
 	// query dictionary term data
 	const [samples, byTermId] = await getSampleData_dictionaryTerms(q, dictTerms)
@@ -272,7 +269,8 @@ async function getSampleData(q, ds) {
 				terms: [tw],
 				filter: q.filter,
 				filter0: q.filter0,
-				dataTypeDetails: tw.term.dataTypeDetails
+				dataTypeDetails: tw.term.dataTypeDetails,
+				mapParent2Children: q.mapParent2Children
 			}
 			const data = await queryHandler.get(args, q.ds) // 2nd ds parameter is needed for ds-supplied getter
 			const values = data.term2sample2value.get(tw.$id)

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -61,7 +61,12 @@ export async function getData(q, ds, mapParent2Children) {
 
 		const { expandedTerms, tcMappings } = expandCustomTermCollection(q.terms)
 		q.terms = expandedTerms
-		const data = await getSampleData(q, ds, mapParent2Children)
+
+		// migrate the flag to q
+		// TODO: do the same when calling getData()
+		q.mapParent2Children = mapParent2Children
+
+		const data = await getSampleData(q, ds)
 		reconstituteCustomTermCollection(data, tcMappings)
 
 		checkAccessToSampleData(data, ds, q)
@@ -121,15 +126,15 @@ const maxPendingQueriesBeforeRejectingRequest = serverconfig.features?.maxPendin
 let numActiveQueriesAcrossUsers = 0,
 	numPendingQueriesAcrossUsers = 0
 
-async function getSampleData(q, ds, mapParent2Children) {
+async function getSampleData(q, ds) {
 	// dictionary and non-dictionary terms require different methods for data query
 	const [dictTerms, geneVariantTws, nonDictTerms] = divideTerms(q, ds)
 
 	// determine whether parent annotations should be mapped onto child samples
-	mapParent2Children = maySetMapParent2Children(q, ds, mapParent2Children)
+	maySetMapParent2Children(q, ds)
 
 	// query dictionary term data
-	const [samples, byTermId] = await getSampleData_dictionaryTerms(q, dictTerms, mapParent2Children)
+	const [samples, byTermId] = await getSampleData_dictionaryTerms(q, dictTerms)
 	/* samples={}
 	this object collects term annotation data on all samples; even if there's no dict term it still return blank {}
 	non-dict term data will be appended to it
@@ -523,14 +528,15 @@ export function divideTerms(q, ds) {
 
 // function to set the mapParent2Children flag, which controls
 // whether to map parent-level data onto child samples
-function maySetMapParent2Children(q, ds, mapParent2Children) {
+function maySetMapParent2Children(q, ds) {
 	if (!ds.cohort.termdb.hasSampleAncestry) {
 		// no sample ancestry, so should not map parent to children
-		return false
+		q.mapParent2Children = false
+		return
 	}
-	if (typeof mapParent2Children === 'boolean') {
-		// flag already defined so return it
-		return mapParent2Children
+	if (typeof q.mapParent2Children === 'boolean') {
+		// flag already defined, do not override it
+		return
 	}
 	// ds has sample ancestry and mapParent2Children is undefined
 	const sampleTypeConfig = ds.cohort.termdb.sampleTypes
@@ -542,8 +548,8 @@ function maySetMapParent2Children(q, ds, mapParent2Children) {
 		// single sample type, no need to map parent to children
 		const type = types[0]
 		if (!sampleTypeConfig[type]) throw 'invalid sample type'
-		return false
-	} else if (types.length > 1) {
+		q.mapParent2Children = false
+	} else {
 		// multiple sample types
 		// validate that one is parent and one is child
 		if (types.length != 2) throw 'unexpected number of sample types'
@@ -560,7 +566,7 @@ function maySetMapParent2Children(q, ds, mapParent2Children) {
 		if (!Number.isInteger(parentType)) throw 'invalid parent sample type'
 		if (!Number.isInteger(childType)) throw 'invalid child sample type'
 		// set flag to true to map parent annotations onto child samples
-		return true
+		q.mapParent2Children = true
 	}
 }
 
@@ -583,15 +589,15 @@ output:
 		{ byTermId: {} }
 }
 */
-async function getSampleData_dictionaryTerms(q, termWrappers, mapParent2Children) {
+async function getSampleData_dictionaryTerms(q, termWrappers) {
 	if (!termWrappers.length) return [{}, {}]
 	if (q.ds?.cohort?.db) {
 		// dataset uses server-side sqlite db, must use this method for dictionary terms
-		return await getSampleData_dictionaryTerms_termdb(q, termWrappers, mapParent2Children)
+		return await getSampleData_dictionaryTerms_termdb(q, termWrappers)
 	}
 	if (q.ds.cohort.termdb.dictionary?.get) {
 		// ds-supplied getter to retrieve dictionary term data
-		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers, mapParent2Children)
+		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers)
 	}
 	/* gdc ds has no cohort.db. thus call v2s.get() to return sample annotations for its dictionary terms
 	 */
@@ -606,12 +612,12 @@ async function getSampleData_dictionaryTerms(q, termWrappers, mapParent2Children
 	throw 'unknown method for dictionary terms'
 }
 
-export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, mapParent2Children) {
+export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 	const byTermId = {} // to return
 	// must copy filter.values as its copy may be used in separate SQL statements,
 	// for example get_rows or numeric min-max, and each CTE generator would
 	// have to independently extend its copy of filter values
-	const filter = await getFilterCTEs(q.filter, q.ds, mapParent2Children)
+	const filter = await getFilterCTEs(q.filter, q.ds, q.mapParent2Children)
 	const values = filter ? filter.values.slice() : []
 	const CTEs = await Promise.all(
 		termWrappers.map(async (tw, i) => {
@@ -642,7 +648,7 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers, mapP
 
 	// for "samplelst" term, term.id is missing and must use term.name
 	values.push(...termWrappers.map(tw => tw.$id || tw.term.id || tw.term.name))
-	const rows = await getAnnotationRows(q, termWrappers, filter, CTEs, values, mapParent2Children)
+	const rows = await getAnnotationRows(q, termWrappers, filter, CTEs, values)
 	const samples = await getSamples(q, rows, termWrappers)
 	return [samples, byTermId]
 }
@@ -687,14 +693,14 @@ When querying sample annotations for dictionary terms, the query is split into t
 
 Mapping parent annotations onto child samples: when a term annotates parent samples and mapParent2Children is true, then annotations will get mapped onto child samples
 */
-export async function getAnnotationRows(q, termWrappers, filter, CTEs, values, mapParent2Children) {
+export async function getAnnotationRows(q, termWrappers, filter, CTEs, values) {
 	const sql = `WITH
 		${filter ? filter.filters + ',' : ''}
 		${CTEs.map(t => t.sql).join(',\n')}
 		${CTEs.map((t, i) => {
 			const tw = termWrappers[i]
 			let query
-			if (isParentType(tw.term, q.ds) && mapParent2Children) {
+			if (isParentType(tw.term, q.ds) && q.mapParent2Children) {
 				// term is parent-level term and need to map
 				// parent annotations onto child samples
 				query = ` select sa.sample_id as sample, key, value, ? as term_id

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -48,7 +48,7 @@ Returns:
 	- see ValidGetDataResponse type in shared/types/src/termdb.matrix.ts for documentation
 	- please update types in shared/types/src/termdb.matrix.ts if the return object is changed
 
-// TODO: pass mapParent2Children in q{} when calling getData()
+TODO: pass mapParent2Children in q{}, instead of as a separate arg, when calling getData()
 */
 
 export async function getData(q, ds, mapParent2Children) {
@@ -528,7 +528,7 @@ export function divideTerms(q, ds) {
 // function to set the mapParent2Children flag, which controls
 // whether to map parent-level data onto child samples
 export function maySetMapParent2Children(q, ds, mapParent2Children) {
-	if (!ds.cohort.termdb.hasSampleAncestry) {
+	if (!ds.cohort?.termdb?.hasSampleAncestry) {
 		// no sample ancestry, so should not map parent to children
 		q.mapParent2Children = false
 		return

--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -61,7 +61,7 @@ export async function get_samples(q, ds, canDisplay = false) {
 	q.__protected__.ignoreTermIds is modified or if routeTwLst can be supplied at this point
 	*/
 
-	const filter = await getFilterCTEs(q.filter, ds) // if q.filter is blank, it returns null
+	const filter = await getFilterCTEs(q.filter, ds, q.mapParent2Children) // if q.filter is blank, it returns null
 	const sql = filter
 		? `WITH ${filter.filters} SELECT sample as id, name FROM ${filter.CTEname} join sampleidmap on sample = sampleidmap.id`
 		: `SELECT id, name FROM sampleidmap`


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1357

In this PR, the `mapParent2Children` flag is migrated to `q{}` to allow it to more easily get passed into getter functions. Now, non-dictionary sample level terms can be filtered by patient-level terms (e.g. [geneExpression barchart filter by sex](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22summary%22,%22term%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22}},%22filter%22:{%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22type%22:%22categorical%22,%22name%22:%22XX%22,%22id%22:%22sex%22},%22values%22:[{%22key%22:%222%22,%22label%22:%22Female%22}]}}]}}]})). Sample-level mds3 tk data can now also be filtered by patient-level terms (e.g. [mds3 subtk filter by sex](http://localhost:3000/?genome=hg38-test&gene=p53&mds3=TermdbTest&filterObj=%7B%22type%22:%22tvslst%22,%22in%22:true,%22join%22:%22%22,%22lst%22:%5B%7B%22type%22:%22tvs%22,%22tvs%22:%7B%22term%22:%7B%22id%22:%22sex%22%7D,%22values%22:%5B%7B%22key%22:%221%22%7D%5D%7D%7D%5D%7D), reported in https://github.com/stjude/sjpp/issues/1311).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
