### PR TITLE
Implement caching meta results files

### DIFF
--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -227,10 +227,9 @@ class gsea extends PlotBase {
 						dslabel: this.app.vocabApi.vocab.dslabel,
 						sample: config.sample,
 						termId: config.termId,
-						categoryName: config.categoryName,
-						signal: this.api?.getAbortSignal()
+						categoryName: config.categoryName
 					}
-					const response = await dofetch3('termdb/singlecellDEgenes', { body })
+					const response = await dofetch3('termdb/singlecellDEgenes', { body, signal: this.api?.getAbortSignal() })
 					if (response.error) throw response.error
 					if (!Array.isArray(response.data) || response.data.length === 0) throw 'No DE genes returned for this cluster'
 					const genes = []

--- a/client/plots/gsea.js
+++ b/client/plots/gsea.js
@@ -227,7 +227,8 @@ class gsea extends PlotBase {
 						dslabel: this.app.vocabApi.vocab.dslabel,
 						sample: config.sample,
 						termId: config.termId,
-						categoryName: config.categoryName
+						categoryName: config.categoryName,
+						signal: this.api?.getAbortSignal()
 					}
 					const response = await dofetch3('termdb/singlecellDEgenes', { body })
 					if (response.error) throw response.error
@@ -253,7 +254,7 @@ class gsea extends PlotBase {
 				} else {
 					const volcanoSettings =
 						config.settings?.volcano || getDefaultVolcanoSettings({}, { termType: 'geneExpression' })
-					const model = new VolcanoModel(this.app, config.termType)
+					const model = new VolcanoModel(this, config.termType)
 					const response = await model.getData(config, volcanoSettings)
 					if (!response?.data?.cacheId || response.error) {
 						throw response.error || 'No DE cacheId returned from volcano model'

--- a/client/plots/sc/model/SCModel.ts
+++ b/client/plots/sc/model/SCModel.ts
@@ -26,7 +26,7 @@ export class SCModel {
 			filter: getNormalRoot(state.termfilter.filter),
 			filter0: state.termfilter.filter0
 		}
-		return await dofetch3('termdb/singlecellSamples', { body })
+		return await dofetch3('termdb/singlecellSamples', { body, signal: this.sc.api?.getAbortSignal() })
 	}
 
 	//Fetches optional name for ds defined columns
@@ -54,10 +54,10 @@ export class SCModel {
 	/********** Single Cell DATA for rendering plots ********
 	 * This is for the plot buttons. Returns an array plots with found files or
 	 * available data. */
-	async getSampleData() {
+	async getSampleData() { 
 		const body = this.getDataRequestOpts()
 		if (!body) return
-		return await dofetch3('termdb/singlecellData', { body })
+		return await dofetch3('termdb/singlecellData', { body, signal: this.sc.api?.getAbortSignal() })
 	}
 
 	/** May provide active plots to the request and return plot data when
@@ -82,8 +82,7 @@ export class SCModel {
 			sample: {
 				eID: config.settings.sc.item.eID,
 				sID: config.settings.sc.item.sID
-			},
-			signal: this.sc.api?.getAbortSignal()
+			}
 		}
 	}
 
@@ -94,7 +93,7 @@ export class SCModel {
 
 		let res
 		try {
-			res = await dofetch3('termdb/singlecellData', { body })
+			res = await dofetch3('termdb/singlecellData', { body, signal: this.sc.api?.getAbortSignal() })
 		} catch (e: any) {
 			if (e instanceof Error) console.error(`${e.message || e}`)
 		}

--- a/client/plots/sc/model/SCModel.ts
+++ b/client/plots/sc/model/SCModel.ts
@@ -6,11 +6,13 @@ import { getNormalRoot } from '#filter/filter.utils'
 
 /** Fetches data for sc app */
 export class SCModel {
+	sc: SCViewer
 	app: AppApi
 	id?: string
 	state: SCFormattedState
 
 	constructor(sc: SCViewer) {
+		this.sc = sc
 		this.app = sc.app
 		this.id = sc.id
 		this.state = sc.app.getState()
@@ -80,7 +82,8 @@ export class SCModel {
 			sample: {
 				eID: config.settings.sc.item.eID,
 				sID: config.settings.sc.item.sID
-			}
+			},
+			signal: this.sc.api?.getAbortSignal()
 		}
 	}
 

--- a/client/plots/sc/subplots/SubplotManager.ts
+++ b/client/plots/sc/subplots/SubplotManager.ts
@@ -114,17 +114,18 @@ export class SubplotManager {
 	}
 
 	getPlotName(subplot: any): string {
-		let plotName = subplot?.plotName || subplot?.singleCellPlot?.name
+		/** Hardcoding logic for some transient and parent plots for now. May consider
+		 * adding to the config if this becomes more complex. Must weight against
+		 * adding unnecessary complexity to the config for edge cases though.*/
+		const nameOverrides = new Map([
+			['GeneExpInput', 'Gene expression'],
+			['imagePlot', subplot?.imgDir?.label || 'Image'],
+			['dictionary', 'Summary'],
+			['summary', 'Summary']
+		])
+		let plotName = subplot?.plotName || nameOverrides.get(subplot?.chartType) || subplot?.singleCellPlot?.name
 		if (!plotName) {
-			/** Hardcoding logic for some transient and parent plots for now. May consider
-			 * adding to the config if this becomes more complex. Must weight against
-			 * adding unnecessary complexity to the config for edge cases though.*/
-			if (subplot.chartType === 'dictionary') plotName = 'Summary'
-			else if (subplot.chartType === 'summary') plotName = 'Summary'
-			else if (subplot.chartType === 'GeneExpInput') plotName = 'Gene expression'
-			else if (subplot.chartType === 'imagePlot') {
-				plotName = subplot?.imgDir?.label || 'Image'
-			} else if (subplot?.term?.term?.plot) plotName = subplot.term.term.plot
+			if (subplot?.term?.term?.plot) plotName = subplot.term.term.plot
 			else plotName = subplot.chartType || 'Plot'
 		}
 		return plotName

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -14,7 +14,7 @@ import { VolcanoControlInputs } from './VolcanoControlInputs'
 import { getCombinedTermFilter } from '#filter'
 import { GENE_EXPRESSION, SINGLECELL_CELLTYPE } from '#shared/terms.js'
 
-class Volcano extends PlotBase implements RxComponent {
+export class Volcano extends PlotBase implements RxComponent {
 	static type = 'volcano'
 	type: string
 	components: { controls: any }
@@ -101,7 +101,7 @@ class Volcano extends PlotBase implements RxComponent {
 
 	async init() {
 		this.interactions = new VolcanoInteractions(this.app, this.id, this.dom)
-		this.model = new VolcanoModel(this.app, this.termType)
+		this.model = new VolcanoModel(this, this.termType)
 		this.view = new VolcanoPlotView(this.dom, this.interactions, this.termType)
 		await this.setControls()
 	}

--- a/client/plots/volcano/model/VolcanoModel.ts
+++ b/client/plots/volcano/model/VolcanoModel.ts
@@ -3,15 +3,18 @@ import { dofetch3 } from '#common/dofetch'
 import type { DERequest, DiffMethRequest, TermdbSingleCellDEgenesRequest, VolcanoRenderRequest } from '#types'
 import { DNA_METHYLATION, GENE_EXPRESSION, SINGLECELL_CELLTYPE, PROTEOME_DAP } from '#types'
 import { getGroupColors, toHex } from '../colors'
+import type { Volcano } from '../Volcano'
 
 export class VolcanoModel {
+	volcano: Volcano
 	app: MassAppApi
 	config!: any
 	settings!: any
 	termType: string
 
-	constructor(app: MassAppApi, termType: string) {
-		this.app = app
+	constructor(volcano: Volcano, termType: string) {
+		this.volcano = volcano
+		this.app = volcano.app
 		this.termType = termType
 	}
 
@@ -84,7 +87,8 @@ export class VolcanoModel {
 			filter: state.termfilter.filter,
 			filter0: state.termfilter.filter0,
 			min_samples_per_group: this.settings.minSamplesPerGroup,
-			volcanoRender: this.getVolcanoRender()
+			volcanoRender: this.getVolcanoRender(),
+			signal: this.volcano.api?.getAbortSignal()
 		} as Partial<DiffMethRequest>
 
 		this.addConfounderTw(body)
@@ -126,7 +130,8 @@ export class VolcanoModel {
 			// at fetch time — bigger headroom = more tolerable post-render
 			// zoom before pixelation appears). The server clamp keeps the
 			// bitmap memory bounded.
-			devicePixelRatio: (typeof window !== 'undefined' ? window.devicePixelRatio : 1) * 2
+			devicePixelRatio: (typeof window !== 'undefined' ? window.devicePixelRatio : 1) * 2,
+			signal: this.volcano.api?.getAbortSignal()
 		}
 	}
 
@@ -147,7 +152,8 @@ export class VolcanoModel {
 			sample: this.config.sample,
 			termId: this.config.termId,
 			categoryName: this.config.categoryName,
-			volcanoRender: this.getVolcanoRender()
+			volcanoRender: this.getVolcanoRender(),
+			signal: this.volcano.api?.getAbortSignal()
 		}
 		return body
 	}
@@ -160,7 +166,8 @@ export class VolcanoModel {
 			organism,
 			assay,
 			cohort,
-			volcanoRender: this.getVolcanoRender()
+			volcanoRender: this.getVolcanoRender(),
+			signal: this.volcano.api?.getAbortSignal()
 		}
 	}
 

--- a/client/plots/volcano/model/VolcanoModel.ts
+++ b/client/plots/volcano/model/VolcanoModel.ts
@@ -25,7 +25,7 @@ export class VolcanoModel {
 
 		if (this.termType === GENE_EXPRESSION) {
 			const body = await this.getGERequestBody()
-			const response = await dofetch3('termdb/DE', { body })
+			const response = await dofetch3('termdb/DE', { body, signal: this.volcano.api?.getAbortSignal() })
 			// Surface the DE request so downstream plots (GSEA) can snapshot
 			// it and later ask the server to recompute the DA cache if the
 			// file is missing on a peer node or after TTL eviction.
@@ -34,7 +34,7 @@ export class VolcanoModel {
 		}
 		if (this.termType === DNA_METHYLATION) {
 			const body = await this.getDMRequestBody()
-			const response = await dofetch3('termdb/diffMeth', { body })
+			const response = await dofetch3('termdb/diffMeth', { body, signal: this.volcano.api?.getAbortSignal() })
 			// Surface the DM request the same way the GE branch above does so
 			// the GSEA tab can snapshot it and the server can recompute the DM
 			// cache if the file is missing on a peer node or after TTL.
@@ -43,11 +43,11 @@ export class VolcanoModel {
 		}
 		if (this.termType === SINGLECELL_CELLTYPE) {
 			const body = await this.getSCCTRequestBody()
-			return await dofetch3('termdb/singlecellDEgenes', { body })
+			return await dofetch3('termdb/singlecellDEgenes', { body, signal: this.volcano.api?.getAbortSignal() })
 		}
 		if (this.termType === PROTEOME_DAP) {
 			const body = this.getDapRequestBody()
-			return await dofetch3('termdb/dapVolcano', { body })
+			return await dofetch3('termdb/dapVolcano', { body, signal: this.volcano.api?.getAbortSignal() })
 		}
 		throw new Error(`Volcano plot does not support route for termType='${this.termType}'`)
 	}
@@ -87,8 +87,7 @@ export class VolcanoModel {
 			filter: state.termfilter.filter,
 			filter0: state.termfilter.filter0,
 			min_samples_per_group: this.settings.minSamplesPerGroup,
-			volcanoRender: this.getVolcanoRender(),
-			signal: this.volcano.api?.getAbortSignal()
+			volcanoRender: this.getVolcanoRender()
 		} as Partial<DiffMethRequest>
 
 		this.addConfounderTw(body)
@@ -130,9 +129,7 @@ export class VolcanoModel {
 			// at fetch time — bigger headroom = more tolerable post-render
 			// zoom before pixelation appears). The server clamp keeps the
 			// bitmap memory bounded.
-			devicePixelRatio: (typeof window !== 'undefined' ? window.devicePixelRatio : 1) * 2,
-			signal: this.volcano.api?.getAbortSignal()
-		}
+			devicePixelRatio: (typeof window !== 'undefined' ? window.devicePixelRatio : 1) * 2		}
 	}
 
 	//This is a workaround until the server can accept an arr of confounder tws
@@ -152,9 +149,7 @@ export class VolcanoModel {
 			sample: this.config.sample,
 			termId: this.config.termId,
 			categoryName: this.config.categoryName,
-			volcanoRender: this.getVolcanoRender(),
-			signal: this.volcano.api?.getAbortSignal()
-		}
+			volcanoRender: this.getVolcanoRender()		}
 		return body
 	}
 
@@ -166,8 +161,7 @@ export class VolcanoModel {
 			organism,
 			assay,
 			cohort,
-			volcanoRender: this.getVolcanoRender(),
-			signal: this.volcano.api?.getAbortSignal()
+			volcanoRender: this.getVolcanoRender()
 		}
 	}
 

--- a/server/src/singleCell/SingleCellMetaCache.ts
+++ b/server/src/singleCell/SingleCellMetaCache.ts
@@ -1,0 +1,112 @@
+type CellCache = {
+  cellIds: string[]
+  sampleIds: string[]
+  x: Float32Array
+  y: Float32Array
+
+  byCellId: Map<string, number>
+}
+
+type CoordsColumns = { x: number; y: number }
+
+export class SingleCellMetaCache {
+  sampleIntIds = new Set<any>()
+  sampleIntId2Name = new Map<any, string>()
+  sampleName2IntId = new Map<string, any>()
+  metaIdMap = new Map<string, Map<string, string>>()
+  metaResultNames = new Set<string>()
+
+  registerCohortSample(sampleName: string, sampleIntId: any): void {
+    /** Sample INT ids correspond to the primary key in the termdb */
+    this.sampleIntIds.add(sampleIntId)
+    this.sampleIntId2Name.set(sampleIntId, sampleName)
+    this.sampleName2IntId.set(sampleName, sampleIntId)
+  }
+
+  addMetaResult(
+    metaResultName: string,
+    text: string,
+    coordsColumns: CoordsColumns,
+    sampleName2id: (sampleName: string) => any
+  ): void {
+    const cellCache = this.initCellCacheFromText(text, coordsColumns)
+    this.mapMetaResult(metaResultName, cellCache, sampleName2id)
+  }
+
+  private initCellCacheFromText(text: string, coordsColumns: CoordsColumns): CellCache {
+    const lines = text.trim().split('\n')
+    if (!lines[0]) throw new Error('meta result file is empty')
+    const headerColumnCount = lines[0].split('\t').length
+
+    const cellIdIdx = 0 //May need to be defined in the ds file or force in file structure.
+    const sampleIdIdx = 1 //May need to be defined in the ds file or force in file structure.
+    const xIdx = coordsColumns.x
+    const yIdx = coordsColumns.y
+
+    if (!Number.isInteger(xIdx) || xIdx < 0 || xIdx >= headerColumnCount)
+      throw new Error('X column index is invalid in ds file')
+    if (!Number.isInteger(yIdx) || yIdx < 0 || yIdx >= headerColumnCount)
+      throw new Error('Y column index is invalid in ds file')
+
+    const n = lines.length - 1
+
+    const cellIds: string[] = new Array(n)
+    const sampleIds: string[] = new Array(n)
+    const x = new Float32Array(n)
+    const y = new Float32Array(n)
+
+    const byCellId = new Map<string, number>()
+    const sampleBuckets = new Map<string, number[]>()
+
+    for (let i = 1; i < lines.length; i++) {
+      const row = lines[i].split('\t')
+      const rowIdx = i - 1
+
+      const cellId = row[cellIdIdx]
+      const sampleName = row[sampleIdIdx]
+
+      cellIds[rowIdx] = cellId
+      sampleIds[rowIdx] = sampleName
+      x[rowIdx] = Number(row[xIdx])
+      y[rowIdx] = Number(row[yIdx])
+
+      byCellId.set(cellId, rowIdx)
+
+      if (!sampleBuckets.has(sampleName)) sampleBuckets.set(sampleName, [])
+      sampleBuckets.get(sampleName)!.push(rowIdx)
+    }
+
+    return {
+      cellIds,
+      sampleIds,
+      x,
+      y,
+      byCellId
+    }
+  }
+
+  private mapMetaResult(
+    metaResultName: string,
+    cellCache: CellCache,
+    sampleName2id: (sampleName: string) => any
+  ): void {
+    const byCellId = new Map<string, string>()
+
+    for (let i = 0; i < cellCache.cellIds.length; i++) {
+      const cellId = cellCache.cellIds[i]
+      const sampleName = cellCache.sampleIds[i]
+      if (!cellId) throw new Error(`meta result row missing cell id at row index ${i + 1}`)
+      if (!sampleName) throw new Error(`meta result row missing sample id at row index ${i + 1}`)
+
+      byCellId.set(cellId, sampleName)
+
+      const sampleIntId = sampleName2id(sampleName)
+      if (sampleIntId !== undefined) {
+        this.registerCohortSample(sampleName, sampleIntId)
+      }
+    }
+
+    this.metaResultNames.add(metaResultName)
+    this.metaIdMap.set(metaResultName, byCellId)
+  }
+}

--- a/server/src/singleCell/SingleCellMetaCache.ts
+++ b/server/src/singleCell/SingleCellMetaCache.ts
@@ -56,10 +56,9 @@ export class SingleCellMetaCache {
     const y = new Float32Array(n)
 
     const byCellId = new Map<string, number>()
-    const sampleBuckets = new Map<string, number[]>()
 
     for (let i = 1; i < lines.length; i++) {
-      const row = lines[i].split('\t')
+      const row = lines[i].split('\t').map(s => s.trim())
       const rowIdx = i - 1
 
       const cellId = row[cellIdIdx]
@@ -70,10 +69,13 @@ export class SingleCellMetaCache {
       x[rowIdx] = Number(row[xIdx])
       y[rowIdx] = Number(row[yIdx])
 
-      byCellId.set(cellId, rowIdx)
+      if (!cellId) throw new Error(`meta result row missing cell id at row index ${rowIdx + 1}`)
+      if (!sampleName) throw new Error(`meta result row missing sample id at row index ${rowIdx + 1}`)
+      if (!Number.isFinite(x[rowIdx]) || !Number.isFinite(y[rowIdx])) {
+        throw new Error(`meta result row has non-numeric x/y at row index ${rowIdx + 1}`)
+      }
 
-      if (!sampleBuckets.has(sampleName)) sampleBuckets.set(sampleName, [])
-      sampleBuckets.get(sampleName)!.push(rowIdx)
+      byCellId.set(cellId, rowIdx)
     }
 
     return {

--- a/server/src/singleCell/plotsRoute.ts
+++ b/server/src/singleCell/plotsRoute.ts
@@ -128,7 +128,8 @@ async function getSingleCellScatter(req, res, ds) {
 		throw new Error('Using coordTWs with colorTW is not implemented for single cell scatter plot')
 	}
 
-	const { name, sample, isMetaResult } = q.singleCellPlot
+	const { name, sample } = q.singleCellPlot
+	const isMetaResult = sample?.['isMetaResult']
 
 	try {
 		const { arg, tw, genes } = getSingleCellDataArgs(q, name, sample)

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -163,7 +163,9 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 		if (plot.isMetaResult) {
 			/** Quick fix to skip plots with data issues. */
 			if (plot.doNotCache) {
-				console.log(`Skipping meta analysis result ${plot.name} due to data issues. Please remove the doNotCache flag when the issue is resolved.`)
+				console.log(
+					`Skipping meta analysis result ${plot.name} due to data issues. Please remove the doNotCache flag when the issue is resolved.`
+				)
 				continue
 			}
 			/** Meta analysis results may not be separated into folders like the sample files
@@ -179,8 +181,12 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 				/** Files should exist for each meta analysis result. */
 				await file_is_readable(tsvfile)
 				samples.set(sampleName, { sample: sampleName, isMetaResult: true })
+				const t0 = Date.now()
 				const text = await read_file(tsvfile)
+				const t1 = Date.now()
+				mayLog(ds.label, 'sc meta read file time:', t1 - t0)
 				metaCache.addMetaResult(sampleName, text, plot.coordsColumns, ds.cohort.termdb.q.sampleName2id)
+				mayLog(ds.label, 'sc meta caching time:', Date.now() - t0)
 			} catch (e: any) {
 				throw new Error(`meta result data file missing or unreadable: ${sampleName} (${tsvfile}): ${e.message || e}`)
 			}
@@ -290,7 +296,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 		nameSet.add(plot.name)
 		if (!plot.folder) throw new Error('plot.folder missing')
 	}
-	
+
 	// caches files contents between requests so each file is only loaded once
 	const file2Lines = {} // key: file path, value: string[]
 
@@ -345,7 +351,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 				if (!cellId) throw new Error('cell id missing')
 				if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error('x/y not number')
 				const cell: Cell = { cellId, x, y, category }
-			
+
 				if (checkGeneExpMap) {
 					if (geneExpMap[cellId] !== undefined) {
 						cell.geneExp = geneExpMap[cellId]
@@ -471,7 +477,7 @@ function gdc_validateGeneExpression(G: SingleCellGeneExpressionGdc, ds: any, gen
 			}
 			const hdf5id = ds.__gdc.scrnaAnalysis2hdf5.get(fileid)
 			if (!hdf5id) throw new Error('cannot map eID to hdf5 id')
-		
+
 			const aliasLst = genome.genedb.getAliasByName.all(q.gene)
 			const gencodeId = aliasLst.find(a => a?.alias.toUpperCase().startsWith('ENSG'))?.alias
 			if (!gencodeId) throw new Error('cannot map gene symbol to GENCODE')

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -28,6 +28,7 @@ import { gdc_validate_query_singleCell_data } from '#src/mds3.gdc.js'
 import { SINGLECELL_CELLTYPE } from '#shared/terms.js'
 import { mayLimitSamples } from '#src/mds3.filter.js'
 import { maySetMapParent2Children } from '#src/termdb.matrix.js'
+import { SingleCellMetaCache } from './SingleCellMetaCache.ts'
 import { run_python } from '@sjcrh/proteinpaint-python'
 
 export const payload: RoutePayload = {
@@ -155,24 +156,16 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 	// k: sample integer id
 	// v: { sample: string name, tid1:v1, ...} term ids are from S.sampleColumns[]. list of sample objects are returned in getter
 	const samples = new Map()
-	/** Create lookups for getFilteredSingleCellSamples. Created on server
-	 * init for performance.
-	 *
-	 * Captures ids and names that may exist only in a meta result file but
-	 * there is no corresponding tsv file. Do not include in samples map which
-	 * returns samples with available files. */
-	const sampleIntIds = new Set()
-	const sampleIntId2Name = new Map() // maps numeric cohort ID to sample name
-	const sampleName2IntId = new Map() // maps sample name to numeric cohort ID
+	/** Shared lookups for filtered sample IDs, sample-name resolution, and
+	 * meta-result cellId->sample mappings used by other routes. */
+	const metaCache = new SingleCellMetaCache()
 	for (const plot of D.plots) {
 		if (plot.isMetaResult) {
-			/** Meta analysis files are read on init to create a sample name 2 cell id
-			 * 2 sample id map. The map is a lookup for data getters to retrieve the
-			 * sampleId to match with cohort level terms. Attaching the map to
-			 * ds.queries.singleCell.data allows getters (e.g. getData() in termdb.matrix)
-			 * access to when needed.
-			 * Becomes <plotName(i.e metaResultID), <cellId, sampleId >> */
-			if (!D.metaIdMap) D.metaIdMap = new Map()
+			/** Quick fix to skip plots with data issues. */
+			if (plot.doNotCache) {
+				console.log(`Skipping meta analysis result ${plot.name} due to data issues. Please remove the doNotCache flag when the issue is resolved.`)
+				continue
+			}
 			/** Meta analysis results may not be separated into folders like the sample files
 			 * for other plots. Check the file exists with the appropriate "sample name". This
 			 * method ensure the file can be queried as intended later.
@@ -187,22 +180,7 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 				await file_is_readable(tsvfile)
 				samples.set(sampleName, { sample: sampleName, isMetaResult: true })
 				const text = await read_file(tsvfile)
-				const lines = text.trim().split('\n')
-				const cellIdMap = new Map()
-				for (let i = 1; i < lines.length; i++) {
-					const [cellId, sampleId] = lines[i].split('\t').map(s => s.trim())
-					if (!cellId) throw new Error(`meta result row missing, index = ${i}, cell id: ${cellId}`)
-					if (!sampleId) throw new Error(`meta result row missing sample id, index = ${i}, sample id: ${sampleId}`)
-					cellIdMap.set(cellId, sampleId)
-					// Treat sampleId from file as a sample name and look up the cohort sample ID
-					const sampleIntId = ds.cohort.termdb.q.sampleName2id(sampleId)
-					if (sampleIntId !== undefined) {
-						sampleIntIds.add(sampleIntId)
-						sampleIntId2Name.set(sampleIntId, sampleId)
-						sampleName2IntId.set(sampleId, sampleIntId)
-					}
-				}
-				D.metaIdMap.set(sampleName, cellIdMap)
+				metaCache.addMetaResult(sampleName, text, plot.coordsColumns, ds.cohort.termdb.q.sampleName2id)
 			} catch (e: any) {
 				throw new Error(`meta result data file missing or unreadable: ${sampleName} (${tsvfile}): ${e.message || e}`)
 			}
@@ -221,15 +199,14 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 			if (sid == undefined) throw new Error(`singlecell.sample: unknown sample name ${sampleName}`)
 			// is valid sample, add to holder
 			samples.set(sid, { sample: sampleName })
-			/** Add to lookups for filtering. This is a fallback if no meta results */
-			sampleIntIds.add(sid)
-			sampleIntId2Name.set(sid, sampleName)
-			sampleName2IntId.set(sampleName, sid)
+			metaCache.registerCohortSample(sampleName, sid)
 		}
 
 		if (!plot.colorColumns || plot.colorColumns.length == 0) continue
 	}
 	if (samples.size == 0) throw new Error('no scrna samples found')
+	S.sampleMappingCache = metaCache
+	if (metaCache.metaIdMap.size) D.metaIdMap = metaCache.metaIdMap
 
 	// samples map populated with samples with sc data
 	if (S.sampleColumns) {
@@ -252,9 +229,10 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 		const re: any = { samples: _samples }
 		if (_q.filter?.lst?.length || _q.filter0) {
 			const tmp = await S.getFilteredSingleCellSamples!(_q, true)
-			re.samples = Array.from(tmp).map(s => {
+			re.samples = Array.from(tmp as Set<string>).map(s => {
 				if (samples.has(s)) return samples.get(s)
-				else if (samples.has(sampleName2IntId.get(s))) return samples.get(sampleName2IntId.get(s))
+				const sampleIntId = metaCache.sampleName2IntId.get(s)
+				if (samples.has(sampleIntId)) return samples.get(sampleIntId)
 				else return { sample: s }
 			})
 		}
@@ -283,17 +261,16 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 		// setting mapParent2Children=true here to be able to
 		// map patient-level data onto the single cell data
 		maySetMapParent2Children(arg, ds, true)
-		const filteredSampleIds = (await mayLimitSamples(arg, Array.from(sampleIntIds), ds)) || new Set()
+		const filteredSampleIds = (await mayLimitSamples(arg, Array.from(metaCache.sampleIntIds), ds)) || new Set()
 
 		// Convert cohort sample IDs to sample names
 		const result = new Set<string>()
 		for (const sid of filteredSampleIds) {
-			const sampleName = sampleIntId2Name.get(sid)
+			const sampleName = metaCache.sampleIntId2Name.get(sid)
 			if (sampleName) result.add(sampleName)
 		}
-		// Add meta result names if requested
 		if (includeMeta) {
-			for (const metaResultName of D.metaIdMap?.keys() || []) {
+			for (const metaResultName of metaCache.metaResultNames) {
 				result.add(metaResultName)
 			}
 		}

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -290,7 +290,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 		nameSet.add(plot.name)
 		if (!plot.folder) throw new Error('plot.folder missing')
 	}
-
+	
 	// caches files contents between requests so each file is only loaded once
 	const file2Lines = {} // key: file path, value: string[]
 
@@ -306,6 +306,7 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 			if (!sample) throw new Error('sample is required for gene expression query')
 			geneExpMap = await ds.queries.singleCell.geneExpression.get({ sample, gene: q.gene })
 		}
+		const checkGeneExpMap = geneExpMap && Object.keys(geneExpMap).length > 0
 		// given a sample name, collect every plot data for this sample and return
 		const plots: Plot[] = []
 		for (const plot of D.plots) {
@@ -344,7 +345,8 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 				if (!cellId) throw new Error('cell id missing')
 				if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error('x/y not number')
 				const cell: Cell = { cellId, x, y, category }
-				if (Object.keys(geneExpMap || {}).length > 0) {
+			
+				if (checkGeneExpMap) {
 					if (geneExpMap[cellId] !== undefined) {
 						cell.geneExp = geneExpMap[cellId]
 						expCells.push(cell)
@@ -367,7 +369,6 @@ function validateDataNative(D: SingleCellDataNative, ds: any): void {
 			// no data available for this sample
 			return { nodata: true }
 		}
-
 		return { plots }
 	}
 }

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -459,10 +459,21 @@ function getSampleId4Cell(ds, tw, cell, filteredSamples) {
 	/** Note: Do not use .eID. Only for GDC in separate pathway */
 	const metaResultId = tw.term.sample.sID
 	const metaIdMap = ds.queries?.singleCell?.data?.metaIdMap?.get?.(metaResultId)
-	const sampleName = metaIdMap?.get?.(cell.cellId) || cell.sampleId
+	const sampleMappingCache = ds.queries?.singleCell?.samples?.sampleMappingCache
+	let sampleName = metaIdMap?.get?.(cell.cellId)
+	if (!sampleName && cell.sampleId != undefined) {
+		sampleName = sampleMappingCache?.sampleIntId2Name?.get?.(cell.sampleId)
+		if (!sampleName) {
+			const numericSampleId = Number(cell.sampleId)
+			if (Number.isFinite(numericSampleId)) {
+				sampleName = sampleMappingCache?.sampleIntId2Name?.get?.(numericSampleId)
+			}
+		}
+		if (!sampleName && typeof cell.sampleId == 'string') sampleName = cell.sampleId
+	}
 	if (!sampleName) return
 	if (filteredSamples.size > 0 && !filteredSamples.has(sampleName)) return
-	const sampleId = ds.cohort?.termdb?.q?.sampleName2id?.(sampleName)
+	const sampleId = sampleMappingCache?.sampleName2IntId?.get?.(sampleName) ?? ds.cohort?.termdb?.q?.sampleName2id?.(sampleName)
 	if (sampleId == undefined) {
 		throw new Error(`single cell meta result cannot map sample name = ${sampleName} to sample id`)
 	}

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -949,6 +949,14 @@ export type SingleCellSamples = {
 	/** extra label to show along with sample, must be a term id as in sampleColumns[] and allow to retrieve value from sample object */
 	extraSampleTabLabel?: string
 	getFilteredSingleCellSamples?: (q: TermdbSingleCellSamplesRequest, includeMeta: boolean) => any
+	/** server-only cache for single-cell sample and meta-result mappings */
+	sampleMappingCache?: {
+		sampleIntIds: Set<any>
+		sampleIntId2Name: Map<any, string>
+		sampleName2IntId: Map<string, any>
+		metaIdMap: Map<string, Map<string, string>>
+		metaResultNames: Set<string>
+	}
 }
 
 type SingleCellDataBase = {
@@ -1030,6 +1038,9 @@ export type SingleCellPlot = {
 	 * server requests. If not provided, the file name or the plot name with the
 	 * spaces replaced with '_' is used. */
 	sampleId?: string
+	/** DELETE FLAG LATER. 
+	 * Quick fix for meta analysis plots with data issues. */
+	doNotCache: boolean
 }
 export type SingleCellDataNative = SingleCellDataBase & {
 	src: 'native'

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1040,7 +1040,7 @@ export type SingleCellPlot = {
 	sampleId?: string
 	/** DELETE FLAG LATER. 
 	 * Quick fix for meta analysis plots with data issues. */
-	doNotCache: boolean
+	doNotCache?: boolean
 }
 export type SingleCellDataNative = SingleCellDataBase & {
 	src: 'native'

--- a/shared/types/src/routes/termdb.DE.ts
+++ b/shared/types/src/routes/termdb.DE.ts
@@ -29,6 +29,7 @@ export type DERequest = {
 	 * PNG dimensions, and dot styling. The server always renders the volcano PNG
 	 * and returns it plus the threshold-passing rows as the interactive `data`. */
 	volcanoRender: VolcanoRenderRequest
+	signal?: any
 }
 
 /** Thresholds used to classify a data point as "significant" on the volcano plot.
@@ -70,6 +71,7 @@ export type VolcanoRenderRequest = {
 	 * the browser uses the extra resolution for sharpness. Defaults to 1.0
 	 * server-side. */
 	devicePixelRatio?: number
+	signal?: any
 }
 
 /** Everything the client needs to draw one volcano: the pre-rendered PNG of


### PR DESCRIPTION
# Description

This pull request introduces several improvements and refactorings to the single-cell data handling, especially around meta-analysis sample mapping and caching. The main change is the introduction of a new `SingleCellMetaCache` class, which centralizes and streamlines the management of sample and meta-result mappings across the server and client code. This refactor replaces scattered sample mapping logic with a reusable cache, improves error handling, and adds flexibility for handling meta-analysis results with data issues.

Changes: 
1. Introduced the `SingleCellMetaCache` class to manage sample IDs, sample names, and meta-result mappings, consolidating logic for registering cohort samples and parsing meta-result files.
2. Refactored `samplesRoute.ts` to use `SingleCellMetaCache` for all sample and meta-result lookups, replacing previous ad-hoc Set/Map structures and logic. This includes improved error handling and a mechanism to skip problematic meta-analysis results via a `doNotCache` flag. 
3. Updated the logic in `termdb.matrix.js` to use the new cache for resolving sample names and IDs, improving robustness when mapping cell IDs to sample IDs, including fallback handling for numeric and string sample ID
4.  Added a `doNotCache` flag for skipping meta-analysis plots with known data issues, preventing them from being loaded into the cache.
5.  Updated all relevant client code (`gsea.js`, `Volcano.ts`, `VolcanoModel.ts`, `SCModel.ts`) to pass the abort signal to all single cell routes. 

Test: 
1. Pull https://github.com/stjude/sjpp/pull/1402
2. Use any SC app example in http://localhost:3000/url.html. 

This PR supports the ongoing tasks in the [SC roadmap](https://github.com/stjude/sjpp/issues/658).

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
