### PR TITLE
Hardening chatbot code to handle non-JSON output returned by LLM

### DIFF
--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -146,8 +146,13 @@ export async function getTermObj(
 const refEmbedding = await loadOrBuildEmbeddings(dbPath, llm)
 const topK: number = 3
 const match = await findBestMatch(twEntity.phrase, refEmbedding, llm, topK)
-*/
-		const match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
+        */
+		let match: any
+		try {
+			match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
+		} catch (e) {
+			console.error(`Error in findBestMatchLLM for phrase "${twEntity.phrase}":`, e)
+		}
 		if (!match) {
 			console.warn(`findBestMatchLLM returned no match for query "${twEntity.phrase}"`)
 			return undefined

--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -8,7 +8,8 @@ import type {
 	HierPhrase2EntityResult,
 	SurvivalPhrase2EntityResult,
 	MatrixPhrase2EntityResult,
-	PrebuiltScatterPhrase2EntityResult
+	PrebuiltScatterPhrase2EntityResult,
+	MsgToUser
 } from './scaffoldTypes.ts'
 //import { loadOrBuildEmbeddings, findBestMatch } from './semanticSearch.ts'
 import {
@@ -52,6 +53,11 @@ export type Value = {
 	phrase: string
 	type: string
 	logicalOperator?: '&' | '|'
+}
+
+/** Discriminate a MsgToUser (a {type:'text', text} message to surface to the client) from a resolved Value. */
+export function isMsgToUser(x: unknown): x is MsgToUser {
+	return !!x && typeof x === 'object' && (x as any).type === 'text' && 'text' in (x as any)
 }
 
 function buildNonDictTermObj(twEntity: Entity, genes_list: string[], genome: any): Value | undefined {
@@ -132,7 +138,7 @@ export async function getTermObj(
 	dbPath: string,
 	genes_list: string[],
 	genome: any
-): Promise<Value | undefined> {
+): Promise<Value | MsgToUser | undefined> {
 	// Nested LLM-based replacement for semanticSearch.findBestMatch(). Parses the dataset DB
 	// via parse_dataset_db() to get the full rag_docs list and hands it to the classifier LLM
 	// with the user phrase; the LLM returns the single rag_docs row whose term best matches.
@@ -152,12 +158,14 @@ const refEmbedding = await loadOrBuildEmbeddings(dbPath, llm)
 const topK: number = 3
 const match = await findBestMatch(twEntity.phrase, refEmbedding, llm, topK)
         */
-		let match: any
+		let match: { id: string; type: string; name: string; score: number; msg?: string } | MsgToUser | undefined
 		try {
 			match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
 		} catch (e) {
 			console.error(`Error in findBestMatchLLM for phrase "${twEntity.phrase}":`, e)
 		}
+		// findBestMatchLLM returns a MsgToUser when it cannot resolve the phrase; surface it to the client.
+		if (isMsgToUser(match)) return match
 		if (!match) {
 			console.warn(`findBestMatchLLM returned no match for query "${twEntity.phrase}"`)
 			return undefined
@@ -189,7 +197,7 @@ export async function inferTermObjFromEntity(
 	dbPath: string,
 	genes_list: string[], // redundant (must be fixed)
 	genome: any
-): Promise<Record<string, Value | Value[] | string>> {
+): Promise<Record<string, Value | Value[] | string> | MsgToUser> {
 	const twObjects: Record<string, Value | Value[] | string> = {}
 	if (plotType === 'summary') {
 		const summaryEntity = entity as SummaryPhrase2EntityResult
@@ -203,6 +211,7 @@ export async function inferTermObjFromEntity(
 				for (const filterTerm of filterResult) {
 					mayLog('Evaluating filter term:', filterTerm)
 					const termObj = await getTermObj(key, filterTerm, llm, dbPath, genes_list, genome)
+					if (isMsgToUser(termObj)) return termObj
 					if (!termObj) {
 						continue
 					}
@@ -220,6 +229,7 @@ export async function inferTermObjFromEntity(
 			if (!entry) continue
 			const twEntity = entry[0]
 			const termObj = await getTermObj(key, twEntity, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (!termObj) {
 				throw `Failed to get term object for key "${key}" and phrase "${twEntity.phrase}".`
 			}
@@ -239,6 +249,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of filterResult) {
 				mayLog(`Evaluating ${key} term:`, filterTerm)
 				const termObj = await getTermObj(key, filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) {
 					console.warn(`Skipping filter term "${filterTerm.phrase}" — failed to get term object`)
 					continue
@@ -262,6 +273,7 @@ export async function inferTermObjFromEntity(
 
 		// term2 is the REQUIRED stratification variable; resolve it like a single tw entity.
 		const term2Obj = await getTermObj('term2', survivalEntity.term2, llm, dbPath, genes_list, genome)
+		if (isMsgToUser(term2Obj)) return term2Obj
 		if (!term2Obj) {
 			throw `Failed to get term object for key "term2" and phrase "${survivalEntity.term2.phrase}".`
 		}
@@ -273,6 +285,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of survivalEntity.filter) {
 				mayLog('Evaluating survival filter term:', filterTerm)
 				const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) {
 					continue
 				}
@@ -290,6 +303,7 @@ export async function inferTermObjFromEntity(
 		for (const phrase of hierEntity.phrases) {
 			mayLog('Evaluating hierCluster phrase:', phrase)
 			const termObj = await getTermObj('DictPhrases', phrase, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (!termObj) {
 				console.warn(`Skipping hierCluster gene "${phrase.phrase}" — failed to get term object`)
 				continue
@@ -306,6 +320,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of hierEntity.filter) {
 				mayLog('Evaluating hierCluster filter term:', filterTerm)
 				const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) continue
 				if (filterTerm.logicalOperator) termObj.logicalOperator = filterTerm.logicalOperator
 				filterValues.push(termObj)
@@ -325,6 +340,7 @@ export async function inferTermObjFromEntity(
 				for (const filterTerm of filterResult) {
 					mayLog('Evaluating filter term:', filterTerm)
 					const termObj = await getTermObj(key, filterTerm, llm, dbPath, genes_list, genome)
+					if (isMsgToUser(termObj)) return termObj
 					if (!termObj) {
 						continue
 					}
@@ -343,6 +359,7 @@ export async function inferTermObjFromEntity(
 				for (const [index, twEntity] of twEntities.entries()) {
 					mayLog(`Evaluating twLst[${index}] entity:`, twEntity)
 					const termObj = await getTermObj(key, twEntity, llm, dbPath, genes_list, genome)
+					if (isMsgToUser(termObj)) return termObj
 					if (!termObj) {
 						console.warn(`Skipping twLst[${index}] — failed to get term object for phrase "${twEntity.phrase}"`)
 						continue
@@ -362,6 +379,7 @@ export async function inferTermObjFromEntity(
 			const twEntity = value as Entity | undefined
 			if (!twEntity) continue
 			const termObj = await getTermObj(key, twEntity, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (!termObj) {
 				throw `Failed to get term object for key "${key}" and phrase "${twEntity.phrase}".`
 			}
@@ -381,6 +399,7 @@ export async function inferTermObjFromEntity(
 			twObjects['colorBy'] = 'null'
 		} else if (scatterEntity.colorBy) {
 			const termObj = await getTermObj('colorBy', scatterEntity.colorBy, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (termObj) {
 				twObjects['colorBy'] = termObj
 			} else {
@@ -393,6 +412,7 @@ export async function inferTermObjFromEntity(
 			twObjects['shapeBy'] = 'null'
 		} else if (scatterEntity.shapeBy) {
 			const termObj = await getTermObj('shapeBy', scatterEntity.shapeBy, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (termObj) {
 				twObjects['shapeBy'] = termObj
 			} else {
@@ -404,6 +424,7 @@ export async function inferTermObjFromEntity(
 
 		if (scatterEntity.divideBy) {
 			const termObj = await getTermObj('divideBy', scatterEntity.divideBy, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (termObj) {
 				twObjects['divideBy'] = termObj
 			} else {
@@ -425,6 +446,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of filterResult) {
 				mayLog('Evaluating filter term:', filterTerm)
 				const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) {
 					continue
 				}
@@ -445,12 +467,12 @@ async function findBestMatchLLM(
 	phrase: string,
 	dbPath: string,
 	llm: LlmConfig
-): Promise<{ id: string; type: string; name: string; score: number; msg?: string } | undefined> {
+): Promise<{ id: string; type: string; name: string; score: number; msg?: string } | MsgToUser> {
 	const dataset_db_output = await parse_dataset_db(dbPath)
 	const { db_rows, rag_docs } = dataset_db_output
 	if (rag_docs.length === 0) {
 		console.warn('findBestMatchLLM: no rag_docs in DB')
-		return undefined
+		return { type: 'text', text: `Could not match "${phrase}" because the dataset dictionary has no terms to search.` }
 	}
 	const prompt = `You are an assistant that maps a user phrase to a dataset dictionary term.
 	IMPORTANT: Your goal is NOT to always select a match. Your goal is to AVOID incorrect matches.
@@ -504,16 +526,22 @@ async function findBestMatchLLM(
 	if (!response) {
 		// Gracefully handle a missing/empty response instead of throwing (which can crash the server).
 		console.warn('findBestMatchLLM: no response from LLM')
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: the language model returned no response.`
+		}
 	}
 	// mayLog("Raw Response: ", JSON.stringify(response))
 
 	// Tolerantly parse the LLM output. If the model did not return usable JSON,
-	// bail out gracefully rather than throwing.
+	// surface a message to the user rather than throwing.
 	const parsed = safeExtractJsonObject(response)
 	if (!parsed) {
 		console.warn(`findBestMatchLLM: LLM response was not valid JSON, skipping: ${response}`)
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: the language model did not return a valid response.`
+		}
 	}
 
 	let parsedTerm: string
@@ -531,7 +559,10 @@ async function findBestMatchLLM(
 	} else {
 		// JSON parsed, but it doesn't contain a usable "term" field.
 		console.warn(`findBestMatchLLM: LLM response missing a valid "term" field: ${response}`)
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: the language model response did not identify a term.`
+		}
 	}
 	/*
 try {
@@ -549,7 +580,10 @@ return undefined
 	const matchedRow = db_rows.find(r => r.name === parsedTerm)
 	if (!matchedRow) {
 		console.warn(`findBestMatchLLM: LLM returned term "${parsedTerm}" that was not found in db_rows`)
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: no dictionary term corresponds to the suggested match.`
+		}
 	}
 	// db_rows.name is the dictionary term id (see parse_dataset_db in utils.ts).
 	// LLM doesn't produce a native similarity score; use 1 so the downstream threshold treats this as confident.

--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -11,7 +11,12 @@ import type {
 	PrebuiltScatterPhrase2EntityResult
 } from './scaffoldTypes.ts'
 //import { loadOrBuildEmbeddings, findBestMatch } from './semanticSearch.ts'
-import { extractGenesetsFromPromptNew, extractGenesFromPrompt, getGenesetNames } from './utils.ts'
+import {
+	extractGenesetsFromPromptNew,
+	extractGenesFromPrompt,
+	getGenesetNames,
+	safeExtractJsonObject
+} from './utils.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import Database from 'better-sqlite3'
 import assert from 'assert'
@@ -497,28 +502,35 @@ async function findBestMatchLLM(
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	if (!response) {
-		throw new Error('No response from LLM for findBestMatchLLM')
+		// Gracefully handle a missing/empty response instead of throwing (which can crash the server).
+		console.warn('findBestMatchLLM: no response from LLM')
+		return undefined
 	}
 	// mayLog("Raw Response: ", JSON.stringify(response))
+
+	// Tolerantly parse the LLM output. If the model did not return usable JSON,
+	// bail out gracefully rather than throwing.
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		console.warn(`findBestMatchLLM: LLM response was not valid JSON, skipping: ${response}`)
+		return undefined
+	}
+
 	let parsedTerm: string
-	// let msg: string
-	try {
-		const parsed = JSON.parse(response) as { term: string; possible?: string[] }
-		if (parsed.term === 'ambiguous') {
-			mayLog('Ambiguous!!! Possible matches: ')
-			if (parsed.possible) {
-				parsedTerm = parsed.possible[0]
-				mayLog(parsed.possible)
-				mayLog('But choosing the first choice: ', parsedTerm)
-			} else {
-				parsedTerm = 'ambiguous_no_candidates'
-			}
+	if (parsed.term === 'ambiguous') {
+		mayLog('Ambiguous!!! Possible matches: ')
+		if (Array.isArray(parsed.possible) && parsed.possible.length > 0) {
+			parsedTerm = String(parsed.possible[0])
+			mayLog(parsed.possible)
+			mayLog('But choosing the first choice: ', parsedTerm)
 		} else {
-			parsedTerm = parsed.term
-			// msg = ''
+			parsedTerm = 'ambiguous_no_candidates'
 		}
-	} catch (e) {
-		console.warn(`findBestMatchLLM: failed to parse LLM response: ${response}`, e)
+	} else if (typeof parsed.term === 'string' && parsed.term.length > 0) {
+		parsedTerm = parsed.term
+	} else {
+		// JSON parsed, but it doesn't contain a usable "term" field.
+		console.warn(`findBestMatchLLM: LLM response missing a valid "term" field: ${response}`)
 		return undefined
 	}
 	/*

--- a/server/src/chat/filter.ts
+++ b/server/src/chat/filter.ts
@@ -1,6 +1,6 @@
 import { phrase2entitytw, collectLeaves, evaluateFilterTerm } from './utils.ts'
 import type { FilterTreeResult } from './scaffoldTypes.ts'
-import { getTermObj, type Value } from './entity2termObj.ts'
+import { getTermObj, isMsgToUser, type Value } from './entity2termObj.ts'
 import { resolveToTvs } from './entity2twTvs.ts'
 import type { MsgToUser, Entity } from './scaffoldTypes.ts'
 import { mayLog } from '#src/helpers.ts'
@@ -45,6 +45,7 @@ export async function generateFilterTerm(
 	for (const filterTerm of filterEntities) {
 		mayLog('generateFilterTerm evaluating filter term:', filterTerm)
 		const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+		if (isMsgToUser(termObj)) return termObj
 		if (!termObj) continue
 		if (filterTerm.logicalOperator) termObj.logicalOperator = filterTerm.logicalOperator
 		filterValues.push(termObj)

--- a/server/src/chat/genedatatype.ts
+++ b/server/src/chat/genedatatype.ts
@@ -1,6 +1,8 @@
 import type { LlmConfig, GeneDataTypeResult } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
+import { safeExtractJsonArray } from './utils.ts'
+import type { MsgToUser } from './scaffoldTypes.ts'
 
 // ---------------------------------------------------------------------------
 //  Function 1: Classify each term as "gene" or "group"
@@ -25,7 +27,7 @@ export async function classifyGeneOrGroup(
 	user_prompt: string,
 	llm: LlmConfig,
 	gene_group_intersection: string[] // Genes from db that are present in the user prompt
-): Promise<{ term: string; role: string }[]> {
+): Promise<{ term: string; role: string }[] | MsgToUser> {
 	//const allTerms = relevant_genes.map(x => x.toUpperCase()).join(', ')
 	const ambiguousTerms = gene_group_intersection.join(', ')
 
@@ -123,16 +125,16 @@ Response:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 
-	let results: GeneOrGroupOrAmbiguousResult[]
-	try {
-		const cleaned = stripMarkdownFencing(response)
-		results = JSON.parse(cleaned)
-	} catch {
+	// Tolerantly parse the LLM output (handles code fences / surrounding prose). If the model
+	// did not return a valid JSON array, surface a message to the user instead of throwing.
+	const results = safeExtractJsonArray(response) as GeneOrGroupOrAmbiguousResult[] | undefined
+	if (!results) {
 		mayLog('classifyGeneOrGroup: failed to parse LLM response as JSON:', response)
-		throw 'Failed to parse LLM response as JSON'
+		return {
+			type: 'text',
+			text: `Could not classify the ambiguous terms (${ambiguousTerms}): the language model did not return a valid response.`
+		}
 	}
-
-	if (!Array.isArray(results)) throw 'classifyGeneOrGroup response is not an array'
 
 	const geneTerms: { term: string; role: string }[] = results.filter(r => r.role === 'group')
 	//const filteredGenes = gene_group_intersection.filter(g => geneTerms.includes(g.toLowerCase()))
@@ -158,15 +160,16 @@ export async function classifyGeneDataType(
 	llm: LlmConfig,
 	relevant_genes: string[],
 	dataset_json: any
-): Promise<GeneDataTypeResult[] | string> {
+): Promise<GeneDataTypeResult[] | string | MsgToUser> {
 	const exclude_keywords: string[] = dataset_json?.ExcludedKeywords ?? []
 	let genes: string[] = []
 	if (exclude_keywords.length > 0) {
 		const gene_group_intersection = exclude_keywords.filter(x => relevant_genes.includes(x.toLowerCase()))
 		if (gene_group_intersection.length > 0) {
-			const classified_genes = (await classifyGeneOrGroup(user_prompt, llm, gene_group_intersection))
-				.filter(geneTerm => geneTerm.role === 'group')
-				.map(g => g.term.toLowerCase())
+			const classified = await classifyGeneOrGroup(user_prompt, llm, gene_group_intersection)
+			// A MsgToUser (non-array) means classification failed; propagate it for UI display.
+			if (!Array.isArray(classified)) return classified
+			const classified_genes = classified.filter(geneTerm => geneTerm.role === 'group').map(g => g.term.toLowerCase())
 			genes = relevant_genes.filter(x => !classified_genes.includes(x))
 		} else {
 			genes = relevant_genes

--- a/server/src/chat/route.ts
+++ b/server/src/chat/route.ts
@@ -276,6 +276,9 @@ export async function run_chat_pipeline(
 			genome
 		)
 		mayLog('Time taken to infer term objects:', formatElapsedTime(Date.now() - time))
+		if ('type' in termObj && termObj.type === 'text') {
+			return termObj // Return msg/error to client for display
+		}
 		mayLog('Inferred termObj from entity:', JSON.stringify(termObj))
 
 		mayLog('#################################################')

--- a/server/src/chat/scaffold.ts
+++ b/server/src/chat/scaffold.ts
@@ -16,7 +16,7 @@ import type {
 	PrebuiltScatterScaffold,
 	MsgToUser
 } from './scaffoldTypes.ts'
-import { extractGenesFromPrompt } from './utils.ts'
+import { extractGenesFromPrompt, safeExtractJsonObject } from './utils.ts'
 import { generateFilterTerm } from './filter.ts'
 import { classifyGeneDataType } from './genedatatype.ts'
 import { determineAmbiguousGenePrompt } from './determineAmbiguousGene.ts'
@@ -114,21 +114,20 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Survival scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response)
-		if (parsed && parsed.type === 'text') return parsed as MsgToUser
-		if (!parsed.term2) {
-			return {
-				type: 'text',
-				text: 'No stratification variable (term2) could be extracted from the prompt for the survival plot.'
-			}
-		}
-		const scaffold = parsed as SurvivalScaffold
-		scaffold.plotType = 'survival'
-		return scaffold
-	} catch {
-		throw new Error(`Failed to parse SurvivalScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a survival plot configuration from the response: ${response}` }
 	}
+	if (parsed.type === 'text') return parsed as MsgToUser
+	if (!parsed.term2) {
+		return {
+			type: 'text',
+			text: 'No stratification variable (term2) could be extracted from the prompt for the survival plot.'
+		}
+	}
+	const scaffold = parsed as SurvivalScaffold
+	scaffold.plotType = 'survival'
+	return scaffold
 }
 
 async function getScaffold_genomeBrowser(
@@ -229,16 +228,16 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Genome browser scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as GenomeBrowserScaffold
-		parsed.plotType = 'genomeBrowser'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse GenomeBrowserScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a genome browser configuration from the response: ${response}` }
 	}
+	const scaffold = parsed as GenomeBrowserScaffold
+	scaffold.plotType = 'genomeBrowser'
+	return scaffold
 }
 
-async function getScaffold_matrix(user_prompt: string, llm: LlmConfig): Promise<MatrixScaffold> {
+async function getScaffold_matrix(user_prompt: string, llm: LlmConfig): Promise<MatrixScaffold | MsgToUser> {
 	const prompt = ` You are a ProteinPaint matrix plot assistant. Your task is to extract the necessary variables from a user's natural language question to populate a strict JSON scaffold for configuring a matrix plot. 
 
 ## OUTPUT SCHEMA
@@ -323,16 +322,16 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm)
 	mayLog(`--> Matrix Scaffold LLM response: ${response}`)
-	try {
-		const scaffold = JSON.parse(response)
-		scaffold.plotType = 'matrix' // add plotType to the scaffold for downstream use
-		return scaffold
-	} catch (error) {
-		throw new Error(`Failed to parse LLM response as JSON: ${response}\nError: ${error}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a matrix plot configuration from the response: ${response}` }
 	}
+	const scaffold = parsed as MatrixScaffold
+	scaffold.plotType = 'matrix' // add plotType to the scaffold for downstream use
+	return scaffold
 }
 
-async function getScaffold_dge(user_prompt: string, llm: LlmConfig): Promise<DEScaffold> {
+async function getScaffold_dge(user_prompt: string, llm: LlmConfig): Promise<DEScaffold | MsgToUser> {
 	const prompt = ` You are a ProteinPaint differential expression analysis assistant. Your task is to extract exactly two comparison groups and an optional cohort filter from a user's natural language question.
 
 ## OUTPUT SCHEMA
@@ -486,16 +485,19 @@ Query: ${user_prompt}
 	// let response = summaryScaffold
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> DE scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as DEScaffold
-		parsed.plotType = 'dge'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse DEScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return {
+			type: 'text',
+			text: `Could not parse a differential expression configuration from the response: ${response}`
+		}
 	}
+	const scaffold = parsed as DEScaffold
+	scaffold.plotType = 'dge'
+	return scaffold
 }
 
-async function getScaffold_summary(user_prompt: string, llm: LlmConfig): Promise<SummaryScaffold> {
+async function getScaffold_summary(user_prompt: string, llm: LlmConfig): Promise<SummaryScaffold | MsgToUser> {
 	const prompt = `You are a structured data extraction assistant. Your job is to parse the user prompt string and extract variables into a strict JSON scaffold for a summary plot configuration.
 ## Output Schema
 Always return ONLY a JSON object in this exact format:
@@ -608,13 +610,13 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Summary scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as SummaryScaffold
-		parsed.plotType = 'summary'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse SummaryScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a summary plot configuration from the response: ${response}` }
 	}
+	const scaffold = parsed as SummaryScaffold
+	scaffold.plotType = 'summary'
+	return scaffold
 }
 
 async function hierarchicalGeneExpression(
@@ -680,8 +682,15 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as HierarchicalGeneExpressionScaffold
+	{
+		const parsedObj = safeExtractJsonObject(response)
+		if (!parsedObj) {
+			return {
+				type: 'text',
+				text: `Could not parse a hierarchical clustering configuration from the response: ${response}`
+			}
+		}
+		const parsed = parsedObj as HierarchicalGeneExpressionScaffold
 		parsed.plotType = 'hiercluster'
 		// Ensure each gene symbol is followed by "expression" so downstream phrase2entity
 		// resolves it to the geneExpression term type rather than flagging it as ambiguous.
@@ -737,8 +746,6 @@ Query: ${user_prompt}
 		)
 		mayLog('Time taken for hierCluster agent:', formatElapsedTime(Date.now() - time))
 		return ai_output_json
-	} catch {
-		throw new Error(`Failed to parse HierarchicalScaffold from LLM response: ${response}`)
 	}
 }
 
@@ -944,26 +951,25 @@ Query: ${user_prompt}
 `*/
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Prebuilt scatter scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as PrebuiltScatterScaffold
-		if (!parsed.name)
-			return {
-				type: 'text',
-				text: 'Name of pre-built map (e.g. t-SNE, UMAP, etc) is required for prebuilt scatter scaffold'
-			}
-		if (parsed.name === 'unsure') {
-			return {
-				type: 'text',
-				text: 'LLM was unsure which prebuilt scatter plot the user query corresponded to based on the descriptions, indicating that the query did not clearly match any of the available options.'
-			}
-		} else if (parsed.name === 'nomatch') {
-			return { type: 'text', text: 'The plot you are asking for is not currently supported.' }
-		}
-		parsed.plotType = 'prebuiltscatter'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse PrebuiltScatterScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response) as PrebuiltScatterScaffold | undefined
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a prebuilt scatter configuration from the response: ${response}` }
 	}
+	if (!parsed.name)
+		return {
+			type: 'text',
+			text: 'Name of pre-built map (e.g. t-SNE, UMAP, etc) is required for prebuilt scatter scaffold'
+		}
+	if (parsed.name === 'unsure') {
+		return {
+			type: 'text',
+			text: 'LLM was unsure which prebuilt scatter plot the user query corresponded to based on the descriptions, indicating that the query did not clearly match any of the available options.'
+		}
+	} else if (parsed.name === 'nomatch') {
+		return { type: 'text', text: 'The plot you are asking for is not currently supported.' }
+	}
+	parsed.plotType = 'prebuiltscatter'
+	return parsed
 }
 
 export async function getScaffold_hierarchical(
@@ -1031,13 +1037,14 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical variable-type classifier: ${response}`)
-	let variableType: string
-	try {
-		const parsed = JSON.parse(response)
-		variableType = parsed.variableType
-	} catch {
-		throw new Error(`Failed to parse hierarchical variable-type classifier response: ${response}`)
+	const parsedClassifier = safeExtractJsonObject(response)
+	if (!parsedClassifier) {
+		return {
+			type: 'text',
+			text: `Could not parse the hierarchical variable-type classification from the response: ${response}`
+		}
 	}
+	const variableType: string = parsedClassifier.variableType
 	if (variableType === TermTypes.GENE_EXPRESSION) {
 		if (allowedTermTypes.includes(TermTypes.GENE_EXPRESSION)) {
 			return await hierarchicalGeneExpression(user_prompt, llm, genome, genes_list, dataset_json, ds, dbPath)
@@ -1150,12 +1157,14 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical dictionary scaffold: ${response}`)
-	let parsed: HierarchicalScaffold
-	try {
-		parsed = JSON.parse(response) as HierarchicalScaffold
-	} catch {
-		throw new Error(`Failed to parse HierarchicalScaffold from LLM response: ${response}`)
+	const parsedObj = safeExtractJsonObject(response)
+	if (!parsedObj) {
+		return {
+			type: 'text',
+			text: `Could not parse a hierarchical clustering configuration from the response: ${response}`
+		}
 	}
+	const parsed = parsedObj as HierarchicalScaffold
 	parsed.plotType = 'hiercluster'
 
 	if (!parsed.hierarchicalPhrases) {

--- a/server/src/chat/scaffold.ts
+++ b/server/src/chat/scaffold.ts
@@ -729,6 +729,8 @@ Query: ${user_prompt}
 				throw 'classifyGeneDataType agent returned an empty string, which is unexpected.'
 			} else if (Array.isArray(geneDataTypeMessage)) {
 				geneFeatures = geneDataTypeMessage
+			} else if (geneDataTypeMessage && geneDataTypeMessage.type === 'text') {
+				return geneDataTypeMessage // MsgToUser — surface to the client for display
 			} else {
 				throw 'geneDataTypeMessage has unknown data type returned from classifyGeneDataType agent'
 			}

--- a/server/src/chat/utils.ts
+++ b/server/src/chat/utils.ts
@@ -12,6 +12,39 @@ import { GENE_SET_KEYWORDS } from './genesetdatatype.ts'
 import { classifyGeneDataTypePhrase } from './genedatatypenew.ts'
 import { classifyGeneSetDataType } from './genesetdatatype.ts'
 
+/**
+ * Tolerantly extract a JSON object from an LLM response.
+ * LLMs frequently wrap JSON in markdown code fences or prepend/append prose
+ * (e.g. reasoning text), which makes a direct JSON.parse() throw. This helper
+ * never throws: it returns the first parseable JSON object, or undefined.
+ */
+export function safeExtractJsonObject(response: unknown): Record<string, any> | undefined {
+	if (typeof response !== 'string') return undefined
+	const candidates: string[] = []
+	const trimmed = response.trim()
+	candidates.push(trimmed)
+	// Strip a leading/trailing markdown code fence such as ```json ... ```
+	const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
+	if (fenceMatch) candidates.push(fenceMatch[1].trim())
+	// Fall back to the first balanced-looking {...} block embedded in the text
+	const braceMatch = trimmed.match(/\{[\s\S]*\}/)
+	if (braceMatch) candidates.push(braceMatch[0])
+
+	for (const candidate of candidates) {
+		if (!candidate) continue
+		try {
+			const parsed = JSON.parse(candidate)
+			// Only accept a non-null JSON object (reject strings, numbers, arrays, null)
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				return parsed as Record<string, any>
+			}
+		} catch {
+			// try the next candidate
+		}
+	}
+	return undefined
+}
+
 export function getChatRelatedPlotTypes(supportedPlotTypes: string[] | undefined): string[] {
 	if (!supportedPlotTypes) {
 		mayLog(

--- a/server/src/chat/utils.ts
+++ b/server/src/chat/utils.ts
@@ -45,6 +45,35 @@ export function safeExtractJsonObject(response: unknown): Record<string, any> | 
 	return undefined
 }
 
+/**
+ * Tolerantly extract a JSON array from an LLM response. Array counterpart to
+ * safeExtractJsonObject() — handles markdown code fences and surrounding prose.
+ * Never throws: returns the first parseable JSON array, or undefined.
+ */
+export function safeExtractJsonArray(response: unknown): any[] | undefined {
+	if (typeof response !== 'string') return undefined
+	const candidates: string[] = []
+	const trimmed = response.trim()
+	candidates.push(trimmed)
+	// Strip a leading/trailing markdown code fence such as ```json ... ```
+	const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
+	if (fenceMatch) candidates.push(fenceMatch[1].trim())
+	// Fall back to the first balanced-looking [...] block embedded in the text
+	const bracketMatch = trimmed.match(/\[[\s\S]*\]/)
+	if (bracketMatch) candidates.push(bracketMatch[0])
+
+	for (const candidate of candidates) {
+		if (!candidate) continue
+		try {
+			const parsed = JSON.parse(candidate)
+			if (Array.isArray(parsed)) return parsed
+		} catch {
+			// try the next candidate
+		}
+	}
+	return undefined
+}
+
 export function getChatRelatedPlotTypes(supportedPlotTypes: string[] | undefined): string[] {
 	if (!supportedPlotTypes) {
 		mayLog(


### PR DESCRIPTION
# Description
Hardening chatbot code to handle non-JSON output returned by LLM.

1) Implemented `safeExtractJsonArray()` and `safeExtractJsonObject()` to handle cases when an LLM returns a non-JSON output (when it should).

2) When absolutely no JSON output is returned it should send appropriate error message to client so as to prevent server crash.  


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
