### PR TITLE
fix: aarange=[a,b] to zoom in on block protein mode

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -952,6 +952,7 @@ async function launchgeneview(arg, app) {
 		mset: arg.mset,
 		tklst: arg.tracks,
 		gmmode: arg.gmmode,
+		aarange: arg.aarange,
 		geneDomains: arg.geneDomains,
 		mclassOverride: arg.mclassOverride,
 		hide_dsHandles: arg.hide_dsHandles,

--- a/client/src/app.parseurl.js
+++ b/client/src/app.parseurl.js
@@ -556,6 +556,14 @@ upon error, throw err message as a string
 			}
 			if (lst.length) par.hlregions = lst
 		}
+		if (urlp.has('aarange')) {
+			const [a, b] = urlp.get('aarange').split(',').map(Number)
+			if (Number.isInteger(a) && Number.isInteger(b) && a > 0 && b > a) {
+				par.aarange = [a, b]
+			} else {
+				throw 'invalid aarange'
+			}
+		}
 
 		par.tklst = await get_tklst(urlp, par.genome)
 

--- a/client/src/block.init.js
+++ b/client/src/block.init.js
@@ -325,6 +325,7 @@ async function step3(arg) {
 		hlaachange: arg.hlaachange,
 		hlvariants: arg.hlvariants,
 		hlregions: arg.hlregions,
+		aarange: arg.aarange,
 		gmmode: mode,
 		hidedatasetexpression: arg.hidedatasetexpression,
 		hidegenecontrol: arg.hidegenecontrol,

--- a/client/src/block.js
+++ b/client/src/block.js
@@ -4,7 +4,20 @@ import { format as d3format } from 'd3-format'
 import { axisTop, axisLeft } from 'd3-axis'
 import { debounce } from 'debounce'
 import * as client from './client'
-import { axisstyle, Menu, newSandboxDiv, sayerror, appear, disappear, isoformSelect, allgm2sum, sketchGene, sketchSplicerna, sketchRna, sketchProtein2 } from '#dom'
+import {
+	axisstyle,
+	Menu,
+	newSandboxDiv,
+	sayerror,
+	appear,
+	disappear,
+	isoformSelect,
+	allgm2sum,
+	sketchGene,
+	sketchSplicerna,
+	sketchRna,
+	sketchProtein2
+} from '#dom'
 import { dofetch3 } from '../common/dofetch'
 import * as common from '#shared/common.js'
 import * as coord from './coord'
@@ -382,6 +395,29 @@ export class Block {
 			// do this after legend is set
 			// fills this.rglst[], this.startidx, this.stopidx
 			this.setgmmode(arg.gmmode || client.gmmode.genomic)
+			if (arg.aarange) {
+				const a = coord.aa2gmcoord(arg.aarange[0], this.usegm)
+				const b = coord.aa2gmcoord(arg.aarange[1], this.usegm)
+				if (!Number.isInteger(a) || !Number.isInteger(b)) throw new Error('invalid aarange')
+				for (const [i, r] of this.rglst.entries()) {
+					if (a > r.start && a < r.stop) {
+						this.startidx = i
+						if (r.reverse) {
+							r.stop = a
+						} else {
+							r.start = a
+						}
+					}
+					if (b > r.start && b < r.stop) {
+						this.stopidx = i
+						if (r.reverse) {
+							r.start = b
+						} else {
+							r.stop = b
+						}
+					}
+				}
+			}
 		}
 
 		// rglst is set, can process ideogram

--- a/client/src/block.js
+++ b/client/src/block.js
@@ -400,7 +400,7 @@ export class Block {
 				const b = coord.aa2gmcoord(arg.aarange[1], this.usegm)
 				if (!Number.isInteger(a) || !Number.isInteger(b)) throw new Error('invalid aarange')
 				for (const [i, r] of this.rglst.entries()) {
-					if (a > r.start && a < r.stop) {
+					if (a >= r.start && a <= r.stop) {
 						this.startidx = i
 						if (r.reverse) {
 							r.stop = a
@@ -408,7 +408,7 @@ export class Block {
 							r.start = a
 						}
 					}
-					if (b > r.start && b < r.stop) {
+					if (b >= r.start && b <= r.stop) {
 						this.stopidx = i
 						if (r.reverse) {
 							r.start = b

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- aarange=[a,b] to zoom in on block protein mode


### PR DESCRIPTION
# Description
http://localhost:3000/?genome=hg38&gene=ENST00000407796&mds3=GDC&aarange=100,200
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
