### PR TITLE
CohortMAF: forward the user's real User-Agent to GDC downloads

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Fixes:
+- forward the end user's real User-Agent onto the GDC cohort MAF file downloads instead of a hardcoded browser User-Agent

--- a/server/src/routes/gdc.mafBuild.ts
+++ b/server/src/routes/gdc.mafBuild.ts
@@ -7,13 +7,6 @@ import { maxTotalSizeCompressed } from './gdc.maf.ts'
 import { mayLog } from '#src/helpers.ts'
 import serverconfig from '#src/serverconfig.js'
 
-// GDC's stricter environments (e.g. qa-int) sit behind a proxy/WAF that can reject requests
-// from header-less HTTP clients. Identify the file downloads with a normal browser User-Agent.
-// (prod works without it; this is a defensive measure for qa-int and can be swapped for a
-// descriptive UA if a browser-like agent turns out not to be required.)
-const gdcDownloadUserAgent =
-	'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'
-
 // watchdog kill threshold (ms) for the gdcmaf rust process; a safety backstop against a
 // hung/leaked download. Defaults to 5 minutes; overridable via serverconfig for slower
 // GDC environments (e.g. qa-int) where a legitimate large download may need more time.
@@ -46,7 +39,10 @@ export function init({ genomes }) {
 			const ds = g.datasets.GDC
 			if (!ds) throw 'hg38 GDC missing'
 			const q: GdcMafBuildRequest = req.query
-			await buildMaf(q, res, ds)
+			// the end user's real User-Agent, forwarded onto the GDC file downloads so GDC's
+			// proxy/WAF sees the actual client rather than a header-less rust client
+			const userAgent = req.headers['user-agent']
+			await buildMaf(q, res, ds, userAgent)
 		} catch (e: any) {
 			if (e.stack) console.log(e.stack)
 			res.send({ status: 'error', error: e.message || e })
@@ -68,7 +64,7 @@ type EmitJsonDataArg =
 q{}
 res{}
 */
-async function buildMaf(q: GdcMafBuildRequest, res, ds) {
+async function buildMaf(q: GdcMafBuildRequest, res, ds, userAgent?: string) {
 	const t0 = Date.now()
 	const { host, headers } = ds.getHostHeaders(q)
 	const fileLst2: string[] = await getFileLstUnderSizeLimit(q.fileIdLst, host, headers)
@@ -81,8 +77,10 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	// defeats keep-alive and forces a brand-new connection per file, and the application/json
 	// content-negotiation is wrong for a gzip download. Against a stricter GDC environment
 	// (e.g. qa-int, behind a proxy/WAF) this can cause all but the first concurrent download to
-	// be rejected. Forward only what a download needs: auth, plus a browser-like User-Agent.
-	const downloadHeaders: { [key: string]: string } = { 'User-Agent': gdcDownloadUserAgent }
+	// be rejected. Forward only what a download needs: auth, plus the end user's real User-Agent
+	// (passed in from the route handler) so GDC's proxy/WAF sees the actual client.
+	const downloadHeaders: { [key: string]: string } = {}
+	if (userAgent) downloadHeaders['User-Agent'] = userAgent
 	for (const [k, v] of Object.entries(headers)) {
 		const lk = k.toLowerCase()
 		if (lk === 'cookie' || lk === 'x-auth-token') downloadHeaders[k] = v as string


### PR DESCRIPTION
# Description
Send the **end user's real User-Agent** on the GDC cohort-MAF binary `/data/<uuid>` downloads, instead of the hardcoded browser User-Agent introduced with the qa-int connection fix. This way GDC's proxy/WAF (e.g. on qa-int) sees the actual client rather than a static string.

Follow-up to the qa-int multi-file MAF download fix (already merged into `release-2.191`).

## Changes
- Capture the user agent in the route handler: `req.headers['x-forwarded-agent'] || req.headers['user-agent']` — the forwarded agent set by an upstream proxy, falling back to the direct request's UA.
- Thread it into `buildMaf(...)` and set it on the download headers **only when present** (so no `User-Agent` is sent if neither is available, rather than an invalid `undefined`).
- Remove the hardcoded `gdcDownloadUserAgent` constant.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
