### PR TITLE
stop mds3 init retry if any validation step fails

### DIFF
--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -88,7 +88,7 @@ async function mayRefreshCache(ds) {
 		clearMemFetchDataCache()
 
 		// on first call, ds.__gdc.doneCaching will be false as expected,
-		// and `gdcBuildDictionary(ds)` would have been called once in mds3.init.js within validated_termdb(),
+		// and `gdcBuildDictionary(ds)` would have been called once in mds3.init.js within validate_termdb(),
 		// so no need to repeat `gdcBuildDictionary(ds)` on the first call;
 		// rebuild the dictionary only after the initial cache and subsequent calls to mayRefreshCache()
 		if (ds.__gdc?.doneCaching) await gdcBuildDictionary(ds)

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -88,7 +88,7 @@ async function mayRefreshCache(ds) {
 		clearMemFetchDataCache()
 
 		// on first call, ds.__gdc.doneCaching will be false as expected,
-		// and `gdcBuildDictionary(ds)` would have been called once in mds3.init.js,
+		// and `gdcBuildDictionary(ds)` would have been called once in mds3.init.js within validated_termdb(),
 		// so no need to repeat `gdcBuildDictionary(ds)` on the first call;
 		// rebuild the dictionary only after the initial cache and subsequent calls to mayRefreshCache()
 		if (ds.__gdc?.doneCaching) await gdcBuildDictionary(ds)

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -472,7 +472,7 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 				// no error bubbled up to be caught, and there are no nonblocking step being performed, init is done
 				if (ds.init.status == 'started') ds.init.status = 'done'
 			} catch (e) {
-				mayRetryInit(g, ds, d, e)
+				mayRetryInit(g, ds, d, e, totalRawDsLst)
 			}
 		}
 		delete g.rawdslst
@@ -480,7 +480,7 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 	return trackedDatasets
 }
 
-function mayRetryInit(g, ds, d, e) {
+function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 	// if initial attempt fails, can stop or retry
 	const gdlabel = `${g.label}/${ds.label}`
 	console.log(`Init error with ${gdlabel}`)
@@ -544,7 +544,8 @@ function mayRetryInit(g, ds, d, e) {
 			if (!ds.init.status) ds.init.status = 'done'
 		} catch (e) {
 			if (ds.init.status != 'recoverableError' && !ds.init.recoverableError && !utils.isRecoverableError(e)) {
-				const msg = `Fatal error on ${gdlabel} retry, stopping retry`
+				const msg =
+					`Fatal error on ${gdlabel} retry, stopping retry` + (ds.init?.fatalError ? ': ' + ds.init?.fatalError : '')
 				console.log(msg)
 				clearInterval(interval) // cancel since retrying will not change the outcome
 				ds.init.status = 'fatalError'
@@ -555,6 +556,8 @@ function mayRetryInit(g, ds, d, e) {
 						path.join(serverconfig.cachedir, '/slack/last_message_hash.txt')
 					)
 				}
+				// this will crash the server with an uncaught error, the server will stop responding to HTTP requests
+				if (totalRawDsLst === 1) throw msg
 			} else {
 				console.warn(
 					`${gdlabel} init() failed. Retrying in ${Math.round(ds.init.retryDelay / 1000)} second(s) ... (${

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -536,7 +536,7 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 		ds.init.currentRetry = currentRetry
 		try {
 			console.log(`Retrying ${gdlabel} init(), attempt #${currentRetry} ...`)
-			if (ds.isMds3) await mds3_init.init(ds, g)
+			if (ds.isMds3) await mds3_init.init(ds, g, totalRawDsLst)
 			else if (ds.isMds) await mds_init(ds, g, d)
 			else initLegacyDataset(ds, g, serverconfig)
 			// as long as no error bubbles up to here, the retry is considered successful
@@ -557,7 +557,10 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 					)
 				}
 				// this will crash the server with an uncaught error, the server will stop responding to HTTP requests
-				if (totalRawDsLst === 1) throw msg
+				if (totalRawDsLst === 1)
+					setImmediate(() => {
+						throw new Error(msg)
+					})
 			} else {
 				console.warn(
 					`${gdlabel} init() failed. Retrying in ${Math.round(ds.init.retryDelay / 1000)} second(s) ... (${

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -158,60 +158,70 @@ export async function init(ds, genome, totalDsLst = 0) {
 		if (response?.status != 'OK') throw response
 	}
 
-	// must validate termdb first
-	await validate_termdb(ds)
-	validateDemoJwtInputs(ds)
+	try {
+		// must validate termdb first
+		await validate_termdb(ds)
+		validateDemoJwtInputs(ds)
 
-	if (ds.queries) {
-		// must validate snvindel query before variant2sample
-		// as vcf header must be parsed to supply samples for variant2samples
-		await validate_query_snvindel(ds, genome)
-		await validate_query_svfusion(ds, genome)
-		await validate_query_geneCnv(ds, genome)
-		await validate_query_cnv(ds, genome)
-		await validate_query_ld(ds, genome)
-		await validate_query_geneExpression(ds, genome)
-		await validateQueryIsoformExpression(ds, genome)
-		await validate_query_ssGSEA(ds, genome)
-		await validate_query_dnaMethylation(ds, genome)
-		await validate_query_metaboliteIntensity(ds, genome)
-		await validate_query_proteome(ds, genome)
-		await validate_query_getTopTermsByType(ds, genome)
-		await validate_query_getTopMutatedGenes(ds, genome)
-		await validate_query_getSampleImages(ds, genome)
-		await validate_query_getWSIAnnotations(ds)
-		await validate_query_getWSIClassesQuery(ds)
-		await validate_query_getSampleWSImages(ds, genome)
-		await validate_query_deleteWSIAnnotation(ds)
-		await validate_query_saveWSIAnnotation(ds)
-		await validate_query_getWSISamples(ds, genome)
-		await makeAdHocDicTermdbQueries(ds)
-		await validate_query_rnaseqGeneCount(ds, genome)
-		await validate_query_singleSampleMutation(ds, genome)
-		await validate_query_singleSampleGenomeQuantification(ds, genome)
-		await validate_query_singleSampleGbtk(ds, genome)
-		//await validate_query_probe2cnv(ds, genome)
-		await validate_query_singleCell(ds, genome)
-		await validate_query_TopVariablyExpressedGenes(ds)
-		await validate_query_trackLst(ds, genome)
+		if (ds.queries) {
+			// must validate snvindel query before variant2sample
+			// as vcf header must be parsed to supply samples for variant2samples
+			await validate_query_snvindel(ds, genome)
+			await validate_query_svfusion(ds, genome)
+			await validate_query_geneCnv(ds, genome)
+			await validate_query_cnv(ds, genome)
+			await validate_query_ld(ds, genome)
+			await validate_query_geneExpression(ds, genome)
+			await validateQueryIsoformExpression(ds, genome)
+			await validate_query_ssGSEA(ds, genome)
+			await validate_query_dnaMethylation(ds, genome)
+			await validate_query_metaboliteIntensity(ds, genome)
+			await validate_query_proteome(ds, genome)
+			await validate_query_getTopTermsByType(ds, genome)
+			await validate_query_getTopMutatedGenes(ds, genome)
+			await validate_query_getSampleImages(ds, genome)
+			await validate_query_getWSIAnnotations(ds)
+			await validate_query_getWSIClassesQuery(ds)
+			await validate_query_getSampleWSImages(ds, genome)
+			await validate_query_deleteWSIAnnotation(ds)
+			await validate_query_saveWSIAnnotation(ds)
+			await validate_query_getWSISamples(ds, genome)
+			await makeAdHocDicTermdbQueries(ds)
+			await validate_query_rnaseqGeneCount(ds, genome)
+			await validate_query_singleSampleMutation(ds, genome)
+			await validate_query_singleSampleGenomeQuantification(ds, genome)
+			await validate_query_singleSampleGbtk(ds, genome)
+			//await validate_query_probe2cnv(ds, genome)
+			await validate_query_singleCell(ds, genome)
+			await validate_query_TopVariablyExpressedGenes(ds)
+			await validate_query_trackLst(ds, genome)
 
-		await validate_variant2samples(ds)
-		await validate_ssm2canonicalisoform(ds)
+			await validate_variant2samples(ds)
+			await validate_ssm2canonicalisoform(ds)
 
-		await mayAdd_refseq2ensembl(ds, genome)
+			await mayAdd_refseq2ensembl(ds, genome)
 
-		await mayAdd_mayGetGeneVariantData(ds, genome)
+			await mayAdd_mayGetGeneVariantData(ds, genome)
+		}
+
+		await mayValidateAssayAvailability(ds)
+		await mayValidateViewModes(ds)
+
+		// uncomment below to manually trigger server crash if there is only 1 dataset;
+		// make sure that serverconfig only has one genome and datasets[] entry,
+		// and that the ds.label below matches that entry
+		// if (ds.label == 'GDC') {ds.init = {status: 'fatalError', fatalError: 'test server crash'}; throw ds.init.fatalError}
+
+		if (ds.cohort?.db?.refresh) throw `!!! ds.cohort.db.refresh has been deprecated !!!`
+	} catch (e) {
+		if (!ds.init) ds.init = {}
+		if (ds.init.step != 'gdcBuildDictionary()') {
+			delete ds.init.recoverableError
+			ds.init.fatalError = e.error || e
+			ds.init.status = 'fatalError'
+		}
+		throw e
 	}
-
-	await mayValidateAssayAvailability(ds)
-	await mayValidateViewModes(ds)
-
-	// uncomment below to manually trigger server crash if there is only 1 dataset;
-	// make sure that serverconfig only has one genome and datasets[] entry,
-	// and that the ds.label below matches that entry
-	// if (ds.label == 'GDC') {ds.init = {status: 'fatalError', fatalError: 'test server crash'}; throw ds.init.fatalError}
-
-	if (ds.cohort?.db?.refresh) throw `!!! ds.cohort.db.refresh has been deprecated !!!`
 
 	// invoke non-blocking initialization steps at the end, after validation is complete,
 	// otherwise it will be difficult to coordinate the handling of errors from either
@@ -220,7 +230,7 @@ export async function init(ds, genome, totalDsLst = 0) {
 	if (ds.init?.hasNonblockingSteps) {
 		// if only one dataset is being loaded by the server,
 		// then await to allow server to crash on fatal error
-		if (totalDsLst > 1) await mds3InitNonblocking(ds)
+		if (totalDsLst == 1) await mds3InitNonblocking(ds)
 		else mds3InitNonblocking(ds)
 	} else {
 		if (!ds.init) ds.init = {}
@@ -300,7 +310,10 @@ export async function validate_termdb(ds) {
 		if (typeof tdb.dictionary.build != 'function') throw 'termdb.dictionary.build() is not a function'
 		await tdb.dictionary.build(ds)
 	} else if (tdb.dictionary?.gdcapi) {
+		if (!ds.init) ds.init = {}
+		ds.init.step = 'gdcBuildDictionary()'
 		await gdcBuildDictionary(ds)
+		ds.init.step = ''
 	} else if (ds.cohort.db) {
 		if (!ds.cohort.db.file && !ds.cohort.db.file_fullpath) throw 'ds.cohort.db.file missing'
 		server_init_db_queries(ds)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -215,7 +215,7 @@ export async function init(ds, genome, totalDsLst = 0) {
 		if (ds.cohort?.db?.refresh) throw `!!! ds.cohort.db.refresh has been deprecated !!!`
 	} catch (e) {
 		if (!ds.init) ds.init = {}
-		if (ds.init.step != 'gdcBuildDictionary()') {
+		if (ds.init.step != 'gdcBuildDictionary()' || !ds.init.recoverableError) {
 			delete ds.init.recoverableError
 			ds.init.fatalError = e.error || e
 			ds.init.status = 'fatalError'


### PR DESCRIPTION
 # Description

.... except for known recoverable errors (like dictionary build/cache), and crash the server if there is only 1 dataset entry.

To test manually:
- pull `sjpp/master`
- disable all dataset entries in serverconfig.json except GDC
- change `demographic.sex_at_birth` to `demographic.sex_at_birth-000` or similar
- the server restart should crash (no log for `standby at port 3000`): in non-watch/prod process, this will immediately crash the server
- revert the change: the server should restart as expected
- if another dataset like TermdbTest is enabled, the server should not crash with the `sex_at_birth` edit, there should be a `failed dataset init` log and the server should still listen on port 3000

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
