### PR TITLE
Allow `dsname` to be lower case from URL param

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes
+- Re-enable submitting 'dsname' as case insensitive input for dslabel. 

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -149,9 +149,12 @@ export function setAppMiddlewares(app, genomes, doneLoading, routes) {
 				/** Traditionally, 'dsname' is allowed to be case insensitive.
 				 * (e.g. 'pediatric' == 'Pediatric'). Assign the correct ds key
 				 * when a case-insensitive match is found.*/
-				for (const k in g.datasets) {
+				for (const k in g.datasets || {}) {
 					if (k.toLowerCase() == dslabel.toLowerCase()) {
 						ds = g.datasets[k]
+						dslabel = k
+						req.query.dslabel = k
+						if (req.query.dsname) req.query.dsname = k
 						break
 					}
 				}

--- a/server/src/app.middlewares.js
+++ b/server/src/app.middlewares.js
@@ -145,6 +145,17 @@ export function setAppMiddlewares(app, genomes, doneLoading, routes) {
 				return
 			}
 			ds = g.datasets?.[dslabel]
+			if (dsname && !ds) {
+				/** Traditionally, 'dsname' is allowed to be case insensitive.
+				 * (e.g. 'pediatric' == 'Pediatric'). Assign the correct ds key
+				 * when a case-insensitive match is found.*/
+				for (const k in g.datasets) {
+					if (k.toLowerCase() == dslabel.toLowerCase()) {
+						ds = g.datasets[k]
+						break
+					}
+				}
+			}
 			// do not check genome-level termdb, not dataset-level termdb
 			if (!ds && !g.termdbs?.[dslabel]) {
 				const paramName = mds3 ? 'mds3' : dsname ? 'dsname' : 'dslabel'


### PR DESCRIPTION
# Description

This PR re-enables `dsname` from a URL param to be case insensitive. Test with: http://localhost:3000/getDataset?genome=hg38&dsname=ball-scrna&embedder=localhost:3000. 

All client and server tests pass. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
