### PR TITLE
Support `allow2selectSamples{}` in summary charts

### DIFF
--- a/client/dom/summary/ListSamples.ts
+++ b/client/dom/summary/ListSamples.ts
@@ -252,7 +252,13 @@ export class ListSamples {
 	}
 
 	/** Formats the data for #dom/table/renderTable() */
-	setTableData(data: AnnotatedSampleData): [TableRow[], TableColumn[]] {
+	// also returning a samples[] array that includes samples
+	// that pass the filtering steps
+	// TODO: make a general function to get and filter sample data upon
+	// selecting a bar/violin (similar to "getSamples" in
+	// "client/plots/barchart.events.js"). This sample data can then be used
+	// for listing samples, create group, create cohort, create filter, etc.
+	setTableData(data: AnnotatedSampleData): [TableRow[], TableColumn[], AnnotatedSampleEntry[]] {
 		//Validation check
 		const foundInvalidGvTerm = [this.t1, this.t2, this.t0].find(tw => {
 			return tw && tw.term.type === TermTypes.GENE_VARIANT && (tw?.q as any)?.type == 'values'
@@ -263,6 +269,7 @@ export class ListSamples {
 		const rows: { value: string | number }[][] = []
 		const urlTemplate = this.app.vocabApi.termdbConfig?.urlTemplates?.sample
 
+		const samples: AnnotatedSampleEntry[] = []
 		for (const s of Object.values(data.lst)) {
 			const filterSample = this.mayFilterGVSample(s)
 			if (filterSample) continue
@@ -296,6 +303,7 @@ export class ListSamples {
 				this.addRowValue(s, this.t0, row)
 			}
 			rows.push(row)
+			samples.push(s)
 		}
 
 		//Formatting columns
@@ -304,7 +312,7 @@ export class ListSamples {
 		if (this.t2) this.addColValue(this.t2, columns)
 		if (this.t0) this.addColValue(this.t0, columns)
 
-		return [rows, columns]
+		return [rows, columns, samples]
 	}
 
 	mayFilterGVSample(sample: AnnotatedSampleEntry): boolean {

--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -22,6 +22,7 @@ interface InitArg {
 		app?: Record<string, any>
 		barchart?: Record<string, any>
 		violin?: Record<string, any>
+		boxplot?: Record<string, any>
 	}
 }
 
@@ -62,6 +63,7 @@ export async function init(
 		),
 		barchart: arg.opts?.barchart || {},
 		violin: arg.opts?.violin || {},
+		boxplot: arg.opts?.boxplot || {},
 		app: arg.opts?.app || {}
 	})
 	const api = {

--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -20,6 +20,7 @@ interface InitArg {
 	}
 	opts?: {
 		app?: Record<string, any>
+		barchart?: Record<string, any>
 	}
 }
 
@@ -58,6 +59,7 @@ export async function init(
 			},
 			arg.opts || {}
 		),
+		barchart: arg.opts?.barchart || {},
 		app: arg.opts?.app || {}
 	})
 	const api = {

--- a/client/gdc/correlation.ts
+++ b/client/gdc/correlation.ts
@@ -21,6 +21,7 @@ interface InitArg {
 	opts?: {
 		app?: Record<string, any>
 		barchart?: Record<string, any>
+		violin?: Record<string, any>
 	}
 }
 
@@ -60,6 +61,7 @@ export async function init(
 			arg.opts || {}
 		),
 		barchart: arg.opts?.barchart || {},
+		violin: arg.opts?.violin || {},
 		app: arg.opts?.app || {}
 	})
 	const api = {

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -612,6 +612,7 @@ function getTvs(termIndex, value, self, geneVariant) {
 	return tvs
 }
 
+// TODO: merge with "getSamples()" and dom/summary/ListSamples.ts
 export async function listSamples(arg, seriesId, dataId, chartId) {
 	// validate arg
 	for (const k of Object.keys(arg)) {
@@ -848,28 +849,12 @@ async function getSamples(arg) {
 }
 
 async function getSampleGrp(arg) {
-	// query sample data
-	const { event, self, terms, tvslst, geneVariant, tip } = arg
-	const opts = {
-		terms,
-		filter: filterJoin([self.state.termfilter.filter, tvslst]),
-		filter0: self.state.termfilter.filter0,
-		isSummary: true
-	}
-	const data = await self.app.vocabApi.getAnnotatedSampleData(opts)
-	const samples = []
-	for (const sample of data.lst) {
-		const pass = mayFilterByGeneVariant(sample, self, geneVariant)
-		if (!pass) continue
-		const t1entry = sample[self.config.term.$id]
-		if (!t1entry) continue
-		if (self.config.term.q?.hiddenValues && self.config.term.q.hiddenValues[t1entry.value]) continue
-		samples.push({ sampleId: sample.sample })
-	}
-
+	const samples = await getSamples(arg)
 	const group = {
 		name: 'Group',
-		items: samples
+		items: samples.map(s => {
+			return { sampleId: s.sample }
+		})
 	}
 	return group
 }

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -497,6 +497,21 @@ function handle_click(event, self, chart) {
 		})
 	}
 
+	if (self.opts.allow2selectSamples) {
+		const ss = self.opts.allow2selectSamples
+		options.push({
+			label: ss.buttonText,
+			callback: async () => {
+				const arg = getListSamplesArg(event, self, data.seriesId, data.dataId, chart.chartId)
+				const samples = await getSamples(arg)
+				ss.callback({
+					samples: await self.app.vocabApi.convertSampleId(samples, ss.attributes),
+					source: ss.defaultSelectionLabel || `Selected from barchart`
+				})
+			}
+		})
+	}
+
 	// TODO: add to cart
 	//
 	// if (self.opts.bar_click_opts.includes('add_to_cart')) {
@@ -798,6 +813,40 @@ export async function listSamples(arg, seriesId, dataId, chartId) {
 		})
 	}
 }
+
+async function getSamples(arg) {
+	// query sample data
+	const { self, terms, tvslst, geneVariant } = arg
+	const opts = {
+		terms,
+		filter: filterJoin([self.state.termfilter.filter, tvslst]),
+		filter0: self.state.termfilter.filter0,
+		isSummary: true
+	}
+	const data = await self.app.vocabApi.getAnnotatedSampleData(opts)
+	const samples = []
+	for (const sample of data.lst) {
+		const pass = mayFilterByGeneVariant(sample, self, geneVariant)
+		if (!pass) continue
+		const t1entry = sample[self.config.term.$id]
+		if (!t1entry) continue
+		if (self.config.term.q?.hiddenValues && self.config.term.q.hiddenValues[t1entry.value]) continue
+		if (self.config.term2) {
+			const t2entry = sample[self.config.term2.$id]
+			if (!t2entry) continue
+			if (self.config.term2.q?.hiddenValues && self.config.term2.q.hiddenValues[t2entry.value]) continue
+		}
+		if (self.config.term0) {
+			const t0entry = sample[self.config.term0.$id]
+			if (!t0entry) continue
+			//Don't show hidden values in the results
+			if (self.config.term0.q?.hiddenValues && self.config.term0.q.hiddenValues[t0entry.value]) continue
+		}
+		samples.push(sample)
+	}
+	return samples
+}
+
 async function getSampleGrp(arg) {
 	// query sample data
 	const { event, self, terms, tvslst, geneVariant, tip } = arg

--- a/client/plots/barchart.events.js
+++ b/client/plots/barchart.events.js
@@ -495,21 +495,21 @@ function handle_click(event, self, chart) {
 				}
 			}
 		})
-	}
 
-	if (self.opts.allow2selectSamples) {
-		const ss = self.opts.allow2selectSamples
-		options.push({
-			label: ss.buttonText,
-			callback: async () => {
-				const arg = getListSamplesArg(event, self, data.seriesId, data.dataId, chart.chartId)
-				const samples = await getSamples(arg)
-				ss.callback({
-					samples: await self.app.vocabApi.convertSampleId(samples, ss.attributes),
-					source: ss.defaultSelectionLabel || `Selected from barchart`
-				})
-			}
-		})
+		if (self.opts.allow2selectSamples) {
+			const ss = self.opts.allow2selectSamples
+			options.push({
+				label: ss.buttonText,
+				callback: async () => {
+					const arg = getListSamplesArg(event, self, data.seriesId, data.dataId, chart.chartId)
+					const samples = await getSamples(arg)
+					ss.callback({
+						samples: await self.app.vocabApi.convertSampleId(samples, ss.attributes),
+						source: ss.defaultSelectionLabel || `Selected from barchart`
+					})
+				}
+			})
+		}
 	}
 
 	// TODO: add to cart

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -96,8 +96,8 @@ export class BoxPlotInteractions {
 	async listSamples(plot: any) {
 		const sampleList = this.initListSamples(plot)
 		const data = await sampleList.getData()
-		const [rows, columns] = sampleList.setTableData(data)
-		return [rows, columns]
+		const [rows, columns, samples] = sampleList.setTableData(data)
+		return [rows, columns, samples]
 	}
 
 	/** Callback for color picker in plot(s) label menu */

--- a/client/plots/boxplot/view/BoxPlotLabelMenu.ts
+++ b/client/plots/boxplot/view/BoxPlotLabelMenu.ts
@@ -50,6 +50,22 @@ export class BoxPlotLabelMenu {
 				}
 			})
 
+		if (app.opts?.boxplot?.allow2selectSamples) {
+			const ss = app.opts.boxplot.allow2selectSamples
+			options.push({
+				text: ss.buttonText,
+				isVisible: () => true,
+				callback: async () => {
+					const table = await interactions.listSamples(plot)
+					const samples = table[2]
+					ss.callback({
+						samples: await app.vocabApi.convertSampleId(samples, ss.attributes),
+						source: ss.defaultSelectionLabel || `Selected from boxplot`
+					})
+				}
+			})
+		}
+
 		plot.boxplot.labelG.on('click', (event: MouseEvent) => {
 			tip.clear()
 			if (isVertical) tip.show(event.clientX, event.clientY)

--- a/client/plots/boxplot/view/BoxPlotLabelMenu.ts
+++ b/client/plots/boxplot/view/BoxPlotLabelMenu.ts
@@ -54,7 +54,7 @@ export class BoxPlotLabelMenu {
 			const ss = app.opts.boxplot.allow2selectSamples
 			options.push({
 				text: ss.buttonText,
-				isVisible: () => true,
+				isVisible: (state: MassState) => state.termdbConfig.displaySampleIds && app.vocabApi.hasVerifiedToken(),
 				callback: async () => {
 					const table = await interactions.listSamples(plot)
 					const samples = table[2]

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -70,16 +70,17 @@ export function setInteractivity(self) {
 					await self.callListSamples(event, plot, start, end)
 				}
 			})
-		}
-		if (self.opts.allow2selectSamples) {
-			const ss = self.opts.allow2selectSamples
-			options.push({
-				label: ss.buttonText,
-				callback: async () => {
-					const [start, end] = [self.data.min, self.data.max]
-					await self.selectSamples(plot, start, end, ss)
-				}
-			})
+
+			if (self.opts.allow2selectSamples) {
+				const ss = self.opts.allow2selectSamples
+				options.push({
+					label: ss.buttonText,
+					callback: async () => {
+						const [start, end] = [self.data.min, self.data.max]
+						await self.selectSamples(plot, start, end, ss)
+					}
+				})
+			}
 		}
 		self.displayMenu(event, options)
 	}
@@ -105,16 +106,16 @@ export function setInteractivity(self) {
 				testid: 'sjpp-violinBrushOpt-list',
 				callback: async () => self.callListSamples(event.sourceEvent, plot, start, end)
 			})
-		}
 
-		if (self.opts.allow2selectSamples) {
-			const ss = self.opts.allow2selectSamples
-			options.push({
-				label: ss.buttonText,
-				callback: async () => {
-					await self.selectSamples(plot, start, end, ss)
-				}
-			})
+			if (self.opts.allow2selectSamples) {
+				const ss = self.opts.allow2selectSamples
+				options.push({
+					label: ss.buttonText,
+					callback: async () => {
+						await self.selectSamples(plot, start, end, ss)
+					}
+				})
+			}
 		}
 
 		self.displayMenu(event.sourceEvent, options, start, end)

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -71,6 +71,16 @@ export function setInteractivity(self) {
 				}
 			})
 		}
+		if (self.opts.allow2selectSamples) {
+			const ss = self.opts.allow2selectSamples
+			options.push({
+				label: ss.buttonText,
+				callback: async () => {
+					const [start, end] = [self.data.min, self.data.max]
+					await self.selectSamples(plot, start, end, ss)
+				}
+			})
+		}
 		self.displayMenu(event, options)
 	}
 
@@ -96,6 +106,17 @@ export function setInteractivity(self) {
 				callback: async () => self.callListSamples(event.sourceEvent, plot, start, end)
 			})
 		}
+
+		if (self.opts.allow2selectSamples) {
+			const ss = self.opts.allow2selectSamples
+			options.push({
+				label: ss.buttonText,
+				callback: async () => {
+					await self.selectSamples(plot, start, end, ss)
+				}
+			})
+		}
+
 		self.displayMenu(event.sourceEvent, options, start, end)
 	}
 
@@ -127,6 +148,17 @@ export function setInteractivity(self) {
 				await d.callback()
 				tip.hide()
 			})
+	}
+
+	self.selectSamples = async function (plot, start, end, ss) {
+		const ls = self.getSampleList(plot, start, end)
+		const data = await ls.getData()
+		const table = ls.setTableData(data)
+		const samples = table[2]
+		ss.callback({
+			samples: await self.app.vocabApi.convertSampleId(samples, ss.attributes),
+			source: ss.defaultSelectionLabel || `Selected from violin`
+		})
 	}
 
 	//get sample list for menu option callbacks


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1377

Supporting `allow2selectSamples{}` in barchart, violin, and boxplot. This allows a `Create Cohort` button to be displayed for mmrf.

Can test by:
- Launching http://localhost:3000/example.mmrf.correlation.html
- For barchart, click on a bar and select `Create Cohort`
- For violin, click on a violin plot or brush a violin plot and select `Create Cohort`
- For boxplot, click on a boxplot and select `Create Cohort`

Open browser console and an object `{samples: [], source: string}` should be logged.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
