### PR TITLE
Sample hierarchy support for DE and DM analysis

### DIFF
--- a/client/plots/DEinput.ts
+++ b/client/plots/DEinput.ts
@@ -262,7 +262,7 @@ class DEinputPlot extends PlotBase implements RxComponent {
 				filterJoin([g.filter, this.state.termfilter.filter])
 			)
 			const sampleIds = samples.map(s => {
-				return { sampleId: s }
+				return { sampleId: s.id }
 			})
 			samplelstTW.q.groups.push({
 				name: g.name,

--- a/server/routes/termdb.diffMeth.ts
+++ b/server/routes/termdb.diffMeth.ts
@@ -28,7 +28,7 @@ export function init({ genomes }) {
 
 			if ((q as any).preAnalysis) {
 				const { ds, term_results, term_results2 } = await resolveDaContext(q, genomes)
-				const groups = resolveDmSampleGroups(q, ds, term_results, term_results2)
+				const groups = await resolveDmSampleGroups(q, ds, term_results, term_results2)
 				const group1Name = q.samplelst.groups[0].name
 				const group2Name = q.samplelst.groups[1].name
 				res.send({
@@ -117,7 +117,7 @@ async function runDmFresh(
 	term_results: any,
 	term_results2: any
 ): Promise<DmCacheResult> {
-	const groups = resolveDmSampleGroups(param, ds, term_results, term_results2)
+	const groups = await resolveDmSampleGroups(param, ds, term_results, term_results2)
 	if (groups.alerts.length) throw new Error(groups.alerts.join(' | '))
 
 	const q = ds.queries.dnaMethylation.promoter
@@ -160,12 +160,12 @@ async function runDmFresh(
  * Wraps the shared `buildGroupValues` with DM-specific dataset query
  * lookup and user-facing alert messages (rendered directly in the
  * volcano UI, vs DE's engineer-facing strings). */
-export function resolveDmSampleGroups(
+export async function resolveDmSampleGroups(
 	param: DiffMethRequest,
 	ds: any,
 	term_results: any,
 	term_results2: any
-): SampleGroups {
+): Promise<SampleGroups> {
 	if (param.samplelst?.groups?.length != 2)
 		throw new Error('Exactly 2 sample groups are required for differential methylation analysis.')
 	if (param.samplelst.groups[0].values?.length < 1)
@@ -177,8 +177,24 @@ export function resolveDmSampleGroups(
 	if (!q) throw new Error('This dataset does not have promoter-level methylation data configured.')
 	if (!q.file) throw new Error('Promoter methylation data file is not configured for this dataset.')
 
-	const g1 = buildGroupValues(param.samplelst.groups[0].values, q, ds, param.tw, param.tw2, term_results, term_results2)
-	const g2 = buildGroupValues(param.samplelst.groups[1].values, q, ds, param.tw, param.tw2, term_results, term_results2)
+	const g1 = await buildGroupValues(
+		param.samplelst.groups[0].values,
+		q,
+		ds,
+		param.tw,
+		param.tw2,
+		term_results,
+		term_results2
+	)
+	const g2 = await buildGroupValues(
+		param.samplelst.groups[1].values,
+		q,
+		ds,
+		param.tw,
+		param.tw2,
+		term_results,
+		term_results2
+	)
 
 	const alerts: string[] = []
 	if (g1.names.length < 1) alerts.push('No samples in group 1 have methylation data available.')

--- a/server/src/routes/termdb.DE.ts
+++ b/server/src/routes/termdb.DE.ts
@@ -47,7 +47,7 @@ export function init({ genomes }) {
 			// preAnalysis short-circuit: just sample counts, no cache touch.
 			if ((q as any).preAnalysis) {
 				const { ds, term_results, term_results2 } = await resolveDaContext(q, genomes)
-				const groups = resolveSampleGroups(q, ds, term_results, term_results2)
+				const groups = await resolveSampleGroups(q, ds, term_results, term_results2)
 				const group1Name = q.samplelst.groups[0].name
 				const group2Name = q.samplelst.groups[1].name
 				res.send({
@@ -144,7 +144,7 @@ export async function getDeCacheResult(
  * diagnostic PNGs back inline (base64) in its stdout JSON, so no
  * intermediate files touch disk. */
 async function runDeFresh(param: DERequest, ds: any, term_results: any, term_results2: any): Promise<DeCacheResult> {
-	const groups = resolveSampleGroups(param, ds, term_results, term_results2)
+	const groups = await resolveSampleGroups(param, ds, term_results, term_results2)
 	if (groups.alerts.length) throw new Error(groups.alerts.join(' | '))
 
 	const q = ds.queries.rnaseqGeneCount
@@ -221,7 +221,12 @@ async function runDeFresh(param: DERequest, ds: any, term_results: any, term_res
 /** Resolve the two sample groups + any confounder value arrays for DE.
  * Wraps the shared `buildGroupValues` with DE-specific dataset query
  * lookup and engineer-facing alert messages. */
-export function resolveSampleGroups(param: DERequest, ds: any, term_results: any, term_results2: any): SampleGroups {
+export async function resolveSampleGroups(
+	param: DERequest,
+	ds: any,
+	term_results: any,
+	term_results2: any
+): Promise<SampleGroups> {
 	if (param.samplelst?.groups?.length != 2) throw new Error('.samplelst.groups.length!=2')
 	if (param.samplelst.groups[0].values?.length < 1) throw new Error('samplelst.groups[0].values.length<1')
 	if (param.samplelst.groups[1].values?.length < 1) throw new Error('samplelst.groups[1].values.length<1')
@@ -231,8 +236,24 @@ export function resolveSampleGroups(param: DERequest, ds: any, term_results: any
 	if (!q.file) throw new Error('unknown data type for rnaseqGeneCount')
 	if (!q.storage_type) throw new Error('storage_type is not defined')
 
-	const g1 = buildGroupValues(param.samplelst.groups[0].values, q, ds, param.tw, param.tw2, term_results, term_results2)
-	const g2 = buildGroupValues(param.samplelst.groups[1].values, q, ds, param.tw, param.tw2, term_results, term_results2)
+	const g1 = await buildGroupValues(
+		param.samplelst.groups[0].values,
+		q,
+		ds,
+		param.tw,
+		param.tw2,
+		term_results,
+		term_results2
+	)
+	const g2 = await buildGroupValues(
+		param.samplelst.groups[1].values,
+		q,
+		ds,
+		param.tw,
+		param.tw2,
+		term_results,
+		term_results2
+	)
 
 	const alerts: string[] = []
 	if (g1.names.length < 1) alerts.push('sample size of group1 < 1')

--- a/server/src/utils/sampleGroups.ts
+++ b/server/src/utils/sampleGroups.ts
@@ -42,7 +42,8 @@ export async function resolveDaContext(
 				filter0: (req as any).filter0,
 				terms: [req.tw]
 			},
-			ds
+			ds,
+			true // always map parent annotations to child samples for DA analysis
 		)
 		if (term_results.error) throw new Error(term_results.error)
 	}
@@ -55,7 +56,8 @@ export async function resolveDaContext(
 				filter0: (req as any).filter0,
 				terms: [req.tw2]
 			},
-			ds
+			ds,
+			true // always map parent annotations to child samples for DA analysis
 		)
 		if (term_results2.error) throw new Error(term_results2.error)
 	}

--- a/server/src/utils/sampleGroups.ts
+++ b/server/src/utils/sampleGroups.ts
@@ -1,6 +1,8 @@
 import type { DERequest, DiffMethRequest } from '#types'
 import { getData } from '#src/termdb.matrix.js'
 import { get_ds_tdb } from '#src/termdb.js'
+import { get_samples } from '#src/termdb.sql.js'
+import { isParentType } from '#shared/terms.js'
 
 /** Two-group sample resolution result. The conf{1,2}_group{1,2} arrays
  * carry the confounder values for samples that survived the per-confounder
@@ -66,7 +68,7 @@ export async function resolveDaContext(
  * for that sample — the two early-return guards enforce that without a
  * nested if/else cascade. Used by both DE and DM resolvers; the per-route
  * wrappers add their own validation + alert messages around this. */
-export function buildGroupValues(
+export async function buildGroupValues(
 	values: Array<{ sampleId: number }>,
 	q: { allSampleSet: Set<string> },
 	ds: any,
@@ -74,11 +76,37 @@ export function buildGroupValues(
 	tw2: any,
 	term_results: any,
 	term_results2: any
-): { names: string[]; conf1: (string | number)[]; conf2: (string | number)[] } {
+): Promise<{ names: string[]; conf1: (string | number)[]; conf2: (string | number)[] }> {
 	const names: string[] = []
 	const conf1: (string | number)[] = []
 	const conf2: (string | number)[] = []
-	for (const s of values) {
+	let sampleLst = values
+	if (ds.cohort.termdb.hasSampleAncestry) {
+		// ds has sample ancestry
+		const term = {
+			type: 'samplelst',
+			values: {
+				'': { key: '', list: values }
+			}
+		}
+		if (isParentType(term, ds)) {
+			// term is parent sample type, so map term annotations onto
+			// child samples because DE/DM data is at sample level
+			// TODO: support different sample types for genomic data to
+			// avoid assuming genomic data is always at sample-level
+			const filter = {
+				type: 'tvslst',
+				in: true,
+				join: '',
+				lst: [{ type: 'tvs', tvs: { term } }]
+			}
+			const samples = await get_samples({ filter, mapParent2Children: true }, ds, true)
+			sampleLst = samples.map(s => {
+				return { sampleId: s.id, sample: s.name }
+			})
+		}
+	}
+	for (const s of sampleLst) {
 		if (!Number.isInteger(s.sampleId)) continue
 		const n = ds.cohort.termdb.q.id2sampleName(s.sampleId)
 		if (!n || !q.allSampleSet.has(n)) continue

--- a/server/src/utils/test/sampleGroups.unit.spec.ts
+++ b/server/src/utils/test/sampleGroups.unit.spec.ts
@@ -106,20 +106,20 @@ function makeDs(idToName: Record<number, string>) {
 	}
 }
 
-tape('buildGroupValues happy path: includes samples whose id is integer and name is in allSampleSet', t => {
+tape('buildGroupValues happy path: includes samples whose id is integer and name is in allSampleSet', async t => {
 	const ds = makeDs({ 1: 'sampleA', 2: 'sampleB' })
 	const q = { allSampleSet: new Set(['sampleA', 'sampleB']) }
-	const out = buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, null, [], [])
+	const out = await buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, null, [], [])
 	t.deepEqual(out.names, ['sampleA', 'sampleB'], 'both samples included')
 	t.deepEqual(out.conf1, [], 'no tw → empty conf1')
 	t.deepEqual(out.conf2, [], 'no tw2 → empty conf2')
 	t.end()
 })
 
-tape('buildGroupValues skips non-integer sampleId', t => {
+tape('buildGroupValues skips non-integer sampleId', async t => {
 	const ds = makeDs({ 1: 'sampleA' })
 	const q = { allSampleSet: new Set(['sampleA']) }
-	const out = buildGroupValues(
+	const out = await buildGroupValues(
 		[{ sampleId: 1 }, { sampleId: 1.5 as any }, { sampleId: 'x' as any }],
 		q,
 		ds,
@@ -132,45 +132,45 @@ tape('buildGroupValues skips non-integer sampleId', t => {
 	t.end()
 })
 
-tape('buildGroupValues skips when id2sampleName returns falsy', t => {
+tape('buildGroupValues skips when id2sampleName returns falsy', async t => {
 	const ds = makeDs({ 1: 'sampleA' }) // sampleId 2 maps to undefined
 	const q = { allSampleSet: new Set(['sampleA']) }
-	const out = buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, null, [], [])
+	const out = await buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, null, [], [])
 	t.deepEqual(out.names, ['sampleA'], 'sample with no name resolution was skipped')
 	t.end()
 })
 
-tape('buildGroupValues skips when name is not in allSampleSet', t => {
+tape('buildGroupValues skips when name is not in allSampleSet', async t => {
 	const ds = makeDs({ 1: 'sampleA', 2: 'sampleB' })
 	const q = { allSampleSet: new Set(['sampleA']) } // sampleB missing
-	const out = buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, null, [], [])
+	const out = await buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, null, [], [])
 	t.deepEqual(out.names, ['sampleA'], 'sample not in allSampleSet was skipped')
 	t.end()
 })
 
-tape('buildGroupValues skips when tw is configured but term_results has no row for that sample', t => {
+tape('buildGroupValues skips when tw is configured but term_results has no row for that sample', async t => {
 	const ds = makeDs({ 1: 'sampleA', 2: 'sampleB' })
 	const q = { allSampleSet: new Set(['sampleA', 'sampleB']) }
 	const tw = { $id: 'tw1', q: { mode: 'discrete' } }
 	const term_results = { samples: { 1: { tw1: { key: 'M', value: 'M' } } } } // sample 2 missing
-	const out = buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, tw, null, term_results, [])
+	const out = await buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, tw, null, term_results, [])
 	t.deepEqual(out.names, ['sampleA'], 'sample missing tw data was skipped')
 	t.deepEqual(out.conf1, ['M'], 'conf1 picked up the discrete key for the kept sample')
 	t.end()
 })
 
-tape('buildGroupValues skips when tw2 is configured but term_results2 has no row for that sample', t => {
+tape('buildGroupValues skips when tw2 is configured but term_results2 has no row for that sample', async t => {
 	const ds = makeDs({ 1: 'sampleA', 2: 'sampleB' })
 	const q = { allSampleSet: new Set(['sampleA', 'sampleB']) }
 	const tw2 = { $id: 'tw2', q: { mode: 'discrete' } }
 	const term_results2 = { samples: { 1: { tw2: { key: 'X', value: 'X' } } } } // sample 2 missing
-	const out = buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, tw2, [], term_results2)
+	const out = await buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, null, tw2, [], term_results2)
 	t.deepEqual(out.names, ['sampleA'], 'sample missing tw2 data was skipped')
 	t.deepEqual(out.conf2, ['X'], 'conf2 picked up the discrete key for the kept sample')
 	t.end()
 })
 
-tape('buildGroupValues reads .value for continuous mode and .key otherwise', t => {
+tape('buildGroupValues reads .value for continuous mode and .key otherwise', async t => {
 	const ds = makeDs({ 1: 'sampleA', 2: 'sampleB' })
 	const q = { allSampleSet: new Set(['sampleA', 'sampleB']) }
 
@@ -182,7 +182,7 @@ tape('buildGroupValues reads .value for continuous mode and .key otherwise', t =
 			2: { twC: { key: 'unused', value: 2.5 } }
 		}
 	}
-	const outCont = buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, twCont, null, term_results_cont, [])
+	const outCont = await buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, twCont, null, term_results_cont, [])
 	t.deepEqual(outCont.conf1, [1.5, 2.5], 'continuous mode used v.value')
 
 	// Discrete: conf1 collects v.key
@@ -193,17 +193,17 @@ tape('buildGroupValues reads .value for continuous mode and .key otherwise', t =
 			2: { twD: { key: 'F', value: 'unused' } }
 		}
 	}
-	const outDisc = buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, twDisc, null, term_results_disc, [])
+	const outDisc = await buildGroupValues([{ sampleId: 1 }, { sampleId: 2 }], q, ds, twDisc, null, term_results_disc, [])
 	t.deepEqual(outDisc.conf1, ['M', 'F'], 'non-continuous mode used v.key')
 	t.end()
 })
 
-tape('buildGroupValues populates conf2 from tw2 with the same continuous/discrete split', t => {
+tape('buildGroupValues populates conf2 from tw2 with the same continuous/discrete split', async t => {
 	const ds = makeDs({ 1: 'sampleA' })
 	const q = { allSampleSet: new Set(['sampleA']) }
 	const tw2Cont = { $id: 'twC2', q: { mode: 'continuous' } }
 	const term_results2 = { samples: { 1: { twC2: { key: 'unused', value: 9.9 } } } }
-	const out = buildGroupValues([{ sampleId: 1 }], q, ds, null, tw2Cont, [], term_results2)
+	const out = await buildGroupValues([{ sampleId: 1 }], q, ds, null, tw2Cont, [], term_results2)
 	t.deepEqual(out.conf2, [9.9], 'conf2 continuous reads v.value')
 	t.end()
 })


### PR DESCRIPTION
# Description

Map parent term annotations onto child samples for DE and DM analysis.

Can test with [AML dataset](http://localhost:3000/?massnative=hg38,AML) -> Set up DE analysis with patient-level term (e.g. `Sex` -> Male vs. Female) -> Samples are properly retrieved and reported in pre-analysis UI.

Running DE in AML will not yet work due to a sample having only 0 counts. Jian is looking into it.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
