### PR TITLE
do not show regression chart buttons in the Correlation Plot tool

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Fixes:
+- make the fatal error consistent message consistent on initial validation and retries
+- do not show regression chart buttons in the Correlation Plot tool

--- a/release.txt
+++ b/release.txt
@@ -1,3 +1,3 @@
 Fixes:
-- make the fatal error consistent message consistent on initial validation and retries
+- make the fatal error message consistent on initial validation and retries
 - do not show regression chart buttons in the Correlation Plot tool

--- a/server/src/gdc.buildDictionary.js
+++ b/server/src/gdc.buildDictionary.js
@@ -121,6 +121,11 @@ re.expand: []
 const mapping_prefix = 'ssm_occurrence_centrics'
 
 export async function gdcBuildDictionary(ds) {
+	if (!ds.init) ds.init = {}
+	// track this step so that an error may be associated with the dictionary build step;
+	// this steps typically takes about 0.7 seconds from start to finish
+	ds.init.step = 'gdcBuildDictionary()'
+
 	const id2term = new Map()
 	// k: term id, string with full path
 	// v: term obj
@@ -341,6 +346,10 @@ export async function gdcBuildDictionary(ds) {
 		ds.cohort.termdb.termtypeByCohort.push({ cohort: '', termType: 'survival', termCount: survivalCount })
 		ds.cohort.termdb.termtypeByCohort.nested[''].survival = survivalCount
 	}
+
+	// dictionary build completed successfully, a subsequent error
+	// will not be related to this initialization step
+	ds.init.step = ''
 }
 
 function mayAddTermAttribute(t) {
@@ -742,9 +751,9 @@ function makeTermdbQueries(ds, id2term) {
 				'summarizeCnvGeneexp',
 				'summarizeMutationSurvival',
 				'summarizeMutationCnv',
-				'summarizeGeneexpSurvival',
-				'regression',
-				'cox'
+				'summarizeGeneexpSurvival'
+				// 'regression',  // re-enable thee after Xanthopoulos release
+				// 'cox'
 			]
 		}
 		const numericTypeCount = {}

--- a/server/src/gdc.buildDictionary.js
+++ b/server/src/gdc.buildDictionary.js
@@ -123,7 +123,7 @@ const mapping_prefix = 'ssm_occurrence_centrics'
 export async function gdcBuildDictionary(ds) {
 	if (!ds.init) ds.init = {}
 	// track this step so that an error may be associated with the dictionary build step;
-	// this steps typically takes about 0.7 seconds from start to finish
+	// this step typically takes about 0.7 seconds from start to finish
 	ds.init.step = 'gdcBuildDictionary()'
 
 	const id2term = new Map()
@@ -752,8 +752,8 @@ function makeTermdbQueries(ds, id2term) {
 				'summarizeMutationSurvival',
 				'summarizeMutationCnv',
 				'summarizeGeneexpSurvival'
-				// 'regression',  // re-enable thee after Xanthopoulos release
-				// 'cox'
+				// 'regression',  // re-enable after Xanthopoulos release
+				// 'cox', // re-enable after Xanthopoulos release
 			]
 		}
 		const numericTypeCount = {}

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -519,7 +519,7 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 		if (totalRawDsLst === 1)
 			setImmediate(() => {
 				const msg = ds.init.fatalError === e ? e : ds.init.fatalError + ': ' + e
-				throw new Error(gdlabel + ' ' + msg)
+				throw new Error(gdlabel + ' fatal error: ' + msg)
 			})
 		return
 	}
@@ -549,9 +549,9 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 			if (!ds.init.status) ds.init.status = 'done'
 		} catch (e) {
 			if (ds.init.status != 'recoverableError' && !ds.init.recoverableError && !utils.isRecoverableError(e)) {
-				const msg = `Fatal error on ${gdlabel} retry, stopping retry${
-					ds.init?.fatalError ? ': ' + ds.init?.fatalError : ''
-				} [${e?.error || e}]`
+				const msg = `${gdlabel} fatal error: stopping retry${ds.init?.fatalError ? ': ' + ds.init?.fatalError : ''} [${
+					e?.error || e
+				}]`
 				console.log(msg)
 				clearInterval(interval) // cancel since retrying will not change the outcome
 				ds.init.status = 'fatalError'
@@ -562,7 +562,7 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 						path.join(serverconfig.cachedir, '/slack/last_message_hash.txt')
 					)
 				}
-				// this will crash the server with an uncaught error, the server will stop responding to HTTP requests
+				// this will crash the server with a fatal error message, the server will not respond to HTTP requests
 				if (totalRawDsLst === 1)
 					setImmediate(() => {
 						throw new Error(msg)

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -160,62 +160,62 @@ export async function init(ds, genome, totalDsLst = 0) {
 		if (response?.status != 'OK') throw response
 	}
 
-  try {
-	// must validate termdb first
-	await validate_termdb(ds)
-	validateDemoJwtInputs(ds)
+	try {
+		// must validate termdb first
+		await validate_termdb(ds)
+		validateDemoJwtInputs(ds)
 
-	if (ds.queries) {
-		// must validate snvindel query before variant2sample
-		// as vcf header must be parsed to supply samples for variant2samples
-		await validate_query_snvindel(ds, genome)
-		await validate_query_svfusion(ds, genome)
-		await validate_query_geneCnv(ds, genome)
-		await validate_query_cnv(ds, genome)
-		await validate_query_itd(ds, genome)
-		await validate_query_ld(ds, genome)
-		await validate_query_geneExpression(ds, genome)
-		await validateQueryIsoformExpression(ds, genome)
-		await validate_query_ssGSEA(ds, genome)
-		await validate_query_dnaMethylation(ds, genome)
-		await validate_query_metaboliteIntensity(ds, genome)
-		await validate_query_proteome(ds, genome)
-		await validate_query_getTopTermsByType(ds, genome)
-		await validate_query_getTopMutatedGenes(ds, genome)
-		await validate_query_getSampleImages(ds, genome)
-		await validate_query_getWSIAnnotations(ds)
-		await validate_query_getWSIClassesQuery(ds)
-		await validate_query_getSampleWSImages(ds, genome)
-		await validate_query_deleteWSIAnnotation(ds)
-		await validate_query_saveWSIAnnotation(ds)
-		await validate_query_getWSISamples(ds, genome)
-		await makeAdHocDicTermdbQueries(ds)
-		await validate_query_rnaseqGeneCount(ds, genome)
-		await validate_query_singleSampleMutation(ds, genome)
-		await validate_query_singleSampleGenomeQuantification(ds, genome)
-		await validate_query_singleSampleGbtk(ds, genome)
-		//await validate_query_probe2cnv(ds, genome)
-		await validate_query_singleCell(ds, genome)
-		await validate_query_TopVariablyExpressedGenes(ds)
-		await validate_query_trackLst(ds, genome)
+		if (ds.queries) {
+			// must validate snvindel query before variant2sample
+			// as vcf header must be parsed to supply samples for variant2samples
+			await validate_query_snvindel(ds, genome)
+			await validate_query_svfusion(ds, genome)
+			await validate_query_geneCnv(ds, genome)
+			await validate_query_cnv(ds, genome)
+			await validate_query_itd(ds, genome)
+			await validate_query_ld(ds, genome)
+			await validate_query_geneExpression(ds, genome)
+			await validateQueryIsoformExpression(ds, genome)
+			await validate_query_ssGSEA(ds, genome)
+			await validate_query_dnaMethylation(ds, genome)
+			await validate_query_metaboliteIntensity(ds, genome)
+			await validate_query_proteome(ds, genome)
+			await validate_query_getTopTermsByType(ds, genome)
+			await validate_query_getTopMutatedGenes(ds, genome)
+			await validate_query_getSampleImages(ds, genome)
+			await validate_query_getWSIAnnotations(ds)
+			await validate_query_getWSIClassesQuery(ds)
+			await validate_query_getSampleWSImages(ds, genome)
+			await validate_query_deleteWSIAnnotation(ds)
+			await validate_query_saveWSIAnnotation(ds)
+			await validate_query_getWSISamples(ds, genome)
+			await makeAdHocDicTermdbQueries(ds)
+			await validate_query_rnaseqGeneCount(ds, genome)
+			await validate_query_singleSampleMutation(ds, genome)
+			await validate_query_singleSampleGenomeQuantification(ds, genome)
+			await validate_query_singleSampleGbtk(ds, genome)
+			//await validate_query_probe2cnv(ds, genome)
+			await validate_query_singleCell(ds, genome)
+			await validate_query_TopVariablyExpressedGenes(ds)
+			await validate_query_trackLst(ds, genome)
 
-		await validate_variant2samples(ds)
-		await validate_ssm2canonicalisoform(ds)
+			await validate_variant2samples(ds)
+			await validate_ssm2canonicalisoform(ds)
 
-		await mayAdd_refseq2ensembl(ds, genome)
+			await mayAdd_refseq2ensembl(ds, genome)
 
-		await mayAdd_mayGetGeneVariantData(ds, genome)
-	}
+			await mayAdd_mayGetGeneVariantData(ds, genome)
+		}
 
-	await mayValidateAssayAvailability(ds)
-	await mayValidateViewModes(ds)
+		await mayValidateAssayAvailability(ds)
+		await mayValidateViewModes(ds)
 
-	// uncomment below to manually trigger server crash if there is only 1 dataset;
-	// make sure that serverconfig only has one genome and datasets[] entry,
-	// and that the ds.label below matches that entry
-	// if (ds.label == 'GDC') {ds.init = {status: 'fatalError', fatalError: 'test server crash'}; throw ds.init.fatalError}
+		// uncomment below to manually trigger server crash if there is only 1 dataset;
+		// make sure that serverconfig only has one genome and datasets[] entry,
+		// and that the ds.label below matches that entry
+		// if (ds.label == 'GDC') {ds.init = {status: 'fatalError', fatalError: 'test server crash'}; throw ds.init.fatalError}
 
-	if (ds.cohort?.db?.refresh) throw `!!! ds.cohort.db.refresh has been deprecated !!!`
+		if (ds.cohort?.db?.refresh) throw `!!! ds.cohort.db.refresh has been deprecated !!!`
 	} catch (e) {
 		if (!ds.init) ds.init = {}
 		if (ds.init.step != 'gdcBuildDictionary()' || !ds.init.recoverableError) {
@@ -313,10 +313,7 @@ export async function validate_termdb(ds) {
 		if (typeof tdb.dictionary.build != 'function') throw 'termdb.dictionary.build() is not a function'
 		await tdb.dictionary.build(ds)
 	} else if (tdb.dictionary?.gdcapi) {
-		if (!ds.init) ds.init = {}
-		ds.init.step = 'gdcBuildDictionary()'
 		await gdcBuildDictionary(ds)
-		ds.init.step = ''
 	} else if (ds.cohort.db) {
 		if (!ds.cohort.db.file && !ds.cohort.db.file_fullpath) throw 'ds.cohort.db.file missing'
 		server_init_db_queries(ds)


### PR DESCRIPTION

# Description

- do not show regression chart buttons in the Correlation Plot tool
- make the fatal error consistent message consistent on initial validation and retries
- improve comments related to ds init and errors

Tests
- [Correlation Plot ](http://localhost:3000/example.gdc.correlation.html?noheader=1&cohort=TCGA-LUAD) should not show Regression and Cox chart buttons
- disable all datasets except GDC in serverconfig, change the `"updateAttr" to have `gender-0` to force a validation error, the server log should crash and have `hg38-gdc/GDC fatal error`. Note that in GDC portal, there will be no genome alias and the message will be `hg38/GDC fatal error`.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
