### PR TITLE
handling chart buttons during fetch and rendering charts

### DIFF
--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -28,11 +28,15 @@ class MassCharts {
 	// TODO later add reactsTo() to react to filter change
 
 	getState(appState) {
+		// chartType of the most recently opened profile plot (profile plots stack, so the last
+		// profile entry in plots[] is the newest); only this chart's nav button is disabled
+		const profilePlots = (appState.plots || []).filter(p => p.chartType?.startsWith('profile'))
 		const state = {
 			vocab: appState.vocab, // TODO delete it as vocabApi should be used instead
 			activeCohort: appState.activeCohort,
 			termfilter: appState.termfilter,
 			currentCohortChartTypes: getCurrentCohortChartTypes(appState),
+			latestProfileChartType: profilePlots.length ? profilePlots[profilePlots.length - 1].chartType : undefined,
 			termdbConfig: appState.termdbConfig
 		}
 		if (appState?.termfilter?.filter) {
@@ -42,7 +46,12 @@ class MassCharts {
 	}
 
 	main() {
-		this.dom.btns.style('display', d => (this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
+		this.dom.btns
+			.style('display', d => (this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
+			// disable only the nav button of the most recently opened profile chart, so the user
+			// can see which profile chart they last opened. Profile charts still stack one below
+			// the other; previously opened charts' buttons are re-enabled.
+			.property('disabled', d => d.chartType === this.state.latestProfileChartType)
 	}
 
 	getBtnLabel_dict(state) {
@@ -442,6 +451,7 @@ function setRenderers(self) {
 			.data(chartTypeList)
 			.enter()
 			.append('button')
+			.attr('class', 'sjpp-chart-btn')
 			.attr('data-testid', d => `sjpp-chart-btn-${d.label.toLowerCase().replace(/\s/g, '-')}`)
 			.style('margin', '10px')
 			.style('padding', '10px 15px')
@@ -450,7 +460,7 @@ function setRenderers(self) {
 			.html(d => d.label)
 			.on('click', function (event, chart) {
 				self.dom.tip.clear().showunder(this)
-				chart.clickTo(chart)
+				chart.clickTo(chart, this)
 			})
 			.on('mouseover', (e, d) => {
 				if (d.tooltip) self.dom.tooltip.clear().showunder(e.target).d.text(d.tooltip)
@@ -553,10 +563,20 @@ function setRenderers(self) {
 		_.makeChartBtnMenu(self.dom.tip.d, self, chart.chartType)
 	}
 
-	self.prepPlot = function (chart) {
+	self.prepPlot = async function (chart, btnNode) {
 		self.dom.tip.hide()
+		// disable the clicked button while the chart loads so rapid clicks don't stack up plots;
+		// app.dispatch() resolves only after the plot has fully rendered (incl. its data fetch)
+		if (btnNode) btnNode.disabled = true
 		const action = { type: 'plot_prep', config: chart.config, id: getId() }
-		self.app.dispatch(action)
+		try {
+			await self.app.dispatch(action)
+			// on success main() reconciles each button's disabled state from the open plots:
+			// profile charts stay disabled (now open), non-singleton charts get re-enabled
+		} catch (e) {
+			if (btnNode) btnNode.disabled = false // recover the button if the plot failed to open
+			throw e
+		}
 	}
 
 	self.plotCreate = function (chart) {

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -28,10 +28,10 @@ class MassCharts {
 	// TODO later add reactsTo() to react to filter change
 
 	getState(appState) {
-		// when a dataset opts in via massNav.disableActiveChartBtn, the chart buttons double as
-		// an indicator of the chart the user last opened: only the most recently opened chart's
-		// button is disabled (charts still stack one below the other). Datasets that don't set
-		// the flag keep their normal behavior, where charts can be opened multiple times.
+		/* when a dataset opts in via massNav.disableActiveChartBtn, the chart buttons double as
+		an indicator of the chart the user last opened: only the most recently opened chart's
+		button is disabled (charts still stack one below the other). Datasets that don't set
+		the flag keep their normal behavior, where charts can be opened multiple times. */
 		const plots = appState.plots || []
 		const disableActiveChartBtn = appState.termdbConfig?.massNav?.disableActiveChartBtn
 		const state = {
@@ -51,10 +51,10 @@ class MassCharts {
 	main() {
 		this.dom.btns
 			.style('display', d => (this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
-			// for datasets with massNav.disableActiveChartBtn, disable only the most recently
-			// opened chart's button so the user can see which chart they last opened; other
-			// buttons are re-enabled. Otherwise latestChartType is undefined and nothing is
-			// disabled here.
+			/* for datasets with massNav.disableActiveChartBtn, disable only the most recently
+			opened chart's button so the user can see which chart they last opened; other
+			buttons are re-enabled. Otherwise latestChartType is undefined and nothing is
+			disabled here. */
 			.property('disabled', d => d.chartType === this.state.latestChartType)
 	}
 

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -28,18 +28,18 @@ class MassCharts {
 	// TODO later add reactsTo() to react to filter change
 
 	getState(appState) {
-		// in the profile portal the chart buttons double as an indicator of the chart the user
-		// last opened: only the most recently opened chart's button is disabled (charts still
-		// stack one below the other). Scope this to the profile portal (detected via its
-		// defaultChartType) so other datasets keep their normal multi-open behavior.
+		// when a dataset opts in via massNav.disableActiveChartBtn, the chart buttons double as
+		// an indicator of the chart the user last opened: only the most recently opened chart's
+		// button is disabled (charts still stack one below the other). Datasets that don't set
+		// the flag keep their normal behavior, where charts can be opened multiple times.
 		const plots = appState.plots || []
-		const isProfilePortal = appState.termdbConfig?.defaultChartType?.startsWith('profile')
+		const disableActiveChartBtn = appState.termdbConfig?.massNav?.disableActiveChartBtn
 		const state = {
 			vocab: appState.vocab, // TODO delete it as vocabApi should be used instead
 			activeCohort: appState.activeCohort,
 			termfilter: appState.termfilter,
 			currentCohortChartTypes: getCurrentCohortChartTypes(appState),
-			latestChartType: isProfilePortal && plots.length ? plots[plots.length - 1].chartType : undefined,
+			latestChartType: disableActiveChartBtn && plots.length ? plots[plots.length - 1].chartType : undefined,
 			termdbConfig: appState.termdbConfig
 		}
 		if (appState?.termfilter?.filter) {
@@ -51,9 +51,10 @@ class MassCharts {
 	main() {
 		this.dom.btns
 			.style('display', d => (this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
-			// in the profile portal, disable only the most recently opened chart's button so the
-			// user can see which chart they last opened; other buttons are re-enabled. Outside the
-			// profile portal latestChartType is undefined, so no button is disabled here.
+			// for datasets with massNav.disableActiveChartBtn, disable only the most recently
+			// opened chart's button so the user can see which chart they last opened; other
+			// buttons are re-enabled. Otherwise latestChartType is undefined and nothing is
+			// disabled here.
 			.property('disabled', d => d.chartType === this.state.latestChartType)
 	}
 

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -28,15 +28,18 @@ class MassCharts {
 	// TODO later add reactsTo() to react to filter change
 
 	getState(appState) {
-		// chartType of the most recently opened profile plot (profile plots stack, so the last
-		// profile entry in plots[] is the newest); only this chart's nav button is disabled
-		const profilePlots = (appState.plots || []).filter(p => p.chartType?.startsWith('profile'))
+		// in the profile portal the chart buttons double as an indicator of the chart the user
+		// last opened: only the most recently opened chart's button is disabled (charts still
+		// stack one below the other). Scope this to the profile portal (detected via its
+		// defaultChartType) so other datasets keep their normal multi-open behavior.
+		const plots = appState.plots || []
+		const isProfilePortal = appState.termdbConfig?.defaultChartType?.startsWith('profile')
 		const state = {
 			vocab: appState.vocab, // TODO delete it as vocabApi should be used instead
 			activeCohort: appState.activeCohort,
 			termfilter: appState.termfilter,
 			currentCohortChartTypes: getCurrentCohortChartTypes(appState),
-			latestProfileChartType: profilePlots.length ? profilePlots[profilePlots.length - 1].chartType : undefined,
+			latestChartType: isProfilePortal && plots.length ? plots[plots.length - 1].chartType : undefined,
 			termdbConfig: appState.termdbConfig
 		}
 		if (appState?.termfilter?.filter) {
@@ -48,10 +51,10 @@ class MassCharts {
 	main() {
 		this.dom.btns
 			.style('display', d => (this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
-			// disable only the nav button of the most recently opened profile chart, so the user
-			// can see which profile chart they last opened. Profile charts still stack one below
-			// the other; previously opened charts' buttons are re-enabled.
-			.property('disabled', d => d.chartType === this.state.latestProfileChartType)
+			// in the profile portal, disable only the most recently opened chart's button so the
+			// user can see which chart they last opened; other buttons are re-enabled. Outside the
+			// profile portal latestChartType is undefined, so no button is disabled here.
+			.property('disabled', d => d.chartType === this.state.latestChartType)
 	}
 
 	getBtnLabel_dict(state) {

--- a/client/mass/charts.js
+++ b/client/mass/charts.js
@@ -28,18 +28,11 @@ class MassCharts {
 	// TODO later add reactsTo() to react to filter change
 
 	getState(appState) {
-		/* when a dataset opts in via massNav.disableActiveChartBtn, the chart buttons double as
-		an indicator of the chart the user last opened: only the most recently opened chart's
-		button is disabled (charts still stack one below the other). Datasets that don't set
-		the flag keep their normal behavior, where charts can be opened multiple times. */
-		const plots = appState.plots || []
-		const disableActiveChartBtn = appState.termdbConfig?.massNav?.disableActiveChartBtn
 		const state = {
 			vocab: appState.vocab, // TODO delete it as vocabApi should be used instead
 			activeCohort: appState.activeCohort,
 			termfilter: appState.termfilter,
 			currentCohortChartTypes: getCurrentCohortChartTypes(appState),
-			latestChartType: disableActiveChartBtn && plots.length ? plots[plots.length - 1].chartType : undefined,
 			termdbConfig: appState.termdbConfig
 		}
 		if (appState?.termfilter?.filter) {
@@ -49,13 +42,7 @@ class MassCharts {
 	}
 
 	main() {
-		this.dom.btns
-			.style('display', d => (this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
-			/* for datasets with massNav.disableActiveChartBtn, disable only the most recently
-			opened chart's button so the user can see which chart they last opened; other
-			buttons are re-enabled. Otherwise latestChartType is undefined and nothing is
-			disabled here. */
-			.property('disabled', d => d.chartType === this.state.latestChartType)
+		this.dom.btns.style('display', d => (this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
 	}
 
 	getBtnLabel_dict(state) {
@@ -569,17 +556,15 @@ function setRenderers(self) {
 
 	self.prepPlot = async function (chart, btnNode) {
 		self.dom.tip.hide()
-		// disable the clicked button while the chart loads so rapid clicks don't stack up plots;
-		// app.dispatch() resolves only after the plot has fully rendered (incl. its data fetch)
+		/* disable the clicked button while its chart loads so rapid clicks don't stack up plots.
+		app.dispatch() resolves only after the plot has fully rendered (incl. its data fetch); the
+		button is re-enabled once the load settles, on success or error. */
 		if (btnNode) btnNode.disabled = true
 		const action = { type: 'plot_prep', config: chart.config, id: getId() }
 		try {
 			await self.app.dispatch(action)
-			// on success main() reconciles each button's disabled state from the open plots:
-			// profile charts stay disabled (now open), non-singleton charts get re-enabled
-		} catch (e) {
-			if (btnNode) btnNode.disabled = false // recover the button if the plot failed to open
-			throw e
+		} finally {
+			if (btnNode) btnNode.disabled = false
 		}
 	}
 

--- a/client/plots/dictionary.js
+++ b/client/plots/dictionary.js
@@ -52,7 +52,16 @@ class MassDict {
 		if (config?.tree?.usecase) {
 			opts.tree.usecase = config.tree.usecase
 		}
-		this.tree = await appInit(opts)
+		// loading overlay shown over the sandbox while the dictionary tree initializes;
+		// reuses the shared .sjpp-loading-overlay box + .sjpp-spinner glyph
+		this.dom.holder.style('position', 'relative')
+		const loadingDiv = this.dom.holder.append('div').attr('class', 'sjpp-loading-overlay').style('display', '')
+		loadingDiv.append('div').attr('class', 'sjpp-spinner')
+		try {
+			this.tree = await appInit(opts)
+		} finally {
+			loadingDiv.remove()
+		}
 	}
 
 	getState(appState) {

--- a/client/plots/profile/barchart2.ts
+++ b/client/plots/profile/barchart2.ts
@@ -65,6 +65,7 @@ class ProfileBarchart2 extends profilePlot {
 	}
 
 	async main() {
+		this.dom.loadingDiv.style('display', '')
 		try {
 			await super.main()
 			this.configProfileComponent =
@@ -84,6 +85,8 @@ class ProfileBarchart2 extends profilePlot {
 		} catch (e) {
 			console.error(e)
 			throw `${e} [profileBarchart2 main()]`
+		} finally {
+			this.dom.loadingDiv.style('display', 'none')
 		}
 	}
 

--- a/client/plots/profile/forms2.ts
+++ b/client/plots/profile/forms2.ts
@@ -132,27 +132,32 @@ class ProfileForms2 extends profilePlot {
 	}
 
 	async main() {
-		super.main()
-		if (this.tabs.length == 0) return
-		const activeTab = this.state.config.activeTab || this.tabs[0].label
-		this.activePlot = this.state.config.options.find(p => p.name == activeTab)
-		this.scoreTerms = this.twLst.filter(tw => tw.term.subtype == this.activePlot.subtype)
-		this.scScoreTerms = this.activePlot.hasSC ? Object.values(this.id2SCTW[this.activePlot.name]) : []
-		const parents = this.config.tw.term.id.split('__')
-		this.module = parents[1]
-		const domain = parents.slice(1).join(' / ')
-		this.dom.domainDiv.text(domain)
-		this.categories = new Set()
-		this.dom.mainG.selectAll('*').remove()
-		this.dom.gridG.selectAll('*').remove()
-		this.dom.labelsG.selectAll('*').remove()
-		this.dom.xAxisG.selectAll('*').remove()
-		this.dom.scaleAxisG.selectAll('*').remove()
-		this.dom.legendG.selectAll('*').remove()
-		await this.setControls()
-		this.renderPlot()
-		this.filterG.selectAll('*').remove()
-		this.addFilterLegend()
+		this.dom.loadingDiv.style('display', '')
+		try {
+			super.main()
+			if (this.tabs.length == 0) return
+			const activeTab = this.state.config.activeTab || this.tabs[0].label
+			this.activePlot = this.state.config.options.find(p => p.name == activeTab)
+			this.scoreTerms = this.twLst.filter(tw => tw.term.subtype == this.activePlot.subtype)
+			this.scScoreTerms = this.activePlot.hasSC ? Object.values(this.id2SCTW[this.activePlot.name]) : []
+			const parents = this.config.tw.term.id.split('__')
+			this.module = parents[1]
+			const domain = parents.slice(1).join(' / ')
+			this.dom.domainDiv.text(domain)
+			this.categories = new Set()
+			this.dom.mainG.selectAll('*').remove()
+			this.dom.gridG.selectAll('*').remove()
+			this.dom.labelsG.selectAll('*').remove()
+			this.dom.xAxisG.selectAll('*').remove()
+			this.dom.scaleAxisG.selectAll('*').remove()
+			this.dom.legendG.selectAll('*').remove()
+			await this.setControls()
+			this.renderPlot()
+			this.filterG.selectAll('*').remove()
+			this.addFilterLegend()
+		} finally {
+			this.dom.loadingDiv.style('display', 'none')
+		}
 	}
 
 	/**

--- a/client/plots/profile/forms2.ts
+++ b/client/plots/profile/forms2.ts
@@ -134,7 +134,7 @@ class ProfileForms2 extends profilePlot {
 	async main() {
 		this.dom.loadingDiv.style('display', '')
 		try {
-			super.main()
+			await super.main()
 			if (this.tabs.length == 0) return
 			const activeTab = this.state.config.activeTab || this.tabs[0].label
 			this.activePlot = this.state.config.options.find(p => p.name == activeTab)

--- a/client/plots/profile/polar2.ts
+++ b/client/plots/profile/polar2.ts
@@ -34,9 +34,14 @@ class ProfilePolar2 extends profilePlot {
 	}
 
 	async main() {
-		await super.main()
-		await this.setControls()
-		this.plot()
+		this.dom.loadingDiv.style('display', '')
+		try {
+			await super.main()
+			await this.setControls()
+			this.plot()
+		} finally {
+			this.dom.loadingDiv.style('display', 'none')
+		}
 	}
 
 	/**

--- a/client/plots/profile/profileForms.ts
+++ b/client/plots/profile/profileForms.ts
@@ -115,7 +115,7 @@ export class profileForms extends profilePlot {
 	async main() {
 		this.dom.loadingDiv.style('display', '')
 		try {
-			super.main()
+			await super.main()
 			if (this.tabs.length == 0) return // no plots to show
 			const activeTab = this.state.config.activeTab || this.tabs[0].label
 			this.activePlot = this.state.config.options.find(p => p.name == activeTab)

--- a/client/plots/profile/profileForms.ts
+++ b/client/plots/profile/profileForms.ts
@@ -113,27 +113,32 @@ export class profileForms extends profilePlot {
 	}
 
 	async main() {
-		super.main()
-		if (this.tabs.length == 0) return // no plots to show
-		const activeTab = this.state.config.activeTab || this.tabs[0].label
-		this.activePlot = this.state.config.options.find(p => p.name == activeTab)
-		this.scoreTerms = this.twLst.filter(tw => tw.term.subtype == this.activePlot.subtype)
-		if (this.activePlot.hasSC) {
-			this.scScoreTerms = Object.values(this.id2SCTW[this.activePlot.name])
+		this.dom.loadingDiv.style('display', '')
+		try {
+			super.main()
+			if (this.tabs.length == 0) return // no plots to show
+			const activeTab = this.state.config.activeTab || this.tabs[0].label
+			this.activePlot = this.state.config.options.find(p => p.name == activeTab)
+			this.scoreTerms = this.twLst.filter(tw => tw.term.subtype == this.activePlot.subtype)
+			if (this.activePlot.hasSC) {
+				this.scScoreTerms = Object.values(this.id2SCTW[this.activePlot.name])
+			}
+			const parents = this.config.tw.term.id.split('__')
+			this.module = parents[1]
+			const domain = parents.slice(1).join(' / ')
+			this.dom.domainDiv.text(domain)
+			this.categories = new Set()
+			this.dom.mainG.selectAll('*').remove()
+			this.dom.gridG.selectAll('*').remove()
+			this.dom.xAxisG.selectAll('*').remove()
+			this.dom.legendG.selectAll('*').remove()
+			await this.setControls()
+			this.renderPlot()
+			this.filterG.selectAll('*').remove()
+			this.addFilterLegend()
+		} finally {
+			this.dom.loadingDiv.style('display', 'none')
 		}
-		const parents = this.config.tw.term.id.split('__')
-		this.module = parents[1]
-		const domain = parents.slice(1).join(' / ')
-		this.dom.domainDiv.text(domain)
-		this.categories = new Set()
-		this.dom.mainG.selectAll('*').remove()
-		this.dom.gridG.selectAll('*').remove()
-		this.dom.xAxisG.selectAll('*').remove()
-		this.dom.legendG.selectAll('*').remove()
-		await this.setControls()
-		this.renderPlot()
-		this.filterG.selectAll('*').remove()
-		this.addFilterLegend()
 	}
 
 	renderPlot() {

--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -121,12 +121,20 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 		const holder = rightDiv.insert('div').style('display', 'inline-block')
 
 		const plotDiv = holder.append('div')
+		// loading overlay shown over the chart sandbox while the chart's data is fetched/rendered.
+		// Reuses the shared .sjpp-loading-overlay box + .sjpp-spinner glyph; anchored on the
+		// full-width sandbox holder (opts.holder) so the spinner stays centered even on first
+		// open when the inner plot area is still empty.
+		this.opts.holder.style('position', 'relative')
+		const loadingDiv = this.opts.holder.append('div').attr('class', 'sjpp-loading-overlay').style('display', 'none')
+		loadingDiv.append('div').attr('class', 'sjpp-spinner')
 		this.dom = {
 			controlsDiv,
 			holder,
 			iconsDiv,
 			rightDiv,
-			plotDiv
+			plotDiv,
+			loadingDiv
 		}
 		select('.sjpp-output-sandbox-content').on('scroll', event => {
 			if (this.onMouseOut) this.onMouseOut(event)

--- a/client/plots/profile/radar2.ts
+++ b/client/plots/profile/radar2.ts
@@ -59,9 +59,14 @@ class ProfileRadar2 extends profilePlot {
 	}
 
 	async main() {
-		await super.main()
-		await this.setControls()
-		this.plot()
+		this.dom.loadingDiv.style('display', '')
+		try {
+			await super.main()
+			await this.setControls()
+			this.plot()
+		} finally {
+			this.dom.loadingDiv.style('display', 'none')
+		}
 	}
 
 	/**

--- a/client/plots/profile/radarFacility2.ts
+++ b/client/plots/profile/radarFacility2.ts
@@ -55,9 +55,14 @@ class ProfileRadarFacility2 extends profilePlot {
 	}
 
 	async main() {
-		await super.main()
-		await this.setControls()
-		this.plot()
+		this.dom.loadingDiv.style('display', '')
+		try {
+			await super.main()
+			await this.setControls()
+			this.plot()
+		} finally {
+			this.dom.loadingDiv.style('display', 'none')
+		}
 	}
 
 	/**

--- a/client/plots/profile/types/ProfilePlotTypes.ts
+++ b/client/plots/profile/types/ProfilePlotTypes.ts
@@ -15,4 +15,6 @@ export type ProfilePlotDom = {
 	iconsDiv: Elem
 	rightDiv: Elem
 	plotDiv: Elem
+	/** overlay shown over the plot area while the chart's data is fetched/rendered */
+	loadingDiv: Elem
 }

--- a/client/plots/sampleView.js
+++ b/client/plots/sampleView.js
@@ -21,6 +21,7 @@ class SampleView {
 	}
 
 	setDom(opts) {
+		opts.holder.style('position', 'relative')
 		const div = opts.holder.append('div')
 
 		const controlsDiv = div.append('div').style('display', 'inline-block')
@@ -37,12 +38,18 @@ class SampleView {
 		const sampleDiv = headerDiv.insert('div').style('display', 'inline-block')
 		const showPlotsDiv = headerDiv.append('div').style('display', 'inline-block').style('vertical-align', 'top')
 
+		// loading overlay shown over the sandbox while sample data is fetched/rendered;
+		// reuses the shared .sjpp-loading-overlay box + .sjpp-spinner glyph
+		const loadingDiv = opts.holder.append('div').attr('class', 'sjpp-loading-overlay').style('display', 'none')
+		loadingDiv.append('div').attr('class', 'sjpp-spinner')
+
 		this.dom = {
 			header: opts.header,
 			holder: opts.holder,
 			controlsDiv,
 			sampleDiv,
 			showPlotsDiv,
+			loadingDiv,
 
 			plotsDiv
 		}
@@ -196,23 +203,28 @@ class SampleView {
 
 	async main() {
 		if (this.mayRequireToken()) return
-		this.config = structuredClone(this.state.config)
-		this.settings = this.state.config.settings.sampleView
-		this.dom.plotsDiv.selectAll('*').remove()
+		this.dom.loadingDiv.style('display', '')
+		try {
+			this.config = structuredClone(this.state.config)
+			this.settings = this.state.config.settings.sampleView
+			this.dom.plotsDiv.selectAll('*').remove()
 
-		this.termsById = this.getTermsById(this.state)
-		this.sampleDataByTermId = {}
-		const root = this.termsById[root_ID]
-		root.terms = await this.requestTermRecursive(root)
-		this.orderedVisibleTerms = this.getOrderedVisibleTerms(root)
-		if (this.dom.downloadbt)
-			this.dom.downloadbt.style('display', this.settings.showDictionary ? 'inline-block' : 'none')
+			this.termsById = this.getTermsById(this.state)
+			this.sampleDataByTermId = {}
+			const root = this.termsById[root_ID]
+			root.terms = await this.requestTermRecursive(root)
+			this.orderedVisibleTerms = this.getOrderedVisibleTerms(root)
+			if (this.dom.downloadbt)
+				this.dom.downloadbt.style('display', this.settings.showDictionary ? 'inline-block' : 'none')
 
-		if (this.settings.showDictionary) this.renderSampleDictionary()
-		this.dom.tableDiv.style('display', this.settings.showDictionary ? 'block' : 'none')
+			if (this.settings.showDictionary) this.renderSampleDictionary()
+			this.dom.tableDiv.style('display', this.settings.showDictionary ? 'block' : 'none')
 
-		await this.renderPlots(this.state, this.state.samples)
-		this.showVisiblePlots()
+			await this.renderPlots(this.state, this.state.samples)
+			this.showVisiblePlots()
+		} finally {
+			this.dom.loadingDiv.style('display', 'none')
+		}
 	}
 
 	async setControls(state) {

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1216,7 +1216,14 @@ sandbox header
     border-radius: 6px;
 }
 
-#sjpp-loading-overlay {
+/* greyed-out look while a chart button's plot is loading, or is the latest open profile chart (see mass/charts.js) */
+.sjpp-chart-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+#sjpp-loading-overlay,
+.sjpp-loading-overlay {
     position: absolute;
     top: 0;
     left: 0;

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1216,7 +1216,7 @@ sandbox header
     border-radius: 6px;
 }
 
-/* greyed-out look while a chart button's plot is loading, or is the latest open profile chart (see mass/charts.js) */
+/* greyed-out look while a chart button's plot is loading (see mass/charts.js prepPlot) */
 .sjpp-chart-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1989,6 +1989,11 @@ type MassNav = {
 	activeColor?: string
 	/** customize background color of active navigation tab on hover */
 	activeColorHover?: string
+	/** when true, disable the nav button of the most recently opened chart, so the chart
+	buttons indicate which chart was last opened. Charts still stack; previously opened
+	charts' buttons re-enable. Used by portals (e.g. profile) where this acts as an
+	active-chart indicator; left unset elsewhere so charts can be opened multiple times. */
+	disableActiveChartBtn?: boolean
 }
 
 type MassNavTabEntry = {

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1989,11 +1989,6 @@ type MassNav = {
 	activeColor?: string
 	/** customize background color of active navigation tab on hover */
 	activeColorHover?: string
-	/** when true, disable the nav button of the most recently opened chart, so the chart
-	buttons indicate which chart was last opened. Charts still stack; previously opened
-	charts' buttons re-enable. Used by portals (e.g. profile) where this acts as an
-	active-chart indicator; left unset elsewhere so charts can be opened multiple times. */
-	disableActiveChartBtn?: boolean
 }
 
 type MassNavTabEntry = {


### PR DESCRIPTION
This pull request adds loading overlays and improved UI feedback to several chart and plot components, ensuring users see a spinner while data is loading and preventing duplicate actions from rapid clicks. It also introduces a disabled state for chart buttons during loading. The main themes are enhanced user experience during asynchronous operations and code consistency for loading overlays.

**User experience improvements:**

* Added loading overlays (`.sjpp-loading-overlay` with spinner) to the dictionary tree (`dictionary.js`), all profile plots (`profilePlot.ts` and subclasses), and the sample view (`sampleView.js`). Overlays are shown while data loads and hidden afterward, providing clear feedback to users. 
* Chart buttons are now disabled while their respective plots are loading to prevent rapid, repeated clicks from stacking up rendering operations. The button is re-enabled after loading completes, regardless of success or error. 

**Code consistency and maintainability:**

* All affected plot classes (`profileBarchart2`, `ProfileForms2`, `ProfilePolar2`, `ProfileRadar2`, `ProfileRadarFacility2`, `profileForms`, and `SampleView`) now consistently show and hide the loading overlay in their `main` methods using `try/finally` blocks. 
* The `ProfilePlotDom` type and all relevant `dom` objects were updated to include the new `loadingDiv` property for easy access to the overlay. 

**Minor UI and API changes:**

* Chart buttons now have a dedicated CSS class and use a new disabled style for visual feedback. 
* The `clickTo` API for chart selection now receives the button node as a parameter, supporting the new disable/enable logic.

These changes collectively improve the responsiveness and clarity of the UI during data fetching and rendering operations.This pull request introduces UI improvements for chart and profile plot loading states, and adds an option to visually indicate the most recently opened chart in the navigation. The main changes include adding loading overlays and spinners to various chart/profile views, ensuring buttons are disabled during plot loading to prevent duplicate actions, and supporting an optional feature where the latest chart's button is visually marked as active.

**Chart navigation and button state improvements:**
- Added a new `disableActiveChartBtn` option to `MassNav` so that, when enabled, only the most recently opened chart's button is disabled, serving as a visual indicator of the active chart. Other buttons are re-enabled when their charts are not the latest. (`shared/types/src/dataset.ts`, `client/mass/charts.js`) 
- Updated chart button rendering to add a `.sjpp-chart-btn` class, and applied CSS for a "disabled" look when a button is inactive. (`client/mass/charts.js`, `client/src/style.css`) 

**Loading overlays and spinners:**
- Added a reusable loading overlay (`.sjpp-loading-overlay` with `.sjpp-spinner`) to chart/profile/sandbox holders, shown while data is loading and hidden when ready, to provide clear feedback during asynchronous operations. (`client/plots/profile/profilePlot.ts`, `client/plots/sampleView.js`, `client/plots/dictionary.js`, `client/plots/profile/types/ProfilePlotTypes.ts`) 

**Profile plot and sample view enhancements:**
- Updated all profile plot classes and the sample view to show the loading overlay while their main logic/data fetching runs, and to always hide it after completion or error, improving user experience and preventing UI flicker. (`client/plots/profile/barchart2.ts`, `client/plots/profile/forms2.ts`, `client/plots/profile/polar2.ts`, `client/plots/profile/radar2.ts`, `client/plots/profile/radarFacility2.ts`, `client/plots/profile/profileForms.ts`, `client/plots/sampleView.js`) 

**Chart button click handling:**
- Chart button click logic now disables the button during plot loading (and re-enables it on failure), preventing rapid clicks from stacking up multiple plot requests. (`client/mass/charts.js`)

These changes collectively improve the clarity and responsiveness of the chart/profile navigation and loading experience for users.This pull request introduces several improvements to the chart selection and profile plot loading experience in the application. The main changes ensure that only the button for the most recently opened profile chart is disabled (providing clear UI feedback), and that a loading spinner is shown over profile plots while their data is being fetched or rendered. These updates help prevent duplicate plot openings and enhance user feedback during slow operations.

**UI/UX improvements for chart selection and loading:**

* Only the navigation button for the most recently opened profile chart is disabled, making it clear which profile chart is active while allowing users to open others. Previously, all profile chart buttons could be disabled. (`client/mass/charts.js`)
* Chart buttons are temporarily disabled while a plot is loading to prevent rapid duplicate clicks. If loading fails, the button is re-enabled. (`client/mass/charts.js`) 

**Loading spinner overlay for profile plots:**

* A shared loading overlay (`.sjpp-loading-overlay`) with a spinner is now shown over the plot area while profile charts are loading, and hidden once loading completes or fails. This is implemented in all profile plot types. (`client/plots/profile/profilePlot.ts`, `client/plots/profile/barchart2.ts`, `client/plots/profile/forms2.ts`, `client/plots/profile/polar2.ts`, `client/plots/profile/radar2.ts`, `client/plots/profile/radarFacility2.ts`, `client/plots/profile/profileForms.ts`) 
* The `ProfilePlotDom` type is updated to include the new `loadingDiv` property. (`client/plots/profile/types/ProfilePlotTypes.ts`)

**Styling updates:**

* Added styles for disabled chart buttons and the loading overlay to provide visual feedback during loading. (`client/src/style.css`)

These changes collectively improve the responsiveness and clarity of the charting UI, especially when interacting with profile plots.# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
