### PR TITLE
GRIN2: MAF filter + hypermutator cutoffs for GDC, and general-route refactor

### DIFF
--- a/client/plots/grin2/GRIN2Types.ts
+++ b/client/plots/grin2/GRIN2Types.ts
@@ -55,7 +55,14 @@ export interface GRIN2RequestData {
 	hardCap?: number
 	binSize?: number
 	snvindelOptions?: { consequences: string[]; mafFilter?: any }
-	cnvOptions?: { lossThreshold?: number; gainThreshold?: number; maxSegLength: number; cnvType?: string }
+	cnvOptions?: {
+		lossThreshold?: number
+		gainThreshold?: number
+		maxSegLength: number
+		cnvType?: string
+		/** categorical cnv (ds.queries.cnv.type='category'): mclass keys of the cnv-segment types to include */
+		cnvCategories?: string[]
+	}
 	fusionOptions?: Record<string, any>
 	svOptions?: Record<string, any>
 	excludeOptions?: { blacklists?: string[]; overlapFrac?: number }

--- a/client/plots/grin2/GRIN2Types.ts
+++ b/client/plots/grin2/GRIN2Types.ts
@@ -54,7 +54,7 @@ export interface GRIN2RequestData {
 	maxCappedPoints?: number
 	hardCap?: number
 	binSize?: number
-	snvindelOptions?: { consequences: string[]; mafFilter?: any }
+	snvindelOptions?: { consequences: string[]; mafFilter?: any; hyperMutator?: number }
 	cnvOptions?: {
 		lossThreshold?: number
 		gainThreshold?: number
@@ -62,6 +62,8 @@ export interface GRIN2RequestData {
 		cnvType?: string
 		/** categorical cnv (ds.queries.cnv.type='category'): mclass keys of the cnv-segment types to include */
 		cnvCategories?: string[]
+		/** samples with more raw cnv segments than this are excluded from cnv (0 disables) */
+		hyperMutator?: number
 	}
 	fusionOptions?: Record<string, any>
 	svOptions?: Record<string, any>

--- a/client/plots/grin2/settings/defaults.ts
+++ b/client/plots/grin2/settings/defaults.ts
@@ -4,9 +4,13 @@ export const CNV_GAIN_THRESHOLD_FALLBACK = 0.4
 export const CNV_MAX_SEG_LENGTH_FALLBACK = 2_000_000
 
 /** Hypermutator cutoffs: a sample with more than this many raw records for a data type is excluded from
- * that data type (0 disables). Defaults mirror the GDC GRIN2 prototype. */
+ * that data type (0 disables). SNV/indel counts mutation burden (source-agnostic), so 8000 is a safe
+ * default. CNV counts *segments*, which varies hugely by data source: sparse for GDC's categorical cnv
+ * (~30/case) but hundreds-to-thousands for dense native segmentation — where a fixed 500 silently drops
+ * whole-sample CNV (esp. aneuploid, gain-heavy samples). So CNV defaults OFF (opt-in); set it per-run when
+ * the source warrants it. */
 export const SNVINDEL_HYPERMUTATOR_FALLBACK = 8000
-export const CNV_HYPERMUTATOR_FALLBACK = 500
+export const CNV_HYPERMUTATOR_FALLBACK = 0
 
 /** How a dataset quantifies cnv values; declared at ds.queries.cnv.type. Mirrors CnvSegmentQuery in #types. */
 export type CnvType = 'log2ratio' | 'segmean' | 'category' | 'copyNumber'

--- a/client/plots/grin2/settings/defaults.ts
+++ b/client/plots/grin2/settings/defaults.ts
@@ -3,6 +3,11 @@ export const CNV_LOSS_THRESHOLD_FALLBACK = -0.4
 export const CNV_GAIN_THRESHOLD_FALLBACK = 0.4
 export const CNV_MAX_SEG_LENGTH_FALLBACK = 2_000_000
 
+/** Hypermutator cutoffs: a sample with more than this many raw records for a data type is excluded from
+ * that data type (0 disables). Defaults mirror the GDC GRIN2 prototype. */
+export const SNVINDEL_HYPERMUTATOR_FALLBACK = 8000
+export const CNV_HYPERMUTATOR_FALLBACK = 500
+
 /** How a dataset quantifies cnv values; declared at ds.queries.cnv.type. Mirrors CnvSegmentQuery in #types. */
 export type CnvType = 'log2ratio' | 'segmean' | 'category' | 'copyNumber'
 

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -179,8 +179,21 @@ export class GRIN2ControlsView {
 
 	private updateRunButtonFromCheckboxes() {
 		const dtUsage = this.snvindelCheckbox ? this.getDtUsage() : (this.config.settings.dtUsage as DtUsage)
-		const anyChecked = Object.values(dtUsage).some(info => info.checked)
-		this.runButton?.property('disabled', !anyChecked)
+		// A run needs at least one data type that would actually contribute data. A ticked data type usually
+		// qualifies, except when it has an explicit include-list with nothing selected: snvindel with no
+		// consequence checked, or categorical CNV with no class checked, both match nothing (an empty list =
+		// "include none"), so they can't drive a run on their own.
+		const anyEffective = Object.entries(dtUsage).some(([dt, info]) => {
+			if (!info.checked) return false
+			if (Number(dt) === dtsnvindel && Object.keys(this.consequenceCheckboxes).length > 0) {
+				return this.getSelectedConsequences().length > 0
+			}
+			if (Number(dt) === dtcnv && Object.keys(this.cnvCategoryCheckboxes).length > 0) {
+				return this.getSelectedCnvCategories().length > 0
+			}
+			return true
+		})
+		this.runButton?.property('disabled', !anyEffective)
 	}
 
 	private getSelectedConsequences(): string[] {
@@ -492,7 +505,9 @@ export class GRIN2ControlsView {
 				labeltext: classInfo.label,
 				checked: initialChecked.has(classKey),
 				divstyle: { 'font-size': `${tableFontSize}px` },
-				callback: () => {}
+				// clearing every consequence includes nothing, which can disable the run button (see
+				// updateRunButtonFromCheckboxes), so re-evaluate it on each toggle
+				callback: () => this.updateRunButtonFromCheckboxes()
 			})
 			checkboxDiv.select('label').attr('title', classInfo.desc)
 			this.consequenceCheckboxes[classKey] = checkbox
@@ -500,14 +515,17 @@ export class GRIN2ControlsView {
 
 		this.snvindelSelectAllBtn.on('click', () => {
 			Object.values(this.consequenceCheckboxes).forEach(cb => cb.property('checked', true))
+			this.updateRunButtonFromCheckboxes()
 		})
 		this.snvindelClearAllBtn.on('click', () => {
 			Object.values(this.consequenceCheckboxes).forEach(cb => cb.property('checked', false))
+			this.updateRunButtonFromCheckboxes()
 		})
 		this.snvindelDefaultBtn.on('click', () => {
 			Object.entries(this.consequenceCheckboxes).forEach(([classKey, checkbox]) => {
 				checkbox.property('checked', canonicalDefault.has(classKey))
 			})
+			this.updateRunButtonFromCheckboxes()
 		})
 	}
 
@@ -571,7 +589,9 @@ export class GRIN2ControlsView {
 				labeltext: c.label,
 				checked: initialChecked.has(c.key),
 				divstyle: { 'font-size': `${tableFontSize}px` },
-				callback: () => {}
+				// clearing every class excludes all cnv, which can disable the run button (see
+				// updateRunButtonFromCheckboxes), so re-evaluate it on each toggle
+				callback: () => this.updateRunButtonFromCheckboxes()
 			})
 			if (c.desc) checkboxDiv.select('label').attr('title', c.desc)
 			this.cnvCategoryCheckboxes[c.key] = checkbox
@@ -579,9 +599,11 @@ export class GRIN2ControlsView {
 
 		selectAllBtn.on('click', () => {
 			Object.values(this.cnvCategoryCheckboxes).forEach(cb => cb.property('checked', true))
+			this.updateRunButtonFromCheckboxes()
 		})
 		clearAllBtn.on('click', () => {
 			Object.values(this.cnvCategoryCheckboxes).forEach(cb => cb.property('checked', false))
+			this.updateRunButtonFromCheckboxes()
 		})
 	}
 }

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -142,7 +142,10 @@ export class GRIN2ControlsView {
 				consequences: this.getSelectedConsequences()
 			}
 			if (this.snvindel_hyperMutator) {
-				requestConfig.snvindelOptions.hyperMutator = parseFloat(this.snvindel_hyperMutator.property('value'))
+				// a cleared input yields NaN; fall back to the default so we never send NaN (which would silently
+				// disable the cutoff server-side and leak "NaN" into summary strings)
+				const v = parseFloat(this.snvindel_hyperMutator.property('value'))
+				requestConfig.snvindelOptions.hyperMutator = Number.isFinite(v) ? v : SNVINDEL_HYPERMUTATOR_FALLBACK
 			}
 			if (this.snvindelMafFilter) {
 				requestConfig.snvindelOptions.mafFilter = this.snvindelMafFilter
@@ -153,7 +156,9 @@ export class GRIN2ControlsView {
 				maxSegLength: parseFloat(this.cnv_maxSegLength.property('value'))
 			}
 			if (this.cnv_hyperMutator) {
-				requestConfig.cnvOptions.hyperMutator = parseFloat(this.cnv_hyperMutator.property('value'))
+				// cleared input => NaN; fall back to the default (see snvindel hyperMutator above)
+				const v = parseFloat(this.cnv_hyperMutator.property('value'))
+				requestConfig.cnvOptions.hyperMutator = Number.isFinite(v) ? v : CNV_HYPERMUTATOR_FALLBACK
 			}
 			// id of the selected cnv file type (datasets exposing singleSampleMutation.cnvTypes, e.g. GDC)
 			if (this.cnvSelectedTypeId) requestConfig.cnvOptions.cnvType = this.cnvSelectedTypeId

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -1,5 +1,23 @@
 import { table2col, make_one_checkbox, make_radios } from '#dom'
-import { dtsnvindel, mclass, dtcnv, dtfusionrna, dtsv, proteinChangingMutations, dt2lesion } from '#shared/common.js'
+import {
+	dtsnvindel,
+	mclass,
+	dtcnv,
+	dtfusionrna,
+	dtsv,
+	proteinChangingMutations,
+	dt2lesion,
+	mclasscnvgain,
+	mclasscnvAmp,
+	mclasscnvloss,
+	mclasscnvHomozygousDel,
+	mclasscnvloh
+} from '#shared/common.js'
+
+// display order for categorical cnv-class checkboxes: gains first (gain, amplification), then losses
+// (heterozygous deletion, homozygous deletion) so the two deletions sit next to each other. Any class not
+// listed here (dataset-specific) is appended after, in its declared order.
+const CNV_CLASS_ORDER = [mclasscnvgain, mclasscnvAmp, mclasscnvloss, mclasscnvHomozygousDel, mclasscnvloh]
 import { filterInit } from '#filter'
 import type { GRIN2ControlsCallbacks, DtUsage } from '../GRIN2Types'
 import { CNV_MAX_SEG_LENGTH_FALLBACK, CNV_TYPE_CONFIG, EXCLUDE_OVERLAP_FRAC_FALLBACK } from '../settings/defaults'
@@ -16,6 +34,9 @@ const checkboxContainerMaxHeight = '150px'
 const checkboxContainerBorder = '1px solid #ddd'
 const controlGap = '8px'
 const checkboxMarginBottom = '2px'
+// shared width for the "Consequences" / "Classes" label cells so their checkbox boxes line up vertically
+// (each lives in its own table2col, whose label column would otherwise size to its own label text)
+const checkboxRowLabelWidth = '110px'
 
 /** Builds and owns the GRIN2 config form (citation header + data-type rows + run button).
  *  Reads its own state from the live DOM and exposes it to the controller via getDtUsage/getConfigValues. */
@@ -35,6 +56,8 @@ export class GRIN2ControlsView {
 	private snvindelSelectAllBtn: any = null
 	private snvindelClearAllBtn: any = null
 	private snvindelDefaultBtn: any = null
+	// one checkbox per supported categorical cnv-segment class (populated only for ds.queries.cnv.type='category')
+	private cnvCategoryCheckboxes: Record<string, any> = {}
 
 	private cnv_lossThreshold: any = null
 	private cnv_gainThreshold: any = null
@@ -125,6 +148,10 @@ export class GRIN2ControlsView {
 				requestConfig.cnvOptions.lossThreshold = parseFloat(this.cnv_lossThreshold.property('value'))
 				requestConfig.cnvOptions.gainThreshold = parseFloat(this.cnv_gainThreshold.property('value'))
 			}
+			// categorical cnv: the checked cnv-segment classes to include (e.g. GDC gain/loss/amp/homdel)
+			if (Object.keys(this.cnvCategoryCheckboxes).length) {
+				requestConfig.cnvOptions.cnvCategories = this.getSelectedCnvCategories()
+			}
 		}
 		if (dtUsage[dtfusionrna]?.checked) requestConfig.fusionOptions = {}
 		if (dtUsage[dtsv]?.checked) requestConfig.svOptions = {}
@@ -171,7 +198,7 @@ export class GRIN2ControlsView {
 		// Consequences section header + checkbox grid
 		{
 			const [labelCell, containerCell] = t2.addRow()
-			labelCell.text('Consequences').style('padding-top', '8px')
+			labelCell.text('Consequences').style('padding-top', '8px').style('min-width', checkboxRowLabelWidth)
 			this.createConsequenceCheckboxes(containerCell)
 		}
 
@@ -285,6 +312,19 @@ export class GRIN2ControlsView {
 		holder.selectAll('*').remove()
 		this.cnvType = valueType
 		const cfg = CNV_TYPE_CONFIG[valueType]
+		// reset per-render; only categorical cnv populates category checkboxes (below)
+		this.cnvCategoryCheckboxes = {}
+
+		if (cfg.hideThresholds) {
+			// qualitative call: no numeric thresholds; instead offer one checkbox per supported cnv-segment
+			// class (mirrors the snvindel consequence checkboxes). Rendered in its own table (before the
+			// Max Segment Length table below) so that label doesn't widen the "Classes" column, keeping the
+			// checkbox box aligned with "Consequences" above. Clear stale threshold inputs.
+			this.cnv_lossThreshold = null
+			this.cnv_gainThreshold = null
+			this.createCnvCategoryCheckboxes(holder, savedCnv)
+		}
+
 		const t2 = table2col({ holder })
 
 		if (!cfg.hideThresholds) {
@@ -304,10 +344,6 @@ export class GRIN2ControlsView {
 				cfg.gainMax,
 				cfg.step
 			)
-		} else {
-			// qualitative call: no numeric thresholds; clear any stale inputs so getConfigValues omits them
-			this.cnv_lossThreshold = null
-			this.cnv_gainThreshold = null
 		}
 		this.cnv_maxSegLength = this.addOptionRowToTable(
 			t2,
@@ -472,6 +508,80 @@ export class GRIN2ControlsView {
 			Object.entries(this.consequenceCheckboxes).forEach(([classKey, checkbox]) => {
 				checkbox.property('checked', canonicalDefault.has(classKey))
 			})
+		})
+	}
+
+	private getSelectedCnvCategories(): string[] {
+		const categories: string[] = []
+		Object.entries(this.cnvCategoryCheckboxes).forEach(([classKey, checkbox]) => {
+			if (checkbox.property('checked')) categories.push(classKey)
+		})
+		return categories
+	}
+
+	/** One checkbox per categorical cnv-segment class supported by this dataset, all checked by default —
+	 * the cnv analog of the snvindel consequence checkboxes. The supported classes are the CNV entries the
+	 * dataset declares in termdbConfig.mclass (e.g. GDC: Gain / Heterozygous Deletion / Amplification /
+	 * Homozygous Deletion), identified via the global mclass dt; labels prefer the dataset override. Rendered
+	 * in its own table2col with a fixed label width so the checkbox box aligns with "Consequences" above. */
+	private createCnvCategoryCheckboxes(holder: any, savedCnv: any) {
+		const dsMclass = this.vocabApi.termdbConfig?.mclass || {}
+		const cnvClasses = Object.keys(dsMclass)
+			.filter(key => mclass[key]?.dt === dtcnv)
+			.map(key => ({ key, label: dsMclass[key]?.label || mclass[key]?.label || key, desc: mclass[key]?.desc || '' }))
+			// gains together, deletions together (see CNV_CLASS_ORDER); unlisted classes keep declared order at end
+			.sort((a, b) => {
+				const ia = CNV_CLASS_ORDER.indexOf(a.key)
+				const ib = CNV_CLASS_ORDER.indexOf(b.key)
+				return (ia === -1 ? Infinity : ia) - (ib === -1 ? Infinity : ib)
+			})
+		this.cnvCategoryCheckboxes = {}
+		if (!cnvClasses.length) return
+
+		// default = all classes on; restore an exact saved selection only after a completed run
+		const saved = savedCnv?.cnvCategories as string[] | undefined
+		const useSaved = this.config.settings.runAnalysis === true && Array.isArray(saved)
+		const initialChecked = useSaved ? new Set<string>(saved!) : new Set<string>(cnvClasses.map(c => c.key))
+
+		// own table so the wide "Max Segment Length" label doesn't push these checkboxes right; fixed label
+		// width matches the snvindel "Consequences" cell so the two checkbox boxes line up vertically
+		const t2 = table2col({ holder })
+		const [labelCell, containerCell] = t2.addRow()
+		labelCell.text('Classes').style('padding-top', '8px').style('min-width', checkboxRowLabelWidth)
+
+		const controlDiv = containerCell
+			.append('div')
+			.style('margin-bottom', '6px')
+			.style('display', 'flex')
+			.style('gap', controlGap)
+		const selectAllBtn = controlDiv.append('button').style('font-size', `${tableFontSize}px`).text('Select All')
+		const clearAllBtn = controlDiv.append('button').style('font-size', `${tableFontSize}px`).text('Clear All')
+
+		const checkboxContainer = containerCell
+			.append('div')
+			.style('max-height', checkboxContainerMaxHeight)
+			.style('overflow-y', 'auto')
+			.style('border', checkboxContainerBorder)
+			.style('margin-bottom', '6px')
+
+		cnvClasses.forEach(c => {
+			const checkboxDiv = checkboxContainer.append('div').style('margin-bottom', checkboxMarginBottom)
+			const checkbox = make_one_checkbox({
+				holder: checkboxDiv,
+				labeltext: c.label,
+				checked: initialChecked.has(c.key),
+				divstyle: { 'font-size': `${tableFontSize}px` },
+				callback: () => {}
+			})
+			if (c.desc) checkboxDiv.select('label').attr('title', c.desc)
+			this.cnvCategoryCheckboxes[c.key] = checkbox
+		})
+
+		selectAllBtn.on('click', () => {
+			Object.values(this.cnvCategoryCheckboxes).forEach(cb => cb.property('checked', true))
+		})
+		clearAllBtn.on('click', () => {
+			Object.values(this.cnvCategoryCheckboxes).forEach(cb => cb.property('checked', false))
 		})
 	}
 }

--- a/client/plots/grin2/view/GRIN2ControlsView.ts
+++ b/client/plots/grin2/view/GRIN2ControlsView.ts
@@ -20,7 +20,13 @@ import {
 const CNV_CLASS_ORDER = [mclasscnvgain, mclasscnvAmp, mclasscnvloss, mclasscnvHomozygousDel, mclasscnvloh]
 import { filterInit } from '#filter'
 import type { GRIN2ControlsCallbacks, DtUsage } from '../GRIN2Types'
-import { CNV_MAX_SEG_LENGTH_FALLBACK, CNV_TYPE_CONFIG, EXCLUDE_OVERLAP_FRAC_FALLBACK } from '../settings/defaults'
+import {
+	CNV_MAX_SEG_LENGTH_FALLBACK,
+	CNV_TYPE_CONFIG,
+	EXCLUDE_OVERLAP_FRAC_FALLBACK,
+	SNVINDEL_HYPERMUTATOR_FALLBACK,
+	CNV_HYPERMUTATOR_FALLBACK
+} from '../settings/defaults'
 import type { CnvType } from '../settings/defaults'
 
 // Styling constants used only by the controls view
@@ -62,6 +68,8 @@ export class GRIN2ControlsView {
 	private cnv_lossThreshold: any = null
 	private cnv_gainThreshold: any = null
 	private cnv_maxSegLength: any = null
+	private cnv_hyperMutator: any = null
+	private snvindel_hyperMutator: any = null
 	/** how this ds quantifies cnv values; from the selected cnv type or ds.queries.cnv.type, default 'log2ratio' */
 	private cnvType: CnvType = 'log2ratio'
 	/** id of the user-selected cnv file type, when the ds exposes singleSampleMutation.cnvTypes (else null) */
@@ -133,6 +141,9 @@ export class GRIN2ControlsView {
 			requestConfig.snvindelOptions = {
 				consequences: this.getSelectedConsequences()
 			}
+			if (this.snvindel_hyperMutator) {
+				requestConfig.snvindelOptions.hyperMutator = parseFloat(this.snvindel_hyperMutator.property('value'))
+			}
 			if (this.snvindelMafFilter) {
 				requestConfig.snvindelOptions.mafFilter = this.snvindelMafFilter
 			}
@@ -140,6 +151,9 @@ export class GRIN2ControlsView {
 		if (dtUsage[dtcnv]?.checked) {
 			requestConfig.cnvOptions = {
 				maxSegLength: parseFloat(this.cnv_maxSegLength.property('value'))
+			}
+			if (this.cnv_hyperMutator) {
+				requestConfig.cnvOptions.hyperMutator = parseFloat(this.cnv_hyperMutator.property('value'))
 			}
 			// id of the selected cnv file type (datasets exposing singleSampleMutation.cnvTypes, e.g. GDC)
 			if (this.cnvSelectedTypeId) requestConfig.cnvOptions.cnvType = this.cnvSelectedTypeId
@@ -233,6 +247,16 @@ export class GRIN2ControlsView {
 				}
 			}).main(this.snvindelMafFilter)
 		}
+
+		// Hypermutator cutoff: samples with more SNV/indel records than this are excluded from snvindel (0 disables)
+		this.snvindel_hyperMutator = this.addOptionRowToTable(
+			t2,
+			'Hypermutator Cutoff',
+			this.config.settings?.snvindelOptions?.hyperMutator ?? SNVINDEL_HYPERMUTATOR_FALLBACK,
+			0,
+			undefined,
+			1
+		).attr('title', 'Exclude a sample from SNV/indel when it has more than this many records. 0 disables.')
 
 		const isChecked = this.config.settings.dtUsage[dtsnvindel].checked
 		t2.table.style('display', isChecked ? '' : 'none')
@@ -366,6 +390,15 @@ export class GRIN2ControlsView {
 			1e9,
 			1000
 		)
+		// Hypermutator cutoff: samples with more cnv segments than this are excluded from cnv (0 disables)
+		this.cnv_hyperMutator = this.addOptionRowToTable(
+			t2,
+			'Hypermutator Cutoff',
+			savedCnv?.hyperMutator ?? CNV_HYPERMUTATOR_FALLBACK,
+			0,
+			undefined,
+			1
+		).attr('title', 'Exclude a sample from CNV when it has more than this many segments. 0 disables.')
 	}
 
 	private addFusionRow(table: any) {

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,12 @@
+Features:
+- GRIN2 - MAF filter (tumor VAF / total-depth / alt-depth) support for GDC, matching non-GDC datasets
+- GRIN2 - hypermutator per-sample cutoff for SNV/indel and CNV, excluding a sample from a data type when its raw record count exceeds the cutoff
+- GRIN2 - CNV classification unified across log2ratio, segmean, copyNumber, and categorical quantification, with per-type thresholds for mixed cohorts
+- GRIN2 - CNV-segment controls: multi cnv-type selection, categorical class checkboxes, and clearer reporting; clearing all consequences/classes now sends "none" of that data type
+- GRIN2 - refactored the general route (main.ts split into lesions.ts and memory.ts; typed processing summary)
 
+Fixes:
+- GRIN2 - CNV hypermutator cutoff now defaults to off; the previous default silently dropped whole-sample CNV on dense native segmentation data
+- GRIN2 - MAF validation resolves the FORMAT definition from q.format so the filter runs on GDC (whose FORMAT is not under byrange._tk)
+- GRIN2 - client hypermutator inputs guard against a cleared field (NaN), falling back to the configured default instead of disabling the cutoff server-side
+- GRIN2 - Linux available-memory parsing tolerates free -m format shifts, falling back to os.freemem instead of producing NaN in the lesion-cap math

--- a/server/src/grin2/lesions.ts
+++ b/server/src/grin2/lesions.ts
@@ -1,0 +1,265 @@
+/** Per-sample mutation → lesion conversion for GRIN2. Pure functions (no I/O): route an mlst by data type
+ * and filter/convert each entry to the lesion tuple [sampleName, chrom, start, end, lesionType]. Split out
+ * of main.ts so the request/response orchestration there stays focused on the cache + Python + render flow.
+ * These are the functions exercised directly by grin2.unit.spec.ts. */
+
+import {
+	dtsnvindel,
+	dtcnv,
+	dtfusionrna,
+	dtsv,
+	dt2lesion,
+	optionToDt,
+	mclasscnvgain,
+	mclasscnvloss,
+	mclasscnvAmp,
+	mclasscnvHomozygousDel
+} from '#shared'
+import type { GRIN2Request } from '#types'
+import { mayFilterByMaf } from '../mds3.init.js'
+import { mayLog } from '../helpers.ts'
+import type { CnvType, Lesion } from './types.ts'
+
+// Building the lesion map to send to python
+export function buildLesionTypeMap(availableOptions: string[]): Record<string, string> {
+	const lesionTypeMap: Record<string, string> = {}
+
+	for (const option of availableOptions) {
+		const dt = optionToDt[option]
+		if (!dt || !dt2lesion[dt]) continue
+
+		dt2lesion[dt].lesionTypes.forEach(lt => {
+			lesionTypeMap[lt.lesionType] = lt.name
+		})
+	}
+
+	return lesionTypeMap
+}
+
+// Function to get CNV lesion type based on gain or loss in a more robust way
+export function getCnvLesionType(isGain: boolean): string {
+	const cnvConfig = dt2lesion[dtcnv]
+	const targetName = isGain ? 'Gain' : 'Loss'
+
+	const lesionType = cnvConfig.lesionTypes.find(lt => lt.name === targetName)
+	if (!lesionType) {
+		throw new Error(`CNV lesion type '${targetName}' not found`)
+	}
+
+	return lesionType.lesionType
+}
+
+/** Process the MLST data for each sample: apply the per-dt hypermutator cutoff, then filter and convert.
+ * hyperMutatedDt lists the data types (dtsnvindel/dtcnv) dropped for this sample as hypermutated, so the
+ * caller can report them. */
+export function processSampleMlst(
+	sampleName: string,
+	mlst: any[],
+	request: GRIN2Request,
+	cnvType: CnvType
+): { sampleLesions: Lesion[]; contributedTypes: Set<number>; hyperMutatedDt: number[] } {
+	const sampleLesions: Lesion[] = []
+	const contributedTypes = new Set<number>()
+
+	// Hypermutator cutoff: a sample with more than the per-dt cutoff of raw records for a data type is
+	// treated as hypermutated for that dt and contributes none of it (such samples dominate the gene-level
+	// statistics). Counted on raw mlst records before consequence/threshold filtering, mirroring the GDC
+	// prototype's per-file count. cutoff <= 0 (or absent) disables the check; only snvindel and cnv have one.
+	const snvCutoff = request.snvindelOptions?.hyperMutator ?? 0
+	const cnvCutoff = request.cnvOptions?.hyperMutator ?? 0
+	let skipSnvHyper = false
+	let skipCnvHyper = false
+	if (snvCutoff > 0 || cnvCutoff > 0) {
+		let snvCount = 0
+		let cnvCount = 0
+		for (const m of mlst) {
+			if (m.dt === dtsnvindel) snvCount++
+			else if (m.dt === dtcnv) cnvCount++
+		}
+		skipSnvHyper = snvCutoff > 0 && snvCount > snvCutoff
+		skipCnvHyper = cnvCutoff > 0 && cnvCount > cnvCutoff
+	}
+	const hyperMutatedDt: number[] = []
+	if (skipSnvHyper) hyperMutatedDt.push(dtsnvindel)
+	if (skipCnvHyper) hyperMutatedDt.push(dtcnv)
+
+	for (const m of mlst) {
+		switch (m.dt) {
+			case dtsnvindel: {
+				if (!request.snvindelOptions || skipSnvHyper) break
+
+				const les = filterAndConvertSnvIndel(sampleName, m, request.snvindelOptions)
+				if (les) {
+					sampleLesions.push(les)
+					contributedTypes.add(dtsnvindel)
+				}
+				break
+			}
+
+			case dtcnv: {
+				if (!request.cnvOptions || skipCnvHyper) break
+
+				const les = filterAndConvertCnv(sampleName, m, request.cnvOptions, cnvType)
+				if (les) {
+					sampleLesions.push(les)
+					contributedTypes.add(dtcnv)
+				}
+				break
+			}
+
+			case dtfusionrna: {
+				if (!request.fusionOptions) break
+
+				const les = breakpointsToLesions(sampleName, m, dtfusionrna)
+				if (les.length) {
+					sampleLesions.push(...les)
+					contributedTypes.add(dtfusionrna)
+				}
+				break
+			}
+
+			case dtsv: {
+				if (!request.svOptions) break
+
+				const les = breakpointsToLesions(sampleName, m, dtsv)
+				if (les.length) {
+					sampleLesions.push(...les)
+					contributedTypes.add(dtsv)
+				}
+				break
+			}
+
+			default:
+				break
+		}
+	}
+
+	return { sampleLesions, contributedTypes, hyperMutatedDt }
+}
+
+export function filterAndConvertSnvIndel(
+	sampleName: string,
+	entry: any,
+	options: GRIN2Request['snvindelOptions']
+): Lesion | null {
+	// Check if options and consequences exist for typescript
+	if (!options?.consequences) {
+		return null
+	}
+
+	// Only include mutations whose consequence class is selected. An empty list means no consequence is
+	// selected, so nothing is included — mirrors cnvOptions.cnvCategories, and the UI disables Run when
+	// snvindel is the only enabled data type with no consequence checked.
+	if (!options.consequences.includes(entry.class)) {
+		return null
+	}
+
+	if (!Number.isInteger(entry.pos)) {
+		return null
+	}
+
+	if (options.mafFilter?.lst?.length) {
+		// has non-empty maf filter. apply maf filtering
+		if (!Array.isArray(entry.vafs)) return null // lacks vaf and skip entry
+		// TEMP fix! delete this and use !mayFilterByMaf(options.mafFilter, entry) when helper accepts .vafs[]
+		const copy = { dt: dtsnvindel }
+		for (const v of entry.vafs) {
+			copy[v.id] = v.refCount + ',' + v.altCount
+		}
+		try {
+			if (!mayFilterByMaf(options.mafFilter, copy)) return null
+		} catch (e: unknown) {
+			mayLog('mayFilterByMaf() crashed on a snvindel ' + (e instanceof Error ? e.message : String(e)))
+			return null
+		}
+	}
+
+	const start = entry.pos
+	const end = entry.pos
+
+	return [sampleName, entry.chr, start, end, dt2lesion[dtsnvindel].lesionTypes[0].lesionType]
+}
+
+/** Pick the gain/loss thresholds for a cnv segment's resolved value type. A per-type entry in
+ * cnvOptions.byType (mixed cohort) wins over the flat lossThreshold/gainThreshold (single-type
+ * cohort). Returns null when neither supplies a complete pair. 'category' never reaches here. */
+function resolveCnvThresholds(
+	options: NonNullable<GRIN2Request['cnvOptions']>,
+	effectiveType: CnvType
+): { lossThreshold: number; gainThreshold: number } | null {
+	const byType = options.byType?.[effectiveType as 'log2ratio' | 'segmean' | 'copyNumber']
+	const lossThreshold = byType?.lossThreshold ?? options.lossThreshold
+	const gainThreshold = byType?.gainThreshold ?? options.gainThreshold
+	if (lossThreshold === undefined || gainThreshold === undefined) return null
+	return { lossThreshold, gainThreshold }
+}
+
+export function filterAndConvertCnv(
+	sampleName: string,
+	entry: any,
+	options: GRIN2Request['cnvOptions'],
+	cnvType: CnvType
+): Lesion | null {
+	if (!options) return null
+
+	if (!Number.isInteger(entry.start)) return null
+	if (!Number.isInteger(entry.stop)) return null
+
+	// Filter max segment length (applies to every cnv type). Default 0 = no filter, matching the
+	// request contract; an omitted maxSegLength must not silently drop all segments.
+	const maxSegLength = options.maxSegLength ?? 0
+	if (maxSegLength > 0 && entry.stop - entry.start > maxSegLength) {
+		return null
+	}
+
+	// Classify the segment as gain or loss according to how this cnv value is quantified.
+	// A per-entry valueType (stamped at the data source, e.g. GDC loadCnvFile) wins over the
+	// dataset-level default, so a single cohort may mix segmean and copyNumber segments.
+	const effectiveType: CnvType = entry.valueType ?? cnvType
+	let isGain: boolean
+	if (effectiveType == 'category') {
+		// qualitative call carried in the segment's class; no numeric thresholds.
+		// When the request lists cnvCategories (UI checkboxes), drop any segment whose class isn't selected;
+		// an omitted list (undefined) means "all classes", an empty list means "none".
+		if (Array.isArray(options.cnvCategories) && !options.cnvCategories.includes(entry.class)) return null
+		// map the class to a gain/loss lesion. GDC's 5-category data distinguishes a gain from a high-level
+		// amplification and a loss from a homozygous deletion; GRIN2 renders only gain vs loss, so both
+		// gain-like classes => gain and both loss-like classes => loss.
+		if (entry.class == mclasscnvgain || entry.class == mclasscnvAmp) isGain = true
+		else if (entry.class == mclasscnvloss || entry.class == mclasscnvHomozygousDel) isGain = false
+		else return null
+	} else {
+		// numeric value: log2ratio/segmean (baseline 0) or copyNumber (baseline 2).
+		// The comparison is identical across these; only the threshold values differ,
+		// e.g. copyNumber uses positive cutoffs straddling baseline 2 (loss<=1, gain>=3).
+		// In a mixed cohort, cnvOptions.byType[effectiveType] supplies the right cutoffs for this
+		// segment; otherwise fall back to the flat lossThreshold/gainThreshold (single-type cohort).
+		const thresholds = resolveCnvThresholds(options, effectiveType)
+		if (!thresholds) return null
+		if (!Number.isFinite(entry.value)) return null
+		if (entry.value >= thresholds.gainThreshold) isGain = true
+		else if (entry.value <= thresholds.lossThreshold) isGain = false
+		else return null // between thresholds = neutral
+	}
+
+	const lesionType = getCnvLesionType(isGain)
+
+	const start = entry.start
+	const end = entry.stop
+
+	return [sampleName, entry.chr, start, end, lesionType]
+}
+
+/** Convert a fusion or sv breakpoint entry to lesions — one per breakpoint (chrA, and chrB when present).
+ * Fusion and sv are byte-identical here (no filtering; each breakpoint becomes a lesion), differing only
+ * by dt for the lesion-type label, so they share this. Returns [] when the entry lacks a valid chrA/posA.
+ * Emitting both partners as separate lesions lets GRIN2 identify genes affected at each breakpoint. */
+export function breakpointsToLesions(sampleName: string, entry: any, dt: number): Lesion[] {
+	if (!entry.chrA || entry.posA === undefined) return []
+	const lesionType = dt2lesion[dt].lesionTypes[0].lesionType
+	const lesions: Lesion[] = [[sampleName, entry.chrA, entry.posA, entry.posA, lesionType]]
+	if (entry.chrB && entry.posB !== undefined) {
+		lesions.push([sampleName, entry.chrB, entry.posB, entry.posB, lesionType])
+	}
+	return lesions
+}

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -305,6 +305,16 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 				).toLocaleString()} of ${expectedToProcess.toLocaleString()} samples.`
 		])
 	}
+	// The batched CNV fetch has its own cap (independent of ssm's), so warn separately when it truncated.
+	if (processing.cnvCapReached) {
+		capWarningRows.push([
+			'Note',
+			`Lesion cap of ${processing.lesionCap?.toLocaleString()} was reached while loading CNV segments. ` +
+				`CNV data was not loaded for ${(
+					processing.cnvSamplesDropped ?? 0
+				).toLocaleString()} of ${expectedToProcess.toLocaleString()} samples.`
+		])
+	}
 
 	// Coverage note: samples that contributed no open-access SNV/indel lesions, broken down by reason so the
 	// user can see why. Independent of the lesion cap above — both can apply — so it's its own note.
@@ -362,6 +372,16 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 									[
 										'Open-access samples without mutations',
 										`${processing.ssmSamplesNoMutations.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
+									]
+							  ]
+							: []),
+						// queried samples that returned no cnv segment (batched GDC cnv path); shown only when cnv
+						// was requested and some samples had none.
+						...(processing.cnvSamplesNoData
+							? [
+									[
+										'Samples without CNV data',
+										`${processing.cnvSamplesNoData.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
 									]
 							  ]
 							: []),
@@ -725,6 +745,12 @@ async function processSampleData(
 		// samples that mapped to no GDC case at all (batched path), so were never queried; counted in neither
 		// samplesWithData nor ssmSamplesNoOpenAccess, hence surfaced separately so the cohort tallies reconcile.
 		unmatchedSamples?: number
+		// cnv analogs of the ssm* fields above (batched GDC cnv fetch). cnvCapReached/cnvSamplesDropped mirror
+		// ssmCapReached/ssmSamplesDropped; cnvSamplesNoData is queried samples that returned no cnv segment
+		// (cnv segment data is open-access, so there is no controlled-access split like ssm has).
+		cnvCapReached?: boolean
+		cnvSamplesDropped?: number
+		cnvSamplesNoData?: number
 		lesionCap?: number
 		lesionCounts?: {
 			total: number
@@ -780,6 +806,14 @@ async function processSampleData(
 		processing.ssmSamplesControlledAccess = batch.samplesControlledAccess
 		processing.ssmSamplesNoMutations = batch.samplesNoMutations
 		processing.unmatchedSamples = batch.unresolvedSamples
+		// cnv coverage from the same batch (0 when cnv wasn't requested). cnvCapReached mirrors ssmCapReached
+		// (the cap skipped some samples' cnv while the loop still "processed" them); cnvSamplesNoData is a
+		// coverage note for queried samples that had no cnv segment.
+		if (batch.cnvCapReached) {
+			processing.cnvCapReached = true
+			processing.cnvSamplesDropped = batch.cnvSamplesDropped
+		}
+		processing.cnvSamplesNoData = batch.cnvSamplesNoData
 	}
 	// When mutations are batched, skip snvindel + cnv in the per-sample loop so get() doesn't re-fetch them
 	// (fusion/sv, if enabled, still flow through get()).
@@ -997,9 +1031,10 @@ export function filterAndConvertSnvIndel(
 		return null
 	}
 
-	// Check consequence filtering. If no consequences selected, include all consequences
-	// If consequences are selected, only include those
-	if (options.consequences.length > 0 && entry.class && !options.consequences.includes(entry.class)) {
+	// Only include mutations whose consequence class is selected. An empty list means no consequence is
+	// selected, so nothing is included — mirrors cnvOptions.cnvCategories, and the UI disables Run when
+	// snvindel is the only enabled data type with no consequence checked.
+	if (!options.consequences.includes(entry.class)) {
 		return null
 	}
 

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -4,28 +4,13 @@ import path from 'path'
 import { run_python } from '@sjcrh/proteinpaint-python'
 import { renderManhattan } from '../renderManhattan.ts'
 import { mayLog } from '../helpers.ts'
-import os from 'os'
 import { get_samples } from '../termdb.sql.js'
-import {
-	dtsnvindel,
-	dtcnv,
-	dtfusionrna,
-	dtsv,
-	dt2lesion,
-	optionToDt,
-	formatElapsedTime,
-	mclasscnvgain,
-	mclasscnvloss,
-	mclasscnvAmp,
-	mclasscnvHomozygousDel
-} from '#shared'
-
-import { mayFilterByMaf } from '../mds3.init.js'
+import { dtsnvindel, dtcnv, dtfusionrna, dtsv, dt2lesion, optionToDt, formatElapsedTime } from '#shared'
 import { cacheOrRecompute } from '../utils/cacheOrRecompute.ts'
 import { mapConcurrent } from '../utils/concurrencyLimiter.ts'
-import { promisify } from 'node:util'
-import { exec as execCallback } from 'node:child_process'
-import type { CnvType, Grin2CacheResult } from './types.ts'
+import { getMaxLesions } from './memory.ts'
+import { processSampleMlst, buildLesionTypeMap } from './lesions.ts'
+import type { CnvType, Grin2CacheResult, Grin2Processing, Lesion } from './types.ts'
 
 /**
  * General GRIN2 analysis route
@@ -72,13 +57,6 @@ import type { CnvType, Grin2CacheResult } from './types.ts'
  *   runGrin2Fresh → helpers
  */
 
-// Constants
-const MAX_LESIONS = serverconfig.features.grin2maxLesions || 250000 // Maximum total number of lesions to process to avoid overwhelming the production server
-const GRIN2_MEMORY_BUDGET_MB = 950
-const MEMORY_BASE_MB = 260
-const MEMORY_PER_1K_LESIONS = 2.4
-const MIN_LESIONS = 50000
-
 export function init({ genomes }) {
 	return async (req: any, res: any): Promise<void> => {
 		// __abortSignal is set by maySetAbortCtrl() middleware in app.middlewares.js
@@ -117,94 +95,6 @@ export function init({ genomes }) {
 			res.status(e.status || 500).send(errorResponse)
 		}
 	}
-}
-
-// =============================================================================
-// MEMORY MANAGEMENT
-// =============================================================================
-
-const exec = promisify(execCallback)
-
-async function getAvailableMemoryMB(): Promise<number> {
-	try {
-		if (process.platform === 'darwin') {
-			// macOS: use vm_stat
-			const { stdout } = await exec('vm_stat')
-			const output = stdout.toString()
-
-			// Parse page size from vm_stat header: "page size of 4096 bytes for Apple silicon, 16384 bytes for Intel macs"
-			const headerLine = output.split('\n')[0] || ''
-			const pageSizeMatch = headerLine.match(/page size of\s+(\d+)\s+bytes/i)
-			const pageSize = pageSizeMatch ? parseInt(pageSizeMatch[1], 10) : 16384
-			const freeMatch = output.match(/Pages free:\s+(\d+)/)
-			const inactiveMatch = output.match(/Pages inactive:\s+(\d+)/)
-			const freePages = freeMatch ? parseInt(freeMatch[1], 10) : 0
-			const inactivePages = inactiveMatch ? parseInt(inactiveMatch[1], 10) : 0
-
-			// Available ≈ free + inactive
-			return ((freePages + inactivePages) * pageSize) / (1024 * 1024)
-		} else {
-			// Linux: use free command
-			const { stdout } = await exec('free -m')
-			const output = stdout.toString()
-			const lines = output.split('\n')
-			const memLine = lines.find(l => l.startsWith('Mem:'))
-			if (memLine) {
-				const parts = memLine.split(/\s+/)
-				return parseInt(parts[6]) // "available" column
-			}
-		}
-	} catch (e) {
-		mayLog(`[GRIN2] Memory check failed, using fallback: ${e}`)
-	}
-
-	// Fallback: os.freemem (less accurate but always works)
-	return os.freemem() / (1024 * 1024)
-}
-
-async function getMaxLesions(): Promise<number> {
-	const availableMemoryMB = await getAvailableMemoryMB()
-	mayLog(`[GRIN2] Available system memory: ${availableMemoryMB.toFixed(0)} MB`)
-
-	// If server is under heavy load, reduce lesion cap. Our calculation assumes each 1,000 lesions use ~2.4MB of memory plus a base overhead (i.e. a linear relationship).
-	if (availableMemoryMB < GRIN2_MEMORY_BUDGET_MB * 2) {
-		const reducedBudget = availableMemoryMB * 0.4
-		mayLog(`[GRIN2] Reducing lesion cap due to memory constraints. New budget: ${reducedBudget.toFixed(2)} MB`)
-		const calculated = Math.floor((reducedBudget - MEMORY_BASE_MB) / MEMORY_PER_1K_LESIONS) * 1000
-		mayLog(`[GRIN2] Calculated lesion cap based on memory: ${calculated.toLocaleString()}`)
-		return Math.max(MIN_LESIONS, Math.min(MAX_LESIONS, calculated))
-	}
-
-	return MAX_LESIONS
-}
-
-// Building the lesion map to send to python
-export function buildLesionTypeMap(availableOptions: string[]): Record<string, string> {
-	const lesionTypeMap: Record<string, string> = {}
-
-	for (const option of availableOptions) {
-		const dt = optionToDt[option]
-		if (!dt || !dt2lesion[dt]) continue
-
-		dt2lesion[dt].lesionTypes.forEach(lt => {
-			lesionTypeMap[lt.lesionType] = lt.name
-		})
-	}
-
-	return lesionTypeMap
-}
-
-// Function to get CNV lesion type based on gain or loss in a more robust way
-export function getCnvLesionType(isGain: boolean): string {
-	const cnvConfig = dt2lesion[dtcnv]
-	const targetName = isGain ? 'Gain' : 'Loss'
-
-	const lesionType = cnvConfig.lesionTypes.find(lt => lt.name === targetName)
-	if (!lesionType) {
-		throw new Error(`CNV lesion type '${targetName}' not found`)
-	}
-
-	return lesionType.lesionType
 }
 
 async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSignal): Promise<GRIN2Response> {
@@ -254,6 +144,14 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 
 	const totalTime = cohortTime + processingTime + grin2AnalysisTime + manhattanPlotTime
 
+	// compact stat-row helpers: fracOfTotal formats "N / totalSamples"; optRow yields one row only when
+	// count > 0 (spread into the summary); note appends a cap/coverage "Note" row.
+	const total = processing.totalSamples!
+	const fracOfTotal = (n?: number) => `${(n ?? 0).toLocaleString()} / ${total.toLocaleString()}`
+	const optRow = (count: number | undefined, label: string): string[][] => (count ? [[label, fracOfTotal(count)]] : [])
+	const capWarningRows: string[][] = []
+	const note = (msg: string) => capWarningRows.push(['Note', msg])
+
 	// Build lesion type display rows
 	const lesionTypeRows: string[][] = []
 	if (processing.lesionCounts?.byType) {
@@ -286,34 +184,27 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 	}
 
 	// Build cap warning if applicable
-	const capWarningRows: string[][] = []
+	const cap = processing.lesionCap?.toLocaleString()
 	const expectedToProcess = processing.totalSamples! - processing.failedSamples!
 	if (processing.processedSamples! < expectedToProcess) {
-		capWarningRows.push([
-			'Note',
-			`Lesion cap of ${processing.lesionCap?.toLocaleString()} was reached before all samples could be processed. ` +
+		note(
+			`Lesion cap of ${cap} was reached before all samples could be processed. ` +
 				`Analysis ran on ${processing.processedSamples!.toLocaleString()} of ${expectedToProcess.toLocaleString()} samples.`
-		])
+		)
 	} else if (processing.ssmCapReached) {
 		// The batched SNV/indel fetch hit the cap and skipped some samples' mutations, but the per-sample
 		// loop still processed every sample — so the check above won't catch it. Warn the same way.
-		capWarningRows.push([
-			'Note',
-			`Lesion cap of ${processing.lesionCap?.toLocaleString()} was reached while loading mutations. ` +
-				`SNV/indel data was not loaded for ${(
-					processing.ssmSamplesDropped ?? 0
-				).toLocaleString()} of ${expectedToProcess.toLocaleString()} samples.`
-		])
+		note(
+			`Lesion cap of ${cap} was reached while loading mutations. SNV/indel data was not loaded for ` +
+				`${(processing.ssmSamplesDropped ?? 0).toLocaleString()} of ${expectedToProcess.toLocaleString()} samples.`
+		)
 	}
 	// The batched CNV fetch has its own cap (independent of ssm's), so warn separately when it truncated.
 	if (processing.cnvCapReached) {
-		capWarningRows.push([
-			'Note',
-			`Lesion cap of ${processing.lesionCap?.toLocaleString()} was reached while loading CNV segments. ` +
-				`CNV data was not loaded for ${(
-					processing.cnvSamplesDropped ?? 0
-				).toLocaleString()} of ${expectedToProcess.toLocaleString()} samples.`
-		])
+		note(
+			`Lesion cap of ${cap} was reached while loading CNV segments. CNV data was not loaded for ` +
+				`${(processing.cnvSamplesDropped ?? 0).toLocaleString()} of ${expectedToProcess.toLocaleString()} samples.`
+		)
 	}
 
 	// Coverage note: samples that contributed no open-access SNV/indel lesions, broken down by reason so the
@@ -330,11 +221,26 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 		if (processing.unmatchedSamples)
 			reasons.push(`${processing.unmatchedSamples.toLocaleString()} could not be matched to a GDC case`)
 		const affected = (processing.ssmSamplesNoOpenAccess ?? 0) + (processing.unmatchedSamples ?? 0)
-		capWarningRows.push([
-			'Note',
-			`${affected.toLocaleString()} of ${processing.totalSamples!.toLocaleString()} samples contributed no SNV/indel lesions: ` +
-				`${reasons.join('; ')}.`
-		])
+		note(
+			`${affected.toLocaleString()} of ${total.toLocaleString()} samples contributed no SNV/indel lesions: ${reasons.join(
+				'; '
+			)}.`
+		)
+	}
+
+	// Coverage note: samples dropped from a data type by the hypermutator cutoff (too many raw records for
+	// that dt). Per-dt, so a sample can appear under both counts; each is shown with its cutoff.
+	if (processing.ssmSamplesHypermutated || processing.cnvSamplesHypermutated) {
+		const parts: string[] = []
+		if (processing.ssmSamplesHypermutated)
+			parts.push(
+				`${processing.ssmSamplesHypermutated.toLocaleString()} exceeded the SNV/indel cutoff (${request.snvindelOptions?.hyperMutator?.toLocaleString()})`
+			)
+		if (processing.cnvSamplesHypermutated)
+			parts.push(
+				`${processing.cnvSamplesHypermutated.toLocaleString()} exceeded the CNV cutoff (${request.cnvOptions?.hyperMutator?.toLocaleString()})`
+			)
+		note(`Hypermutated samples excluded from a data type: ${parts.join('; ')}.`)
 	}
 
 	const response: GRIN2Response = {
@@ -357,44 +263,13 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 							'Samples with data',
 							`${(processing.samplesWithData ?? 0).toLocaleString()} / ${processing.processedSamples!.toLocaleString()}`
 						],
-						// breakdown of samples with no open-access SNV/indel (batched GDC path), each shown only when
-						// non-zero: controlled-access (data exists but isn't open) vs genuinely no mutation found.
-						...(processing.ssmSamplesControlledAccess
-							? [
-									[
-										'Samples in controlled-access projects',
-										`${processing.ssmSamplesControlledAccess.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
-									]
-							  ]
-							: []),
-						...(processing.ssmSamplesNoMutations
-							? [
-									[
-										'Open-access samples without mutations',
-										`${processing.ssmSamplesNoMutations.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
-									]
-							  ]
-							: []),
-						// queried samples that returned no cnv segment (batched GDC cnv path); shown only when cnv
-						// was requested and some samples had none.
-						...(processing.cnvSamplesNoData
-							? [
-									[
-										'Samples without CNV data',
-										`${processing.cnvSamplesNoData.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
-									]
-							  ]
-							: []),
-						// samples that matched no GDC case at all (never queried) — surfaced so the cohort tallies
-						// reconcile (they're in neither "with data" nor the no-open-access buckets above).
-						...(processing.unmatchedSamples
-							? [
-									[
-										'Unmatched samples (no GDC case)',
-										`${processing.unmatchedSamples.toLocaleString()} / ${processing.totalSamples!.toLocaleString()}`
-									]
-							  ]
-							: []),
+						// coverage rows, each shown only when non-zero (batched GDC path): controlled-access (data
+						// exists but isn't open) vs genuinely no mutation; queried samples with no cnv segment; and
+						// samples that matched no GDC case at all — surfaced so the cohort tallies reconcile.
+						...optRow(processing.ssmSamplesControlledAccess, 'Samples in controlled-access projects'),
+						...optRow(processing.ssmSamplesNoMutations, 'Open-access samples without mutations'),
+						...optRow(processing.cnvSamplesNoData, 'Samples without CNV data'),
+						...optRow(processing.unmatchedSamples, 'Unmatched samples (no GDC case)'),
 						['Unprocessed Samples', (processing.unprocessedSamples ?? 0).toLocaleString()],
 						['Failed Samples', processing.failedSamples!.toLocaleString()],
 						['Total Lesions', processing.totalLesions!.toLocaleString()],
@@ -603,9 +478,9 @@ async function runGrin2Fresh(
 	const processingTime = Date.now() - processStart
 	mayLog(`[GRIN2] Data processing took ${formatElapsedTime(processingTime)}`)
 	mayLog(
-		`[GRIN2] Processing summary: ${processing?.processedSamples ?? 0}/${
+		`[GRIN2] Processing summary: ${(processing?.processedSamples ?? 0).toLocaleString()}/${(
 			processing?.totalSamples ?? 0
-		} samples processed successfully`
+		).toLocaleString()} samples processed successfully`
 	)
 
 	if (processing?.failedSamples !== undefined && processing.failedSamples > 0) {
@@ -673,23 +548,8 @@ async function processSampleData(
 	ds: any,
 	request: GRIN2Request,
 	signal?: AbortSignal
-): Promise<{
-	lesions: any[]
-	processing: {
-		totalSamples: number
-		processedSamples: number
-		failedSamples: number
-		totalLesions: number
-		processedLesions: number
-		unprocessedSamples: number
-		lesionCap?: number
-		lesionCounts?: {
-			total: number
-			byType: Record<string, { count: number; samples: number }>
-		}
-	}
-}> {
-	const lesions: any[] = []
+): Promise<{ lesions: Lesion[]; processing: Grin2Processing }> {
+	const lesions: Lesion[] = []
 	const maxLesions = await getMaxLesions()
 	mayLog(`[GRIN2] Max lesions for this run: ${maxLesions.toLocaleString()}`)
 
@@ -713,49 +573,13 @@ async function processSampleData(
 		samplesPerType.set(type, new Set<string>())
 	}
 
-	const processing = {
+	const processing: Grin2Processing = {
 		totalSamples: samples.length,
 		processedSamples: 0,
 		failedSamples: 0,
 		totalLesions: 0,
 		processedLesions: 0,
 		unprocessedSamples: 0
-	} as {
-		totalSamples: number
-		processedSamples: number
-		failedSamples: number
-		totalLesions: number
-		processedLesions: number
-		unprocessedSamples: number
-		// unique samples that contributed >=1 lesion to the final result (union across all lesion types).
-		// distinct from processedSamples: many cohort cases have no qualifying mutation, so this is smaller.
-		samplesWithData?: number
-		// set when the batched SNV/indel fetch (GDC) hit maxLesions and skipped some samples' ssm. distinct
-		// from the loop cap (unprocessedSamples) because the loop still processed those samples.
-		ssmCapReached?: boolean
-		ssmSamplesDropped?: number
-		// samples whose case returned no open-access SNV/indel (batched GDC path); a coverage note, not the
-		// cap. distinct from ssmSamplesDropped (cap-skipped) and from failedSamples (per-sample errors).
-		// ssmSamplesNoOpenAccess is the total; the two below break it down for the summary.
-		ssmSamplesNoOpenAccess?: number
-		// of ssmSamplesNoOpenAccess: samples in controlled-access GDC projects (data exists but isn't open).
-		ssmSamplesControlledAccess?: number
-		// of ssmSamplesNoOpenAccess: open-access samples that genuinely returned no SNV/indel mutation.
-		ssmSamplesNoMutations?: number
-		// samples that mapped to no GDC case at all (batched path), so were never queried; counted in neither
-		// samplesWithData nor ssmSamplesNoOpenAccess, hence surfaced separately so the cohort tallies reconcile.
-		unmatchedSamples?: number
-		// cnv analogs of the ssm* fields above (batched GDC cnv fetch). cnvCapReached/cnvSamplesDropped mirror
-		// ssmCapReached/ssmSamplesDropped; cnvSamplesNoData is queried samples that returned no cnv segment
-		// (cnv segment data is open-access, so there is no controlled-access split like ssm has).
-		cnvCapReached?: boolean
-		cnvSamplesDropped?: number
-		cnvSamplesNoData?: number
-		lesionCap?: number
-		lesionCounts?: {
-			total: number
-			byType: Record<string, { count: number; samples: number }>
-		}
 	}
 
 	// Fetch and convert per-sample mutation data with bounded concurrency. For sqlite datasets each
@@ -847,7 +671,19 @@ async function processSampleData(
 				}
 				const mlst = batchMlst.length ? [...batchMlst, ...getMlst] : getMlst
 
-				const { sampleLesions, contributedTypes } = processSampleMlst(sample.name, mlst, request, cnvType)
+				const { sampleLesions, contributedTypes, hyperMutatedDt } = processSampleMlst(
+					sample.name,
+					mlst,
+					request,
+					cnvType
+				)
+
+				// Tally per-dt hypermutator exclusions (a sample can be hypermutated for snvindel, cnv, both,
+				// or neither). Synchronous like the counters below, so concurrent workers can't interleave.
+				for (const dt of hyperMutatedDt) {
+					if (dt === dtsnvindel) processing.ssmSamplesHypermutated = (processing.ssmSamplesHypermutated ?? 0) + 1
+					else if (dt === dtcnv) processing.cnvSamplesHypermutated = (processing.cnvSamplesHypermutated ?? 0) + 1
+				}
 
 				// Filter out chrM lesions
 				const filteredLesions = ds.queries.singleSampleMutation.discoPlot?.skipChrM
@@ -937,268 +773,4 @@ async function processSampleData(
 	processing.samplesWithData = samplesWithData.size
 
 	return { lesions, processing }
-}
-
-/** Process the MLST data for each sample - no per-type caps, just filter and convert */
-export function processSampleMlst(
-	sampleName: string,
-	mlst: any[],
-	request: GRIN2Request,
-	cnvType: CnvType
-): { sampleLesions: any[]; contributedTypes: Set<number> } {
-	const sampleLesions: any[] = []
-	const contributedTypes = new Set<number>()
-
-	for (const m of mlst) {
-		switch (m.dt) {
-			case dtsnvindel: {
-				if (!request.snvindelOptions) break
-
-				const les = filterAndConvertSnvIndel(sampleName, m, request.snvindelOptions)
-				if (les) {
-					sampleLesions.push(les)
-					contributedTypes.add(dtsnvindel)
-				}
-				break
-			}
-
-			case dtcnv: {
-				if (!request.cnvOptions) break
-
-				const les = filterAndConvertCnv(sampleName, m, request.cnvOptions, cnvType)
-				if (les) {
-					sampleLesions.push(les)
-					contributedTypes.add(dtcnv)
-				}
-				break
-			}
-
-			case dtfusionrna: {
-				if (!request.fusionOptions) break
-
-				const les = filterAndConvertFusion(sampleName, m, request.fusionOptions)
-				if (les) {
-					// Add all lesions (breakpoints) to the list
-					if (Array.isArray(les[0])) {
-						// Multiple lesions (two breakpoints)
-						for (const lesion of les as string[][]) {
-							sampleLesions.push(lesion)
-						}
-					} else {
-						// Single lesion
-						sampleLesions.push(les)
-					}
-					contributedTypes.add(dtfusionrna)
-				}
-				break
-			}
-
-			case dtsv: {
-				if (!request.svOptions) break
-
-				const les = filterAndConvertSV(sampleName, m, request.svOptions)
-				if (les) {
-					// Add all lesions (breakpoints) to the list
-					if (Array.isArray(les[0])) {
-						// Multiple lesions (two breakpoints)
-						for (const lesion of les as string[][]) {
-							sampleLesions.push(lesion)
-						}
-					} else {
-						// Single lesion
-						sampleLesions.push(les)
-					}
-					contributedTypes.add(dtsv)
-				}
-				break
-			}
-
-			default:
-				break
-		}
-	}
-
-	return { sampleLesions, contributedTypes }
-}
-
-export function filterAndConvertSnvIndel(
-	sampleName: string,
-	entry: any,
-	options: GRIN2Request['snvindelOptions']
-): string[] | null {
-	// Check if options and consequences exist for typescript
-	if (!options?.consequences) {
-		return null
-	}
-
-	// Only include mutations whose consequence class is selected. An empty list means no consequence is
-	// selected, so nothing is included — mirrors cnvOptions.cnvCategories, and the UI disables Run when
-	// snvindel is the only enabled data type with no consequence checked.
-	if (!options.consequences.includes(entry.class)) {
-		return null
-	}
-
-	if (!Number.isInteger(entry.pos)) {
-		return null
-	}
-
-	if (options.mafFilter?.lst?.length) {
-		// has non-empty maf filter. apply maf filtering
-		if (!Array.isArray(entry.vafs)) return null // lacks vaf and skip entry
-		// TEMP fix! delete this and use !mayFilterByMaf(options.mafFilter, entry) when helper accepts .vafs[]
-		const copy = { dt: dtsnvindel }
-		for (const v of entry.vafs) {
-			copy[v.id] = v.refCount + ',' + v.altCount
-		}
-		try {
-			if (!mayFilterByMaf(options.mafFilter, copy)) return null
-		} catch (e: unknown) {
-			mayLog('mayFilterByMaf() crashed on a snvindel ' + (e instanceof Error ? e.message : String(e)))
-			return null
-		}
-	}
-
-	const start = entry.pos
-	const end = entry.pos
-
-	// TODO: implement hypermutator threshold filter (maybe calculate number of mutations per sample?)
-
-	return [sampleName, entry.chr, start, end, dt2lesion[dtsnvindel].lesionTypes[0].lesionType]
-}
-
-/** Pick the gain/loss thresholds for a cnv segment's resolved value type. A per-type entry in
- * cnvOptions.byType (mixed cohort) wins over the flat lossThreshold/gainThreshold (single-type
- * cohort). Returns null when neither supplies a complete pair. 'category' never reaches here. */
-function resolveCnvThresholds(
-	options: NonNullable<GRIN2Request['cnvOptions']>,
-	effectiveType: CnvType
-): { lossThreshold: number; gainThreshold: number } | null {
-	const byType = options.byType?.[effectiveType as 'log2ratio' | 'segmean' | 'copyNumber']
-	const lossThreshold = byType?.lossThreshold ?? options.lossThreshold
-	const gainThreshold = byType?.gainThreshold ?? options.gainThreshold
-	if (lossThreshold === undefined || gainThreshold === undefined) return null
-	return { lossThreshold, gainThreshold }
-}
-
-export function filterAndConvertCnv(
-	sampleName: string,
-	entry: any,
-	options: GRIN2Request['cnvOptions'],
-	cnvType: CnvType
-): string[] | null {
-	if (!options) return null
-
-	if (!Number.isInteger(entry.start)) return null
-	if (!Number.isInteger(entry.stop)) return null
-
-	// Filter max segment length (applies to every cnv type). Default 0 = no filter, matching the
-	// request contract; an omitted maxSegLength must not silently drop all segments.
-	const maxSegLength = options.maxSegLength ?? 0
-	if (maxSegLength > 0 && entry.stop - entry.start > maxSegLength) {
-		return null
-	}
-
-	// Classify the segment as gain or loss according to how this cnv value is quantified.
-	// A per-entry valueType (stamped at the data source, e.g. GDC loadCnvFile) wins over the
-	// dataset-level default, so a single cohort may mix segmean and copyNumber segments.
-	const effectiveType: CnvType = entry.valueType ?? cnvType
-	let isGain: boolean
-	if (effectiveType == 'category') {
-		// qualitative call carried in the segment's class; no numeric thresholds.
-		// When the request lists cnvCategories (UI checkboxes), drop any segment whose class isn't selected;
-		// an omitted list (undefined) means "all classes", an empty list means "none".
-		if (Array.isArray(options.cnvCategories) && !options.cnvCategories.includes(entry.class)) return null
-		// map the class to a gain/loss lesion. GDC's 5-category data distinguishes a gain from a high-level
-		// amplification and a loss from a homozygous deletion; GRIN2 renders only gain vs loss, so both
-		// gain-like classes => gain and both loss-like classes => loss.
-		if (entry.class == mclasscnvgain || entry.class == mclasscnvAmp) isGain = true
-		else if (entry.class == mclasscnvloss || entry.class == mclasscnvHomozygousDel) isGain = false
-		else return null
-	} else {
-		// numeric value: log2ratio/segmean (baseline 0) or copyNumber (baseline 2).
-		// The comparison is identical across these; only the threshold values differ,
-		// e.g. copyNumber uses positive cutoffs straddling baseline 2 (loss<=1, gain>=3).
-		// In a mixed cohort, cnvOptions.byType[effectiveType] supplies the right cutoffs for this
-		// segment; otherwise fall back to the flat lossThreshold/gainThreshold (single-type cohort).
-		const thresholds = resolveCnvThresholds(options, effectiveType)
-		if (!thresholds) return null
-		if (!Number.isFinite(entry.value)) return null
-		if (entry.value >= thresholds.gainThreshold) isGain = true
-		else if (entry.value <= thresholds.lossThreshold) isGain = false
-		else return null // between thresholds = neutral
-	}
-
-	const lesionType = getCnvLesionType(isGain)
-
-	// TODO: implement hypermutator threshold filter (maybe calculate number of mutations per sample?)
-
-	const start = entry.start
-	const end = entry.stop
-
-	return [sampleName, entry.chr, start, end, lesionType]
-}
-
-export function filterAndConvertFusion(
-	sampleName: string,
-	entry: any,
-	_options: GRIN2Request['fusionOptions']
-): string[] | string[][] | null {
-	// Validate required fields and check for undefined for typescript
-	if (!entry.chrA || entry.posA === undefined) {
-		return null
-	}
-
-	// First breakpoint on chrA
-	const startA = entry.posA
-	const endA = entry.posA
-
-	const lesionA: string[] = [sampleName, entry.chrA, startA, endA, dt2lesion[dtfusionrna].lesionTypes[0].lesionType]
-
-	// Check if there's a second breakpoint on chrB
-	if (entry.chrB && entry.posB !== undefined) {
-		// Inter-chromosomal fusion or same chromosome with two breakpoints
-		const startB = entry.posB
-		const endB = entry.posB
-
-		const lesionB: string[] = [sampleName, entry.chrB, startB, endB, dt2lesion[dtfusionrna].lesionTypes[0].lesionType]
-
-		// Return both breakpoints as separate lesions
-		// This will correctly identify genes affected at both fusion partners
-		return [lesionA, lesionB]
-	}
-
-	// Only chrA breakpoint available
-	return lesionA
-}
-
-export function filterAndConvertSV(
-	sampleName: string,
-	entry: any,
-	_options: GRIN2Request['svOptions']
-): string[] | string[][] | null {
-	// Validate required fields for for typescript
-	if (!entry.chrA || entry.posA === undefined) {
-		return null
-	}
-
-	// First breakpoint on chrA
-	const startA = entry.posA
-	const endA = entry.posA
-
-	const lesionA: string[] = [sampleName, entry.chrA, startA, endA, dt2lesion[dtsv].lesionTypes[0].lesionType]
-
-	// Check if there's a second breakpoint on chrB
-	if (entry.chrB && entry.posB !== undefined) {
-		// Inter-chromosomal SV or same chromosome with two breakpoints
-		const startB = entry.posB
-		const endB = entry.posB
-
-		const lesionB: string[] = [sampleName, entry.chrB, startB, endB, dt2lesion[dtsv].lesionTypes[0].lesionType]
-
-		// Return both breakpoints as separate lesions
-		return [lesionA, lesionB]
-	}
-
-	// Only chrA breakpoint available
-	return lesionA
 }

--- a/server/src/grin2/main.ts
+++ b/server/src/grin2/main.ts
@@ -15,7 +15,9 @@ import {
 	optionToDt,
 	formatElapsedTime,
 	mclasscnvgain,
-	mclasscnvloss
+	mclasscnvloss,
+	mclasscnvAmp,
+	mclasscnvHomozygousDel
 } from '#shared'
 
 import { mayFilterByMaf } from '../mds3.init.js'
@@ -48,7 +50,9 @@ import type { CnvType, Grin2CacheResult } from './types.ts'
  *      dataset quantifies cnv values (ds.queries.cnv.type, defaulting to 'log2ratio'):
  *        - 'log2ratio'/'segmean': numeric value, diploid baseline 0 (gain >= gainThreshold, loss <= lossThreshold)
  *        - 'copyNumber': numeric absolute copy number, diploid baseline 2 (e.g. loss <= 1, gain >= 3, neutral = 2)
- *        - 'category': qualitative call carried in the segment's class (CNV_amp/CNV_loss); thresholds ignored
+ *        - 'category': qualitative call carried in the segment's class; thresholds ignored. Gain-like classes
+ *          (CNV_amp/CNV_amplification) => gain, loss-like (CNV_loss/CNV_homozygous_deletion) => loss, and
+ *          cnvOptions.cnvCategories (UI checkboxes) restricts which classes are included.
  *      See filterAndConvertCnv() and the CnvType type in ./types.ts
  *    - Fusion: No filtering applied; each breakpoint (chrA, and chrB when present) becomes a lesion.
  *    - SV: No filtering applied; same breakpoint-to-lesion conversion as fusion.
@@ -373,10 +377,6 @@ async function runGrin2(g: any, ds: any, request: GRIN2Request, signal?: AbortSi
 							: []),
 						['Unprocessed Samples', (processing.unprocessedSamples ?? 0).toLocaleString()],
 						['Failed Samples', processing.failedSamples!.toLocaleString()],
-						// only shown when a cnv-type selection actually dropped some samples' cnv
-						...(processing.droppedCnvNoType
-							? [['Dropped (CNV type unavailable)', processing.droppedCnvNoType.toLocaleString()]]
-							: []),
 						['Total Lesions', processing.totalLesions!.toLocaleString()],
 						['Processed Lesions', processing.processedLesions!.toLocaleString()]
 					]
@@ -662,7 +662,6 @@ async function processSampleData(
 		totalLesions: number
 		processedLesions: number
 		unprocessedSamples: number
-		droppedCnvNoType: number
 		lesionCap?: number
 		lesionCounts?: {
 			total: number
@@ -674,19 +673,10 @@ async function processSampleData(
 	const maxLesions = await getMaxLesions()
 	mayLog(`[GRIN2] Max lesions for this run: ${maxLesions.toLocaleString()}`)
 
-	// The user may select one of several cnv file types the ds declares (ds.queries.singleSampleMutation.cnvTypes,
-	// e.g. GDC masked-segment vs allele-specific). The selected def's valueType is the authoritative cnv
-	// quantification for this run; pass the def to the getter so it loads only that file type.
-	const cnvTypeDefs = ds.queries?.singleSampleMutation?.cnvTypes as
-		| { id: string; label: string; valueType: CnvType; dataType: string }[]
-		| undefined
-	const selectedCnvDef = request.cnvOptions?.cnvType
-		? cnvTypeDefs?.find(t => t.id === request.cnvOptions!.cnvType)
-		: undefined
-
-	// How this ds quantifies cnv values; drives gain/loss classification. The selected type wins; else the
-	// ds-level default (file-based datasets); else 'log2ratio' (legacy default, diploid baseline 0).
-	const cnvType: CnvType = selectedCnvDef?.valueType ?? ds.queries?.cnv?.type ?? 'log2ratio'
+	// How this ds quantifies cnv values; drives gain/loss classification. The ds-level default is used for
+	// file-based datasets; else 'log2ratio' (legacy default, diploid baseline 0). GDC's batched cnv records
+	// carry their own valueType:'category' per segment, so they classify correctly regardless of this default.
+	const cnvType: CnvType = ds.queries?.cnv?.type ?? 'log2ratio'
 
 	// Track unique samples per lesion type for reporting
 	const samplesPerType = new Map<number, Set<string>>()
@@ -709,9 +699,7 @@ async function processSampleData(
 		failedSamples: 0,
 		totalLesions: 0,
 		processedLesions: 0,
-		unprocessedSamples: 0,
-		// cases that had cnv file(s) but none of the user-selected cnv type (their cnv was dropped, ssm kept)
-		droppedCnvNoType: 0
+		unprocessedSamples: 0
 	} as {
 		totalSamples: number
 		processedSamples: number
@@ -719,7 +707,6 @@ async function processSampleData(
 		totalLesions: number
 		processedLesions: number
 		unprocessedSamples: number
-		droppedCnvNoType: number
 		// unique samples that contributed >=1 lesion to the final result (union across all lesion types).
 		// distinct from processedSamples: many cohort cases have no qualifying mutation, so this is smaller.
 		samplesWithData?: number
@@ -760,24 +747,25 @@ async function processSampleData(
 	// when those options are off; for native ds it filters out unrequested dt before return.
 	const skipDt = new Set<number>(Object.values(optionToDt).filter(dt => !enabledTypes.includes(dt)))
 
-	// If the ds offers a batch SNV/indel getter (GDC) and snvindel is requested, fetch all SNV/indel up
-	// front in batched requests (GDC: one ssm_occurrences POST per chunk of cases) instead of one per
-	// sample. cnv/fusion still come from the per-sample get() below. ssmBySample maps sample name -> {mlst}.
-	const ssmBatchGet = ds.queries.singleSampleMutation.batchGet
-	const useBatchSsm = typeof ssmBatchGet == 'function' && enabledTypes.includes(dtsnvindel)
-	let ssmBySample: Map<string, { mlst: any[] }> | undefined
-	if (useBatchSsm) {
-		const batch = await ssmBatchGet({
+	// If the ds offers a batch mutation getter (GDC) and snvindel and/or cnv is requested, fetch those up
+	// front in batched requests (GDC: ssm_occurrences + segment_cnv_occurrences POSTs per chunk of cases)
+	// instead of one per sample. fusion/sv still come from the per-sample get() below. batchBySample maps
+	// sample name -> {mlst} holding the batched snvindel and categorical cnv records.
+	const batchGet = ds.queries.singleSampleMutation.batchGet
+	const useBatch = typeof batchGet == 'function' && (enabledTypes.includes(dtsnvindel) || enabledTypes.includes(dtcnv))
+	let batchBySample: Map<string, { mlst: any[] }> | undefined
+	if (useBatch) {
+		const batch = await batchGet({
 			samples: samples.map(s => s.name),
-			skipDt,
+			skipDt, // getter fetches only the enabled dts among snvindel/cnv
 			ds, // batch getter reads ds from q.ds (gdc.hg38.ts convention)
 			filter0: request.filter0,
-			// cap the up-front ssm fetch at the run's lesion budget so a huge cohort / entire GDC doesn't
-			// pull millions of ssm before the per-sample loop's cap would ever discard them
+			// cap the up-front fetch at the run's lesion budget so a huge cohort / entire GDC doesn't
+			// pull millions of records before the per-sample loop's cap would ever discard them
 			maxLesions,
 			__abortSignal: signal
 		})
-		ssmBySample = batch.bySample
+		batchBySample = batch.bySample
 		// If the cap truncated the batch fetch, some samples got no SNV/indel data even though the loop
 		// below still "processes" them — so the loop's "ran on N of M" check won't catch it. Record it here
 		// so the summary can warn the user, like the non-batched path does.
@@ -787,14 +775,15 @@ async function processSampleData(
 		}
 		// Samples whose case had no open-access SNV/indel, surfaced so users don't read a partial cohort as
 		// complete (not an error, just a coverage note). Split into controlled-access vs genuinely-no-mutation,
-		// plus samples that matched no GDC case at all, so all 3,716 reconcile in the summary.
+		// plus samples that matched no GDC case at all, so they reconcile in the summary.
 		processing.ssmSamplesNoOpenAccess = batch.samplesNoOpenSsm
 		processing.ssmSamplesControlledAccess = batch.samplesControlledAccess
 		processing.ssmSamplesNoMutations = batch.samplesNoMutations
 		processing.unmatchedSamples = batch.unresolvedSamples
 	}
-	// When ssm is batched, skip it in the per-sample loop so get() doesn't re-fetch it.
-	const loopSkipDt = useBatchSsm ? new Set<number>(skipDt).add(dtsnvindel) : skipDt
+	// When mutations are batched, skip snvindel + cnv in the per-sample loop so get() doesn't re-fetch them
+	// (fusion/sv, if enabled, still flow through get()).
+	const loopSkipDt = useBatch ? new Set<number>(skipDt).add(dtsnvindel).add(dtcnv) : skipDt
 	// If batching ssm leaves no other enabled dt for this case, the per-sample get() has nothing to
 	// fetch — skip the call entirely (avoids one empty round-trip per sample for snvindel-only runs).
 	const needPerSampleGet = enabledTypes.some(dt => !loopSkipDt.has(dt))
@@ -808,30 +797,21 @@ async function processSampleData(
 				// per-sample work (including the GDC network call below) once the request is aborted.
 				if (signal?.aborted) return
 
-				// batched SNV/indel for this sample (fetched up front); [] when not batched / none found
-				const ssmMlst = ssmBySample?.get(sample.name)?.mlst ?? []
+				// batched snvindel + categorical cnv for this sample (fetched up front); [] when not batched / none found
+				const batchMlst = batchBySample?.get(sample.name)?.mlst ?? []
 
 				let getMlst: any[] = []
-				let droppedCnvNoMatch = false
 				if (needPerSampleGet) {
 					const r = await ds.queries.singleSampleMutation.get({
 						sample: sample.name,
 						skipDt: loopSkipDt,
 						// propagate the request abort signal so the GDC getter's xfetch stops issuing network
 						// requests once the client disconnects/cancels (the getter reads q.__abortSignal)
-						__abortSignal: signal,
-						// only set when the user selected a specific cnv type; the getter loads only this type and
-						// flags droppedCnvNoMatch when the case has cnv but not of this type
-						cnvType: selectedCnvDef
-							? { id: selectedCnvDef.id, dataType: selectedCnvDef.dataType, valueType: selectedCnvDef.valueType }
-							: undefined
+						__abortSignal: signal
 					})
 					getMlst = r.mlst || []
-					droppedCnvNoMatch = r.droppedCnvNoMatch
 				}
-				const mlst = ssmMlst.length ? [...ssmMlst, ...getMlst] : getMlst
-
-				if (droppedCnvNoMatch) processing.droppedCnvNoType! += 1
+				const mlst = batchMlst.length ? [...batchMlst, ...getMlst] : getMlst
 
 				const { sampleLesions, contributedTypes } = processSampleMlst(sample.name, mlst, request, cnvType)
 
@@ -866,10 +846,10 @@ async function processSampleData(
 				processing.totalLesions! += filteredLesions.length
 
 				const done = processing.processedSamples! + processing.failedSamples!
-				// On the batched path (GDC) ssm is fetched up front, so this per-sample loop races to
+				// On the batched path (GDC) mutations are fetched up front, so this per-sample loop races to
 				// completion and this counter is misleading — progress is logged by the batch getter's
 				// per-chunk fetch instead. Native/SQLite datasets do the real work here, so keep the line.
-				if (!useBatchSsm && done % 200 === 0) mayLog(`[GRIN2] Processed ${done}/${samples.length} samples`)
+				if (!useBatch && done % 200 === 0) mayLog(`[GRIN2] Processed ${done}/${samples.length} samples`)
 			} catch (e: any) {
 				processing.failedSamples! += 1
 				mayLog(`[GRIN2] Error processing sample ${sample.name}: ${e.message || e}`)
@@ -1089,9 +1069,15 @@ export function filterAndConvertCnv(
 	const effectiveType: CnvType = entry.valueType ?? cnvType
 	let isGain: boolean
 	if (effectiveType == 'category') {
-		// qualitative call carried in the segment's class; no numeric thresholds
-		if (entry.class == mclasscnvgain) isGain = true
-		else if (entry.class == mclasscnvloss) isGain = false
+		// qualitative call carried in the segment's class; no numeric thresholds.
+		// When the request lists cnvCategories (UI checkboxes), drop any segment whose class isn't selected;
+		// an omitted list (undefined) means "all classes", an empty list means "none".
+		if (Array.isArray(options.cnvCategories) && !options.cnvCategories.includes(entry.class)) return null
+		// map the class to a gain/loss lesion. GDC's 5-category data distinguishes a gain from a high-level
+		// amplification and a loss from a homozygous deletion; GRIN2 renders only gain vs loss, so both
+		// gain-like classes => gain and both loss-like classes => loss.
+		if (entry.class == mclasscnvgain || entry.class == mclasscnvAmp) isGain = true
+		else if (entry.class == mclasscnvloss || entry.class == mclasscnvHomozygousDel) isGain = false
 		else return null
 	} else {
 		// numeric value: log2ratio/segmean (baseline 0) or copyNumber (baseline 2).

--- a/server/src/grin2/memory.ts
+++ b/server/src/grin2/memory.ts
@@ -1,0 +1,71 @@
+/** Memory-aware lesion cap for GRIN2. Reads available system memory and derives how many lesions a run
+ * may hold, so a busy server scales the cap down instead of OOMing. Split out of main.ts as a self-contained
+ * concern; getMaxLesions() is the only export (processSampleData calls it). */
+
+import serverconfig from '../serverconfig.js'
+import os from 'os'
+import { mayLog } from '../helpers.ts'
+import { promisify } from 'node:util'
+import { exec as execCallback } from 'node:child_process'
+
+const exec = promisify(execCallback)
+
+// Constants
+const MAX_LESIONS = serverconfig.features.grin2maxLesions || 250000 // Maximum total number of lesions to process to avoid overwhelming the production server
+const GRIN2_MEMORY_BUDGET_MB = 950
+const MEMORY_BASE_MB = 260
+const MEMORY_PER_1K_LESIONS = 2.4
+const MIN_LESIONS = 50000
+
+async function getAvailableMemoryMB(): Promise<number> {
+	try {
+		if (process.platform === 'darwin') {
+			// macOS: use vm_stat
+			const { stdout } = await exec('vm_stat')
+			const output = stdout.toString()
+
+			// Parse page size from vm_stat header: "page size of 4096 bytes for Apple silicon, 16384 bytes for Intel macs"
+			const headerLine = output.split('\n')[0] || ''
+			const pageSizeMatch = headerLine.match(/page size of\s+(\d+)\s+bytes/i)
+			const pageSize = pageSizeMatch ? parseInt(pageSizeMatch[1], 10) : 16384
+			const freeMatch = output.match(/Pages free:\s+(\d+)/)
+			const inactiveMatch = output.match(/Pages inactive:\s+(\d+)/)
+			const freePages = freeMatch ? parseInt(freeMatch[1], 10) : 0
+			const inactivePages = inactiveMatch ? parseInt(inactiveMatch[1], 10) : 0
+
+			// Available ≈ free + inactive
+			return ((freePages + inactivePages) * pageSize) / (1024 * 1024)
+		} else {
+			// Linux: use free command
+			const { stdout } = await exec('free -m')
+			const output = stdout.toString()
+			const lines = output.split('\n')
+			const memLine = lines.find(l => l.startsWith('Mem:'))
+			if (memLine) {
+				const parts = memLine.split(/\s+/)
+				return parseInt(parts[6]) // "available" column
+			}
+		}
+	} catch (e) {
+		mayLog(`[GRIN2] Memory check failed, using fallback: ${e}`)
+	}
+
+	// Fallback: os.freemem (less accurate but always works)
+	return os.freemem() / (1024 * 1024)
+}
+
+export async function getMaxLesions(): Promise<number> {
+	const availableMemoryMB = await getAvailableMemoryMB()
+	mayLog(`[GRIN2] Available system memory: ${availableMemoryMB.toFixed(0)} MB`)
+
+	// If server is under heavy load, reduce lesion cap. Our calculation assumes each 1,000 lesions use ~2.4MB of memory plus a base overhead (i.e. a linear relationship).
+	if (availableMemoryMB < GRIN2_MEMORY_BUDGET_MB * 2) {
+		const reducedBudget = availableMemoryMB * 0.4
+		mayLog(`[GRIN2] Reducing lesion cap due to memory constraints. New budget: ${reducedBudget.toFixed(2)} MB`)
+		const calculated = Math.floor((reducedBudget - MEMORY_BASE_MB) / MEMORY_PER_1K_LESIONS) * 1000
+		mayLog(`[GRIN2] Calculated lesion cap based on memory: ${calculated.toLocaleString()}`)
+		return Math.max(MIN_LESIONS, Math.min(MAX_LESIONS, calculated))
+	}
+
+	return MAX_LESIONS
+}

--- a/server/src/grin2/memory.ts
+++ b/server/src/grin2/memory.ts
@@ -40,10 +40,13 @@ async function getAvailableMemoryMB(): Promise<number> {
 			const { stdout } = await exec('free -m')
 			const output = stdout.toString()
 			const lines = output.split('\n')
-			const memLine = lines.find(l => l.startsWith('Mem:'))
+			const memLine = lines.find(l => l.trim().startsWith('Mem:'))
 			if (memLine) {
-				const parts = memLine.split(/\s+/)
-				return parseInt(parts[6]) // "available" column
+				const parts = memLine.trim().split(/\s+/)
+				const available = parseInt(parts[6], 10) // "available" column
+				// if free's output format shifts (or the column is absent), fall through to os.freemem below
+				// rather than returning NaN, which would poison the cap math and logs
+				if (Number.isFinite(available)) return available
 			}
 		}
 	} catch (e) {

--- a/server/src/grin2/test/grin2.unit.spec.ts
+++ b/server/src/grin2/test/grin2.unit.spec.ts
@@ -69,10 +69,10 @@ tape('filterAndConvertSnvIndel', test => {
 		null,
 		'class not in selected consequences => null'
 	)
-	test.deepEqual(
+	test.equal(
 		filterAndConvertSnvIndel(sample, m, { consequences: [] }),
-		[sample, 'chr17', m.pos, m.pos, 'mutation'],
-		'empty consequences list => include all'
+		null,
+		'empty consequences list => include none (mirrors cnvCategories)'
 	)
 	test.equal(
 		filterAndConvertSnvIndel(sample, { chr: 'chr17', pos: 1.5, class: 'M' }, { consequences: [] }),
@@ -352,7 +352,7 @@ tape('processSampleMlst: routing, breakpoint expansion, cnvType threading', test
 		{ dt: 999, chr: 'chrX', pos: 1 } // unknown dt is ignored
 	]
 	const request = {
-		snvindelOptions: { consequences: [] },
+		snvindelOptions: { consequences: ['M'] }, // include the MISSENSE snv in mlst
 		cnvOptions: copyNumberOpts,
 		fusionOptions: {},
 		svOptions: {}
@@ -375,7 +375,7 @@ tape('processSampleMlst: routing, breakpoint expansion, cnvType threading', test
 	const snvOnly = processSampleMlst(
 		sample,
 		mlst,
-		{ snvindelOptions: { consequences: [] } } as unknown as GRIN2Request,
+		{ snvindelOptions: { consequences: ['M'] } } as unknown as GRIN2Request,
 		'log2ratio'
 	)
 	test.deepEqual([...snvOnly.contributedTypes], [dtsnvindel], 'absent option groups are skipped')

--- a/server/src/grin2/test/grin2.unit.spec.ts
+++ b/server/src/grin2/test/grin2.unit.spec.ts
@@ -11,7 +11,16 @@ import {
 	normalizeExcludeOptions,
 	resolveExcludeBeds
 } from '../main.ts'
-import { dtsnvindel, dtcnv, dtfusionrna, dtsv, mclasscnvgain, mclasscnvloss } from '#shared'
+import {
+	dtsnvindel,
+	dtcnv,
+	dtfusionrna,
+	dtsv,
+	mclasscnvgain,
+	mclasscnvloss,
+	mclasscnvAmp,
+	mclasscnvHomozygousDel
+} from '#shared'
 import type { GRIN2Request } from '#types'
 
 /* test sections
@@ -135,6 +144,72 @@ tape('filterAndConvertCnv: category (qualitative class, thresholds ignored)', te
 		filterAndConvertCnv(sample, { ...SEG, class: 'SomethingElse' }, categoryOpts, 'category'),
 		null,
 		'category: unrecognized class => null'
+	)
+	test.end()
+})
+
+tape('processSampleMlst: GDC batched categorical cnv records route to gain/loss', test => {
+	// Records shaped exactly as the GDC batchGet (fetchCnvForCases in gdc.hg38.ts) emits: a lean segment
+	// carrying valueType:'category' and the finer 5-category class. Gain/Amplification => gain lesion,
+	// Loss/Homozygous Deletion => loss lesion. GDC's ds cnvType default resolves to log2ratio, so this also
+	// locks that the per-entry valueType wins over that numeric default with no thresholds sent.
+	const gdcMlst = [
+		{ dt: dtcnv, class: mclasscnvgain, valueType: 'category', ...SEG }, // Gain
+		{ dt: dtcnv, class: mclasscnvAmp, valueType: 'category', ...SEG }, // Amplification
+		{ dt: dtcnv, class: mclasscnvloss, valueType: 'category', ...SEG }, // Loss
+		{ dt: dtcnv, class: mclasscnvHomozygousDel, valueType: 'category', ...SEG } // Homozygous Deletion
+	]
+	const gdcRequest = { cnvOptions: { maxSegLength: 0 } } as unknown as GRIN2Request
+	const gdc = processSampleMlst(sample, gdcMlst, gdcRequest, 'log2ratio')
+	test.deepEqual(
+		gdc.sampleLesions.map(l => l[4]),
+		['gain', 'gain', 'loss', 'loss'],
+		'gain/amplification => gain lesion; loss/homozygous deletion => loss lesion (regardless of log2ratio default)'
+	)
+	test.deepEqual([...gdc.contributedTypes], [dtcnv], 'only cnv contributed')
+	test.end()
+})
+
+tape('filterAndConvertCnv: category cnvCategories filter (UI checkboxes)', test => {
+	const catOpts = (cats?: string[]) => ({ maxSegLength: 0, cnvCategories: cats })
+	// class listed in cnvCategories => included
+	test.deepEqual(
+		filterAndConvertCnv(
+			sample,
+			{ ...SEG, valueType: 'category', class: mclasscnvAmp },
+			catOpts([mclasscnvAmp]),
+			'category'
+		),
+		[sample, SEG.chr, SEG.start, SEG.stop, 'gain'],
+		'class in cnvCategories => amplification included as gain'
+	)
+	// class not listed => dropped
+	test.equal(
+		filterAndConvertCnv(
+			sample,
+			{ ...SEG, valueType: 'category', class: mclasscnvloss },
+			catOpts([mclasscnvAmp]),
+			'category'
+		),
+		null,
+		'class not in cnvCategories => null'
+	)
+	// empty list => nothing included
+	test.equal(
+		filterAndConvertCnv(sample, { ...SEG, valueType: 'category', class: mclasscnvgain }, catOpts([]), 'category'),
+		null,
+		'empty cnvCategories => null'
+	)
+	// omitted list => all classes included (backward compatible)
+	test.deepEqual(
+		filterAndConvertCnv(
+			sample,
+			{ ...SEG, valueType: 'category', class: mclasscnvHomozygousDel },
+			catOpts(undefined),
+			'category'
+		),
+		[sample, SEG.chr, SEG.start, SEG.stop, 'loss'],
+		'undefined cnvCategories => homozygous deletion included as loss'
 	)
 	test.end()
 })

--- a/server/src/grin2/test/grin2.unit.spec.ts
+++ b/server/src/grin2/test/grin2.unit.spec.ts
@@ -2,15 +2,12 @@ import tape from 'tape'
 import {
 	filterAndConvertSnvIndel,
 	filterAndConvertCnv,
-	filterAndConvertFusion,
-	filterAndConvertSV,
+	breakpointsToLesions,
 	processSampleMlst,
 	buildLesionTypeMap,
-	getCnvLesionType,
-	grin2KeyInputs,
-	normalizeExcludeOptions,
-	resolveExcludeBeds
-} from '../main.ts'
+	getCnvLesionType
+} from '../lesions.ts'
+import { grin2KeyInputs, normalizeExcludeOptions, resolveExcludeBeds } from '../main.ts'
 import {
 	dtsnvindel,
 	dtcnv,
@@ -30,8 +27,8 @@ filterAndConvertCnv: log2ratio / segmean (baseline 0)
 filterAndConvertCnv: copyNumber (baseline 2, absolute thresholds)
 filterAndConvertCnv: category (qualitative class, thresholds ignored)
 filterAndConvertCnv: maxSegLength + shared guards
-filterAndConvertFusion
-filterAndConvertSV
+breakpointsToLesions: fusion
+breakpointsToLesions: sv
 processSampleMlst: routing, breakpoint expansion, cnvType threading
 buildLesionTypeMap
 getCnvLesionType
@@ -304,42 +301,42 @@ tape('filterAndConvertCnv: maxSegLength + shared guards', test => {
 	test.end()
 })
 
-tape('filterAndConvertFusion', test => {
-	// single breakpoint (only chrA)
+tape('breakpointsToLesions: fusion', test => {
+	// single breakpoint (only chrA) => one lesion
 	test.deepEqual(
-		filterAndConvertFusion(sample, { chrA: 'chr12', posA: 25225245 }, {}),
-		[sample, 'chr12', 25225245, 25225245, 'fusion'],
+		breakpointsToLesions(sample, { chrA: 'chr12', posA: 25225245 }, dtfusionrna),
+		[[sample, 'chr12', 25225245, 25225245, 'fusion']],
 		'single breakpoint => one fusion lesion'
 	)
 	// two breakpoints (chrA + chrB) => two lesions
 	test.deepEqual(
-		filterAndConvertFusion(sample, { chrA: 'chr12', posA: 25225245, chrB: 'chr14', posB: 104779948 }, {}),
+		breakpointsToLesions(sample, { chrA: 'chr12', posA: 25225245, chrB: 'chr14', posB: 104779948 }, dtfusionrna),
 		[
 			[sample, 'chr12', 25225245, 25225245, 'fusion'],
 			[sample, 'chr14', 104779948, 104779948, 'fusion']
 		],
 		'two breakpoints => two fusion lesions'
 	)
-	test.equal(filterAndConvertFusion(sample, { posA: 1 }, {}), null, 'missing chrA => null')
-	test.equal(filterAndConvertFusion(sample, { chrA: 'chr1' }, {}), null, 'missing posA => null')
+	test.deepEqual(breakpointsToLesions(sample, { posA: 1 }, dtfusionrna), [], 'missing chrA => []')
+	test.deepEqual(breakpointsToLesions(sample, { chrA: 'chr1' }, dtfusionrna), [], 'missing posA => []')
 	test.end()
 })
 
-tape('filterAndConvertSV', test => {
+tape('breakpointsToLesions: sv', test => {
 	test.deepEqual(
-		filterAndConvertSV(sample, { chrA: 'chr9', posA: 100 }, {}),
-		[sample, 'chr9', 100, 100, 'sv'],
+		breakpointsToLesions(sample, { chrA: 'chr9', posA: 100 }, dtsv),
+		[[sample, 'chr9', 100, 100, 'sv']],
 		'single breakpoint => one sv lesion'
 	)
 	test.deepEqual(
-		filterAndConvertSV(sample, { chrA: 'chr9', posA: 100, chrB: 'chr22', posB: 200 }, {}),
+		breakpointsToLesions(sample, { chrA: 'chr9', posA: 100, chrB: 'chr22', posB: 200 }, dtsv),
 		[
 			[sample, 'chr9', 100, 100, 'sv'],
 			[sample, 'chr22', 200, 200, 'sv']
 		],
 		'two breakpoints => two sv lesions'
 	)
-	test.equal(filterAndConvertSV(sample, { posA: 1 }, {}), null, 'missing chrA => null')
+	test.deepEqual(breakpointsToLesions(sample, { posA: 1 }, dtsv), [], 'missing chrA => []')
 	test.end()
 })
 
@@ -402,6 +399,53 @@ tape('processSampleMlst: routing, breakpoint expansion, cnvType threading', test
 		['gain', 'gain'],
 		'mixed segmean+copyNumber segments both classify as gain under their own byType cutoffs'
 	)
+	test.end()
+})
+
+tape('processSampleMlst: hypermutator cutoff', test => {
+	// 3 snvindel + 1 cnv; snvindel cutoff 2 => snvindel dropped as hypermutated, cnv still kept
+	const mlst = [
+		{ dt: dtsnvindel, chr: 'chr1', pos: 10, class: 'M' },
+		{ dt: dtsnvindel, chr: 'chr1', pos: 20, class: 'M' },
+		{ dt: dtsnvindel, chr: 'chr1', pos: 30, class: 'M' },
+		{ dt: dtcnv, chr: 'chr1', start: 100, stop: 200, value: 4 }
+	]
+	const req = {
+		snvindelOptions: { consequences: ['M'], hyperMutator: 2 },
+		cnvOptions: { lossThreshold: 1, gainThreshold: 3, maxSegLength: 0 }
+	} as unknown as GRIN2Request
+
+	const over = processSampleMlst(sample, mlst, req, 'copyNumber')
+	test.deepEqual(over.hyperMutatedDt, [dtsnvindel], 'snvindel over cutoff => reported hypermutated')
+	test.deepEqual(
+		over.sampleLesions.map(l => l[4]),
+		['gain'],
+		'snvindel dropped, cnv gain kept'
+	)
+	test.notOk(over.contributedTypes.has(dtsnvindel), 'hypermutated dt not in contributedTypes')
+
+	// at the cutoff (3 <= 3) => not hypermutated, all kept
+	const atLimit = processSampleMlst(
+		sample,
+		mlst,
+		{ ...req, snvindelOptions: { consequences: ['M'], hyperMutator: 3 } } as unknown as GRIN2Request,
+		'copyNumber'
+	)
+	test.deepEqual(atLimit.hyperMutatedDt, [], 'count == cutoff is not over the cutoff')
+	test.equal(atLimit.sampleLesions.length, 4, '3 snvindel + 1 cnv all kept')
+
+	// cutoff 0 / absent => disabled even with many records
+	const disabled = processSampleMlst(
+		sample,
+		mlst,
+		{
+			snvindelOptions: { consequences: ['M'] },
+			cnvOptions: { lossThreshold: 1, gainThreshold: 3 }
+		} as unknown as GRIN2Request,
+		'copyNumber'
+	)
+	test.deepEqual(disabled.hyperMutatedDt, [], 'absent cutoff disables the check')
+	test.equal(disabled.sampleLesions.length, 4, 'nothing dropped when cutoff is absent')
 	test.end()
 })
 

--- a/server/src/grin2/types.ts
+++ b/server/src/grin2/types.ts
@@ -5,10 +5,59 @@
 /** How a dataset quantifies cnv values; declared at ds.queries.cnv.type. See CnvSegmentQuery in #types. */
 export type CnvType = 'log2ratio' | 'segmean' | 'category' | 'copyNumber'
 
+/** One GRIN2 lesion row passed to Python: [sampleName, chrom, start, end, lesionType].
+ * start/end are numeric genomic positions (not strings) — see the data-flow comment at the top of main.ts. */
+export type Lesion = [string, string, number, number, string]
+
+/** Processing summary produced by processSampleData and surfaced in the response stats + coverage notes.
+ * The first six fields are always set; the rest are populated only on the batched GDC path or when a cap
+ * is hit. Kept as one named type so runGrin2's stat-row assembly is type-checked (not read off `any`). */
+export interface Grin2Processing {
+	totalSamples: number
+	processedSamples: number
+	failedSamples: number
+	totalLesions: number
+	processedLesions: number
+	unprocessedSamples: number
+	// unique samples that contributed >=1 lesion to the final result (union across all lesion types).
+	// distinct from processedSamples: many cohort cases have no qualifying mutation, so this is smaller.
+	samplesWithData?: number
+	// set when the batched SNV/indel fetch (GDC) hit maxLesions and skipped some samples' ssm. distinct
+	// from the loop cap (unprocessedSamples) because the loop still processed those samples.
+	ssmCapReached?: boolean
+	ssmSamplesDropped?: number
+	// samples whose case returned no open-access SNV/indel (batched GDC path); a coverage note, not the
+	// cap. distinct from ssmSamplesDropped (cap-skipped) and from failedSamples (per-sample errors).
+	// ssmSamplesNoOpenAccess is the total; the two below break it down for the summary.
+	ssmSamplesNoOpenAccess?: number
+	// of ssmSamplesNoOpenAccess: samples in controlled-access GDC projects (data exists but isn't open).
+	ssmSamplesControlledAccess?: number
+	// of ssmSamplesNoOpenAccess: open-access samples that genuinely returned no SNV/indel mutation.
+	ssmSamplesNoMutations?: number
+	// samples that mapped to no GDC case at all (batched path), so were never queried; counted in neither
+	// samplesWithData nor ssmSamplesNoOpenAccess, hence surfaced separately so the cohort tallies reconcile.
+	unmatchedSamples?: number
+	// cnv analogs of the ssm* fields above (batched GDC cnv fetch). cnvCapReached/cnvSamplesDropped mirror
+	// ssmCapReached/ssmSamplesDropped; cnvSamplesNoData is queried samples that returned no cnv segment
+	// (cnv segment data is open-access, so there is no controlled-access split like ssm has).
+	cnvCapReached?: boolean
+	cnvSamplesDropped?: number
+	cnvSamplesNoData?: number
+	// samples excluded from a data type by the hypermutator cutoff (raw record count over the per-dt
+	// cutoff). Per-dt: a sample can be hypermutated for snvindel, cnv, both, or neither.
+	ssmSamplesHypermutated?: number
+	cnvSamplesHypermutated?: number
+	lesionCap?: number
+	lesionCounts?: {
+		total: number
+		byType: Record<string, { count: number; samples: number }>
+	}
+}
+
 /** grin2/{cacheid}.json. Self-contained: the per-gene rows Rust needs
  * for the Manhattan plot live inside `resultData.geneHits`, so the Rust
  * step opens this file directly. */
 export type Grin2CacheResult = {
 	resultData: any
-	processing: any
+	processing: Grin2Processing
 }

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -838,8 +838,10 @@ q = ds.queries.snvindel
 */
 export function mayValidateBcfMafFilter(q) {
 	if (!q.mafFilter) return // no maf filter on this ds
-	const format = q.byrange?._tk?.format
-	if (!format) throw 'snvindel.mafFilter is set but byrange._tk.format is missing'
+	// bcf datasets carry FORMAT under byrange._tk.format; API-backed datasets (e.g. GDC) declare it at the
+	// query level as q.format. Either supplies the same FORMAT shape, so depth-term auto-population works for both.
+	const format = q.byrange?._tk?.format || q.format
+	if (!format) throw 'snvindel.mafFilter is set but no FORMAT (byrange._tk.format or q.format) is available'
 	if (q.mafFilter._depthTermsAdded) return // already processed (init may run more than once)
 
 	// validate that every term references real FORMAT keys, branching by mode.

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -1664,10 +1664,10 @@ test('mayValidateBcfMafFilter: validate and auto-populate depth terms', t => {
 	qBad.mafFilter.terms[0].id = 'no_such_field'
 	t.throws(() => mayValidateBcfMafFilter(qBad), /unknown FORMAT key/, 'throws on unknown FORMAT key')
 
-	// no byrange format throws when mafFilter present
+	// no FORMAT anywhere (neither byrange._tk.format nor q.format) throws when mafFilter present
 	const qNoFormat = makeQ()
 	delete qNoFormat.byrange._tk.format
-	t.throws(() => mayValidateBcfMafFilter(qNoFormat), /byrange._tk.format is missing/, 'throws when format missing')
+	t.throws(() => mayValidateBcfMafFilter(qNoFormat), /no FORMAT/, 'throws when format missing')
 
 	// a dataset-configured depth term with a valid mafFormatKey passes validation
 	const qDepth = makeQ()

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -1721,6 +1721,24 @@ test('mayValidateBcfMafFilter: validate and auto-populate depth terms', t => {
 	t.throws(() => mayValidateBcfMafFilter(qBadMode), /unknown mafFilterMode/, 'unknown mafFilterMode throws')
 })
 
+test('mayValidateBcfMafFilter: GDC-shaped q resolves FORMAT from q.format', t => {
+	t.plan(2)
+	// GDC has byrange.gdcapi (no _tk.format); its FORMAT is on q.format. The `|| q.format` fallback in
+	// mayValidateBcfMafFilter is the whole reason GDC MAF works — guard it so a cleanup can't silently
+	// break GDC (validation would then throw /no FORMAT/ and take down the GDC snvindel query).
+	const q = {
+		byrange: { gdcapi: true },
+		format: { TumorAC: { ID: 'TumorAC', Number: 'R', Type: 'Integer', Description: 'tumor allele counts' } },
+		mafFilter: {
+			opts: { joinWith: ['and', 'or'] },
+			filter: { type: 'tvslst', join: '', in: true, lst: [] },
+			terms: [{ id: 'TumorAC', name: 'Tumor MAF', parent_id: null, isleaf: true, type: 'float' }]
+		}
+	}
+	t.doesNotThrow(() => mayValidateBcfMafFilter(q), 'GDC-shaped q (format on q.format) passes validation')
+	t.equal(q.mafFilter.terms.length, 3, 'auto-populated totalDepth + altDepth terms from q.format')
+})
+
 const mafFilter = {
 	type: 'tvslst',
 	join: '',

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -57,7 +57,9 @@ export type GRIN2Request = {
 
 	/** Options for filtering SNV/indel content: consequence types and an optional MAF filter. */
 	snvindelOptions?: {
-		/** String array of consequence types to include (pp mclass keys, as emitted by the shared GRIN2 UI). */
+		/** Consequence types to include (pp mclass keys, as emitted by the shared GRIN2 UI). Only mutations
+		 * whose class is listed are included; an empty array includes none (mirrors cnvOptions.cnvCategories).
+		 * Absent (undefined) yields no snvindel lesions (the getter guards on it). */
 		consequences?: string[]
 		/** Maximum mutation count cutoff for highly mutated scenarios */
 		hyperMutator?: number // Default: 1000
@@ -88,6 +90,12 @@ export type GRIN2Request = {
 		}
 		/** Maximum segment length to include (0 = no filter) */
 		maxSegLength?: number // Default: 0
+		/** For categorical cnv (ds.queries.cnv.type='category', e.g. GDC), the set of cnv-segment classes
+		 * (pp mclass keys: CNV_amp/CNV_amplification/CNV_loss/CNV_homozygous_deletion) to include, as chosen
+		 * via the UI checkboxes. A segment whose class is not listed is dropped. Omit (undefined) to include
+		 * every class; an empty array includes none. Ignored for numeric cnv types (gain/loss come from
+		 * thresholds, not discrete classes). */
+		cnvCategories?: string[]
 		/** Hypermutator max cut off for CNVs per case */
 		hyperMutator?: number // Default: 500
 		/** For datasets that expose multiple cnv file types (ds.queries.singleSampleMutation.cnvTypes),

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -62,7 +62,7 @@ export type GRIN2Request = {
 		 * Absent (undefined) yields no snvindel lesions (the getter guards on it). */
 		consequences?: string[]
 		/** Maximum mutation count cutoff for highly mutated scenarios */
-		hyperMutator?: number // Default: 1000
+		hyperMutator?: number // Default: 8000
 		/** MAF filter object (tvslst) to filter mutations by allele frequency / read depth, sourced from
 		 * queries.snvindel.mafFilter (bcf-backed datasets that expose per-sample allelic depth). */
 		mafFilter?: Filter

--- a/shared/types/src/routes/grin2.ts
+++ b/shared/types/src/routes/grin2.ts
@@ -96,8 +96,10 @@ export type GRIN2Request = {
 		 * every class; an empty array includes none. Ignored for numeric cnv types (gain/loss come from
 		 * thresholds, not discrete classes). */
 		cnvCategories?: string[]
-		/** Hypermutator max cut off for CNVs per case */
-		hyperMutator?: number // Default: 500
+		/** Hypermutator max cut off: exclude a sample's CNV when it has more than this many segments (0 =
+		 * disabled). Off by default — segment counts vary too much across data sources for a safe fixed value
+		 * (see CNV_HYPERMUTATOR_FALLBACK). Set per-run when the source warrants it. */
+		hyperMutator?: number // Default: 0 (off)
 		/** For datasets that expose multiple cnv file types (ds.queries.singleSampleMutation.cnvTypes),
 		 * the id of the user-selected type. The server resolves this id to a source-specific data_type
 		 * and a valueType, loads only the matching file, and classifies segments with that type's


### PR DESCRIPTION
# Description
Brings the last GDC-GRIN2 prototype features into the unified general GRIN2 route
and refactors the route for maintainability. Four related changes:

1. **MAF (VAF) filter for GDC** — enables the existing tumor-MAF/depth filter on
   the GDC dataset, matching non-GDC datasets.
2. **Hypermutator cutoffs** — per-sample, per-dt exclusion carried over from the
   prototype (SNV/indel + CNV), CNV off by default.
3. **General-route refactor** — `main.ts` split into focused modules; typed
   processing summary.
4. **CNV-segment UI** — clearer reporting and explicit "clear all = send none of
   this data type" semantics. Also changed MAF consequences to also explicitly be "clear all = send none of
   this data type" semantics" so that it and CNV are in-sync behavior-wise

## MAF filter for GDC

`mayValidateBcfMafFilter` now resolves the FORMAT definition from `q.format` when
`q.byrange._tk.format` is absent (`byrange?._tk?.format || q.format`). GDC exposes
FORMAT at `q.format` (its `byrange` is `{gdcapi:true}`), so this one-line fallback
is what lets the MAF filter validate and run on GDC. The UI is already generic
(reads `queries.snvindel.mafFilter`), so no client change was needed for MAF.

- New unit test guards the fallback: a GDC-shaped `q` (FORMAT on `q.format`) must
  pass validation and auto-populate the totalDepth/altDepth terms. Without the
  fallback this throws `no FORMAT` and takes down the GDC snvindel query.

## Hypermutator cutoffs

A sample with more raw records than the per-dt cutoff is excluded from that data
type (it would otherwise dominate the gene-level stats). Counted on raw mlst
records before filtering, mirroring the prototype's per-file count.

- **SNV/indel default 8000** — source-agnostic mutation burden; safe.
- **CNV default 0 (off)** — CNV counts *segments*, which vary enormously by data
  source: sparse for GDC's categorical cnv (~30/case) but hundreds-to-thousands
  for dense native segmentation. A fixed cutoff silently dropped whole-sample CNV
  (disproportionately aneuploid, gain-heavy samples) on native datasets, so it's
  opt-in. See `CNV_HYPERMUTATOR_FALLBACK`.

## General-route refactor

- `main.ts` (1204 → 777 lines): lesion conversion → `lesions.ts`, memory/lesion-cap
  logic → `memory.ts`.
- CNV classification unified across quantification types (`log2ratio`, `segmean`,
  `copyNumber`, `category`) via `ds.queries.cnv.type`, with per-entry `valueType`
  and per-type `byType` thresholds for mixed cohorts. Fusion/SV converters
  collapsed into one breakpoint-to-lesion helper.
- `Grin2Processing` type replaces reading the summary off `any`; `Lesion` tuple type.

## Test plan

- `server/src/grin2/test/grin2.unit.spec.ts` — lesion converters, CNV type
  matrix, hypermutator cutoff.
- `server/src/test/mds3.init.unit.spec.js` — MAF validation incl. the new GDC
  `q.format` case (291/291).
- Verified end-to-end on GDC (breast) and native (ETP-like ASHOP): MAF filter
  monotonic on real data; ASHOP gain/loss/mutation counts match master after the
  CNV-hypermutator default fix.

## Follow-ups (not in this PR)

- CNV hypermutator needs a source-aware threshold (or normalized count) before it's
  usable-by-default for native data.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
