### PR TITLE
Pass q.filter instead of q.filterObj to termdb.filterSamples()

### DIFF
--- a/server/src/mds3.filter.js
+++ b/server/src/mds3.filter.js
@@ -41,12 +41,12 @@ export async function mayLimitSamples(param, _allSamples, ds) {
 		}
 		// get samples that match filter
 		// get_samples() return [{id:int}] with possibly duplicated items, deduplicate and return list of integer ids
-		filterSamples = new Set(
-			(await get_samples({ filter, mapParent2Children: param.mapParent2Children }, ds)).map(i => i.id)
-		)
+		const q = { filter, mapParent2Children: param.mapParent2Children }
+		filterSamples = new Set((await get_samples(q, ds)).map(i => i.id))
 	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
 		// ds-supplied filter method
-		filterSamples = await ds.cohort.termdb.filterSamples(param, ds)
+		const q = { filter, filter0, mapParent2Children: param.mapParent2Children }
+		filterSamples = await ds.cohort.termdb.filterSamples(q, ds)
 	} else {
 		throw new Error('no method available to get samples')
 	}


### PR DESCRIPTION
# Description

Fixes mds3 tk filter: [link](http://localhost:3000/?genome=hg38&gene=kras&mds3=MMRF&snvindelonly=1) -> select male -> subtk should show filtered set of samples

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
