### PR TITLE
Hardening chat bot code so as to handle non JSON output from LLMs

### DIFF
--- a/server/src/chat/classify1.ts
+++ b/server/src/chat/classify1.ts
@@ -1,5 +1,7 @@
 import type { LlmConfig, QueryClassification } from '#types'
 import { mayLog } from '#src/helpers.ts'
+import type { MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 
 /**
@@ -9,7 +11,7 @@ import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
  * @param llm          LLM configuration (provider, model names, API endpoint).
  * @returns            'plot' | 'notplot'
  */
-export async function classifyQuery(user_prompt: string, llm: LlmConfig): Promise<QueryClassification> {
+export async function classifyQuery(user_prompt: string, llm: LlmConfig): Promise<QueryClassification | MsgToUser> {
 	const prompt = `You are a classifier for a genomics/clinical dataset analysis tool. Classify the following user query into exactly one category.
 
 - "plot": the query asks to visualize, explore, retrieve, or ask questions about data values in the dataset, OR to modify an existing plot. This includes ANY question that can be answered by looking at the actual patient/sample data — such as gene expression, survival, mutations, clinical variables (age, sex, diagnosis, ancestry, etc.), subtypes, karyotypes, distributions, comparisons, ranges, counts, or plot modifications (change color, remove overlay, update filters, switch chart type). Examples: "What are the karyotypes of chr8?", "Show TP53 expression", "How many patients have subtype X?", "What's the age range of female patients?", "Remove the color from the t-SNE", "Color the UMAP by sex".
@@ -22,6 +24,7 @@ Query: "${user_prompt}"
 Category:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	if (isMsgToUser(response)) return response
 	const category = response.trim().toLowerCase()
 	mayLog(`--> classifyQuery: "${category}"`)
 

--- a/server/src/chat/classify2.ts
+++ b/server/src/chat/classify2.ts
@@ -1,5 +1,6 @@
 import type { LlmConfig } from '#types'
 import { mayLog } from '#src/helpers.ts'
+import type { MsgToUser } from './scaffoldTypes.ts'
 import { extractResourceResponse } from './resource.ts'
 
 /**
@@ -19,7 +20,7 @@ export async function classifyNotPlot(
 	agentFiles: string[],
 	aiFilesDir: string
 	// _allowedTermTypes: string[]
-): Promise<{ type: 'none' } | { type: 'html'; html: string }> {
+): Promise<{ type: 'none' } | { type: 'html'; html: string } | MsgToUser> {
 	if (agentFiles.includes('resources.json')) {
 		mayLog('classify2: dataset has resources, delegating to resource agent')
 		return await extractResourceResponse(userPrompt, llm, aiFilesDir)

--- a/server/src/chat/dataQueries.ts
+++ b/server/src/chat/dataQueries.ts
@@ -1,6 +1,7 @@
 import type { LlmConfig } from '#types'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { mayLog } from '#src/helpers.ts'
 import { TermTypes } from '#shared/terms.js'
 
@@ -88,6 +89,8 @@ export async function answerDataQueries(
     Answer:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 	let parsed: any
 	try {
 		parsed = JSON.parse(response) as { ans: string; term: string }

--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -12,12 +12,7 @@ import type {
 	MsgToUser
 } from './scaffoldTypes.ts'
 //import { loadOrBuildEmbeddings, findBestMatch } from './semanticSearch.ts'
-import {
-	extractGenesetsFromPromptNew,
-	extractGenesFromPrompt,
-	getGenesetNames,
-	safeExtractJsonObject
-} from './utils.ts'
+import { extractGenesetsFromPromptNew, extractGenesFromPrompt, getGenesetNames } from './utils.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import Database from 'better-sqlite3'
 import assert from 'assert'
@@ -157,7 +152,7 @@ export async function getTermObj(
 const refEmbedding = await loadOrBuildEmbeddings(dbPath, llm)
 const topK: number = 3
 const match = await findBestMatch(twEntity.phrase, refEmbedding, llm, topK)
-        */
+*/
 		let match: { id: string; type: string; name: string; score: number; msg?: string } | MsgToUser | undefined
 		try {
 			match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
@@ -469,6 +464,8 @@ async function findBestMatchLLM(
 	llm: LlmConfig
 ): Promise<{ id: string; type: string; name: string; score: number; msg?: string } | MsgToUser> {
 	const dataset_db_output = await parse_dataset_db(dbPath)
+	// parse_dataset_db returns a MsgToUser if the dictionary could not be read; propagate it to the client.
+	if (isMsgToUser(dataset_db_output)) return dataset_db_output
 	const { db_rows, rag_docs } = dataset_db_output
 	if (rag_docs.length === 0) {
 		console.warn('findBestMatchLLM: no rag_docs in DB')
@@ -535,12 +532,14 @@ async function findBestMatchLLM(
 
 	// Tolerantly parse the LLM output. If the model did not return usable JSON,
 	// surface a message to the user rather than throwing.
-	const parsed = safeExtractJsonObject(response)
-	if (!parsed) {
+	let parsed: any
+	try {
+		parsed = JSON.parse(response)
+	} catch {
 		console.warn(`findBestMatchLLM: LLM response was not valid JSON, skipping: ${response}`)
 		return {
 			type: 'text',
-			text: `Could not match "${phrase}" to a dataset term: the language model did not return a valid response.`
+			text: `Could not match "${phrase}" to a dataset term: the language model did not return a valid response:${response}`
 		}
 	}
 
@@ -596,7 +595,9 @@ return undefined
 	return retVal
 }
 
-export async function parse_dataset_db(dataset_db: string) {
+export async function parse_dataset_db(
+	dataset_db: string
+): Promise<{ db_rows: DbRows[]; rag_docs: string[] } | MsgToUser> {
 	const db = new Database(dataset_db)
 	const rag_docs: string[] = []
 	const db_rows: DbRows[] = []
@@ -607,10 +608,29 @@ export async function parse_dataset_db(dataset_db: string) {
 			)
 			.all()
 
-		rows.forEach((row: any) => {
-			const jsonhtml = JSON.parse(row.jsonhtml)
+		for (const row of rows as any[]) {
+			let jsonhtml: any
+			try {
+				jsonhtml = JSON.parse(row.jsonhtml)
+			} catch (e) {
+				mayLog(`Failed to parse jsonhtml for row id ${row.id}, name ${row.name}:`, e)
+				// Surface a message to the client instead of crashing on the malformed term definition below.
+				return {
+					type: 'text',
+					text: `Failed to read the dataset dictionary: the definition for term "${row.name}" is malformed.`
+				}
+			}
 			const description: string = jsonhtml.description[0].value
-			const jsondata = JSON.parse(row.jsondata)
+			let jsondata: any
+			try {
+				jsondata = JSON.parse(row.jsondata)
+			} catch (e) {
+				mayLog(`Failed to parse jsondata for row id ${row.id}, name ${row.name}:`, e)
+				return {
+					type: 'text',
+					text: `Failed to read the dataset dictionary: the data for term "${row.name}" is malformed. Error response: ${e}`
+				}
+			}
 
 			const values: DbValue[] = []
 			if (jsondata.values && Object.keys(jsondata.values).length > 0) {
@@ -630,7 +650,7 @@ export async function parse_dataset_db(dataset_db: string) {
 			const stringified_db = parse_db_rows(db_row)
 			rag_docs.push(stringified_db)
 			db_rows.push(db_row)
-		})
+		}
 	} catch (error) {
 		throw 'Error in parsing dataset DB:' + error
 	} finally {

--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -146,8 +146,13 @@ export async function getTermObj(
 const refEmbedding = await loadOrBuildEmbeddings(dbPath, llm)
 const topK: number = 3
 const match = await findBestMatch(twEntity.phrase, refEmbedding, llm, topK)
-*/
-		const match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
+        */
+		let match: any
+		try {
+			match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
+		} catch (e) {
+			console.error(`Error in findBestMatchLLM for phrase "${twEntity.phrase}":`, e)
+		}
 		if (!match) {
 			console.warn(`findBestMatchLLM returned no match for query "${twEntity.phrase}"`)
 			return undefined

--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -8,7 +8,8 @@ import type {
 	HierPhrase2EntityResult,
 	SurvivalPhrase2EntityResult,
 	MatrixPhrase2EntityResult,
-	PrebuiltScatterPhrase2EntityResult
+	PrebuiltScatterPhrase2EntityResult,
+	MsgToUser
 } from './scaffoldTypes.ts'
 //import { loadOrBuildEmbeddings, findBestMatch } from './semanticSearch.ts'
 import {
@@ -52,6 +53,11 @@ export type Value = {
 	phrase: string
 	type: string
 	logicalOperator?: '&' | '|'
+}
+
+/** Discriminate a MsgToUser (a {type:'text', text} message to surface to the client) from a resolved Value. */
+export function isMsgToUser(x: unknown): x is MsgToUser {
+	return !!x && typeof x === 'object' && (x as any).type === 'text' && 'text' in (x as any)
 }
 
 function buildNonDictTermObj(twEntity: Entity, genes_list: string[], genome: any): Value | undefined {
@@ -132,7 +138,7 @@ export async function getTermObj(
 	dbPath: string,
 	genes_list: string[],
 	genome: any
-): Promise<Value | undefined> {
+): Promise<Value | MsgToUser | undefined> {
 	// Nested LLM-based replacement for semanticSearch.findBestMatch(). Parses the dataset DB
 	// via parse_dataset_db() to get the full rag_docs list and hands it to the classifier LLM
 	// with the user phrase; the LLM returns the single rag_docs row whose term best matches.
@@ -152,12 +158,14 @@ const refEmbedding = await loadOrBuildEmbeddings(dbPath, llm)
 const topK: number = 3
 const match = await findBestMatch(twEntity.phrase, refEmbedding, llm, topK)
         */
-		let match: any
+		let match: { id: string; type: string; name: string; score: number; msg?: string } | MsgToUser | undefined
 		try {
 			match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
 		} catch (e) {
 			console.error(`Error in findBestMatchLLM for phrase "${twEntity.phrase}":`, e)
 		}
+		// findBestMatchLLM returns a MsgToUser when it cannot resolve the phrase; surface it to the client.
+		if (isMsgToUser(match)) return match
 		if (!match) {
 			console.warn(`findBestMatchLLM returned no match for query "${twEntity.phrase}"`)
 			return undefined
@@ -189,7 +197,7 @@ export async function inferTermObjFromEntity(
 	dbPath: string,
 	genes_list: string[], // redundant (must be fixed)
 	genome: any
-): Promise<Record<string, Value | Value[] | string>> {
+): Promise<Record<string, Value | Value[] | string> | MsgToUser> {
 	const twObjects: Record<string, Value | Value[] | string> = {}
 	if (plotType === 'summary') {
 		const summaryEntity = entity as SummaryPhrase2EntityResult
@@ -203,6 +211,7 @@ export async function inferTermObjFromEntity(
 				for (const filterTerm of filterResult) {
 					mayLog('Evaluating filter term:', filterTerm)
 					const termObj = await getTermObj(key, filterTerm, llm, dbPath, genes_list, genome)
+					if (isMsgToUser(termObj)) return termObj
 					if (!termObj) {
 						continue
 					}
@@ -220,6 +229,7 @@ export async function inferTermObjFromEntity(
 			if (!entry) continue
 			const twEntity = entry[0]
 			const termObj = await getTermObj(key, twEntity, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (!termObj) {
 				throw `Failed to get term object for key "${key}" and phrase "${twEntity.phrase}".`
 			}
@@ -239,6 +249,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of filterResult) {
 				mayLog(`Evaluating ${key} term:`, filterTerm)
 				const termObj = await getTermObj(key, filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) {
 					console.warn(`Skipping filter term "${filterTerm.phrase}" — failed to get term object`)
 					continue
@@ -262,6 +273,7 @@ export async function inferTermObjFromEntity(
 
 		// term2 is the REQUIRED stratification variable; resolve it like a single tw entity.
 		const term2Obj = await getTermObj('term2', survivalEntity.term2, llm, dbPath, genes_list, genome)
+		if (isMsgToUser(term2Obj)) return term2Obj
 		if (!term2Obj) {
 			throw `Failed to get term object for key "term2" and phrase "${survivalEntity.term2.phrase}".`
 		}
@@ -273,6 +285,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of survivalEntity.filter) {
 				mayLog('Evaluating survival filter term:', filterTerm)
 				const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) {
 					continue
 				}
@@ -290,6 +303,7 @@ export async function inferTermObjFromEntity(
 		for (const phrase of hierEntity.phrases) {
 			mayLog('Evaluating hierCluster phrase:', phrase)
 			const termObj = await getTermObj('DictPhrases', phrase, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (!termObj) {
 				console.warn(`Skipping hierCluster gene "${phrase.phrase}" — failed to get term object`)
 				continue
@@ -306,6 +320,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of hierEntity.filter) {
 				mayLog('Evaluating hierCluster filter term:', filterTerm)
 				const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) continue
 				if (filterTerm.logicalOperator) termObj.logicalOperator = filterTerm.logicalOperator
 				filterValues.push(termObj)
@@ -325,6 +340,7 @@ export async function inferTermObjFromEntity(
 				for (const filterTerm of filterResult) {
 					mayLog('Evaluating filter term:', filterTerm)
 					const termObj = await getTermObj(key, filterTerm, llm, dbPath, genes_list, genome)
+					if (isMsgToUser(termObj)) return termObj
 					if (!termObj) {
 						continue
 					}
@@ -343,6 +359,7 @@ export async function inferTermObjFromEntity(
 				for (const [index, twEntity] of twEntities.entries()) {
 					mayLog(`Evaluating twLst[${index}] entity:`, twEntity)
 					const termObj = await getTermObj(key, twEntity, llm, dbPath, genes_list, genome)
+					if (isMsgToUser(termObj)) return termObj
 					if (!termObj) {
 						console.warn(`Skipping twLst[${index}] — failed to get term object for phrase "${twEntity.phrase}"`)
 						continue
@@ -362,6 +379,7 @@ export async function inferTermObjFromEntity(
 			const twEntity = value as Entity | undefined
 			if (!twEntity) continue
 			const termObj = await getTermObj(key, twEntity, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (!termObj) {
 				throw `Failed to get term object for key "${key}" and phrase "${twEntity.phrase}".`
 			}
@@ -381,6 +399,7 @@ export async function inferTermObjFromEntity(
 			twObjects['colorBy'] = 'null'
 		} else if (scatterEntity.colorBy) {
 			const termObj = await getTermObj('colorBy', scatterEntity.colorBy, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (termObj) {
 				twObjects['colorBy'] = termObj
 			} else {
@@ -393,6 +412,7 @@ export async function inferTermObjFromEntity(
 			twObjects['shapeBy'] = 'null'
 		} else if (scatterEntity.shapeBy) {
 			const termObj = await getTermObj('shapeBy', scatterEntity.shapeBy, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (termObj) {
 				twObjects['shapeBy'] = termObj
 			} else {
@@ -404,6 +424,7 @@ export async function inferTermObjFromEntity(
 
 		if (scatterEntity.divideBy) {
 			const termObj = await getTermObj('divideBy', scatterEntity.divideBy, llm, dbPath, genes_list, genome)
+			if (isMsgToUser(termObj)) return termObj
 			if (termObj) {
 				twObjects['divideBy'] = termObj
 			} else {
@@ -425,6 +446,7 @@ export async function inferTermObjFromEntity(
 			for (const filterTerm of filterResult) {
 				mayLog('Evaluating filter term:', filterTerm)
 				const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) {
 					continue
 				}
@@ -445,12 +467,12 @@ async function findBestMatchLLM(
 	phrase: string,
 	dbPath: string,
 	llm: LlmConfig
-): Promise<{ id: string; type: string; name: string; score: number; msg?: string } | undefined> {
+): Promise<{ id: string; type: string; name: string; score: number; msg?: string } | MsgToUser> {
 	const dataset_db_output = await parse_dataset_db(dbPath)
 	const { db_rows, rag_docs } = dataset_db_output
 	if (rag_docs.length === 0) {
 		console.warn('findBestMatchLLM: no rag_docs in DB')
-		return undefined
+		return { type: 'text', text: `Could not match "${phrase}" because the dataset dictionary has no terms to search.` }
 	}
 	const prompt = `You are an assistant that maps a user phrase to a dataset dictionary term.
 	IMPORTANT: Your goal is NOT to always select a match. Your goal is to AVOID incorrect matches.
@@ -504,16 +526,22 @@ async function findBestMatchLLM(
 	if (!response) {
 		// Gracefully handle a missing/empty response instead of throwing (which can crash the server).
 		console.warn('findBestMatchLLM: no response from LLM')
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: the language model returned no response.`
+		}
 	}
 	// mayLog("Raw Response: ", JSON.stringify(response))
 
 	// Tolerantly parse the LLM output. If the model did not return usable JSON,
-	// bail out gracefully rather than throwing.
+	// surface a message to the user rather than throwing.
 	const parsed = safeExtractJsonObject(response)
 	if (!parsed) {
 		console.warn(`findBestMatchLLM: LLM response was not valid JSON, skipping: ${response}`)
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: the language model did not return a valid response.`
+		}
 	}
 
 	let parsedTerm: string
@@ -531,7 +559,10 @@ async function findBestMatchLLM(
 	} else {
 		// JSON parsed, but it doesn't contain a usable "term" field.
 		console.warn(`findBestMatchLLM: LLM response missing a valid "term" field: ${response}`)
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: the language model response did not identify a term.`
+		}
 	}
 	/*
 try {
@@ -549,7 +580,10 @@ return undefined
 	const matchedRow = db_rows.find(r => r.name === parsedTerm)
 	if (!matchedRow) {
 		console.warn(`findBestMatchLLM: LLM returned term "${parsedTerm}" that was not found in db_rows`)
-		return undefined
+		return {
+			type: 'text',
+			text: `Could not match "${phrase}" to a dataset term: no dictionary term corresponds to the suggested match.`
+		}
 	}
 	// db_rows.name is the dictionary term id (see parse_dataset_db in utils.ts).
 	// LLM doesn't produce a native similarity score; use 1 so the downstream threshold treats this as confident.

--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -11,6 +11,7 @@ import type {
 	PrebuiltScatterPhrase2EntityResult,
 	MsgToUser
 } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 //import { loadOrBuildEmbeddings, findBestMatch } from './semanticSearch.ts'
 import { extractGenesetsFromPromptNew, extractGenesFromPrompt, getGenesetNames } from './utils.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
@@ -48,11 +49,6 @@ export type Value = {
 	phrase: string
 	type: string
 	logicalOperator?: '&' | '|'
-}
-
-/** Discriminate a MsgToUser (a {type:'text', text} message to surface to the client) from a resolved Value. */
-export function isMsgToUser(x: unknown): x is MsgToUser {
-	return !!x && typeof x === 'object' && (x as any).type === 'text' && 'text' in (x as any)
 }
 
 function buildNonDictTermObj(twEntity: Entity, genes_list: string[], genome: any): Value | undefined {
@@ -120,7 +116,7 @@ function buildNonDictTermObj(twEntity: Entity, genes_list: string[], genome: any
 			return undefined
 		}
 		default: {
-			console.warn(`Unrecognized termType "${twEntity.termType}" for phrase "${twEntity.phrase}".`)
+			mayLog(`Unrecognized termType "${twEntity.termType}" for phrase "${twEntity.phrase}".`)
 			return undefined
 		}
 	}
@@ -143,7 +139,7 @@ export async function getTermObj(
 	if (twEntity.termType !== 'dictionary') {
 		const twRes = buildNonDictTermObj(twEntity, genes_list, genome)
 		if (!twRes) {
-			console.warn(`Skipping ${key} — could not build term for type "${twEntity.termType}"`)
+			mayLog(`Skipping ${key} — could not build term for type "${twEntity.termType}"`)
 			return undefined
 		}
 		return twRes
@@ -157,18 +153,19 @@ const match = await findBestMatch(twEntity.phrase, refEmbedding, llm, topK)
 		try {
 			match = await findBestMatchLLM(twEntity.phrase, dbPath, llm)
 		} catch (e) {
-			console.error(`Error in findBestMatchLLM for phrase "${twEntity.phrase}":`, e)
+			mayLog(`Error in findBestMatchLLM for phrase "${twEntity.phrase}":`, e)
+			return { type: 'text', text: `Error in findBestMatchLLM for phrase "${twEntity.phrase}": ${e}` } as MsgToUser
 		}
 		// findBestMatchLLM returns a MsgToUser when it cannot resolve the phrase; surface it to the client.
 		if (isMsgToUser(match)) return match
 		if (!match) {
-			console.warn(`findBestMatchLLM returned no match for query "${twEntity.phrase}"`)
+			mayLog(`findBestMatchLLM returned no match for query "${twEntity.phrase}"`)
 			return undefined
 		}
 		const similarityThreshold = 0.85
 		if (match.score < similarityThreshold) {
 			// Threshold for "good enough" match, can be tuned
-			console.warn(`Low similarity score (${(match.score * 100).toFixed(1)}%) for query "${twEntity.phrase}"`)
+			mayLog(`Low similarity score (${(match.score * 100).toFixed(1)}%) for query "${twEntity.phrase}"`)
 		} else {
 			mayLog(
 				`${key}: "${twEntity.phrase}" → best match: id="${match.id}" type="${match.type}" name="${match.name}" score=${(
@@ -246,7 +243,7 @@ export async function inferTermObjFromEntity(
 				const termObj = await getTermObj(key, filterTerm, llm, dbPath, genes_list, genome)
 				if (isMsgToUser(termObj)) return termObj
 				if (!termObj) {
-					console.warn(`Skipping filter term "${filterTerm.phrase}" — failed to get term object`)
+					mayLog(`Skipping filter term "${filterTerm.phrase}" — failed to get term object`)
 					continue
 				}
 				const filterEntity = filterTerm as Entity
@@ -300,7 +297,7 @@ export async function inferTermObjFromEntity(
 			const termObj = await getTermObj('DictPhrases', phrase, llm, dbPath, genes_list, genome)
 			if (isMsgToUser(termObj)) return termObj
 			if (!termObj) {
-				console.warn(`Skipping hierCluster gene "${phrase.phrase}" — failed to get term object`)
+				mayLog(`Skipping hierCluster gene "${phrase.phrase}" — failed to get term object`)
 				continue
 			}
 			DictValues.push(termObj)
@@ -356,7 +353,7 @@ export async function inferTermObjFromEntity(
 					const termObj = await getTermObj(key, twEntity, llm, dbPath, genes_list, genome)
 					if (isMsgToUser(termObj)) return termObj
 					if (!termObj) {
-						console.warn(`Skipping twLst[${index}] — failed to get term object for phrase "${twEntity.phrase}"`)
+						mayLog(`Skipping twLst[${index}] — failed to get term object for phrase "${twEntity.phrase}"`)
 						continue
 					}
 					termObjs.push(termObj)
@@ -364,7 +361,7 @@ export async function inferTermObjFromEntity(
 				if (termObjs.length > 0) {
 					twObjects[key] = termObjs
 				} else {
-					console.warn('No valid term objects could be resolved for any entries in twLst.')
+					mayLog('No valid term objects could be resolved for any entries in twLst.')
 				}
 				continue
 			}
@@ -398,7 +395,7 @@ export async function inferTermObjFromEntity(
 			if (termObj) {
 				twObjects['colorBy'] = termObj
 			} else {
-				console.warn(
+				mayLog(
 					`Failed to resolve colorBy term "${scatterEntity.colorBy.phrase}" for prebuilt scatter — skipping this attribute.`
 				)
 			}
@@ -411,7 +408,7 @@ export async function inferTermObjFromEntity(
 			if (termObj) {
 				twObjects['shapeBy'] = termObj
 			} else {
-				console.warn(
+				mayLog(
 					`Failed to resolve shapeBy term "${scatterEntity.shapeBy.phrase}" for prebuilt scatter — skipping this attribute.`
 				)
 			}
@@ -423,7 +420,7 @@ export async function inferTermObjFromEntity(
 			if (termObj) {
 				twObjects['divideBy'] = termObj
 			} else {
-				console.warn(
+				mayLog(
 					`Failed to resolve divideBy term "${scatterEntity.divideBy.phrase}" for prebuilt scatter — skipping this attribute.`
 				)
 			}
@@ -432,7 +429,7 @@ export async function inferTermObjFromEntity(
 		if (scatterEntity.filter) {
 			const filterResult = scatterEntity.filter as Entity[]
 			if (!filterResult) {
-				console.warn(
+				mayLog(
 					`Failed to resolve filter term "${scatterEntity.filter}" for prebuilt scatter — skipping this attribute.`
 				)
 			}
@@ -468,7 +465,7 @@ async function findBestMatchLLM(
 	if (isMsgToUser(dataset_db_output)) return dataset_db_output
 	const { db_rows, rag_docs } = dataset_db_output
 	if (rag_docs.length === 0) {
-		console.warn('findBestMatchLLM: no rag_docs in DB')
+		mayLog('findBestMatchLLM: no rag_docs in DB')
 		return { type: 'text', text: `Could not match "${phrase}" because the dataset dictionary has no terms to search.` }
 	}
 	const prompt = `You are an assistant that maps a user phrase to a dataset dictionary term.
@@ -520,9 +517,11 @@ async function findBestMatchLLM(
 	JSON response:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 	if (!response) {
 		// Gracefully handle a missing/empty response instead of throwing (which can crash the server).
-		console.warn('findBestMatchLLM: no response from LLM')
+		mayLog('findBestMatchLLM: no response from LLM')
 		return {
 			type: 'text',
 			text: `Could not match "${phrase}" to a dataset term: the language model returned no response.`
@@ -536,7 +535,7 @@ async function findBestMatchLLM(
 	try {
 		parsed = JSON.parse(response)
 	} catch {
-		console.warn(`findBestMatchLLM: LLM response was not valid JSON, skipping: ${response}`)
+		mayLog(`findBestMatchLLM: LLM response was not valid JSON, skipping: ${response}`)
 		return {
 			type: 'text',
 			text: `Could not match "${phrase}" to a dataset term: the language model did not return a valid response:${response}`
@@ -557,7 +556,7 @@ async function findBestMatchLLM(
 		parsedTerm = parsed.term
 	} else {
 		// JSON parsed, but it doesn't contain a usable "term" field.
-		console.warn(`findBestMatchLLM: LLM response missing a valid "term" field: ${response}`)
+		mayLog(`findBestMatchLLM: LLM response missing a valid "term" field: ${response}`)
 		return {
 			type: 'text',
 			text: `Could not match "${phrase}" to a dataset term: the language model response did not identify a term.`
@@ -567,18 +566,18 @@ async function findBestMatchLLM(
 try {
 const parsed = JSON.parse(response) as { term: string }
 if (!parsed.term) {
-console.warn(`findBestMatchLLM: LLM response missing term: ${response}`)
+mayLog(`findBestMatchLLM: LLM response missing term: ${response}`)
 return undefined
 }
 parsedTerm = parsed.term
 } catch (e) {
-console.warn(`findBestMatchLLM: failed to parse LLM response: ${response}`, e)
+mayLog(`findBestMatchLLM: failed to parse LLM response: ${response}`, e)
 return undefined
 }*/
 
 	const matchedRow = db_rows.find(r => r.name === parsedTerm)
 	if (!matchedRow) {
-		console.warn(`findBestMatchLLM: LLM returned term "${parsedTerm}" that was not found in db_rows`)
+		mayLog(`findBestMatchLLM: LLM returned term "${parsedTerm}" that was not found in db_rows`)
 		return {
 			type: 'text',
 			text: `Could not match "${phrase}" to a dataset term: no dictionary term corresponds to the suggested match.`

--- a/server/src/chat/entity2termObj.ts
+++ b/server/src/chat/entity2termObj.ts
@@ -11,7 +11,12 @@ import type {
 	PrebuiltScatterPhrase2EntityResult
 } from './scaffoldTypes.ts'
 //import { loadOrBuildEmbeddings, findBestMatch } from './semanticSearch.ts'
-import { extractGenesetsFromPromptNew, extractGenesFromPrompt, getGenesetNames } from './utils.ts'
+import {
+	extractGenesetsFromPromptNew,
+	extractGenesFromPrompt,
+	getGenesetNames,
+	safeExtractJsonObject
+} from './utils.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import Database from 'better-sqlite3'
 import assert from 'assert'
@@ -497,28 +502,35 @@ async function findBestMatchLLM(
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	if (!response) {
-		throw new Error('No response from LLM for findBestMatchLLM')
+		// Gracefully handle a missing/empty response instead of throwing (which can crash the server).
+		console.warn('findBestMatchLLM: no response from LLM')
+		return undefined
 	}
 	// mayLog("Raw Response: ", JSON.stringify(response))
+
+	// Tolerantly parse the LLM output. If the model did not return usable JSON,
+	// bail out gracefully rather than throwing.
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		console.warn(`findBestMatchLLM: LLM response was not valid JSON, skipping: ${response}`)
+		return undefined
+	}
+
 	let parsedTerm: string
-	// let msg: string
-	try {
-		const parsed = JSON.parse(response) as { term: string; possible?: string[] }
-		if (parsed.term === 'ambiguous') {
-			mayLog('Ambiguous!!! Possible matches: ')
-			if (parsed.possible) {
-				parsedTerm = parsed.possible[0]
-				mayLog(parsed.possible)
-				mayLog('But choosing the first choice: ', parsedTerm)
-			} else {
-				parsedTerm = 'ambiguous_no_candidates'
-			}
+	if (parsed.term === 'ambiguous') {
+		mayLog('Ambiguous!!! Possible matches: ')
+		if (Array.isArray(parsed.possible) && parsed.possible.length > 0) {
+			parsedTerm = String(parsed.possible[0])
+			mayLog(parsed.possible)
+			mayLog('But choosing the first choice: ', parsedTerm)
 		} else {
-			parsedTerm = parsed.term
-			// msg = ''
+			parsedTerm = 'ambiguous_no_candidates'
 		}
-	} catch (e) {
-		console.warn(`findBestMatchLLM: failed to parse LLM response: ${response}`, e)
+	} else if (typeof parsed.term === 'string' && parsed.term.length > 0) {
+		parsedTerm = parsed.term
+	} else {
+		// JSON parsed, but it doesn't contain a usable "term" field.
+		console.warn(`findBestMatchLLM: LLM response missing a valid "term" field: ${response}`)
 		return undefined
 	}
 	/*

--- a/server/src/chat/entity2twTvs.ts
+++ b/server/src/chat/entity2twTvs.ts
@@ -697,8 +697,9 @@ Phrase: "${termObj.phrase}"
 JSON response:`
 
 		const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+		let parsed: { term: string; value: string }
 		try {
-			const parsed = JSON.parse(response) as { term: string; value: string }
+			parsed = JSON.parse(response) as { term: string; value: string }
 			if (!parsed.term || !parsed.value) {
 				console.warn(`getCategoricalFilterTermValues: LLM response missing term/value: ${response}`)
 				return undefined
@@ -708,13 +709,17 @@ JSON response:`
 			)
 			return parsed
 		} catch (e) {
-			console.warn(`getCategoricalFilterTermValues: failed to parse LLM response: ${response}`, e)
-			return undefined
+			mayLog(`getCategoricalFilterTermValues: failed to parse LLM response: ${response}`, e)
+			return {
+				type: 'text',
+				text: `getCategoricalFilterTermValues: failed to parse LLM response: ${response}` + e
+			}
 		}
 	} else {
 		throw 'getCategoricalFilterTermValues: termObj.term is not from dictionary, cannot determine categorical filter values'
 	}
 }
+
 async function getNumericFilterTermValues(
 	termObj: Value,
 	dbPath: string,
@@ -762,15 +767,19 @@ Phrase: "${termObj.phrase}"
 JSON response:`
 
 		const termResponse = await route_to_appropriate_llm_provider(termPrompt, llm, llm.classifierModelName)
+		let parsed: { term: string }
 		try {
-			const parsed = JSON.parse(termResponse) as { term: string }
-			if (!parsed.term) {
-				console.warn(`getNumericFilterTermValues: LLM response missing term: ${termResponse}`)
-				return undefined
-			}
+			parsed = JSON.parse(termResponse) as { term: string }
 			termName = parsed.term
 		} catch (e) {
-			console.warn(`getNumericFilterTermValues: failed to parse term response: ${termResponse}`, e)
+			mayLog(`getNumericFilterTermValues: failed to parse term response: ${termResponse}`, e)
+			return {
+				type: 'text',
+				text: `getNumericFilterTermValues: failed to parse term response: ${termResponse}` + e
+			} as MsgToUser
+		}
+		if (!parsed.term) {
+			mayLog(`getNumericFilterTermValues: LLM response missing term: ${termResponse}`)
 			return undefined
 		}
 	} else if ('gene' in termObj.term) {
@@ -807,7 +816,11 @@ JSON response:`
 		start = parsed.start
 		stop = parsed.stop
 	} catch (e) {
-		console.warn(`getNumericFilterTermValues: failed to parse cutoff response: ${cutoffResponse}`, e)
+		mayLog(`getNumericFilterTermValues: failed to parse cutoff response: ${cutoffResponse}`, e)
+		return {
+			type: 'text',
+			text: `getNumericFilterTermValues: failed to parse cutoff response: ${cutoffResponse}` + e
+		} as MsgToUser
 	}
 
 	if (!start && !stop) {

--- a/server/src/chat/entity2twTvs.ts
+++ b/server/src/chat/entity2twTvs.ts
@@ -1,7 +1,7 @@
 import type { LlmConfig } from '@sjcrh/proteinpaint-types'
 import type { Value, DictTerm, GeneSetTerm } from './entity2termObj.ts'
-import { isMsgToUser } from './entity2termObj.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import { parse_dataset_db, getGenesForGeneset } from './utils.ts'
 import { mayLog } from '#src/helpers.ts'
@@ -185,7 +185,7 @@ export async function resolveToTvs(tvsValues: Value[], dbPath: string, llm: LlmC
 			const categoricalFilterTerm = await getCategoricalFilterTermValues(termObj, dbPath, llm)
 			if (isMsgToUser(categoricalFilterTerm)) return categoricalFilterTerm
 			if (!categoricalFilterTerm) {
-				console.warn(`resolveToTvs: skipping categorical filter term (no result): "${termObj.phrase}"`)
+				mayLog(`resolveToTvs: skipping categorical filter term (no result): "${termObj.phrase}"`)
 				continue
 			}
 			// Validate the category value against the term's actual values
@@ -226,7 +226,7 @@ export async function resolveToTvs(tvsValues: Value[], dbPath: string, llm: LlmC
 			const numericFilterTerm = await getNumericFilterTermValues(termObj, dbPath, llm)
 			if (isMsgToUser(numericFilterTerm)) return numericFilterTerm
 			if (!numericFilterTerm) {
-				console.warn(`resolveToTvs: skipping numeric filter term (no result): "${termObj.phrase}"`)
+				mayLog(`resolveToTvs: skipping numeric filter term (no result): "${termObj.phrase}"`)
 				continue
 			}
 			resolved.push({
@@ -275,7 +275,7 @@ export async function resolveToTvs(tvsValues: Value[], dbPath: string, llm: LlmC
 }
 
 // This function's main task is to detect if custom binning is requested in the user prompt
-async function parseBinConfig(phrase: string, llm: LlmConfig): Promise<BinConfig> {
+async function parseBinConfig(phrase: string, llm: LlmConfig): Promise<BinConfig | MsgToUser> {
 	const prompt = `You are a bioinformatics visualization assistant specialized in data binning configuration.
 Your task is to analyze a user phrase and determine if it contains a request for custom binning of a numeric variable.
 Respond ONLY with a valid JSON object. No explanation, no markdown, no code blocks.
@@ -388,6 +388,8 @@ Output:
 Analyze this phrase and return the appropriate JSON object: "${phrase}"
 `
 	const raw = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(raw)) return raw
 
 	// ── Parse and validate response ───────────────────────────────────────
 	const text = raw
@@ -401,7 +403,7 @@ Analyze this phrase and return the appropriate JSON object: "${phrase}"
 	try {
 		parsed = JSON.parse(text)
 	} catch {
-		console.warn('Failed to parse bin config response:', text)
+		mayLog('Failed to parse bin config response:', text)
 		// Safe fallback — return regular bin if parsing fails
 		return { type: 'regular-bin', mode: 'discrete' } as RegularBinConfig
 	}
@@ -409,7 +411,7 @@ Analyze this phrase and return the appropriate JSON object: "${phrase}"
 	// ── Validate structure ────────────────────────────────────────────────
 	if (parsed.type === 'custom-bin') {
 		if (!Array.isArray(parsed.lst) || parsed.lst.length === 0) {
-			console.warn('custom-bin response missing lst array — falling back to regular-bin')
+			mayLog('custom-bin response missing lst array — falling back to regular-bin')
 			return { type: 'regular-bin', mode: 'discrete' } as RegularBinConfig
 		}
 		// Ensure first bin has startunbounded and last bin has stopunbounded
@@ -430,6 +432,8 @@ async function resolveToTw(twValue: Value, llm: LlmConfig, genome: any) {
 		} else {
 			// For numeric terms, check if the phrase contains any binning language (e.g. "binned into 5 groups", "divided into quartiles", etc.)
 			const binConfig = await parseBinConfig(twValue.phrase, llm)
+			// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+			if (isMsgToUser(binConfig)) return binConfig
 			if (!binConfig) throw new Error(`Failed to parse bin config from phrase: ${twValue.phrase}`)
 			mayLog('Parsed bin config:', JSON.stringify(binConfig))
 			return { id: twValueTerm.id, type: twValueTerm.type, q: binConfig, isDictionary: true }
@@ -505,6 +509,7 @@ export async function resolveToTwTvs(
 			const twValue = value as Value | undefined
 			if (!twValue) throw new Error(`Invalid term entity for key ${key}`)
 			const termWrapper = await resolveToTw(twValue, llm, genome)
+			if (isMsgToUser(termWrapper)) return termWrapper
 			mayLog(`Resolved term for key ${key}:`, JSON.stringify(termWrapper))
 			twTvsObjects[key] = termWrapper
 		}
@@ -527,6 +532,7 @@ export async function resolveToTwTvs(
 		const DictTws: any[] = []
 		for (const gv of DictValues) {
 			const tw = await resolveToTw(gv, llm, genome)
+			if (isMsgToUser(tw)) return tw
 			if (!tw) throw new Error(`Failed to resolve Dict tw for phrase "${gv.phrase}"`)
 			if (tw.type != 'float' && tw.type != 'integer' && tw.type != TermTypes.SSGSEA) {
 				return {
@@ -555,6 +561,7 @@ export async function resolveToTwTvs(
 		const term2Value = entity['term2'] as Value | undefined
 		if (!term2Value) throw new Error('Invalid term2 entity for survival')
 		const term2Wrapper = await resolveToTw(term2Value, llm, genome)
+		if (isMsgToUser(term2Wrapper)) return term2Wrapper
 		if (!term2Wrapper) throw new Error(`Failed to resolve term2 for phrase "${term2Value.phrase}"`)
 		mayLog('Resolved survival term2:', JSON.stringify(term2Wrapper))
 		twTvsObjects['term2'] = term2Wrapper
@@ -586,6 +593,7 @@ export async function resolveToTwTvs(
 				for (const twValue of twValues) {
 					if (!twValue) throw new Error(`Invalid term entity for key ${key}`)
 					const termWrapper = await resolveToTw(twValue, llm, genome)
+					if (isMsgToUser(termWrapper)) return termWrapper
 					if (!termWrapper) throw new Error(`Failed to resolve tw for phrase "${twValue.phrase}"`)
 					mayLog(`Resolved term for twLst item:`, JSON.stringify(termWrapper))
 					twLst.push(termWrapper)
@@ -597,6 +605,7 @@ export async function resolveToTwTvs(
 			const twValue = value as Value | undefined
 			if (!twValue) throw new Error(`Invalid term entity for key ${key}`)
 			const termWrapper = await resolveToTw(twValue, llm, genome)
+			if (isMsgToUser(termWrapper)) return termWrapper
 			if (!termWrapper) throw new Error(`Failed to resolve tw for phrase "${twValue.phrase}"`)
 			mayLog(`Resolved term for key ${key}:`, JSON.stringify(termWrapper))
 			twTvsObjects[key] = termWrapper
@@ -615,6 +624,7 @@ export async function resolveToTwTvs(
 			const colorByValue = entity['colorBy'] as Value | undefined
 			if (!colorByValue) throw new Error('Invalid colorBy term entity for prebuiltScatter')
 			const termWrapper = await resolveToTw(colorByValue, llm, genome)
+			if (isMsgToUser(termWrapper)) return termWrapper
 			if (!termWrapper) throw new Error(`Failed to resolve colorBy term for phrase "${colorByValue.phrase}"`)
 			twTvsObjects['colorBy'] = termWrapper
 		}
@@ -625,6 +635,7 @@ export async function resolveToTwTvs(
 			const shapeByValue = entity['shapeBy'] as Value | undefined
 			if (!shapeByValue) throw new Error('Invalid shapeBy term entity for prebuiltScatter')
 			const termWrapper = await resolveToTw(shapeByValue, llm, genome)
+			if (isMsgToUser(termWrapper)) return termWrapper
 			if (!termWrapper) throw new Error(`Failed to resolve shapeBy term for phrase "${shapeByValue.phrase}"`)
 			twTvsObjects['shapeBy'] = termWrapper
 		}
@@ -633,6 +644,7 @@ export async function resolveToTwTvs(
 			const divideByValue = entity['divideBy'] as Value | undefined
 			if (!divideByValue) throw new Error('Invalid divideBy term entity for prebuiltScatter')
 			const termWrapper = await resolveToTw(divideByValue, llm, genome)
+			if (isMsgToUser(termWrapper)) return termWrapper
 			if (!termWrapper) throw new Error(`Failed to resolve divideBy term for phrase "${divideByValue.phrase}"`)
 			twTvsObjects['divideBy'] = termWrapper
 		}
@@ -673,7 +685,7 @@ async function getCategoricalFilterTermValues(
 			}
 		}
 		if (candidateDocs.length === 0) {
-			console.warn('getCategoricalFilterTermValues: no categorical rows in DB')
+			mayLog('getCategoricalFilterTermValues: no categorical rows in DB')
 			return undefined
 		}
 
@@ -697,17 +709,11 @@ Phrase: "${termObj.phrase}"
 JSON response:`
 
 		const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+		// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+		if (isMsgToUser(response)) return response
 		let parsed: { term: string; value: string }
 		try {
 			parsed = JSON.parse(response) as { term: string; value: string }
-			if (!parsed.term || !parsed.value) {
-				console.warn(`getCategoricalFilterTermValues: LLM response missing term/value: ${response}`)
-				return undefined
-			}
-			mayLog(
-				`getCategoricalFilterTermValues: phrase="${termObj.phrase}" → term="${parsed.term}" value="${parsed.value}"`
-			)
-			return parsed
 		} catch (e) {
 			mayLog(`getCategoricalFilterTermValues: failed to parse LLM response: ${response}`, e)
 			return {
@@ -715,6 +721,12 @@ JSON response:`
 				text: `getCategoricalFilterTermValues: failed to parse LLM response: ${response}` + e
 			}
 		}
+		if (!parsed.term || !parsed.value) {
+			mayLog(`getCategoricalFilterTermValues: LLM response missing term/value: ${response}`)
+			return undefined
+		}
+		mayLog(`getCategoricalFilterTermValues: phrase="${termObj.phrase}" → term="${parsed.term}" value="${parsed.value}"`)
+		return parsed
 	} else {
 		throw 'getCategoricalFilterTermValues: termObj.term is not from dictionary, cannot determine categorical filter values'
 	}
@@ -744,7 +756,7 @@ async function getNumericFilterTermValues(
 			}
 		}
 		if (candidateDocs.length === 0) {
-			console.warn('getNumericFilterTermValues: no numeric rows in DB')
+			mayLog('getNumericFilterTermValues: no numeric rows in DB')
 			return undefined
 		}
 
@@ -767,6 +779,8 @@ Phrase: "${termObj.phrase}"
 JSON response:`
 
 		const termResponse = await route_to_appropriate_llm_provider(termPrompt, llm, llm.classifierModelName)
+		// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+		if (isMsgToUser(termResponse)) return termResponse
 		let parsed: { term: string }
 		try {
 			parsed = JSON.parse(termResponse) as { term: string }
@@ -809,6 +823,8 @@ Phrase: "${termObj.phrase}"
 JSON response:`
 
 	const cutoffResponse = await route_to_appropriate_llm_provider(cutoffPrompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(cutoffResponse)) return cutoffResponse
 	let start: string | undefined
 	let stop: string | undefined
 	try {

--- a/server/src/chat/entity2twTvs.ts
+++ b/server/src/chat/entity2twTvs.ts
@@ -1,5 +1,6 @@
 import type { LlmConfig } from '@sjcrh/proteinpaint-types'
 import type { Value, DictTerm, GeneSetTerm } from './entity2termObj.ts'
+import { isMsgToUser } from './entity2termObj.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import { parse_dataset_db, getGenesForGeneset } from './utils.ts'
@@ -182,6 +183,7 @@ export async function resolveToTvs(tvsValues: Value[], dbPath: string, llm: LlmC
 	for (const termObj of tvsValues) {
 		if (termObj.term.type === 'categorical') {
 			const categoricalFilterTerm = await getCategoricalFilterTermValues(termObj, dbPath, llm)
+			if (isMsgToUser(categoricalFilterTerm)) return categoricalFilterTerm
 			if (!categoricalFilterTerm) {
 				console.warn(`resolveToTvs: skipping categorical filter term (no result): "${termObj.phrase}"`)
 				continue
@@ -190,7 +192,9 @@ export async function resolveToTvs(tvsValues: Value[], dbPath: string, llm: LlmC
 			// (similar logic to generate_filter_term() in filter.ts)
 			let cat: string | undefined
 			if ('id' in termObj.term) {
-				const { db_rows } = await parse_dataset_db(dbPath)
+				const dataset_db_output = await parse_dataset_db(dbPath)
+				if (isMsgToUser(dataset_db_output)) return dataset_db_output
+				const { db_rows } = dataset_db_output
 				const dbRow = db_rows.find(r => r.name === (termObj.term as DictTerm).id)
 				if (dbRow) {
 					for (const dbVal of dbRow.values) {
@@ -220,6 +224,7 @@ export async function resolveToTvs(tvsValues: Value[], dbPath: string, llm: LlmC
 			termObj.term.type === TermTypes.SSGSEA // Will need to add more nonDict term types here as needed, e.g. methylation, CNV, etc.
 		) {
 			const numericFilterTerm = await getNumericFilterTermValues(termObj, dbPath, llm)
+			if (isMsgToUser(numericFilterTerm)) return numericFilterTerm
 			if (!numericFilterTerm) {
 				console.warn(`resolveToTvs: skipping numeric filter term (no result): "${termObj.phrase}"`)
 				continue
@@ -649,13 +654,14 @@ async function getCategoricalFilterTermValues(
 	termObj: Value,
 	dbPath: string,
 	llm: LlmConfig
-): Promise<{ term: string; value: string } | undefined> {
+): Promise<{ term: string; value: string } | MsgToUser | undefined> {
 	// For categorical filters, we need to determine both the term and the specific value being filtered on
 	// (e.g. "T cell" → term="cell_type" value="T_cell"). We ask an LLM to pick the rag_docs row whose
 	// term + one of its enumerated values best matches termObj.phrase.
 	if ('id' in termObj.term) {
 		// Assuming categorical terms from the dictionary will have an 'id' field, while non-dictionary terms won't.
 		const dataset_db_output = await parse_dataset_db(dbPath)
+		if (isMsgToUser(dataset_db_output)) return dataset_db_output
 		const { db_rows, rag_docs } = dataset_db_output
 
 		// Narrow to rows that actually describe a categorical term with enumerated values,
@@ -713,7 +719,7 @@ async function getNumericFilterTermValues(
 	termObj: Value,
 	dbPath: string,
 	llm: LlmConfig
-): Promise<{ term: string; start?: string; stop?: string } | undefined> {
+): Promise<{ term: string; start?: string; stop?: string } | MsgToUser | undefined> {
 	// For numeric filters, we need to determine the term being filtered on and any specified cutoffs
 	// (e.g. "age > 60" → term="age" start="60"). Branch by termObj.term shape:
 	//   - DictTerm: use an LLM against numeric (integer/float) rag_docs rows to pick the term
@@ -723,6 +729,7 @@ async function getNumericFilterTermValues(
 
 	if ('id' in termObj.term) {
 		const dataset_db_output = await parse_dataset_db(dbPath)
+		if (isMsgToUser(dataset_db_output)) return dataset_db_output
 		const { db_rows, rag_docs } = dataset_db_output
 
 		const candidateDocs: string[] = []

--- a/server/src/chat/filter.ts
+++ b/server/src/chat/filter.ts
@@ -1,6 +1,6 @@
 import { phrase2entitytw, collectLeaves, evaluateFilterTerm } from './utils.ts'
 import type { FilterTreeResult } from './scaffoldTypes.ts'
-import { getTermObj, type Value } from './entity2termObj.ts'
+import { getTermObj, isMsgToUser, type Value } from './entity2termObj.ts'
 import { resolveToTvs } from './entity2twTvs.ts'
 import type { MsgToUser, Entity } from './scaffoldTypes.ts'
 import { mayLog } from '#src/helpers.ts'
@@ -45,6 +45,7 @@ export async function generateFilterTerm(
 	for (const filterTerm of filterEntities) {
 		mayLog('generateFilterTerm evaluating filter term:', filterTerm)
 		const termObj = await getTermObj('filter', filterTerm, llm, dbPath, genes_list, genome)
+		if (isMsgToUser(termObj)) return termObj
 		if (!termObj) continue
 		if (filterTerm.logicalOperator) termObj.logicalOperator = filterTerm.logicalOperator
 		filterValues.push(termObj)

--- a/server/src/chat/filter.ts
+++ b/server/src/chat/filter.ts
@@ -1,8 +1,8 @@
 import { phrase2entitytw, collectLeaves, evaluateFilterTerm } from './utils.ts'
-import type { FilterTreeResult } from './scaffoldTypes.ts'
-import { getTermObj, isMsgToUser, type Value } from './entity2termObj.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
+import { getTermObj, type Value } from './entity2termObj.ts'
 import { resolveToTvs } from './entity2twTvs.ts'
-import type { MsgToUser, Entity } from './scaffoldTypes.ts'
+import type { FilterTreeResult, MsgToUser, Entity } from './scaffoldTypes.ts'
 import { mayLog } from '#src/helpers.ts'
 import type { LlmConfig } from '#types'
 
@@ -25,7 +25,9 @@ export async function generateFilterTerm(
 	dbPath: string,
 	genome: any
 ): Promise<any | MsgToUser> {
-	const filterTree: FilterTreeResult = await evaluateFilterTerm(phrase, llm)
+	const filterTree: FilterTreeResult | MsgToUser = await evaluateFilterTerm(phrase, llm)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(filterTree)) return filterTree
 	mayLog('generateFilterTerm parsed filter tree:', JSON.stringify(filterTree, null, 2))
 
 	const leafPhrases = collectLeaves(filterTree.tree)

--- a/server/src/chat/genedatatype.ts
+++ b/server/src/chat/genedatatype.ts
@@ -2,6 +2,7 @@ import type { LlmConfig, GeneDataTypeResult } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 
 // ---------------------------------------------------------------------------
 //  Function 1: Classify each term as "gene" or "group"
@@ -123,6 +124,8 @@ Ambiguous terms (both gene and group name): [${ambiguousTerms}]
 Response:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 
 	// Tolerantly parse the LLM output (handles code fences / surrounding prose). If the model
 	// did not return a valid JSON array, surface a message to the user instead of throwing.
@@ -134,6 +137,13 @@ Response:`
 		return {
 			type: 'text',
 			text: `Could not classify the ambiguous terms (${ambiguousTerms}): the language model did not return a valid response.${response}`
+		}
+	}
+
+	if (!Array.isArray(results)) {
+		return {
+			type: 'text',
+			text: `classifyGeneOrGroup response is not an array: ${JSON.stringify(results)}`
 		}
 	}
 
@@ -209,6 +219,8 @@ Genes: [${geneList}]
 Response:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 
 	let results: GeneDataTypeResult[]
 	try {
@@ -221,8 +233,12 @@ Response:`
 			text: 'classifyGeneDataType: failed to parse LLM response as JSON:' + response
 		}
 	}
-	if (!Array.isArray(results)) throw 'classifyGeneDataType response is not an array'
-
+	if (!Array.isArray(results)) {
+		return {
+			type: 'text',
+			text: 'classifyGeneDataType response is not an array'
+		} as MsgToUser
+	}
 	const missingGenes = results.filter(r => r.dataType === 'missing').map(r => r.gene)
 	const classifiedGenes = results.filter(r => r.dataType !== 'missing')
 

--- a/server/src/chat/genedatatype.ts
+++ b/server/src/chat/genedatatype.ts
@@ -1,7 +1,6 @@
 import type { LlmConfig, GeneDataTypeResult } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
-import { safeExtractJsonArray } from './utils.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
 
 // ---------------------------------------------------------------------------
@@ -127,12 +126,14 @@ Response:`
 
 	// Tolerantly parse the LLM output (handles code fences / surrounding prose). If the model
 	// did not return a valid JSON array, surface a message to the user instead of throwing.
-	const results = safeExtractJsonArray(response) as GeneOrGroupOrAmbiguousResult[] | undefined
-	if (!results) {
+	let results: any
+	try {
+		results = JSON.parse(response) as GeneOrGroupOrAmbiguousResult[]
+	} catch {
 		mayLog('classifyGeneOrGroup: failed to parse LLM response as JSON:', response)
 		return {
 			type: 'text',
-			text: `Could not classify the ambiguous terms (${ambiguousTerms}): the language model did not return a valid response.`
+			text: `Could not classify the ambiguous terms (${ambiguousTerms}): the language model did not return a valid response.${response}`
 		}
 	}
 
@@ -215,7 +216,10 @@ Response:`
 		results = JSON.parse(cleaned)
 	} catch {
 		mayLog('classifyGeneDataType: failed to parse LLM response as JSON:', response)
-		return ''
+		return {
+			type: 'text',
+			text: 'classifyGeneDataType: failed to parse LLM response as JSON:' + response
+		}
 	}
 	if (!Array.isArray(results)) throw 'classifyGeneDataType response is not an array'
 

--- a/server/src/chat/genedatatype.ts
+++ b/server/src/chat/genedatatype.ts
@@ -1,6 +1,8 @@
 import type { LlmConfig, GeneDataTypeResult } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
+import { safeExtractJsonArray } from './utils.ts'
+import type { MsgToUser } from './scaffoldTypes.ts'
 
 // ---------------------------------------------------------------------------
 //  Function 1: Classify each term as "gene" or "group"
@@ -25,7 +27,7 @@ export async function classifyGeneOrGroup(
 	user_prompt: string,
 	llm: LlmConfig,
 	gene_group_intersection: string[] // Genes from db that are present in the user prompt
-): Promise<{ term: string; role: string }[]> {
+): Promise<{ term: string; role: string }[] | MsgToUser> {
 	//const allTerms = relevant_genes.map(x => x.toUpperCase()).join(', ')
 	const ambiguousTerms = gene_group_intersection.join(', ')
 
@@ -123,16 +125,16 @@ Response:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 
-	let results: GeneOrGroupOrAmbiguousResult[]
-	try {
-		const cleaned = stripMarkdownFencing(response)
-		results = JSON.parse(cleaned)
-	} catch {
+	// Tolerantly parse the LLM output (handles code fences / surrounding prose). If the model
+	// did not return a valid JSON array, surface a message to the user instead of throwing.
+	const results = safeExtractJsonArray(response) as GeneOrGroupOrAmbiguousResult[] | undefined
+	if (!results) {
 		mayLog('classifyGeneOrGroup: failed to parse LLM response as JSON:', response)
-		throw 'Failed to parse LLM response as JSON'
+		return {
+			type: 'text',
+			text: `Could not classify the ambiguous terms (${ambiguousTerms}): the language model did not return a valid response.`
+		}
 	}
-
-	if (!Array.isArray(results)) throw 'classifyGeneOrGroup response is not an array'
 
 	const geneTerms: { term: string; role: string }[] = results.filter(r => r.role === 'group')
 	//const filteredGenes = gene_group_intersection.filter(g => geneTerms.includes(g.toLowerCase()))
@@ -158,15 +160,16 @@ export async function classifyGeneDataType(
 	llm: LlmConfig,
 	relevant_genes: string[],
 	dataset_json: any
-): Promise<GeneDataTypeResult[] | string> {
+): Promise<GeneDataTypeResult[] | string | MsgToUser> {
 	const exclude_keywords: string[] = dataset_json?.ExcludedKeywords ?? []
 	let genes: string[] = []
 	if (exclude_keywords.length > 0) {
 		const gene_group_intersection = exclude_keywords.filter(x => relevant_genes.includes(x.toLowerCase()))
 		if (gene_group_intersection.length > 0) {
-			const classified_genes = (await classifyGeneOrGroup(user_prompt, llm, gene_group_intersection))
-				.filter(geneTerm => geneTerm.role === 'group')
-				.map(g => g.term.toLowerCase())
+			const classified = await classifyGeneOrGroup(user_prompt, llm, gene_group_intersection)
+			// A MsgToUser (non-array) means classification failed; propagate it for UI display.
+			if (!Array.isArray(classified)) return classified
+			const classified_genes = classified.filter(geneTerm => geneTerm.role === 'group').map(g => g.term.toLowerCase())
 			genes = relevant_genes.filter(x => !classified_genes.includes(x))
 		} else {
 			genes = relevant_genes

--- a/server/src/chat/genedatatypenew.ts
+++ b/server/src/chat/genedatatypenew.ts
@@ -1,6 +1,7 @@
 import type { LlmConfig, GeneDataTypeResult } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
+import type { MsgToUser } from './scaffoldTypes.ts'
 
 // ---------------------------------------------------------------------------
 //  Function 1: Classify each term as "gene" or "group"
@@ -26,7 +27,7 @@ export async function classifyGeneOrGroup(
 	user_prompt: string,
 	llm: LlmConfig,
 	gene_group_intersection: string[] // Genes from db that are present in the user prompt
-): Promise<{ term: string; role: string }[]> {
+): Promise<{ term: string; role: string }[] | MsgToUser> {
 	//const allTerms = relevant_genes.map(x => x.toUpperCase()).join(', ')
 	const ambiguousTerms = gene_group_intersection.join(', ')
 	const jsonSchema = JSON.stringify(
@@ -129,7 +130,10 @@ Response:`
 		results = JSON.parse(cleaned)
 	} catch {
 		mayLog('classifyGeneOrGroup: failed to parse LLM response as JSON:', response)
-		throw 'Failed to parse LLM response as JSON'
+		return {
+			type: 'text',
+			text: 'classifyGeneOrGroup: failed to parse LLM response as JSON:' + response
+		}
 	}
 
 	if (!Array.isArray(results)) throw 'classifyGeneOrGroup response is not an array'
@@ -157,16 +161,24 @@ export async function classifyGeneDataTypePhrase(
 	llm: LlmConfig,
 	relevant_genes: string[],
 	dataset_json: any
-): Promise<GeneDataTypeResult | string | null> {
+): Promise<GeneDataTypeResult | string | null | MsgToUser> {
 	const exclude_keywords: string[] = dataset_json?.ExcludedKeywords ?? []
 	let genes: string[] = []
 	if (exclude_keywords.length > 0) {
 		const gene_group_intersection = exclude_keywords.filter(x => relevant_genes.includes(x.toLowerCase()))
 		if (gene_group_intersection.length > 0) {
-			const classified_genes = (await classifyGeneOrGroup(user_prompt, llm, gene_group_intersection))
-				.filter(geneTerm => geneTerm.role === 'group')
-				.map(g => g.term.toLowerCase())
-			genes = relevant_genes.filter(x => !classified_genes.includes(x))
+			const GeneOrGroup = await classifyGeneOrGroup(user_prompt, llm, gene_group_intersection)
+			if ('type' in GeneOrGroup) {
+				return {
+					type: 'text',
+					text: GeneOrGroup.text
+				}
+			} else {
+				const classified_genes = GeneOrGroup.filter(geneTerm => geneTerm.role === 'group').map(g =>
+					g.term.toLowerCase()
+				)
+				genes = relevant_genes.filter(x => !classified_genes.includes(x))
+			}
 		} else {
 			genes = relevant_genes
 		}
@@ -219,11 +231,14 @@ Response:`
 			result = JSON.parse(cleaned)
 		} catch {
 			mayLog('classifyGeneDataType: failed to parse LLM response as JSON:', response)
-			return ''
+			return {
+				type: 'text',
+				text: 'classifyGeneDataType: failed to parse LLM response as JSON:' + response
+			}
 		}
 
 		if (result.dataType === 'missing') {
-			return `Gene data type is missing for ${result.gene}. Please specify what you would like to see for this gene (e.g. expression, variant, methylation).`
+			return `Gene data type is missing for ${result.gene}. Please specify what you would like to see for this gene(e.g.expression, variant, methylation).`
 		} else {
 			return result
 		}
@@ -239,7 +254,7 @@ Response:`
 function stripMarkdownFencing(text: string): string {
 	return text
 		.trim()
-		.replace(/^```json\s*/, '')
+		.replace(/^```json\s * /, '')
 		.replace(/^```\s*/, '')
 		.replace(/\s*```$/, '')
 		.trim()

--- a/server/src/chat/genedatatypenew.ts
+++ b/server/src/chat/genedatatypenew.ts
@@ -2,6 +2,7 @@ import type { LlmConfig, GeneDataTypeResult } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 
 // ---------------------------------------------------------------------------
 //  Function 1: Classify each term as "gene" or "group"
@@ -123,6 +124,8 @@ Ambiguous terms (both gene and group name): [${ambiguousTerms}]
 Response:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 
 	let results: GeneOrGroupOrAmbiguousResult[]
 	try {
@@ -224,21 +227,23 @@ Genes: [${geneList}]
 Response:`
 
 		const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+		// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+		if (isMsgToUser(response)) return response
 
 		let result: GeneDataTypeResult
 		try {
 			const cleaned = stripMarkdownFencing(response)
 			result = JSON.parse(cleaned)
-		} catch {
+		} catch (e) {
 			mayLog('classifyGeneDataType: failed to parse LLM response as JSON:', response)
 			return {
 				type: 'text',
-				text: 'classifyGeneDataType: failed to parse LLM response as JSON:' + response
+				text: 'classifyGeneDataType: failed to parse LLM response as JSON:' + response + ' error message:' + e
 			}
 		}
 
 		if (result.dataType === 'missing') {
-			return `Gene data type is missing for ${result.gene}. Please specify what you would like to see for this gene(e.g.expression, variant, methylation).`
+			return `Gene data type is missing for ${result.gene}. Please specify what you would like to see for this gene (e.g. expression, variant, methylation).`
 		} else {
 			return result
 		}
@@ -254,7 +259,7 @@ Response:`
 function stripMarkdownFencing(text: string): string {
 	return text
 		.trim()
-		.replace(/^```json\s * /, '')
+		.replace(/^```json\s*/, '')
 		.replace(/^```\s*/, '')
 		.replace(/\s*```$/, '')
 		.trim()

--- a/server/src/chat/genesetdatatype.ts
+++ b/server/src/chat/genesetdatatype.ts
@@ -2,6 +2,7 @@ import type { LlmConfig, GeneSetDataTypeResult } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { TermTypes } from '#shared/terms.js'
 
 // List of keywords/phrases that may indicate a gene set is being referenced in the user prompt. This is useful when no geneset keywords are found but the user intends to use a geneset. This helps to generate a helpful error message stating no relevant genesets were found in the prompt.
@@ -160,6 +161,8 @@ Geneset: ${geneset}
 Response:`
 
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 
 	let result: GeneSetDataTypeResult
 	try {

--- a/server/src/chat/hiercluster.ts
+++ b/server/src/chat/hiercluster.ts
@@ -1,6 +1,7 @@
 import type { LlmConfig, GeneDataTypeResult, TermdbTopVariablyExpressedGenesRequest } from '#types'
 import { getGenesForGeneset, extractGenesetsFromPromptNew, getGenesetNames } from './utils.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { TermTypes } from '#shared/terms.js'
 //import { mayLog } from '#src/helpers.ts'
 
@@ -142,6 +143,8 @@ export async function extract_hiercluster_terms_from_query(
 		system_prompt += '.\n' + 'User query: ' + prompt
 
 		response = await route_to_appropriate_llm_provider(system_prompt, llm)
+		// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+		if (isMsgToUser(response)) return response
 	} else {
 		return {
 			type: 'text',

--- a/server/src/chat/phrase2entity.ts
+++ b/server/src/chat/phrase2entity.ts
@@ -173,6 +173,8 @@ export async function phrase2entity(
 			const resolved = await find_survival_terms(scaffoldResult.term, llm, dbPath)
 			if (resolved === null) {
 				return { type: 'text', text: 'No survival terms available in this dataset.' }
+			} else if (typeof resolved === 'object' && 'type' in resolved) {
+				return resolved // MsgToUser
 			}
 			// string = matched single term; DbRows[] = ambiguous, list for user disambiguation
 			survival_term.term = resolved
@@ -307,6 +309,9 @@ export async function phrase2entity(
 		}
 		if (scaffoldResult.genomeBrowserPhrase) {
 			const genomicCoordinates = await parseGenomicCoordinates(scaffoldResult.genomeBrowserPhrase, llm)
+			if ('type' in genomicCoordinates) {
+				return genomicCoordinates // MsgToUser
+			}
 			pp_plot_json.geneSearchResult = {
 				chr: genomicCoordinates.chromosome,
 				start: genomicCoordinates.start,
@@ -417,7 +422,7 @@ export async function phrase2entity(
 async function parseGenomicCoordinates(
 	phrase: string,
 	llm: LlmConfig
-): Promise<{ chromosome: string; start: number; stop: number }> {
+): Promise<{ chromosome: string; start: number; stop: number } | MsgToUser> {
 	const prompt = `You are a ProteinPaint genome browser assistant. Your task is to parse the genomic region phrase extracted from the user's query into its component parts: chromosome, start coordinate, and stop coordinate.
 
 ## OUTPUT SCHEMA
@@ -523,22 +528,29 @@ Phrase: "${phrase}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Genomic coordinates parse: ${response}`)
+	let parsed: any
 	try {
-		const parsed = JSON.parse(response) as { chromosome: string; start: number; stop: number }
-		if (!parsed.chromosome || typeof parsed.start !== 'number' || typeof parsed.stop !== 'number') {
-			throw new Error(`LLM response is missing required chromosome/start/stop fields: ${response}`)
-		}
-		return parsed
+		parsed = JSON.parse(response) as { chromosome: string; start: number; stop: number }
 	} catch {
-		throw new Error(`Failed to parse genomic coordinates from LLM response: ${response}`)
+		return {
+			type: 'text',
+			text: `Failed to parse genomic coordinates from LLM response: ${response}`
+		}
 	}
+	if (!parsed.chromosome || typeof parsed.start !== 'number' || typeof parsed.stop !== 'number') {
+		return {
+			type: 'text',
+			text: `LLM response is missing required chromosome/start/stop fields: ${response}`
+		}
+	}
+	return parsed
 }
 
 async function find_survival_terms(
 	user_prompt: string,
 	llm: LlmConfig,
 	dbPath: string
-): Promise<string | DbRows[] | null> {
+): Promise<string | DbRows[] | null | MsgToUser> {
 	const { db_rows } = await parse_survival_terms_from_db(dbPath)
 	if (db_rows.length === 0) return null
 
@@ -582,20 +594,24 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Survival term classifier: ${response}`)
+	let parsed: { survivalTerm: string | null }
 	try {
-		const parsed = JSON.parse(response)
-		const picked = parsed.survivalTerm
-		if (!picked || picked === 'null') return db_rows
-		const match = db_rows.find(r => r.name === picked)
-		if (!match) {
-			mayLog(
-				`Survival term classifier returned "${picked}" which is not in db_rows; returning full list for user disambiguation.`
-			)
-			return db_rows
-		}
-		return match.name
+		parsed = JSON.parse(response)
 	} catch {
 		mayLog(`Failed to parse survival term classifier response: ${response}`)
-		throw new Error(`Failed to parse survival term classifier response: ${response}`)
+		return {
+			type: 'text',
+			text: `Failed to parse survival term classifier response: ${response}`
+		}
 	}
+	const picked = parsed.survivalTerm
+	if (!picked || picked === 'null') return db_rows
+	const match = db_rows.find(r => r.name === picked)
+	if (!match) {
+		mayLog(
+			`Survival term classifier returned "${picked}" which is not in db_rows; returning full list for user disambiguation.`
+		)
+		return db_rows
+	}
+	return match.name
 }

--- a/server/src/chat/phrase2entity.ts
+++ b/server/src/chat/phrase2entity.ts
@@ -26,6 +26,7 @@ import type {
 	PrebuiltScatterScaffold,
 	FilterTreeResult
 } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { mayLog } from '#src/helpers.ts'
 import { TermTypes } from '#shared/terms.js'
 import assert from 'assert'
@@ -91,8 +92,9 @@ export async function phrase2entity(
 				summ_term.tw3 = [tw3 as Entity]
 			}
 			if (scaffoldResult.filter) {
-				const parseFilterResult: FilterTreeResult = await evaluateFilterTerm(scaffoldResult.filter, llm)
+				const parseFilterResult: FilterTreeResult | MsgToUser = await evaluateFilterTerm(scaffoldResult.filter, llm)
 				mayLog('Parsed filter tree:', JSON.stringify(parseFilterResult, null, 2))
+				if (isMsgToUser(parseFilterResult)) return parseFilterResult
 				// Extract all leaf phrases from the filter tree and resolve each to an entity
 				const leafPhrases = collectLeaves(parseFilterResult.tree)
 				summ_term.filter = []
@@ -120,7 +122,8 @@ export async function phrase2entity(
 		}
 
 		// filter 1
-		let parseFilterResult: FilterTreeResult = await evaluateFilterTerm(scaffoldResult.filter1, llm)
+		let parseFilterResult: FilterTreeResult | MsgToUser = await evaluateFilterTerm(scaffoldResult.filter1, llm)
+		if (isMsgToUser(parseFilterResult)) return parseFilterResult
 		const dge_term_filter1 = await parseFilterTree(parseFilterResult, llm, genes_list, dataset_json, ds, genome)
 		if ('type' in dge_term_filter1 && dge_term_filter1.type === 'text') {
 			return dge_term_filter1 // MsgToUser
@@ -130,6 +133,7 @@ export async function phrase2entity(
 
 		// filter 2
 		parseFilterResult = await evaluateFilterTerm(scaffoldResult.filter2, llm)
+		if (isMsgToUser(parseFilterResult)) return parseFilterResult
 		const dge_term_filter2 = await parseFilterTree(parseFilterResult, llm, genes_list, dataset_json, ds, genome)
 		if ('type' in dge_term_filter2 && dge_term_filter2.type === 'text') {
 			return dge_term_filter2 // MsgToUser
@@ -140,6 +144,7 @@ export async function phrase2entity(
 		// filter ?
 		if (scaffoldResult.filter) {
 			parseFilterResult = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			if (isMsgToUser(parseFilterResult)) return parseFilterResult
 			const dge_term_filter = await parseFilterTree(parseFilterResult, llm, genes_list, dataset_json, ds, genome)
 			if ('type' in dge_term_filter && dge_term_filter.type === 'text') {
 				return dge_term_filter // MsgToUser
@@ -189,7 +194,8 @@ export async function phrase2entity(
 
 		// Resolve filter (OPTIONAL cohort filter) to Entity[]
 		if (scaffoldResult.filter) {
-			const parseFilterResult: FilterTreeResult = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			const parseFilterResult: FilterTreeResult | MsgToUser = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			if (isMsgToUser(parseFilterResult)) return parseFilterResult
 			const filter_term = await parseFilterTree(parseFilterResult, llm, genes_list, dataset_json, ds, genome)
 			if ('type' in filter_term && filter_term.type === 'text') {
 				return filter_term // MsgToUser
@@ -231,7 +237,8 @@ export async function phrase2entity(
 
 		// if filter is present, convert to entity as well
 		if (scaffoldResult.filter) {
-			const parseFilterResult: FilterTreeResult = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			const parseFilterResult: FilterTreeResult | MsgToUser = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			if (isMsgToUser(parseFilterResult)) return parseFilterResult
 			mayLog('Parsed filter tree:', JSON.stringify(parseFilterResult, null, 2))
 			// Extract all leaf phrases from the filter tree and resolve each to an entity
 			const filter_term = await parseFilterTree(parseFilterResult, llm, genes_list, dataset_json, ds, genome)
@@ -282,7 +289,8 @@ export async function phrase2entity(
 
 		// Filter term
 		if (scaffoldResult.filter) {
-			const parseFilterResult: FilterTreeResult = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			const parseFilterResult: FilterTreeResult | MsgToUser = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			if (isMsgToUser(parseFilterResult)) return parseFilterResult
 			// mayLog('Parsed filter tree:', JSON.stringify(parseFilterResult, null, 2))
 			// Extract all leaf phrases from the filter tree and resolve each to an entity
 			const filter_term = await parseFilterTree(parseFilterResult, llm, genes_list, dataset_json, ds, genome)
@@ -390,8 +398,9 @@ export async function phrase2entity(
 			}
 		}
 		if (scaffoldResult.filter) {
-			const parseFilterResult: FilterTreeResult = await evaluateFilterTerm(scaffoldResult.filter, llm)
+			const parseFilterResult: FilterTreeResult | MsgToUser = await evaluateFilterTerm(scaffoldResult.filter, llm)
 			mayLog('Parsed filter tree:', JSON.stringify(parseFilterResult, null, 2))
+			if (isMsgToUser(parseFilterResult)) return parseFilterResult
 			// Extract all leaf phrases from the filter tree and resolve each to an entity
 			const leafPhrases = collectLeaves(parseFilterResult.tree)
 			hier_term.filter = []
@@ -527,6 +536,8 @@ Parse the following genomic region phrase into the JSON object according to the 
 Phrase: "${phrase}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 	mayLog(`--> Genomic coordinates parse: ${response}`)
 	let parsed: any
 	try {
@@ -593,6 +604,8 @@ Classify the following user query:
 Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
+	if (isMsgToUser(response)) return response
 	mayLog(`--> Survival term classifier: ${response}`)
 	let parsed: { survivalTerm: string | null }
 	try {

--- a/server/src/chat/plot.ts
+++ b/server/src/chat/plot.ts
@@ -1,5 +1,7 @@
 import type { LlmConfig, PlotType } from '#types'
 import { mayLog } from '#src/helpers.ts'
+import type { MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 
 /**
@@ -9,7 +11,7 @@ import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
  * @param llm          LLM configuration (provider, model names, API endpoint).
  * @returns            The specific plot type (e.g. 'summary', 'dge', 'survival', 'matrix', 'prebuiltscatter', 'hiercluster', 'genomeBrowser').
  */
-export async function classifyPlotType(user_prompt: string, llm: LlmConfig): Promise<PlotType> {
+export async function classifyPlotType(user_prompt: string, llm: LlmConfig): Promise<PlotType | MsgToUser> {
 	/** Currently commented out because we are not using training examples for the plot type classifier, but this is where you would add them if desired in the future. 
 // Parse out training data from the dataset JSON and add it to a string
 const plot_ds = dataset_json.charts.find((chart: any) => chart.type == 'Plot')
@@ -37,6 +39,7 @@ Classification:`
 
 	//Training examples: "${training_data}"
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	if (isMsgToUser(response)) return response
 	const plotType = response.trim() as PlotType
 	mayLog(`--> classifyPlotType: ${plotType}`)
 	return plotType

--- a/server/src/chat/resource.ts
+++ b/server/src/chat/resource.ts
@@ -4,6 +4,8 @@ import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import { mayLog } from '#src/helpers.ts'
 import type { LlmConfig } from '#types'
 import path from 'path'
+import { isMsgToUser } from './scaffoldTypes.ts'
+import type { MsgToUser } from './scaffoldTypes.ts'
 
 /**
  * Ask the LLM to select a resource index from the dataset's `resources` array.
@@ -17,7 +19,7 @@ export async function extractResourceResponse(
 	prompt: string,
 	llm: LlmConfig,
 	aiFilesDir: string
-): Promise<{ type: 'none' } | { type: 'html'; html: string }> {
+): Promise<{ type: 'none' } | { type: 'html'; html: string } | MsgToUser> {
 	//const classification_ds = dataset_json.charts?.find((chart: any) => chart.type == 'Classification')
 	const resources: { label: string; html: string }[] =
 		(await readJSONFile(path.join(aiFilesDir, 'resources.json')))?.Resources ?? []
@@ -40,11 +42,12 @@ export async function extractResourceResponse(
 		prompt +
 		'} answer:'
 
-	const response: string = await route_to_appropriate_llm_provider(
+	const response: string | MsgToUser = await route_to_appropriate_llm_provider(
 		system_prompt,
 		llm,
 		llm.classifierModelName ?? llm.modelName
 	)
+	if (isMsgToUser(response)) return response
 	const idx = parseInt(response.trim())
 
 	// LLM returned something that isn't a number

--- a/server/src/chat/route.ts
+++ b/server/src/chat/route.ts
@@ -12,7 +12,8 @@ import { phrase2entity } from './phrase2entity.ts'
 import { inferTermObjFromEntity } from './entity2termObj.ts'
 import { resolveToTwTvs } from './entity2twTvs.ts'
 import { answerDataQueries } from './dataQueries.ts'
-import type { Scaffold, Phrase2EntityResult, SummaryScaffold } from './scaffoldTypes.ts'
+import type { Scaffold, Phrase2EntityResult, SummaryScaffold, MsgToUser } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { resolveToPlotState } from './scaffold2state.ts'
 import path from 'path'
 import fs from 'fs'
@@ -166,8 +167,9 @@ export async function run_chat_pipeline(
 
 	// Plot vs Not-plot classification
 	const time1 = new Date().valueOf()
-	const class_response: QueryClassification = await classifyQuery(userPrompt, llm)
+	const class_response: QueryClassification | MsgToUser = await classifyQuery(userPrompt, llm)
 	mayLog('Time taken for classification:', formatElapsedTime(Date.now() - time1))
+	if (isMsgToUser(class_response)) return class_response
 
 	let ai_output_json: any
 	if (class_response.type === 'notplot') {
@@ -175,6 +177,7 @@ export async function run_chat_pipeline(
 		const time2 = new Date().valueOf()
 		const notPlotResult = await classifyNotPlot(userPrompt, llm, agentFiles, aiFilesDir) //, allowedTermTypes)
 		mayLog('Time taken for classify2:', formatElapsedTime(Date.now() - time2))
+		if (isMsgToUser(notPlotResult)) return notPlotResult
 
 		if (notPlotResult.type === 'html') {
 			ai_output_json = notPlotResult
@@ -193,7 +196,7 @@ export async function run_chat_pipeline(
 		let time = new Date().valueOf()
 		const plotType = await classifyPlotType(userPrompt, llm)
 		mayLog('Time taken to classify plot type:', formatElapsedTime(Date.now() - time))
-
+		if (isMsgToUser(plotType)) return plotType
 		// Check if the classified plot type is supported by this dataset
 		if (!supportedPlotTypes.map(s => s.toLowerCase()).includes(plotType.toLowerCase())) {
 			const log = 'Plot type: "' + plotType + '" is not supported.'
@@ -276,7 +279,7 @@ export async function run_chat_pipeline(
 			genome
 		)
 		mayLog('Time taken to infer term objects:', formatElapsedTime(Date.now() - time))
-		if ('type' in termObj && termObj.type === 'text') {
+		if (isMsgToUser(termObj)) {
 			return termObj // Return msg/error to client for display
 		}
 		mayLog('Inferred termObj from entity:', JSON.stringify(termObj))

--- a/server/src/chat/route.ts
+++ b/server/src/chat/route.ts
@@ -276,6 +276,9 @@ export async function run_chat_pipeline(
 			genome
 		)
 		mayLog('Time taken to infer term objects:', formatElapsedTime(Date.now() - time))
+		if ('type' in termObj && termObj.type === 'text') {
+			return termObj // Return msg/error to client for display
+		}
 		mayLog('Inferred termObj from entity:', JSON.stringify(termObj))
 
 		mayLog('#################################################')

--- a/server/src/chat/routeAPIcall.ts
+++ b/server/src/chat/routeAPIcall.ts
@@ -1,13 +1,14 @@
 import type { LlmConfig } from '#types'
 import { ezFetch } from '#shared'
+import type { MsgToUser } from './scaffoldTypes.ts'
 
 export async function route_to_appropriate_llm_provider(
 	prompt: string,
 	llm: LlmConfig,
 	modelOverride?: string
-): Promise<string> {
+): Promise<string | MsgToUser> {
 	const model = modelOverride ?? llm.modelName
-	let response: string
+	let response: string | MsgToUser
 	if (llm.provider === 'SJ') {
 		// Local SJ server
 		response = await call_sj_llm(prompt, model, llm.api)
@@ -54,7 +55,7 @@ export async function route_to_appropriate_embedding_provider(
 	}
 }
 
-async function call_sj_llm(prompt: string, model_name: string, apilink: string) {
+async function call_sj_llm(prompt: string, model_name: string, apilink: string): Promise<string | MsgToUser> {
 	const temperature = 0.01
 	const top_p = 0.95
 	const timeout = 200000
@@ -94,9 +95,10 @@ async function call_sj_llm(prompt: string, model_name: string, apilink: string) 
 		if (error && typeof error == 'object' && 'cause' in error)
 			console.error('Cause:', (error as { cause?: unknown }).cause)
 		// Re-throw a real Error that preserves the original
-		throw new Error('SJ API request failed: ' + ((error as { message?: string })?.message ?? error), {
-			cause: error
-		})
+		return {
+			type: 'text',
+			text: 'SJ API request failed: ' + ((error as { message?: string })?.message ?? error)
+		}
 		// throw 'SJ API request failed:' + error
 	}
 }
@@ -170,7 +172,12 @@ export async function callHuggingFaceEmbedding(
 	})
 }
 
-async function call_azure_llm(prompt: string, modelName: string, apilink: string, apiToken: string) {
+async function call_azure_llm(
+	prompt: string,
+	modelName: string,
+	apilink: string,
+	apiToken: string
+): Promise<string | MsgToUser> {
 	const timeout = 200000
 	const max_completion_tokens = 5000
 	const temperature = 0.01
@@ -198,11 +205,11 @@ async function call_azure_llm(prompt: string, modelName: string, apilink: string
 		throw 'Error: Received an unexpected response format:' + JSON.stringify(response)
 	} catch (error) {
 		console.log(error)
-		throw 'Azure API request failed:' + error
+		return { type: 'text', text: 'Azure API request failed:' + error }
 	}
 }
 
-async function call_ollama_llm(prompt: string, model_name: string, apilink: string) {
+async function call_ollama_llm(prompt: string, model_name: string, apilink: string): Promise<string | MsgToUser> {
 	const temperature = 0.01
 	const top_p = 0.95
 	const timeout = 200000
@@ -232,6 +239,6 @@ async function call_ollama_llm(prompt: string, model_name: string, apilink: stri
 			throw 'Error: Received an unexpected response format:' + result
 		}
 	} catch (error) {
-		throw 'Ollama API request failed:' + error
+		return { type: 'text', text: 'Ollama API request failed:' + error }
 	}
 }

--- a/server/src/chat/routeAPIcall.ts
+++ b/server/src/chat/routeAPIcall.ts
@@ -1,5 +1,6 @@
 import type { LlmConfig } from '#types'
 import { ezFetch } from '#shared'
+import { mayLog } from '#src/helpers.ts'
 import type { MsgToUser } from './scaffoldTypes.ts'
 
 export async function route_to_appropriate_llm_provider(
@@ -94,7 +95,7 @@ async function call_sj_llm(prompt: string, model_name: string, apilink: string):
 		console.error('SJ API request failed. Underlying error:', error)
 		if (error && typeof error == 'object' && 'cause' in error)
 			console.error('Cause:', (error as { cause?: unknown }).cause)
-		// Re-throw a real Error that preserves the original
+		// Return a user-facing message instead of throwing, so the UI can surface the failure.
 		return {
 			type: 'text',
 			text: 'SJ API request failed: ' + ((error as { message?: string })?.message ?? error)
@@ -153,7 +154,7 @@ export async function callHuggingFaceEmbedding(
 	})
 
 	if (result?.error && modelName !== HF_FALLBACK_MODEL) {
-		console.warn(`Model ${modelName} returned error — falling back to ${HF_FALLBACK_MODEL}`)
+		mayLog(`Model ${modelName} returned error — falling back to ${HF_FALLBACK_MODEL}`)
 		return callHuggingFaceEmbedding(texts, HF_FALLBACK_MODEL, api, apiToken)
 	}
 
@@ -205,7 +206,10 @@ async function call_azure_llm(
 		throw 'Error: Received an unexpected response format:' + JSON.stringify(response)
 	} catch (error) {
 		console.log(error)
-		return { type: 'text', text: 'Azure API request failed:' + error }
+		return {
+			type: 'text',
+			text: 'Azure API request failed:' + (error instanceof Error ? error.message : String(error))
+		}
 	}
 }
 
@@ -239,6 +243,9 @@ async function call_ollama_llm(prompt: string, model_name: string, apilink: stri
 			throw 'Error: Received an unexpected response format:' + result
 		}
 	} catch (error) {
-		return { type: 'text', text: 'Ollama API request failed:' + error }
+		return {
+			type: 'text',
+			text: 'Ollama API request failed:' + (error instanceof Error ? error.message : String(error))
+		}
 	}
 }

--- a/server/src/chat/scaffold.ts
+++ b/server/src/chat/scaffold.ts
@@ -16,7 +16,7 @@ import type {
 	PrebuiltScatterScaffold,
 	MsgToUser
 } from './scaffoldTypes.ts'
-import { extractGenesFromPrompt } from './utils.ts'
+import { extractGenesFromPrompt, safeExtractJsonObject } from './utils.ts'
 import { generateFilterTerm } from './filter.ts'
 import { classifyGeneDataType } from './genedatatype.ts'
 import { determineAmbiguousGenePrompt } from './determineAmbiguousGene.ts'
@@ -114,21 +114,20 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Survival scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response)
-		if (parsed && parsed.type === 'text') return parsed as MsgToUser
-		if (!parsed.term2) {
-			return {
-				type: 'text',
-				text: 'No stratification variable (term2) could be extracted from the prompt for the survival plot.'
-			}
-		}
-		const scaffold = parsed as SurvivalScaffold
-		scaffold.plotType = 'survival'
-		return scaffold
-	} catch {
-		throw new Error(`Failed to parse SurvivalScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a survival plot configuration from the response: ${response}` }
 	}
+	if (parsed.type === 'text') return parsed as MsgToUser
+	if (!parsed.term2) {
+		return {
+			type: 'text',
+			text: 'No stratification variable (term2) could be extracted from the prompt for the survival plot.'
+		}
+	}
+	const scaffold = parsed as SurvivalScaffold
+	scaffold.plotType = 'survival'
+	return scaffold
 }
 
 async function getScaffold_genomeBrowser(
@@ -229,16 +228,16 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Genome browser scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as GenomeBrowserScaffold
-		parsed.plotType = 'genomeBrowser'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse GenomeBrowserScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a genome browser configuration from the response: ${response}` }
 	}
+	const scaffold = parsed as GenomeBrowserScaffold
+	scaffold.plotType = 'genomeBrowser'
+	return scaffold
 }
 
-async function getScaffold_matrix(user_prompt: string, llm: LlmConfig): Promise<MatrixScaffold> {
+async function getScaffold_matrix(user_prompt: string, llm: LlmConfig): Promise<MatrixScaffold | MsgToUser> {
 	const prompt = ` You are a ProteinPaint matrix plot assistant. Your task is to extract the necessary variables from a user's natural language question to populate a strict JSON scaffold for configuring a matrix plot. 
 
 ## OUTPUT SCHEMA
@@ -323,16 +322,16 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm)
 	mayLog(`--> Matrix Scaffold LLM response: ${response}`)
-	try {
-		const scaffold = JSON.parse(response)
-		scaffold.plotType = 'matrix' // add plotType to the scaffold for downstream use
-		return scaffold
-	} catch (error) {
-		throw new Error(`Failed to parse LLM response as JSON: ${response}\nError: ${error}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a matrix plot configuration from the response: ${response}` }
 	}
+	const scaffold = parsed as MatrixScaffold
+	scaffold.plotType = 'matrix' // add plotType to the scaffold for downstream use
+	return scaffold
 }
 
-async function getScaffold_dge(user_prompt: string, llm: LlmConfig): Promise<DEScaffold> {
+async function getScaffold_dge(user_prompt: string, llm: LlmConfig): Promise<DEScaffold | MsgToUser> {
 	const prompt = ` You are a ProteinPaint differential expression analysis assistant. Your task is to extract exactly two comparison groups and an optional cohort filter from a user's natural language question.
 
 ## OUTPUT SCHEMA
@@ -486,16 +485,19 @@ Query: ${user_prompt}
 	// let response = summaryScaffold
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> DE scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as DEScaffold
-		parsed.plotType = 'dge'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse DEScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return {
+			type: 'text',
+			text: `Could not parse a differential expression configuration from the response: ${response}`
+		}
 	}
+	const scaffold = parsed as DEScaffold
+	scaffold.plotType = 'dge'
+	return scaffold
 }
 
-async function getScaffold_summary(user_prompt: string, llm: LlmConfig): Promise<SummaryScaffold> {
+async function getScaffold_summary(user_prompt: string, llm: LlmConfig): Promise<SummaryScaffold | MsgToUser> {
 	const prompt = `You are a structured data extraction assistant. Your job is to parse the user prompt string and extract variables into a strict JSON scaffold for a summary plot configuration.
 ## Output Schema
 Always return ONLY a JSON object in this exact format:
@@ -608,13 +610,13 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Summary scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as SummaryScaffold
-		parsed.plotType = 'summary'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse SummaryScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response)
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a summary plot configuration from the response: ${response}` }
 	}
+	const scaffold = parsed as SummaryScaffold
+	scaffold.plotType = 'summary'
+	return scaffold
 }
 
 async function hierarchicalGeneExpression(
@@ -680,8 +682,15 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as HierarchicalGeneExpressionScaffold
+	{
+		const parsedObj = safeExtractJsonObject(response)
+		if (!parsedObj) {
+			return {
+				type: 'text',
+				text: `Could not parse a hierarchical clustering configuration from the response: ${response}`
+			}
+		}
+		const parsed = parsedObj as HierarchicalGeneExpressionScaffold
 		parsed.plotType = 'hiercluster'
 		// Ensure each gene symbol is followed by "expression" so downstream phrase2entity
 		// resolves it to the geneExpression term type rather than flagging it as ambiguous.
@@ -737,8 +746,6 @@ Query: ${user_prompt}
 		)
 		mayLog('Time taken for hierCluster agent:', formatElapsedTime(Date.now() - time))
 		return ai_output_json
-	} catch {
-		throw new Error(`Failed to parse HierarchicalScaffold from LLM response: ${response}`)
 	}
 }
 
@@ -944,26 +951,25 @@ Query: ${user_prompt}
 `*/
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Prebuilt scatter scaffold: ${response}`)
-	try {
-		const parsed = JSON.parse(response) as PrebuiltScatterScaffold
-		if (!parsed.name)
-			return {
-				type: 'text',
-				text: 'Name of pre-built map (e.g. t-SNE, UMAP, etc) is required for prebuilt scatter scaffold'
-			}
-		if (parsed.name === 'unsure') {
-			return {
-				type: 'text',
-				text: 'LLM was unsure which prebuilt scatter plot the user query corresponded to based on the descriptions, indicating that the query did not clearly match any of the available options.'
-			}
-		} else if (parsed.name === 'nomatch') {
-			return { type: 'text', text: 'The plot you are asking for is not currently supported.' }
-		}
-		parsed.plotType = 'prebuiltscatter'
-		return parsed
-	} catch {
-		throw new Error(`Failed to parse PrebuiltScatterScaffold from LLM response: ${response}`)
+	const parsed = safeExtractJsonObject(response) as PrebuiltScatterScaffold | undefined
+	if (!parsed) {
+		return { type: 'text', text: `Could not parse a prebuilt scatter configuration from the response: ${response}` }
 	}
+	if (!parsed.name)
+		return {
+			type: 'text',
+			text: 'Name of pre-built map (e.g. t-SNE, UMAP, etc) is required for prebuilt scatter scaffold'
+		}
+	if (parsed.name === 'unsure') {
+		return {
+			type: 'text',
+			text: 'LLM was unsure which prebuilt scatter plot the user query corresponded to based on the descriptions, indicating that the query did not clearly match any of the available options.'
+		}
+	} else if (parsed.name === 'nomatch') {
+		return { type: 'text', text: 'The plot you are asking for is not currently supported.' }
+	}
+	parsed.plotType = 'prebuiltscatter'
+	return parsed
 }
 
 export async function getScaffold_hierarchical(
@@ -1031,13 +1037,14 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical variable-type classifier: ${response}`)
-	let variableType: string
-	try {
-		const parsed = JSON.parse(response)
-		variableType = parsed.variableType
-	} catch {
-		throw new Error(`Failed to parse hierarchical variable-type classifier response: ${response}`)
+	const parsedClassifier = safeExtractJsonObject(response)
+	if (!parsedClassifier) {
+		return {
+			type: 'text',
+			text: `Could not parse the hierarchical variable-type classification from the response: ${response}`
+		}
 	}
+	const variableType: string = parsedClassifier.variableType
 	if (variableType === TermTypes.GENE_EXPRESSION) {
 		if (allowedTermTypes.includes(TermTypes.GENE_EXPRESSION)) {
 			return await hierarchicalGeneExpression(user_prompt, llm, genome, genes_list, dataset_json, ds, dbPath)
@@ -1150,12 +1157,14 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical dictionary scaffold: ${response}`)
-	let parsed: HierarchicalScaffold
-	try {
-		parsed = JSON.parse(response) as HierarchicalScaffold
-	} catch {
-		throw new Error(`Failed to parse HierarchicalScaffold from LLM response: ${response}`)
+	const parsedObj = safeExtractJsonObject(response)
+	if (!parsedObj) {
+		return {
+			type: 'text',
+			text: `Could not parse a hierarchical clustering configuration from the response: ${response}`
+		}
 	}
+	const parsed = parsedObj as HierarchicalScaffold
 	parsed.plotType = 'hiercluster'
 
 	if (!parsed.hierarchicalPhrases) {

--- a/server/src/chat/scaffold.ts
+++ b/server/src/chat/scaffold.ts
@@ -16,6 +16,7 @@ import type {
 	PrebuiltScatterScaffold,
 	MsgToUser
 } from './scaffoldTypes.ts'
+import { isMsgToUser } from './scaffoldTypes.ts'
 import { extractGenesFromPrompt } from './utils.ts'
 import { generateFilterTerm } from './filter.ts'
 import { classifyGeneDataType } from './genedatatype.ts'
@@ -114,6 +115,7 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Survival scaffold: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsed: any
 	try {
 		parsed = JSON.parse(response)
@@ -231,6 +233,7 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Genome browser scaffold: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsed: any
 	try {
 		parsed = JSON.parse(response)
@@ -328,6 +331,7 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm)
 	mayLog(`--> Matrix Scaffold LLM response: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsed: any
 	try {
 		parsed = JSON.parse(response)
@@ -494,6 +498,7 @@ Query: ${user_prompt}
 	// let response = summaryScaffold
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> DE scaffold: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsed: any
 	try {
 		parsed = JSON.parse(response)
@@ -622,6 +627,7 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Summary scaffold: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsed: any
 	try {
 		parsed = JSON.parse(response)
@@ -697,6 +703,7 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical scaffold: ${response}`)
+	if (isMsgToUser(response)) return response
 	{
 		let parsedObj: any
 		try {
@@ -971,6 +978,7 @@ Query: ${user_prompt}
 `*/
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Prebuilt scatter scaffold: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsed: any
 	try {
 		parsed = JSON.parse(response)
@@ -1060,6 +1068,7 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical variable-type classifier: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsedClassifier: any
 	try {
 		parsedClassifier = JSON.parse(response)
@@ -1183,6 +1192,7 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical dictionary scaffold: ${response}`)
+	if (isMsgToUser(response)) return response
 	let parsedObj: any
 	try {
 		parsedObj = JSON.parse(response)

--- a/server/src/chat/scaffold.ts
+++ b/server/src/chat/scaffold.ts
@@ -16,7 +16,7 @@ import type {
 	PrebuiltScatterScaffold,
 	MsgToUser
 } from './scaffoldTypes.ts'
-import { extractGenesFromPrompt, safeExtractJsonObject } from './utils.ts'
+import { extractGenesFromPrompt } from './utils.ts'
 import { generateFilterTerm } from './filter.ts'
 import { classifyGeneDataType } from './genedatatype.ts'
 import { determineAmbiguousGenePrompt } from './determineAmbiguousGene.ts'
@@ -114,8 +114,11 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Survival scaffold: ${response}`)
-	const parsed = safeExtractJsonObject(response)
-	if (!parsed) {
+	let parsed: any
+	try {
+		parsed = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse a survival plot configuration from the response: ${response}`)
 		return { type: 'text', text: `Could not parse a survival plot configuration from the response: ${response}` }
 	}
 	if (parsed.type === 'text') return parsed as MsgToUser
@@ -228,8 +231,11 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Genome browser scaffold: ${response}`)
-	const parsed = safeExtractJsonObject(response)
-	if (!parsed) {
+	let parsed: any
+	try {
+		parsed = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse a genome browser configuration from the response: ${response}`)
 		return { type: 'text', text: `Could not parse a genome browser configuration from the response: ${response}` }
 	}
 	const scaffold = parsed as GenomeBrowserScaffold
@@ -322,8 +328,11 @@ Query: "${user_prompt}"
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm)
 	mayLog(`--> Matrix Scaffold LLM response: ${response}`)
-	const parsed = safeExtractJsonObject(response)
-	if (!parsed) {
+	let parsed: any
+	try {
+		parsed = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse a matrix plot configuration from the response: ${response}`)
 		return { type: 'text', text: `Could not parse a matrix plot configuration from the response: ${response}` }
 	}
 	const scaffold = parsed as MatrixScaffold
@@ -485,8 +494,11 @@ Query: ${user_prompt}
 	// let response = summaryScaffold
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> DE scaffold: ${response}`)
-	const parsed = safeExtractJsonObject(response)
-	if (!parsed) {
+	let parsed: any
+	try {
+		parsed = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse a differential expression configuration from the response: ${response}`)
 		return {
 			type: 'text',
 			text: `Could not parse a differential expression configuration from the response: ${response}`
@@ -610,8 +622,11 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Summary scaffold: ${response}`)
-	const parsed = safeExtractJsonObject(response)
-	if (!parsed) {
+	let parsed: any
+	try {
+		parsed = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse a summary plot configuration from the response: ${response}`)
 		return { type: 'text', text: `Could not parse a summary plot configuration from the response: ${response}` }
 	}
 	const scaffold = parsed as SummaryScaffold
@@ -683,8 +698,11 @@ Query: ${user_prompt}
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical scaffold: ${response}`)
 	{
-		const parsedObj = safeExtractJsonObject(response)
-		if (!parsedObj) {
+		let parsedObj: any
+		try {
+			parsedObj = JSON.parse(response)
+		} catch {
+			mayLog(`Could not parse a hierarchical clustering configuration from the response: ${response}`)
 			return {
 				type: 'text',
 				text: `Could not parse a hierarchical clustering configuration from the response: ${response}`
@@ -953,8 +971,11 @@ Query: ${user_prompt}
 `*/
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Prebuilt scatter scaffold: ${response}`)
-	const parsed = safeExtractJsonObject(response) as PrebuiltScatterScaffold | undefined
-	if (!parsed) {
+	let parsed: any
+	try {
+		parsed = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse a prebuilt scatter configuration from the response: ${response}`)
 		return { type: 'text', text: `Could not parse a prebuilt scatter configuration from the response: ${response}` }
 	}
 	if (!parsed.name)
@@ -1039,8 +1060,11 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical variable-type classifier: ${response}`)
-	const parsedClassifier = safeExtractJsonObject(response)
-	if (!parsedClassifier) {
+	let parsedClassifier: any
+	try {
+		parsedClassifier = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse the hierarchical variable-type classification from the response: ${response}`)
 		return {
 			type: 'text',
 			text: `Could not parse the hierarchical variable-type classification from the response: ${response}`
@@ -1159,11 +1183,14 @@ Query: ${user_prompt}
 `
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
 	mayLog(`--> Hierarchical dictionary scaffold: ${response}`)
-	const parsedObj = safeExtractJsonObject(response)
-	if (!parsedObj) {
+	let parsedObj: any
+	try {
+		parsedObj = JSON.parse(response)
+	} catch {
+		mayLog(`Could not parse hierarchical clustering configuration from the response: ${response}`)
 		return {
 			type: 'text',
-			text: `Could not parse a hierarchical clustering configuration from the response: ${response}`
+			text: `Could not parse hierarchical clustering configuration from the response: ${response}`
 		}
 	}
 	const parsed = parsedObj as HierarchicalScaffold

--- a/server/src/chat/scaffold.ts
+++ b/server/src/chat/scaffold.ts
@@ -729,6 +729,8 @@ Query: ${user_prompt}
 				throw 'classifyGeneDataType agent returned an empty string, which is unexpected.'
 			} else if (Array.isArray(geneDataTypeMessage)) {
 				geneFeatures = geneDataTypeMessage
+			} else if (geneDataTypeMessage && geneDataTypeMessage.type === 'text') {
+				return geneDataTypeMessage // MsgToUser — surface to the client for display
 			} else {
 				throw 'geneDataTypeMessage has unknown data type returned from classifyGeneDataType agent'
 			}

--- a/server/src/chat/scaffoldTypes.ts
+++ b/server/src/chat/scaffoldTypes.ts
@@ -6,6 +6,13 @@ export type MsgToUser = {
 	text: string
 }
 
+/** Discriminate a MsgToUser (a {type:'text', text} message to surface to the client) from any other value. */
+export function isMsgToUser(x: unknown): x is MsgToUser {
+	if (!x || typeof x !== 'object') return false
+	const o = x as Record<string, unknown>
+	return o.type === 'text' && Object.prototype.hasOwnProperty.call(o, 'text') && typeof o.text === 'string'
+}
+
 // *** Scaffold Temp Types *** //
 export type SummaryScaffold = {
 	plotType: 'summary'

--- a/server/src/chat/semanticSearch.ts
+++ b/server/src/chat/semanticSearch.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3'
 import fs from 'fs'
 import path from 'path'
 import type { LlmConfig } from '#types'
+import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_embedding_provider } from './routeAPIcall.ts'
 
 // Return type
@@ -82,7 +83,7 @@ function extractSentences(row: TermRow): string[] {
 			.map(d => d.value)
 			.filter(v => v && v.trim().length > 0)
 	} catch (e) {
-		console.warn(`Failed to parse jsonhtml for id="${row.id}":`, e)
+		mayLog(`Failed to parse jsonhtml for id="${row.id}":`, e)
 		return []
 	}
 }

--- a/server/src/chat/utils.ts
+++ b/server/src/chat/utils.ts
@@ -12,6 +12,39 @@ import { GENE_SET_KEYWORDS } from './genesetdatatype.ts'
 import { classifyGeneDataTypePhrase } from './genedatatypenew.ts'
 import { classifyGeneSetDataType } from './genesetdatatype.ts'
 
+/**
+ * Tolerantly extract a JSON object from an LLM response.
+ * LLMs frequently wrap JSON in markdown code fences or prepend/append prose
+ * (e.g. reasoning text), which makes a direct JSON.parse() throw. This helper
+ * never throws: it returns the first parseable JSON object, or undefined.
+ */
+export function safeExtractJsonObject(response: unknown): Record<string, any> | undefined {
+	if (typeof response !== 'string') return undefined
+	const candidates: string[] = []
+	const trimmed = response.trim()
+	candidates.push(trimmed)
+	// Strip a leading/trailing markdown code fence such as ```json ... ```
+	const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
+	if (fenceMatch) candidates.push(fenceMatch[1].trim())
+	// Fall back to the first balanced-looking {...} block embedded in the text
+	const braceMatch = trimmed.match(/\{[\s\S]*\}/)
+	if (braceMatch) candidates.push(braceMatch[0])
+
+	for (const candidate of candidates) {
+		if (!candidate) continue
+		try {
+			const parsed = JSON.parse(candidate)
+			// Only accept a non-null JSON object (reject strings, numbers, arrays, null)
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				return parsed as Record<string, any>
+			}
+		} catch {
+			// try the next candidate
+		}
+	}
+	return undefined
+}
+
 export function getChatRelatedPlotTypes(supportedPlotTypes: string[] | undefined): string[] {
 	if (!supportedPlotTypes) {
 		mayLog(

--- a/server/src/chat/utils.ts
+++ b/server/src/chat/utils.ts
@@ -3,7 +3,7 @@ import { TermTypes } from '#shared/terms.js'
 import { mayLog } from '#src/helpers.ts'
 import { route_to_appropriate_llm_provider } from './routeAPIcall.ts'
 import type { MsgToUser, Entity, FilterTreeNode, FilterLeafNode, FilterTreeResult } from './scaffoldTypes.ts'
-import { filterTreeJsonSchema } from './scaffoldTypes.ts'
+import { filterTreeJsonSchema, isMsgToUser } from './scaffoldTypes.ts'
 import fs from 'fs'
 import { getDsAllowedTermTypes } from '../routes/termdb.config.ts'
 import Database from 'better-sqlite3'
@@ -494,16 +494,24 @@ export async function parse_dataset_db(
 			try {
 				jsonhtml = JSON.parse(row.jsonhtml)
 			} catch (e) {
-				console.warn(`Failed to parse jsonhtml for row id ${row.id}:`, e)
+				mayLog(`Failed to parse jsonhtml for row id ${row.id}:`, e)
 				// Surface a message to the client instead of crashing on the malformed term definition below.
 				return {
 					type: 'text',
-					text: `Failed to read the dataset dictionary: the definition for term "${row.id}" is malformed.`
+					text: `Failed to read the dataset dictionary: the definition for term "${row.id}" is malformed. The error message is: ${e}.`
 				}
 			}
 			const description: string = jsonhtml.description[0].value
-			const jsondata = JSON.parse(row.jsondata)
-
+			let jsondata: any
+			try {
+				jsondata = JSON.parse(row.jsondata)
+			} catch (e) {
+				mayLog(`Failed to parse jsondata for row id ${row.id}:`, e)
+				return {
+					type: 'text',
+					text: `Failed to read the dataset dictionary: the data for term "${row.id}" is malformed. The error message is: ${e}.`
+				}
+			}
 			const values: DbValue[] = []
 			if (jsondata.values && Object.keys(jsondata.values).length > 0) {
 				for (const key of Object.keys(jsondata.values)) {
@@ -796,7 +804,7 @@ async function classifyGeneSetDataTypePhrase(
  * "young and black patients" -> ["young", "black"]
  * "young and black patients or old and white patients" -> [["young", "black"], ["old", "white"]]
  */
-export async function evaluateFilterTerm(phrase: string, llm: LlmConfig): Promise<FilterTreeResult> {
+export async function evaluateFilterTerm(phrase: string, llm: LlmConfig): Promise<FilterTreeResult | MsgToUser> {
 	const prompt = `You are an assistant that analyzes a filter term written in natural language and converts it into a nested binary S-expression tree using two operators: AND (&) and OR (|).
 Do NOT generate code. You yourself must produce the tree. Return ONLY a JSON string — no explanations, no markdown, no extra keys.
 
@@ -1101,15 +1109,25 @@ Query: ${phrase}
 `
 */
 	const response = await route_to_appropriate_llm_provider(prompt, llm, llm.classifierModelName)
+	// The LLM provider call failed and returned a user-facing message; propagate it for UI display.
 	mayLog('filter response:', response)
+	if (isMsgToUser(response)) return response
+	let parsed: FilterTreeResult
 	try {
-		const parsed = JSON.parse(response) as FilterTreeResult
+		parsed = JSON.parse(response) as FilterTreeResult
+	} catch (e) {
+		return {
+			type: 'text',
+			text: `Failed to parse LLM filter response for phrase: "${phrase}". Error message is "${e}"`
+		} as MsgToUser
+	}
+	try {
 		if (!parsed.tree || !parsed.sexpr) {
 			throw 'Response missing required fields "tree" or "sexpr"'
 		}
 		return parsed
 	} catch (e) {
-		console.warn('Failed to parse LLM filter response, wrapping phrase as single leaf:', response, e)
+		mayLog('Failed to parse LLM filter response, wrapping phrase as single leaf:', response, ' error message:', e)
 		// Fallback: wrap the entire phrase as a single-leaf tree conforming to the schema
 		return {
 			sexpr: phrase,

--- a/server/src/chat/utils.ts
+++ b/server/src/chat/utils.ts
@@ -12,68 +12,6 @@ import { GENE_SET_KEYWORDS } from './genesetdatatype.ts'
 import { classifyGeneDataTypePhrase } from './genedatatypenew.ts'
 import { classifyGeneSetDataType } from './genesetdatatype.ts'
 
-/**
- * Tolerantly extract a JSON object from an LLM response.
- * LLMs frequently wrap JSON in markdown code fences or prepend/append prose
- * (e.g. reasoning text), which makes a direct JSON.parse() throw. This helper
- * never throws: it returns the first parseable JSON object, or undefined.
- */
-export function safeExtractJsonObject(response: unknown): Record<string, any> | undefined {
-	if (typeof response !== 'string') return undefined
-	const candidates: string[] = []
-	const trimmed = response.trim()
-	candidates.push(trimmed)
-	// Strip a leading/trailing markdown code fence such as ```json ... ```
-	const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
-	if (fenceMatch) candidates.push(fenceMatch[1].trim())
-	// Fall back to the first balanced-looking {...} block embedded in the text
-	const braceMatch = trimmed.match(/\{[\s\S]*\}/)
-	if (braceMatch) candidates.push(braceMatch[0])
-
-	for (const candidate of candidates) {
-		if (!candidate) continue
-		try {
-			const parsed = JSON.parse(candidate)
-			// Only accept a non-null JSON object (reject strings, numbers, arrays, null)
-			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-				return parsed as Record<string, any>
-			}
-		} catch {
-			// try the next candidate
-		}
-	}
-	return undefined
-}
-
-/**
- * Tolerantly extract a JSON array from an LLM response. Array counterpart to
- * safeExtractJsonObject() — handles markdown code fences and surrounding prose.
- * Never throws: returns the first parseable JSON array, or undefined.
- */
-export function safeExtractJsonArray(response: unknown): any[] | undefined {
-	if (typeof response !== 'string') return undefined
-	const candidates: string[] = []
-	const trimmed = response.trim()
-	candidates.push(trimmed)
-	// Strip a leading/trailing markdown code fence such as ```json ... ```
-	const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
-	if (fenceMatch) candidates.push(fenceMatch[1].trim())
-	// Fall back to the first balanced-looking [...] block embedded in the text
-	const bracketMatch = trimmed.match(/\[[\s\S]*\]/)
-	if (bracketMatch) candidates.push(bracketMatch[0])
-
-	for (const candidate of candidates) {
-		if (!candidate) continue
-		try {
-			const parsed = JSON.parse(candidate)
-			if (Array.isArray(parsed)) return parsed
-		} catch {
-			// try the next candidate
-		}
-	}
-	return undefined
-}
-
 export function getChatRelatedPlotTypes(supportedPlotTypes: string[] | undefined): string[] {
 	if (!supportedPlotTypes) {
 		mayLog(
@@ -540,7 +478,9 @@ export async function parse_geneset_db(genedb: string) {
 	return genes_list
 }
 
-export async function parse_dataset_db(dataset_db: string) {
+export async function parse_dataset_db(
+	dataset_db: string
+): Promise<{ db_rows: DbRows[]; rag_docs: string[] } | MsgToUser> {
 	const db = new Database(dataset_db)
 	const rag_docs: string[] = []
 	const db_rows: DbRows[] = []
@@ -549,8 +489,18 @@ export async function parse_dataset_db(dataset_db: string) {
 			.prepare('SELECT t.id, t.type, t.jsondata, h.jsonhtml FROM terms t INNER JOIN termhtmldef h ON t.id = h.id')
 			.all()
 
-		rows.forEach((row: any) => {
-			const jsonhtml = JSON.parse(row.jsonhtml)
+		for (const row of rows as any[]) {
+			let jsonhtml: any
+			try {
+				jsonhtml = JSON.parse(row.jsonhtml)
+			} catch (e) {
+				console.warn(`Failed to parse jsonhtml for row id ${row.id}:`, e)
+				// Surface a message to the client instead of crashing on the malformed term definition below.
+				return {
+					type: 'text',
+					text: `Failed to read the dataset dictionary: the definition for term "${row.id}" is malformed.`
+				}
+			}
 			const description: string = jsonhtml.description[0].value
 			const jsondata = JSON.parse(row.jsondata)
 
@@ -571,7 +521,7 @@ export async function parse_dataset_db(dataset_db: string) {
 			const stringified_db = parse_db_rows(db_row)
 			rag_docs.push(stringified_db)
 			db_rows.push(db_row)
-		})
+		}
 	} catch (error) {
 		throw 'Error in parsing dataset DB:' + error
 	} finally {

--- a/server/src/chat/utils.ts
+++ b/server/src/chat/utils.ts
@@ -45,6 +45,35 @@ export function safeExtractJsonObject(response: unknown): Record<string, any> | 
 	return undefined
 }
 
+/**
+ * Tolerantly extract a JSON array from an LLM response. Array counterpart to
+ * safeExtractJsonObject() — handles markdown code fences and surrounding prose.
+ * Never throws: returns the first parseable JSON array, or undefined.
+ */
+export function safeExtractJsonArray(response: unknown): any[] | undefined {
+	if (typeof response !== 'string') return undefined
+	const candidates: string[] = []
+	const trimmed = response.trim()
+	candidates.push(trimmed)
+	// Strip a leading/trailing markdown code fence such as ```json ... ```
+	const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)
+	if (fenceMatch) candidates.push(fenceMatch[1].trim())
+	// Fall back to the first balanced-looking [...] block embedded in the text
+	const bracketMatch = trimmed.match(/\[[\s\S]*\]/)
+	if (bracketMatch) candidates.push(bracketMatch[0])
+
+	for (const candidate of candidates) {
+		if (!candidate) continue
+		try {
+			const parsed = JSON.parse(candidate)
+			if (Array.isArray(parsed)) return parsed
+		} catch {
+			// try the next candidate
+		}
+	}
+	return undefined
+}
+
 export function getChatRelatedPlotTypes(supportedPlotTypes: string[] | undefined): string[] {
 	if (!supportedPlotTypes) {
 		mayLog(

--- a/server/src/test/chat.unit.spec.ts
+++ b/server/src/test/chat.unit.spec.ts
@@ -1,0 +1,29 @@
+/********************************************
+Unit Test for isMsgToUser() (server/src/chat/scaffoldTypes.ts)
+Run with:  node server/src/test/chat.unit.spec.ts
+*********************************************/
+
+import tape from 'tape'
+import { isMsgToUser } from '../chat/scaffoldTypes.ts'
+
+tape('scaffoldTypes.ts  - isMsgToUser - valid MsgToUser object', async t => {
+	const testCase = { type: 'text', text: 'This is a test message.' }
+	const result = isMsgToUser(testCase)
+	t.ok(result, 'Should return true for valid MsgToUser object')
+	t.equal(typeof result, 'boolean', 'Result should be a boolean')
+	t.equal(result, true, 'Should be true')
+})
+
+tape('scaffoldTypes.ts  - isMsgToUser - invalid object1: message field instead of text', async t => {
+	const invalidCase = { type: 'text', message: 'This is an invalid message.' }
+	const result = isMsgToUser(invalidCase)
+	t.equal(typeof result, 'boolean', 'Result should be a boolean')
+	t.equal(result, false, 'Should be false')
+})
+
+tape('scaffoldTypes.ts  - isMsgToUser - invalid object2: type plot instead of text', async t => {
+	const invalidCase = { type: 'plot', text: 'This is an invalid message.' }
+	const result = isMsgToUser(invalidCase)
+	t.equal(typeof result, 'boolean', 'Result should be a boolean')
+	t.equal(result, false, 'Should be false')
+})


### PR DESCRIPTION
# Description
Hardening chat bot code so as to handle non JSON output from LLMs

1) Put `JSON.parse` behind try/catch block.
2) In catch block, when JSON.parse fails error message is sent to client side.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
