### PR TITLE
GRIN2: Enable skipping of specific dt types in both GDC and non-GDC fetches

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GRIN2: Enable skipping of specific dt types in both GDC and non-GDC fetches

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -639,9 +639,6 @@ async function processSampleData(
 	// can avoid fetching them. For GDC this skips per-sample snvindel/cnv/fusion file reads (network round-trips)
 	// when those options are off; for native ds it filters out unrequested dt before return.
 	const skipDt = new Set<number>(Object.values(optionToDt).filter(dt => !enabledTypes.includes(dt)))
-	console.log('[GRIN2] enabledTypes: ', enabledTypes.join(', '))
-	console.log('[GRIN2] optionToDt: ', JSON.stringify(optionToDt))
-	console.log('[GRIN2] skipDt: ', Array.from(skipDt).join(', '))
 
 	await mapConcurrent(
 		samples,

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -635,12 +635,17 @@ async function processSampleData(
 	// fetches once the overall lesion cap is reached.
 	const concurrency = Math.max(1, ds.cohort?.termdb?.maxConcurrentQueries || 10)
 
+	// dt types this query may return but that the caller didn't request; pass to the getter so backends
+	// can avoid fetching them. For GDC this skips per-sample snvindel/cnv/fusion file reads (network round-trips)
+	// when those options are off; for native ds it filters out unrequested dt before merge.
+	const skipDt = new Set<number>([dtsnvindel, dtcnv, dtfusionrna, dtsv].filter(dt => !enabledTypes.includes(dt)))
+
 	await mapConcurrent(
 		samples,
 		concurrency,
 		async sample => {
 			try {
-				const { mlst } = await ds.queries.singleSampleMutation.get({ sample: sample.name })
+				const { mlst } = await ds.queries.singleSampleMutation.get({ sample: sample.name, skipDt })
 
 				const { sampleLesions, contributedTypes } = processSampleMlst(sample.name, mlst, request, cnvType)
 

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -637,8 +637,11 @@ async function processSampleData(
 
 	// dt types this query may return but that the caller didn't request; pass to the getter so backends
 	// can avoid fetching them. For GDC this skips per-sample snvindel/cnv/fusion file reads (network round-trips)
-	// when those options are off; for native ds it filters out unrequested dt before merge.
-	const skipDt = new Set<number>([dtsnvindel, dtcnv, dtfusionrna, dtsv].filter(dt => !enabledTypes.includes(dt)))
+	// when those options are off; for native ds it filters out unrequested dt before return.
+	const skipDt = new Set<number>(Object.values(optionToDt).filter(dt => !enabledTypes.includes(dt)))
+	console.log('[GRIN2] enabledTypes: ', enabledTypes.join(', '))
+	console.log('[GRIN2] optionToDt: ', JSON.stringify(optionToDt))
+	console.log('[GRIN2] skipDt: ', Array.from(skipDt).join(', '))
 
 	await mapConcurrent(
 		samples,

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -765,6 +765,12 @@ opts{}
 	.case_id=str
 */
 async function getCnvFusion4oneCase(opts, ds) {
+	// caller may only want a subset of dt; skip loading files for unrequested ones to avoid network reads
+	const skipCnv = opts.skipDt?.has(common.dtcnv)
+	const skipFusion = opts.skipDt?.has(common.dtfusionrna)
+	// neither cnv nor fusion requested: skip the files listing fetch entirely
+	if (skipCnv && skipFusion) return {}
+
 	const fields = [
 		'cases.samples.tissue_type',
 		'cases.samples.tumor_descriptor',
@@ -797,6 +803,7 @@ async function getCnvFusion4oneCase(opts, ds) {
 	for (const h of re.data.hits) {
 		if (!h.cases?.[0]) throw new Error(`h.cases[0] missing for file =${h.file_id}`)
 		if (h.data_format == 'BEDPE') {
+			if (skipFusion) continue
 			if (h.experimental_strategy != 'RNA-Seq') continue
 			if (h.analysis?.workflow_type != 'Arriba') continue
 			if (h.data_type != 'Transcript Fusion') continue
@@ -813,6 +820,7 @@ async function getCnvFusion4oneCase(opts, ds) {
 		}
 
 		if (h.data_format == 'TXT') {
+			if (skipCnv) continue
 			if (h.experimental_strategy == 'Genotyping Array') {
 				if (h.data_type == 'Masked Copy Number Segment' || h.data_type == ascns) {
 					cnvfiles.push({
@@ -2456,7 +2464,7 @@ async function getSingleSampleMutations(query, ds, genome) {
 	}
 
 	// ssm
-	{
+	if (!query.skipDt?.has(common.dtsnvindel)) {
 		const { host, headers } = ds.getHostHeaders(query)
 
 		const re = await xfetch(joinUrl(host.rest, isoform2ssm_query1_getvariant.endpoint), {

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -2171,6 +2171,10 @@ function termid2size_filters(p, ds) {
 
 export function gdcValidate_query_singleSampleMutation(ds, genome) {
 	ds.queries.singleSampleMutation.get = async q => {
+		// skipDt is a server-internal Set (set by GRIN2). A client could send a look-alike value via the
+		// route (POST bodies merge into req.query); drop anything that isn't a real Set so the downstream
+		// ?.has() guards can't throw and turn malformed input into a 500
+		if (q.skipDt && !(q.skipDt instanceof Set)) q.skipDt = undefined
 		/*
 		q.sample value can be multiple types:
 		- sample submitter id from mds3 tk (if cached, if not cached it is aliquot id)

--- a/server/src/routes/termdb.singleSampleMutation.ts
+++ b/server/src/routes/termdb.singleSampleMutation.ts
@@ -85,8 +85,12 @@ export async function validate_query_singleSampleMutation(ds: any, genome: any) 
 			await file_is_readable(file)
 			const data = await read_file(file)
 			let mlst = JSON.parse(data)
-			// caller (e.g. GRIN2) may only want a subset of dt; drop the rest before returning
-			if (q.skipDt?.size) mlst = mlst.filter((m: any) => !q.skipDt!.has(m.dt))
+			// caller (e.g. GRIN2) may only want a subset of dt; drop the rest before returning.
+			// skipDt is a server-internal Set; guard with instanceof so a malformed client-sent value
+			// (POST bodies merge into req.query) can't reach .has() and turn into a 500
+			if (q.skipDt instanceof Set && q.skipDt.size && Array.isArray(mlst)) {
+				mlst = mlst.filter((m: any) => !q.skipDt!.has(m.dt))
+			}
 			// object wraps around mlst[] so it's possible to add other attr e.g. total number of mutations that exceeds viewing limit
 			return { mlst }
 		}

--- a/server/src/routes/termdb.singleSampleMutation.ts
+++ b/server/src/routes/termdb.singleSampleMutation.ts
@@ -84,8 +84,11 @@ export async function validate_query_singleSampleMutation(ds: any, genome: any) 
 			if (!file) throw 'no file returned'
 			await file_is_readable(file)
 			const data = await read_file(file)
+			let mlst = JSON.parse(data)
+			// caller (e.g. GRIN2) may only want a subset of dt; drop the rest before returning
+			if (q.skipDt?.size) mlst = mlst.filter((m: any) => !q.skipDt!.has(m.dt))
 			// object wraps around mlst[] so it's possible to add other attr e.g. total number of mutations that exceeds viewing limit
-			return { mlst: JSON.parse(data) }
+			return { mlst }
 		}
 	} else {
 		throw 'unknown singleSampleMutation.src'

--- a/shared/types/src/routes/termdb.singleSampleMutation.ts
+++ b/shared/types/src/routes/termdb.singleSampleMutation.ts
@@ -7,6 +7,10 @@ export type TermdbSingleSampleMutationRequest = {
 	dslabel: string
 	/** sample id, allow string or number; for native ds, sample name in number will be cast into string */
 	sample: string | number
+	/** optional set of dt (data type) numbers to skip fetching, for callers (e.g. GRIN2) that only need
+	a subset of mutation types. Server-internal only — not sent over HTTP, so it's a Set rather than JSON.
+	When omitted, all dt are returned. */
+	skipDt?: Set<number>
 }
 type ValidResponse = {
 	/** List of mutation data points from this sample TODO change to type of M elements */


### PR DESCRIPTION
# Description
First step towards supporting different CNV types in GDC. This branch introduces the `skipDt` set (made as a complement of the `enabledTypes` work done earlier to GRIN2) (i.e. if the dt is not included in `enabledTypes` include it in `skipDt`). This now allows only the data types that are selected to be fetched. This noticeably speeds up fetching especially for the much smaller snvindel files 

# To test
Go [here](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:-1},%22plots%22:[{%22chartType%22:%22grin2%22}],%22termfilter%22:{%22filter0%22:{%22op%22:%22and%22,%22content%22:[{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.disease_type%22,%22value%22:%22ductal%20and%20lobular%20neoplasms%22}}]}}}) and uncheck CNV. Run GRIN2. Should run much faster. You can also check CNV only branch and it should take a little less time as well but is slower due to the CNV files being a good bit larger than snvindel files

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
