### PR TITLE
GRIN2: Adding blacklist filtering to deal with artifacts seen in results

### DIFF
--- a/client/plots/grin2/GRIN2Types.ts
+++ b/client/plots/grin2/GRIN2Types.ts
@@ -58,6 +58,7 @@ export interface GRIN2RequestData {
 	cnvOptions?: { lossThreshold: number; gainThreshold: number; maxSegLength: number }
 	fusionOptions?: Record<string, any>
 	svOptions?: Record<string, any>
+	excludeOptions?: { enabled: boolean; overlapFrac: number }
 }
 
 /** Raw response from vocabApi.getGrin2Data. */

--- a/client/plots/grin2/GRIN2Types.ts
+++ b/client/plots/grin2/GRIN2Types.ts
@@ -58,7 +58,7 @@ export interface GRIN2RequestData {
 	cnvOptions?: { lossThreshold: number; gainThreshold: number; maxSegLength: number }
 	fusionOptions?: Record<string, any>
 	svOptions?: Record<string, any>
-	excludeOptions?: { enabled: boolean; overlapFrac: number }
+	excludeOptions?: { blacklists?: string[]; overlapFrac?: number }
 }
 
 /** Raw response from vocabApi.getGrin2Data. */

--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -76,6 +76,7 @@ class GRIN2 extends PlotBase implements RxComponent {
 				controlsHolder: this.dom.controls,
 				config: this.state.config,
 				vocabApi: this.app.vocabApi,
+				genome: this.app.opts.genome,
 				callbacks: { onRun: () => this.handleRun() }
 			})
 			this.controlsView.build()

--- a/client/plots/grin2/settings/defaults.ts
+++ b/client/plots/grin2/settings/defaults.ts
@@ -3,6 +3,11 @@ export const CNV_LOSS_THRESHOLD_FALLBACK = -0.4
 export const CNV_GAIN_THRESHOLD_FALLBACK = 0.4
 export const CNV_MAX_SEG_LENGTH_FALLBACK = 2_000_000
 
+/** Artifact-region exclude mask fallbacks. When enabled, lesions overlapping
+ * low-mappability / segdup / blacklist / gap regions are dropped before stats. */
+export const EXCLUDE_ENABLED_FALLBACK = true
+export const EXCLUDE_OVERLAP_FRAC_FALLBACK = 0.5
+
 export function getDefaultGRIN2Settings(opts: any) {
 	const defaults = {
 		manhattan: {

--- a/client/plots/grin2/settings/defaults.ts
+++ b/client/plots/grin2/settings/defaults.ts
@@ -3,9 +3,10 @@ export const CNV_LOSS_THRESHOLD_FALLBACK = -0.4
 export const CNV_GAIN_THRESHOLD_FALLBACK = 0.4
 export const CNV_MAX_SEG_LENGTH_FALLBACK = 2_000_000
 
-/** Artifact-region exclude mask fallbacks. When enabled, lesions overlapping
- * low-mappability / segdup / blacklist / gap regions are dropped before stats. */
-export const EXCLUDE_ENABLED_FALLBACK = true
+/** Default gene-overlap-fraction for the artifact-region mask: a gene is excluded when at least
+ * this fraction of its span lies inside a selected blacklist region. The set of blacklist sources
+ * (and whether the mask runs at all) comes from the per-source checkboxes, which are populated from
+ * the genome's declared blacklists. */
 export const EXCLUDE_OVERLAP_FRAC_FALLBACK = 0.5
 
 export function getDefaultGRIN2Settings(opts: any) {

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -129,11 +129,12 @@ export class GRIN2ControlsView {
 			const blacklists = Object.entries(this.excludeCheckboxes)
 				.filter(([, cb]) => cb.property('checked'))
 				.map(([name]) => name)
+			const overlapFracRaw = this.exclude_overlapFrac
+				? parseFloat(this.exclude_overlapFrac.property('value'))
+				: EXCLUDE_OVERLAP_FRAC_FALLBACK
 			requestConfig.excludeOptions = {
 				blacklists,
-				overlapFrac: this.exclude_overlapFrac
-					? parseFloat(this.exclude_overlapFrac.property('value'))
-					: EXCLUDE_OVERLAP_FRAC_FALLBACK
+				overlapFrac: Number.isFinite(overlapFracRaw) ? overlapFracRaw : EXCLUDE_OVERLAP_FRAC_FALLBACK
 			}
 		}
 		return requestConfig

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -6,7 +6,6 @@ import {
 	CNV_LOSS_THRESHOLD_FALLBACK,
 	CNV_GAIN_THRESHOLD_FALLBACK,
 	CNV_MAX_SEG_LENGTH_FALLBACK,
-	EXCLUDE_ENABLED_FALLBACK,
 	EXCLUDE_OVERLAP_FRAC_FALLBACK
 } from '../settings/defaults'
 
@@ -45,22 +44,27 @@ export class GRIN2ControlsView {
 	private cnv_gainThreshold: any = null
 	private cnv_maxSegLength: any = null
 
-	private excludeCheckbox: any = null
+	// one checkbox per genome-declared blacklist source, keyed by source name
+	private excludeCheckboxes: Record<string, any> = {}
 	private exclude_overlapFrac: any = null
 
 	private snvindelMafFilter: any = null
+
+	private genome: any
 
 	constructor(opts: {
 		headerHolder: any
 		controlsHolder: any
 		config: any
 		vocabApi: any
+		genome: any
 		callbacks: GRIN2ControlsCallbacks
 	}) {
 		this.headerHolder = opts.headerHolder
 		this.controlsHolder = opts.controlsHolder
 		this.config = opts.config
 		this.vocabApi = opts.vocabApi
+		this.genome = opts.genome
 		this.callbacks = opts.callbacks
 	}
 
@@ -119,11 +123,18 @@ export class GRIN2ControlsView {
 		}
 		if (dtUsage[dtfusionrna]?.checked) requestConfig.fusionOptions = {}
 		if (dtUsage[dtsv]?.checked) requestConfig.svOptions = {}
-		requestConfig.excludeOptions = {
-			enabled: this.excludeCheckbox ? this.excludeCheckbox.property('checked') : EXCLUDE_ENABLED_FALLBACK,
-			overlapFrac: this.exclude_overlapFrac
-				? parseFloat(this.exclude_overlapFrac.property('value'))
-				: EXCLUDE_OVERLAP_FRAC_FALLBACK
+		// excludeOptions.blacklists = names of the checked genome-declared sources.
+		// Only emitted when the genome declares blacklists (otherwise the mask is unavailable).
+		if (Object.keys(this.excludeCheckboxes).length > 0) {
+			const blacklists = Object.entries(this.excludeCheckboxes)
+				.filter(([, cb]) => cb.property('checked'))
+				.map(([name]) => name)
+			requestConfig.excludeOptions = {
+				blacklists,
+				overlapFrac: this.exclude_overlapFrac
+					? parseFloat(this.exclude_overlapFrac.property('value'))
+					: EXCLUDE_OVERLAP_FRAC_FALLBACK
+			}
 		}
 		return requestConfig
 	}
@@ -277,14 +288,36 @@ export class GRIN2ControlsView {
 		})
 	}
 
+	/** Artifact-region mask row. Renders one checkbox per blacklist source declared for the genome
+	 * (Genome.blacklists, exposed to the client as {name}[]), plus the gene-overlap-fraction input.
+	 * Skipped entirely when the genome declares no blacklists. Unchecking all sources disables the
+	 * mask (server resolves an empty source list to no masking). */
 	private addExcludeRow(table: any) {
+		const blacklists: { name: string }[] = this.genome?.blacklists || []
+		if (!blacklists.length) return
+
 		const [left, right] = table.addRow()
+		left.text('Exclude genes overlapping').style('padding-top', '4px')
+
+		// default = all sources on; if a previous run saved a selection, restore exactly that set
+		const savedExclude = this.config.settings.runAnalysis === true ? this.config.settings.excludeOptions : undefined
+		const savedNames: string[] | undefined = savedExclude?.blacklists
+		const isChecked = (name: string) => (savedNames ? savedNames.includes(name) : true)
+
+		this.excludeCheckboxes = {}
+		const cbContainer = right.append('div').style('margin-bottom', '6px')
+		blacklists.forEach(bl => {
+			const div = cbContainer.append('div').style('margin-bottom', checkboxMarginBottom)
+			this.excludeCheckboxes[bl.name] = make_one_checkbox({
+				holder: div,
+				labeltext: bl.name,
+				checked: isChecked(bl.name),
+				divstyle: { 'font-size': `${tableFontSize}px` },
+				callback: () => {}
+			})
+		})
+
 		const t2 = table2col({ holder: right })
-
-		const useSaved = this.config.settings.runAnalysis === true
-		const savedExclude = useSaved ? this.config.settings.excludeOptions : undefined
-		const isChecked = savedExclude?.enabled ?? EXCLUDE_ENABLED_FALLBACK
-
 		this.exclude_overlapFrac = this.addOptionRowToTable(
 			t2,
 			'Min gene overlap',
@@ -293,18 +326,6 @@ export class GRIN2ControlsView {
 			1,
 			0.05
 		)
-
-		t2.table.style('display', isChecked ? '' : 'none')
-
-		this.excludeCheckbox = make_one_checkbox({
-			holder: left,
-			labeltext: 'Exclude artifact genes (segmental dups + blacklist + gaps + common germline CNVs)',
-			checked: isChecked,
-			testid: 'sjpp-grin2-checkbox-exclude',
-			callback: (checked: boolean) => {
-				t2.table.style('display', checked ? '' : 'none')
-			}
-		})
 	}
 
 	private addOptionRowToTable(

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -5,7 +5,9 @@ import type { GRIN2ControlsCallbacks, DtUsage } from '../GRIN2Types'
 import {
 	CNV_LOSS_THRESHOLD_FALLBACK,
 	CNV_GAIN_THRESHOLD_FALLBACK,
-	CNV_MAX_SEG_LENGTH_FALLBACK
+	CNV_MAX_SEG_LENGTH_FALLBACK,
+	EXCLUDE_ENABLED_FALLBACK,
+	EXCLUDE_OVERLAP_FRAC_FALLBACK
 } from '../settings/defaults'
 
 // Styling constants used only by the controls view
@@ -43,6 +45,9 @@ export class GRIN2ControlsView {
 	private cnv_gainThreshold: any = null
 	private cnv_maxSegLength: any = null
 
+	private excludeCheckbox: any = null
+	private exclude_overlapFrac: any = null
+
 	private snvindelMafFilter: any = null
 
 	constructor(opts: {
@@ -72,6 +77,9 @@ export class GRIN2ControlsView {
 		if (queries.cnv) this.addCnvRow(table)
 		if (queries.svfusion?.dtLst?.includes(dtfusionrna)) this.addFusionRow(table)
 		if (queries.svfusion?.dtLst?.includes(dtsv)) this.addSvRow(table)
+
+		// Artifact-region exclude mask (applies to all lesion types).
+		this.addExcludeRow(table)
 
 		this.runButton = this.controlsHolder
 			.append('button')
@@ -111,6 +119,12 @@ export class GRIN2ControlsView {
 		}
 		if (dtUsage[dtfusionrna]?.checked) requestConfig.fusionOptions = {}
 		if (dtUsage[dtsv]?.checked) requestConfig.svOptions = {}
+		requestConfig.excludeOptions = {
+			enabled: this.excludeCheckbox ? this.excludeCheckbox.property('checked') : EXCLUDE_ENABLED_FALLBACK,
+			overlapFrac: this.exclude_overlapFrac
+				? parseFloat(this.exclude_overlapFrac.property('value'))
+				: EXCLUDE_OVERLAP_FRAC_FALLBACK
+		}
 		return requestConfig
 	}
 
@@ -259,6 +273,36 @@ export class GRIN2ControlsView {
 			callback: (checked: boolean) => {
 				t2.table.style('display', checked ? '' : 'none')
 				this.updateRunButtonFromCheckboxes()
+			}
+		})
+	}
+
+	private addExcludeRow(table: any) {
+		const [left, right] = table.addRow()
+		const t2 = table2col({ holder: right })
+
+		const useSaved = this.config.settings.runAnalysis === true
+		const savedExclude = useSaved ? this.config.settings.excludeOptions : undefined
+		const isChecked = savedExclude?.enabled ?? EXCLUDE_ENABLED_FALLBACK
+
+		this.exclude_overlapFrac = this.addOptionRowToTable(
+			t2,
+			'Min gene overlap',
+			savedExclude?.overlapFrac ?? EXCLUDE_OVERLAP_FRAC_FALLBACK,
+			0,
+			1,
+			0.05
+		)
+
+		t2.table.style('display', isChecked ? '' : 'none')
+
+		this.excludeCheckbox = make_one_checkbox({
+			holder: left,
+			labeltext: 'Exclude artifact genes (segmental dups + blacklist + gaps + common germline CNVs)',
+			checked: isChecked,
+			testid: 'sjpp-grin2-checkbox-exclude',
+			callback: (checked: boolean) => {
+				t2.table.style('display', checked ? '' : 'none')
 			}
 		})
 	}

--- a/client/types/clientGenome.ts
+++ b/client/types/clientGenome.ts
@@ -46,6 +46,8 @@ export type ClientGenome = {
 	/** Common name of the animal (e.g. human, mouse, etc.) */
 	species: string
 	termdbs?: { [index: string]: { label: string } }
+	/** genome-level blacklisted region sources; only names are exposed to the client */
+	blacklists?: { name: string }[]
 	tkset?: any
 	tracks: Track[]
 }

--- a/python/src/grin2PpWrapper.py
+++ b/python/src/grin2PpWrapper.py
@@ -253,7 +253,8 @@ try:
 	exclude_frac = min(max(exclude_frac, 0.0), 1.0)
 	if exclude_enabled and exclude_beds:
 		mask = load_exclude_intervals(exclude_beds)
-		gene_anno, mask_report = apply_gene_mask(gene_anno, mask, exclude_frac)
+		genome_size_bp = int(chrom_size["size"].sum())
+		gene_anno, mask_report = apply_gene_mask(gene_anno, mask, exclude_frac, genome_size_bp=genome_size_bp)
 		if gene_anno.empty:
 			write_error("No genes remain after applying the exclude mask")
 			sys.exit(1)

--- a/python/src/grin2PpWrapper.py
+++ b/python/src/grin2PpWrapper.py
@@ -243,7 +243,14 @@ try:
 	mask_report = None
 	exclude_beds = input_data.get("excludeBeds") or []
 	exclude_enabled = input_data.get("excludeEnabled", True)
-	exclude_frac = float(input_data.get("excludeOverlapFrac", 0.5))
+	exclude_frac_raw = input_data.get("excludeOverlapFrac", 0.5)
+	try:
+		exclude_frac = float(exclude_frac_raw)
+	except (TypeError, ValueError):
+		exclude_frac = 0.5
+	if not np.isfinite(exclude_frac):
+		exclude_frac = 0.5
+	exclude_frac = min(max(exclude_frac, 0.0), 1.0)
 	if exclude_enabled and exclude_beds:
 		mask = load_exclude_intervals(exclude_beds)
 		gene_anno, mask_report = apply_gene_mask(gene_anno, mask, exclude_frac)

--- a/python/src/grin2PpWrapper.py
+++ b/python/src/grin2PpWrapper.py
@@ -28,7 +28,7 @@ import warnings, json, sys
 import sqlite3
 import pandas as pd
 import numpy as np
-from grin2_core import grin_stats
+from grin2_core import grin_stats, load_exclude_intervals, apply_gene_mask
 # from grin2_core import timed_grin_stats
 
 warnings.filterwarnings('ignore')
@@ -231,10 +231,26 @@ try:
 	)
 	
 	lesion_counts = lesion_df["lsn.type"].value_counts()
-	
+
 	# Lesion types are the keys of lesionTypeMap (e.g. "mutation", "gain", "loss")
 	lesion_types = list(lesion_type_map.keys())
-	
+
+	# 4b. Apply artifact-region exclude mask (literature-backed; see grin2_core).
+	# Drops GENES whose span lies in low-mappability/segdup/blacklist/gap regions
+	# before the statistics run — the correct primitive for a gene-level recurrence
+	# test (masking lesions misses broad passenger deletions that clip a tiny
+	# artifact gene). No-op when disabled or no BEDs are resolved.
+	mask_report = None
+	exclude_beds = input_data.get("excludeBeds") or []
+	exclude_enabled = input_data.get("excludeEnabled", True)
+	exclude_frac = float(input_data.get("excludeOverlapFrac", 0.5))
+	if exclude_enabled and exclude_beds:
+		mask = load_exclude_intervals(exclude_beds)
+		gene_anno, mask_report = apply_gene_mask(gene_anno, mask, exclude_frac)
+		if gene_anno.empty:
+			write_error("No genes remain after applying the exclude mask")
+			sys.exit(1)
+
 	# 5. Run GRIN2
 	grin_results = grin_stats(lesion_df, gene_anno, chrom_size)
 	# grin_results = timed_grin_stats(lesion_df, gene_anno, chrom_size)
@@ -267,6 +283,7 @@ try:
 		"totalGenes": len(sorted_results),
 		"showingTop": num_rows,
 		"lesionCounts": {"byType": lesion_counts.to_dict()},
+		"maskReport": mask_report,
 		"memory": grin_results.get("memory_profile", {}),
 		"geneHits": gene_hits
 	}))

--- a/python/src/grin2_core.py
+++ b/python/src/grin2_core.py
@@ -1077,11 +1077,16 @@ def row_prob_subj_hit(P, IDs):
 # REGION EXCLUSION / MASKING
 # =============================================================================
 #
-# Hard region mask applied to GENES BEFORE the GRIN statistics run. This is the
-# literature-backed `exclude` step: removing genes that sit in low-mappability /
-# segmental-duplication / blacklist / assembly-gap / common-CNV regions stops
-# artifact-dense loci (e.g. OR clusters, FAM90, POTE, GOLGA8, HLA) from
-# accruing spurious recurrence under GRIN's uniform random-interval null.
+# Hard region mask applied to GENES BEFORE the GRIN statistics run. This is the
+
+# literature-backed `exclude` step: removing genes that sit in low-mappability /
+
+# segmental-duplication / blacklist / assembly-gap / common-CNV regions stops
+
+# artifact-dense loci (e.g. OR clusters, FAM90, POTE, GOLGA8, HLA) from
+
+# accruing spurious recurrence under GRIN's uniform random-interval null.
+
 # Mirrors Bioconductor nullranges/bootRanges `exclude`; see Amemiya/Kundaje/Boyle
 # 2019 (ENCODE blacklist), Karimzadeh 2018 (Umap/Bismap mappability), Sharp 2005
 # (segmental duplications), Ogata/Mu 2023 (excluderanges).
@@ -1242,8 +1247,8 @@ def apply_gene_mask(gene_data, mask, frac=0.5):
         ov = _masked_overlap_bp(s, e, intervals)
         if ov / (e - s) >= frac:
             drop[i] = True
-
-    kept = gene_data.loc[~drop].reset_index(drop=True)
+    # report a coarse fraction for sanity-checking mask size; defaults to ~hg38 size when not provided
+    genome_fraction_masked = round(total_masked_bp / float(genome_size_bp or 3.1e9), 4)
     dropped_genes = gene_data.loc[drop, "gene"].astype(str).tolist()
 
     total_masked_bp = int(sum(int((iv[:, 1] - iv[:, 0]).sum()) for iv in mask.values()))

--- a/python/src/grin2_core.py
+++ b/python/src/grin2_core.py
@@ -1125,10 +1125,8 @@ def load_exclude_intervals(bed_paths):
         try:
             with opener(path, "rt") as fh:
                 for line in fh:
-                    if not line or line[0] in "#tb":
-                        # skip comments and UCSC "track"/"browser" header lines
-                        if line.startswith(("#", "track", "browser")):
-                            continue
+                    if not line.strip() or line.startswith(("#", "track", "browser")):
+                        continue
                     fields = line.rstrip("\n").split("\t")
                     if len(fields) < 3:
                         continue
@@ -1247,8 +1245,10 @@ def apply_gene_mask(gene_data, mask, frac=0.5):
         ov = _masked_overlap_bp(s, e, intervals)
         if ov / (e - s) >= frac:
             drop[i] = True
-    # report a coarse fraction for sanity-checking mask size; defaults to ~hg38 size when not provided
-    genome_fraction_masked = round(total_masked_bp / float(genome_size_bp or 3.1e9), 4)
+    # report a coarse fraction for sanity-checking mask size; defaults to ~hg38 size when not provided
+
+    genome_fraction_masked = round(total_masked_bp / float(genome_size_bp or 3.1e9), 4)
+
     dropped_genes = gene_data.loc[drop, "gene"].astype(str).tolist()
 
     total_masked_bp = int(sum(int((iv[:, 1] - iv[:, 0]).sum()) for iv in mask.values()))

--- a/python/src/grin2_core.py
+++ b/python/src/grin2_core.py
@@ -1074,6 +1074,193 @@ def row_prob_subj_hit(P, IDs):
 
 
 # =============================================================================
+# REGION EXCLUSION / MASKING
+# =============================================================================
+#
+# Hard region mask applied to lesions BEFORE the GRIN statistics run. This is
+# the literature-backed `exclude` step: removing lesions that fall in
+# low-mappability / segmental-duplication / blacklist / assembly-gap regions
+# stops those artifact-dense loci (e.g. OR clusters, FAM90, POTE, GOLGA8, HLA)
+# from accruing spurious recurrence under GRIN's uniform random-interval null.
+# Mirrors Bioconductor nullranges/bootRanges `exclude`; see Amemiya/Kundaje/Boyle
+# 2019 (ENCODE blacklist), Karimzadeh 2018 (Umap/Bismap mappability), Sharp 2005
+# (segmental duplications), Ogata/Mu 2023 (excluderanges).
+#
+# The mask BEDs are small enough to read fully via gzip, so no pysam/tabix
+# dependency is required.
+
+def load_exclude_intervals(bed_paths):
+    """
+    Load one or more (optionally bgzip'd) BED files into per-chromosome,
+    sorted, overlap-merged interval arrays.
+
+    Parameters
+    ----------
+    bed_paths : list[str]
+        Paths to BED files. Plain or gzip/bgzip-compressed (".gz") are both
+        accepted. Only the first three columns (chrom, start, end) are used.
+        BED is 0-based half-open; lesion coords are treated on the same axis
+        for overlap (the small 1-bp convention difference is immaterial to a
+        fractional-overlap drop decision).
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        chrom -> (N, 2) int64 array of merged [start, end) intervals, sorted
+        by start. Chrom names are normalized to be `chr`-prefixed to match
+        lesion chrom values.
+    """
+    import gzip
+
+    raw = {}  # chrom -> list of [start, end]
+    for path in bed_paths or []:
+        if not path:
+            continue
+        opener = gzip.open if str(path).endswith(".gz") else open
+        try:
+            with opener(path, "rt") as fh:
+                for line in fh:
+                    if not line or line[0] in "#tb":
+                        # skip comments and UCSC "track"/"browser" header lines
+                        if line.startswith(("#", "track", "browser")):
+                            continue
+                    fields = line.rstrip("\n").split("\t")
+                    if len(fields) < 3:
+                        continue
+                    chrom = fields[0]
+                    if not chrom.startswith("chr"):
+                        chrom = f"chr{chrom}"
+                    try:
+                        start = int(fields[1])
+                        end = int(fields[2])
+                    except ValueError:
+                        continue
+                    if end <= start:
+                        continue
+                    raw.setdefault(chrom, []).append([start, end])
+        except FileNotFoundError:
+            write_error(f"exclude BED not found, skipping: {path}")
+            continue
+
+    merged = {}
+    for chrom, intervals in raw.items():
+        arr = np.asarray(intervals, dtype=np.int64)
+        arr = arr[np.argsort(arr[:, 0], kind="mergesort")]
+        # merge overlapping/adjacent intervals
+        out = []
+        cur_start, cur_end = arr[0, 0], arr[0, 1]
+        for s, e in arr[1:]:
+            if s <= cur_end:
+                if e > cur_end:
+                    cur_end = e
+            else:
+                out.append([cur_start, cur_end])
+                cur_start, cur_end = s, e
+        out.append([cur_start, cur_end])
+        merged[chrom] = np.asarray(out, dtype=np.int64)
+    return merged
+
+
+def _masked_overlap_bp(start, end, intervals):
+    """Total bp of [start, end) covered by the sorted, merged `intervals` (N,2)."""
+    if intervals is None or len(intervals) == 0 or end <= start:
+        return 0
+    starts = intervals[:, 0]
+    # first interval whose end > start, via the interval starts: find candidates
+    # whose start < end and end > start. Use searchsorted on starts for a window.
+    lo = np.searchsorted(starts, start, side="right") - 1
+    if lo < 0:
+        lo = 0
+    hi = np.searchsorted(starts, end, side="left")
+    total = 0
+    for i in range(lo, hi):
+        s = intervals[i, 0]
+        e = intervals[i, 1]
+        if e <= start:
+            continue
+        if s >= end:
+            break
+        ov = min(end, e) - max(start, s)
+        if ov > 0:
+            total += ov
+    return int(total)
+
+
+def apply_gene_mask(gene_data, mask, frac=0.5):
+    """
+    Drop GENES whose span lies predominantly inside masked (artifact) regions,
+    BEFORE the gene-lesion overlap/counting step.
+
+    This is the correct primitive for a gene-level recurrence test. Masking
+    lesions instead fails for these artifacts: the artifact genes (OR clusters,
+    HLA, FAM90, POTE, APOBEC) are tiny, but the lesions hitting them are often
+    broad (arm/chromosome-scale) passenger deletions whose fraction-inside-mask
+    is small — so the lesion survives and still hits the gene. Removing the
+    gene from consideration collapses the artifact regardless of lesion size.
+
+    A gene is dropped when the fraction of its span overlapping masked regions
+    is >= `frac` (default 0.5). This spares true drivers that merely abut an
+    artifact region (e.g. KRAS overlaps a segdup by ~10%).
+
+    Parameters
+    ----------
+    gene_data : DataFrame
+        Gene annotations with columns: gene, chrom, loc.start, loc.end
+    mask : dict[str, np.ndarray]
+        Output of load_exclude_intervals(): chrom -> sorted merged intervals.
+    frac : float
+        Overlap-fraction threshold for dropping a gene (default 0.5).
+
+    Returns
+    -------
+    (DataFrame, dict)
+        Kept genes (same schema), and a report dict:
+        {genes_in, genes_dropped, dropped_examples, genome_fraction_masked, overlap_frac}
+    """
+    n_in = len(gene_data)
+    empty_report = {
+        "genes_in": n_in,
+        "genes_dropped": 0,
+        "dropped_examples": [],
+        "genome_fraction_masked": 0.0,
+        "overlap_frac": frac,
+    }
+    if n_in == 0 or not mask:
+        return gene_data, empty_report
+
+    chroms = gene_data["chrom"].to_numpy()
+    starts = gene_data["loc.start"].to_numpy()
+    ends = gene_data["loc.end"].to_numpy()
+
+    drop = np.zeros(n_in, dtype=bool)
+    for i in range(n_in):
+        intervals = mask.get(chroms[i])
+        if intervals is None:
+            continue
+        s = int(starts[i])
+        e = max(int(ends[i]), s + 1)
+        ov = _masked_overlap_bp(s, e, intervals)
+        if ov / (e - s) >= frac:
+            drop[i] = True
+
+    kept = gene_data.loc[~drop].reset_index(drop=True)
+    dropped_genes = gene_data.loc[drop, "gene"].astype(str).tolist()
+
+    total_masked_bp = int(sum(int((iv[:, 1] - iv[:, 0]).sum()) for iv in mask.values()))
+    # hg38 ~3.1e9 bp; report a coarse fraction for sanity-checking the mask size
+    genome_fraction_masked = round(total_masked_bp / 3.1e9, 4)
+
+    report = {
+        "genes_in": n_in,
+        "genes_dropped": int(drop.sum()),
+        "dropped_examples": dropped_genes[:20],
+        "genome_fraction_masked": genome_fraction_masked,
+        "overlap_frac": frac,
+    }
+    return kept, report
+
+
+# =============================================================================
 # MAIN ENTRY POINT
 # =============================================================================
 

--- a/python/src/grin2_core.py
+++ b/python/src/grin2_core.py
@@ -1077,11 +1077,11 @@ def row_prob_subj_hit(P, IDs):
 # REGION EXCLUSION / MASKING
 # =============================================================================
 #
-# Hard region mask applied to lesions BEFORE the GRIN statistics run. This is
-# the literature-backed `exclude` step: removing lesions that fall in
-# low-mappability / segmental-duplication / blacklist / assembly-gap regions
-# stops those artifact-dense loci (e.g. OR clusters, FAM90, POTE, GOLGA8, HLA)
-# from accruing spurious recurrence under GRIN's uniform random-interval null.
+# Hard region mask applied to GENES BEFORE the GRIN statistics run. This is the
+# literature-backed `exclude` step: removing genes that sit in low-mappability /
+# segmental-duplication / blacklist / assembly-gap / common-CNV regions stops
+# artifact-dense loci (e.g. OR clusters, FAM90, POTE, GOLGA8, HLA) from
+# accruing spurious recurrence under GRIN's uniform random-interval null.
 # Mirrors Bioconductor nullranges/bootRanges `exclude`; see Amemiya/Kundaje/Boyle
 # 2019 (ENCODE blacklist), Karimzadeh 2018 (Umap/Bismap mappability), Sharp 2005
 # (segmental duplications), Ogata/Mu 2023 (excluderanges).

--- a/python/src/grin2_core.py
+++ b/python/src/grin2_core.py
@@ -1253,7 +1253,7 @@ def apply_gene_mask(gene_data, mask, frac=0.5):
     report = {
         "genes_in": n_in,
         "genes_dropped": int(drop.sum()),
-        "dropped_examples": dropped_genes[:20],
+        "dropped_examples": sorted(dropped_genes)[:20],
         "genome_fraction_masked": genome_fraction_masked,
         "overlap_frac": frac,
     }

--- a/python/src/grin2_core.py
+++ b/python/src/grin2_core.py
@@ -1125,8 +1125,8 @@ def load_exclude_intervals(bed_paths):
         try:
             with opener(path, "rt") as fh:
                 for line in fh:
-                    if not line.strip() or line.startswith(("#", "track", "browser")):
-                        continue
+                    if not line.strip() or line.startswith(("#", "track", "browser")):
+                        continue
                     fields = line.rstrip("\n").split("\t")
                     if len(fields) < 3:
                         continue
@@ -1189,7 +1189,7 @@ def _masked_overlap_bp(start, end, intervals):
     return int(total)
 
 
-def apply_gene_mask(gene_data, mask, frac=0.5):
+def apply_gene_mask(gene_data, mask, frac=0.5, genome_size_bp=None):
     """
     Drop GENES whose span lies predominantly inside masked (artifact) regions,
     BEFORE the gene-lesion overlap/counting step.
@@ -1245,15 +1245,14 @@ def apply_gene_mask(gene_data, mask, frac=0.5):
         ov = _masked_overlap_bp(s, e, intervals)
         if ov / (e - s) >= frac:
             drop[i] = True
-    # report a coarse fraction for sanity-checking mask size; defaults to ~hg38 size when not provided
 
-    genome_fraction_masked = round(total_masked_bp / float(genome_size_bp or 3.1e9), 4)
-
+    kept = gene_data.loc[~drop].reset_index(drop=True)
     dropped_genes = gene_data.loc[drop, "gene"].astype(str).tolist()
 
     total_masked_bp = int(sum(int((iv[:, 1] - iv[:, 0]).sum()) for iv in mask.values()))
-    # hg38 ~3.1e9 bp; report a coarse fraction for sanity-checking the mask size
-    genome_fraction_masked = round(total_masked_bp / 3.1e9, 4)
+    # coarse fraction for sanity-checking mask size; genome_size_bp is passed by the caller
+    # (sum of chromosome sizes) so this is genome-agnostic, with a human-genome fallback
+    genome_fraction_masked = round(total_masked_bp / float(genome_size_bp or 3.1e9), 4)
 
     report = {
         "genes_in": n_in,

--- a/server/genome/hg38.base.ts
+++ b/server/genome/hg38.base.ts
@@ -126,6 +126,15 @@ export function getHg38(): Genome {
 			}
 		],
 
+		// sources of blacklisted genomic regions (artifact-prone / germline-CNV loci),
+		// consumed e.g. by GRIN2 to drop genes lying in these regions before recurrence testing
+		blacklists: [
+			{ name: 'ENCODE blacklist', file: 'anno/encodeBlacklist.hg38.bed.gz' },
+			{ name: 'Segmental duplications', file: 'anno/genomicSuperDups.hg38.bed.gz' },
+			{ name: 'Assembly gaps', file: 'anno/gaps.hg38.bed.gz' },
+			{ name: 'Common germline CNVs (DGV)', file: 'anno/dgvCommon.hg38.bed.gz' }
+		],
+
 		geneset: [
 			{
 				name: 'Cancer Gene Census',

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -1,6 +1,7 @@
 import type { GRIN2Request, GRIN2Response } from '#types'
 import serverconfig from '../serverconfig.js'
 import path from 'path'
+import { file_is_readable } from '#src/utils.js'
 import { run_python } from '@sjcrh/proteinpaint-python'
 import { renderManhattan } from '../renderManhattan.ts'
 import { mayLog } from '../helpers.ts'
@@ -252,6 +253,23 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 		}
 	}
 
+	// Build region-mask report rows (artifact-region exclude mask). Only shown
+	// when the mask actually ran (resultData.maskReport is non-null).
+	const maskReport = resultData?.maskReport
+	const maskRows: string[][] = []
+	if (maskReport) {
+		const examples: string[] = maskReport.dropped_examples || []
+		const examplesStr =
+			examples.length > 0 ? `${examples.slice(0, 12).join(', ')}${examples.length > 12 ? ', …' : ''}` : 'none'
+		maskRows.push(
+			['Genes In', Number(maskReport.genes_in ?? 0).toLocaleString()],
+			['Genes Excluded', Number(maskReport.genes_dropped ?? 0).toLocaleString()],
+			['Examples', examplesStr],
+			['Genome Fraction Masked', `${((maskReport.genome_fraction_masked ?? 0) * 100).toFixed(2)}%`],
+			['Overlap Threshold', `${maskReport.overlap_frac ?? 0.5}`]
+		)
+	}
+
 	// Build cap warning if applicable
 	const capWarningRows: string[][] = []
 	const expectedToProcess = processing.totalSamples! - processing.failedSamples!
@@ -287,6 +305,7 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 					name: 'Lesion Counts',
 					rows: lesionTypeRows
 				},
+				...(maskRows.length > 0 ? [{ name: 'Region Mask (excluded artifact genes)', rows: maskRows }] : []),
 				{
 					name: 'Memory Usage',
 					rows: [
@@ -332,8 +351,31 @@ function grin2KeyInputs(req: GRIN2Request) {
 		cnvOptions: req.cnvOptions ?? null,
 		fusionOptions: req.fusionOptions ?? null,
 		svOptions: req.svOptions ?? null,
+		excludeOptions: req.excludeOptions ?? null,
 		maxGenesToShow: req.maxGenesToShow ?? null
 	}
+}
+
+/** Resolve the artifact-region mask BEDs bundled under tp/anno by genome name.
+ * Returns absolute paths to the BEDs that exist on disk; missing ones are
+ * skipped so the mask degrades gracefully. The Python wrapper unions + merges
+ * whatever it receives. Mask set: ENCODE/Kundaje blacklist + segmental duplications +
+ * assembly gaps + common germline CNVs (DGV Gold Standard, freq>=1%). The germline-CNV
+ * layer is essential — the dominant artifacts (OR clusters, HLA, KANSL1) are well-mapped but
+ * copy-number-polymorphic in the normal population, so mappability does not catch them. */
+async function resolveExcludeBeds(genome: string): Promise<string[]> {
+	const names = ['encodeBlacklist', 'genomicSuperDups', 'gaps', 'dgvCommon']
+	const beds: string[] = []
+	for (const name of names) {
+		const p = path.join(serverconfig.tpmasterdir, 'anno', `${name}.${genome}.bed.gz`)
+		try {
+			await file_is_readable(p)
+			beds.push(p)
+		} catch (e) {
+			mayLog(`[GRIN2] exclude BED not found, skipping: ${p} (${e})`)
+		}
+	}
+	return beds
 }
 
 /** Single read-or-recompute entry point for the GRIN2 cache. The Rust
@@ -441,12 +483,18 @@ async function runGrin2Fresh(
 	// Rust reads them straight from this JSON file, no sibling file.
 	const availableDataTypes = Object.keys(optionToDt).filter(key => key in request)
 
+	const excludeEnabled = request.excludeOptions?.enabled ?? true
+	const excludeBeds = excludeEnabled ? await resolveExcludeBeds(request.genome) : []
+
 	const pyInput = {
 		genedb: path.join(serverconfig.tpmasterdir, g.genedb.dbfile),
 		chromosomelist,
 		lesion: JSON.stringify(lesions),
 		maxGenesToShow: request.maxGenesToShow,
-		lesionTypeMap: buildLesionTypeMap(availableDataTypes)
+		lesionTypeMap: buildLesionTypeMap(availableDataTypes),
+		excludeEnabled,
+		excludeBeds,
+		excludeOverlapFrac: request.excludeOptions?.overlapFrac ?? 0.5
 	}
 
 	// Step 4: Run GRIN2 analysis via Python

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -1,7 +1,6 @@
 import type { GRIN2Request, GRIN2Response } from '#types'
 import serverconfig from '../serverconfig.js'
 import path from 'path'
-import { file_is_readable } from '#src/utils.js'
 import { run_python } from '@sjcrh/proteinpaint-python'
 import { renderManhattan } from '../renderManhattan.ts'
 import { mayLog } from '../helpers.ts'
@@ -259,8 +258,7 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 	const maskRows: string[][] = []
 	if (maskReport) {
 		const examples: string[] = maskReport.dropped_examples || []
-		const examplesStr =
-			examples.length > 0 ? `${examples.slice(0, 12).join(', ')}${examples.length > 12 ? ', …' : ''}` : 'none'
+		const examplesStr = examples.length > 0 ? examples.join(', ') : 'none'
 		maskRows.push(
 			['Genes In', Number(maskReport.genes_in ?? 0).toLocaleString()],
 			['Genes Excluded', Number(maskReport.genes_dropped ?? 0).toLocaleString()],
@@ -305,7 +303,7 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 					name: 'Lesion Counts',
 					rows: lesionTypeRows
 				},
-				...(maskRows.length > 0 ? [{ name: 'Region Mask (excluded artifact genes)', rows: maskRows }] : []),
+				...(maskRows.length > 0 ? [{ name: 'Excluded Genes (region mask)', rows: maskRows }] : []),
 				{
 					name: 'Memory Usage',
 					rows: [
@@ -356,26 +354,15 @@ function grin2KeyInputs(req: GRIN2Request) {
 	}
 }
 
-/** Resolve the artifact-region mask BEDs bundled under tp/anno by genome name.
- * Returns absolute paths to the BEDs that exist on disk; missing ones are
- * skipped so the mask degrades gracefully. The Python wrapper unions + merges
- * whatever it receives. Mask set: ENCODE/Kundaje blacklist + segmental duplications +
- * assembly gaps + common germline CNVs (DGV Gold Standard, freq>=1%). The germline-CNV
- * layer is essential — the dominant artifacts (OR clusters, HLA, KANSL1) are well-mapped but
- * copy-number-polymorphic in the normal population, so mappability does not catch them. */
-async function resolveExcludeBeds(genome: string): Promise<string[]> {
-	const names = ['encodeBlacklist', 'genomicSuperDups', 'gaps', 'dgvCommon']
-	const beds: string[] = []
-	for (const name of names) {
-		const p = path.join(serverconfig.tpmasterdir, 'anno', `${name}.${genome}.bed.gz`)
-		try {
-			await file_is_readable(p)
-			beds.push(p)
-		} catch (e) {
-			mayLog(`[GRIN2] exclude BED not found, skipping: ${p} (${e})`)
-		}
-	}
-	return beds
+/** Resolve genome-declared blacklist BED files for GRIN2's gene mask. Blacklist sources are declared
+ * in the genome config (Genome.blacklists) and their file paths absolutized at genome init.
+ * `selectedNames` chooses which sources to apply: undefined = all declared, [] = none, otherwise the
+ * named subset. Unknown names are ignored. Returns absolute BED file paths. */
+function resolveExcludeBeds(g: any, selectedNames?: string[]): string[] {
+	const all = g.blacklists as { name: string; file: string }[] | undefined
+	if (!all?.length) return []
+	const wanted = new Set(selectedNames ?? all.map(b => b.name))
+	return all.filter(b => wanted.has(b.name)).map(b => b.file)
 }
 
 /** Single read-or-recompute entry point for the GRIN2 cache. The Rust
@@ -483,8 +470,8 @@ async function runGrin2Fresh(
 	// Rust reads them straight from this JSON file, no sibling file.
 	const availableDataTypes = Object.keys(optionToDt).filter(key => key in request)
 
-	const excludeEnabled = request.excludeOptions?.enabled ?? true
-	const excludeBeds = excludeEnabled ? await resolveExcludeBeds(request.genome) : []
+	const excludeBeds = resolveExcludeBeds(g, request.excludeOptions?.blacklists)
+	const excludeEnabled = excludeBeds.length > 0
 
 	const pyInput = {
 		genedb: path.join(serverconfig.tpmasterdir, g.genedb.dbfile),

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -349,7 +349,7 @@ function grin2KeyInputs(req: GRIN2Request) {
 		cnvOptions: req.cnvOptions ?? null,
 		fusionOptions: req.fusionOptions ?? null,
 		svOptions: req.svOptions ?? null,
-		excludeOptions: req.excludeOptions ?? null,
+		excludeOptions: normalizeExcludeOptions(req.excludeOptions),
 		maxGenesToShow: req.maxGenesToShow ?? null
 	}
 }
@@ -363,6 +363,22 @@ function resolveExcludeBeds(g: any, selectedNames?: string[]): string[] {
 	if (!all?.length) return []
 	const wanted = new Set(selectedNames ?? all.map(b => b.name))
 	return all.filter(b => wanted.has(b.name)).map(b => b.file)
+}
+
+/** Normalize excludeOptions so the cache key and the Python input always agree and never carry a
+ * non-finite overlapFrac. A NaN (e.g. from an empty client input) would be serialized by
+ * JSON.stringify to null, and the Python wrapper's float(None) would then throw. Clamp to a finite
+ * value in [0, 1] (default 0.5). Returns null when no excludeOptions are provided. */
+function normalizeExcludeOptions(opts: GRIN2Request['excludeOptions']): {
+	blacklists?: string[]
+	overlapFrac: number
+} | null {
+	if (!opts) return null
+	const frac = Number(opts.overlapFrac)
+	return {
+		blacklists: Array.isArray(opts.blacklists) ? opts.blacklists : undefined,
+		overlapFrac: Number.isFinite(frac) ? Math.min(Math.max(frac, 0), 1) : 0.5
+	}
 }
 
 /** Single read-or-recompute entry point for the GRIN2 cache. The Rust
@@ -470,7 +486,9 @@ async function runGrin2Fresh(
 	// Rust reads them straight from this JSON file, no sibling file.
 	const availableDataTypes = Object.keys(optionToDt).filter(key => key in request)
 
-	const excludeBeds = resolveExcludeBeds(g, request.excludeOptions?.blacklists)
+	// normalized once so pyInput matches the cache key (and never carries a non-finite overlapFrac)
+	const excludeOpts = normalizeExcludeOptions(request.excludeOptions)
+	const excludeBeds = resolveExcludeBeds(g, excludeOpts?.blacklists)
 	const excludeEnabled = excludeBeds.length > 0
 
 	const pyInput = {
@@ -481,7 +499,7 @@ async function runGrin2Fresh(
 		lesionTypeMap: buildLesionTypeMap(availableDataTypes),
 		excludeEnabled,
 		excludeBeds,
-		excludeOverlapFrac: request.excludeOptions?.overlapFrac ?? 0.5
+		excludeOverlapFrac: excludeOpts?.overlapFrac ?? 0.5
 	}
 
 	// Step 4: Run GRIN2 analysis via Python

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -378,6 +378,26 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 			}
 		}
 
+		if (g.blacklists) {
+			// genome-level blacklisted region sources (e.g. consumed by GRIN2). Absolutize file
+			// paths in place (kept server-side; clientcopy_genome exposes only name). Lenient:
+			// an unreadable file is warned + dropped so a deployment missing a BED still boots.
+			if (!Array.isArray(g.blacklists)) throw genomename + '.blacklists should be an array'
+			const keptBlacklists = []
+			for (const bl of g.blacklists) {
+				if (!bl.name) throw genomename + ': .name missing for one element of blacklists[]'
+				if (!bl.file) throw genomename + ': .file missing for one element of blacklists[]'
+				bl.file = path.join(serverconfig.tpmasterdir, bl.file)
+				try {
+					await utils.file_is_readable(bl.file)
+					keptBlacklists.push(bl)
+				} catch (e) {
+					console.warn(`[genome ${genomename}] blacklist '${bl.name}' skipped: ${e}`)
+				}
+			}
+			g.blacklists = keptBlacklists
+		}
+
 		if (g.hicdomain) {
 			if (!g.hicdomain.groups) throw '.groups{} missing from hicdomain'
 			for (const groupname in g.hicdomain.groups) {

--- a/server/src/routes/genomes.ts
+++ b/server/src/routes/genomes.ts
@@ -44,7 +44,7 @@ return error message as the service is out
 		}
 
 		const hash = {}
-		if (req.query && req.query.genome) {
+		if (req.query?.genome) {
 			hash[req.query.genome] = clientcopy_genome(req.query.genome, genomes)
 		} else {
 			for (const genomename in genomes) {
@@ -94,6 +94,11 @@ function clientcopy_genome(genomename, genomes) {
 		hideOnClient: g.hideOnClient
 	}
 
+	if (g.blacklists) {
+		g2.blacklists = g.blacklists.map(i => {
+			return { name: i.name }
+		})
+	}
 	if (g.termdbs) {
 		g2.termdbs = {}
 		for (const k in g.termdbs) {

--- a/shared/types/src/genome.ts
+++ b/shared/types/src/genome.ts
@@ -126,4 +126,15 @@ export type Genome = MinGenome & {
 	geneset?: GeneSet[]
 	hicdomain?: HicDomain
 	minorchr?: string
+	/** sources of blacklisted genomic regions */
+	blacklists?: {
+		/** name to identify this source */
+		name: string
+		/** tabular text file with columns:
+		1. chr
+		2. start
+		3. stop
+		*/
+		file: string
+	}[]
 }

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -92,15 +92,16 @@ export type GRIN2Request = {
 		/** Number of bases to include as 3' flank around the sv position */
 		threePrimeFlankSize?: number
 	}
-	/** Artifact-region exclude mask applied to lesions before the GRIN2 statistics run.
-	 * Lesions whose span lies predominantly inside low-mappability / segmental-duplication /
-	 * ENCODE-blacklist / assembly-gap regions are dropped. Literature-backed (nullranges/bootRanges
-	 * `exclude`, ENCODE blacklist, Umap/Bismap, UCSC segdups). Mask BEDs are resolved server-side
-	 * by genome name; absent BEDs are skipped gracefully. */
+	/** Artifact-region exclude mask applied before the GRIN2 statistics run: genes whose span lies
+	 * >= overlapFrac inside the selected blacklist regions are dropped. Blacklist sources are
+	 * declared per genome (Genome.blacklists) and selected here by name; their BED files are
+	 * resolved server-side. Literature-backed (ENCODE/Kundaje blacklist, UCSC segdups, assembly
+	 * gaps, DGV common germline CNVs). */
 	excludeOptions?: {
-		/** Whether to apply the region mask (default: true) */
-		enabled?: boolean
-		/** Drop a lesion when >= this fraction of its span overlaps masked regions (default: 0.5) */
+		/** names of genome-declared blacklist sources to apply (match Genome.blacklists[].name);
+		 * omitted = apply all declared sources; empty array = apply none */
+		blacklists?: string[]
+		/** drop a gene when >= this fraction of its span overlaps masked regions (default: 0.5) */
 		overlapFrac?: number
 	}
 

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -92,6 +92,18 @@ export type GRIN2Request = {
 		/** Number of bases to include as 3' flank around the sv position */
 		threePrimeFlankSize?: number
 	}
+	/** Artifact-region exclude mask applied to lesions before the GRIN2 statistics run.
+	 * Lesions whose span lies predominantly inside low-mappability / segmental-duplication /
+	 * ENCODE-blacklist / assembly-gap regions are dropped. Literature-backed (nullranges/bootRanges
+	 * `exclude`, ENCODE blacklist, Umap/Bismap, UCSC segdups). Mask BEDs are resolved server-side
+	 * by genome name; absent BEDs are skipped gracefully. */
+	excludeOptions?: {
+		/** Whether to apply the region mask (default: true) */
+		enabled?: boolean
+		/** Drop a lesion when >= this fraction of its span overlaps masked regions (default: 0.5) */
+		overlapFrac?: number
+	}
+
 	maxGenesToShow?: number // Default: 500
 }
 


### PR DESCRIPTION
# Description

GRIN2's top-genes table was dominated by genes that are not plausible somatic drivers — olfactory-receptor clusters, HLA, FAM90, POTE, GOLGA8, APOBEC3, KANSL1, etc. These recur across a cohort for technical/germline reasons (low mappability, segmental duplications, common germline CNVs), not selection, so they crowd out real drivers under GRIN's uniform random-interval null.

This PR adds an optional, literature-backed **artifact-region gene mask** that removes genes sitting in known artifact regions **before** the statistics run. Blacklist sources are declared at the **genome level** and selected per-source in the UI; the mask is on by default and is a true removal (not a flag column).

## What changed

**Masking core (Python)**
- New primitives in `python/src/grin2_core.py`:
  - `load_exclude_intervals(bed_paths)` — reads one or more `.bed.gz` files via `gzip` (no `pysam`/tabix dependency), unions them, returns per-chromosome sorted, overlap-merged intervals.
  - `apply_gene_mask(gene_data, mask, frac=0.5)` — drops a gene when ≥ `frac` of its span lies inside masked regions; returns the kept genes plus a report (`genes_in`, `genes_dropped`, `dropped_examples`, `genome_fraction_masked`, `overlap_frac`).
- `python/src/grin2PpWrapper.py`: reads `excludeBeds` / `excludeEnabled` / `excludeOverlapFrac` from the input JSON, applies `apply_gene_mask` to the gene set right before `grin_stats`, and emits a `maskReport`. No-op (unchanged behavior) when disabled or no BEDs resolve.

**Genome-level blacklist declaration (server)**
- `shared/types/src/genome.ts`: new `Genome.blacklists: { name, file }[]` type (sources of blacklisted regions, tabular `chr/start/stop` files).
- `server/genome/hg38.base.ts`: declares the four hg38 blacklist sources (tpmasterdir-relative paths).
- `server/src/initGenomesDs.js`: validates + absolutizes each `blacklists[].file` at genome init (mirrors the `hicenzymefragment`/`hicdomain` pattern). **Lenient** — an unreadable file is warned and dropped so a deployment missing a BED still boots.
- `server/src/routes/genomes.ts`: `clientcopy_genome` exposes only each blacklist's `{ name }` to the client (file paths stay server-side).
- `client/types/clientGenome.ts`: client genome type gains `blacklists?: { name }[]`.

**GRIN2 request + server wiring**
- `shared/types/src/routes/grin2.ts` + `client/plots/grin2/GRIN2Types.ts`: `excludeOptions { blacklists?: string[]; overlapFrac? }` — `blacklists` is the list of selected source names (omitted = all declared, `[]` = none).
- `server/src/grin2/main.ts`: `resolveExcludeBeds(g, selectedNames?)` maps the selected names → `g.blacklists[].file` (absolutized at init); passes `excludeBeds`/`excludeOverlapFrac` to Python; `excludeOptions` is part of the GRIN2 **cache key**; the `maskReport` is surfaced as an **"Excluded Genes (region mask)"** stats section (counts, genome fraction, overlap threshold, and a 20-gene sample).

**Client UI**
- `client/plots/grin2/view/GRIN2ControlsView.ts`: an **"Exclude genes overlapping"** row that renders **one checkbox per genome-declared blacklist source** (all on by default) plus a **"Min gene overlap"** input (default 0.5). The row is skipped entirely when the genome declares no blacklists.
- `client/plots/grin2/grin2.ts`: passes the genome object (`this.app.opts.genome`) into the controls view.
- `client/plots/grin2/settings/defaults.ts`: `EXCLUDE_OVERLAP_FRAC_FALLBACK = 0.5`. Selection (and whether the mask runs) now comes from the per-source checkboxes.
- Options round-trip through the request and saved settings.

### Blacklist sources (declared in `hg38.base.ts`, user-selectable)

| Source (checkbox label) | Data |
|---|---|
| ENCODE blacklist | ENCODE / Kundaje GRCh38 unified blacklist |
| Segmental duplications | UCSC `genomicSuperDups` |
| Assembly gaps | UCSC `gap` + `centromeres` |
| Common germline CNVs (DGV) | DGV Gold Standard, frequency ≥ 1% |

## Why gene-level (not lesion-level) masking

An initial lesion-masking approach (drop lesions overlapping artifact regions) did **not** work: the artifact genes are tiny but the lesions hitting them are often broad arm/chromosome-scale deletions, so a lesion's fraction-inside-mask is small and it survives — still hitting the gene (e.g. `APOBEC3A`'s gene span is 97% masked, but only 1% of the loss lesions hitting it are ≥50%-masked). Masking **genes** removes the artifact regardless of lesion size.

A mappability layer was also evaluated and dropped: the residual artifact loci (OR2T10, HLA class II, KANSL1) are *well-mapped* (Umap ≈ 0.93–1.0, like real drivers) but germline copy-number-polymorphic — so the **DGV common-CNV layer** is what closes the gap, not mappability.

## Validation (ASH cohort, ~1.1M CNV lesions)

- ~3,500 / ~29,900 genes excluded (~14% of genome masked at `overlapFrac` 0.5).
- Clean separation: every artifact gene tested → gene-fraction ≥ 0.94 (excluded); every canonical leukemia driver (CDKN2A/B, ETV6, CDKN1B, CXCR4, TP53, KRAS, FLT3, WT1, PAX5, IKZF1, RB1, PTEN, NF1, CEBPA) → ≤ 0.23 (kept).
- AML run: top genes are NPM1/CEBPA/FLT3/TET2/DNMT3A/NRAS/SRSF2/WT1/ASXL1/RUNX1/GATA2/IDH1-2/SF3B1/KRAS/KIT/TP53/PTPN11; **zero** OR/HLA/KANSL/APOBEC/FAM90/POTE/GOLGA/MUC/DEFB genes near the top. A T-ALL/ETP run is correctly led by NOTCH1/FBXW7/JAK1/JAK3/PHF6/IL7R/CDKN2A-B/PTEN/GATA3.
- The genome-level refactor reproduces the same output as the earlier hardcoded-path prototype when all sources are selected; client + server `tsc` pass (0 errors), and `GET /genomes?genome=hg38` returns the four blacklist names (no file paths).

## Deployment notes

- The four mask BEDs are **not in the repo**; they must exist under `tp/anno/` as `encodeBlacklist.${genome}.bed.gz`, `genomicSuperDups.${genome}.bed.gz`, `gaps.${genome}.bed.gz`, `dgvCommon.${genome}.bed.gz`. Declared-but-missing files are skipped with a warning at genome init, so the genome still loads (that source just won't appear as a checkbox).
- The feature is genome-config-driven: a genome only gets the mask if it declares `blacklists` (currently hg38).
- `excludeOptions` is part of the GRIN2 cache key, but **clear the GRIN2 result cache** (`<cachedir>/grin2/*.json`) after deploying so existing entries recompute.
- Backward compatible: with the mask disabled (no sources checked) or no BEDs present, output is unchanged.

## Notes / follow-ups

- Scope is the standard (non-GDC) GRIN2 path; the GDC wrapper is not touched in this PR.
- DGV Gold Standard is somewhat European-enriched and misses some pericentromeric NAHR loci (e.g. a recurrent 10q11.22 gain); a **gnomAD-SV common-CNV** BED could be added later as an additional genome-level blacklist source for broader coverage — it would auto-appear as a new checkbox with no code changes.

## References

- Pounds et al., GRIN — Bioinformatics 2013, doi:10.1093/bioinformatics/btt372
- Amemiya et al., ENCODE blacklist — Sci Rep 2019, doi:10.1038/s41598-019-45839-z
- Sharp et al., segmental duplications — AJHG 2005, doi:10.1086/431652
- MacDonald et al., DGV — NAR 2014, doi:10.1093/nar/gkt958
- Ogata et al., excluderanges — Bioinformatics 2023, doi:10.1093/bioinformatics/btad198


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
