### PR TITLE
CohortMAF: Ported `gdc.mafBuild` from Rust to Typescript and bounded it with concurrencyLimiter module

### DIFF
--- a/client/gdc/maf.js
+++ b/client/gdc/maf.js
@@ -263,6 +263,9 @@ function makeControls(obj) {
 					rows,
 					columns: [{ label: 'Column Name' }],
 					selectedRows,
+					// keep the header "select all" checkbox in sync with the rows: tick it when every
+					// column is currently selected (e.g. the all-selected default state)
+					selectAll: selectedRows.length === mafColumns.length,
 					dataTestId: 'sjpp-gdcmaf-columnTableUi',
 					noButtonCallback: (i, n) => {
 						mafColumns[i].selected = n.checked
@@ -275,9 +278,9 @@ function makeControls(obj) {
 
 		function updateText() {
 			clickText.text(
-				`${mafColumns.reduce((c, i) => c + (i.selected ? 1 : 0), 0)} of ${
-					mafColumns.length
-				} columns selected. Click to change`
+				`${mafColumns
+					.reduce((c, i) => c + (i.selected ? 1 : 0), 0)
+					.toLocaleString()} of ${mafColumns.length.toLocaleString()} columns selected. Click to change`
 			)
 		}
 	}
@@ -301,9 +304,11 @@ async function getFilesAndShowTable(obj) {
 
 		// render
 		if (result.filesTotal > result.files.length) {
-			wait.text(`Showing first ${result.files.length} MAF files out of ${result.filesTotal} total.`)
+			wait.text(
+				`Showing first ${result.files.length.toLocaleString()} MAF files out of ${result.filesTotal.toLocaleString()} total.`
+			)
 		} else {
-			wait.text(`Showing ${result.files.length} MAF files.`)
+			wait.text(`Showing ${result.files.length.toLocaleString()} MAF files.`)
 		}
 
 		const rows = []

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
 Features:
-- Ported gdc.mafBuild from Rust to Typescript and bounded it with the concurrencyLimiter fixed sized logic
+- Ported gdc.mafBuild from Rust to TypeScript and bounded it with the concurrencyLimiter fixed-size logic

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,2 @@
+Features:
+- Ported gdc.mafBuild from Rust to Typescript and bounded it with the concurrencyLimiter fixed sized logic

--- a/server/src/routes/gdc.mafBuild.ts
+++ b/server/src/routes/gdc.mafBuild.ts
@@ -53,7 +53,18 @@ export function init({ genomes }) {
 // without a rebuild; falls back to 20 when absent (parity with the previous rust buffer_unordered(20)).
 const defaultConcurrency = 20
 
-type FileError = { url: string; error: string }
+export type FileError = { url: string; error: string }
+
+export type MafMergeResult = {
+	/** number of files successfully decompressed, column-selected, and written */
+	merged: number
+	/** per-file failures (download/decompress/column errors); never aborts the batch */
+	errors: FileError[]
+	/** summed timings across files; download/decompress overlap wall-clock, parse does not (see buildMaf) */
+	totalDownloadMs: number
+	totalDecompressMs: number
+	totalParseMs: number
+}
 
 /*
 q{}
@@ -102,6 +113,7 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	// Timing instrumentation, summed across files, to see where the wall-clock goes. download/decompress
 	// run concurrently so their sums overlap wall-clock; parse has no awaits so it can't overlap itself —
 	// totalParseMs is therefore the real main-thread time spent parsing (i.e. event-loop blocking).
+	// Reassigned from the mergeMafFiles() result below; default to 0 so the finalize log is always valid.
 	let merged = 0
 	let totalDownloadMs = 0
 	let totalDecompressMs = 0 // async gunzip on the libuv threadpool (parallel up to UV_THREADPOOL_SIZE)
@@ -151,37 +163,27 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		// header row first (matches the former rust output: header line then all selected data rows)
 		await writeGz(columns.join('\t') + '\n')
 
-		await mapConcurrent(
-			fileLst2,
+		// the download fan-out + decompress + column-select + per-file error collection lives in
+		// mergeMafFiles() so it can be unit-tested with an injected fetcher (no GDC/network). Here the
+		// fetcher is a real GDC /data download via ky, and the write sink is the serialized gzip writer.
+		const result = await mergeMafFiles({
+			fileIdLst: fileLst2,
+			columns,
 			concurrency,
-			async (fileId: string) => {
-				if (controller.signal.aborted) return
-				const url = joinUrl(dataHost, fileId)
-				try {
-					const dl0 = Date.now()
-					const buf = Buffer.from(
-						await ky
-							.get(url, { headers, timeout: downloadTimeoutMs, retry: { limit: 2 }, signal: controller.signal })
-							.arrayBuffer()
-					)
-					const dl1 = Date.now()
-					const decompressed = await gunzipAsync(buf)
-					const dec1 = Date.now()
-					const rows = selectMafCols(decompressed.toString('utf8'), columns) // throws on missing column / empty file
-					const ps1 = Date.now()
-					totalDownloadMs += dl1 - dl0
-					totalDecompressMs += dec1 - dl1
-					totalParseMs += ps1 - dec1
-					merged++
-					await writeGz(rows)
-				} catch (e: any) {
-					// record per-file failure; the rest of the cohort still merges (settled semantics)
-					if (!controller.signal.aborted) errors.push({ url: fileId, error: e?.message || String(e) })
-				}
-				completed++
-			},
-			{ signal: controller.signal }
-		)
+			signal: controller.signal,
+			fetchGz: (fileId, signal) =>
+				ky
+					.get(joinUrl(dataHost, fileId), { headers, timeout: downloadTimeoutMs, retry: { limit: 2 }, signal })
+					.arrayBuffer()
+					.then(ab => Buffer.from(ab)),
+			write: writeGz,
+			onFileSettled: () => completed++
+		})
+		errors.push(...result.errors)
+		merged = result.merged
+		totalDownloadMs = result.totalDownloadMs
+		totalDecompressMs = result.totalDecompressMs
+		totalParseMs = result.totalParseMs
 
 		// flush any pending serialized writes before closing the gzip stream
 		await writeChain.catch(() => {})
@@ -220,6 +222,62 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		res.end()
 	})
 	gz.end()
+}
+
+/*
+Core of the cohort-MAF build, factored out of buildMaf() so it can be unit-tested without GDC or a
+network: download each file (via the injected `fetchGz`), decompress, select the requested columns, and
+hand the selected rows to the injected `write` sink. Downloads run through mapConcurrent() so at most
+`concurrency` are in flight at once. A per-file failure is recorded in `errors` and never aborts the
+batch (settled semantics); an aborted `signal` stops scheduling new files and suppresses late errors.
+`fetchGz(fileId, signal)` returns the gzipped bytes of one file; `write(rows)` consumes one file's
+selected rows (the caller serializes writes / handles backpressure); `onFileSettled` fires once per
+finished file for live progress reporting.
+*/
+export async function mergeMafFiles(opts: {
+	fileIdLst: string[]
+	columns: string[]
+	concurrency: number
+	signal: AbortSignal
+	fetchGz: (fileId: string, signal: AbortSignal) => Promise<Buffer>
+	write: (rows: string) => Promise<void>
+	onFileSettled?: () => void
+}): Promise<MafMergeResult> {
+	const { fileIdLst, columns, concurrency, signal, fetchGz, write, onFileSettled } = opts
+	const errors: FileError[] = []
+	let merged = 0
+	let totalDownloadMs = 0
+	let totalDecompressMs = 0
+	let totalParseMs = 0
+
+	await mapConcurrent(
+		fileIdLst,
+		concurrency,
+		async (fileId: string) => {
+			if (signal.aborted) return
+			try {
+				const dl0 = Date.now()
+				const buf = await fetchGz(fileId, signal)
+				const dl1 = Date.now()
+				const decompressed = await gunzipAsync(buf)
+				const dec1 = Date.now()
+				const rows = selectMafCols(decompressed.toString('utf8'), columns) // throws on missing column / empty file
+				const ps1 = Date.now()
+				totalDownloadMs += dl1 - dl0
+				totalDecompressMs += dec1 - dl1
+				totalParseMs += ps1 - dec1
+				merged++
+				await write(rows)
+			} catch (e: any) {
+				// record per-file failure; the rest of the cohort still merges (settled semantics)
+				if (!signal.aborted) errors.push({ url: fileId, error: e?.message || String(e) })
+			}
+			onFileSettled?.()
+		},
+		{ signal }
+	)
+
+	return { merged, errors, totalDownloadMs, totalDecompressMs, totalParseMs }
 }
 
 /*
@@ -264,7 +322,7 @@ header line by its Hugo_Symbol column, and resolves each requested column to its
 requested column is absent or the file has no data rows, so the caller records it as a per-file error.
 Returns the selected rows as a single string, each row newline-terminated.
 */
-function selectMafCols(text: string, columns: string[]): string {
+export function selectMafCols(text: string, columns: string[]): string {
 	const lines = text.replace(/\n+$/, '').split('\n')
 	let headerIndices: number[] | null = null
 	const out: string[] = []

--- a/server/src/routes/gdc.mafBuild.ts
+++ b/server/src/routes/gdc.mafBuild.ts
@@ -62,7 +62,13 @@ export type MafMergeResult = {
 	merged: number
 	/** per-file failures (download/decompress/column errors); never aborts the batch */
 	errors: FileError[]
-	/** summed per-file stream time (download+decompress+parse interleaved); overlaps wall-clock under concurrency */
+	/** summed per-file fetch time: request start → GDC response ready to stream (connection setup + TLS +
+	 * request + time-to-first-byte). Split out from body streaming so the HTTP-client/connection cost — the
+	 * part that differs between the ky/undici and rust/reqwest setups — is visible on its own. */
+	totalFetchMs: number
+	/** summed per-file body-streaming time: network body transfer + threadpool decompress + main-thread
+	 * parse + gzip backpressure, interleaved. Overlaps wall-clock under concurrency. Body transfer and
+	 * decompress are pipelined and cannot be separated in wall time; totalParseMs is the main-thread slice. */
 	totalStreamMs: number
 	/** summed main-thread time in line parsing/column-selection — the only event-loop-blocking work */
 	totalParseMs: number
@@ -131,6 +137,20 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 
 	const dataHost = joinUrl(host.rest, 'data') // must use the /data/ endpoint from current host
 
+	// getHostHeaders() returns headers tuned for the JSON metadata API (ky): they include
+	// `connection: close` plus Content-Type/Accept: application/json. Forwarding `connection: close`
+	// onto the downloads makes the server tear down the socket after each response, so every file pays a
+	// fresh TLS handshake (the dominant per-file fetch/TTFB cost) and Node fetch's default keep-alive
+	// connection reuse is defeated; the application/json negotiation is also wrong for a gzip download.
+	// Forward only what a download needs — auth + any forwarded client headers — so the underlying
+	// connections can be reused across files.
+	const downloadHeaders: { [k: string]: string } = {}
+	for (const [k, v] of Object.entries(headers)) {
+		const lk = k.toLowerCase()
+		if (lk === 'connection' || lk === 'content-type' || lk === 'accept') continue
+		downloadHeaders[k] = v as string
+	}
+
 	// Abort active downloads if the client disconnects (e.g. browser tab refreshed mid-download), so
 	// orphaned GDC requests don't keep running after no one is listening.
 	const controller = new AbortController()
@@ -151,6 +171,7 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	// parsing — the only event-loop-blocking work. Reassigned from the mergeMafFiles() result below;
 	// default to 0 so the finalize log is always valid.
 	let merged = 0
+	let totalFetchMs = 0 // per-file connect + TLS + request + time-to-first-byte (HTTP-client/connection cost)
 	let totalStreamMs = 0
 	let totalParseMs = 0 // main-thread: per-chunk utf8 + line split + column selection
 
@@ -215,8 +236,10 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 			// former .arrayBuffer(): ky's retry no longer covers a mid-stream network drop — that now
 			// surfaces as a per-file error (settled semantics), not a silent retry.
 			fetchGzStream: async (fileId, signal) => {
+				// ky handles retry (limit:2, with backoff + Retry-After) and redirect-following. downloadHeaders
+				// omits `connection: close`, so Node fetch keep-alives and reuses connections across files.
 				const r = await ky.get(joinUrl(dataHost, fileId), {
-					headers,
+					headers: downloadHeaders,
 					timeout: false,
 					retry: { limit: 2 },
 					signal: AbortSignal.any([signal, AbortSignal.timeout(downloadTimeoutMs)])
@@ -233,6 +256,7 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		// the uuid as the final path segment, so matching keeps working.
 		errors.push(...result.errors.map(e => ({ ...e, url: joinUrl(dataHost, e.url) })))
 		merged = result.merged
+		totalFetchMs = result.totalFetchMs
 		totalStreamMs = result.totalStreamMs
 		totalParseMs = result.totalParseMs
 
@@ -257,9 +281,11 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		res.write('\r\n\r\n' + json)
 		res.write(`\r\n--${boundary}--\r\n`)
 		const elapsed = Date.now() - t0
+		const avgFetchMs = merged ? Math.round(totalFetchMs / merged) : 0
 		const avgStreamMs = merged ? Math.round(totalStreamMs / merged) : 0
 		// totalStreamMs sums concurrent per-file stream times, so dividing by wall-clock gives the implied
 		// parallelism (how many were overlapping on average) rather than a misleading multi-minute sum
+		const fetchParallelism = elapsed ? (totalFetchMs / elapsed).toFixed(1) : '0'
 		const streamParallelism = elapsed ? (totalStreamMs / elapsed).toFixed(1) : '0'
 		// final RSS sample, in case the last spike landed between 250ms ticks
 		const rssEnd = process.memoryUsage().rss
@@ -269,7 +295,8 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 				` (concurrency ${concurrency})` +
 				` in ${formatElapsedTime(elapsed)}` +
 				` | main-thread parse: ${formatElapsedTime(totalParseMs)}` +
-				` | stream (download+decompress+parse): avg ${avgStreamMs}ms/file, ~${streamParallelism}× parallel` +
+				` | fetch (connect+TTFB): avg ${avgFetchMs}ms/file, ~${fetchParallelism}× parallel` +
+				` | stream (body download+decompress+parse): avg ${avgStreamMs}ms/file, ~${streamParallelism}× parallel` +
 				` (UV_THREADPOOL_SIZE=${process.env.UV_THREADPOOL_SIZE || '4 (default)'})` +
 				` | mem: start ${fileSize(rss0)}, peak ${fileSize(peakRss)} (Δ ${fileSize(peakRss - rss0)}), end ${fileSize(
 					rssEnd
@@ -303,6 +330,7 @@ export async function mergeMafFiles(opts: {
 	const { fileIdLst, columns, concurrency, signal, fetchGzStream, write, onFileSettled } = opts
 	const errors: FileError[] = []
 	let merged = 0
+	let totalFetchMs = 0
 	let totalStreamMs = 0
 	let totalParseMs = 0
 
@@ -312,14 +340,21 @@ export async function mergeMafFiles(opts: {
 		async (fileId: string) => {
 			if (signal.aborted) return
 			try {
-				const t0 = Date.now()
+				// fetch phase: request start → GDC response ready to stream (connect + TLS + request + TTFB).
+				// Measured on its own so the HTTP-client/connection cost is separable from body streaming.
+				const fetchStart = Date.now()
 				const gzStream = await fetchGzStream(fileId, signal)
+				const fetchMs = Date.now() - fetchStart
+				// stream phase: body transfer + threadpool decompress + main-thread parse (interleaved).
 				// throws on missing column / empty file / mid-stream download error
+				const streamStart = Date.now()
 				const { parseMs } = await streamSelectMafCols({ gzStream, columns, write, signal })
+				const streamMs = Date.now() - streamStart
 				// only count a file as merged once all its rows are written, and accumulate the timings in
 				// lockstep with `merged` — so a failure (recorded below as a per-file error) can't both
 				// inflate `merged` and skew the total*/merged averages.
-				totalStreamMs += Date.now() - t0
+				totalFetchMs += fetchMs
+				totalStreamMs += streamMs
 				totalParseMs += parseMs
 				merged++
 			} catch (e: any) {
@@ -331,7 +366,7 @@ export async function mergeMafFiles(opts: {
 		{ signal }
 	)
 
-	return { merged, errors, totalStreamMs, totalParseMs }
+	return { merged, errors, totalFetchMs, totalStreamMs, totalParseMs }
 }
 
 /*

--- a/server/src/routes/gdc.mafBuild.ts
+++ b/server/src/routes/gdc.mafBuild.ts
@@ -179,7 +179,11 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 			write: writeGz,
 			onFileSettled: () => completed++
 		})
-		errors.push(...result.errors)
+		// mergeMafFiles keys per-file errors by fileId (it's URL-agnostic by design, taking an injected
+		// fetcher). Rebuild the full GDC /data/<uuid> download URL here so the client renders a clickable
+		// link — parity with the former rust path, which returned the full URL. The client still extracts
+		// the uuid as the final path segment, so matching keeps working.
+		errors.push(...result.errors.map(e => ({ ...e, url: joinUrl(dataHost, e.url) })))
 		merged = result.merged
 		totalDownloadMs = result.totalDownloadMs
 		totalDecompressMs = result.totalDecompressMs
@@ -263,11 +267,14 @@ export async function mergeMafFiles(opts: {
 				const dec1 = Date.now()
 				const rows = selectMafCols(decompressed.toString('utf8'), columns) // throws on missing column / empty file
 				const ps1 = Date.now()
+				await write(rows)
+				// only count a file as merged once its rows are actually written, and accumulate the
+				// timings in lockstep with `merged` — so a write() failure (recorded below as a per-file
+				// error) can't both inflate `merged` and skew the total*/merged averages.
 				totalDownloadMs += dl1 - dl0
 				totalDecompressMs += dec1 - dl1
 				totalParseMs += ps1 - dec1
 				merged++
-				await write(rows)
 			} catch (e: any) {
 				// record per-file failure; the rest of the cohort still merges (settled semantics)
 				if (!signal.aborted) errors.push({ url: fileId, error: e?.message || String(e) })

--- a/server/src/routes/gdc.mafBuild.ts
+++ b/server/src/routes/gdc.mafBuild.ts
@@ -1,21 +1,22 @@
 import type { RoutePayload, RouteApi } from '#types'
 import ky from 'ky'
 import { joinUrl } from '#shared/joinUrl.js'
-import { stream_rust } from '@sjcrh/proteinpaint-rust'
 import type { GdcMafBuildRequest } from '#types'
 import { maxTotalSizeCompressed } from './gdc.maf.ts'
 import { mayLog } from '#src/helpers.ts'
+import { formatElapsedTime } from '#shared'
 import serverconfig from '#src/serverconfig.js'
+import { mapConcurrent } from '#src/utils/concurrencyLimiter.ts'
+import { createGzip, gunzip } from 'zlib'
+import { once } from 'events'
+import { promisify } from 'util'
 
-// watchdog kill threshold (ms) for the gdcmaf rust process; a safety backstop against a
-// hung/leaked download. Defaults to 5 minutes; overridable via serverconfig for slower
-// GDC environments (e.g. qa-int) where a legitimate large download may need more time.
-const gdcMafMaxElapsed = serverconfig.features.gdcMafMaxElapsed || 300000 // 5 min
+// async (libuv threadpool) gunzip so decompressing each downloaded MAF doesn't block the event loop
+const gunzipAsync = promisify(gunzip)
 
-// number of MAF files the gdcmaf rust tool downloads concurrently. Defaults to 20 (matching the
-// gdcGRIN2 downloader); overridable via serverconfig to dial down for stricter GDC environments
-// (e.g. qa-int, which appears to cap simultaneous connections) without a rebuild.
-const gdcMafConcurrency = serverconfig.features.gdcMafConcurrency || 20
+// per-file download timeout (ms); matches the former rust reqwest per-request timeout so a single
+// stalled GDC download can't hold a worker slot indefinitely
+const downloadTimeoutMs = 60000
 
 export const GdcMafPayload: RoutePayload = {
 	init,
@@ -47,50 +48,46 @@ export function init({ genomes }) {
 	}
 }
 
-type EmitJsonDataArg =
-	| string
-	| {
-			status?: string
-			ok?: boolean
-			error?: string
-			errors?: any[]
-			message?: string
-	  }
+// Number of files downloaded concurrently. Driven by serverconfig.features.gdcMafConcurrency so it
+// can be dialed down per environment (e.g. qa-int, which appears to cap simultaneous connections)
+// without a rebuild; falls back to 20 when absent (parity with the previous rust buffer_unordered(20)).
+const defaultConcurrency = 20
+
+type FileError = { url: string; error: string }
 
 /*
 q{}
 res{}
+ds{}
+
+Downloads each requested MAF file from GDC, selects the requested columns, and concatenates the rows
+into a single gzip-compressed cohort MAF that is streamed back as the "gzfile" part of a
+multipart/form-data response. Per-file failures are collected and returned as the "errors" part
+(jsonlines) so one bad file can't abort the whole download. Downloads run through mapConcurrent() so
+at most `concurrency` files are in flight at once.
+
+This replaces the former rust `gdcmaf` binary, which coupled download + column-select + gzip-merge
+with a hardcoded concurrency; moving the download into node lets it reuse the shared, tested
+concurrencyLimiter and a config-driven, per-environment concurrency cap.
 */
 async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	const t0 = Date.now()
 	const { host, headers } = ds.getHostHeaders(q)
 	const fileLst2: string[] = await getFileLstUnderSizeLimit(q.fileIdLst, host, headers)
 
-	mayLog(`${fileLst2.length} out of ${q.fileIdLst.length} input MAF files accepted by size limit`, Date.now() - t0)
+	mayLog(
+		`${fileLst2.length.toLocaleString()} out of ${q.fileIdLst.length.toLocaleString()} input MAF files accepted by size limit. Time elapsed: ${formatElapsedTime(
+			Date.now() - t0
+		)}`
+	)
 
-	// getHostHeaders() returns headers tuned for the JSON metadata API calls (ky): they include
-	// `connection: close` plus Content-Type/Accept: application/json. Those must NOT be forwarded
-	// onto the binary /data/<uuid> file downloads done by the rust tool: `connection: close`
-	// defeats keep-alive and forces a brand-new connection per file, and the application/json
-	// content-negotiation is wrong for a gzip download. Against a stricter GDC environment
-	// (e.g. qa-int, behind a proxy/WAF) this can cause all but the first concurrent download to
-	// be rejected. Forward only what a download needs: auth, plus X-Forwarded-* from ds.getHostHeaders()
-	// (passed in from the route handler) so GDC's proxy/WAF sees the actual client.
-	const downloadHeaders: { [key: string]: string } = {}
-	for (const [k, v] of Object.entries(headers)) {
-		const lk = k.toLowerCase()
-		if (lk === 'cookie' || lk === 'x-auth-token' || lk.startsWith('x-forwarded')) downloadHeaders[k] = v as string
-	}
+	const concurrency = serverconfig.features.gdcMafConcurrency || defaultConcurrency
+	const dataHost = joinUrl(host.rest, 'data') // must use the /data/ endpoint from current host
+	const columns = q.columns
 
-	const arg = {
-		fileIdLst: fileLst2,
-		columns: q.columns,
-		host: joinUrl(host.rest, 'data'), // must use the /data/ endpoint from current host
-		headers: downloadHeaders,
-		concurrency: gdcMafConcurrency
-	}
-	// uncomment for manual error testing
-	// const arg = {"host": "https://api.gdc.cancer.gov/data/","columns": ["Hugo_Symbol", "Entrez_Gene_Id", "Center", "NCBI_Build", "Chromosome", "Start_Position"], "fileIdLst": ["8b31d6d1-56f7-4aa8-b026-c64bafd531e7", "83ea587b-1e92-41b3-a8e3-12df30496724"]};
+	// Abort active downloads if the client disconnects (e.g. browser tab refreshed mid-download), so
+	// orphaned GDC requests don't keep running after no one is listening.
+	const controller = new AbortController()
 
 	const boundary = '------------------------GDC-MAF-BUILD'
 	res.setHeader('Content-Type', `multipart/form-data; boundary=${boundary}`)
@@ -99,69 +96,130 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	res.write('\r\nContent-Type: application/gzip\r\n\r\n')
 	res.flush() // header text should be sent as a separate chunk from the content that will be streamed next
 
-	try {
-		const streams = stream_rust('gdcmaf', JSON.stringify(arg), emitJson, { maxElapsed: gdcMafMaxElapsed })
-		if (streams) {
-			const { rustStream, endStream } = streams
-			// Important: rustStream.pipe(res, { end: false }) may cause a stalemate
-			// where the spawned rust process, stream transform, and res instance
-			// wait on each other to trigger a "stop", but does not happen automatically
-			// when a browser tab is refreshed during a file download
-			res.on('close', () => {
-				if (res.writableEnded) return
-				try {
-					console.log('\n-- forced res.end() ---\n')
-					res.end()
-				} catch (e) {
-					console.log('error with forced res.end()', e)
-				}
+	const errors: FileError[] = []
+	let completed = 0 // files that finished (merged or errored); lets the disconnect log report how many were still pending
 
-				try {
-					endStream()
-				} catch (e) {
-					console.log('error in calling endStream()', e)
-				}
-			})
+	// Timing instrumentation, summed across files, to see where the wall-clock goes. download/decompress
+	// run concurrently so their sums overlap wall-clock; parse has no awaits so it can't overlap itself —
+	// totalParseMs is therefore the real main-thread time spent parsing (i.e. event-loop blocking).
+	let merged = 0
+	let totalDownloadMs = 0
+	let totalDecompressMs = 0 // async gunzip on the libuv threadpool (parallel up to UV_THREADPOOL_SIZE)
+	let totalParseMs = 0 // main-thread: buffer->utf8 + selectMafCols column selection
 
-			rustStream
-				.pipe(res, { end: false })
-				.on('error', e => {
-					// this is not triggered when a request is disconnected
-					console.log('rustStream.pipe().on(error)', e)
-				})
-				.on('end', () => {
-					if (res.writableEnded) return
-					console.log('rustStream.on(end), trigger res.end()')
-					res.end()
-				})
-		} else {
-			emitJson({ error: 'server error: undefined rustStream' })
-		}
-	} catch (e) {
-		console.log('error calling stream_rust(gdcmaf)', e)
-	}
+	// Single gzip stream for the merged MAF, piped into the multipart body. { end: false } keeps res
+	// open after gz finishes so the trailing "errors" part + closing boundary can still be written.
+	const gz = createGzip()
+	gz.pipe(res, { end: false }).on('error', (e: any) => {
+		console.log('gz.pipe(res) error', e)
+	})
 
-	function emitJson(data?: EmitJsonDataArg, end: boolean = true) {
+	res.on('close', () => {
 		if (res.writableEnded) return
-		if (data) {
-			res.write(`\r\n--${boundary}`)
-			res.write('\r\nContent-Disposition: form-data; name="errors"')
-			res.write('\r\nContent-Type: application/x-jsonlines')
-			const json = typeof data === 'string' ? data : JSON.stringify(data || { ok: true, status: 'ok' })
-			res.write('\r\n\r\n' + json)
+		// client went away before we finished: stop downloads and tear down
+		mayLog(
+			`gdcmaf build: client disconnected, aborting downloads (${completed.toLocaleString()}/${fileLst2.length.toLocaleString()} files done). Time elapsed: ${formatElapsedTime(
+				Date.now() - t0
+			)}`
+		)
+		controller.abort()
+		try {
+			gz.destroy()
+		} catch (e) {
+			console.log('error destroying gz on close', e)
 		}
-		res.write(`\r\n--${boundary}--\r\n`)
-		// report amount of time taken to run rust
-		mayLog('rust gdcmaf', Date.now() - t0)
-		if (end) res.end()
+		try {
+			res.end()
+		} catch (e) {
+			console.log('error with forced res.end()', e)
+		}
+	})
+
+	// Serialize writes to the gzip stream behind a promise chain so concurrent download workers can't
+	// interleave their row chunks mid-line, and so each write honors backpressure (await 'drain' when
+	// gz.write() returns false). once() is given the abort signal so a write parked on 'drain' doesn't
+	// hang forever if the client disconnects.
+	let writeChain: Promise<void> = Promise.resolve()
+	function writeGz(str: string): Promise<void> {
+		writeChain = writeChain.then(async () => {
+			if (!gz.write(str)) await once(gz, 'drain', { signal: controller.signal })
+		})
+		return writeChain
 	}
 
-	// const rustStream = stream_rust('gdcmaf', JSON.stringify(arg))
-	// const form = new FormData({ maxDataSize: 120 * 1024 * 1024 }) // file size in in MB
-	// res.setHeader('content-type', `multipart/form-data; boundary=${form.getBoundary()}`)
-	// form.append('gzfile', rustStream.stdout, { filename: 'test.gz' })
-	// form.append('errors', rustStream.stderr, { contentType: 'application/x-jsonlines' })
-	// form.pipe(res)
+	try {
+		// header row first (matches the former rust output: header line then all selected data rows)
+		await writeGz(columns.join('\t') + '\n')
+
+		await mapConcurrent(
+			fileLst2,
+			concurrency,
+			async (fileId: string) => {
+				if (controller.signal.aborted) return
+				const url = joinUrl(dataHost, fileId)
+				try {
+					const dl0 = Date.now()
+					const buf = Buffer.from(
+						await ky
+							.get(url, { headers, timeout: downloadTimeoutMs, retry: { limit: 2 }, signal: controller.signal })
+							.arrayBuffer()
+					)
+					const dl1 = Date.now()
+					const decompressed = await gunzipAsync(buf)
+					const dec1 = Date.now()
+					const rows = selectMafCols(decompressed.toString('utf8'), columns) // throws on missing column / empty file
+					const ps1 = Date.now()
+					totalDownloadMs += dl1 - dl0
+					totalDecompressMs += dec1 - dl1
+					totalParseMs += ps1 - dec1
+					merged++
+					await writeGz(rows)
+				} catch (e: any) {
+					// record per-file failure; the rest of the cohort still merges (settled semantics)
+					if (!controller.signal.aborted) errors.push({ url: fileId, error: e?.message || String(e) })
+				}
+				completed++
+			},
+			{ signal: controller.signal }
+		)
+
+		// flush any pending serialized writes before closing the gzip stream
+		await writeChain.catch(() => {})
+	} catch (e) {
+		console.log('error building cohort MAF', e)
+		if (!errors.some(d => !d.url)) errors.push({ url: '', error: (e as any)?.message || String(e) } as FileError)
+	}
+
+	if (res.writableEnded) return
+
+	// finalize: end the gzip stream, then once its data has fully flushed into res, append the
+	// "errors" part and the closing multipart boundary, then end the response.
+	gz.on('end', () => {
+		if (res.writableEnded) return
+		res.write(`\r\n--${boundary}`)
+		res.write('\r\nContent-Disposition: form-data; name="errors"')
+		res.write('\r\nContent-Type: application/x-jsonlines')
+		const json = errors.map(e => JSON.stringify(e)).join('\n')
+		res.write('\r\n\r\n' + json)
+		res.write(`\r\n--${boundary}--\r\n`)
+		const elapsed = Date.now() - t0
+		const avgDownloadMs = merged ? Math.round(totalDownloadMs / merged) : 0
+		const avgDecompressMs = merged ? Math.round(totalDecompressMs / merged) : 0
+		// totalDownloadMs sums concurrent downloads, so dividing by wall-clock gives the implied
+		// parallelism (how many were overlapping on average) rather than a misleading multi-minute sum
+		const downloadParallelism = elapsed ? (totalDownloadMs / elapsed).toFixed(1) : '0'
+		mayLog(
+			`gdcmaf build: ${merged.toLocaleString()} merged / ${errors.length.toLocaleString()} failed of ${fileLst2.length.toLocaleString()} files` +
+				` in ${formatElapsedTime(elapsed)}` +
+				` | main-thread parse: ${formatElapsedTime(totalParseMs)}` +
+				` | decompress: avg ${avgDecompressMs}ms/file (UV_THREADPOOL_SIZE=${
+					process.env.UV_THREADPOOL_SIZE || '4 (default)'
+				})` +
+				` | download: avg ${avgDownloadMs}ms/file, ~${downloadParallelism}× parallel`
+		)
+		res.end()
+	})
+	gz.end()
 }
 
 /*
@@ -197,4 +255,36 @@ async function getFileLstUnderSizeLimit(lst: string[], host, headers) {
 	}
 	if (out.length == 0) throw 'no file available'
 	return out
+}
+
+/*
+Port of the former rust select_maf_col: from one decompressed MAF file's text, keep only the requested
+columns (in the requested order) for every data row, tab-joined. Skips `#` comment lines, finds the
+header line by its Hugo_Symbol column, and resolves each requested column to its index. Throws if a
+requested column is absent or the file has no data rows, so the caller records it as a per-file error.
+Returns the selected rows as a single string, each row newline-terminated.
+*/
+function selectMafCols(text: string, columns: string[]): string {
+	const lines = text.replace(/\n+$/, '').split('\n')
+	let headerIndices: number[] | null = null
+	const out: string[] = []
+	for (const line of lines) {
+		if (line.startsWith('#')) continue
+		if (line.includes('Hugo_Symbol')) {
+			const header = line.split('\t')
+			headerIndices = []
+			for (const col of columns) {
+				const idx = header.indexOf(col)
+				if (idx === -1) throw `Column ${col} was not found`
+				headerIndices.push(idx)
+			}
+			if (headerIndices.length === 0) throw 'No matching columns found'
+		} else {
+			if (!headerIndices) continue // data before header (shouldn't happen); nothing to select yet
+			const cells = line.split('\t')
+			out.push(headerIndices.map(i => cells[i] ?? '').join('\t'))
+		}
+	}
+	if (out.length === 0) throw 'Empty MAF file'
+	return out.join('\n') + '\n'
 }

--- a/server/src/routes/gdc.mafBuild.ts
+++ b/server/src/routes/gdc.mafBuild.ts
@@ -86,6 +86,28 @@ concurrencyLimiter and a config-driven, per-environment concurrency cap.
 async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	const t0 = Date.now()
 
+	// Validate/normalize request + config inputs BEFORE any multipart response bytes are written (and
+	// before the GDC size query / RSS timer), so a bad value produces a clean early error — handled by
+	// init()'s catch as a JSON error response — instead of corrupting an already-started multipart stream
+	// or failing deep inside mapConcurrent().
+	const columns = q.columns
+	if (!Array.isArray(columns) || columns.length === 0) throw 'columns must be a non-empty array'
+	if (columns.some(c => typeof c != 'string' || c.length == 0)) throw 'every column must be a non-empty string'
+
+	// serverconfig is operator-supplied JSON, so gdcMafConcurrency may be absent, a string, or otherwise
+	// not a positive integer. Coerce + validate here (a set-but-invalid value falls back to the default,
+	// with a log) rather than letting it propagate into mapConcurrent() and throw mid-response.
+	const rawConcurrency = serverconfig.features.gdcMafConcurrency
+	const concurrencyNum = Number(rawConcurrency)
+	const concurrency = Number.isInteger(concurrencyNum) && concurrencyNum > 0 ? concurrencyNum : defaultConcurrency
+	if (rawConcurrency != null && concurrency !== concurrencyNum) {
+		mayLog(
+			`gdcmaf: invalid serverconfig.features.gdcMafConcurrency=${JSON.stringify(
+				rawConcurrency
+			)}, falling back to ${defaultConcurrency}`
+		)
+	}
+
 	// Sample process RSS through the build so the finalize log can report the peak working set (helps
 	// catch memory spikes from large cohorts / many concurrent downloads). Caveat: rss is process-wide,
 	// not request-local — if two /gdc/mafBuild builds overlap, one peak can include the other's memory;
@@ -107,9 +129,7 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		)}`
 	)
 
-	const concurrency = serverconfig.features.gdcMafConcurrency || defaultConcurrency
 	const dataHost = joinUrl(host.rest, 'data') // must use the /data/ endpoint from current host
-	const columns = q.columns
 
 	// Abort active downloads if the client disconnects (e.g. browser tab refreshed mid-download), so
 	// orphaned GDC requests don't keep running after no one is listening.
@@ -351,10 +371,15 @@ async function getFileLstUnderSizeLimit(lst: string[], host, headers) {
 
 /*
 Shared, stateful core of the rust select_maf_col port: feed it MAF lines one at a time and it finds the
-header (by its Hugo_Symbol column), resolves each requested column to its index, and returns the selected
-tab-joined row for each data line (or null for comment/header/pre-header lines). Throws if a requested
-column is absent from the header. Keeping this incremental lets the same logic drive both selectMafCols()
-(whole-string, unit-tested) and streamSelectMafCols() (line-by-line, low memory) with identical behavior.
+header (the first non-comment line with an exact Hugo_Symbol column), resolves each requested column to
+its index, and returns the selected tab-joined row for each data line (or null for comment/header/
+pre-header lines). Throws if a requested column is absent from the header. Keeping this incremental lets
+the same logic drive both selectMafCols() (whole-string, unit-tested) and streamSelectMafCols()
+(line-by-line, low memory) with identical behavior.
+
+Header detection is deliberately (a) an exact tab-split field match, not a substring — so a data value
+containing "Hugo_Symbol" can't be mistaken for the header — and (b) only attempted while headerIndices
+is still null, so a later matching line can't reset the indices and corrupt column selection mid-file.
 */
 function createMafRowSelector(columns: string[]) {
 	let headerIndices: number[] | null = null
@@ -362,18 +387,18 @@ function createMafRowSelector(columns: string[]) {
 	return {
 		processLine(line: string): string | null {
 			if (line.startsWith('#')) return null
-			if (line.includes('Hugo_Symbol')) {
-				const header = line.split('\t')
-				headerIndices = []
-				for (const col of columns) {
-					const idx = header.indexOf(col)
+			if (!headerIndices) {
+				// still looking for the header row; identify it by an exact Hugo_Symbol column
+				const fields = line.split('\t')
+				if (!fields.includes('Hugo_Symbol')) return null // pre-header line (shouldn't happen); skip
+				headerIndices = columns.map(col => {
+					const idx = fields.indexOf(col)
 					if (idx === -1) throw `Column ${col} was not found`
-					headerIndices.push(idx)
-				}
+					return idx
+				})
 				if (headerIndices.length === 0) throw 'No matching columns found'
 				return null
 			}
-			if (!headerIndices) return null // data before header (shouldn't happen); nothing to select yet
 			const cells = line.split('\t')
 			dataRowCount++
 			return headerIndices.map(i => cells[i] ?? '').join('\t')

--- a/server/src/routes/gdc.mafBuild.ts
+++ b/server/src/routes/gdc.mafBuild.ts
@@ -4,19 +4,21 @@ import { joinUrl } from '#shared/joinUrl.js'
 import type { GdcMafBuildRequest } from '#types'
 import { maxTotalSizeCompressed } from './gdc.maf.ts'
 import { mayLog } from '#src/helpers.ts'
-import { formatElapsedTime } from '#shared'
+import { formatElapsedTime, fileSize } from '#shared'
 import serverconfig from '#src/serverconfig.js'
 import { mapConcurrent } from '#src/utils/concurrencyLimiter.ts'
-import { createGzip, gunzip } from 'zlib'
+import { createGzip, createGunzip } from 'zlib'
+import { Readable } from 'stream'
 import { once } from 'events'
-import { promisify } from 'util'
 
-// async (libuv threadpool) gunzip so decompressing each downloaded MAF doesn't block the event loop
-const gunzipAsync = promisify(gunzip)
-
-// per-file download timeout (ms); matches the former rust reqwest per-request timeout so a single
+// per-file whole-download timeout (ms); matches the former rust reqwest per-request timeout so a single
 // stalled GDC download can't hold a worker slot indefinitely
 const downloadTimeoutMs = 60000
+
+// flush accumulated selected rows to the gzip sink once a file's pending batch exceeds this, so the
+// per-file working set stays bounded (~one decompressed chunk + one batch) instead of the whole
+// decompressed file and its split/join copies; see streamSelectMafCols
+const writeFlushBytes = 256 * 1024
 
 export const GdcMafPayload: RoutePayload = {
 	init,
@@ -56,13 +58,13 @@ const defaultConcurrency = 20
 export type FileError = { url: string; error: string }
 
 export type MafMergeResult = {
-	/** number of files successfully decompressed, column-selected, and written */
+	/** number of files successfully streamed, column-selected, and written */
 	merged: number
 	/** per-file failures (download/decompress/column errors); never aborts the batch */
 	errors: FileError[]
-	/** summed timings across files; download/decompress overlap wall-clock, parse does not (see buildMaf) */
-	totalDownloadMs: number
-	totalDecompressMs: number
+	/** summed per-file stream time (download+decompress+parse interleaved); overlaps wall-clock under concurrency */
+	totalStreamMs: number
+	/** summed main-thread time in line parsing/column-selection — the only event-loop-blocking work */
 	totalParseMs: number
 }
 
@@ -83,6 +85,19 @@ concurrencyLimiter and a config-driven, per-environment concurrency cap.
 */
 async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	const t0 = Date.now()
+
+	// Sample process RSS through the build so the finalize log can report the peak working set (helps
+	// catch memory spikes from large cohorts / many concurrent downloads). Caveat: rss is process-wide,
+	// not request-local — if two /gdc/mafBuild builds overlap, one peak can include the other's memory;
+	// the log prints file count + concurrency so overlapping builds stay visible when reading logs.
+	const rss0 = process.memoryUsage().rss
+	let peakRss = rss0
+	const rssTimer = setInterval(() => {
+		const rss = process.memoryUsage().rss
+		if (rss > peakRss) peakRss = rss
+	}, 250)
+	rssTimer.unref() // the sampler must never keep the event loop / process alive on its own
+
 	const { host, headers } = ds.getHostHeaders(q)
 	const fileLst2: string[] = await getFileLstUnderSizeLimit(q.fileIdLst, host, headers)
 
@@ -110,14 +125,14 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	const errors: FileError[] = []
 	let completed = 0 // files that finished (merged or errored); lets the disconnect log report how many were still pending
 
-	// Timing instrumentation, summed across files, to see where the wall-clock goes. download/decompress
-	// run concurrently so their sums overlap wall-clock; parse has no awaits so it can't overlap itself —
-	// totalParseMs is therefore the real main-thread time spent parsing (i.e. event-loop blocking).
-	// Reassigned from the mergeMafFiles() result below; default to 0 so the finalize log is always valid.
+	// Timing instrumentation, summed across files. Each file is downloaded + decompressed + column-selected
+	// as a single interleaved stream (see streamSelectMafCols), so totalStreamMs is the summed per-file
+	// wall time (overlaps across concurrent files) and totalParseMs is the summed main-thread time in line
+	// parsing — the only event-loop-blocking work. Reassigned from the mergeMafFiles() result below;
+	// default to 0 so the finalize log is always valid.
 	let merged = 0
-	let totalDownloadMs = 0
-	let totalDecompressMs = 0 // async gunzip on the libuv threadpool (parallel up to UV_THREADPOOL_SIZE)
-	let totalParseMs = 0 // main-thread: buffer->utf8 + selectMafCols column selection
+	let totalStreamMs = 0
+	let totalParseMs = 0 // main-thread: per-chunk utf8 + line split + column selection
 
 	// Single gzip stream for the merged MAF, piped into the multipart body. { end: false } keeps res
 	// open after gz finishes so the trailing "errors" part + closing boundary can still be written.
@@ -128,11 +143,12 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 
 	res.on('close', () => {
 		if (res.writableEnded) return
+		clearInterval(rssTimer)
 		// client went away before we finished: stop downloads and tear down
 		mayLog(
-			`gdcmaf build: client disconnected, aborting downloads (${completed.toLocaleString()}/${fileLst2.length.toLocaleString()} files done). Time elapsed: ${formatElapsedTime(
-				Date.now() - t0
-			)}`
+			`gdcmaf build: client disconnected, aborting downloads (${completed.toLocaleString()}/${fileLst2.length.toLocaleString()} files done)` +
+				` | mem: peak ${fileSize(peakRss)} (Δ ${fileSize(peakRss - rss0)})` +
+				` | Time elapsed: ${formatElapsedTime(Date.now() - t0)}`
 		)
 		controller.abort()
 		try {
@@ -163,19 +179,31 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		// header row first (matches the former rust output: header line then all selected data rows)
 		await writeGz(columns.join('\t') + '\n')
 
-		// the download fan-out + decompress + column-select + per-file error collection lives in
+		// the download fan-out + streaming decompress/column-select + per-file error collection lives in
 		// mergeMafFiles() so it can be unit-tested with an injected fetcher (no GDC/network). Here the
-		// fetcher is a real GDC /data download via ky, and the write sink is the serialized gzip writer.
+		// fetcher streams a real GDC /data download via ky, and the write sink is the serialized gzip writer.
 		const result = await mergeMafFiles({
 			fileIdLst: fileLst2,
 			columns,
 			concurrency,
 			signal: controller.signal,
-			fetchGz: (fileId, signal) =>
-				ky
-					.get(joinUrl(dataHost, fileId), { headers, timeout: downloadTimeoutMs, retry: { limit: 2 }, signal })
-					.arrayBuffer()
-					.then(ab => Buffer.from(ab)),
+			// Stream the gz bytes straight from GDC into the decompress+parse pipeline instead of buffering
+			// the whole file — this is what caps the per-file memory to ~one chunk + one flush batch.
+			// AbortSignal.any combines the client-disconnect controller with a per-file whole-download
+			// timeout (covers response + body streaming), mirroring the former rust per-request timeout;
+			// ky's own timeout is disabled so that single signal is the sole authority. Tradeoff vs the
+			// former .arrayBuffer(): ky's retry no longer covers a mid-stream network drop — that now
+			// surfaces as a per-file error (settled semantics), not a silent retry.
+			fetchGzStream: async (fileId, signal) => {
+				const r = await ky.get(joinUrl(dataHost, fileId), {
+					headers,
+					timeout: false,
+					retry: { limit: 2 },
+					signal: AbortSignal.any([signal, AbortSignal.timeout(downloadTimeoutMs)])
+				})
+				if (!r.body) throw 'no response body from GDC'
+				return Readable.fromWeb(r.body as any)
+			},
 			write: writeGz,
 			onFileSettled: () => completed++
 		})
@@ -185,8 +213,7 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		// the uuid as the final path segment, so matching keeps working.
 		errors.push(...result.errors.map(e => ({ ...e, url: joinUrl(dataHost, e.url) })))
 		merged = result.merged
-		totalDownloadMs = result.totalDownloadMs
-		totalDecompressMs = result.totalDecompressMs
+		totalStreamMs = result.totalStreamMs
 		totalParseMs = result.totalParseMs
 
 		// flush any pending serialized writes before closing the gzip stream
@@ -202,6 +229,7 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 	// "errors" part and the closing multipart boundary, then end the response.
 	gz.on('end', () => {
 		if (res.writableEnded) return
+		clearInterval(rssTimer)
 		res.write(`\r\n--${boundary}`)
 		res.write('\r\nContent-Disposition: form-data; name="errors"')
 		res.write('\r\nContent-Type: application/x-jsonlines')
@@ -209,19 +237,23 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 		res.write('\r\n\r\n' + json)
 		res.write(`\r\n--${boundary}--\r\n`)
 		const elapsed = Date.now() - t0
-		const avgDownloadMs = merged ? Math.round(totalDownloadMs / merged) : 0
-		const avgDecompressMs = merged ? Math.round(totalDecompressMs / merged) : 0
-		// totalDownloadMs sums concurrent downloads, so dividing by wall-clock gives the implied
+		const avgStreamMs = merged ? Math.round(totalStreamMs / merged) : 0
+		// totalStreamMs sums concurrent per-file stream times, so dividing by wall-clock gives the implied
 		// parallelism (how many were overlapping on average) rather than a misleading multi-minute sum
-		const downloadParallelism = elapsed ? (totalDownloadMs / elapsed).toFixed(1) : '0'
+		const streamParallelism = elapsed ? (totalStreamMs / elapsed).toFixed(1) : '0'
+		// final RSS sample, in case the last spike landed between 250ms ticks
+		const rssEnd = process.memoryUsage().rss
+		if (rssEnd > peakRss) peakRss = rssEnd
 		mayLog(
 			`gdcmaf build: ${merged.toLocaleString()} merged / ${errors.length.toLocaleString()} failed of ${fileLst2.length.toLocaleString()} files` +
+				` (concurrency ${concurrency})` +
 				` in ${formatElapsedTime(elapsed)}` +
 				` | main-thread parse: ${formatElapsedTime(totalParseMs)}` +
-				` | decompress: avg ${avgDecompressMs}ms/file (UV_THREADPOOL_SIZE=${
-					process.env.UV_THREADPOOL_SIZE || '4 (default)'
-				})` +
-				` | download: avg ${avgDownloadMs}ms/file, ~${downloadParallelism}× parallel`
+				` | stream (download+decompress+parse): avg ${avgStreamMs}ms/file, ~${streamParallelism}× parallel` +
+				` (UV_THREADPOOL_SIZE=${process.env.UV_THREADPOOL_SIZE || '4 (default)'})` +
+				` | mem: start ${fileSize(rss0)}, peak ${fileSize(peakRss)} (Δ ${fileSize(peakRss - rss0)}), end ${fileSize(
+					rssEnd
+				)}`
 		)
 		res.end()
 	})
@@ -230,28 +262,28 @@ async function buildMaf(q: GdcMafBuildRequest, res, ds) {
 
 /*
 Core of the cohort-MAF build, factored out of buildMaf() so it can be unit-tested without GDC or a
-network: download each file (via the injected `fetchGz`), decompress, select the requested columns, and
-hand the selected rows to the injected `write` sink. Downloads run through mapConcurrent() so at most
-`concurrency` are in flight at once. A per-file failure is recorded in `errors` and never aborts the
+network. For each file: open its gzipped byte stream (via the injected `fetchGzStream`) and run it
+through streamSelectMafCols(), which decompresses + column-selects + writes the rows incrementally so
+the per-file working set stays bounded (no whole-file buffering). Files run through mapConcurrent() so at
+most `concurrency` are in flight at once. A per-file failure is recorded in `errors` and never aborts the
 batch (settled semantics); an aborted `signal` stops scheduling new files and suppresses late errors.
-`fetchGz(fileId, signal)` returns the gzipped bytes of one file; `write(rows)` consumes one file's
-selected rows (the caller serializes writes / handles backpressure); `onFileSettled` fires once per
-finished file for live progress reporting.
+`fetchGzStream(fileId, signal)` returns a Readable of one file's gzipped bytes; `write(rows)` consumes a
+batch of selected rows (the caller serializes writes / handles backpressure); `onFileSettled` fires once
+per finished file for live progress reporting.
 */
 export async function mergeMafFiles(opts: {
 	fileIdLst: string[]
 	columns: string[]
 	concurrency: number
 	signal: AbortSignal
-	fetchGz: (fileId: string, signal: AbortSignal) => Promise<Buffer>
+	fetchGzStream: (fileId: string, signal: AbortSignal) => Promise<Readable>
 	write: (rows: string) => Promise<void>
 	onFileSettled?: () => void
 }): Promise<MafMergeResult> {
-	const { fileIdLst, columns, concurrency, signal, fetchGz, write, onFileSettled } = opts
+	const { fileIdLst, columns, concurrency, signal, fetchGzStream, write, onFileSettled } = opts
 	const errors: FileError[] = []
 	let merged = 0
-	let totalDownloadMs = 0
-	let totalDecompressMs = 0
+	let totalStreamMs = 0
 	let totalParseMs = 0
 
 	await mapConcurrent(
@@ -260,20 +292,15 @@ export async function mergeMafFiles(opts: {
 		async (fileId: string) => {
 			if (signal.aborted) return
 			try {
-				const dl0 = Date.now()
-				const buf = await fetchGz(fileId, signal)
-				const dl1 = Date.now()
-				const decompressed = await gunzipAsync(buf)
-				const dec1 = Date.now()
-				const rows = selectMafCols(decompressed.toString('utf8'), columns) // throws on missing column / empty file
-				const ps1 = Date.now()
-				await write(rows)
-				// only count a file as merged once its rows are actually written, and accumulate the
-				// timings in lockstep with `merged` — so a write() failure (recorded below as a per-file
-				// error) can't both inflate `merged` and skew the total*/merged averages.
-				totalDownloadMs += dl1 - dl0
-				totalDecompressMs += dec1 - dl1
-				totalParseMs += ps1 - dec1
+				const t0 = Date.now()
+				const gzStream = await fetchGzStream(fileId, signal)
+				// throws on missing column / empty file / mid-stream download error
+				const { parseMs } = await streamSelectMafCols({ gzStream, columns, write, signal })
+				// only count a file as merged once all its rows are written, and accumulate the timings in
+				// lockstep with `merged` — so a failure (recorded below as a per-file error) can't both
+				// inflate `merged` and skew the total*/merged averages.
+				totalStreamMs += Date.now() - t0
+				totalParseMs += parseMs
 				merged++
 			} catch (e: any) {
 				// record per-file failure; the rest of the cohort still merges (settled semantics)
@@ -284,7 +311,7 @@ export async function mergeMafFiles(opts: {
 		{ signal }
 	)
 
-	return { merged, errors, totalDownloadMs, totalDecompressMs, totalParseMs }
+	return { merged, errors, totalStreamMs, totalParseMs }
 }
 
 /*
@@ -323,33 +350,117 @@ async function getFileLstUnderSizeLimit(lst: string[], host, headers) {
 }
 
 /*
-Port of the former rust select_maf_col: from one decompressed MAF file's text, keep only the requested
-columns (in the requested order) for every data row, tab-joined. Skips `#` comment lines, finds the
-header line by its Hugo_Symbol column, and resolves each requested column to its index. Throws if a
-requested column is absent or the file has no data rows, so the caller records it as a per-file error.
-Returns the selected rows as a single string, each row newline-terminated.
+Shared, stateful core of the rust select_maf_col port: feed it MAF lines one at a time and it finds the
+header (by its Hugo_Symbol column), resolves each requested column to its index, and returns the selected
+tab-joined row for each data line (or null for comment/header/pre-header lines). Throws if a requested
+column is absent from the header. Keeping this incremental lets the same logic drive both selectMafCols()
+(whole-string, unit-tested) and streamSelectMafCols() (line-by-line, low memory) with identical behavior.
 */
-export function selectMafCols(text: string, columns: string[]): string {
-	const lines = text.replace(/\n+$/, '').split('\n')
+function createMafRowSelector(columns: string[]) {
 	let headerIndices: number[] | null = null
-	const out: string[] = []
-	for (const line of lines) {
-		if (line.startsWith('#')) continue
-		if (line.includes('Hugo_Symbol')) {
-			const header = line.split('\t')
-			headerIndices = []
-			for (const col of columns) {
-				const idx = header.indexOf(col)
-				if (idx === -1) throw `Column ${col} was not found`
-				headerIndices.push(idx)
+	let dataRowCount = 0
+	return {
+		processLine(line: string): string | null {
+			if (line.startsWith('#')) return null
+			if (line.includes('Hugo_Symbol')) {
+				const header = line.split('\t')
+				headerIndices = []
+				for (const col of columns) {
+					const idx = header.indexOf(col)
+					if (idx === -1) throw `Column ${col} was not found`
+					headerIndices.push(idx)
+				}
+				if (headerIndices.length === 0) throw 'No matching columns found'
+				return null
 			}
-			if (headerIndices.length === 0) throw 'No matching columns found'
-		} else {
-			if (!headerIndices) continue // data before header (shouldn't happen); nothing to select yet
+			if (!headerIndices) return null // data before header (shouldn't happen); nothing to select yet
 			const cells = line.split('\t')
-			out.push(headerIndices.map(i => cells[i] ?? '').join('\t'))
+			dataRowCount++
+			return headerIndices.map(i => cells[i] ?? '').join('\t')
+		},
+		get dataRowCount() {
+			return dataRowCount
 		}
 	}
-	if (out.length === 0) throw 'Empty MAF file'
+}
+
+/*
+Whole-string column selection: from one decompressed MAF file's text, keep only the requested columns
+(in the requested order) for every data row, tab-joined. Throws if a requested column is absent or the
+file has no data rows, so the caller records it as a per-file error. Returns the selected rows as a single
+string, each row newline-terminated. The streaming path (streamSelectMafCols) is what production uses;
+this stays for direct, deterministic unit testing of the column-selection logic.
+*/
+export function selectMafCols(text: string, columns: string[]): string {
+	const selector = createMafRowSelector(columns)
+	const out: string[] = []
+	for (const line of text.replace(/\n+$/, '').split('\n')) {
+		const row = selector.processLine(line)
+		if (row !== null) out.push(row)
+	}
+	if (selector.dataRowCount === 0) throw 'Empty MAF file'
 	return out.join('\n') + '\n'
+}
+
+/*
+Streaming select+merge for one file: consume its gzipped byte stream, decompress incrementally
+(createGunzip on the libuv threadpool), split into lines as decompressed chunks arrive (carrying any
+partial trailing line across chunk boundaries), select the requested columns line-by-line, and flush
+selected rows to `write` in ~writeFlushBytes batches. This caps the per-file working set to roughly one
+decompressed chunk + one batch, instead of holding the whole decompressed file (and its split/join
+copies) at once — the dominant driver of the build's peak RSS. Awaiting each flush propagates gzip
+backpressure up through gunzip to the download, so a slow client throttles the download rather than
+buffering. Throws on a missing column, an empty file (no data rows), or a stream/decompress error,
+matching selectMafCols() so the caller records a per-file error. Returns the rows written and the
+main-thread time spent parsing.
+*/
+export async function streamSelectMafCols(opts: {
+	gzStream: Readable
+	columns: string[]
+	write: (rows: string) => Promise<void>
+	signal: AbortSignal
+}): Promise<{ rowCount: number; parseMs: number }> {
+	const { gzStream, columns, write, signal } = opts
+	const selector = createMafRowSelector(columns)
+	const gunzip = createGunzip()
+	let parseMs = 0
+	let buf = '' // pending selected rows, flushed in batches
+	let leftover = '' // partial trailing line carried across chunk boundaries
+	try {
+		// pipe doesn't forward source errors, so wire gzStream errors into gunzip; that makes the for-await
+		// reject (e.g. on a mid-stream network drop) instead of hanging
+		gzStream.on('error', err => gunzip.destroy(err))
+		gzStream.pipe(gunzip)
+		for await (const chunk of gunzip) {
+			if (signal.aborted) break
+			const t0 = Date.now()
+			const text = leftover + chunk.toString('utf8')
+			const lines = text.split('\n')
+			leftover = lines.pop() ?? '' // last element is the (possibly empty) partial line
+			for (const line of lines) {
+				const row = selector.processLine(line)
+				if (row !== null) buf += row + '\n'
+			}
+			parseMs += Date.now() - t0
+			if (buf.length >= writeFlushBytes) {
+				await write(buf)
+				buf = ''
+			}
+		}
+		// the final line has no trailing newline, so it sits in leftover; process it now
+		if (leftover) {
+			const t0 = Date.now()
+			const row = selector.processLine(leftover)
+			if (row !== null) buf += row + '\n'
+			parseMs += Date.now() - t0
+		}
+		if (buf) await write(buf)
+		if (selector.dataRowCount === 0) throw 'Empty MAF file'
+		return { rowCount: selector.dataRowCount, parseMs }
+	} finally {
+		// tear down on any exit (success / abort / column or stream error) so a half-read download can't
+		// leak a socket or threadpool slot
+		gzStream.destroy()
+		gunzip.destroy()
+	}
 }

--- a/server/src/routes/test/gdc.mafBuild.unit.spec.ts
+++ b/server/src/routes/test/gdc.mafBuild.unit.spec.ts
@@ -206,3 +206,24 @@ tape('an already-aborted signal processes nothing', async function (test) {
 	test.equal(written.length, 0, 'nothing written')
 	test.end()
 })
+
+tape('a write() failure is counted as an error, not a merge', async function (test) {
+	// `merged` and the timing totals must only advance after write() succeeds, so a failed write can't
+	// both inflate `merged` and skew the total*/merged averages. 'b' downloads + selects fine but its
+	// write throws; it must be recorded as a per-file error and excluded from `merged`.
+	const result = await mergeMafFiles({
+		fileIdLst: ['a', 'b', 'c'],
+		columns: OUT_COLS,
+		concurrency: 1,
+		signal: new AbortController().signal,
+		fetchGz,
+		write: async rows => {
+			if (rows.includes('KRAS')) throw new Error('simulated write failure')
+		}
+	})
+	test.equal(result.merged, 2, 'only the two files whose write succeeded count as merged')
+	const byUrl = Object.fromEntries(result.errors.map(e => [e.url, e.error]))
+	test.equal(result.errors.length, 1, 'the failed-write file is recorded as a single error')
+	test.match(byUrl.b, /simulated write failure/, 'write failure recorded against the right file')
+	test.end()
+})

--- a/server/src/routes/test/gdc.mafBuild.unit.spec.ts
+++ b/server/src/routes/test/gdc.mafBuild.unit.spec.ts
@@ -45,6 +45,8 @@ tape('\n', function (test) {
 })
 
 tape('selects requested columns in the requested order', function (test) {
+	test.timeoutAfter(1000) // fail fast instead of hanging CI
+
 	// request a subset, reordered relative to the file's column order
 	const out = selectMafCols(maf, ['Variant_Classification', 'Hugo_Symbol'])
 	test.equal(
@@ -56,6 +58,8 @@ tape('selects requested columns in the requested order', function (test) {
 })
 
 tape('selects all columns when all are requested', function (test) {
+	test.timeoutAfter(1000) // fail fast instead of hanging CI
+
 	const out = selectMafCols(maf, HEADER)
 	test.equal(
 		out,
@@ -66,6 +70,8 @@ tape('selects all columns when all are requested', function (test) {
 })
 
 tape('throws when a requested column is not in the header', function (test) {
+	test.timeoutAfter(1000) // fail fast instead of hanging CI
+
 	test.throws(
 		() => selectMafCols(maf, ['Hugo_Symbol', 'No_Such_Column']),
 		/Column No_Such_Column was not found/,
@@ -75,6 +81,8 @@ tape('throws when a requested column is not in the header', function (test) {
 })
 
 tape('throws "Empty MAF file" when there are no data rows', function (test) {
+	test.timeoutAfter(1000) // fail fast instead of hanging CI
+
 	const headerOnly = ['#meta', HEADER.join('\t')].join('\n')
 	test.throws(() => selectMafCols(headerOnly, ['Hugo_Symbol']), /Empty MAF file/, 'header but no data rows → throws')
 
@@ -84,6 +92,8 @@ tape('throws "Empty MAF file" when there are no data rows', function (test) {
 })
 
 tape('pads a ragged (short) data row with empty fields', function (test) {
+	test.timeoutAfter(1000) // fail fast instead of hanging CI
+
 	// second data row is missing its trailing Variant_Classification cell
 	const ragged = [
 		HEADER.join('\t'),
@@ -100,9 +110,31 @@ tape('pads a ragged (short) data row with empty fields', function (test) {
 })
 
 tape('trims trailing blank lines so no empty data row leaks through', function (test) {
+	test.timeoutAfter(1000) // fail fast instead of hanging CI
+
 	const trailing = maf + '\n\n\n'
 	const out = selectMafCols(trailing, ['Hugo_Symbol'])
 	test.equal(out, 'TP53\nKRAS\n', 'trailing newlines should not produce extra empty rows')
+	test.end()
+})
+
+tape('does not treat a data field containing "Hugo_Symbol" as a second header', function (test) {
+	test.timeoutAfter(1000) // fail fast instead of hanging CI
+
+	// only the first exact-Hugo_Symbol line is the header; a later data row whose field merely CONTAINS
+	// the substring must be selected as data, not re-parsed as a header (which would reset column indices
+	// or throw "Column ... was not found")
+	const withSubstring = [
+		HEADER.join('\t'),
+		['TP53', 'chr17', '7577120', 'Missense_Mutation'].join('\t'),
+		['BRCA1', 'chr17', '41197694', 'note_Hugo_Symbol_x'].join('\t')
+	].join('\n')
+	const out = selectMafCols(withSubstring, ['Hugo_Symbol', 'Variant_Classification'])
+	test.equal(
+		out,
+		'TP53\tMissense_Mutation\nBRCA1\tnote_Hugo_Symbol_x\n',
+		'a data row with a "Hugo_Symbol" substring is selected as data, not misread as a header'
+	)
 	test.end()
 })
 
@@ -145,6 +177,8 @@ tape('\n', function (test) {
 })
 
 tape('merges good files and isolates per-file failures', async function (test) {
+	test.timeoutAfter(5000) // fail fast instead of hanging CI
+
 	const written: string[] = []
 	let settled = 0
 	// concurrency 1 → deterministic write order matching fileIdLst, so we can assert exact output
@@ -177,6 +211,8 @@ tape('merges good files and isolates per-file failures', async function (test) {
 })
 
 tape('merges every good file exactly once with concurrency > 1', async function (test) {
+	test.timeoutAfter(5000) // fail fast instead of hanging CI
+
 	const written: string[] = []
 	const result = await mergeMafFiles({
 		fileIdLst: ['a', 'b', 'c'],
@@ -199,6 +235,8 @@ tape('merges every good file exactly once with concurrency > 1', async function 
 })
 
 tape('an already-aborted signal processes nothing', async function (test) {
+	test.timeoutAfter(5000) // fail fast instead of hanging CI
+
 	const controller = new AbortController()
 	controller.abort()
 	const written: string[] = []
@@ -219,6 +257,8 @@ tape('an already-aborted signal processes nothing', async function (test) {
 })
 
 tape('a write() failure is counted as an error, not a merge', async function (test) {
+	test.timeoutAfter(5000) // fail fast instead of hanging CI
+
 	// `merged` and the timing totals must only advance after write() succeeds, so a failed write can't
 	// both inflate `merged` and skew the total*/merged averages. 'b' downloads + selects fine but its
 	// write throws; it must be recorded as a per-file error and excluded from `merged`.

--- a/server/src/routes/test/gdc.mafBuild.unit.spec.ts
+++ b/server/src/routes/test/gdc.mafBuild.unit.spec.ts
@@ -48,7 +48,7 @@ tape('selects all columns when all are requested', function (test) {
 	const out = selectMafCols(maf, HEADER)
 	test.equal(
 		out,
-		'TP53\tchr17\t7577120\tMissense_Mutation\nKRAS\tchr12\t25398284\tNonsense_Mutation\n',
+		'TP53\tchr17\t7577120\tMissense_Mutation\nKRAS\tchr12\t25398284\tNonsense_Mutation\n', // pragma: allowlist secret
 		'should pass through every data row with all columns intact'
 	)
 	test.end()

--- a/server/src/routes/test/gdc.mafBuild.unit.spec.ts
+++ b/server/src/routes/test/gdc.mafBuild.unit.spec.ts
@@ -1,0 +1,208 @@
+import tape from 'tape'
+import { gzipSync } from 'zlib'
+import { selectMafCols, mergeMafFiles } from '../gdc.mafBuild.ts'
+
+/*
+selectMafCols() is the column-selection logic ported from the former rust gdcmaf binary. It takes one
+decompressed MAF file's text and returns only the requested columns (in the requested order) for every
+data row, tab-joined and newline-terminated. It does NOT emit the header row (buildMaf writes that once
+for the merged file). These specs lock in the port's behavior so it can't silently drift from the rust
+original.
+
+test sections:
+- selects requested columns and preserves the requested order (not the file's column order)
+- skips leading #-comment lines and finds the header by its Hugo_Symbol column
+- throws "Column X was not found" when a requested column is absent from the header
+- throws "Empty MAF file" when there are no data rows (header only, or comments only)
+- pads a short/ragged data row with empty fields rather than emitting undefined
+- trims trailing blank lines so no empty data row leaks into the output
+*/
+
+// a small but realistic MAF fixture: two comment lines, a header, two data rows
+const HEADER = ['Hugo_Symbol', 'Chromosome', 'Start_Position', 'Variant_Classification']
+const maf = [
+	'#version 2.4',
+	'#filedate 20240101',
+	HEADER.join('\t'),
+	['TP53', 'chr17', '7577120', 'Missense_Mutation'].join('\t'),
+	['KRAS', 'chr12', '25398284', 'Nonsense_Mutation'].join('\t')
+].join('\n')
+
+tape('\n', function (test) {
+	test.comment('-***- #routes/gdc.mafBuild selectMafCols -***-')
+	test.end()
+})
+
+tape('selects requested columns in the requested order', function (test) {
+	// request a subset, reordered relative to the file's column order
+	const out = selectMafCols(maf, ['Variant_Classification', 'Hugo_Symbol'])
+	test.equal(
+		out,
+		'Missense_Mutation\tTP53\nNonsense_Mutation\tKRAS\n',
+		'should emit only the requested columns, in request order, one data row per line, newline-terminated'
+	)
+	test.end()
+})
+
+tape('selects all columns when all are requested', function (test) {
+	const out = selectMafCols(maf, HEADER)
+	test.equal(
+		out,
+		'TP53\tchr17\t7577120\tMissense_Mutation\nKRAS\tchr12\t25398284\tNonsense_Mutation\n',
+		'should pass through every data row with all columns intact'
+	)
+	test.end()
+})
+
+tape('throws when a requested column is not in the header', function (test) {
+	test.throws(
+		() => selectMafCols(maf, ['Hugo_Symbol', 'No_Such_Column']),
+		/Column No_Such_Column was not found/,
+		'should throw a descriptive error naming the missing column'
+	)
+	test.end()
+})
+
+tape('throws "Empty MAF file" when there are no data rows', function (test) {
+	const headerOnly = ['#meta', HEADER.join('\t')].join('\n')
+	test.throws(() => selectMafCols(headerOnly, ['Hugo_Symbol']), /Empty MAF file/, 'header but no data rows → throws')
+
+	const commentsOnly = ['#a', '#b'].join('\n')
+	test.throws(() => selectMafCols(commentsOnly, ['Hugo_Symbol']), /Empty MAF file/, 'no header/data at all → throws')
+	test.end()
+})
+
+tape('pads a ragged (short) data row with empty fields', function (test) {
+	// second data row is missing its trailing Variant_Classification cell
+	const ragged = [
+		HEADER.join('\t'),
+		['TP53', 'chr17', '7577120', 'Missense_Mutation'].join('\t'),
+		['EGFR', 'chr7', '55249071'].join('\t') // only 3 of 4 cells
+	].join('\n')
+	const out = selectMafCols(ragged, ['Hugo_Symbol', 'Variant_Classification'])
+	test.equal(
+		out,
+		'TP53\tMissense_Mutation\nEGFR\t\n',
+		'missing trailing cell should render as an empty field, not the string "undefined"'
+	)
+	test.end()
+})
+
+tape('trims trailing blank lines so no empty data row leaks through', function (test) {
+	const trailing = maf + '\n\n\n'
+	const out = selectMafCols(trailing, ['Hugo_Symbol'])
+	test.equal(out, 'TP53\nKRAS\n', 'trailing newlines should not produce extra empty rows')
+	test.end()
+})
+
+/*
+mergeMafFiles() is the download+decompress+select+merge pipeline, with the GDC fetch injected so we can
+drive the whole thing deterministically in-process (no network/server). These cover the behaviors that
+matter beyond a single file's column selection: concurrent merge, per-file error isolation, and abort.
+
+test sections:
+- merges good files and isolates per-file failures (download error / empty file / missing column) without aborting the batch
+- runs with concurrency > 1 and still merges every good file exactly once
+- an already-aborted signal processes nothing
+*/
+
+// build a gzipped MAF "download" for one file; the injected fetcher returns these
+function makeGzMaf(header: string[], dataRows: string[][]): Buffer {
+	const text = ['#comment line', header.join('\t'), ...dataRows.map(r => r.join('\t'))].join('\n')
+	return gzipSync(Buffer.from(text))
+}
+const OUT_COLS = ['Hugo_Symbol', 'Variant_Classification']
+const gzByFile: Record<string, Buffer> = {
+	a: makeGzMaf(HEADER, [['TP53', 'chr17', '7577120', 'Missense_Mutation']]),
+	b: makeGzMaf(HEADER, [
+		['KRAS', 'chr12', '25398284', 'Nonsense_Mutation'],
+		['EGFR', 'chr7', '55249071', 'Silent']
+	]),
+	c: makeGzMaf(HEADER, [['BRAF', 'chr7', '140453136', 'Missense_Mutation']]),
+	empty: makeGzMaf(HEADER, []), // header only → selectMafCols throws "Empty MAF file"
+	missingcol: makeGzMaf(['Hugo_Symbol', 'Chromosome'], [['PTEN', 'chr10']]) // lacks a requested column
+}
+// injected fetcher: returns canned bytes, or throws to simulate a failed download for id 'bad'
+const fetchGz = async (fileId: string): Promise<Buffer> => {
+	if (fileId === 'bad') throw new Error('simulated download failure')
+	return gzByFile[fileId]
+}
+
+tape('\n', function (test) {
+	test.comment('-***- #routes/gdc.mafBuild mergeMafFiles -***-')
+	test.end()
+})
+
+tape('merges good files and isolates per-file failures', async function (test) {
+	const written: string[] = []
+	let settled = 0
+	// concurrency 1 → deterministic write order matching fileIdLst, so we can assert exact output
+	const result = await mergeMafFiles({
+		fileIdLst: ['a', 'bad', 'b', 'empty', 'missingcol'],
+		columns: OUT_COLS,
+		concurrency: 1,
+		signal: new AbortController().signal,
+		fetchGz,
+		write: async rows => {
+			written.push(rows)
+		},
+		onFileSettled: () => settled++
+	})
+
+	test.equal(result.merged, 2, 'two good files (a, b) merged')
+	test.equal(settled, 5, 'onFileSettled fired once per input file (merged + errored)')
+	test.equal(
+		written.join(''),
+		'TP53\tMissense_Mutation\nKRAS\tNonsense_Mutation\nEGFR\tSilent\n',
+		'only good files contribute rows, in input order, with the selected columns'
+	)
+
+	const byUrl = Object.fromEntries(result.errors.map(e => [e.url, e.error]))
+	test.equal(result.errors.length, 3, 'three files failed')
+	test.match(byUrl.bad, /simulated download failure/, 'download failure recorded for "bad"')
+	test.match(byUrl.empty, /Empty MAF file/, 'empty-file error recorded for "empty"')
+	test.match(byUrl.missingcol, /Column Variant_Classification was not found/, 'missing-column error recorded')
+	test.end()
+})
+
+tape('merges every good file exactly once with concurrency > 1', async function (test) {
+	const written: string[] = []
+	const result = await mergeMafFiles({
+		fileIdLst: ['a', 'b', 'c'],
+		columns: OUT_COLS,
+		concurrency: 3,
+		signal: new AbortController().signal,
+		fetchGz,
+		write: async rows => {
+			written.push(rows)
+		}
+	})
+	test.equal(result.merged, 3, 'all three good files merged')
+	test.equal(result.errors.length, 0, 'no errors')
+	// write order is non-deterministic under concurrency, so assert membership rather than order
+	const all = written.join('')
+	for (const sym of ['TP53', 'KRAS', 'EGFR', 'BRAF']) {
+		test.ok(all.includes(sym), `merged output contains rows from each file (${sym})`)
+	}
+	test.end()
+})
+
+tape('an already-aborted signal processes nothing', async function (test) {
+	const controller = new AbortController()
+	controller.abort()
+	const written: string[] = []
+	const result = await mergeMafFiles({
+		fileIdLst: ['a', 'b', 'c'],
+		columns: OUT_COLS,
+		concurrency: 2,
+		signal: controller.signal,
+		fetchGz,
+		write: async rows => {
+			written.push(rows)
+		}
+	})
+	test.equal(result.merged, 0, 'no files merged when aborted up front')
+	test.equal(result.errors.length, 0, 'no errors recorded under abort (late errors suppressed)')
+	test.equal(written.length, 0, 'nothing written')
+	test.end()
+})

--- a/server/src/routes/test/gdc.mafBuild.unit.spec.ts
+++ b/server/src/routes/test/gdc.mafBuild.unit.spec.ts
@@ -1,6 +1,17 @@
 import tape from 'tape'
 import { gzipSync } from 'zlib'
+import { Readable } from 'stream'
 import { selectMafCols, mergeMafFiles } from '../gdc.mafBuild.ts'
+
+// a single-chunk binary Readable of the given gz bytes, standing in for one file's GDC download stream
+function gzStreamFrom(buf: Buffer): Readable {
+	return new Readable({
+		read() {
+			this.push(buf)
+			this.push(null)
+		}
+	})
+}
 
 /*
 selectMafCols() is the column-selection logic ported from the former rust gdcmaf binary. It takes one
@@ -122,10 +133,10 @@ const gzByFile: Record<string, Buffer> = {
 	empty: makeGzMaf(HEADER, []), // header only → selectMafCols throws "Empty MAF file"
 	missingcol: makeGzMaf(['Hugo_Symbol', 'Chromosome'], [['PTEN', 'chr10']]) // lacks a requested column
 }
-// injected fetcher: returns canned bytes, or throws to simulate a failed download for id 'bad'
-const fetchGz = async (fileId: string): Promise<Buffer> => {
+// injected fetcher: returns a gz byte stream for the file, or throws to simulate a failed download ('bad')
+const fetchGzStream = async (fileId: string): Promise<Readable> => {
 	if (fileId === 'bad') throw new Error('simulated download failure')
-	return gzByFile[fileId]
+	return gzStreamFrom(gzByFile[fileId])
 }
 
 tape('\n', function (test) {
@@ -142,7 +153,7 @@ tape('merges good files and isolates per-file failures', async function (test) {
 		columns: OUT_COLS,
 		concurrency: 1,
 		signal: new AbortController().signal,
-		fetchGz,
+		fetchGzStream,
 		write: async rows => {
 			written.push(rows)
 		},
@@ -172,7 +183,7 @@ tape('merges every good file exactly once with concurrency > 1', async function 
 		columns: OUT_COLS,
 		concurrency: 3,
 		signal: new AbortController().signal,
-		fetchGz,
+		fetchGzStream,
 		write: async rows => {
 			written.push(rows)
 		}
@@ -196,7 +207,7 @@ tape('an already-aborted signal processes nothing', async function (test) {
 		columns: OUT_COLS,
 		concurrency: 2,
 		signal: controller.signal,
-		fetchGz,
+		fetchGzStream,
 		write: async rows => {
 			written.push(rows)
 		}
@@ -216,7 +227,7 @@ tape('a write() failure is counted as an error, not a merge', async function (te
 		columns: OUT_COLS,
 		concurrency: 1,
 		signal: new AbortController().signal,
-		fetchGz,
+		fetchGzStream,
 		write: async rows => {
 			if (rows.includes('KRAS')) throw new Error('simulated write failure')
 		}

--- a/server/src/test/gdc.mafBuild.integration.spec.js
+++ b/server/src/test/gdc.mafBuild.integration.spec.js
@@ -1,0 +1,62 @@
+import tape from 'tape'
+import { gunzipSync } from 'zlib'
+import serverconfig from '../serverconfig.js'
+
+/*
+End-to-end check of the /gdc/mafBuild route against a RUNNING server with GDC access (like the other
+*.integration.spec.js files, this is not part of the unit sweep and assumes a live server on
+serverconfig.port). It exercises the real wire path the deterministic unit tests can't: the forwarded
+GDC headers, the actual file downloads, and the multipart/form-data response framing.
+
+Note: depends on GDC open-access files that are subject to change; assertions are structural (valid
+gzip, header == requested columns, >0 rows, parseable errors part) rather than exact content.
+
+The two file UUIDs below are the canonical open-access MAF files used elsewhere for manual testing
+(see rust/src/gdcmaf.rs and the commented example in routes/gdc.mafBuild.ts).
+*/
+
+const url = `http://localhost:${serverconfig.port}/gdc/mafBuild`
+const fileIdLst = ['8b31d6d1-56f7-4aa8-b026-c64bafd531e7', '83ea587b-1e92-41b3-a8e3-12df30496724']
+const columns = ['Hugo_Symbol', 'Chromosome', 'Start_Position', 'Variant_Classification']
+
+tape('\n', test => {
+	test.comment('-***- gdc.mafBuild integration specs -***-')
+	test.end()
+})
+
+tape('gdc/mafBuild builds a merged cohort MAF', async test => {
+	try {
+		const res = await fetch(url, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ fileIdLst, columns })
+		})
+		test.ok(
+			res.headers.get('content-type')?.includes('multipart/form-data'),
+			'response content-type is multipart/form-data'
+		)
+
+		// parse the multipart response the same way the browser client does (res.formData()): the gzfile
+		// part has a filename so it comes back as a Blob; the errors part has no filename so it's a string
+		const form = await res.formData()
+
+		const gzfile = form.get('gzfile')
+		test.ok(gzfile && typeof gzfile !== 'string', 'response has a gzfile (binary) part')
+
+		const text = gunzipSync(Buffer.from(await gzfile.arrayBuffer())).toString('utf8')
+		const lines = text.replace(/\n+$/, '').split('\n')
+		test.equal(lines[0], columns.join('\t'), 'merged header row equals the requested columns, in order')
+		test.ok(lines.length > 1, 'merged MAF contains at least one data row')
+		test.equal(lines[1].split('\t').length, columns.length, 'each data row has exactly one field per requested column')
+
+		// errors part must be present and parse as jsonlines (array of { url, error }); empty is fine
+		const errorsRaw = form.get('errors')
+		const errors = typeof errorsRaw === 'string' && errorsRaw.trim() ? errorsRaw.trim().split('\n').map(JSON.parse) : []
+		test.ok(Array.isArray(errors), 'errors part parses as a jsonlines array (empty when all files succeed)')
+
+		test.end()
+	} catch (e) {
+		test.fail(`request to ${url} failed (this spec needs a running server with GDC access): ${e?.message || e}`)
+		test.end()
+	}
+})

--- a/server/src/test/gdc.mafBuild.integration.spec.js
+++ b/server/src/test/gdc.mafBuild.integration.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env node, es2021 */
 import tape from 'tape'
 import { gunzipSync } from 'zlib'
 import serverconfig from '../serverconfig.js'
@@ -13,7 +14,15 @@ gzip, header == requested columns, >0 rows, parseable errors part) rather than e
 
 The two file UUIDs below are the canonical open-access MAF files used elsewhere for manual testing
 (see rust/src/gdcmaf.rs and the commented example in routes/gdc.mafBuild.ts).
+
+fetch: bound explicitly from globalThis rather than imported from node-fetch (as the urlencoded
+integration specs do) because this spec parses the multipart/form-data response with res.formData() —
+which node-fetch v2 does not implement. The global fetch (undici, Node 18+) returns the gzfile part as
+a Blob, which is what the browser client also relies on. The binding makes the dependency explicit (no
+undeclared global) and the guard below skips cleanly if a runtime ever lacks it, instead of throwing a
+bare ReferenceError mid-test.
 */
+const fetch = globalThis.fetch
 
 const url = `http://localhost:${serverconfig.port}/gdc/mafBuild`
 const fileIdLst = ['8b31d6d1-56f7-4aa8-b026-c64bafd531e7', '83ea587b-1e92-41b3-a8e3-12df30496724']
@@ -25,6 +34,13 @@ tape('\n', test => {
 })
 
 tape('gdc/mafBuild builds a merged cohort MAF', async test => {
+	if (typeof fetch != 'function') {
+		// no global fetch (Node < 18); this spec needs its spec-compliant multipart formData(), so skip
+		// with a clear message rather than throwing further down
+		test.skip('global fetch unavailable in this runtime (needs Node 18+); skipping integration spec')
+		test.end()
+		return
+	}
 	try {
 		const res = await fetch(url, {
 			method: 'POST',

--- a/server/src/test/gdc.mafBuild.integration.spec.js
+++ b/server/src/test/gdc.mafBuild.integration.spec.js
@@ -34,6 +34,9 @@ tape('\n', test => {
 })
 
 tape('gdc/mafBuild builds a merged cohort MAF', async test => {
+	// bound the real GDC download+build so a hung server/network fails the test instead of hanging CI;
+	// generous headroom for a genuine 2-file download over the wire
+	test.timeoutAfter(60000)
 	if (typeof fetch != 'function') {
 		// no global fetch (Node < 18); this spec needs its spec-compliant multipart formData(), so skip
 		// with a clear message rather than throwing further down
@@ -45,12 +48,25 @@ tape('gdc/mafBuild builds a merged cohort MAF', async test => {
 		const res = await fetch(url, {
 			method: 'POST',
 			headers: { 'content-type': 'application/json' },
-			body: JSON.stringify({ fileIdLst, columns })
+			body: JSON.stringify({ fileIdLst, columns }),
+			// abort the request just under the tape timeout above, so a hung server actually releases the
+			// socket (rather than leaving a dangling handle that keeps the process — and CI — alive)
+			signal: AbortSignal.timeout(55000)
 		})
-		test.ok(
-			res.headers.get('content-type')?.includes('multipart/form-data'),
-			'response content-type is multipart/form-data'
-		)
+
+		// assert a successful multipart response BEFORE parsing it. On a non-2xx (server down / proxy error /
+		// route error) the body is a plain error string, not multipart — surface it as the root cause here
+		// rather than letting res.formData() throw an opaque multipart-parse error further down.
+		const contentType = res.headers.get('content-type') || ''
+		if (!res.ok || !contentType.includes('multipart/form-data')) {
+			const body = await res.text().catch(() => '<unreadable body>')
+			test.fail(
+				`expected 2xx multipart/form-data, got HTTP ${res.status} (${contentType || 'no content-type'}): ${body}`
+			)
+			test.end()
+			return
+		}
+		test.pass('response is 2xx multipart/form-data')
 
 		// parse the multipart response the same way the browser client does (res.formData()): the gzfile
 		// part has a filename so it comes back as a Blob; the errors part has no filename so it's a string


### PR DESCRIPTION
# Description
Replaces the former Rust `gdcmaf` binary with a Node/TypeScript implementation of the
`/gdc/mafBuild` route. The Rust binary coupled download + column-select + gzip-merge with a
hardcoded concurrency; moving it into Node lets the route reuse the shared, tested
`concurrencyLimiter` and a config-driven, per-environment concurrency cap. The Rust `gdcmaf` binary is still present and won't be removed until this is thoroughly tested and such. Setting as draft until Edgar is back and has a chance to review

## What changed

**Server — `server/src/routes/gdc.mafBuild.ts`**
- Downloads each requested MAF from GDC's `/data/` endpoint (via `ky`, with per-file timeout +
  retry), async-gunzips off the event loop, selects the requested columns, and streams the merged
  cohort MAF back as the `gzfile` part of a `multipart/form-data` response.
- Fan-out runs through `mapConcurrent()` so at most `concurrency` files are in flight. Concurrency
  is driven by `serverconfig.features.gdcMafConcurrency` (falls back to 20, matching the old Rust
  `buffer_unordered(20)`), so it can be dialed down per environment (e.g. qa-int) without a rebuild.
- Per-file failures are collected and returned as the `errors` part (jsonlines) so one bad file
  can't abort the whole batch (settled semantics).
- Writes to the single gzip stream are serialized behind a promise chain and honor backpressure;
  client disconnect aborts in-flight downloads and tears down cleanly.
- `selectMafCols()` ports the Rust `select_maf_col` column-selection logic; `mergeMafFiles()` is
  factored out with an injected fetcher so it can be unit-tested without GDC or a network.
- Timing instrumentation (download / decompress / parse) is logged to show where wall-clock goes.

**Client — `client/gdc/maf.js`**
- "Select all" header checkbox now stays in sync with the column rows.
- Counts in the UI use `toLocaleString()` for readability.

**Tests**
- `server/src/routes/test/gdc.mafBuild.unit.spec.ts` — deterministic unit tests for `selectMafCols`
  (column order, missing column, empty/header-only/comments-only, ragged rows, trailing newlines)
  and `mergeMafFiles` (merge, per-file errors, injected fetcher; no network).
- `server/src/test/gdc.mafBuild.integration.spec.js` — end-to-end check against a running server
  with GDC access: validates multipart framing, gzip validity, header == requested columns, >0 data
  rows, and a parseable errors part.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
