### PR TITLE
use uiLabels in violin and boxplot interactions menus

### DIFF
--- a/client/dom/summary/ListSamples.ts
+++ b/client/dom/summary/ListSamples.ts
@@ -6,6 +6,7 @@ import { getSamplelstFilter } from '../../mass/groups.js'
 import { TermTypes, isNumericTerm, roundValueAuto, isStrictNumeric } from '#shared'
 import { filterJoin } from '#filter'
 import { addGvRowVals, addGvCols } from '#plots/barchart.events.js'
+import { defaultUiLabels } from '#plots/PlotBase.ts'
 
 /** Temp type scoped for this file.
  * Properties required in the plot arg. */
@@ -147,6 +148,7 @@ export class ListSamples {
 	}
 
 	createTvsValues(tvsEntry: any, tw: any, key: string): any {
+		const { Sample } = this.app.vocabApi?.termdbConfig?.uiLabels || defaultUiLabels
 		if (
 			(tw?.q?.type == 'custom-groupset' || tw?.q?.type == 'predefined-groupset') &&
 			tw.term.type !== TermTypes.GENE_VARIANT
@@ -157,7 +159,7 @@ export class ListSamples {
 			if (!group) throw new Error(`Group not found in groupset for ${tw.term.name}: ${key}`)
 			tvsEntry.tvs.values = group.values
 		} else if (tw.term.type === TermTypes.SAMPLELST) {
-			if (!tw.term.values?.[key]) throw new Error(`Sample list not found for ${tw.term.name}: ${key}`)
+			if (!tw.term.values?.[key]) throw new Error(`${Sample} list not found for ${tw.term.name}: ${key}`)
 			const ids = (tw.term.values[key].list || []).map(s => s.sampleId)
 			// Returns filter obj with lst array of 1 tvs
 			const tmpTvsLst = getSamplelstFilter(ids)
@@ -233,6 +235,7 @@ export class ListSamples {
 	}
 
 	async getData(): Promise<AnnotatedSampleData> {
+		const { sample } = this.app.vocabApi.termdbConfig.uiLabels
 		try {
 			const opts = {
 				terms: this.terms,
@@ -241,12 +244,12 @@ export class ListSamples {
 				isSummary: true
 			}
 			const data = await this.app.vocabApi.getAnnotatedSampleData(opts)
-			if (!data) throw new Error('No sample data returned')
+			if (!data) throw new Error(`No ${sample} data returned`)
 			return data
 		} catch (e: any) {
 			if (e instanceof Error) throw e
 			else {
-				throw new Error(`Error fetching sample data: ${e.message || e}`)
+				throw new Error(`Error fetching ${sample} data: ${e.message || e}`)
 			}
 		}
 	}
@@ -305,9 +308,9 @@ export class ListSamples {
 			rows.push(row)
 			samples.push(s)
 		}
-
+		const { Sample } = this.app.vocabApi.termdbConfig.uiLabels
 		//Formatting columns
-		const columns: TableColumn[] = [{ label: 'Sample' }]
+		const columns: TableColumn[] = [{ label: Sample }]
 		this.addColValue(this.t1, columns)
 		if (this.t2) this.addColValue(this.t2, columns)
 		if (this.t0) this.addColValue(this.t0, columns)

--- a/client/dom/summary/ListSamples.ts
+++ b/client/dom/summary/ListSamples.ts
@@ -235,7 +235,7 @@ export class ListSamples {
 	}
 
 	async getData(): Promise<AnnotatedSampleData> {
-		const { sample } = this.app.vocabApi.termdbConfig.uiLabels
+		const { sample } = this.app.vocabApi?.termdbConfig?.uiLabels || defaultUiLabels
 		try {
 			const opts = {
 				terms: this.terms,
@@ -308,7 +308,7 @@ export class ListSamples {
 			rows.push(row)
 			samples.push(s)
 		}
-		const { Sample } = this.app.vocabApi.termdbConfig.uiLabels
+		const { Sample } = this.app.vocabApi?.termdbConfig?.uiLabels || defaultUiLabels
 		//Formatting columns
 		const columns: TableColumn[] = [{ label: Sample }]
 		this.addColValue(this.t1, columns)

--- a/client/dom/summary/ListSamples.ts
+++ b/client/dom/summary/ListSamples.ts
@@ -148,7 +148,7 @@ export class ListSamples {
 	}
 
 	createTvsValues(tvsEntry: any, tw: any, key: string): any {
-		const { Sample } = this.app.vocabApi?.termdbConfig?.uiLabels || defaultUiLabels
+		const { Sample } = Object.assign({}, defaultUiLabels, this.app.vocabApi?.termdbConfig?.uiLabels || {})
 		if (
 			(tw?.q?.type == 'custom-groupset' || tw?.q?.type == 'predefined-groupset') &&
 			tw.term.type !== TermTypes.GENE_VARIANT
@@ -235,7 +235,7 @@ export class ListSamples {
 	}
 
 	async getData(): Promise<AnnotatedSampleData> {
-		const { sample } = this.app.vocabApi?.termdbConfig?.uiLabels || defaultUiLabels
+		const { sample } = Object.assign({}, defaultUiLabels, this.app.vocabApi?.termdbConfig?.uiLabels || {})
 		try {
 			const opts = {
 				terms: this.terms,
@@ -308,7 +308,7 @@ export class ListSamples {
 			rows.push(row)
 			samples.push(s)
 		}
-		const { Sample } = this.app.vocabApi?.termdbConfig?.uiLabels || defaultUiLabels
+		const { Sample } = Object.assign({}, defaultUiLabels, this.app.vocabApi?.termdbConfig?.uiLabels || {})
 		//Formatting columns
 		const columns: TableColumn[] = [{ label: Sample }]
 		this.addColValue(this.t1, columns)

--- a/client/plots/PlotBase.ts
+++ b/client/plots/PlotBase.ts
@@ -45,7 +45,7 @@ export class PlotBase {
 		this.id = opts?.id
 		this.app = opts?.app
 		this.parentId = opts?.parentId
-		// plot dhild class should use config.controlLabels, app.termdbConfig.uilLabels or this default
+		// plot child class should use config.controlLabels, app.vocabApi.termdbConfig.uiLabels, or this default
 		this.uiLabels = defaultUiLabels
 		// Below creates a vocabApi instance that is unique to the plot instance,
 		// so that there'd be a plot-level request cancellation using plotApi.getAbortSignal()

--- a/client/plots/PlotBase.ts
+++ b/client/plots/PlotBase.ts
@@ -16,6 +16,15 @@ export class PlotBase {
 		[name: string]: any
 	} = {}
 
+	uiLabels: {
+		[labelKey: string]:
+			| string
+			| {
+					label?: string
+					title: string
+			  }
+	}
+
 	components: {
 		[name: string]: ComponentApi | { [name: string]: ComponentApi }
 	} = {}
@@ -36,6 +45,8 @@ export class PlotBase {
 		this.id = opts?.id
 		this.app = opts?.app
 		this.parentId = opts?.parentId
+		// plot dhild class should use config.controlLabels, app.termdbConfig.uilLabels or this default
+		this.uiLabels = defaultUiLabels
 		// Below creates a vocabApi instance that is unique to the plot instance,
 		// so that there'd be a plot-level request cancellation using plotApi.getAbortSignal()
 		if (this.app?.vocabApi) this.vocabApi = this.app.vocabApi.create(() => this.api?.getAbortSignal())

--- a/client/plots/boxplot/BoxPlot.ts
+++ b/client/plots/boxplot/BoxPlot.ts
@@ -126,9 +126,7 @@ export class TdbBoxplot extends PlotBase implements RxComponent {
 
 	async init() {
 		this.dom.div.style('display', 'inline-block').style('margin-left', '20px')
-		this.interactions = new BoxPlotInteractions(this.app, this.dom, this.id, () => {
-			return this.data
-		})
+		this.interactions = new BoxPlotInteractions(this, () => this.data)
 		await this.setControls()
 	}
 

--- a/client/plots/boxplot/interactions/BoxPlotInteractions.ts
+++ b/client/plots/boxplot/interactions/BoxPlotInteractions.ts
@@ -1,6 +1,7 @@
-import type { BoxPlotDom, LegendItemEntry, BoxPlotConfig } from '../BoxPlotTypes'
+import type { BoxPlotDom, LegendItemEntry } from '../BoxPlotTypes'
 import type { MassAppApi } from '#mass/types/mass'
 import type { RenderedPlot } from '../view/RenderedPlot'
+import type { TdbBoxplot } from '../BoxPlot.ts'
 import { ListSamples } from '#dom/summary/ListSamples'
 import { filterJoin, getFilterItemByTag } from '#filter'
 
@@ -8,12 +9,14 @@ export class BoxPlotInteractions {
 	app: MassAppApi
 	dom: BoxPlotDom
 	id: string
+	boxplot: TdbBoxplot
 	getResData: () => any
 
-	constructor(app: MassAppApi, dom: BoxPlotDom, id: string, getResData: () => any) {
-		this.app = app
-		this.dom = dom
-		this.id = id
+	constructor(boxplot: TdbBoxplot, getResData: () => any) {
+		this.app = boxplot.app
+		this.boxplot = boxplot
+		this.dom = boxplot.dom
+		this.id = boxplot.id
 		this.getResData = getResData
 	}
 
@@ -114,7 +117,7 @@ export class BoxPlotInteractions {
 	}
 
 	getPlotConfig() {
-		return this.app.getState().plots.find((p: BoxPlotConfig) => p.id === this.id)
+		return this.boxplot.state.config
 	}
 
 	clearDom() {

--- a/client/plots/boxplot/view/BoxPlotLabelMenu.ts
+++ b/client/plots/boxplot/view/BoxPlotLabelMenu.ts
@@ -28,9 +28,10 @@ export class BoxPlotLabelMenu {
 			callback: () => interactions.hidePlot(plot)
 		})
 
+		const { samples } = interactions.getPlotConfig().controlLabels
 		if (app.getState().nav.header_mode === 'with_tabs')
 			options.push({
-				text: `List samples`,
+				text: `List ${samples}`,
 				isVisible: (state: MassState) => state.termdbConfig.displaySampleIds && app.vocabApi.hasVerifiedToken(),
 				callback: async (event: MouseEvent) => {
 					if (isVertical) tip.clear().show(event.clientX, event.clientY)

--- a/client/plots/violin.interactivity.js
+++ b/client/plots/violin.interactivity.js
@@ -56,9 +56,10 @@ export function setInteractivity(self) {
 				})
 			}
 		})
+		const { samples } = self.config.controlLabels
 		if (self.state.displaySampleIds && self.state.hasVerifiedToken) {
 			options.push({
-				label: `List samples`,
+				label: `List ${samples}`,
 				testid: 'sjpp-violinLabOpt-list',
 				callback: async () => {
 					/** self.data.max * 2 appears to be a workaround for a
@@ -100,9 +101,10 @@ export function setInteractivity(self) {
 				callback: getAddFilterCallback(self, plot, start, end)
 			})
 
+		const { samples } = self.config.controlLabels
 		if (self.state.displaySampleIds && self.state.hasVerifiedToken) {
 			options.push({
-				label: `List samples`,
+				label: `List ${samples}`,
 				testid: 'sjpp-violinBrushOpt-list',
 				callback: async () => self.callListSamples(event.sourceEvent, plot, start, end)
 			})


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2754

Tests:
- open http://localhost:3000//example.gdc.correlation.html?noheader=1&cohort=TCGA-LGG
- use numeric terms as primary and overlay variables
- click on `Violin` tab, then click on a series label, there should be a `List cases` option, instead of `List samples`, click that option, the table should have a `Case` column title instead of `Sample`
- click on `Boxplot` tab and do similar clicks/interactions as with the violin plot
- also tested locally with all unit and integration tests

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
