### PR TITLE
avoid showing stale numeric edit input values 

### DIFF
--- a/client/termsetting/handlers/NumBinaryEditor.ts
+++ b/client/termsetting/handlers/NumBinaryEditor.ts
@@ -30,6 +30,7 @@ export class NumBinaryEditor extends HandlerBase implements Handler {
 
 	async showEditMenu(div) {
 		this.tw = this.handler.tw as NumCustomBins
+		this.q = this.getDefaultQ()
 		if (this.dom.density_div) {
 			if (this.handler.dom.editDiv?.node().contains(this.dom.density_div.node())) {
 				await this.handler.density.showViolin(this.dom.density_div, this.getBoundaryOpts())
@@ -39,7 +40,6 @@ export class NumBinaryEditor extends HandlerBase implements Handler {
 				delete this.dom.density_div
 			}
 		}
-		this.q = this.getDefaultQ()
 		this.dom.density_div = div.append('div')
 		await this.handler.density.showViolin(this.dom.density_div)
 		await this.handler.density.setBinLines(this.getBoundaryOpts())

--- a/client/termsetting/handlers/NumBinaryEditor.ts
+++ b/client/termsetting/handlers/NumBinaryEditor.ts
@@ -29,6 +29,7 @@ export class NumBinaryEditor extends HandlerBase implements Handler {
 	}
 
 	async showEditMenu(div) {
+		this.tw = this.handler.tw as NumCustomBins
 		if (this.dom.density_div) {
 			if (this.handler.dom.editDiv?.node().contains(this.dom.density_div.node())) {
 				await this.handler.density.showViolin(this.dom.density_div, this.getBoundaryOpts())

--- a/client/termsetting/handlers/NumContEditor.ts
+++ b/client/termsetting/handlers/NumContEditor.ts
@@ -32,6 +32,8 @@ export class NumContEditor extends HandlerBase implements Handler {
 	}
 
 	async showEditMenu(div: any) {
+		this.tw = this.handler.tw as NumCont
+		this.q = this.setDefaultQ()
 		if (this.dom.inputsDiv) {
 			if (div.node().contains(this.dom.inputsDiv.node())) return
 			else delete this.dom.inputsDiv

--- a/client/termsetting/handlers/NumCustomBinEditor.ts
+++ b/client/termsetting/handlers/NumCustomBinEditor.ts
@@ -26,7 +26,8 @@ export class NumCustomBinEditor {
 	}
 
 	async render(div) {
-		if (this.q?.type != 'custom-bin') this.q = this.getDefaultQ()
+		this.tw = this.editHandler.tw as NumCustomBins
+		this.q = this.getDefaultQ()
 		await this.editHandler.handler.density.setBinLines(this.getBoundaryOpts())
 		if (this.dom.inputsDiv) {
 			if (this.editHandler.dom.binsDiv?.node().contains(this.dom.inputsDiv.node())) return

--- a/client/termsetting/handlers/NumRegularBinEditor.ts
+++ b/client/termsetting/handlers/NumRegularBinEditor.ts
@@ -28,7 +28,8 @@ export class NumRegularBinEditor {
 	}
 
 	render(div) {
-		if (this.q?.type != 'regular-bin') this.q = this.getDefaultQ()
+		this.tw = this.editHandler.tw as NumRegularBin
+		this.q = this.getDefaultQ()
 		this.editHandler.handler.density.setBinLines(this.getBoundaryOpts())
 		if (this.dom.binsTable) {
 			if (this.editHandler.dom.binsDiv?.node().contains(this.dom.binsTable.node())) return

--- a/client/termsetting/handlers/NumSplineEditor.ts
+++ b/client/termsetting/handlers/NumSplineEditor.ts
@@ -70,6 +70,7 @@ export class NumSplineEditor extends HandlerBase implements Handler {
 	}
 
 	async showEditMenu(div) {
+		this.tw = this.handler.tw as NumSpline
 		if (this.dom.density_div) {
 			if (this.handler.dom.editDiv?.node().contains(this.dom.density_div.node())) {
 				await this.handler.density.showViolin(this.dom.density_div, this.getBoundaryOpts())

--- a/client/termsetting/handlers/NumSplineEditor.ts
+++ b/client/termsetting/handlers/NumSplineEditor.ts
@@ -71,6 +71,7 @@ export class NumSplineEditor extends HandlerBase implements Handler {
 
 	async showEditMenu(div) {
 		this.tw = this.handler.tw as NumSpline
+		this.q = await this.getDefaultQ()
 		if (this.dom.density_div) {
 			if (this.handler.dom.editDiv?.node().contains(this.dom.density_div.node())) {
 				await this.handler.density.showViolin(this.dom.density_div, this.getBoundaryOpts())
@@ -80,7 +81,6 @@ export class NumSplineEditor extends HandlerBase implements Handler {
 				delete this.dom.density_div
 			}
 		}
-		this.q = await this.getDefaultQ()
 		this.dom.density_div = div.append('div')
 		await this.handler.density.showViolin(this.dom.density_div)
 		await this.handler.density.setBinLines(this.getBoundaryOpts())

--- a/client/termsetting/test/termsetting.integration.spec.js
+++ b/client/termsetting/test/termsetting.integration.spec.js
@@ -419,16 +419,12 @@ tape('Numerical term: fixed bins', async test => {
 	)
 
 	// test 'reset' button
+	const binSizeInputId = '[data-testid="sjpp-num-reg-bin-editor-size"]'
+	await tipLoc.shows(binSizeInputId).set('value', 9)
 	const reset_btn = await tipLoc.shows('[data-testid="sjpp_numeric_edit_reset"]').get(0)
 	reset_btn.click()
-	await sleep(50)
-	await opts.pillMenuClick('Edit')
-	test.deepEqual(
-		await tipLoc.shows('[data-testid="sjpp-num-reg-bin-editor-size"]').value(),
-		['3'],
-		'Should reset the bins by "Reset" button'
-	)
-	//if (test._ok) opts.pill.destroy()
+	test.deepEqual(await tipLoc.shows(binSizeInputId).value(), ['5'], 'Should reset the bins by "Reset" button')
+	if (test._ok) opts.pill.destroy()
 })
 
 tape('Numerical term: float custom bins', async test => {

--- a/client/test/Locator.ts
+++ b/client/test/Locator.ts
@@ -124,18 +124,32 @@ export class Locator {
 		throw `invalid Locator.get() argument='${arg}'`
 	}
 
-	// TODO: support .set(arg, value)???
+	// propName: string property name, can be dot-separated like 'style.padding'
+	// value: string, number, boolean, any valid value for the given property name
+	async set(propName, value) {
+		const keyChain = propName.split('.')
+		const lastKey = keyChain.pop()
+		const elems = await this.get()
+		for (const elem of elems) {
+			let obj = elem
+			for (const key of keyChain) obj = obj[key]
+			obj[lastKey] = value
+		}
+		return elems
+	}
 
 	/*** convenient aliased methods for .get(arg) ***/
 	async length() {
 		return await this.get('length')
 	}
 
-	async value() {
+	async value(val?: number | string | boolean) {
+		if (arguments.length) return await this.set('value', val)
 		return await this.get('.value')
 	}
 
-	async text() {
+	async text(str?: string) {
+		if (arguments.length) return await this.set('innerText', str)
 		return await this.get('.innerText')
 	}
 

--- a/client/test/Locator.ts
+++ b/client/test/Locator.ts
@@ -126,9 +126,11 @@ export class Locator {
 
 	// propName: string property name, can be dot-separated like 'style.padding'
 	// value: string, number, boolean, any valid value for the given property name
-	async set(propName, value) {
+	async set(propName: string, value: any) {
+		if (!propName) throw `invalid Locator.set() propName='${propName}'`
 		const keyChain = propName.split('.')
 		const lastKey = keyChain.pop()
+		if (!lastKey) throw `invalid Locator.set() propName='${propName}'`
 		const elems = await this.get()
 		for (const elem of elems) {
 			let obj = elem

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- avoid showing stale numeric edit input values by always resetting the referenced tw and q objects in a numeric edit handler instance


### PR DESCRIPTION
# Description

This branch always resets the referenced tw and q objects in a numeric edit handler instance before showing the edit menu, in order to avoid showing stale numeric edit inputs.

Fixes https://github.com/stjude/proteinpaint/pull/4554#issuecomment-4606314792.

Test:
- all unit and integration tests
- manually: [ASH TP53 survival](http://localhost:3000/?mass={%22dslabel%22:%22ASH%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22survival%22,%22term%22:{%22id%22:%22Overall_Survival%22},%22term2%22:{%22term%22:{%22type%22:%22geneExpression%22,%22gene%22:%22TP53%22}}}]}) -> Edit TP53 -> See correct boundary line in violin plot -> replace with HOXA1 -> Edit HOXA1 -> incorrect boundary line (same as that for TP53)

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
