### PR TITLE
GRIN2: CNV type selection

### DIFF
--- a/client/plots/grin2/GRIN2Types.ts
+++ b/client/plots/grin2/GRIN2Types.ts
@@ -55,7 +55,7 @@ export interface GRIN2RequestData {
 	hardCap?: number
 	binSize?: number
 	snvindelOptions?: { consequences: string[]; mafFilter?: any }
-	cnvOptions?: { lossThreshold: number; gainThreshold: number; maxSegLength: number }
+	cnvOptions?: { lossThreshold?: number; gainThreshold?: number; maxSegLength: number; cnvType?: string }
 	fusionOptions?: Record<string, any>
 	svOptions?: Record<string, any>
 	excludeOptions?: { blacklists?: string[]; overlapFrac?: number }

--- a/client/plots/grin2/grin2.ts
+++ b/client/plots/grin2/grin2.ts
@@ -152,7 +152,9 @@ export async function getPlotConfig(opts: GRIN2Opts, app: MassAppApi) {
 	if (queries?.snvindel) {
 		dtUsage[dtsnvindel] = { checked: true, label: dt2lesion[dtsnvindel].uilabel }
 	}
-	if (queries?.cnv) {
+	// CNV is available either via a ds-level cnv query (file-based ds) or via per-sample cnv file types
+	// declared on singleSampleMutation (e.g. GDC, which has no queries.cnv but serves cnv per case).
+	if (queries?.cnv || queries?.singleSampleMutation?.cnvTypes?.length) {
 		dtUsage[dtcnv] = { checked: true, label: dt2lesion[dtcnv].uilabel }
 	}
 	if (queries?.svfusion) {

--- a/client/plots/grin2/settings/Settings.ts
+++ b/client/plots/grin2/settings/Settings.ts
@@ -12,9 +12,11 @@ export interface GRIN2Settings {
 
 	/** Persisted CNV options. Populated after the first Run from the form. */
 	cnvOptions?: {
-		lossThreshold: number
-		gainThreshold: number
+		lossThreshold?: number
+		gainThreshold?: number
 		maxSegLength: number
+		/** id of the selected cnv file type, for datasets exposing queries.singleSampleMutation.cnvTypes */
+		cnvType?: string
 	}
 
 	/** Persisted fusion options (currently no user-configurable fields). */

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -1,4 +1,4 @@
-import { table2col, make_one_checkbox } from '#dom'
+import { table2col, make_one_checkbox, make_radios } from '#dom'
 import { dtsnvindel, mclass, dtcnv, dtfusionrna, dtsv, proteinChangingMutations, dt2lesion } from '#shared/common.js'
 import { filterInit } from '#filter'
 import type { GRIN2ControlsCallbacks, DtUsage } from '../GRIN2Types'
@@ -39,8 +39,10 @@ export class GRIN2ControlsView {
 	private cnv_lossThreshold: any = null
 	private cnv_gainThreshold: any = null
 	private cnv_maxSegLength: any = null
-	/** how this ds quantifies cnv values; from ds.queries.cnv.type, default 'log2ratio' */
+	/** how this ds quantifies cnv values; from the selected cnv type or ds.queries.cnv.type, default 'log2ratio' */
 	private cnvType: CnvType = 'log2ratio'
+	/** id of the user-selected cnv file type, when the ds exposes singleSampleMutation.cnvTypes (else null) */
+	private cnvSelectedTypeId: string | null = null
 
 	// one checkbox per genome-declared blacklist source, keyed by source name
 	private excludeCheckboxes: Record<string, any> = {}
@@ -76,7 +78,7 @@ export class GRIN2ControlsView {
 		const table = table2col({ holder: this.controlsHolder, disableScroll: true })
 		const queries = this.vocabApi.termdbConfig.queries
 		if (queries.snvindel) this.addSnvindelRow(table)
-		if (queries.cnv) this.addCnvRow(table)
+		if (queries.cnv || queries.singleSampleMutation?.cnvTypes?.length) this.addCnvRow(table)
 		if (queries.svfusion?.dtLst?.includes(dtfusionrna)) this.addFusionRow(table)
 		if (queries.svfusion?.dtLst?.includes(dtsv)) this.addSvRow(table)
 
@@ -116,6 +118,8 @@ export class GRIN2ControlsView {
 			requestConfig.cnvOptions = {
 				maxSegLength: parseFloat(this.cnv_maxSegLength.property('value'))
 			}
+			// id of the selected cnv file type (datasets exposing singleSampleMutation.cnvTypes, e.g. GDC)
+			if (this.cnvSelectedTypeId) requestConfig.cnvOptions.cnvType = this.cnvSelectedTypeId
 			// 'category' is a qualitative call with no numeric thresholds; the rows aren't rendered
 			if (this.cnv_lossThreshold && this.cnv_gainThreshold) {
 				requestConfig.cnvOptions.lossThreshold = parseFloat(this.cnv_lossThreshold.property('value'))
@@ -206,18 +210,82 @@ export class GRIN2ControlsView {
 
 	private addCnvRow(table: any) {
 		const [left, right] = table.addRow()
-		const t2 = table2col({ holder: right })
+		// container toggled by the cnv checkbox; holds the type radios (if any) + threshold inputs
+		const cnvBody = right.append('div')
 
 		// Only use saved CNV settings if a previous run completed
 		const useSaved = this.config.settings.runAnalysis === true
 		const savedCnv = useSaved ? this.config.settings.cnvOptions : undefined
 		const cnvQuery = this.vocabApi.termdbConfig.queries.cnv
+		// datasets that serve multiple cnv file types per sample (e.g. GDC masked vs allele-specific)
+		const cnvTypes = this.vocabApi.termdbConfig.queries.singleSampleMutation?.cnvTypes as
+			| { id: string; label: string; valueType: CnvType; dataType: string }[]
+			| undefined
 
-		// How this ds quantifies cnv values drives the threshold controls.
-		// Numeric types (log2ratio/segmean/copyNumber) show loss/gain thresholds with type-specific
-		// defaults and ranges; 'category' is qualitative and hides them.
-		this.cnvType = cnvQuery?.type ?? 'log2ratio'
-		const cfg = CNV_TYPE_CONFIG[this.cnvType]
+		// radios (if any) sit above the threshold inputs, which are rebuilt when the selected type changes
+		const radioHolder = cnvTypes?.length ? cnvBody.append('div').style('margin-bottom', '6px') : null
+		const thresholdHolder = cnvBody.append('div')
+
+		if (cnvTypes?.length) {
+			// initial selection: a saved & still-valid type, else the first declared type
+			const savedId = savedCnv?.cnvType
+			this.cnvSelectedTypeId = (savedId && cnvTypes.find(t => t.id === savedId)?.id) || cnvTypes[0].id
+
+			// one radio per declared cnv type; switching rebuilds the threshold rows for the new valueType
+			make_radios({
+				holder: radioHolder,
+				options: cnvTypes.map(t => ({
+					label: t.label,
+					value: t.id,
+					checked: t.id === this.cnvSelectedTypeId,
+					testid: `sjpp-grin2-cnvtype-${t.id}`
+				})),
+				styles: { display: 'block' },
+				callback: (value: string) => {
+					this.cnvSelectedTypeId = value
+					const def = cnvTypes.find(t => t.id === value)
+					// only reuse saved thresholds when the user is back on the saved type; otherwise show defaults
+					const savedForType = value === savedCnv?.cnvType ? savedCnv : undefined
+					this.renderCnvThresholdRows(thresholdHolder, def?.valueType ?? 'log2ratio', savedForType, cnvQuery)
+				}
+			})
+		} else {
+			this.cnvSelectedTypeId = null
+		}
+
+		// initial threshold rows. valueType from the selected type (cnvTypes ds) or ds-level cnv.type (file ds)
+		const initialValueType: CnvType =
+			(cnvTypes?.length ? cnvTypes.find(t => t.id === this.cnvSelectedTypeId)?.valueType : cnvQuery?.type) ??
+			'log2ratio'
+		// savedCnv only applies to the initially-selected type (or to the single-type file ds case)
+		const initialSaved = !cnvTypes?.length || this.cnvSelectedTypeId === savedCnv?.cnvType ? savedCnv : undefined
+		this.renderCnvThresholdRows(thresholdHolder, initialValueType, initialSaved, cnvQuery)
+
+		const dtUsage = this.config.settings.dtUsage
+		const isChecked =
+			useSaved && dtUsage[dtcnv]?.checked !== undefined ? dtUsage[dtcnv].checked : !!(cnvQuery || cnvTypes?.length)
+		cnvBody.style('display', isChecked ? '' : 'none')
+
+		this.cnvCheckbox = make_one_checkbox({
+			holder: left,
+			labeltext: dt2lesion[dtcnv].uilabel,
+			checked: isChecked,
+			testid: 'sjpp-grin2-checkbox-cnv',
+			callback: (checked: boolean) => {
+				cnvBody.style('display', checked ? '' : 'none')
+				this.updateRunButtonFromCheckboxes()
+			}
+		})
+	}
+
+	/** (Re)build the loss/gain/maxSeg inputs for a given cnv value type. Called on first render and whenever
+	 *  the user switches cnv type — segmean/copyNumber/log2ratio have type-specific defaults and ranges, and
+	 *  'category' is qualitative and hides the thresholds entirely. */
+	private renderCnvThresholdRows(holder: any, valueType: CnvType, savedCnv: any, cnvQuery: any) {
+		holder.selectAll('*').remove()
+		this.cnvType = valueType
+		const cfg = CNV_TYPE_CONFIG[valueType]
+		const t2 = table2col({ holder })
 
 		if (!cfg.hideThresholds) {
 			this.cnv_lossThreshold = this.addOptionRowToTable(
@@ -236,6 +304,10 @@ export class GRIN2ControlsView {
 				cfg.gainMax,
 				cfg.step
 			)
+		} else {
+			// qualitative call: no numeric thresholds; clear any stale inputs so getConfigValues omits them
+			this.cnv_lossThreshold = null
+			this.cnv_gainThreshold = null
 		}
 		this.cnv_maxSegLength = this.addOptionRowToTable(
 			t2,
@@ -245,21 +317,6 @@ export class GRIN2ControlsView {
 			1e9,
 			1000
 		)
-
-		const dtUsage = this.config.settings.dtUsage
-		const isChecked = useSaved && dtUsage[dtcnv]?.checked !== undefined ? dtUsage[dtcnv].checked : !!cnvQuery
-		t2.table.style('display', isChecked ? '' : 'none')
-
-		this.cnvCheckbox = make_one_checkbox({
-			holder: left,
-			labeltext: dt2lesion[dtcnv].uilabel,
-			checked: isChecked,
-			testid: 'sjpp-grin2-checkbox-cnv',
-			callback: (checked: boolean) => {
-				t2.table.style('display', checked ? '' : 'none')
-				this.updateRunButtonFromCheckboxes()
-			}
-		})
 	}
 
 	private addFusionRow(table: any) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GRIN2: per-type CNV selection with drop reporting

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -307,6 +307,10 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 						['Processed Samples', processing.processedSamples!.toLocaleString()],
 						['Unprocessed Samples', (processing.unprocessedSamples ?? 0).toLocaleString()],
 						['Failed Samples', processing.failedSamples!.toLocaleString()],
+						// only shown when a cnv-type selection actually dropped some samples' cnv
+						...(processing.droppedCnvNoType
+							? [['Dropped (CNV type unavailable)', processing.droppedCnvNoType.toLocaleString()]]
+							: []),
 						['Total Lesions', processing.totalLesions!.toLocaleString()],
 						['Processed Lesions', processing.processedLesions!.toLocaleString()]
 					]
@@ -577,6 +581,7 @@ async function processSampleData(
 		totalLesions: number
 		processedLesions: number
 		unprocessedSamples: number
+		droppedCnvNoType: number
 		lesionCap?: number
 		lesionCounts?: {
 			total: number
@@ -588,12 +593,25 @@ async function processSampleData(
 	const maxLesions = await getMaxLesions()
 	mayLog(`[GRIN2] Max lesions for this run: ${maxLesions.toLocaleString()}`)
 
-	// How this ds quantifies cnv values; drives gain/loss classification.
-	// Absent => 'log2ratio' (legacy default, diploid baseline 0).
-	const cnvType: CnvType = ds.queries?.cnv?.type ?? 'log2ratio'
+	// The user may select one of several cnv file types the ds declares (ds.queries.singleSampleMutation.cnvTypes,
+	// e.g. GDC masked-segment vs allele-specific). The selected def's valueType is the authoritative cnv
+	// quantification for this run; pass the def to the getter so it loads only that file type.
+	const cnvTypeDefs = ds.queries?.singleSampleMutation?.cnvTypes as
+		| { id: string; label: string; valueType: CnvType; dataType: string }[]
+		| undefined
+	const selectedCnvDef = request.cnvOptions?.cnvType
+		? cnvTypeDefs?.find(t => t.id === request.cnvOptions!.cnvType)
+		: undefined
+
+	// How this ds quantifies cnv values; drives gain/loss classification. The selected type wins; else the
+	// ds-level default (file-based datasets); else 'log2ratio' (legacy default, diploid baseline 0).
+	const cnvType: CnvType = selectedCnvDef?.valueType ?? ds.queries?.cnv?.type ?? 'log2ratio'
 
 	// Track unique samples per lesion type for reporting
 	const samplesPerType = new Map<number, Set<string>>()
+	// Track unique samples per *lesion type* (gain/loss/mutation/...) so the summary can report, e.g.,
+	// how many samples have a gain vs a loss — distinct from samplesPerType, which is per data type.
+	const samplesPerLesionType = new Map<string, Set<string>>()
 	const enabledTypes: number[] = []
 	if (request.snvindelOptions) enabledTypes.push(dtsnvindel)
 	if (request.cnvOptions) enabledTypes.push(dtcnv)
@@ -610,7 +628,9 @@ async function processSampleData(
 		failedSamples: 0,
 		totalLesions: 0,
 		processedLesions: 0,
-		unprocessedSamples: 0
+		unprocessedSamples: 0,
+		// cases that had cnv file(s) but none of the user-selected cnv type (their cnv was dropped, ssm kept)
+		droppedCnvNoType: 0
 	} as {
 		totalSamples: number
 		processedSamples: number
@@ -618,6 +638,7 @@ async function processSampleData(
 		totalLesions: number
 		processedLesions: number
 		unprocessedSamples: number
+		droppedCnvNoType: number
 		lesionCap?: number
 		lesionCounts?: {
 			total: number
@@ -645,7 +666,17 @@ async function processSampleData(
 		concurrency,
 		async sample => {
 			try {
-				const { mlst } = await ds.queries.singleSampleMutation.get({ sample: sample.name, skipDt })
+				const { mlst, droppedCnvNoMatch } = await ds.queries.singleSampleMutation.get({
+					sample: sample.name,
+					skipDt,
+					// only set when the user selected a specific cnv type; the getter loads only this type and
+					// flags droppedCnvNoMatch when the case has cnv but not of this type
+					cnvType: selectedCnvDef
+						? { id: selectedCnvDef.id, dataType: selectedCnvDef.dataType, valueType: selectedCnvDef.valueType }
+						: undefined
+				})
+
+				if (droppedCnvNoMatch) processing.droppedCnvNoType! += 1
 
 				const { sampleLesions, contributedTypes } = processSampleMlst(sample.name, mlst, request, cnvType)
 
@@ -657,11 +688,23 @@ async function processSampleData(
 				// Merge synchronously (no await below) so concurrent workers can't interleave the cap math
 				const remainingCapacity = maxLesions - lesions.length
 				if (remainingCapacity <= 0) return
-				lesions.push(...filteredLesions.slice(0, remainingCapacity))
+				const usedLesions = filteredLesions.slice(0, remainingCapacity)
+				lesions.push(...usedLesions)
 
 				// Track samples for each type they contributed to
 				for (const type of contributedTypes) {
 					samplesPerType.get(type)?.add(sample.name)
+				}
+
+				// Track samples per lesion type from the lesions actually used (consistent with lesionTypeCounts)
+				for (const lesion of usedLesions) {
+					const lt = lesion[4]
+					let set = samplesPerLesionType.get(lt)
+					if (!set) {
+						set = new Set<string>()
+						samplesPerLesionType.set(lt, set)
+					}
+					set.add(sample.name)
 				}
 
 				processing.processedSamples! += 1
@@ -697,7 +740,6 @@ async function processSampleData(
 	}
 
 	for (const type of enabledTypes) {
-		const sampleCount = samplesPerType.get(type)?.size || 0
 		const dtConfig = dt2lesion[type]
 
 		if (!dtConfig) continue
@@ -705,7 +747,8 @@ async function processSampleData(
 		dtConfig.lesionTypes.forEach(lt => {
 			lesionCounts.byType[lt.lesionType] = {
 				count: lesionTypeCounts[lt.lesionType] || 0,
-				samples: sampleCount
+				// samples with at least one lesion of this specific lesion type (e.g. gain vs loss separately)
+				samples: samplesPerLesionType.get(lt.lesionType)?.size || 0
 			}
 		})
 	}

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -769,7 +769,7 @@ async function getCnvFusion4oneCase(opts, ds) {
 	const skipCnv = opts.skipDt?.has(common.dtcnv)
 	const skipFusion = opts.skipDt?.has(common.dtfusionrna)
 	// neither cnv nor fusion requested: skip the files listing fetch entirely
-	if (skipCnv && skipFusion) return {}
+	if (skipCnv && skipFusion) return { dt2files: {}, cnvAnyType: false }
 
 	const fields = [
 		'cases.samples.tissue_type',
@@ -800,6 +800,12 @@ async function getCnvFusion4oneCase(opts, ds) {
 	const cnvfiles = [],
 		fusionfiles = []
 
+	// when a specific cnv type is requested (GRIN2 radio selection), load only files of that GDC data_type.
+	// cnvAnyType still flips true for any cnv-eligible hit (pre-filter) so the caller can tell apart
+	// "case has no cnv at all" from "case has cnv but not the requested type".
+	const wantDataType = opts.cnvType?.dataType
+	let cnvAnyType = false
+
 	for (const h of re.data.hits) {
 		if (!h.cases?.[0]) throw new Error(`h.cases[0] missing for file =${h.file_id}`)
 		if (h.data_format == 'BEDPE') {
@@ -823,6 +829,8 @@ async function getCnvFusion4oneCase(opts, ds) {
 			if (skipCnv) continue
 			if (h.experimental_strategy == 'Genotyping Array') {
 				if (h.data_type == 'Masked Copy Number Segment' || h.data_type == ascns) {
+					cnvAnyType = true
+					if (wantDataType && h.data_type != wantDataType) continue
 					cnvfiles.push({
 						nameHtml: `<a href=https://portal.gdc.cancer.gov/files/${h.file_id} target=_blank>${h.file_name}</a>`,
 						mlst: await loadCnvFile(host, h.file_id),
@@ -835,6 +843,8 @@ async function getCnvFusion4oneCase(opts, ds) {
 				// is wgs, no need to check tissue_type, the file is usable
 				if (!h.file_id) continue
 				if (h.data_type != ascns) continue
+				cnvAnyType = true
+				if (wantDataType && h.data_type != wantDataType) continue
 				cnvfiles.push({
 					nameHtml: `<a href=https://portal.gdc.cancer.gov/files/${h.file_id} target=_blank>${h.file_name}</a>`,
 					mlst: await loadCnvFile(host, h.file_id),
@@ -847,7 +857,7 @@ async function getCnvFusion4oneCase(opts, ds) {
 	const dt2files = {}
 	if (fusionfiles.length) dt2files[common.dtfusionrna] = fusionfiles
 	if (cnvfiles.length) dt2files[common.dtcnv] = cnvfiles
-	return dt2files
+	return { dt2files, cnvAnyType }
 
 	function getAttr(h) {
 		return {
@@ -909,7 +919,17 @@ cnv files come in different formats. detect by header line
 */
 async function loadCnvFile(host, fid) {
 	const re = await xfetch(joinUrl(host.rest, 'data', fid), { timeout: false })
-	const lines = re.trim().split('\n')
+	return parseGdcCnvFile(re)
+}
+
+/*
+Parse the text content of a GDC cnv file into an mlst[]. Kept pure (no network) so it can be unit tested.
+The file format is detected by header line; each format stamps a cnv valueType that drives downstream
+gain/loss classification (segment-mean => 'segmean' baseline 0; total copy number => 'copyNumber' baseline 2).
+The copy-number format additionally emits a dtloh event for strict one-allele loss (minor==0, major>0).
+*/
+export function parseGdcCnvFile(text) {
+	const lines = text.trim().split('\n')
 	const mlst = []
 	switch (lines[0]) {
 		case 'GDC_Aliquot_ID\tChromosome\tStart\tEnd\tNum_Probes\tSegment_Mean':
@@ -925,7 +945,9 @@ async function loadCnvFile(host, fid) {
 					chr,
 					start: Number(l[2]),
 					stop: Number(l[3]),
-					value: Number(l[5])
+					value: Number(l[5]),
+					// segment-mean header => log2ratio-style value, diploid baseline 0
+					valueType: 'segmean'
 				}
 				if (Number.isNaN(cnv.start) || Number.isNaN(cnv.stop) || Number.isNaN(cnv.value))
 					throw 'start/stop/value not a number in cnv file: ' + l
@@ -945,7 +967,9 @@ async function loadCnvFile(host, fid) {
 					chr: l[1],
 					start: Number(l[2]),
 					stop: Number(l[3]),
-					value: total
+					value: total,
+					// total-copy-number header => absolute copy number, diploid baseline 2
+					valueType: 'copyNumber'
 				}
 				if (!cnv.chr || Number.isNaN(cnv.start) || Number.isNaN(cnv.stop)) continue
 				mlst.push(cnv)
@@ -2175,6 +2199,10 @@ export function gdcValidate_query_singleSampleMutation(ds, genome) {
 		// route (POST bodies merge into req.query); drop anything that isn't a real Set so the downstream
 		// ?.has() guards can't throw and turn malformed input into a 500
 		if (q.skipDt && !(q.skipDt instanceof Set)) q.skipDt = undefined
+		// cnvType is a server-internal descriptor {id,dataType,valueType} set by GRIN2 to pick a cnv file
+		// type. Drop anything that isn't a well-formed object so a client look-alike can't influence which
+		// file loads or crash the getter
+		if (q.cnvType && (typeof q.cnvType != 'object' || typeof q.cnvType.dataType != 'string')) q.cnvType = undefined
 		/*
 		q.sample value can be multiple types:
 		- sample submitter id from mds3 tk (if cached, if not cached it is aliquot id)
@@ -2517,8 +2545,11 @@ async function getSingleSampleMutations(query, ds, genome) {
 	}
 
 	// cnv and fusion are loaded from per-sample text files
-	const dt2files = await getCnvFusion4oneCase(query, ds)
+	const { dt2files, cnvAnyType } = await getCnvFusion4oneCase(query, ds)
 	const cfs = dt2files[common.dtcnv]
+	// GRIN2 may request a specific cnv type. If the case had cnv file(s) but none of the requested
+	// type, drop only its cnv contribution (ssm/fusion are untouched) and let the caller report it.
+	if (query.cnvType && cnvAnyType && !cfs?.length) result.droppedCnvNoMatch = true
 	if (cfs) {
 		// select a default set of cnvs to insert to mlst so it shows on disco;
 		const usefile = cfs.find(f => f.attrs['Experimental Strategy'] == 'WGS' || f.attrs['Data Type'] == ascns) || cfs[0]

--- a/server/src/routes/termdb.config.ts
+++ b/server/src/routes/termdb.config.ts
@@ -259,6 +259,15 @@ function addNonDictionaryQueries(c, ds: Mds3WithCohort, genome): void {
 			sample_id_key: q.singleSampleMutation.sample_id_key,
 			discoPlot: q.singleSampleMutation.discoPlot
 		}
+		// supported cnv file types (e.g. GDC masked vs allele-specific). GRIN2 renders these as radios.
+		if (Array.isArray(q.singleSampleMutation.cnvTypes) && q.singleSampleMutation.cnvTypes.length) {
+			q2.singleSampleMutation.cnvTypes = q.singleSampleMutation.cnvTypes.map(t => ({
+				id: t.id,
+				label: t.label,
+				valueType: t.valueType,
+				dataType: t.dataType
+			}))
+		}
 	}
 	if (q.singleSampleGenomeQuantification) {
 		q2.singleSampleGenomeQuantification = {}

--- a/server/src/test/mds3.gdc.unit.spec.js
+++ b/server/src/test/mds3.gdc.unit.spec.js
@@ -1,5 +1,6 @@
 import tape from 'tape'
-import { flattenCaseByFields } from '../mds3.gdc.js'
+import { flattenCaseByFields, parseGdcCnvFile } from '../mds3.gdc.js'
+import { dtcnv, dtloh } from '#shared/common.js'
 
 tape('\n', function (test) {
 	test.comment('-***- src/mds3.gdc.specs specs -***-')
@@ -51,5 +52,60 @@ tape('flattenCaseByFields(): multiple diagnoses entries', test => {
 	const sample = {}
 	flattenCaseByFields(sample, hit, tw)
 	test.deepEqual(sample, { 'case.diagnoses.age_at_diagnosis': 20 }, 'should flatten nested case data')
+	test.end()
+})
+
+tape("parseGdcCnvFile(): segment-mean file stamps valueType='segmean'", test => {
+	// snp-array "Masked Copy Number Segment" format: 6 cols, chr without "chr" prefix
+	const text = [
+		'GDC_Aliquot\tChromosome\tStart\tEnd\tNum_Probes\tSegment_Mean',
+		'aliquot1\t1\t1000\t2000\t50\t0.8',
+		'aliquot1\t17\t3000\t4000\t60\t-0.6'
+	].join('\n')
+
+	const mlst = parseGdcCnvFile(text)
+	test.equal(mlst.length, 2, 'two cnv segments parsed')
+	test.deepEqual(
+		mlst[0],
+		{ dt: dtcnv, chr: 'chr1', start: 1000, stop: 2000, value: 0.8, valueType: 'segmean' },
+		"first segment carries valueType 'segmean' and chr prefix added"
+	)
+	test.ok(
+		mlst.every(m => m.dt === dtcnv && m.valueType === 'segmean'),
+		'every segment is dtcnv with segmean valueType'
+	)
+	test.end()
+})
+
+tape("parseGdcCnvFile(): copy-number file stamps valueType='copyNumber' and emits LOH", test => {
+	// allele-specific "Allele-specific Copy Number Segment" format: 7 cols (total/major/minor)
+	const text = [
+		'GDC_Aliquot\tChromosome\tStart\tEnd\tCopy_Number\tMajor_Copy_Number\tMinor_Copy_Number',
+		'aliquot1\tchr1\t1000\t2000\t3\t2\t1', // total=3, minor!=0 => no loh
+		'aliquot1\tchr2\t5000\t6000\t2\t2\t0' // total=2>0, minor=0 & major>0 => strict one-allele loss => loh
+	].join('\n')
+
+	const mlst = parseGdcCnvFile(text)
+	const cnvs = mlst.filter(m => m.dt === dtcnv)
+	const lohs = mlst.filter(m => m.dt === dtloh)
+
+	test.equal(cnvs.length, 2, 'two cnv segments parsed')
+	test.ok(
+		cnvs.every(m => m.valueType === 'copyNumber'),
+		"every cnv segment carries valueType 'copyNumber'"
+	)
+	test.equal(cnvs[0].value, 3, 'cnv value is the total copy number')
+	test.equal(lohs.length, 1, 'one LOH event emitted for strict one-allele loss')
+	test.notOk('valueType' in lohs[0], 'LOH event is not stamped with a cnv valueType')
+	test.equal(lohs[0].segmean, 0.5, 'LOH event keeps its hardcoded segmean')
+	test.end()
+})
+
+tape('parseGdcCnvFile(): unknown header throws', test => {
+	test.throws(
+		() => parseGdcCnvFile('Some\tUnexpected\tHeader\nfoo\tbar\tbaz'),
+		/unknown CNV file header line/,
+		'rejects an unrecognized header line'
+	)
 	test.end()
 })

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -425,6 +425,20 @@ type SingleSampleMutationQuery = {
 		/** if true, filter mutations by predefined geneset by default */
 		prioritizeGeneLabelsByGeneSets?: true
 	}
+	/** CNV file types this ds can serve for a single sample. Present when a sample may have more than one
+	 * CNV file type (e.g. GDC: masked segment-mean vs allele-specific copy-number). GRIN2 renders these as
+	 * radio buttons and passes the chosen id to get() so only the matching file is loaded and classified.
+	 * Absent for single-type datasets, which classify by ds.queries.cnv.type. */
+	cnvTypes?: {
+		/** stable id sent in the request (GRIN2Request.cnvOptions.cnvType) */
+		id: string
+		/** radio button label */
+		label: string
+		/** how this type quantifies cnv values; drives gain/loss thresholds and classification */
+		valueType: 'log2ratio' | 'segmean' | 'copyNumber' | 'category'
+		/** source-specific selector the getter matches files against (GDC files-API data_type) */
+		dataType: string
+	}[]
 	/** rest of properties are required for native ds without ds-supplied getter
 	TODO migrate gdc to get() and delete .src=native
 	*/

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -90,6 +90,11 @@ export type GRIN2Request = {
 		maxSegLength?: number // Default: 0
 		/** Hypermutator max cut off for CNVs per case */
 		hyperMutator?: number // Default: 500
+		/** For datasets that expose multiple cnv file types (ds.queries.singleSampleMutation.cnvTypes),
+		 * the id of the user-selected type. The server resolves this id to a source-specific data_type
+		 * and a valueType, loads only the matching file, and classifies segments with that type's
+		 * baseline. Omitted for single-type datasets, which classify by ds.queries.cnv.type. */
+		cnvType?: string
 	}
 
 	/** Presence enables fusions in the analysis; no per-fusion filtering options yet */


### PR DESCRIPTION
# Description
GRIN2 previously had no way to choose which CNV file type to analyze. For datasets like **GDC**, a single case can have multiple CNV file types (e.g. *Masked Copy Number Segment* from SNP array with segment-mean values, vs *Allele-specific Copy Number Segment* with copy-number values), and the getter silently picked one default per case — mixing value semantics under a single set of thresholds, and classifying allele-specific (baseline-2) segments against log2-ratio thresholds.

This PR lets the user pick the CNV type via radio buttons, loads only the selected type, classifies it with the correct value baseline, and reports cases whose CNV was dropped because they lack the requested type.

## What changed

**Data model**
- New optional `ds.queries.singleSampleMutation.cnvTypes[]` (`{ id, label, valueType, dataType }`), exposed to the client via `termdb/config`. GDC declares two: masked (`segmean`) and allele-specific (`copyNumber`).
- New optional `cnvOptions.cnvType` (the selected type id) on the GRIN2 request.

**Server**
- `grin2/main.ts` resolves the selected type, passes it to `singleSampleMutation.get()`, and classifies with that type's `valueType` (selected type → ds-level `cnv.type` → `log2ratio` fallback). Non-`cnvTypes` datasets are unaffected.
- GDC getter (`mds3.gdc.js`): `getCnvFusion4oneCase` loads only the requested `data_type` and tracks whether the case had *any* CNV; `getSingleSampleMutations` flags `droppedCnvNoMatch` when a case has CNV but none of the requested type.
- GDC CNV parsing now stamps a per-segment `valueType`. The parsing was extracted into a pure, exported `parseGdcCnvFile()`.

**Drop semantics (by design)**: a mismatched case loses **only its CNV** contribution; its SNV/fusion/SV lesions are kept, so it still counts as "processed." The count surfaces as a gated **"Dropped (CNV type unavailable)"** row in the stats Summary.

**Stats**
- Loss/Gain sample counts are now reported **per lesion type** (samples with ≥1 loss vs ≥1 gain) instead of a single per-data-type count.

**Client**
- CNV row now renders for datasets exposing `cnvTypes` (GDC has no `queries.cnv`). Radio buttons are sourced from `cnvTypes`; switching rebuilds the threshold inputs for the new type's `valueType` (defaults/ranges differ). Selection is sent in the request and persisted across runs.
- Radios get per-option `data-testid="sjpp-grin2-cnvtype-<id>"`; existing testids unchanged.

## Testing

- Existing `grin2` unit suite (61 tests) covers `filterAndConvertCnv` per-`valueType` classification — still green.
- New unit tests for `parseGdcCnvFile()`: segment-mean stamps `valueType:'segmean'` (+ `chr` prefix handling); copy-number stamps `valueType:'copyNumber'`, emits a `dtloh` event only for strict one-allele loss, and leaves LOH unstamped; unknown header throws.
- `tsc` clean across shared/types, server, client; prettier clean.

**Manual validation** across GBM and breast (ductal+lobular) cohorts, both CNV types:
- Mutation lesion/sample counts are **byte-identical** between the two CNV types in each cohort (confirms the CNV-type switch never touches SNV).
- Drop count tracks data coverage (GBM allele-specific 74 → masked 244; breast 14 → 216).
- Drivers are stable and biologically faithful (GBM: EGFR/CDKN2A/B/PTEN/TP53; breast: CDH1, 11q13 amplicon, ERBB2), with amplicon magnitude correctly softening under log2-ratio thresholds.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
