### PR TITLE
Extended MAF filter to support allelic-depth filtering

### DIFF
--- a/client/filter/tvs.numeric.js
+++ b/client/filter/tvs.numeric.js
@@ -239,7 +239,9 @@ function addRangeTableNoDensity(self, tvs) {
 	brush.equation_td = rangeTr.append('td')
 	brush.rangeInput = new NumericRangeInput(brush.equation_td, range, () => {}, { width: '125px' })
 
-	if (self.opts.isMafFilter) {
+	// for maf filter tvs, the term's mode determines which metric is filtered
+	const mafFilterMode = self.opts.isMafFilter ? tvs.term.mafFilterMode || 'maf' : null
+	if (mafFilterMode == 'maf') {
 		// maf filter tvs
 		// render maf range input and min allelic depth input
 		rangeLabelTd.text('MAF Range (0-1)')
@@ -259,6 +261,20 @@ function addRangeTableNoDensity(self, tvs) {
 			.attr('class', 'sja_filter_tag_btn sjpp_apply_btn')
 			.style('border-radius', '13px')
 			.style('margin-top', '10px')
+			.style('font-size', '.8em')
+			.style('text-transform', 'uppercase')
+			.text('apply')
+			.on('click', clickApply)
+	} else if (mafFilterMode == 'totalDepth' || mafFilterMode == 'altDepth') {
+		// allelic depth filter tvs; render an integer range input
+		rangeLabelTd.text(mafFilterMode == 'totalDepth' ? 'Total Depth' : 'Alt Allele Depth')
+		brush.apply_btn = rangeTr
+			.append('td')
+			.attr('class', 'sja_filter_tag_btn sjpp_apply_btn')
+			.style('border-radius', '13px')
+			.style('margin', '5px')
+			.style('margin-left', '10px')
+			.style('text-align', 'center')
 			.style('font-size', '.8em')
 			.style('text-transform', 'uppercase')
 			.text('apply')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Extended MAF filter to support allelic-depth filtering

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -867,12 +867,23 @@ export function mayValidateBcfMafFilter(q) {
 	if (!format) throw 'snvindel.mafFilter is set but byrange._tk.format is missing'
 	if (q.mafFilter._depthTermsAdded) return // already processed (init may run more than once)
 
-	// validate that user-defined terms reference real FORMAT keys
+	// validate that every term references real FORMAT keys, branching by mode.
+	// (depth terms are appended below, after this loop, so only user-defined terms are seen here.)
 	for (const term of q.mafFilter.terms) {
-		if (term.mafFilterMode) continue // generated depth term, skip
-		const keys = term.child_ids?.length ? term.child_ids : [term.id]
-		for (const key of keys) {
-			if (!format[key]) throw `snvindel.mafFilter term "${term.id}" references unknown FORMAT key "${key}"`
+		const mode = term.mafFilterMode || 'maf'
+		if (mode == 'maf') {
+			// maf-mode term reads term.id, or sums across term.child_ids[]
+			const keys = term.child_ids?.length ? term.child_ids : [term.id]
+			for (const key of keys) {
+				if (!format[key]) throw `snvindel.mafFilter term "${term.id}" references unknown FORMAT key "${key}"`
+			}
+		} else if (mode == 'totalDepth' || mode == 'altDepth') {
+			// depth-mode term reads a single raw FORMAT key from term.mafFormatKey
+			if (!term.mafFormatKey) throw `snvindel.mafFilter term "${term.id}" (${mode}) is missing mafFormatKey`
+			if (!format[term.mafFormatKey])
+				throw `snvindel.mafFilter term "${term.id}" references unknown FORMAT key "${term.mafFormatKey}"`
+		} else {
+			throw `snvindel.mafFilter term "${term.id}" has unknown mafFilterMode "${term.mafFilterMode}"`
 		}
 	}
 

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -794,6 +794,7 @@ async function validate_query_snvindel(ds, genome) {
 		} else {
 			throw 'unknown query method for queries.snvindel.byrange'
 		}
+		mayValidateBcfMafFilter(q)
 	}
 
 	if (q.byisoform) {
@@ -846,6 +847,65 @@ async function validate_query_snvindel(ds, genome) {
 			}
 		}
 	}
+}
+
+/*
+validates queries.snvindel.mafFilter against the bcf FORMAT fields, and auto-populates
+allelic-depth filter terms.
+
+q = ds.queries.snvindel
+
+- verifies every FORMAT key referenced by mafFilter.terms[] (via term.id or term.child_ids[])
+  exists in q.byrange._tk.format{}
+- for every FORMAT key with Number=="R" (one value per allele incl. reference, i.e. AD-style
+  "<ref>,<alt>"), appends two depth terms to mafFilter.terms[]: one for total depth (ref+alt)
+  and one for alternate-allele depth (alt). these surface as additional terms in the maf filter UI.
+*/
+export function mayValidateBcfMafFilter(q) {
+	if (!q.mafFilter) return // no maf filter on this ds
+	const format = q.byrange?._tk?.format
+	if (!format) throw 'snvindel.mafFilter is set but byrange._tk.format is missing'
+	if (q.mafFilter._depthTermsAdded) return // already processed (init may run more than once)
+
+	// validate that user-defined terms reference real FORMAT keys
+	for (const term of q.mafFilter.terms) {
+		if (term.mafFilterMode) continue // generated depth term, skip
+		const keys = term.child_ids?.length ? term.child_ids : [term.id]
+		for (const key of keys) {
+			if (!format[key]) throw `snvindel.mafFilter term "${term.id}" references unknown FORMAT key "${key}"`
+		}
+	}
+
+	// auto-populate allelic-depth terms, one pair per Number=="R" FORMAT key
+	for (const id in format) {
+		const f = format[id]
+		if (f.isGT) continue // genotype field, not a depth field
+		// mirror vcf parsing: AD is coerced to Number==R even if header omits it
+		if (f.Number != 'R' && id != 'AD') continue
+		q.mafFilter.terms.push({
+			id: id + '__totalDepth',
+			name: (f.Description || id) + ' total depth',
+			parent_id: null,
+			isleaf: true,
+			type: 'integer',
+			mafFilterMode: 'totalDepth',
+			mafFormatKey: id,
+			min: 0,
+			tvs: { ranges: [] }
+		})
+		q.mafFilter.terms.push({
+			id: id + '__altDepth',
+			name: (f.Description || id) + ' alt depth',
+			parent_id: null,
+			isleaf: true,
+			type: 'integer',
+			mafFilterMode: 'altDepth',
+			mafFormatKey: id,
+			min: 0,
+			tvs: { ranges: [] }
+		})
+	}
+	q.mafFilter._depthTermsAdded = true
 }
 
 // this function assumes file header uses integer sample id. TODO when all files are migrated to using string sample name, delete this function
@@ -3486,37 +3546,55 @@ export function mayFilterByMaf(mafFilter, m) {
 		let pass = false
 		if (item.type != 'tvs') throw 'unexpected item.type' // not supporting nested tvslst
 		const tvs = item.tvs
+		// each maf filter term has a mode that determines which metric is computed and tested:
+		// - 'maf': minor allele frequency, alt/(ref+alt), gated by minimum total depth (default)
+		// - 'totalDepth': total read depth, ref+alt
+		// - 'altDepth': alternate-allele read depth, alt
+		const mode = tvs.term.mafFilterMode || 'maf'
 		const alleleCnts = { ref: 0, alt: 0 } // allele counts for maf filter term
-		const minAllelicDepth = Number.isFinite(tvs.minAllelicDepth) && tvs.minAllelicDepth != 0 ? tvs.minAllelicDepth : 1
-		if (tvs.term.child_ids?.length) {
-			// maf filter term has child terms
-			// sum allele counts across child terms
+		let annotated = false
+		if (mode == 'maf' && tvs.term.child_ids?.length) {
+			// maf filter term has child terms; sum allele counts across child terms
 			for (const id of tvs.term.child_ids) {
-				addAlleleCnts(m, id, alleleCnts)
+				if (addAlleleCnts(m, id, alleleCnts)) annotated = true
 			}
 		} else {
-			// maf filter term does not have child terms
-			// get allele counts of term directly
-			addAlleleCnts(m, tvs.term.id, alleleCnts)
+			// single field: term.id for maf terms, mafFormatKey for depth terms
+			const fieldId = mode == 'maf' ? tvs.term.id : tvs.term.mafFormatKey
+			if (addAlleleCnts(m, fieldId, alleleCnts)) annotated = true
 		}
-		const { ref, alt } = alleleCnts
-		const total = ref + alt
-		if (total < minAllelicDepth) {
-			// allelic depth does not meet cutoff
-			// sample does not pass
+		if (!annotated) {
+			// sample is not annotated for this field; does not pass
 			passLst.push(pass)
 			continue
 		}
-		const maf = alt / total
-		// test if maf is in range of tvs
+		const { ref, alt } = alleleCnts
+		const total = ref + alt
+		let metric
+		if (mode == 'maf') {
+			const minAllelicDepth = Number.isFinite(tvs.minAllelicDepth) && tvs.minAllelicDepth != 0 ? tvs.minAllelicDepth : 1
+			if (total < minAllelicDepth) {
+				// allelic depth does not meet cutoff; sample does not pass
+				passLst.push(pass)
+				continue
+			}
+			metric = alt / total
+		} else if (mode == 'totalDepth') {
+			metric = total
+		} else if (mode == 'altDepth') {
+			metric = alt
+		} else {
+			throw 'unexpected mafFilterMode'
+		}
+		// test if metric is in range of tvs
 		const intvs = tvs.ranges.every(r => {
 			let startPass = true
 			let stopPass = true
 			if (Number.isFinite(r.start)) {
-				startPass = r.startinclusive ? maf >= r.start : maf > r.start
+				startPass = r.startinclusive ? metric >= r.start : metric > r.start
 			}
 			if (Number.isFinite(r.stop)) {
-				stopPass = r.stopinclusive ? maf <= r.stop : maf < r.stop
+				stopPass = r.stopinclusive ? metric <= r.stop : metric < r.stop
 			}
 			return startPass && stopPass
 		})
@@ -3528,15 +3606,17 @@ export function mayFilterByMaf(mafFilter, m) {
 }
 
 // add allele counts of maf field to total allele counts
+// returns true if the sample was annotated for this field, false otherwise
 function addAlleleCnts(m, mafFieldId, alleleCnts) {
 	const mafField = m[mafFieldId] // <ref read count>,<alt read count>
-	if (!mafField) return // sample not annotated for maf field
+	if (!mafField) return false // sample not annotated for maf field
 	const alleles = mafField.split(',').map(Number)
-	if (alleles.length != 2) return // skip multi-allelic variants
+	if (alleles.length != 2) return false // skip multi-allelic variants
 	const [ref, alt] = alleles
-	if (!Number.isFinite(ref) || !Number.isFinite(alt)) return
+	if (!Number.isFinite(ref) || !Number.isFinite(alt)) return false
 	alleleCnts.ref += ref
 	alleleCnts.alt += alt
+	return true
 }
 
 // may filter cnv segment by a minimum overlap with query

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -1568,7 +1568,7 @@ test('mayFilterByMaf: OR combination of maf and alt depth', t => {
 })
 
 test('mayValidateBcfMafFilter: validate and auto-populate depth terms', t => {
-	t.plan(7)
+	t.plan(11)
 
 	const format = {
 		tumor_DNA_WGS: { ID: 'tumor_DNA_WGS', Number: 'R', Type: 'Integer', Description: 'Tumor DNA WGS' },
@@ -1610,6 +1610,57 @@ test('mayValidateBcfMafFilter: validate and auto-populate depth terms', t => {
 	const qNoFormat = makeQ()
 	delete qNoFormat.byrange._tk.format
 	t.throws(() => mayValidateBcfMafFilter(qNoFormat), /byrange._tk.format is missing/, 'throws when format missing')
+
+	// a dataset-configured depth term with a valid mafFormatKey passes validation
+	const qDepth = makeQ()
+	qDepth.mafFilter.terms.push({
+		id: 'my_total_depth',
+		name: 'my total depth',
+		parent_id: null,
+		isleaf: true,
+		type: 'integer',
+		mafFilterMode: 'totalDepth',
+		mafFormatKey: 'tumor_DNA_WGS'
+	})
+	t.doesNotThrow(() => mayValidateBcfMafFilter(qDepth), 'configured depth term with valid mafFormatKey passes')
+
+	// a configured depth term missing mafFormatKey throws
+	const qNoKey = makeQ()
+	qNoKey.mafFilter.terms.push({
+		id: 'bad_depth',
+		name: 'bad',
+		parent_id: null,
+		isleaf: true,
+		type: 'integer',
+		mafFilterMode: 'altDepth'
+	})
+	t.throws(
+		() => mayValidateBcfMafFilter(qNoKey),
+		/missing mafFormatKey/,
+		'configured depth term without mafFormatKey throws'
+	)
+
+	// a configured depth term with an unknown mafFormatKey throws
+	const qBadKey = makeQ()
+	qBadKey.mafFilter.terms.push({
+		id: 'bad_depth',
+		name: 'bad',
+		parent_id: null,
+		isleaf: true,
+		type: 'integer',
+		mafFilterMode: 'totalDepth',
+		mafFormatKey: 'no_such_field'
+	})
+	t.throws(
+		() => mayValidateBcfMafFilter(qBadKey),
+		/unknown FORMAT key/,
+		'configured depth term with unknown mafFormatKey throws'
+	)
+
+	// an unknown mafFilterMode throws
+	const qBadMode = makeQ()
+	qBadMode.mafFilter.terms[0].mafFilterMode = 'bogus'
+	t.throws(() => mayValidateBcfMafFilter(qBadMode), /unknown mafFilterMode/, 'unknown mafFilterMode throws')
 })
 
 const mafFilter = {

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -1,5 +1,5 @@
 import test from 'tape'
-import { filterByItem, filterByTvsLst, mayFilterByMaf } from '../mds3.init.js'
+import { filterByItem, filterByTvsLst, mayFilterByMaf, mayValidateBcfMafFilter } from '../mds3.init.js'
 
 /*
 Tests:
@@ -1520,6 +1520,98 @@ test('mayFilterByMaf: mafFilter with child ids, min allelic depth', t => {
 	}
 })
 
+test('mayFilterByMaf: total depth filter', t => {
+	t.plan(4)
+	// total depth >= 100
+	t.equal(mayFilterByMaf(mafFilter_totalDepth, { dt: 1, class: 'M', tumor_DNA_WGS: '70,40' }), true, '110 passes')
+	t.equal(
+		mayFilterByMaf(mafFilter_totalDepth, { dt: 1, class: 'M', tumor_DNA_WGS: '70,20' }),
+		false,
+		'90 does not pass'
+	)
+	t.equal(
+		mayFilterByMaf(mafFilter_totalDepth, { dt: 1, class: 'M', tumor_DNA_WGS: '70,30' }),
+		true,
+		'100 passes (inclusive)'
+	)
+	t.equal(mayFilterByMaf(mafFilter_totalDepth, { dt: 1, class: 'M' }), false, 'unannotated does not pass')
+})
+
+test('mayFilterByMaf: alt allele depth filter', t => {
+	t.plan(3)
+	// alt depth >= 20
+	t.equal(mayFilterByMaf(mafFilter_altDepth, { dt: 1, class: 'M', tumor_DNA_WGS: '10,25' }), true, 'alt 25 passes')
+	t.equal(
+		mayFilterByMaf(mafFilter_altDepth, { dt: 1, class: 'M', tumor_DNA_WGS: '10,15' }),
+		false,
+		'alt 15 does not pass'
+	)
+	t.equal(mayFilterByMaf(mafFilter_altDepth, { dt: 1, class: 'M' }), false, 'unannotated does not pass')
+})
+
+test('mayFilterByMaf: AND combination of maf and alt depth', t => {
+	t.plan(4)
+	// maf > 0.1 AND alt depth >= 20
+	t.equal(mayFilterByMaf(mafFilter_and, { dt: 1, class: 'M', tumor_DNA_WGS: '70,30' }), true, 'both pass')
+	t.equal(mayFilterByMaf(mafFilter_and, { dt: 1, class: 'M', tumor_DNA_WGS: '10,15' }), false, 'only maf passes')
+	t.equal(mayFilterByMaf(mafFilter_and, { dt: 1, class: 'M', tumor_DNA_WGS: '300,25' }), false, 'only alt depth passes')
+	t.equal(mayFilterByMaf(mafFilter_and, { dt: 1, class: 'M', tumor_DNA_WGS: '300,5' }), false, 'neither passes')
+})
+
+test('mayFilterByMaf: OR combination of maf and alt depth', t => {
+	t.plan(4)
+	// maf > 0.1 OR alt depth >= 20
+	t.equal(mayFilterByMaf(mafFilter_or, { dt: 1, class: 'M', tumor_DNA_WGS: '70,30' }), true, 'both pass')
+	t.equal(mayFilterByMaf(mafFilter_or, { dt: 1, class: 'M', tumor_DNA_WGS: '10,15' }), true, 'only maf passes')
+	t.equal(mayFilterByMaf(mafFilter_or, { dt: 1, class: 'M', tumor_DNA_WGS: '300,25' }), true, 'only alt depth passes')
+	t.equal(mayFilterByMaf(mafFilter_or, { dt: 1, class: 'M', tumor_DNA_WGS: '300,5' }), false, 'neither passes')
+})
+
+test('mayValidateBcfMafFilter: validate and auto-populate depth terms', t => {
+	t.plan(7)
+
+	const format = {
+		tumor_DNA_WGS: { ID: 'tumor_DNA_WGS', Number: 'R', Type: 'Integer', Description: 'Tumor DNA WGS' },
+		GT: { ID: 'GT', Number: '1', Type: 'String', isGT: true }
+	}
+	const makeQ = () => ({
+		byrange: { _tk: { format } },
+		mafFilter: {
+			opts: { joinWith: ['and', 'or'] },
+			filter: { type: 'tvslst', join: '', in: true, lst: [] },
+			terms: [{ id: 'tumor_DNA_WGS', name: 'Tumor DNA WGS', parent_id: null, isleaf: true, type: 'float' }]
+		}
+	})
+
+	const q = makeQ()
+	t.doesNotThrow(() => mayValidateBcfMafFilter(q), 'does not throw on valid filter')
+	t.equal(q.mafFilter.terms.length, 3, 'appended exactly 2 depth terms (1 user term + 2 generated)')
+	const generated = q.mafFilter.terms.filter(tm => tm.mafFilterMode)
+	t.deepEqual(
+		generated.map(tm => tm.mafFilterMode).sort(),
+		['altDepth', 'totalDepth'],
+		'generated totalDepth and altDepth terms'
+	)
+	t.ok(
+		generated.every(tm => tm.mafFormatKey == 'tumor_DNA_WGS'),
+		'generated terms reference the source FORMAT key, GT skipped'
+	)
+
+	// idempotency: a second call does not double-append
+	mayValidateBcfMafFilter(q)
+	t.equal(q.mafFilter.terms.length, 3, 'second call does not double-append')
+
+	// missing FORMAT key throws
+	const qBad = makeQ()
+	qBad.mafFilter.terms[0].id = 'no_such_field'
+	t.throws(() => mayValidateBcfMafFilter(qBad), /unknown FORMAT key/, 'throws on unknown FORMAT key')
+
+	// no byrange format throws when mafFilter present
+	const qNoFormat = makeQ()
+	delete qNoFormat.byrange._tk.format
+	t.throws(() => mayValidateBcfMafFilter(qNoFormat), /byrange._tk.format is missing/, 'throws when format missing')
+})
+
 const mafFilter = {
 	type: 'tvslst',
 	join: '',
@@ -1551,6 +1643,59 @@ const mafFilter = {
 		}
 	]
 }
+
+const mafFilter_totalDepth = {
+	type: 'tvslst',
+	join: '',
+	in: true,
+	lst: [
+		{
+			type: 'tvs',
+			tvs: {
+				term: {
+					id: 'tumor_DNA_WGS__totalDepth',
+					name: 'Tumor DNA WGS total depth',
+					parent_id: null,
+					isleaf: true,
+					type: 'integer',
+					mafFilterMode: 'totalDepth',
+					mafFormatKey: 'tumor_DNA_WGS',
+					min: 0
+				},
+				ranges: [{ start: 100, startinclusive: true, startunbounded: false, stopunbounded: true }]
+			}
+		}
+	]
+}
+
+const mafFilter_altDepth = {
+	type: 'tvslst',
+	join: '',
+	in: true,
+	lst: [
+		{
+			type: 'tvs',
+			tvs: {
+				term: {
+					id: 'tumor_DNA_WGS__altDepth',
+					name: 'Tumor DNA WGS alt depth',
+					parent_id: null,
+					isleaf: true,
+					type: 'integer',
+					mafFilterMode: 'altDepth',
+					mafFormatKey: 'tumor_DNA_WGS',
+					min: 0
+				},
+				ranges: [{ start: 20, startinclusive: true, startunbounded: false, stopunbounded: true }]
+			}
+		}
+	]
+}
+
+// maf > 0.1 combined with alt depth >= 20, used for AND/OR combination tests
+const mafComboLst = [structuredClone(mafFilter.lst[0]), structuredClone(mafFilter_altDepth.lst[0])]
+const mafFilter_and = { type: 'tvslst', join: 'and', in: true, lst: structuredClone(mafComboLst) }
+const mafFilter_or = { type: 'tvslst', join: 'or', in: true, lst: structuredClone(mafComboLst) }
 
 const mafFilter_childIds = {
 	type: 'tvslst',

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -221,11 +221,21 @@ export type FilterTermEntry = BaseTvsFilter & {
 	tvs?: TvsFilter
 	min?: number
 	max?: number
+	/** child term ids whose allele counts are summed for a maf filter term */
+	child_ids?: string[]
+	/** marks the default maf filter term */
+	default?: boolean
+	/** metric computed for a maf filter term; defaults to 'maf' when absent */
+	mafFilterMode?: 'maf' | 'totalDepth' | 'altDepth'
+	/** underlying bcf FORMAT key read by an auto-generated allelic-depth term */
+	mafFormatKey?: string
 }
 
 type FilterLstTvs = BaseTvsFilter & {
 	term: FilterTermEntry
 	values: (string | number | FilterValues)[]
+	/** minimum total read depth gate for a maf-mode filter term */
+	minAllelicDepth?: number
 }
 
 type FilterLstEntry = {
@@ -244,6 +254,8 @@ type VariantFilter = {
 	opts: { joinWith: string[] }
 	filter?: Filter
 	terms: FilterTermEntry[]
+	/** set once allelic-depth terms have been auto-populated, to keep init idempotent */
+	_depthTermsAdded?: boolean
 }
 
 /** one set of AC and AN info fields to retrieve data for this population */


### PR DESCRIPTION
# Description
The GRIN2 / snvindel **MAF filter** previously only filtered variants by minor allele frequency (MAF = alt / (ref + alt)), with a single fixed total-depth gate (`minAllelicDepth`) baked into each term. This PR promotes read depth to first-class, **composable** filter terms, so users can build any AND/OR combination of:

- **MAF ratio** — existing behavior, unchanged
- **Total depth** — ref + alt read count
- **Alternate-allele depth** — alt read count

For every BCF `FORMAT` field with `Number=R` (allele-depth, i.e. `ref,alt`), the server now auto-generates a *total depth* and an *alt depth* term and exposes them in the filter UI alongside the existing MAF terms — no per-dataset config needed.

### Motivation

Expand the GRIN2 MAF filter to let users filter by total depth and minimum alternate-allele depth in addition to MAF. This enables standard somatic-filtering patterns — e.g. requiring adequate tumor coverage, demanding a minimum number of alt reads, or requiring the matched normal to have low alt depth — combined freely with AND/OR logic.

### What changed

**Server — `server/src/mds3.init.js`**
- New, exported `mayValidateBcfMafFilter(q)`, invoked during `validate_query_snvindel`. It (a) validates that every `FORMAT` key referenced by `mafFilter.terms[]` (via `term.id` / `term.child_ids[]`) actually exists in `byrange._tk.format{}`, and (b) for each `Number=R` field (plus a literal `AD` fallback, skipping `GT`) appends two depth terms carrying `mafFilterMode` (`totalDepth` / `altDepth`) and `mafFormatKey`. An `_depthTermsAdded` flag keeps init idempotent. These terms ship to the client via `termdbConfig`, so they appear in the filter dropdown automatically.
- Refactored `mayFilterByMaf()` to branch on `tvs.term.mafFilterMode` (defaulting to `'maf'`, so all existing terms/datasets behave identically): computes MAF (gated by min total depth), total depth, or alt depth, then tests against the term's ranges. AND/OR composition across modes flows through the existing `filter.join` logic. `addAlleleCnts()` now reports annotation presence, so samples with no value for a depth field fail that filter — consistent with current MAF behavior.

**Client — `client/filter/tvs.numeric.js`**
- Depth-mode terms render a plain integer range input labeled "Total Depth" / "Alt Allele Depth" (no MAF 0–1 label or min-depth box); MAF terms keep their original UI.

**Types — `shared/types/src/dataset.ts`**
- Added `child_ids`, `default`, `mafFilterMode`, `mafFormatKey` to `FilterTermEntry`; `minAllelicDepth` to `FilterLstTvs`; `_depthTermsAdded` to `VariantFilter`.

### Backward compatibility

Fully backward compatible. Terms without `mafFilterMode` default to `'maf'` and take the exact prior code path; `minAllelicDepth` is still honored for MAF terms; `mayFilterByMaf`'s signature and existing call sites are unchanged.

### Testing

- 16 new unit tests in `server/src/test/mds3.init.unit.spec.js` covering total-depth filtering, alt-depth filtering, AND/OR combinations of MAF + depth, unannotated-sample handling, and `mayValidateBcfMafFilter` (auto-population, `GT`-skip, idempotency, and error on missing FORMAT key / missing format). Full suite passes (279/279).
- Verified end-to-end against the ASH hg38 dataset: the MAF filter dropdown now lists `… total depth` / `… alt depth` for each `Number=R` FORMAT assay, and combined MAF + depth filters apply correctly in GRIN2.

### Note for reviewers

Depth terms are generated for **every** `Number=R` FORMAT field in the BCF. For ASH this includes the matched-normal assays (`germline_DNA_WGS`, `germline_DNA_WES`), since their per-site allele depths are stored in the file even though germline variant calling isn't exposed. This is intentional and useful (normal-depth filtering of somatic calls). If we later want to limit which assays surface depth terms, an opt-in allowlist in the dataset config would be the place to add it.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
