### PR TITLE
GRIN2: Improved GRIN2 snvindel fetch performance and reporting

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- Improved GRIN2 snvindel fetch performance and reporting by pre-filtering to open access only projects. Bounded concurrency with concurrencyLimiter.ts

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -260,6 +260,7 @@ async function cacheMappingOnNewRelease(ds, version) {
 	console.log('GDC: Done caching sample IDs. Time:', Math.ceil((new Date() - begin) / 1000), 's')
 	console.log('\t', ds.__gdc.aliquot2submitter.cache.size, 'aliquot IDs to sample submitter id,')
 	console.log('\t', ds.__gdc.caseid2submitter.size, 'case uuid to submitter id,')
+	console.log('\t', ds.__gdc.caseid2project.size, 'case uuid to project_id,')
 	console.log('\t', ds.__gdc.map2caseid.cache.size, 'different ids to case uuid,')
 	console.log('\t', ds.__gdc.casesWithExpData.size, 'cases with gene expression data.')
 	const date = new Date()
@@ -301,6 +302,7 @@ function getCacheRef(ds) {
 			}
 		},
 		caseid2submitter: new Map(), // k: case uuid, v: case submitter id
+		caseid2project: new Map(), // k: case uuid, v: project_id; lets callers tell open- vs controlled-access cases without a query (see gdcOpenProjects)
 		caseIds: new Set(), //
 		casesWithExpData: new Set(),
 		gdcOpenProjects: new Set(), // names of open-access projects
@@ -402,7 +404,9 @@ async function fetchIdsFromGdcApi(ds, size, from, ref, aliquot_id) {
 	// pagination results from the response may be less than the previous version's expected number of cases,
 	// in which case the loop to fetch IDs will never reach the total count, therefore trigger the caching to stop
 	if (mayCancelStalePendingCache(ds, ref)) return 0
-	const param = ['fields=submitter_id,samples.portions.analytes.aliquots.aliquot_id,samples.submitter_id']
+	const param = [
+		'fields=submitter_id,project.project_id,samples.portions.analytes.aliquots.aliquot_id,samples.submitter_id'
+	]
 	if (aliquot_id) {
 		param.push(
 			'filters={"op":"and","content":[{"op":"=","content":{"field":"samples.portions.analytes.aliquots.aliquot_id","value":["' +
@@ -470,6 +474,10 @@ async function fetchIdsFromGdcApi(ds, size, from, ref, aliquot_id) {
 		if (!case_submitter_id) throw 'h.submitter_id missing'
 
 		ref.caseid2submitter.set(case_id, case_submitter_id)
+
+		// project_id per case; used to pre-filter cases to open-access projects before querying (e.g. the
+		// GRIN2 ssm batchGet). project.project_id is requested in the fields above.
+		if (h.project?.project_id) ref.caseid2project.set(case_id, h.project.project_id)
 
 		/*
 		below shows different uuids mapping to same submitter id

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -302,6 +302,27 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 		])
 	}
 
+	// Coverage note: samples that contributed no open-access SNV/indel lesions, broken down by reason so the
+	// user can see why. Independent of the lesion cap above — both can apply — so it's its own note.
+	if (processing.ssmSamplesNoOpenAccess || processing.unmatchedSamples) {
+		const reasons: string[] = []
+		if (processing.ssmSamplesControlledAccess)
+			reasons.push(
+				`${processing.ssmSamplesControlledAccess.toLocaleString()} are in controlled-access GDC projects ` +
+					`(their mutation data requires a logged-in GDC session with the appropriate authorization)`
+			)
+		if (processing.ssmSamplesNoMutations)
+			reasons.push(`${processing.ssmSamplesNoMutations.toLocaleString()} are open-access but had no SNV/indel mutation`)
+		if (processing.unmatchedSamples)
+			reasons.push(`${processing.unmatchedSamples.toLocaleString()} could not be matched to a GDC case`)
+		const affected = (processing.ssmSamplesNoOpenAccess ?? 0) + (processing.unmatchedSamples ?? 0)
+		capWarningRows.push([
+			'Note',
+			`${affected.toLocaleString()} of ${processing.totalSamples!.toLocaleString()} samples contributed no SNV/indel lesions: ` +
+				`${reasons.join('; ')}.`
+		])
+	}
+
 	const response: GRIN2Response = {
 		status: 'success',
 		fromCache: !freshCompute,
@@ -322,6 +343,34 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 							'Samples with data',
 							`${(processing.samplesWithData ?? 0).toLocaleString()} / ${processing.processedSamples!.toLocaleString()}`
 						],
+						// breakdown of samples with no open-access SNV/indel (batched GDC path), each shown only when
+						// non-zero: controlled-access (data exists but isn't open) vs genuinely no mutation found.
+						...(processing.ssmSamplesControlledAccess
+							? [
+									[
+										'Samples in controlled-access projects',
+										`${processing.ssmSamplesControlledAccess.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
+									]
+							  ]
+							: []),
+						...(processing.ssmSamplesNoMutations
+							? [
+									[
+										'Open-access samples without mutations',
+										`${processing.ssmSamplesNoMutations.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
+									]
+							  ]
+							: []),
+						// samples that matched no GDC case at all (never queried) — surfaced so the cohort tallies
+						// reconcile (they're in neither "with data" nor the no-open-access buckets above).
+						...(processing.unmatchedSamples
+							? [
+									[
+										'Unmatched samples (no GDC case)',
+										`${processing.unmatchedSamples.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
+									]
+							  ]
+							: []),
 						['Unprocessed Samples', (processing.unprocessedSamples ?? 0).toLocaleString()],
 						['Failed Samples', processing.failedSamples!.toLocaleString()],
 						// only shown when a cnv-type selection actually dropped some samples' cnv
@@ -678,6 +727,17 @@ async function processSampleData(
 		// from the loop cap (unprocessedSamples) because the loop still processed those samples.
 		ssmCapReached?: boolean
 		ssmSamplesDropped?: number
+		// samples whose case returned no open-access SNV/indel (batched GDC path); a coverage note, not the
+		// cap. distinct from ssmSamplesDropped (cap-skipped) and from failedSamples (per-sample errors).
+		// ssmSamplesNoOpenAccess is the total; the two below break it down for the summary.
+		ssmSamplesNoOpenAccess?: number
+		// of ssmSamplesNoOpenAccess: samples in controlled-access GDC projects (data exists but isn't open).
+		ssmSamplesControlledAccess?: number
+		// of ssmSamplesNoOpenAccess: open-access samples that genuinely returned no SNV/indel mutation.
+		ssmSamplesNoMutations?: number
+		// samples that mapped to no GDC case at all (batched path), so were never queried; counted in neither
+		// samplesWithData nor ssmSamplesNoOpenAccess, hence surfaced separately so the cohort tallies reconcile.
+		unmatchedSamples?: number
 		lesionCap?: number
 		lesionCounts?: {
 			total: number
@@ -725,6 +785,13 @@ async function processSampleData(
 			processing.ssmCapReached = true
 			processing.ssmSamplesDropped = batch.droppedSamples
 		}
+		// Samples whose case had no open-access SNV/indel, surfaced so users don't read a partial cohort as
+		// complete (not an error, just a coverage note). Split into controlled-access vs genuinely-no-mutation,
+		// plus samples that matched no GDC case at all, so all 3,716 reconcile in the summary.
+		processing.ssmSamplesNoOpenAccess = batch.samplesNoOpenSsm
+		processing.ssmSamplesControlledAccess = batch.samplesControlledAccess
+		processing.ssmSamplesNoMutations = batch.samplesNoMutations
+		processing.unmatchedSamples = batch.unresolvedSamples
 	}
 	// When ssm is batched, skip it in the per-sample loop so get() doesn't re-fetch it.
 	const loopSkipDt = useBatchSsm ? new Set<number>(skipDt).add(dtsnvindel) : skipDt
@@ -799,7 +866,10 @@ async function processSampleData(
 				processing.totalLesions! += filteredLesions.length
 
 				const done = processing.processedSamples! + processing.failedSamples!
-				if (done % 200 === 0) mayLog(`[GRIN2] Processed ${done}/${samples.length} samples`)
+				// On the batched path (GDC) ssm is fetched up front, so this per-sample loop races to
+				// completion and this counter is misleading — progress is logged by the batch getter's
+				// per-chunk fetch instead. Native/SQLite datasets do the real work here, so keep the line.
+				if (!useBatchSsm && done % 200 === 0) mayLog(`[GRIN2] Processed ${done}/${samples.length} samples`)
 			} catch (e: any) {
 				processing.failedSamples! += 1
 				mayLog(`[GRIN2] Error processing sample ${sample.name}: ${e.message || e}`)

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -15,6 +15,7 @@ import { mayMapRefseq2ensembl, flattenCaseByFields, may_add_readdepth, mapGenes2
 import { isUsableTerm, joinUrl, ezFetch } from '@sjcrh/proteinpaint-shared'
 import { SelectionPrefixes, createSelectionID, FlagStatus } from '#types'
 import { mayLog } from './helpers.ts'
+import { mapConcurrent } from './utils/concurrencyLimiter.ts'
 
 const dsHelpers = {
 	mayMapRefseq2ensembl,
@@ -28,6 +29,7 @@ const dsHelpers = {
 	cachedFetch: utils.cachedFetch,
 	filterByItem: mds3_init.filterByItem,
 	mayLog,
+	mapConcurrent,
 	createSelectionID,
 	SelectionPrefixes,
 	FlagStatus

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -424,6 +424,9 @@ type SingleSampleMutationQuery = {
 		bySample: Map<any, { mlst: any[] }>
 		capReached: boolean
 		droppedSamples: number
+		/** samples whose case was queried but returned no open-access mutations (e.g. controlled-access
+		GDC projects); distinct from droppedSamples, which the lesion cap skipped before fetching */
+		samplesNoOpenSsm: number
 	}>
 	/** which property of client mutation object to retrieve sample identifier for querying single sample data with */
 	sample_id_key: string


### PR DESCRIPTION
# Description
Supports a faster, clearer GRIN2 SNV/indel fetch for GDC cohorts. The heavy lifting (the
`ssm_occurrences` batchGet rewrite) lives in the companion **sjpp** PR; this PR provides the
ProteinPaint-side infrastructure it depends on and the GRIN2 reporting that surfaces the results.

Two wins, no change to transport or cohort semantics:
- **Performance:** the GDC batchGet now pre-filters cases to open-access projects before chunking.
  ~47% of GDC cases are controlled-access (and return nothing on an unauthenticated request), so
  for a broad cohort this roughly halves the number of requests/connections (e.g. a 3,716-sample
  breast-cancer cohort went from ~13 ssm_occurrences requests to ~7).
- **Reporting:** GRIN2's summary now reconciles the full cohort instead of lumping a single
  "no open-access mutations" bucket.

## Changes (proteinpaint)

- **`server/src/gdc.initCache.js`** — build a `caseid2project` map (case uuid → project_id) in the
  existing cache loop that already paginates every GDC case (adds `project.project_id` to its
  fields). Lets callers classify open- vs controlled-access cases without an extra query.
- **`server/src/initGenomesDs.js`** — expose `mapConcurrent` (from `utils/concurrencyLimiter.ts`)
  via `dsHelpers`, so the GDC dataset file can use it for bounded fan-out (it can't import server
  `#src` directly).
- **`server/src/grin2/main.ts`** — split the cohort coverage report so all samples reconcile:
  `Samples with data`, `Samples in controlled-access projects`, `Open-access samples without
  mutations`, and `Unmatched samples (no GDC case)`. Each line shows only when non-zero; the
  warning note spells out each reason instead of a blanket "likely controlled-access."
- **`shared/types/src/dataset.ts`** — type the batchGet's `samplesNoOpenSsm` return field.
- **`release.txt`** — feature note.

## Companion PR

- **sjpp** (`grin2.sjpp.52`): the `gdc.hg38.ts` batchGet — `mapConcurrent` fan-out, open-project
  server-side filter + `caseid2project` pre-filter, and the per-reason sample counts consumed here.

## Verification

- Verified against the live GDC API: every project with open `ssm_occurrences` data is in the
  open-projects set, so the pre-filter cannot drop an open-access case (no data loss); the
  `cases.project.project_id` filter is accepted and filters correctly.
- Typechecks clean; report tallies reconcile to the full cohort (e.g. 1,590 with data + controlled
  + no-mutation + unmatched = 3,716).
- No transport changes (`connection: close` unchanged); non-GDC datasets unaffected (the new
  lines/fields only populate on the batched GDC path).


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
