### PR TITLE
Make launched Disco plots session-saveable

### DIFF
--- a/client/mds3/sampletable.js
+++ b/client/mds3/sampletable.js
@@ -31,7 +31,7 @@ feedSample2selectCallback
 .block
 .div
 .tid2value={}
- 	sample filters by e.g. clicking on a sunburst ring, for tk.mds.variant2samples.get
+	  sample filters by e.g. clicking on a sunburst ring, for tk.mds.variant2samples.get
 .singleSampleDiv
 	optional, if just one single sample, can show into this table rather than creating a new one
 */
@@ -237,11 +237,11 @@ async function make_singleSampleTable(s, arg) {
 	}
 
 	/* quick fix for accessing details of a single case
-    if (arg.tk.mds.termdb && arg.tk.mds.termdb.allowCaseDetails) {
-        // has one single case
-        arg.div.append('div').text('Case details')
-    }
-    */
+	if (arg.tk.mds.termdb && arg.tk.mds.termdb.allowCaseDetails) {
+		// has one single case
+		arg.div.append('div').text('Case details')
+	}
+	*/
 }
 
 // get display value for a tw from a sample
@@ -333,8 +333,6 @@ function printSampleName(sample, tk, div, block, thisMutation) {
 }
 
 async function createDiscoInSandbox(tk, block, sample, thisMutation) {
-	// create ad-hoc sandbox; if newChartHolder is present, plot into it
-	const sandbox = newSandboxDiv(tk.newChartHolder || block.holder0)
 	const headerTexts = [sample.sample_id] // for sandbox header
 	if (thisMutation) {
 		// mutation of this sample is provided (tooltip currently shows info about this mutation)
@@ -347,20 +345,23 @@ async function createDiscoInSandbox(tk, block, sample, thisMutation) {
 		}
 		headerTexts.push(' ' + thisMutation.mname)
 	}
-	sandbox.header.text(headerTexts.join(''))
+	const sandbox = tk.massApp ? null : newSandboxDiv(tk.newChartHolder || block.holder0)
+	if (sandbox) sandbox.header.text(headerTexts.join(''))
 	try {
 		;(await import('#plots/plot.disco.js')).default(
 			tk.mds.termdbConfig,
 			tk.mds.label,
 			sample,
-			sandbox.body,
+			sandbox ? sandbox.body : tk.newChartHolder || block.holder0,
 			block.genome,
 			{
 				downloadImgName: headerTexts.join('') + ' Disco' // file name of svg downloaded from disco
-			}
+			},
+			true,
+			tk.massApp ? { app: tk.massApp } : {}
 		)
 	} catch (e) {
-		sandbox.body.append('div').text('Error: ' + (e.message || e))
+		;(sandbox ? sandbox.body : tk.newChartHolder || block.holder0).append('div').text('Error: ' + (e.message || e))
 		if (e.stack) console.log(e.stack)
 	}
 }

--- a/client/plots/disco/Disco.ts
+++ b/client/plots/disco/Disco.ts
@@ -51,10 +51,11 @@ export default class Disco {
 
 	async init() {
 		const state = this.app.getState()
-		const settings = state.plots.find(p => p.id === this.id).settings
+		const config = state.plots.find(p => p.id === this.id)
+		const settings = config.settings
 
 		this.stateViewModelMapper = new ViewModelMapper(settings, this.discoInteractions)
-		this.viewModel = this.stateViewModelMapper.map(state)
+		this.viewModel = this.stateViewModelMapper.map({ ...state, args: this.getArgs(state, config) })
 
 		const holder = this.opts.holder
 		const controlsHolder = holder.append('div').style('display', 'inline-block').style('vertical-align', 'top') // on the left
@@ -149,7 +150,7 @@ export default class Disco {
 			title: 'Show gene name labels on the outside of the plot'
 		})
 
-		const genomeChr = this.app.opts.state.args.genome.majorchr
+		const genomeChr = this.getArgs().genome.majorchr
 		const chromosomeConfigOption = {
 			label: 'Chromosomes',
 			title: 'Chromosomes shown in the plot',
@@ -229,7 +230,8 @@ export default class Disco {
 
 		if (this.recreateViewModel) {
 			this.stateViewModelMapper = new ViewModelMapper(settings, this.discoInteractions)
-			this.viewModel = this.stateViewModelMapper.map(this.app.getState())
+			const appState = this.app.getState()
+			this.viewModel = this.stateViewModelMapper.map({ ...appState, args: this.getArgs(appState) })
 		}
 		this.recreateViewModel = true
 
@@ -237,8 +239,9 @@ export default class Disco {
 			// TODO calculate viewModel.filteredSnvDataLength always
 			this.svgDiv.selectAll('*').remove() // todo not to need this
 			const appState = this.app.getState()
+			const discoAppState = { ...appState, args: this.getArgs(appState) }
 			this.viewModel.svgDiv = this.svgDiv
-			this.viewModel.appState = appState
+			this.viewModel.appState = discoAppState
 
 			for (const name in this.features) {
 				this.features[name].update({ state: this.state, appState })
@@ -249,7 +252,7 @@ export default class Disco {
 			const discoRenderer = new DiscoRenderer(
 				this.getRingRenderers(this.viewModel.settings, this.viewModel, this.discoInteractions.geneClickListener),
 				legendRenderer,
-				this.app.opts.state.args.genome
+				this.getArgs().genome
 			)
 
 			discoRenderer.render(this.svgDiv, this.viewModel, this.onCnvSourceSelect)
@@ -263,8 +266,9 @@ export default class Disco {
 	getState(appState: any) {
 		const config = appState.plots.find(p => p.id === this.id)
 		if (!config) return config
+		const args = this.getArgs(appState, config)
 		// include args.data so updates rerender when mutation list changes
-		return { ...config, mlst: appState.args.data }
+		return { ...config, mlst: args.data }
 	}
 
 	getRingRenderers(
@@ -304,9 +308,14 @@ export default class Disco {
 		return renderersMap
 	}
 
+	private getArgs(state = this.app.getState(), config = state.plots.find((p: any) => p.id === this.id)) {
+		return state.args || config?.args
+	}
+
 	private onCnvSourceSelect = (index: number) => {
 		const state = this.app.getState()
-		const args = state.args
+		const config = state.plots.find((p: any) => p.id === this.id)
+		const args = this.getArgs(state, config)
 		const alt = args.alternativeDataByDt?.[dtcnv]
 		if (!alt) return
 		const altClone = structuredClone(args.alternativeDataByDt)
@@ -315,10 +324,19 @@ export default class Disco {
 		selected.mlst.forEach((d: any) => (d.position = d.pos))
 		const baseData = args.data.filter((d: any) => d.dt != dtcnv && d.dt != dtloh)
 		const newData = baseData.concat(selected.mlst)
-		this.app.dispatch({
-			type: 'app_refresh',
-			state: { args: { ...args, data: newData, alternativeDataByDt: altClone } }
-		})
+		const nextArgs = { ...args, data: newData, alternativeDataByDt: altClone }
+		if (state.args) {
+			this.app.dispatch({
+				type: 'app_refresh',
+				state: { args: nextArgs }
+			})
+		} else {
+			this.app.dispatch({
+				type: 'plot_edit',
+				id: this.id,
+				config: { args: nextArgs }
+			})
+		}
 	}
 
 	toggleVisibility(isOpen: boolean) {
@@ -343,6 +361,7 @@ export async function getPlotConfig(opts: any, app: any) {
 		chartType: 'Disco',
 		subfolder: 'disco',
 		extension: 'ts',
-		settings: discoDefaults(opts.overrides, app)
+		settings: discoDefaults(opts.overrides, app),
+		args: opts.args
 	}
 }

--- a/client/plots/gb/GB.ts
+++ b/client/plots/gb/GB.ts
@@ -212,6 +212,7 @@ class TdbGenomeBrowser extends PlotBase implements RxComponent {
 	getOpts() {
 		const opts = {
 			genome: this.app.opts.genome,
+			app: this.app,
 			vocabApi: this.app.vocabApi,
 			debug: this.app.opts.debug,
 			plotDiv: this.opts.plotDiv,

--- a/client/plots/gb/view/View.ts
+++ b/client/plots/gb/view/View.ts
@@ -71,7 +71,8 @@ export class View {
 						this.interactions.maySaveTrackUpdatesToState(this.blockInstance)
 					},
 					// for showing disco etc as ad-hoc sandbox, persistently in the mass plotDiv, rather than a menu
-					newChartHolder: this.opts.plotDiv
+					newChartHolder: this.opts.plotDiv,
+					massApp: this.opts.app
 				}
 				// any cohort filter for this tk
 				{
@@ -108,7 +109,8 @@ export class View {
 								this.interactions.maySaveTrackUpdatesToState(this.blockInstance)
 							},
 							// for showing disco etc as ad-hoc sandbox, persistently in the mass plotDiv, rather than a menu
-							newChartHolder: this.opts.plotDiv
+							newChartHolder: this.opts.plotDiv,
+							massApp: this.opts.app
 						}
 						if (this.state.filter?.lst?.length) {
 							// join sub filter with global

--- a/client/plots/matrix/matrix.interactivity.js
+++ b/client/plots/matrix/matrix.interactivity.js
@@ -364,14 +364,15 @@ export function setInteractivity(self) {
 				.attr('data-testid', 'oncoMatrix_termLabel_disco_button')
 				.text('Disco plot')
 				.on('click', async event => {
-					const sandbox = newSandboxDiv(self.opts.plotDiv || select(self.opts.holder.node().parentNode))
-					sandbox.header.text(sample.sample_id)
 					;(await import('#plots/plot.disco.js')).default(
 						self.state.termdbConfig,
 						self.state.vocab.dslabel,
 						sample,
-						sandbox.body,
-						self.app.opts.genome
+						self.opts.holder,
+						self.app.opts.genome,
+						{},
+						true,
+						{ app: self.app }
 					)
 					menuDiv.remove()
 					self.dom.clickMenu.d.selectAll('*').remove()

--- a/client/plots/plot.disco.js
+++ b/client/plots/plot.disco.js
@@ -33,6 +33,7 @@ export default async function (
 	showError = true,
 	launchOptions = {}
 ) {
+	const plotlaunchOptions = _overrides.launchOptions || {}
 	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
 
 	try {
@@ -53,7 +54,7 @@ export default async function (
 		if (data.error) throw data.error
 		if (!Array.isArray(data.mlst)) throw 'data.mlst is not array'
 
-		if (data.dt2total?.length) {
+		if (!launchOptions.app && data.dt2total?.length) {
 			// array element: {dt:int, total:int}
 			// may pass this to disco argument to display it in legend
 			for (const o of data.dt2total) {
@@ -108,6 +109,7 @@ export default async function (
 
 		const opts = {
 			holder: holder,
+			app: plotlaunchOptions.app,
 
 			state: {
 				genome: genomeObj.name,
@@ -129,8 +131,11 @@ export default async function (
 }
 
 function computeOverrides(o, termdbConfig, genomeObj, sample) {
-	// parameter is duplicated into a new object; this script computes new attributes and add to the new obj
-	const overrides = structuredClone(o)
+	// parameter is duplicated into a new object; this script computes new attributes and add to the new obj.
+	// Do not include launchOptions in this clone: launchOptions.app may hold a live MASS app object
+	// with functions/DOM references that cannot be structured-cloned, and it belongs on PlotApp opts, not plot overrides.
+	const { launchOptions, ...cloneableOverrides } = o
+	const overrides = structuredClone(cloneableOverrides)
 	if (!overrides.Disco) overrides.Disco = {}
 
 	if (genomeObj.geneset) {

--- a/client/plots/plot.disco.js
+++ b/client/plots/plot.disco.js
@@ -23,7 +23,16 @@ genomeObj={}
 _overrides={}
 	optional override parameters to pass to disco
 */
-export default async function (termdbConfig, dslabel, sample, holder, genomeObj, _overrides = {}, showError = true) {
+export default async function (
+	termdbConfig,
+	dslabel,
+	sample,
+	holder,
+	genomeObj,
+	_overrides = {},
+	showError = true,
+	launchOptions = {}
+) {
 	const loadingDiv = holder.append('div').style('margin', '20px').text('Loading...')
 
 	try {
@@ -80,6 +89,23 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj,
 			}
 		}
 
+		const plotConfig = {
+			chartType: 'Disco',
+			subfolder: 'disco',
+			extension: 'ts',
+			overrides: computeOverrides(_overrides, termdbConfig, genomeObj, sample),
+			args: disco_arg
+		}
+
+		if (launchOptions.app) {
+			await launchOptions.app.dispatch({
+				type: 'plot_create',
+				config: plotConfig
+			})
+			loadingDiv.remove()
+			return true
+		}
+
 		const opts = {
 			holder: holder,
 
@@ -88,18 +114,11 @@ export default async function (termdbConfig, dslabel, sample, holder, genomeObj,
 				dslabel: dslabel,
 				args: disco_arg,
 
-				plots: [
-					{
-						chartType: 'Disco',
-						subfolder: 'disco',
-						extension: 'ts',
-						overrides: computeOverrides(_overrides, termdbConfig, genomeObj, sample)
-					}
-				]
+				plots: [plotConfig]
 			}
 		}
 		const plot = await import('#plots/plot.app.js')
-		const plotAppApi = await plot.appInit(opts)
+		await plot.appInit(opts)
 		loadingDiv.remove()
 		return true
 	} catch (e) {


### PR DESCRIPTION
# Description
Disco plots launched ad-hoc from matrix/mds3 were created in an isolated PlotApp and therefore their interactive state (filters, CNV source selection, etc.) could not be saved into the MASS session state.

The change aims to allow launched Disco plots to become ordinary MASS plots so their args and subsequent user edits are persisted and recoverable in saved sessions.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
