### PR TITLE
Replace `termdb.getSamples()` with `termdb.filterSamples()`. Assign sample type config to controlLabels in barchart.

### DIFF
--- a/client/plots/barchart.js
+++ b/client/plots/barchart.js
@@ -333,6 +333,20 @@ export class Barchart extends PlotBase {
 		}
 	}
 
+	setSampleType(sampleType) {
+		if (!sampleType) return
+		const keys = Object.keys(sampleType)
+		if (!keys.includes('name') || !keys.includes('plural_name')) return
+		this.sampleType = sampleType
+		// override control labels with sample type metadata
+		Object.assign(this.config.controlLabels, {
+			sample: sampleType.name,
+			samples: sampleType.plural_name,
+			Sample: sampleType.name.charAt(0).toUpperCase() + sampleType.name.slice(1),
+			Samples: sampleType.plural_name.charAt(0).toUpperCase() + sampleType.plural_name.slice(1)
+		})
+	}
+
 	reactsTo(action) {
 		if (action.type.startsWith('plot_')) {
 			return (
@@ -391,7 +405,7 @@ export class Barchart extends PlotBase {
 			if (results.error) throw results
 			const data = results.data
 			this.charts = data.charts
-			this.sampleType = results.sampleType
+			this.setSampleType(results.sampleType)
 			this.bins = results.bins
 			if (results.chartid2dtterm) this.chartid2dtterm = results.chartid2dtterm
 			this.app.vocabApi.syncTermData(this.config, data, this.prevConfig)

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -26,6 +26,7 @@ const dsHelpers = {
 	ezFetch,
 	xfetch: utils.xfetch,
 	cachedFetch: utils.cachedFetch,
+	filterByItem: mds3_init.filterByItem,
 	mayLog,
 	createSelectionID,
 	SelectionPrefixes,

--- a/server/src/mds3.filter.js
+++ b/server/src/mds3.filter.js
@@ -46,7 +46,7 @@ export async function mayLimitSamples(param, _allSamples, ds) {
 		)
 	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
 		// ds-supplied filter method
-		filterSamples = await ds.cohort.termdb.filterSamples({ filter, filter0, ds })
+		filterSamples = await ds.cohort.termdb.filterSamples(param, ds)
 	} else {
 		throw new Error('no method available to get samples')
 	}

--- a/server/src/mds3.filter.js
+++ b/server/src/mds3.filter.js
@@ -44,16 +44,16 @@ export async function mayLimitSamples(param, _allSamples, ds) {
 		filterSamples = new Set(
 			(await get_samples({ filter, mapParent2Children: param.mapParent2Children }, ds)).map(i => i.id)
 		)
-	} else if (typeof ds.cohort?.termdb?.getSamples === 'function') {
-		// dataset supplies getSamples() function
-		if (!filter && !filter0) {
-			// no filtering, use all samples
-			return
-		}
-		// get samples that match filter/filter0
-		filterSamples = await ds.cohort.termdb.getSamples({ filter, filter0, ds })
+	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
+		// ds-supplied filter method
+		filterSamples = await ds.cohort.termdb.filterSamples({ filter, filter0, ds })
 	} else {
 		throw new Error('no method available to get samples')
+	}
+
+	if (!filterSamples) {
+		// no filtering performed, use all samples
+		return
 	}
 
 	// filterSamples is the set of samples in dataset that match filter/filter0

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -410,7 +410,7 @@ export async function validate_termdb(ds) {
 
 	// minimum empty holder required for all datasets (later gdc should populate it)
 	// k: sampleid, v: type of that sample
-	ds.sampleId2Type = new Map()
+	if (!ds.sampleId2Type) ds.sampleId2Type = new Map()
 
 	if (ds.cohort?.db?.connection) {
 		// gdc does not use db connection

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -3313,7 +3313,15 @@ async function filterSamples4assayAvailability(q, ds) {
 		return null
 	}
 	// not gdc
-	return q.filter && q.filter.lst.length ? new Set((await get_samples(q, ds)).map(i => i.id)) : null
+	if (ds.cohort?.db) {
+		// sql-based dataset
+		if (q.filter && q.filter.lst.length) {
+			return new Set((await get_samples(q, ds)).map(i => i.id))
+		}
+	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
+		// ds-supplied filter method
+		return await ds.cohort.termdb.filterSamples(q, ds)
+	}
 }
 
 function addDataAvailability(sid, sample2mlst, dtKey, c, origin, sampleFilter, gene) {

--- a/server/src/termdb.get_matrix.js
+++ b/server/src/termdb.get_matrix.js
@@ -76,7 +76,7 @@ export async function get_matrix(q, req, res, ds, genome) {
 			? ds.cohort.termdb.disableAssayAvailability(req.path, q)
 			: false
 
-	const data = await getData(q, ds, true) // FIXME hardcoded to true
+	const data = await getData(q, ds)
 	if (data.error) {
 		if (String(data.error).includes('operation was aborted')) console.log(`(!) abort error`)
 		else console.trace(data)

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -144,7 +144,7 @@ async function getSampleList(req, q, ds) {
 		samples = await termdbsql.get_samples(q, ds, canDisplay)
 	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
 		// dataset supplied method
-		const temp = await ds.cohort.termdb.filterSamples({ filter: q.filter, filter0: q.filter0, ds })
+		const temp = await ds.cohort.termdb.filterSamples(q, ds)
 		samples = [...temp]
 	} else {
 		throw new Error('no method available to get sample list')

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -142,9 +142,9 @@ async function getSampleList(req, q, ds) {
 	if (ds.cohort?.db) {
 		// dataset is sqlite-based
 		samples = await termdbsql.get_samples(q, ds, canDisplay)
-	} else if (typeof ds.cohort?.termdb?.getSamples === 'function') {
-		// dataset has getSamples() method
-		const temp = await ds.cohort.termdb.getSamples({ filter: q.filter, filter0: q.filter0, ds })
+	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
+		// dataset supplied method
+		const temp = await ds.cohort.termdb.filterSamples({ filter: q.filter, filter0: q.filter0, ds })
 		samples = [...temp]
 	} else {
 		throw new Error('no method available to get sample list')

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -145,7 +145,11 @@ async function getSampleList(req, q, ds) {
 	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
 		// dataset supplied method
 		const temp = await ds.cohort.termdb.filterSamples(q, ds)
-		samples = [...temp]
+		if (temp) {
+			samples = [...temp].map(sid => {
+				return { id: sid }
+			})
+		}
 	} else {
 		throw new Error('no method available to get sample list')
 	}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -661,9 +661,11 @@ export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {
 function getSampleTypes(q, ds) {
 	const twLst = q.terms ? q.terms : q.tw ? [q.tw] : []
 	const filter = q.filter
+	const filter0 = q.filter0
 	const twTypes = getTwSampleTypes(twLst, ds)
 	const filterTypes = getFilterSampleTypes(filter, ds)
-	const types = new Set([...twTypes, ...filterTypes])
+	const filter0Types = ds.getFilter0SampleTypes ? ds.getFilter0SampleTypes(filter0, ds) : new Set()
+	const types = new Set([...twTypes, ...filterTypes, ...filter0Types])
 	return types
 }
 

--- a/server/src/termdb.survival.js
+++ b/server/src/termdb.survival.js
@@ -68,8 +68,7 @@ export async function get_survival(q, ds) {
 				__protected__: q.__protected__,
 				__abortSignal: q.__abortSignal
 			},
-			ds,
-			ifIsOnlyChildren(q, st, ot, ds)
+			ds
 		)
 		if (data.error) throw data.error
 		const results = getSampleArray(data, st)
@@ -184,16 +183,6 @@ export async function get_survival(q, ds) {
 		if (e.stack) console.log(e.stack)
 		return { error: e.message || e }
 	}
-}
-
-function ifIsOnlyChildren(q, st, ot, ds) {
-	const types = new Set()
-	const ids = [st.id]
-	if (ot) ids.push(ot.id)
-	if (q.term0) ids.push(q.term0.id)
-	for (const id of ids) types.add(ds.cohort.termdb.term2SampleType.get(id))
-	// true if there are multiple sample types, false if there is a single sample type
-	return types.size > 1
 }
 
 function getSurvTermIndex(q) {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1538,7 +1538,7 @@ if missing, name is value of m[url.namekey], as used in url itself (e.g. snp rsi
 	linkText?: string
 }
 
-export type GetSamplesOpts = {
+export type FilterSamplesOpts = {
 	filter: any // pp filter
 	filter0: any // mmrf filter
 	ds: any
@@ -1575,8 +1575,8 @@ export type Termdb = {
 	}
 	/** if true, backend is allowed to send sample names to client in charts */
 	displaySampleIds?: (clientAuthResult: any) => boolean
-	/** get samples that match supplied filter */
-	getSamples?: (opts: GetSamplesOpts) => Promise<Set<any>>
+	/** filter samples based on supplied filter(s) */
+	filterSamples?: (opts: FilterSamplesOpts) => Promise<Set<any>>
 	converSampleIds?: boolean
 	alwaysShowBranchTerms?: boolean
 	minimumSampleAllowed4filter?: number

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1570,7 +1570,7 @@ export type Termdb = {
 	/** if true, backend is allowed to send sample names to client in charts */
 	displaySampleIds?: (clientAuthResult: any) => boolean
 	/** filter samples by supplied filter(s) */
-	filterSamples?: (q: any, ds: any) => Promise<Set<any>>
+	filterSamples?: (q: any, ds: any) => Promise<Set<any> | undefined>
 	converSampleIds?: boolean
 	alwaysShowBranchTerms?: boolean
 	minimumSampleAllowed4filter?: number

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -2175,6 +2175,7 @@ export type Mds3 = BaseMds & {
 	// TODO FIXME nest termdb under cohort
 	termdb?: Termdb
 	validate_filter0?: (f: any) => void
+	getFilter0SampleTypes?: (filter: any, ds: any) => void
 	ssm2canonicalisoform?: GdcApi
 	variant2samples?: Variant2Samples
 	scatterplots?: Scatterplots

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1538,12 +1538,6 @@ if missing, name is value of m[url.namekey], as used in url itself (e.g. snp rsi
 	linkText?: string
 }
 
-export type FilterSamplesOpts = {
-	filter: any // pp filter
-	filter0: any // mmrf filter
-	ds: any
-}
-
 /*** type of ds.cohort.termdb{} ***/
 export type Termdb = {
 	/** Terms */
@@ -1575,8 +1569,8 @@ export type Termdb = {
 	}
 	/** if true, backend is allowed to send sample names to client in charts */
 	displaySampleIds?: (clientAuthResult: any) => boolean
-	/** filter samples based on supplied filter(s) */
-	filterSamples?: (opts: FilterSamplesOpts) => Promise<Set<any>>
+	/** filter samples by supplied filter(s) */
+	filterSamples?: (q: any, ds: any) => Promise<Set<any>>
 	converSampleIds?: boolean
 	alwaysShowBranchTerms?: boolean
 	minimumSampleAllowed4filter?: number


### PR DESCRIPTION
# Description

Supports sjpp PR: https://github.com/stjude/sjpp/pull/1369

- Replace `termdb.getSamples()` with `termdb.filterSamples()`
- Override controlLabels in barchart with sample type config. Allows the labels of the barchart to match the sample type of the returned data (e.g. the label `cases` will be used instead of `samples` if the sample type of the returned data is at case-level).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
