### PR TITLE
Patched scaling mechanics

### DIFF
--- a/client/plots/disco/viewmodel/ViewModelMapper.ts
+++ b/client/plots/disco/viewmodel/ViewModelMapper.ts
@@ -48,14 +48,6 @@ export class ViewModelMapper {
 		this.settings.rings.labelLinesInnerRadius *= scale
 		this.settings.rings.labelsToLinesDistance *= scale
 		this.settings.rings.chromosomeInnerRadius *= scale
-		this.settings.rings.chromosomeWidth *= scale
-		this.settings.rings.nonExonicRingWidth *= scale
-		this.settings.rings.snvRingWidth *= scale
-		this.settings.rings.lohRingWidth *= scale
-		this.settings.rings.cnvRingWidth *= scale
-		this.settings.rings.mutationWaterfallRingWidth *= scale
-		this.settings.label.fontSize *= scale
-		this.settings.legend.fontSize *= scale
 	}
 
 	static computeDynamicRadius(data: Array<any>): number {

--- a/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModelMapper.unit.spec.ts
@@ -4,7 +4,7 @@ import discoDefaults from '../../defaults'
 
 /*
 Tests:
-ViewModelMapper scales rings and dimensions using the radius setting
+ViewModelMapper scales plot diameter dimensions using the radius setting while keeping ring widths and font sizes fixed
 */
 
 const settings = discoDefaults({ Disco: { autoRadius: false, radius: 500 } })
@@ -26,7 +26,7 @@ test('\n', function (t) {
 	t.end()
 })
 
-test('ViewModelMapper.applyRadius adjusts settings and ViewModel dimensions', t => {
+test('ViewModelMapper.applyRadius adjusts diameter settings while preserving widths and font sizes', t => {
 	const vmSettings = viewModel.settings
 	const scale = settings.Disco.radius! / settings.rings.labelLinesInnerRadius
 
@@ -54,44 +54,46 @@ test('ViewModelMapper.applyRadius adjusts settings and ViewModel dimensions', t 
 
 	t.equal(
 		vmSettings.rings.chromosomeWidth,
-		timesScale(settings.rings.chromosomeWidth),
-		'Should calculate chromosomeWidth based on radius setting'
+		settings.rings.chromosomeWidth,
+		'Should keep chromosomeWidth fixed when radius changes'
 	)
 
 	t.equal(
 		vmSettings.rings.nonExonicRingWidth,
-		timesScale(settings.rings.nonExonicRingWidth),
-		'Should calculate nonExonicRingWidth based on radius setting'
+		settings.rings.nonExonicRingWidth,
+		'Should keep nonExonicRingWidth fixed when radius changes'
 	)
 
 	t.equal(
 		vmSettings.rings.snvRingWidth,
-		timesScale(settings.rings.snvRingWidth),
-		'Should calculate snvRingWidth based on radius setting'
+		settings.rings.snvRingWidth,
+		'Should keep snvRingWidth fixed when radius changes'
 	)
 
 	t.equal(
 		vmSettings.rings.lohRingWidth,
-		timesScale(settings.rings.lohRingWidth),
-		'Should calculate lohRingWidth based on radius setting'
+		settings.rings.lohRingWidth,
+		'Should keep lohRingWidth fixed when radius changes'
 	)
 
 	t.equal(
 		vmSettings.rings.cnvRingWidth,
-		timesScale(settings.rings.cnvRingWidth),
-		'Should calculate cnvRingWidth based on radius setting'
+		settings.rings.cnvRingWidth,
+		'Should keep cnvRingWidth fixed when radius changes'
 	)
 
 	t.equal(
-		vmSettings.label.fontSize,
-		timesScale(settings.label.fontSize),
-		'Should calculate label font size based on radius setting'
+		vmSettings.rings.mutationWaterfallRingWidth,
+		settings.rings.mutationWaterfallRingWidth,
+		'Should keep mutationWaterfallRingWidth fixed when radius changes'
 	)
+
+	t.equal(vmSettings.label.fontSize, settings.label.fontSize, 'Should keep label font size fixed when radius changes')
 
 	t.equal(
 		vmSettings.legend.fontSize,
-		timesScale(settings.legend.fontSize),
-		'Should calculate legend font size based on radius setting'
+		settings.legend.fontSize,
+		'Should keep legend font size fixed when radius changes'
 	)
 
 	t.end()

--- a/client/plots/disco/viewmodel/test/ViewModelMapperAutoRadius.unit.spec.ts
+++ b/client/plots/disco/viewmodel/test/ViewModelMapperAutoRadius.unit.spec.ts
@@ -6,7 +6,7 @@ import { dtsnvindel, dtcnv, dtloh } from '#shared/common.js'
 /*
 Tests:
 	computeDynamicRadius returns correct radius for 1, 2, and 3 ring-type combinations
-	Auto-radius path computes radius and scales settings accordingly
+	Auto-radius path computes radius and scales diameter settings while preserving ring widths and font sizes
 	Explicit radius is used when autoRadius is false
 */
 
@@ -66,7 +66,7 @@ test('computeDynamicRadius returns 300 for SNV + CNV + LOH data (3 ring types)',
 
 // ───── Integration: auto-radius path through map() ─────
 
-test('Auto-radius path computes radius=200 and scales settings for SNV-only data', t => {
+test('Auto-radius path computes radius=200 and scales diameter settings for SNV-only data', t => {
 	const settings = discoDefaults({ Disco: { autoRadius: true } })
 	const baseLabel = settings.rings.labelLinesInnerRadius
 	const mapper = new ViewModelMapper(structuredClone(settings as any), {} as any)
@@ -91,6 +91,21 @@ test('Auto-radius path computes radius=200 and scales settings for SNV-only data
 		vm.settings.rings.labelsToLinesDistance,
 		settings.rings.labelsToLinesDistance * expectedScale,
 		'labelsToLinesDistance should be scaled using auto-computed radius 200'
+	)
+	t.equal(
+		vm.settings.rings.snvRingWidth,
+		settings.rings.snvRingWidth,
+		'snvRingWidth should remain fixed when auto-radius changes the plot diameter'
+	)
+	t.equal(
+		vm.settings.label.fontSize,
+		settings.label.fontSize,
+		'label font size should remain fixed when auto-radius changes the plot diameter'
+	)
+	t.equal(
+		vm.settings.legend.fontSize,
+		settings.legend.fontSize,
+		'legend font size should remain fixed when auto-radius changes the plot diameter'
 	)
 	t.end()
 })


### PR DESCRIPTION
# Description
The ring width and font size will now stay fixed even after the diameter is changed. unit tests were also updated

Test here:
used to have bigger diameter and text: [test 1](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=TCGA-4V-A9QQ-01A)
used to have smaller diameter and text: [test 2](http://localhost:3000/?genome=hg38&dslabel=GDC&disco=1&sample=MBCProject_1667_T1_WES)
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
