### PR TITLE
Add config-driven disabling of filter, groups, and survival stratific…

### DIFF
--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -589,7 +589,6 @@ function setInteractivity(self) {
 	}
 
 	self.mouseout = () => {
-		self.dom.tip.hide()
 		const defaultActiveColor = self.state.termdbConfig.massNav?.activeColor || activeTabBgColor
 		self.dom.tds.style('background-color', t => (self.activeTab == t.colNum ? defaultActiveColor : 'transparent'))
 	}

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -402,6 +402,7 @@ function setRenderers(self) {
 			.style('color', '#aaa')
 			.style('opacity', d => (d.disabled ? 0.5 : 1))
 			.style('cursor', d => (d.disabled ? 'not-allowed' : 'pointer'))
+			.attr('title', d => d.disabledMessage || '')
 			.html(d => d.label)
 			.on('click', (event, d) => {
 				self.setTab(event, d)
@@ -576,13 +577,6 @@ function setInteractivity(self) {
 	}
 
 	self.mouseover = (event, d) => {
-		if (d.disabled && d.disabledMessage) {
-			self.dom.tip.clear()
-			self.dom.tip.d.append('div').text(d.disabledMessage)
-			self.dom.tip.showunder(event.target)
-		} else {
-			self.dom.tip.hide()
-		}
 		const defaultActiveColor = self.state.termdbConfig.massNav?.activeColor || activeTabBgColor
 		self.dom.tds.style('background-color', t => {
 			//light yellow for inactive tabs and grey-yellow for this active tab

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -549,8 +549,6 @@ function setInteractivity(self) {
 	self.setTab = async (event, d) => {
 		// a disabled tab is shown to advertise the capability but cannot be activated
 		if (d.disabled) return
-		//Reset the activeTab to the current tab if no tab is selected
-		if (self.activeTab == -1) self.activeTab == d.colNum
 		if (d.colNum === self.activeTab && !self.searching) {
 			// The about tab should not be hidden on double click with or without plots
 			if (self.activeTab == 0) return

--- a/client/mass/nav.js
+++ b/client/mass/nav.js
@@ -378,7 +378,15 @@ function setRenderers(self) {
 			.selectAll('td')
 			.data((key, i) =>
 				self.tabs.map((row, colNum) => {
-					return { rowNum: i, key, colNum, label: row[key], subheader: row.subheader }
+					return {
+						rowNum: i,
+						key,
+						colNum,
+						label: row[key],
+						subheader: row.subheader,
+						disabled: row.disabled,
+						disabledMessage: row.disabledMessage
+					}
 				})
 			)
 			.enter()
@@ -392,7 +400,8 @@ function setRenderers(self) {
 			.style('border-left', '1px solid #ccc')
 			.style('border-right', '1px solid #ccc')
 			.style('color', '#aaa')
-			.style('cursor', 'pointer')
+			.style('opacity', d => (d.disabled ? 0.5 : 1))
+			.style('cursor', d => (d.disabled ? 'not-allowed' : 'pointer'))
 			.html(d => d.label)
 			.on('click', (event, d) => {
 				self.setTab(event, d)
@@ -538,6 +547,8 @@ function setRenderers(self) {
 
 function setInteractivity(self) {
 	self.setTab = async (event, d) => {
+		// a disabled tab is shown to advertise the capability but cannot be activated
+		if (d.disabled) return
 		//Reset the activeTab to the current tab if no tab is selected
 		if (self.activeTab == -1) self.activeTab == d.colNum
 		if (d.colNum === self.activeTab && !self.searching) {
@@ -567,6 +578,13 @@ function setInteractivity(self) {
 	}
 
 	self.mouseover = (event, d) => {
+		if (d.disabled && d.disabledMessage) {
+			self.dom.tip.clear()
+			self.dom.tip.d.append('div').text(d.disabledMessage)
+			self.dom.tip.showunder(event.target)
+		} else {
+			self.dom.tip.hide()
+		}
 		const defaultActiveColor = self.state.termdbConfig.massNav?.activeColor || activeTabBgColor
 		self.dom.tds.style('background-color', t => {
 			//light yellow for inactive tabs and grey-yellow for this active tab
@@ -579,6 +597,7 @@ function setInteractivity(self) {
 	}
 
 	self.mouseout = () => {
+		self.dom.tip.hide()
 		const defaultActiveColor = self.state.termdbConfig.massNav?.activeColor || activeTabBgColor
 		self.dom.tds.style('background-color', t => (self.activeTab == t.colNum ? defaultActiveColor : 'transparent'))
 	}

--- a/client/mass/plot.js
+++ b/client/mass/plot.js
@@ -94,12 +94,22 @@ class MassPlot {
 			})
 		}
 
-		if (!this.state.config.hidePlotFilter)
+		if (!this.state.config.hidePlotFilter) {
+			const filterDisabledMsg = this.app.vocabApi.termdbConfig?.plotFilter?.disabledMessage
+			/*
+			When the local filter is disabled (e.g. for the public/unauthenticated view), render it
+			into an inner greyed, non-interactive div while the outer filterDiv keeps pointer events
+			so its tooltip explaining why still appears on hover.
+			*/
+			const filterHolder = filterDisabledMsg
+				? this.dom.filterDiv.append('div').style('pointer-events', 'none').style('opacity', 0.5)
+				: this.dom.filterDiv
+			if (filterDisabledMsg) this.dom.filterDiv.attr('title', filterDisabledMsg).style('cursor', 'not-allowed')
 			promises.filter = filterRxCompInit({
 				app: this.app,
 				vocabApi: this.app.vocabApi,
 				parentId: this.id,
-				holder: this.dom.filterDiv,
+				holder: filterHolder,
 				hideLabel: true,
 				emptyLabel: '+Add new filter',
 				callback: filter => {
@@ -110,6 +120,7 @@ class MassPlot {
 					})
 				}
 			})
+		}
 
 		this.components = await multiInit(promises)
 	}

--- a/client/plots/controls.config.js
+++ b/client/plots/controls.config.js
@@ -805,13 +805,31 @@ async function setTermInput(opts) {
 		}
 	}
 
+	/*
+	When disabled, the pill sits in a wrapper: the outer div carries the tooltip and "not-allowed"
+	cursor (and still receives hover events) while the inner div turns off pointer events and greys
+	out — a native title on the pill itself would not fire once its pointer-events are off. When not
+	disabled the pill holder is a plain div, leaving the common-case DOM unchanged.
+	*/
+	if (opts.disabledMessage) {
+		self.dom.pillDiv = self.dom.inputTd
+			.append('div')
+			.attr('title', opts.disabledMessage)
+			.style('cursor', 'not-allowed')
+			.append('div')
+			.style('pointer-events', 'none')
+			.style('opacity', 0.5)
+	} else {
+		self.dom.pillDiv = self.dom.inputTd.append('div')
+	}
+
 	const pill = await termsettingInit({
 		menuOptions: opts.menuOptions || '*',
 		numericEditMenuVersion: opts.numericEditMenuVersion || ['continuous', 'discrete'],
 		vocabApi: opts.vocabApi || opts.app.vocabApi,
 		vocab: opts.state?.vocab,
 		activeCohort: opts.state?.activeCohort,
-		holder: self.dom.inputTd.append('div'),
+		holder: self.dom.pillDiv,
 		debug: opts.debug,
 		usecase: opts.usecase,
 		disable_terms: opts.disable_terms,

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -155,6 +155,8 @@ class TdbSurvival extends PlotBase implements RxComponent {
 		const state = this.getState(this.app.getState())
 		const controlLabels = state.config.controlLabels
 		if (!controlLabels) throw 'controls labels not found'
+		// public/unauthenticated views disable stratification to limit inference from aggregated data; admin/user are unaffected
+		const stratDisabledMsg = this.app.vocabApi.termdbConfig?.survival?.stratificationDisabledMessage
 		if (this.opts.controls) {
 			this.opts.controls.on('downloadClick.survival', this.download)
 		} else {
@@ -175,7 +177,8 @@ class TdbSurvival extends PlotBase implements RxComponent {
 							label: controlLabels.term2.label,
 							vocabApi: this.app.vocabApi,
 							numericEditMenuVersion: ['discrete'],
-							defaultQ4fillTW: t0_t2_defaultQ
+							defaultQ4fillTW: t0_t2_defaultQ,
+							disabledMessage: stratDisabledMsg
 						},
 						{
 							type: 'term',
@@ -186,7 +189,8 @@ class TdbSurvival extends PlotBase implements RxComponent {
 							label: controlLabels.term0.label,
 							vocabApi: this.app.vocabApi,
 							numericEditMenuVersion: ['discrete'],
-							defaultQ4fillTW: t0_t2_defaultQ
+							defaultQ4fillTW: t0_t2_defaultQ,
+							disabledMessage: stratDisabledMsg
 						},
 						{
 							label: 'Chart width',

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -43,6 +43,16 @@ export async function get_survival(q, ds) {
 		const ot = q[`term${survTermIndex == 1 ? 2 : 1}`]
 		// dt: divideBy term, the chart term
 		const dt = q.term0
+
+		/*
+		Some datasets restrict stratification for unauthenticated/aggregate views to limit
+		inference from small subgroups. When the dataset opts in, reject any request that
+		carries a divide-by or overlay term so the restriction holds even if a client bypasses
+		the disabled UI controls. Datasets without the hook are unaffected.
+		*/
+		if ((dt || ot) && ds.cohort.termdb.restrictSurvivalStratification?.(q.__protected__)) {
+			throw 'Survival stratification (divide-by and overlay) requires an authenticated login, please email to Registry@stjude.org'
+		}
 		const data = await getData(
 			{
 				terms: twLst,

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -50,8 +50,15 @@ export async function get_survival(q, ds) {
 		carries a divide-by or overlay term so the restriction holds even if a client bypasses
 		the disabled UI controls. Datasets without the hook are unaffected.
 		*/
-		if ((dt || ot) && ds.cohort.termdb.restrictSurvivalStratification?.(q.__protected__)) {
-			throw 'Survival stratification (divide-by and overlay) requires an authenticated login, please email to Registry@stjude.org'
+		if (dt || ot) {
+			// the hook returns the dataset's own rejection message (so the server reason matches the
+			// UI tooltip on the disabled controls), or just `true` to reject with a generic message
+			const restrict = ds.cohort.termdb.restrictSurvivalStratification?.(q.__protected__)
+			if (restrict) {
+				throw typeof restrict == 'string'
+					? restrict
+					: 'Survival stratification (divide-by and overlay) is not available for this view'
+			}
 		}
 		const data = await getData(
 			{

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1756,12 +1756,15 @@ keep this setting here for reason of:
 	 * - Skipped when undefined. */
 	pruneTermdbConfig?: (c: any, q: any, ds: any) => void
 	hiddenIds?: string[]
-	/* (server-side) when this returns true, a survival request carrying a stratification term
-	(term0 divide-by, or an overlay/series term2) is rejected. Pairs with the client-side
-	termdbConfig.survival.stratificationDisabledMessage flag to enforce the same policy server-side
-	against crafted requests. First arg is the request's __protected__ payload (same shape
-	isTermVisible/getAdditionalFilter receive). Skipped when undefined. */
-	restrictSurvivalStratification?: (__protected__: any) => boolean
+	/* (server-side) when this returns a truthy value, a survival request carrying a stratification
+	term (term0 divide-by, or an overlay/series term2) is rejected. Return a non-empty string to use
+	it as the rejection message (let the dataset reuse the same wording it shows on the disabled UI
+	controls, e.g. termdbConfig.survival.stratificationDisabledMessage), or `true` to reject with a
+	generic, dataset-agnostic message. Returning falsy allows the request. Keeping the message on the
+	return value (rather than hard-coded in the server) lets other datasets reuse the hook without
+	inheriting an unrelated contact instruction. First arg is the request's __protected__ payload
+	(same shape isTermVisible/getAdditionalFilter receive). Skipped when undefined. */
+	restrictSurvivalStratification?: (__protected__: any) => boolean | string
 	getAdditionalFilter?: (__protected__: any, term: any) => Filter | undefined
 	/** Populated by server_init_db_queries from the term2role sidecar table when it is non-empty.
 	 * Map keys are role names; values are the Set of term IDs visible to that role. Undefined when

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1440,6 +1440,8 @@ type NumericDictTermClusterPlotsEntry = {
 type Survival = {
 	/** default settings for survival plot */
 	settings?: SurvivalSettings
+	/** when set, disable (grey out) the term0/term2 stratification controls with this tooltip; used to restrict the public/unauthenticated view */
+	stratificationDisabledMessage?: string
 }
 
 type Regression = {
@@ -1586,6 +1588,9 @@ keep this setting here for reason of:
 	numericDictTermCluster?: NumericDictTermCluster
 	survival?: Survival
 	regression?: Regression
+	/** when set, the per-plot local filter in every mass plot header is rendered disabled (greyed,
+	 * non-interactive) with this tooltip; used to restrict the public/unauthenticated view */
+	plotFilter?: { disabledMessage?: string }
 	logscaleBase2?: boolean
 	plotConfigByCohort?: PlotConfigByCohort
 	/** Functionality */
@@ -1751,6 +1756,12 @@ keep this setting here for reason of:
 	 * - Skipped when undefined. */
 	pruneTermdbConfig?: (c: any, q: any, ds: any) => void
 	hiddenIds?: string[]
+	/* (server-side) when this returns true, a survival request carrying a stratification term
+	(term0 divide-by, or an overlay/series term2) is rejected. Pairs with the client-side
+	termdbConfig.survival.stratificationDisabledMessage flag to enforce the same policy server-side
+	against crafted requests. First arg is the request's __protected__ payload (same shape
+	isTermVisible/getAdditionalFilter receive). Skipped when undefined. */
+	restrictSurvivalStratification?: (__protected__: any) => boolean
 	getAdditionalFilter?: (__protected__: any, term: any) => Filter | undefined
 	/** Populated by server_init_db_queries from the term2role sidecar table when it is non-empty.
 	 * Map keys are role names; values are the Set of term IDs visible to that role. Undefined when
@@ -1982,6 +1993,10 @@ type MassNavTabEntry = {
 	btm?: string
 	/** if true, does not show the tab */
 	hide?: boolean
+	/** if true, render the tab as disabled (visible but non-clickable) instead of active */
+	disabled?: boolean
+	/** tooltip shown on hover when the tab is disabled */
+	disabledMessage?: string
 }
 
 type MassNavAboutTabEntry = MassNavTabEntry & {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1440,8 +1440,6 @@ type NumericDictTermClusterPlotsEntry = {
 type Survival = {
 	/** default settings for survival plot */
 	settings?: SurvivalSettings
-	/** when set, disable (grey out) the term0/term2 stratification controls with this tooltip; used to restrict the public/unauthenticated view */
-	stratificationDisabledMessage?: string
 }
 
 type Regression = {
@@ -1588,9 +1586,6 @@ keep this setting here for reason of:
 	numericDictTermCluster?: NumericDictTermCluster
 	survival?: Survival
 	regression?: Regression
-	/** when set, the per-plot local filter in every mass plot header is rendered disabled (greyed,
-	 * non-interactive) with this tooltip; used to restrict the public/unauthenticated view */
-	plotFilter?: { disabledMessage?: string }
 	logscaleBase2?: boolean
 	plotConfigByCohort?: PlotConfigByCohort
 	/** Functionality */
@@ -1996,10 +1991,6 @@ type MassNavTabEntry = {
 	btm?: string
 	/** if true, does not show the tab */
 	hide?: boolean
-	/** if true, render the tab as disabled (visible but non-clickable) instead of active */
-	disabled?: boolean
-	/** tooltip shown on hover when the tab is disabled */
-	disabledMessage?: string
 }
 
 type MassNavAboutTabEntry = MassNavTabEntry & {


### PR DESCRIPTION
This pull request introduces UI and server-side changes to support disabling certain interactive features for public or unauthenticated users, with explanatory tooltips and enforced restrictions. The main focus is on making navigation tabs, plot filters, and survival plot stratification controls visibly disabled (greyed out, non-interactive) when restricted, and ensuring server-side enforcement for survival stratification.

**UI/UX improvements for disabled features:**

* Navigation tabs (`client/mass/nav.js`) now support a disabled state with a tooltip message, greying out the tab, changing the cursor, and preventing interaction. Tooltips are shown on hover for disabled tabs. 
* Mass plot filters (`client/mass/plot.js`) can be rendered disabled with a tooltip explaining why, by wrapping the filter in a non-interactive, greyed-out div when restricted. 
* Term input controls (e.g., survival stratification) (`client/plots/controls.config.js`, `client/plots/survival/survival.ts`) are rendered disabled with a tooltip and greyed out when restricted, using the new `disabledMessage` prop. 

**Server-side enforcement:**

* Survival stratification requests (`server/src/termdb.survival.js`) are now rejected server-side for datasets that opt in, preventing unauthorized access even if the client UI is bypassed. This is controlled by a new dataset hook. 

**Type updates:**

* The shared dataset type definitions (`shared/types/src/dataset.ts`) are extended to support the new disabled states and messages for tabs, plot filters, and survival stratification controls. 

These changes improve the user experience by clearly communicating feature restrictions and ensure that critical access controls are enforced on both the client and server sides.…ation controls

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
