### PR TITLE
Generalized the concurrency limiter logic into its own module. Improved test coverage for renderVolcano

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Generalized concurrency limiter and covered it with unit tests.  Improved unit test coverage of renderVolcano.ts

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,3 @@
 Features:
-- Generalized concurrency limiter and covered it with unit tests.  Improved unit test coverage of renderVolcano.ts
+- Generalized concurrency limiter and covered it with unit tests.
+- Improved unit test coverage of renderVolcano.ts

--- a/server/src/renderVolcano.ts
+++ b/server/src/renderVolcano.ts
@@ -45,26 +45,14 @@ const renderLimiter = createConcurrencyLimiter({
 	// sustained overload. Sized to absorb the anticipated concurrent burst (~20)
 	// with headroom while still shedding a runaway flood.
 	maxQueued: 50,
-	// 429 so it reads as "retry later", not a client error in the request shape.
-	makeBusyError: () => {
-		const err: any = new Error('Volcano render pool is full. Please try again shortly.')
-		err.status = 429
-		err.statusCode = 429
-		err.code = 'RENDER_BUSY'
-		return err
-	},
+	// Names the pool in the 429 busy / 504 timeout messages ("The volcano render
+	// pool is full…", "The volcano render exceeded its time limit…").
+	taskName: 'volcano render'
 	// taskTimeoutMs is left unset, so it inherits the limiter's 30s default — a
 	// safety net for a render that somehow hangs (it would otherwise hold its
 	// slot forever and stall the queue). skia's toBuffer can't observe the
 	// AbortSignal, so an evicted render keeps running until it finishes; freeing
-	// the slot is what keeps the queue alive. 504 so it reads as "took too long".
-	makeTimeoutError: () => {
-		const err: any = new Error('Volcano render timed out.')
-		err.status = 504
-		err.statusCode = 504
-		err.code = 'RENDER_TIMEOUT'
-		return err
-	}
+	// the slot is what keeps the queue alive.
 })
 
 const DEFAULT_REQ: VolcanoRenderRequest = {

--- a/server/src/renderVolcano.ts
+++ b/server/src/renderVolcano.ts
@@ -52,6 +52,18 @@ const renderLimiter = createConcurrencyLimiter({
 		err.statusCode = 429
 		err.code = 'RENDER_BUSY'
 		return err
+	},
+	// taskTimeoutMs is left unset, so it inherits the limiter's 30s default — a
+	// safety net for a render that somehow hangs (it would otherwise hold its
+	// slot forever and stall the queue). skia's toBuffer can't observe the
+	// AbortSignal, so an evicted render keeps running until it finishes; freeing
+	// the slot is what keeps the queue alive. 504 so it reads as "took too long".
+	makeTimeoutError: () => {
+		const err: any = new Error('Volcano render timed out.')
+		err.status = 504
+		err.statusCode = 504
+		err.code = 'RENDER_TIMEOUT'
+		return err
 	}
 })
 

--- a/server/src/renderVolcano.ts
+++ b/server/src/renderVolcano.ts
@@ -3,6 +3,7 @@ import { scaleLinear } from 'd3-scale'
 import type { DataEntry, VolcanoData, VolcanoRenderRequest } from '#types'
 import { mayLog } from './helpers.ts'
 import { formatElapsedTime } from '#shared'
+import { createConcurrencyLimiter } from './utils/concurrencyLimiter.ts'
 
 /**
  * Rasterize a volcano scatter PNG and return the threshold-passing rows
@@ -26,49 +27,33 @@ const MAX_DOT_RADIUS = 20
 // without changing the CSS-space contract.
 const MAX_DEVICE_PIXELS_PER_SIDE = 8192
 
-// Concurrency gate around the heavy render+encode section. skia's
-// `canvas.toBuffer('png')` runs the rasterize+encode on skia's own thread
-// pool, so it doesn't block the event loop, but each in-flight render still
-// holds a device-pixel bitmap (worst case ~256 MB). Cap how many run at once
-// so a burst of requests can't pile bitmaps up and spike memory. 5 is a
-// pragmatic value for a server that also handles unrelated traffic and
-// matches our max pending requests in cacheOrRecompute.ts; raise it
-// to trade memory for throughput under heavier concurrent volcano load.
-const MAX_CONCURRENT_RENDERS = 5
-// Hard cap on renders waiting for a slot. Past this we reject immediately with
-// a 429 rather than letting the wait-queue grow without bound — an unbounded
-// queue is a memory/DoS risk and holds HTTP requests open indefinitely under
-// sustained overload. Mirrors cacheOrRecompute's CACHE_BUSY rejection once its
-// pool is full. Sized to absorb the anticipated concurrent burst (~20) with
-// headroom while still shedding a runaway flood.
-const MAX_QUEUED_RENDERS = 50
-let activeRenders = 0
-const renderQueue: Array<() => void> = []
-
-// 429 so it reads as "retry later", not a client error in the request shape.
-function makeRenderBusyError(): Error {
-	const err: any = new Error('Volcano render pool is full. Please try again shortly.')
-	err.status = 429
-	err.statusCode = 429
-	err.code = 'RENDER_BUSY'
-	return err
-}
-
-async function acquireRenderSlot(): Promise<void> {
-	if (activeRenders < MAX_CONCURRENT_RENDERS) {
-		activeRenders++
-		return
+// Volcano's policy for the generic gating device (see utils/concurrencyLimiter.ts).
+// The module owns the mechanism; this block owns the volcano-specific caps and
+// busy signal — tuned to the render+encode section's memory profile.
+const renderLimiter = createConcurrencyLimiter({
+	// skia's `canvas.toBuffer('png')` runs the rasterize+encode on skia's own
+	// thread pool, so it doesn't block the event loop, but each in-flight render
+	// still holds a device-pixel bitmap (worst case ~256 MB). Cap how many run at
+	// once so a burst of requests can't pile bitmaps up and spike memory. 5 is a
+	// pragmatic value for a server that also handles unrelated traffic and matches
+	// our max pending requests in cacheOrRecompute.ts; raise it to trade memory
+	// for throughput under heavier concurrent volcano load.
+	maxConcurrent: 5,
+	// Hard cap on renders waiting for a slot. Past this we reject immediately with
+	// a 429 rather than letting the wait-queue grow without bound — an unbounded
+	// queue is a memory/DoS risk and holds HTTP requests open indefinitely under
+	// sustained overload. Sized to absorb the anticipated concurrent burst (~20)
+	// with headroom while still shedding a runaway flood.
+	maxQueued: 50,
+	// 429 so it reads as "retry later", not a client error in the request shape.
+	makeBusyError: () => {
+		const err: any = new Error('Volcano render pool is full. Please try again shortly.')
+		err.status = 429
+		err.statusCode = 429
+		err.code = 'RENDER_BUSY'
+		return err
 	}
-	if (renderQueue.length >= MAX_QUEUED_RENDERS) throw makeRenderBusyError()
-	await new Promise<void>(resolve => renderQueue.push(resolve))
-}
-function releaseRenderSlot(): void {
-	const next = renderQueue.shift()
-	// Hand the slot to the next waiter without decrement/increment; only
-	// drop activeRenders when the queue is empty.
-	if (next) next()
-	else activeRenders--
-}
+})
 
 const DEFAULT_REQ: VolcanoRenderRequest = {
 	significanceThresholds: { pValueCutoff: 1.3, pValueType: 'adjusted', foldChangeCutoff: 0.3 },
@@ -225,9 +210,7 @@ export async function renderVolcano<T extends DataEntry>(
 	// and spike memory. skia's toBuffer runs the rasterize+encode on its own
 	// thread pool, so the event loop stays responsive — only the lightweight
 	// path-building below is synchronous on the main thread.
-	await acquireRenderSlot()
-	let png: string
-	try {
+	const png = await renderLimiter.run(async () => {
 		const canvas = new Canvas(w * effectiveDpr, h * effectiveDpr)
 		const ctx = canvas.getContext('2d')
 		ctx.scale(effectiveDpr, effectiveDpr)
@@ -268,10 +251,8 @@ export async function renderVolcano<T extends DataEntry>(
 
 		// Async rasterize+encode on skia's thread pool. Base64 here to preserve
 		// the `volcanoPng` string contract on the route response.
-		png = (await canvas.toBuffer('png')).toString('base64')
-	} finally {
-		releaseRenderSlot()
-	}
+		return (await canvas.toBuffer('png')).toString('base64')
+	})
 
 	// Build the interactive `dots` list: threshold-passers sorted asc by the
 	// chosen p-value column, optionally capped at maxInteractiveDots.

--- a/server/src/test/renderVolcano.unit.spec.ts
+++ b/server/src/test/renderVolcano.unit.spec.ts
@@ -1,0 +1,325 @@
+import tape from 'tape'
+import { renderVolcano } from '#src/renderVolcano.ts'
+import type { VolcanoRenderRequest, DataEntry } from '#types'
+
+/*
+test sections:
+
+input validation: pixelWidth / pixelHeight / dotRadius / maxInteractiveDots / devicePixelRatio
+input validation: pValueType, pValueCutoff, foldChangeCutoff
+input validation: per-row fold_change and chosen p-value field
+basic render: valid PNG, totalRows, plotExtent dims + dotRadiusPx
+significance classification: only rows past both cutoffs are significant
+dots: sorted ascending by p, carry finite pixel_x/pixel_y, preserve pass-through fields
+maxInteractiveDots caps dots but not totalSignificantRows; null returns all
+plotExtent axis math: symmetric x, yMin 0, padding extends the domain
+minNonZeroPValue: smallest positive p, and all-zero-p fallback to 1e-300
+pValueType 'original' classifies/sorts on original_p_value
+both significant up (fc>0) and down (fc<0) render and appear in dots
+empty rows: blank PNG, no dots, zero-spread axis fallbacks
+default req: renderVolcano(rows) with no second arg
+DPR device dimensions: exact w*dpr, and clamp to MAX_DEVICE_PIXELS_PER_SIDE
+*/
+
+/** Unit tests for renderVolcano. The function is mostly pure logic (validation,
+ * significance classification, axis/padding math, dot extraction) wrapped around
+ * one skia-canvas render; we assert on the returned VolcanoData directly and
+ * decode the PNG's IHDR to check device pixel dimensions (and thus DPR clamping)
+ * without pulling in a PNG-decoder dependency. */
+
+/** Decode a base64 PNG's pixel dimensions from its IHDR chunk (width at byte
+ * offset 16, height at 20, big-endian), after asserting the 8-byte signature. */
+function pngSize(b64: string): { width: number; height: number } {
+	const buf = Buffer.from(b64, 'base64')
+	const sig = [137, 80, 78, 71, 13, 10, 26, 10]
+	for (let i = 0; i < 8; i++) if (buf[i] !== sig[i]) throw new Error('not a PNG')
+	return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) }
+}
+
+/** A valid baseline request; `over` shallow-merges (with a nested merge of
+ * significanceThresholds) so a test states only what it varies. */
+function makeReq(over: any = {}): VolcanoRenderRequest {
+	const { significanceThresholds, ...rest } = over
+	return {
+		significanceThresholds: {
+			pValueCutoff: 1.3,
+			pValueType: 'adjusted',
+			foldChangeCutoff: 0.3,
+			...(significanceThresholds || {})
+		},
+		pixelWidth: 400,
+		pixelHeight: 400,
+		...rest
+	} as VolcanoRenderRequest
+}
+
+/** One DataEntry row; `adjusted_p_value` defaults to `original_p_value`. */
+function row(fold_change: number, p: number, extra: any = {}): DataEntry {
+	return { fold_change, original_p_value: p, adjusted_p_value: p, ...extra }
+}
+
+/** Assert an async call rejects with a message matching `re`. */
+async function rejects(t: any, fn: () => Promise<unknown>, re: RegExp, msg: string) {
+	try {
+		await fn()
+		t.fail(`${msg} — expected throw, got none`)
+	} catch (e: any) {
+		t.ok(re.test(e.message), `${msg} (got: ${e.message})`)
+	}
+}
+
+tape('\n', t => {
+	t.comment('-***- renderVolcano specs -***-')
+	t.end()
+})
+
+/* ---------------------------- input validation ---------------------------- */
+
+tape('rejects out-of-range pixelWidth / pixelHeight', async t => {
+	const rows = [row(1, 0.001)]
+	for (const bad of [0, -1, 5000, NaN, Infinity]) {
+		await rejects(t, () => renderVolcano(rows, makeReq({ pixelWidth: bad })), /pixelWidth/, `pixelWidth=${bad}`)
+		await rejects(t, () => renderVolcano(rows, makeReq({ pixelHeight: bad })), /pixelHeight/, `pixelHeight=${bad}`)
+	}
+	t.end()
+})
+
+tape('rejects out-of-range dotRadius, maxInteractiveDots, devicePixelRatio', async t => {
+	const rows = [row(1, 0.001)]
+	await rejects(t, () => renderVolcano(rows, makeReq({ dotRadius: 0.05 })), /dotRadius/, 'dotRadius too small')
+	await rejects(t, () => renderVolcano(rows, makeReq({ dotRadius: 25 })), /dotRadius/, 'dotRadius too large')
+	await rejects(
+		t,
+		() => renderVolcano(rows, makeReq({ maxInteractiveDots: -1 })),
+		/maxInteractiveDots/,
+		'maxInteractiveDots negative'
+	)
+	await rejects(
+		t,
+		() => renderVolcano(rows, makeReq({ maxInteractiveDots: 60000 })),
+		/maxInteractiveDots/,
+		'maxInteractiveDots too large'
+	)
+	await rejects(t, () => renderVolcano(rows, makeReq({ devicePixelRatio: 0.5 })), /devicePixelRatio/, 'dpr < 1')
+	await rejects(t, () => renderVolcano(rows, makeReq({ devicePixelRatio: 7 })), /devicePixelRatio/, 'dpr > 6')
+	t.end()
+})
+
+tape('rejects invalid pValueType and non-finite thresholds', async t => {
+	const rows = [row(1, 0.001)]
+	await rejects(
+		t,
+		() => renderVolcano(rows, makeReq({ significanceThresholds: { pValueType: 'foo' } })),
+		/pValueType/,
+		'bad pValueType'
+	)
+	await rejects(
+		t,
+		() => renderVolcano(rows, makeReq({ significanceThresholds: { pValueCutoff: NaN } })),
+		/pValueCutoff/,
+		'NaN pValueCutoff'
+	)
+	await rejects(
+		t,
+		() => renderVolcano(rows, makeReq({ significanceThresholds: { pValueCutoff: -1 } })),
+		/pValueCutoff/,
+		'negative pValueCutoff'
+	)
+	await rejects(
+		t,
+		() => renderVolcano(rows, makeReq({ significanceThresholds: { foldChangeCutoff: NaN } })),
+		/foldChangeCutoff/,
+		'NaN foldChangeCutoff'
+	)
+	await rejects(
+		t,
+		() => renderVolcano(rows, makeReq({ significanceThresholds: { foldChangeCutoff: -1 } })),
+		/foldChangeCutoff/,
+		'negative foldChangeCutoff'
+	)
+	t.end()
+})
+
+tape('rejects rows with a non-finite fold_change or invalid p-value field', async t => {
+	await rejects(t, () => renderVolcano([row(NaN, 0.01)], makeReq()), /row 0 fold_change/, 'NaN fold_change')
+	await rejects(
+		t,
+		() => renderVolcano([{ original_p_value: 0.01, adjusted_p_value: 0.01 } as any], makeReq()),
+		/row 0 fold_change/,
+		'missing fold_change'
+	)
+	await rejects(
+		t,
+		() => renderVolcano([row(1, -0.1)], makeReq()),
+		/adjusted_p_value must be a finite value/,
+		'negative p'
+	)
+	await rejects(
+		t,
+		() => renderVolcano([{ fold_change: 1, original_p_value: 0.01 } as any], makeReq()),
+		/adjusted_p_value must be a finite value/,
+		'missing adjusted p'
+	)
+	t.end()
+})
+
+/* ------------------------- happy-path output + math ------------------------ */
+
+tape('basic render: valid PNG, totalRows, plotExtent dims and dotRadiusPx', async t => {
+	const rows = [row(2, 0.001), row(-1.5, 0.0001), row(0.1, 0.5)]
+	const out = await renderVolcano(rows, makeReq())
+
+	t.equal(out.totalRows, 3, 'totalRows equals input length')
+	t.ok(typeof out.volcanoPng === 'string' && out.volcanoPng.length > 0, 'volcanoPng is a non-empty base64 string')
+	const sz = pngSize(out.volcanoPng) // throws if not a valid PNG
+	t.ok(sz.width > 0 && sz.height > 0, 'PNG decodes to positive dimensions')
+
+	// default dotRadius 2 → radiusPx 2 → padPx 4 → w = pixelWidth + 4
+	t.equal(out.plotExtent.dotRadiusPx, 2, 'dotRadiusPx is floor(dotRadius) clamped to >=1')
+	t.equal(out.plotExtent.pixelWidth, 404, 'plotExtent.pixelWidth = input + 2*radiusPx')
+	t.equal(out.plotExtent.pixelHeight, 404, 'plotExtent.pixelHeight = input + 2*radiusPx')
+	t.equal(out.plotExtent.plotRight, 404, 'plotRight spans the full padded canvas')
+	t.end()
+})
+
+tape('significance: only rows past BOTH cutoffs are significant', async t => {
+	// cutoffs: -log10(p) > 1.3 (p < ~0.05) AND |fc| > 0.3
+	const rows = [
+		row(2, 0.001), // y=3, |fc|=2  → significant
+		row(-1.5, 0.0001), // significant (down)
+		row(2, 0.5), // y≈0.3, fails p cutoff → not significant
+		row(0.1, 0.0001) // |fc|=0.1 fails fc cutoff → not significant
+	]
+	const out = await renderVolcano(rows, makeReq())
+	t.equal(out.totalSignificantRows, 2, 'exactly the two rows clearing both cutoffs are significant')
+	t.equal(out.dots.length, 2, 'dots holds only the significant rows')
+	t.end()
+})
+
+tape('dots: sorted ascending by p, finite in-bounds pixels, pass-through fields kept', async t => {
+	const rows = [
+		row(2, 0.01, { gene_name: 'mid' }),
+		row(2, 0.0001, { gene_name: 'low' }),
+		row(-2, 0.001, { gene_name: 'high' })
+	]
+	const out = await renderVolcano(rows, makeReq())
+	const ps = out.dots.map((d: any) => d.adjusted_p_value)
+	t.deepEqual(
+		ps,
+		[...ps].sort((a, b) => a - b),
+		'dots are sorted ascending by p-value'
+	)
+	t.deepEqual(
+		out.dots.map((d: any) => d.gene_name),
+		['low', 'high', 'mid'],
+		'sort order is by p and pass-through gene_name is preserved'
+	)
+	const w = out.plotExtent.pixelWidth
+	const h = out.plotExtent.pixelHeight
+	for (const d of out.dots as any[]) {
+		t.ok(Number.isFinite(d.pixel_x) && d.pixel_x >= 0 && d.pixel_x <= w, `pixel_x in [0,${w}]`)
+		t.ok(Number.isFinite(d.pixel_y) && d.pixel_y >= 0 && d.pixel_y <= h, `pixel_y in [0,${h}]`)
+	}
+	t.end()
+})
+
+tape('maxInteractiveDots caps dots to most-significant N; null returns all', async t => {
+	const rows = [row(2, 0.001), row(2, 0.0001), row(-2, 0.00001), row(2, 0.01)]
+	// all four are significant; cap at 2 → keep the two smallest p-values
+	const capped = await renderVolcano(rows, makeReq({ maxInteractiveDots: 2 }))
+	t.equal(capped.totalSignificantRows, 4, 'totalSignificantRows reflects the full count, not the cap')
+	t.equal(capped.dots.length, 2, 'dots truncated to maxInteractiveDots')
+	t.deepEqual(
+		capped.dots.map((d: any) => d.adjusted_p_value),
+		[0.00001, 0.0001],
+		'kept dots are the two most significant (smallest p)'
+	)
+
+	const all = await renderVolcano(rows, makeReq({ maxInteractiveDots: null }))
+	t.equal(all.dots.length, 4, 'null maxInteractiveDots returns every significant row')
+	t.end()
+})
+
+tape('plotExtent axis math: symmetric x, yMin 0, padding extends the domain', async t => {
+	const rows = [row(2, 0.001), row(-1, 0.01), row(0.5, 0.02)]
+	const { plotExtent: pe } = await renderVolcano(rows, makeReq())
+	t.equal(pe.xMaxUnpadded, 2, 'xMaxUnpadded = max|fold_change|')
+	t.equal(pe.xMinUnpadded, -2, 'x domain is symmetric about 0')
+	t.equal(pe.yMinUnpadded, 0, 'y domain starts at 0')
+	t.ok(pe.xMin < pe.xMinUnpadded && pe.xMax > pe.xMaxUnpadded, 'padding extends x beyond the unpadded extent')
+	t.ok(pe.yMin < 0 && pe.yMax > pe.yMaxUnpadded, 'padding extends y beyond the unpadded extent')
+	t.end()
+})
+
+tape('minNonZeroPValue: smallest positive p (zeros capped), all-zero falls back to 1e-300', async t => {
+	const withZero = await renderVolcano([row(2, 0), row(2, 0.002), row(-2, 0.01)], makeReq())
+	t.equal(withZero.plotExtent.minNonZeroPValue, 0.002, 'minNonZeroPValue is the smallest positive p')
+	t.ok(Number.isFinite(withZero.plotExtent.yMax), 'p==0 rows produce a finite (capped) y, not Infinity')
+
+	const allZero = await renderVolcano([row(2, 0), row(-2, 0)], makeReq())
+	t.equal(allZero.plotExtent.minNonZeroPValue, 1e-300, 'all-zero p input falls back to 1e-300')
+	t.end()
+})
+
+tape("pValueType 'original' classifies and sorts on original_p_value", async t => {
+	// A: significant only by original p; B: significant only by adjusted p.
+	const A = row(2, 0.0001, { gene_name: 'A' })
+	A.adjusted_p_value = 0.9 // not significant under 'adjusted'
+	const B = row(2, 0.9, { gene_name: 'B' })
+	B.adjusted_p_value = 0.0001 // significant under 'adjusted' only
+
+	const out = await renderVolcano([A, B], makeReq({ significanceThresholds: { pValueType: 'original' } }))
+	t.equal(out.totalSignificantRows, 1, 'exactly one row is significant by original p')
+	t.equal((out.dots[0] as any).gene_name, 'A', 'the row significant by ORIGINAL p is the one kept')
+	t.end()
+})
+
+tape('renders both significant up (fc>0) and down (fc<0) rows', async t => {
+	const rows = [row(2, 0.0001, { gene_name: 'up' }), row(-2, 0.0001, { gene_name: 'down' })]
+	const out = await renderVolcano(rows, makeReq())
+	t.equal(out.totalSignificantRows, 2, 'both directional rows are significant')
+	const names = (out.dots as any[]).map(d => d.gene_name).sort()
+	t.deepEqual(names, ['down', 'up'], 'both up and down rows appear in dots')
+	pngSize(out.volcanoPng) // both stroke batches ran → still a valid PNG
+	t.pass('render with both up/down batches produced a valid PNG')
+	t.end()
+})
+
+/* ------------------------------ edge + DPR -------------------------------- */
+
+tape('empty rows: blank PNG, no dots, zero-spread axis fallbacks', async t => {
+	const out = await renderVolcano([] as DataEntry[], makeReq())
+	t.equal(out.totalRows, 0, 'totalRows is 0')
+	t.equal(out.totalSignificantRows, 0, 'no significant rows')
+	t.deepEqual(out.dots, [], 'dots is empty')
+	t.equal(out.plotExtent.xMaxUnpadded, 1, 'x extent falls back to 1 when there is no spread')
+	t.equal(out.plotExtent.yMaxUnpadded, 1, 'y extent falls back to 1 when there is no spread')
+	pngSize(out.volcanoPng)
+	t.pass('blank input still produces a valid PNG')
+	t.end()
+})
+
+tape('default req: renderVolcano(rows) with no second arg', async t => {
+	const out = await renderVolcano([row(2, 0.001), row(-1, 0.0001)])
+	t.ok(out.volcanoPng.length > 0, 'uses DEFAULT_REQ and renders')
+	t.equal(out.plotExtent.pixelWidth, 404, 'DEFAULT_REQ pixelWidth 400 + padding')
+	t.end()
+})
+
+tape('DPR: exact device dimensions, and clamp to MAX_DEVICE_PIXELS_PER_SIDE', async t => {
+	// w = 404, dpr 2 → 808 device px exactly (no clamp: 8192/404 ≈ 20.3 >> 2).
+	const exact = await renderVolcano([row(2, 0.001)], makeReq({ devicePixelRatio: 2 }))
+	t.deepEqual(pngSize(exact.volcanoPng), { width: 808, height: 808 }, 'device dims = w*dpr when under the cap')
+
+	// w = 4000 (pixelWidth 3996 + pad 4), h = 125 (pixelHeight 121 + pad 4).
+	// dpr 6 would give 24000 px wide; effectiveDpr clamps to 8192/4000 = 2.048,
+	// so the wide axis lands exactly on the 8192 cap (height 125*2.048 = 256).
+	const clamped = await renderVolcano(
+		[row(2, 0.001)],
+		makeReq({ pixelWidth: 3996, pixelHeight: 121, devicePixelRatio: 6 })
+	)
+	const sz = pngSize(clamped.volcanoPng)
+	t.equal(sz.width, 8192, 'wide axis is clamped to MAX_DEVICE_PIXELS_PER_SIDE (not 24000)')
+	t.equal(sz.height, 256, 'short axis scales by the same clamped effectiveDpr')
+	t.end()
+})

--- a/server/src/utils/concurrencyLimiter.ts
+++ b/server/src/utils/concurrencyLimiter.ts
@@ -1,4 +1,17 @@
-import type { ConcurrencyLimiterOpts, ConcurrencyLimiter } from '#src/utils/types.ts'
+import type { ConcurrencyLimiterOpts, ConcurrencyLimiter, ConcurrencyLimiterRunContext } from './types.ts'
+
+/** Default per-task execution timeout. A task holding its slot longer than this
+ * is evicted (slot freed, caller rejected) so one hung task can't stall the
+ * whole queue. 30s is deliberately generous — orders of magnitude above any
+ * healthy task — so it only ever fires on a genuine hang, not a merely slow
+ * task. Callers with legitimately long-running work pass `taskTimeoutMs:
+ * Infinity` to disable, or a tuned value to override. */
+export const DEFAULT_TASK_TIMEOUT_MS = 30000
+
+/** A shared, never-aborted signal handed to `fn` when a limiter's timeout is
+ * disabled (`Infinity`), so the run context always carries a real `AbortSignal`
+ * without allocating an AbortController per call on the no-timeout fast path. */
+const NEVER_ABORT = new AbortController().signal
 
 /** A generic concurrency gating device. `createConcurrencyLimiter` returns a
  * limiter that runs at most `maxConcurrent` async tasks at once; further tasks
@@ -23,8 +36,41 @@ function defaultBusyError(): Error {
 	return err
 }
 
+/** Generic 504 so it reads as "the work took too long", not a client error.
+ * Mirrors the busy-error shape above. */
+function defaultTimeoutError(): Error {
+	const err: any = new Error('Task exceeded its time limit and was evicted.')
+	err.status = 504
+	err.statusCode = 504
+	err.code = 'TASK_TIMEOUT'
+	return err
+}
+
 export function createConcurrencyLimiter(opts: ConcurrencyLimiterOpts): ConcurrencyLimiter {
-	const { maxConcurrent, maxQueued, makeBusyError = defaultBusyError } = opts
+	const {
+		maxConcurrent,
+		maxQueued,
+		makeBusyError = defaultBusyError,
+		makeTimeoutError = defaultTimeoutError,
+		taskTimeoutMs = DEFAULT_TASK_TIMEOUT_MS
+	} = opts
+	// Validate the caps at construction — these are programmer config, not
+	// request input, so fail fast and loudly rather than degrading silently:
+	// a non-integer or <1 maxConcurrent would never let tasks run (or drive
+	// `active` negative), and a negative/non-integer maxQueued would shed or
+	// queue unpredictably. maxQueued === 0 is allowed (no waiting room: shed
+	// immediately once all slots are busy).
+	if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1)
+		throw new Error(`createConcurrencyLimiter: maxConcurrent must be an integer >= 1 (got ${maxConcurrent})`)
+	if (!Number.isInteger(maxQueued) || maxQueued < 0)
+		throw new Error(`createConcurrencyLimiter: maxQueued must be an integer >= 0 (got ${maxQueued})`)
+	// `Infinity` disables the timeout; otherwise require a positive finite ms.
+	// Reject 0/negative/NaN so a misconfigured value can't silently evict every
+	// task immediately (0) or behave unpredictably.
+	if (taskTimeoutMs !== Infinity && (!Number.isFinite(taskTimeoutMs) || taskTimeoutMs <= 0))
+		throw new Error(
+			`createConcurrencyLimiter: taskTimeoutMs must be a positive number or Infinity (got ${taskTimeoutMs})`
+		)
 	let active = 0
 	const queue: Array<() => void> = []
 
@@ -45,12 +91,48 @@ export function createConcurrencyLimiter(opts: ConcurrencyLimiterOpts): Concurre
 		else active--
 	}
 
-	async function run<T>(fn: () => Promise<T>): Promise<T> {
+	async function run<T>(fn: (ctx: ConcurrencyLimiterRunContext) => Promise<T>): Promise<T> {
 		await acquire()
-		try {
-			return await fn()
-		} finally {
+
+		// Disabled-timeout fast path: no timer, no AbortController — hand `fn` a
+		// shared never-aborted signal and just release the slot when it settles.
+		if (taskTimeoutMs === Infinity) {
+			try {
+				return await fn({ signal: NEVER_ABORT })
+			} finally {
+				release()
+			}
+		}
+
+		// Bounded path: race `fn` against a timer. `releaseOnce` guarantees the
+		// slot is released exactly once — by the timer on timeout, otherwise by
+		// the `finally`. On timeout we free the slot immediately so the queue can
+		// advance even though the orphaned task may keep running (JS can't kill
+		// it); the AbortSignal lets a cooperative task stop itself.
+		const controller = new AbortController()
+		let released = false
+		const releaseOnce = () => {
+			if (released) return
+			released = true
 			release()
+		}
+		let timer: ReturnType<typeof setTimeout> | undefined
+		try {
+			const task = fn({ signal: controller.signal })
+			// The orphaned task may reject after we've already timed out; swallow
+			// that late rejection so it can't surface as an unhandledRejection.
+			task.catch(() => {})
+			const timeout = new Promise<never>((_, reject) => {
+				timer = setTimeout(() => {
+					controller.abort()
+					releaseOnce()
+					reject(makeTimeoutError())
+				}, taskTimeoutMs)
+			})
+			return await Promise.race([task, timeout])
+		} finally {
+			if (timer) clearTimeout(timer)
+			releaseOnce()
 		}
 	}
 

--- a/server/src/utils/concurrencyLimiter.ts
+++ b/server/src/utils/concurrencyLimiter.ts
@@ -26,34 +26,28 @@ const NEVER_ABORT = new AbortController().signal
  * pattern that gates concurrent compute jobs. The `ConcurrencyLimiterOpts` and
  * `ConcurrencyLimiter` types live in utils/types.ts alongside cacheOrRecompute's. */
 
-/** Generic 429 so it reads as "retry later", not a client error in the
- * request shape. Mirrors the busy-error shape in utils/cacheOrRecompute.ts. */
-function defaultBusyError(): Error {
-	const err: any = new Error('Concurrency pool is full. Please try again shortly.')
-	err.status = 429
-	err.statusCode = 429
-	err.code = 'POOL_BUSY'
-	return err
-}
-
-/** Generic 504 so it reads as "the work took too long", not a client error.
- * Mirrors the busy-error shape above. */
-function defaultTimeoutError(): Error {
-	const err: any = new Error('Task exceeded its time limit and was evicted.')
-	err.status = 504
-	err.statusCode = 504
-	err.code = 'TASK_TIMEOUT'
-	return err
-}
-
 export function createConcurrencyLimiter(opts: ConcurrencyLimiterOpts): ConcurrencyLimiter {
-	const {
-		maxConcurrent,
-		maxQueued,
-		makeBusyError = defaultBusyError,
-		makeTimeoutError = defaultTimeoutError,
-		taskTimeoutMs = DEFAULT_TASK_TIMEOUT_MS
-	} = opts
+	const { maxConcurrent, maxQueued, taskName = 'task', taskTimeoutMs = DEFAULT_TASK_TIMEOUT_MS } = opts
+
+	// Closured error builders — `taskName` names the gated resource so the
+	// message identifies which pool is full / what timed out, while the status
+	// and code stay fixed (429 "retry later", 504 "took too long"). Both read as
+	// transient server states, not client request errors. If a caller ever needs
+	// a custom statusCode, add it to opts rather than reintroducing a factory.
+	function busyError(): Error {
+		const err: any = new Error(`The ${taskName} pool is full. Please try again shortly.`)
+		err.status = 429
+		err.statusCode = 429
+		err.code = 'POOL_BUSY'
+		return err
+	}
+	function timeoutError(): Error {
+		const err: any = new Error(`The ${taskName} exceeded its time limit and was evicted.`)
+		err.status = 504
+		err.statusCode = 504
+		err.code = 'TASK_TIMEOUT'
+		return err
+	}
 	// Validate the caps at construction — these are programmer config, not
 	// request input, so fail fast and loudly rather than degrading silently:
 	// a non-integer or <1 maxConcurrent would never let tasks run (or drive
@@ -79,7 +73,7 @@ export function createConcurrencyLimiter(opts: ConcurrencyLimiterOpts): Concurre
 			active++
 			return
 		}
-		if (queue.length >= maxQueued) throw makeBusyError()
+		if (queue.length >= maxQueued) throw busyError()
 		await new Promise<void>(resolve => queue.push(resolve))
 	}
 
@@ -126,7 +120,7 @@ export function createConcurrencyLimiter(opts: ConcurrencyLimiterOpts): Concurre
 				timer = setTimeout(() => {
 					controller.abort()
 					releaseOnce()
-					reject(makeTimeoutError())
+					reject(timeoutError())
 				}, taskTimeoutMs)
 			})
 			return await Promise.race([task, timeout])

--- a/server/src/utils/concurrencyLimiter.ts
+++ b/server/src/utils/concurrencyLimiter.ts
@@ -1,0 +1,77 @@
+/** A generic concurrency gating device. `createConcurrencyLimiter` returns a
+ * limiter that runs at most `maxConcurrent` async tasks at once; further tasks
+ * wait in a bounded FIFO queue, and once that queue is full the limiter sheds
+ * load by throwing a 429 busy error rather than letting the queue grow without
+ * bound (an unbounded queue is a memory/DoS risk and holds callers open
+ * indefinitely under sustained overload).
+ *
+ * Each limiter is an independent instance holding all of its state in a
+ * closure, so one process can gate several distinct resources with separate
+ * caps. This was lifted verbatim from the volcano render gate that previously
+ * lived in renderVolcano.ts; see utils/cacheOrRecompute.ts for the sibling
+ * pattern that gates concurrent compute jobs. */
+
+export type ConcurrencyLimiterOpts = {
+	/** Max tasks allowed to run at the same time. */
+	maxConcurrent: number
+
+	/** Max tasks allowed to wait for a slot. Past this, `run` rejects
+	 * immediately with the busy error instead of enqueuing. */
+	maxQueued: number
+
+	/** Optional factory for the error thrown when the wait-queue is full.
+	 * Defaults to a generic 429 (`code: 'POOL_BUSY'`). Supply your own to
+	 * carry a caller-specific code/message (e.g. volcano's `RENDER_BUSY`). */
+	makeBusyError?: () => Error
+}
+
+export type ConcurrencyLimiter = {
+	/** Acquire a slot (waiting or rejecting per the caps), run `fn`, and
+	 * release the slot in a `finally` so it can never leak — even if `fn`
+	 * throws. Resolves/rejects with `fn`'s own result. */
+	run<T>(fn: () => Promise<T>): Promise<T>
+}
+
+/** Generic 429 so it reads as "retry later", not a client error in the
+ * request shape. Mirrors the busy-error shape in utils/cacheOrRecompute.ts. */
+function defaultBusyError(): Error {
+	const err: any = new Error('Concurrency pool is full. Please try again shortly.')
+	err.status = 429
+	err.statusCode = 429
+	err.code = 'POOL_BUSY'
+	return err
+}
+
+export function createConcurrencyLimiter(opts: ConcurrencyLimiterOpts): ConcurrencyLimiter {
+	const { maxConcurrent, maxQueued, makeBusyError = defaultBusyError } = opts
+	let active = 0
+	const queue: Array<() => void> = []
+
+	async function acquire(): Promise<void> {
+		if (active < maxConcurrent) {
+			active++
+			return
+		}
+		if (queue.length >= maxQueued) throw makeBusyError()
+		await new Promise<void>(resolve => queue.push(resolve))
+	}
+
+	function release(): void {
+		const next = queue.shift()
+		// Hand the slot straight to the next waiter without decrement/increment;
+		// only drop `active` when the queue is empty.
+		if (next) next()
+		else active--
+	}
+
+	async function run<T>(fn: () => Promise<T>): Promise<T> {
+		await acquire()
+		try {
+			return await fn()
+		} finally {
+			release()
+		}
+	}
+
+	return { run }
+}

--- a/server/src/utils/concurrencyLimiter.ts
+++ b/server/src/utils/concurrencyLimiter.ts
@@ -1,3 +1,5 @@
+import type { ConcurrencyLimiterOpts, ConcurrencyLimiter } from '#src/utils/types.ts'
+
 /** A generic concurrency gating device. `createConcurrencyLimiter` returns a
  * limiter that runs at most `maxConcurrent` async tasks at once; further tasks
  * wait in a bounded FIFO queue, and once that queue is full the limiter sheds
@@ -7,30 +9,9 @@
  *
  * Each limiter is an independent instance holding all of its state in a
  * closure, so one process can gate several distinct resources with separate
- * caps. This was lifted verbatim from the volcano render gate that previously
- * lived in renderVolcano.ts; see utils/cacheOrRecompute.ts for the sibling
- * pattern that gates concurrent compute jobs. */
-
-export type ConcurrencyLimiterOpts = {
-	/** Max tasks allowed to run at the same time. */
-	maxConcurrent: number
-
-	/** Max tasks allowed to wait for a slot. Past this, `run` rejects
-	 * immediately with the busy error instead of enqueuing. */
-	maxQueued: number
-
-	/** Optional factory for the error thrown when the wait-queue is full.
-	 * Defaults to a generic 429 (`code: 'POOL_BUSY'`). Supply your own to
-	 * carry a caller-specific code/message (e.g. volcano's `RENDER_BUSY`). */
-	makeBusyError?: () => Error
-}
-
-export type ConcurrencyLimiter = {
-	/** Acquire a slot (waiting or rejecting per the caps), run `fn`, and
-	 * release the slot in a `finally` so it can never leak — even if `fn`
-	 * throws. Resolves/rejects with `fn`'s own result. */
-	run<T>(fn: () => Promise<T>): Promise<T>
-}
+ * caps. See utils/cacheOrRecompute.ts for the sibling
+ * pattern that gates concurrent compute jobs. The `ConcurrencyLimiterOpts` and
+ * `ConcurrencyLimiter` types live in utils/types.ts alongside cacheOrRecompute's. */
 
 /** Generic 429 so it reads as "retry later", not a client error in the
  * request shape. Mirrors the busy-error shape in utils/cacheOrRecompute.ts. */

--- a/server/src/utils/test/concurrencyLimiter.unit.spec.ts
+++ b/server/src/utils/test/concurrencyLimiter.unit.spec.ts
@@ -9,13 +9,13 @@ run propagates fn's rejection and frees the slot for the next run
 up to maxConcurrent tasks run at once; the next stays pending until one frees
 a queued task runs once a slot frees, in FIFO order
 queue full → run rejects synchronously with the default POOL_BUSY 429 error
-a provided makeBusyError is used instead of the default
+taskName names the gated resource in the busy error message
 pool recovers: a new run succeeds after the busy queue drains
 maxConcurrent=1 hands slots to waiters one at a time without over-decrementing
 task timeout: hung task evicted with TASK_TIMEOUT 504, slot freed for the queue
 task timeout: AbortSignal fires so a cooperative task can bail
 task timeout: a task finishing in time is not evicted and the timer is cleared
-task timeout: custom makeTimeoutError overrides the default
+task timeout: taskName names the gated resource in the timeout error message
 task timeout: Infinity disables eviction; invalid values rejected at construction
 */
 
@@ -165,6 +165,7 @@ tape('queue full → run rejects synchronously with the default POOL_BUSY 429 er
 		t.equal(e.code, 'POOL_BUSY', 'default busy error code is POOL_BUSY')
 		t.equal(e.status, 429, 'default busy error carries status 429')
 		t.equal(e.statusCode, 429, 'default busy error carries statusCode 429')
+		t.match(e.message, /\btask pool is full\b/, 'default taskName "task" names the pool in the message')
 	}
 
 	blocker.resolve()
@@ -172,15 +173,8 @@ tape('queue full → run rejects synchronously with the default POOL_BUSY 429 er
 	t.end()
 })
 
-tape('a provided makeBusyError is used instead of the default', async t => {
-	const makeBusyError = () => {
-		const err: any = new Error('custom full')
-		err.status = 429
-		err.statusCode = 429
-		err.code = 'RENDER_BUSY'
-		return err
-	}
-	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, makeBusyError })
+tape('taskName names the gated resource in the busy error message', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskName: 'volcano render' })
 	const blocker = defer()
 	const running = limiter.run(async () => {
 		await blocker.promise
@@ -189,10 +183,15 @@ tape('a provided makeBusyError is used instead of the default', async t => {
 
 	try {
 		await limiter.run(async () => 'overflow')
-		t.fail('expected rejection from the custom busy error')
+		t.fail('expected rejection from the busy error')
 	} catch (e: any) {
-		t.equal(e.code, 'RENDER_BUSY', 'the caller-supplied error factory is used')
-		t.equal(e.message, 'custom full', 'custom message is preserved')
+		t.equal(e.code, 'POOL_BUSY', 'code stays the fixed POOL_BUSY')
+		t.equal(e.statusCode, 429, 'status stays the fixed 429')
+		t.equal(
+			e.message,
+			'The volcano render pool is full. Please try again shortly.',
+			'taskName is woven into the message'
+		)
 	}
 
 	blocker.resolve()
@@ -279,6 +278,7 @@ tape('a hung task is evicted with TASK_TIMEOUT (504) and its slot is freed', asy
 		t.equal(e.code, 'TASK_TIMEOUT', 'default timeout error code')
 		t.equal(e.status, 504, 'status 504')
 		t.equal(e.statusCode, 504, 'statusCode 504')
+		t.match(e.message, /\btask exceeded its time limit\b/, 'default taskName "task" names the work in the message')
 	}
 
 	t.equal(await queuedRun, 'ok', 'the queued task ran after the hung one was evicted')
@@ -323,22 +323,25 @@ tape('a task finishing before the timeout is not evicted and the timer is cleare
 	t.end()
 })
 
-tape('a provided makeTimeoutError overrides the default', async t => {
-	const makeTimeoutError = () => {
-		const err: any = new Error('custom slow')
-		err.status = 504
-		err.statusCode = 504
-		err.code = 'RENDER_TIMEOUT'
-		return err
-	}
-	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskTimeoutMs: 15, makeTimeoutError })
+tape('taskName names the gated resource in the timeout error message', async t => {
+	const limiter = createConcurrencyLimiter({
+		maxConcurrent: 1,
+		maxQueued: 0,
+		taskTimeoutMs: 15,
+		taskName: 'volcano render'
+	})
 	const hung = defer()
 	try {
 		await limiter.run(() => hung.promise)
 		t.fail('expected timeout rejection')
 	} catch (e: any) {
-		t.equal(e.code, 'RENDER_TIMEOUT', 'the caller-supplied timeout error is used')
-		t.equal(e.message, 'custom slow', 'custom message is preserved')
+		t.equal(e.code, 'TASK_TIMEOUT', 'code stays the fixed TASK_TIMEOUT')
+		t.equal(e.statusCode, 504, 'status stays the fixed 504')
+		t.equal(
+			e.message,
+			'The volcano render exceeded its time limit and was evicted.',
+			'taskName is woven into the message'
+		)
 	}
 	t.end()
 })

--- a/server/src/utils/test/concurrencyLimiter.unit.spec.ts
+++ b/server/src/utils/test/concurrencyLimiter.unit.spec.ts
@@ -1,0 +1,217 @@
+import tape from 'tape'
+import { createConcurrencyLimiter } from '#src/utils/concurrencyLimiter.ts'
+
+/*
+test sections:
+
+run resolves to fn's return value
+run propagates fn's rejection and frees the slot for the next run
+up to maxConcurrent tasks run at once; the next stays pending until one frees
+a queued task runs once a slot frees, in FIFO order
+queue full → run rejects synchronously with the default POOL_BUSY 429 error
+a provided makeBusyError is used instead of the default
+pool recovers: a new run succeeds after the busy queue drains
+maxConcurrent=1 hands slots to waiters one at a time without over-decrementing
+*/
+
+/** Tests for the generic concurrency gating device. Concurrency is driven
+ * with manually-resolved deferred promises rather than timers so task
+ * ordering is exact and the tests are not flaky. */
+
+/** A promise plus its resolver, so a test can hold a task "in-flight" inside
+ * the limiter and release it on demand. */
+function defer<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } {
+	let resolve!: (v: T) => void
+	const promise = new Promise<T>(r => (resolve = r))
+	return { promise, resolve }
+}
+
+const tick = () => new Promise<void>(r => setTimeout(r, 0))
+
+tape('\n', t => {
+	t.comment('-***- utils/concurrencyLimiter specs -***-')
+	t.end()
+})
+
+tape('run resolves to fn’s return value', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 2, maxQueued: 2 })
+	const out = await limiter.run(async () => 42)
+	t.equal(out, 42, 'run forwards the resolved value of fn')
+	t.end()
+})
+
+tape('run propagates fn’s rejection and frees the slot for the next run', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0 })
+	try {
+		await limiter.run(async () => {
+			throw new Error('boom')
+		})
+		t.fail('expected run to reject')
+	} catch (e: any) {
+		t.equal(e.message, 'boom', 'run rejects with fn’s own error')
+	}
+	// If the slot leaked on the error path, this second run would hang/reject
+	// busy. It resolving proves the slot was released in the finally.
+	const out = await limiter.run(async () => 'ok')
+	t.equal(out, 'ok', 'a follow-up run succeeds — no slot leaked on the error path')
+	t.end()
+})
+
+tape('up to maxConcurrent tasks run at once; the next stays pending until one frees', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 2, maxQueued: 5 })
+	let started = 0
+	const gates = [defer(), defer(), defer()]
+	const task = (i: number) =>
+		limiter.run(async () => {
+			started++
+			await gates[i].promise
+			return i
+		})
+
+	const p0 = task(0)
+	const p1 = task(1)
+	const p2 = task(2)
+	await tick()
+	t.equal(started, 2, 'exactly maxConcurrent (2) tasks have started; the 3rd waits')
+
+	gates[0].resolve() // free a slot
+	await p0
+	await tick()
+	t.equal(started, 3, 'the queued 3rd task starts once a slot frees')
+
+	gates[1].resolve()
+	gates[2].resolve()
+	const results = await Promise.all([p1, p2])
+	t.deepEqual(results, [1, 2], 'all tasks resolve to their own values')
+	t.end()
+})
+
+tape('a queued task runs once a slot frees, in FIFO order', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 5 })
+	const order: number[] = []
+	const blocker = defer()
+
+	// First task occupies the single slot until we release `blocker`.
+	const first = limiter.run(async () => {
+		order.push(0)
+		await blocker.promise
+	})
+	await tick()
+	// These three queue up behind it; they must run in enqueue order.
+	const queued = [1, 2, 3].map(n =>
+		limiter.run(async () => {
+			order.push(n)
+		})
+	)
+	await tick()
+	t.deepEqual(order, [0], 'only the first task has run while the slot is held')
+
+	blocker.resolve()
+	await Promise.all([first, ...queued])
+	t.deepEqual(order, [0, 1, 2, 3], 'queued tasks ran FIFO after the slot freed')
+	t.end()
+})
+
+tape('queue full → run rejects synchronously with the default POOL_BUSY 429 error', async t => {
+	// 1 running + 1 queued is the whole capacity; the 3rd must be shed.
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 1 })
+	const blocker = defer()
+	const running = limiter.run(async () => {
+		await blocker.promise
+	})
+	const waiting = limiter.run(async () => 'queued') // fills the single queue slot
+	await tick()
+
+	try {
+		await limiter.run(async () => 'overflow')
+		t.fail('expected the overflow run to reject')
+	} catch (e: any) {
+		t.equal(e.code, 'POOL_BUSY', 'default busy error code is POOL_BUSY')
+		t.equal(e.status, 429, 'default busy error carries status 429')
+		t.equal(e.statusCode, 429, 'default busy error carries statusCode 429')
+	}
+
+	blocker.resolve()
+	await Promise.all([running, waiting])
+	t.end()
+})
+
+tape('a provided makeBusyError is used instead of the default', async t => {
+	const makeBusyError = () => {
+		const err: any = new Error('custom full')
+		err.status = 429
+		err.statusCode = 429
+		err.code = 'RENDER_BUSY'
+		return err
+	}
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, makeBusyError })
+	const blocker = defer()
+	const running = limiter.run(async () => {
+		await blocker.promise
+	})
+	await tick()
+
+	try {
+		await limiter.run(async () => 'overflow')
+		t.fail('expected rejection from the custom busy error')
+	} catch (e: any) {
+		t.equal(e.code, 'RENDER_BUSY', 'the caller-supplied error factory is used')
+		t.equal(e.message, 'custom full', 'custom message is preserved')
+	}
+
+	blocker.resolve()
+	await running
+	t.end()
+})
+
+tape('pool recovers: a new run succeeds after the busy queue drains', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0 })
+	const blocker = defer()
+	const running = limiter.run(async () => {
+		await blocker.promise
+	})
+	await tick()
+
+	// While the single slot is held and the queue cap is 0, this is rejected.
+	let rejected = false
+	try {
+		await limiter.run(async () => 'overflow')
+	} catch {
+		rejected = true
+	}
+	t.ok(rejected, 'run is shed while the pool is saturated')
+
+	// Drain the pool, then a fresh run must succeed (no negative caching of busy).
+	blocker.resolve()
+	await running
+	const out = await limiter.run(async () => 'recovered')
+	t.equal(out, 'recovered', 'a new run succeeds once the slot frees')
+	t.end()
+})
+
+tape('maxConcurrent=1 hands slots to waiters one at a time without over-decrementing', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 10 })
+	let concurrent = 0
+	let maxObserved = 0
+	const N = 6
+
+	const tasks = Array.from({ length: N }, (_, i) =>
+		limiter.run(async () => {
+			concurrent++
+			maxObserved = Math.max(maxObserved, concurrent)
+			// Yield so any over-decrement bug would let a second task in here.
+			await tick()
+			concurrent--
+			return i
+		})
+	)
+
+	const results = await Promise.all(tasks)
+	t.equal(maxObserved, 1, 'never more than one task ran at a time')
+	t.deepEqual(
+		results,
+		Array.from({ length: N }, (_, i) => i),
+		'every task completed exactly once with its own value'
+	)
+	t.end()
+})

--- a/server/src/utils/test/concurrencyLimiter.unit.spec.ts
+++ b/server/src/utils/test/concurrencyLimiter.unit.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { createConcurrencyLimiter } from '#src/utils/concurrencyLimiter.ts'
+import { createConcurrencyLimiter, DEFAULT_TASK_TIMEOUT_MS } from '#src/utils/concurrencyLimiter.ts'
 
 /*
 test sections:
@@ -12,6 +12,11 @@ queue full → run rejects synchronously with the default POOL_BUSY 429 error
 a provided makeBusyError is used instead of the default
 pool recovers: a new run succeeds after the busy queue drains
 maxConcurrent=1 hands slots to waiters one at a time without over-decrementing
+task timeout: hung task evicted with TASK_TIMEOUT 504, slot freed for the queue
+task timeout: AbortSignal fires so a cooperative task can bail
+task timeout: a task finishing in time is not evicted and the timer is cleared
+task timeout: custom makeTimeoutError overrides the default
+task timeout: Infinity disables eviction; invalid values rejected at construction
 */
 
 /** Tests for the generic concurrency gating device. Concurrency is driven
@@ -26,10 +31,41 @@ function defer<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } {
 	return { promise, resolve }
 }
 
-const tick = () => new Promise<void>(r => setTimeout(r, 0))
+/** Yield one microtask checkpoint. The limiter's handoffs all resume via
+ * promise microtasks (`acquire` awaits a queued resolver; `release` resolves
+ * it), so a single microtask drain lets every ready continuation run, in order
+ * — no macrotask timer needed, which keeps ordering exact and deterministic. */
+const tick = () => Promise.resolve()
+
+/** Real-time delay. The timeout feature is inherently time-based, so the
+ * timeout cases below use small real timers (~15–40ms); the microtask-driven
+ * tests above don't. */
+const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
 
 tape('\n', t => {
 	t.comment('-***- utils/concurrencyLimiter specs -***-')
+	t.end()
+})
+
+tape('rejects invalid caps at construction', t => {
+	for (const bad of [0, -1, 2.5, NaN, Infinity]) {
+		t.throws(
+			() => createConcurrencyLimiter({ maxConcurrent: bad, maxQueued: 5 }),
+			/maxConcurrent must be an integer >= 1/,
+			`maxConcurrent=${bad} is rejected`
+		)
+	}
+	for (const bad of [-1, 1.5, NaN, Infinity]) {
+		t.throws(
+			() => createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: bad }),
+			/maxQueued must be an integer >= 0/,
+			`maxQueued=${bad} is rejected`
+		)
+	}
+	t.doesNotThrow(
+		() => createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0 }),
+		'maxQueued=0 (no waiting room) is allowed'
+	)
 	t.end()
 })
 
@@ -213,5 +249,126 @@ tape('maxConcurrent=1 hands slots to waiters one at a time without over-decremen
 		Array.from({ length: N }, (_, i) => i),
 		'every task completed exactly once with its own value'
 	)
+	t.end()
+})
+
+/* -------------------------------- timeouts -------------------------------- */
+
+tape('DEFAULT_TASK_TIMEOUT_MS is 30s', t => {
+	t.equal(DEFAULT_TASK_TIMEOUT_MS, 30000, 'documented safety default')
+	t.end()
+})
+
+tape('a hung task is evicted with TASK_TIMEOUT (504) and its slot is freed', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 5, taskTimeoutMs: 15 })
+	const hung = defer() // never resolved → the task hangs
+	let queuedRan = false
+
+	// This run holds the only slot and will time out at 15ms.
+	const hungRun = limiter.run(() => hung.promise)
+	// This run is queued behind it; it can only proceed once the slot frees.
+	const queuedRun = limiter.run(async () => {
+		queuedRan = true
+		return 'ok'
+	})
+
+	try {
+		await hungRun
+		t.fail('expected the hung run to reject')
+	} catch (e: any) {
+		t.equal(e.code, 'TASK_TIMEOUT', 'default timeout error code')
+		t.equal(e.status, 504, 'status 504')
+		t.equal(e.statusCode, 504, 'statusCode 504')
+	}
+
+	t.equal(await queuedRun, 'ok', 'the queued task ran after the hung one was evicted')
+	t.ok(queuedRan, 'the freed slot let the queue advance')
+	t.end()
+})
+
+tape('the AbortSignal is aborted on timeout, letting a cooperative task bail', async t => {
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskTimeoutMs: 15 })
+	let observedAbort = false
+	try {
+		await limiter.run(
+			({ signal }) =>
+				new Promise((_, reject) => {
+					signal.addEventListener('abort', () => {
+						observedAbort = true
+						reject(new Error('aborted by signal'))
+					})
+				})
+		)
+		t.fail('expected rejection')
+	} catch {
+		t.ok(observedAbort, 'fn observed the abort signal firing on timeout')
+	}
+	t.end()
+})
+
+tape('a task finishing before the timeout is not evicted and the timer is cleared', async t => {
+	// 15ms timeout, but the task resolves immediately. If the timer were not
+	// cleared it would abort the signal at 15ms; we wait 40ms and assert it didn't.
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskTimeoutMs: 15 })
+	let abortedLater = false
+	const out = await limiter.run(({ signal }) => {
+		signal.addEventListener('abort', () => {
+			abortedLater = true
+		})
+		return Promise.resolve('done')
+	})
+	t.equal(out, 'done', 'returns fn’s value with no spurious timeout rejection')
+	await delay(40)
+	t.notOk(abortedLater, 'signal was not aborted after a clean finish (timer cleared)')
+	t.end()
+})
+
+tape('a provided makeTimeoutError overrides the default', async t => {
+	const makeTimeoutError = () => {
+		const err: any = new Error('custom slow')
+		err.status = 504
+		err.statusCode = 504
+		err.code = 'RENDER_TIMEOUT'
+		return err
+	}
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskTimeoutMs: 15, makeTimeoutError })
+	const hung = defer()
+	try {
+		await limiter.run(() => hung.promise)
+		t.fail('expected timeout rejection')
+	} catch (e: any) {
+		t.equal(e.code, 'RENDER_TIMEOUT', 'the caller-supplied timeout error is used')
+		t.equal(e.message, 'custom slow', 'custom message is preserved')
+	}
+	t.end()
+})
+
+tape('taskTimeoutMs: Infinity disables eviction; invalid values rejected at construction', async t => {
+	for (const bad of [0, -1, NaN]) {
+		t.throws(
+			() => createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskTimeoutMs: bad }),
+			/taskTimeoutMs must be a positive number or Infinity/,
+			`taskTimeoutMs=${bad} is rejected`
+		)
+	}
+	t.doesNotThrow(
+		() => createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskTimeoutMs: Infinity }),
+		'Infinity (disabled) is allowed'
+	)
+
+	// With the timeout disabled, a long-running task is NOT evicted.
+	const limiter = createConcurrencyLimiter({ maxConcurrent: 1, maxQueued: 0, taskTimeoutMs: Infinity })
+	const gate = defer<string>()
+	let settled = false
+	const p = limiter
+		.run(() => gate.promise)
+		.then(v => {
+			settled = true
+			return v
+		})
+	await delay(40) // longer than any of the small timeouts above
+	t.notOk(settled, 'task still in-flight, not evicted, well past a normal timeout window')
+	gate.resolve('late')
+	t.equal(await p, 'late', 'the task completes normally once it finally resolves')
 	t.end()
 })

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -33,10 +33,10 @@ export type ConcurrencyLimiterOpts = {
 	 * immediately with the busy error instead of enqueuing. */
 	maxQueued: number
 
-	/** Optional factory for the error thrown when the wait-queue is full.
-	 * Defaults to a generic 429 (`code: 'POOL_BUSY'`). Supply your own to
-	 * carry a caller-specific code/message (e.g. volcano's `RENDER_BUSY`). */
-	makeBusyError?: () => Error
+	/** Names the gated resource for the busy/timeout error messages — e.g.
+	 * 'volcano render' yields "The volcano render pool is full…". Defaults to
+	 * 'task'. The error status (429 busy / 504 timeout) and code are fixed. */
+	taskName?: string
 
 	/** Per-task execution timeout (ms). A task that holds its slot longer than
 	 * this has its slot released (so the queue advances) and its `run()`
@@ -46,11 +46,6 @@ export type ConcurrencyLimiterOpts = {
 	 * Defaults to `DEFAULT_TASK_TIMEOUT_MS` (30000) when omitted; pass `Infinity`
 	 * to disable (unbounded) for legitimately long-running tasks. */
 	taskTimeoutMs?: number
-
-	/** Optional factory for the error thrown when a task times out. Defaults to
-	 * a 504 (`code: 'TASK_TIMEOUT'`). Supply your own for a caller-specific
-	 * code/message (e.g. volcano's `RENDER_TIMEOUT`). */
-	makeTimeoutError?: () => Error
 }
 
 /** Context handed to each `run()` callback. `signal` is aborted if the task

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -37,11 +37,29 @@ export type ConcurrencyLimiterOpts = {
 	 * Defaults to a generic 429 (`code: 'POOL_BUSY'`). Supply your own to
 	 * carry a caller-specific code/message (e.g. volcano's `RENDER_BUSY`). */
 	makeBusyError?: () => Error
+
+	/** Per-task execution timeout (ms). A task that holds its slot longer than
+	 * this has its slot released (so the queue advances) and its `run()`
+	 * rejected with the timeout error; the `AbortSignal` passed to `fn` is
+	 * aborted so cooperative tasks can stop. A non-cooperative task keeps
+	 * running orphaned — JS can't force-kill it — but it no longer holds a slot.
+	 * Defaults to `DEFAULT_TASK_TIMEOUT_MS` (30000) when omitted; pass `Infinity`
+	 * to disable (unbounded) for legitimately long-running tasks. */
+	taskTimeoutMs?: number
+
+	/** Optional factory for the error thrown when a task times out. Defaults to
+	 * a 504 (`code: 'TASK_TIMEOUT'`). Supply your own for a caller-specific
+	 * code/message (e.g. volcano's `RENDER_TIMEOUT`). */
+	makeTimeoutError?: () => Error
 }
+
+/** Context handed to each `run()` callback. `signal` is aborted if the task
+ * exceeds the limiter's `taskTimeoutMs`, letting cooperative tasks bail early. */
+export type ConcurrencyLimiterRunContext = { signal: AbortSignal }
 
 export type ConcurrencyLimiter = {
 	/** Acquire a slot (waiting or rejecting per the caps), run `fn`, and
 	 * release the slot in a `finally` so it can never leak — even if `fn`
-	 * throws. Resolves/rejects with `fn`'s own result. */
-	run<T>(fn: () => Promise<T>): Promise<T>
+	 * throws or times out. Resolves/rejects with `fn`'s own result. */
+	run<T>(fn: (ctx: ConcurrencyLimiterRunContext) => Promise<T>): Promise<T>
 }

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -24,3 +24,24 @@ export type CacheOrRecomputeResult<TResult> = {
 	cacheId: string
 	cacheFilePath: string
 }
+
+export type ConcurrencyLimiterOpts = {
+	/** Max tasks allowed to run at the same time. */
+	maxConcurrent: number
+
+	/** Max tasks allowed to wait for a slot. Past this, `run` rejects
+	 * immediately with the busy error instead of enqueuing. */
+	maxQueued: number
+
+	/** Optional factory for the error thrown when the wait-queue is full.
+	 * Defaults to a generic 429 (`code: 'POOL_BUSY'`). Supply your own to
+	 * carry a caller-specific code/message (e.g. volcano's `RENDER_BUSY`). */
+	makeBusyError?: () => Error
+}
+
+export type ConcurrencyLimiter = {
+	/** Acquire a slot (waiting or rejecting per the caps), run `fn`, and
+	 * release the slot in a `finally` so it can never leak — even if `fn`
+	 * throws. Resolves/rejects with `fn`'s own result. */
+	run<T>(fn: () => Promise<T>): Promise<T>
+}


### PR DESCRIPTION
# Description
Generalized the concurrency limiter logic into its own module called `concurrencyLimiter.ts` in `server/src/utils/` (alongside the `cacheOrRecompute.ts` module). It now allows the creation of a generic concurrent limiter gating device that allows specifying the concurrent number of jobs allowed,  max number of concurrent jobs allowed to be queued before subsequent jobs are shed, and an optional message to display when the queue is full. This allows different callers to specify different limits for different types of concurrent processes they would like to limit and to customize the message that is displayed when the queue is full. Added an optional per-task time cap to the concurrency limiter so a single hung job can't hold its slot forever and stall the queue for everyone behind it. When a job exceeds the cap, its slot is freed (letting the queue advance) and the caller is rejected with a customizable timeout message. It defaults to 30 seconds, but callers can raise or lower it to suit longer- or shorter-running processes, or disable it entirely by setting it to `Infinity`. Do note that tasks that don't support abort signal will simply be orphaned and run to completion and will still use memory but queue will no longer be stalled. Covered it with unit tests. Applied the generic module to `renderVolcano.ts`. Covered it with unit tests. Added unit tests to cover `renderVolcano.ts`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
