### PR TITLE
display an error message in the gene search UI when the GDC cohort >5k cases

### DIFF
--- a/client/plots/summarizeGeneexpSurvival.ts
+++ b/client/plots/summarizeGeneexpSurvival.ts
@@ -53,9 +53,9 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 						chartsInstance,
 						holder
 					})
-				} catch (e) {
+				} catch (e: any) {
 					loadingDiv.style('display', 'none')
-					errDiv.style('display', 'block').text(e)
+					errDiv.style('display', 'block').text(`Error: ` + (e.message || e.error || String(e)))
 				}
 			}
 		})

--- a/client/plots/summarizeGeneexpSurvival.ts
+++ b/client/plots/summarizeGeneexpSurvival.ts
@@ -35,6 +35,7 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 			.style('margin', '5px')
 			.style('font-size', '.7em')
 			.text('LOADING ...')
+		const errDiv = td2.append('div').style('display', 'none').attr('class', 'sja_errorbar')
 		const result = addGeneSearchbox({
 			row: searchDiv,
 			tip,
@@ -42,15 +43,20 @@ export async function makeChartBtnMenu(holder, chartsInstance) {
 			testid: 'sjpp-summarizeGeneexpSurvival-genesearch',
 			genome: chartsInstance.app.opts.genome!,
 			callback: async () => {
-				loadingDiv.style('display', 'block')
-				const expTw: any = { term: { gene: result.geneSymbol, type: 'geneExpression' } }
-				await fillTermWrapper(expTw, chartsInstance.app.vocabApi, t0_t2_defaultQ)
-				launchPlot({
-					tw1: dictTw,
-					tw2: expTw,
-					chartsInstance,
-					holder
-				})
+				try {
+					loadingDiv.style('display', 'block')
+					const expTw: any = { term: { gene: result.geneSymbol, type: 'geneExpression' } }
+					await fillTermWrapper(expTw, chartsInstance.app.vocabApi, t0_t2_defaultQ)
+					launchPlot({
+						tw1: dictTw,
+						tw2: expTw,
+						chartsInstance,
+						holder
+					})
+				} catch (e) {
+					loadingDiv.style('display', 'none')
+					errDiv.style('display', 'block').text(e)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2796.

The summary plot `Gene Expresssion` chart button menu gets stuck in `Loading ...` when the cohort size is >5k cases. There is an error in the browser console, which should be displayed to the user instead.

Test:
- Using http://localhost:3000//example.gdc.correlation.html?noheader=1&cohort=All_GDC, click on `Gene Exp vs Survival`, type a gene, should see an error similar to the screenshot below. Change the cohort in the dropdown to APOLLO-LUAD, the error should not appear and the summary plot should render.

<img width="714" height="257" alt="Screenshot 2026-07-02 at 5 58 57 PM" src="https://github.com/user-attachments/assets/84f3c0de-3ec2-4b58-9526-e1c313cc93c7" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
