### PR TITLE
use uiLabels in scatter plot

### DIFF
--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -4,7 +4,7 @@ import { fillTermWrapper } from '#termsetting'
 import type { MassState } from '#mass/types/mass'
 import { rebaseGroupFilter } from '#mass/groups'
 import { getCurrentCohortChartTypes } from '#mass/charts'
-import { PlotBase } from '#plots/PlotBase.js'
+import { PlotBase, defaultUiLabels } from '#plots/PlotBase.js'
 import { controlsInit } from '../controls'
 import { select2Terms, DownloadMenu } from '#dom'
 import type { Settings } from './settings/Settings.ts'
@@ -229,9 +229,8 @@ export class Scatter extends PlotBase implements RxComponent {
 export async function getPlotConfig(opts, app) {
 	const plot: any = {
 		groups: [],
-		// scatter controls should not use defaultUiLabels as they
-		// follow a different labeling schema
-		controlLabels: Object.assign({}, /* defaultUiLabels,*/ app.vocabApi.termdbConfig.uiLabels || {}),
+		// scatter controls may use defaultUiLabels or ignore the defaults for custom labels with a different key-value schema
+		controlLabels: Object.assign({}, defaultUiLabels, app.vocabApi.termdbConfig.uiLabels || {}),
 		settings: {
 			controls: {
 				isOpen: false // control panel is hidden by default

--- a/client/plots/scatter/view/scatterView.ts
+++ b/client/plots/scatter/view/scatterView.ts
@@ -177,7 +177,7 @@ export class ScatterView {
 				configKey: 'colorTW',
 				chartType,
 				usecase: { target: 'sampleScatter', detail: 'colorTW', specialCase },
-				title: 'Categories to color the ${labels.sample} symbol',
+				title: `Categories to color the ${labels.sample} symbol`,
 				label: 'Color',
 				vocabApi: this.scatter.app.vocabApi,
 				numericEditMenuVersion: ['continuous', 'discrete'],
@@ -314,7 +314,9 @@ export class ScatterView {
 		} else if (!this.scatter.config.singleCellPlot) {
 			inputs.push(
 				{
-					label: `${labels.Sample} size`, // changed from 'Sample size', but how is this different from `${itemLabel} size`/`Symbol size`?
+					// below was changed from 'Sample size'
+					// TODO: clarify how this is different from `${itemLabel} size`/`Symbol size`?
+					label: `${labels.Sample} size`,
 					type: 'number',
 					chartType,
 					settingsKey: 'threeSize',

--- a/client/plots/scatter/view/scatterView.ts
+++ b/client/plots/scatter/view/scatterView.ts
@@ -66,13 +66,16 @@ export class ScatterView {
 	}
 
 	getControlInputs() {
+		const labels = this.scatter.config.controlLabels
 		const hasRef = this.scatter.model.charts?.[0]?.data?.samples?.find(s => !('sampleId' in s)) || false
+		const chartType = 'sampleScatter'
+		const itemLabel = this.scatter.settings.itemLabel
 		const scaleDotOption = {
 			type: 'term',
 			configKey: 'scaleDotTW',
-			chartType: 'sampleScatter',
+			chartType,
 			usecase: { target: 'sampleScatter', detail: 'numeric' },
-			title: 'Scale sample by term value',
+			title: `Scale symbol size by term value`,
 			label: 'Scale by',
 			vocabApi: this.scatter.app.vocabApi,
 			numericEditMenuVersion: ['continuous'],
@@ -86,7 +89,7 @@ export class ScatterView {
 		const shapeOption = {
 			type: 'term',
 			configKey: 'shapeTW',
-			chartType: 'sampleScatter',
+			chartType,
 			usecase: { target: 'sampleScatter', detail: 'shapeTW' },
 			title: 'Categories to assign a shape',
 			label: 'Shape',
@@ -108,13 +111,11 @@ export class ScatterView {
 			}
 		}
 		const shapeSizeOption = {
-			label: `${this.scatter.settings.itemLabel} size`,
+			label: `${itemLabel} size`,
 			type: 'number',
-			chartType: 'sampleScatter',
+			chartType,
 			settingsKey: 'size',
-			title: `${
-				this.scatter.settings.itemLabel
-			} size, represents the factor used to scale the ${this.scatter.settings.itemLabel.toLowerCase()}`,
+			title: `${itemLabel} size, represents the factor used to scale the ${itemLabel.toLowerCase()}`,
 			min: 0,
 			step: 0.1
 		}
@@ -122,9 +123,9 @@ export class ScatterView {
 		const minShapeSizeOption = {
 			label: 'Min size',
 			type: 'number',
-			chartType: 'sampleScatter',
+			chartType,
 			settingsKey: 'minShapeSize',
-			title: 'Minimum sample size',
+			title: 'Minimum symbol size',
 			min: minShapeSize,
 			max: maxShapeSize,
 			step
@@ -132,9 +133,9 @@ export class ScatterView {
 		const maxShapeSizeOption = {
 			label: 'Max size',
 			type: 'number',
-			chartType: 'sampleScatter',
+			chartType,
 			settingsKey: 'maxShapeSize',
-			title: 'Maximum sample size',
+			title: 'Maximum symbol size',
 			min: minShapeSize,
 			max: maxShapeSize,
 			step
@@ -142,7 +143,7 @@ export class ScatterView {
 		const orientation = {
 			label: 'Scale order',
 			type: 'radio',
-			chartType: 'sampleScatter',
+			chartType,
 			settingsKey: 'scaleDotOrder',
 			options: [
 				{ label: 'Ascending', value: 'Ascending' },
@@ -152,9 +153,9 @@ export class ScatterView {
 		const refSizeOption = {
 			label: 'Reference size',
 			type: 'number',
-			chartType: 'sampleScatter',
+			chartType,
 			settingsKey: 'refSize',
-			title: 'It represents the area of the reference symbol in square pixels',
+			title: 'Set the area of the reference symbol in square pixels.',
 			min: 0,
 			step: 0.1
 		}
@@ -162,7 +163,7 @@ export class ScatterView {
 			boxLabel: '',
 			label: 'Show axes',
 			type: 'checkbox',
-			chartType: 'sampleScatter',
+			chartType,
 			settingsKey: 'showAxes',
 			title: `Option to show/hide plot axes`,
 			testid: 'showAxes'
@@ -174,9 +175,9 @@ export class ScatterView {
 			{
 				type: 'term',
 				configKey: 'colorTW',
-				chartType: 'sampleScatter',
+				chartType,
 				usecase: { target: 'sampleScatter', detail: 'colorTW', specialCase },
-				title: 'Categories to color the samples',
+				title: 'Categories to color the ${labels.sample} symbol',
 				label: 'Color',
 				vocabApi: this.scatter.app.vocabApi,
 				numericEditMenuVersion: ['continuous', 'discrete'],
@@ -190,9 +191,9 @@ export class ScatterView {
 			{
 				label: 'Opacity',
 				type: 'number',
-				chartType: 'sampleScatter',
+				chartType,
 				settingsKey: 'opacity',
-				title: 'It represents the opacity of the elements',
+				title: 'Set the opacity of the elements',
 				min: 0,
 				max: 1,
 				step: 0.1
@@ -200,20 +201,20 @@ export class ScatterView {
 			{
 				label: 'Chart width',
 				type: 'number',
-				chartType: 'sampleScatter',
+				chartType,
 				settingsKey: 'svgw'
 			},
 			{
 				label: 'Chart height',
 				type: 'number',
-				chartType: 'sampleScatter',
+				chartType,
 				settingsKey: 'svgh'
 			},
 			{
 				label: 'Show contour map',
 				boxLabel: '',
 				type: 'checkbox',
-				chartType: 'sampleScatter',
+				chartType,
 				settingsKey: 'showContour',
 				title:
 					"Shows the density of point clouds. If 'Color' is used in continous mode, it uses it to weight the points when calculating the density contours. If 'Z/Divide by' is added in continous mode, it used it instead.",
@@ -226,7 +227,7 @@ export class ScatterView {
 				label: 'Save zoom transform',
 				boxLabel: '',
 				type: 'checkbox',
-				chartType: 'sampleScatter',
+				chartType,
 				settingsKey: 'saveZoomTransform',
 				title: `Option to save the zoom transformation in the state. Needed if you want to save a session with the actual zoom and pan applied`,
 				processInput: value => this.saveZoomTransform(value),
@@ -242,13 +243,13 @@ export class ScatterView {
 					label: 'Color contours',
 					boxLabel: '',
 					type: 'checkbox',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'colorContours'
 				},
 				{
 					label: 'Contour bandwidth',
 					type: 'number',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'contourBandwidth',
 					title: 'Reduce to increase resolution.',
 					min: 5,
@@ -258,7 +259,7 @@ export class ScatterView {
 				{
 					label: 'Contour thresholds',
 					type: 'number',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'contourThresholds',
 					title: 'Increase to enhance contour detail.',
 					min: 5,
@@ -284,7 +285,7 @@ export class ScatterView {
 			const sampleCategory = {
 				label: 'Sample type',
 				type: 'dropdown',
-				chartType: 'sampleScatter',
+				chartType,
 				settingsKey: 'sampleCategory',
 				options
 			}
@@ -296,7 +297,7 @@ export class ScatterView {
 			inputs.unshift({
 				type: 'term',
 				configKey: 'term0',
-				chartType: 'sampleScatter',
+				chartType,
 				usecase: { target: 'sampleScatter', detail: 'term0' },
 				title: 'Term to to divide by categories or to use as Z coordinate',
 				label: 'Z / Divide by',
@@ -313,11 +314,11 @@ export class ScatterView {
 		} else if (!this.scatter.config.singleCellPlot) {
 			inputs.push(
 				{
-					label: 'Sample size',
+					label: `${labels.Sample} size`, // changed from 'Sample size', but how is this different from `${itemLabel} size`/`Symbol size`?
 					type: 'number',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'threeSize',
-					title: 'Sample size',
+					title: `${labels.Sample} size`,
 					min: 0,
 					max: 1,
 					step: 0.001
@@ -325,7 +326,7 @@ export class ScatterView {
 				{
 					label: 'Field of Vision',
 					type: 'number',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'threeFOV',
 					title: 'Field of Vision',
 					min: 50,
@@ -340,9 +341,9 @@ export class ScatterView {
 					{
 						type: 'term',
 						configKey: 'term',
-						chartType: 'sampleScatter',
+						chartType,
 						usecase: { target: 'sampleScatter', detail: 'numeric', specialCase },
-						title: 'X coordinate to plot the samples',
+						title: `X coordinate to plot the ${labels.samples}`,
 						label: 'X',
 						vocabApi: this.scatter.app.vocabApi,
 						menuOptions: '!remove',
@@ -351,9 +352,9 @@ export class ScatterView {
 					{
 						type: 'term',
 						configKey: 'term2',
-						chartType: 'sampleScatter',
+						chartType,
 						usecase: { target: 'sampleScatter', detail: 'numeric', specialCase },
-						title: 'Y coordinate to plot the samples',
+						title: `Y coordinate to plot the ${labels.samples}`,
 						label: 'Y',
 						vocabApi: this.scatter.app.vocabApi,
 						menuOptions: '!remove',
@@ -377,7 +378,7 @@ export class ScatterView {
 				inputs.push({
 					label: 'Show regression',
 					type: 'dropdown',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'regression',
 					options: [
 						{ label: 'None', value: 'None' },
@@ -390,14 +391,14 @@ export class ScatterView {
 				inputs.push({
 					label: 'Chart depth',
 					type: 'number',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'svgd'
 				})
 				inputs.push({
 					label: 'Field of vision',
 					title: 'Camera field of view, in degrees',
 					type: 'number',
-					chartType: 'sampleScatter',
+					chartType,
 					settingsKey: 'fov'
 				})
 			}
@@ -407,7 +408,7 @@ export class ScatterView {
 			inputs.push({
 				label: 'Default color',
 				type: 'color',
-				chartType: 'sampleScatter',
+				chartType,
 				settingsKey: 'defaultColor'
 			})
 		} else if (!this.scatter.model.is2DLarge) {

--- a/client/plots/scatter/viewmodel/scatterLasso.ts
+++ b/client/plots/scatter/viewmodel/scatterLasso.ts
@@ -77,11 +77,12 @@ export class ScatterLasso {
 		if (samples.length == 0) return
 		this.view.dom.tip.show(event.clientX, event.clientY)
 
+		const labels = this.scatter.config.controlLabels
 		const menuDiv = this.view.dom.tip.d.append('div')
 		menuDiv
 			.append('div')
 			.attr('class', 'sja_menuoption sja_sharp_border')
-			.text(`List ${samples.length} samples`)
+			.text(`List ${samples.length} ${labels.samples}`)
 			.on('click', event => {
 				this.view.dom.tip.hide()
 				this.showTable(
@@ -180,7 +181,8 @@ export class ScatterLasso {
 		const rows: TableRow[] = []
 		const columns: TableColumn[] = []
 		const first = group.items[0]
-		if ('sample' in first) columns.push(formatCell('Sample', 'label'))
+		const labels = this.scatter.config.controlLabels
+		if ('sample' in first) columns.push(formatCell(labels.Sample, 'label'))
 		if (this.scatter.config.term) columns.push(formatCell(this.scatter.config.term.term.name, 'label'))
 		if (this.scatter.config.term2) columns.push(formatCell(this.scatter.config.term2.term.name, 'label'))
 		if (this.scatter.config.colorTW) columns.push(formatCell(this.scatter.config.colorTW.term.name, 'label'))


### PR DESCRIPTION
# Description

Fixes https://gdc-ctds.atlassian.net/browse/SV-2754

Tests:
- open http://localhost:3000//example.gdc.correlation.html?noheader=1&cohort=TCGA-LGG
- use numeric terms as primary and overlay variables
- click on `Scatter` tab, then lasso a  group of scatter symbols, there should be a `List cases` option, instead of `List samples`, click that option, the table should have a `Case` column title instead of `Sample`
- Open the control menu, the mouseover description text for inputs should show `Symbol` or `Case` instead of `Sample`

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
