### PR TITLE
Support for ITD in geneVariant term

### DIFF
--- a/client/filter/test/tvs.unit.spec.js
+++ b/client/filter/test/tvs.unit.spec.js
@@ -167,6 +167,18 @@ function getGeneVariantTerm() {
 			},
 			name_noOrigin: 'SV',
 			parentTerm
+		},
+		{
+			id: 'itd',
+			query: 'itd',
+			name: 'ITD',
+			parent_id: null,
+			isleaf: true,
+			type: 'dtitd',
+			dt: 6,
+			values: { ITD: { key: 'ITD', label: 'ITD' } },
+			name_noOrigin: 'ITD',
+			parentTerm
 		}
 	]
 	const term = Object.assign({}, parentTerm, { childTerms })

--- a/client/filter/tvs.dtitd.js
+++ b/client/filter/tvs.dtitd.js
@@ -1,0 +1,7 @@
+import { handler as _handler } from './tvs.dt.js'
+
+/*
+TVS handler for dtitd term
+*/
+
+export const handler = Object.assign({}, _handler, { type: 'dtitd' })

--- a/client/plots/matrix/test/matrix.integration.spec.js
+++ b/client/plots/matrix/test/matrix.integration.spec.js
@@ -364,7 +364,7 @@ tape('geneVariant term', function (test) {
 		)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g rect').size(),
-			240,
+			242,
 			`should render the expected number of cell rects`
 		)
 		if (test._ok) matrix.Inner.app.destroy()
@@ -420,7 +420,7 @@ tape('geneVariant terms and dictionary terms', function (test) {
 		)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g rect').size(),
-			900,
+			902,
 			`should render the expected number of cell rects`
 		)
 		test.equal(
@@ -479,7 +479,7 @@ tape('geneVariant terms with divide by dictionary term', function (test) {
 		)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g rect').size(),
-			720,
+			722,
 			`should render the expected number of cell rects`
 		)
 		test.equal(
@@ -543,7 +543,7 @@ tape('geneVariant terms and dictionary terms divide by dictionary term', functio
 		)
 		test.equal(
 			matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g rect').size(),
-			900,
+			902,
 			`should render the expected number of cell rects`
 		)
 		test.equal(
@@ -1419,7 +1419,7 @@ tape('avoid race condition - cohort change', function (test) {
 			const rects = matrix.Inner.dom.seriesesG.selectAll('.sjpp-mass-series-g rect')
 			test.equal(
 				rects.size(),
-				1200,
+				1202,
 				'should have the expected total number of matrix cell rects, inlcuding WT and not tested'
 			)
 			const hits = rects.filter(d => d.key === 'BCR' && d.value.class != 'WT' && d.value.class != 'Blank')
@@ -1895,7 +1895,7 @@ tape(
 			const rects = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 236,
+				count: 237,
 				trigger: () => {
 					options[0].dispatchEvent(
 						new MouseEvent('click', {
@@ -1941,7 +1941,7 @@ tape(
 			const rects2 = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 240,
+				count: 242,
 				trigger: () => {
 					options2[0].dispatchEvent(
 						new MouseEvent('click', {
@@ -1983,7 +1983,7 @@ tape(
 			const rects3 = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 239,
+				count: 241,
 				trigger: () => {
 					options3[1].dispatchEvent(
 						new MouseEvent('click', {
@@ -2018,7 +2018,7 @@ tape(
 			const rects4 = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 240,
+				count: 242,
 				trigger: () => {
 					options4[0].dispatchEvent(
 						new MouseEvent('click', {
@@ -2103,7 +2103,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		const rects = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 181,
+			count: 183,
 			trigger: () => {
 				options[0].dispatchEvent(
 					new MouseEvent('click', {
@@ -2148,7 +2148,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		const rects2 = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 183,
+			count: 185,
 			trigger: () => {
 				options2[1].dispatchEvent(
 					new MouseEvent('click', {
@@ -2189,7 +2189,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		const rects3 = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 180,
+			count: 182,
 			trigger: () => {
 				options3[2].dispatchEvent(
 					new MouseEvent('click', {
@@ -2230,7 +2230,7 @@ tape('apply legend group filters to a geneVariant term in geneVariant term only 
 		const rects4 = await detectLst({
 			elem: matrix.Inner.dom.seriesesG.node(),
 			selector: '.sjpp-mass-series-g rect',
-			count: 240,
+			count: 242,
 			trigger: () => {
 				options4[0].dispatchEvent(
 					new MouseEvent('click', {
@@ -2317,7 +2317,7 @@ tape(
 			const rects = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 721,
+				count: 723,
 				trigger: () => {
 					options[0].dispatchEvent(
 						new MouseEvent('click', {
@@ -2362,7 +2362,7 @@ tape(
 			const rects2 = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 724,
+				count: 726,
 				trigger: () => {
 					options2[1].dispatchEvent(
 						new MouseEvent('click', {
@@ -2397,7 +2397,7 @@ tape(
 			const rects3 = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 711,
+				count: 712,
 				trigger: () => {
 					options3[0].dispatchEvent(
 						new MouseEvent('click', {
@@ -2438,7 +2438,7 @@ tape(
 			const rects4 = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 724,
+				count: 726,
 				trigger: () => {
 					options4[0].dispatchEvent(
 						new MouseEvent('click', {
@@ -2473,7 +2473,7 @@ tape(
 			const rects5 = await detectLst({
 				elem: matrix.Inner.dom.seriesesG.node(),
 				selector: '.sjpp-mass-series-g rect',
-				count: 900,
+				count: 902,
 				trigger: () => {
 					options5[3].dispatchEvent(
 						new MouseEvent('click', {

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -65,6 +65,18 @@ function testSvGroupset(groupset, test) {
 	test.deepEqual(wtTvs.values, [], 'wildtype tvs should have empty values')
 }
 
+function testItdGroupset(groupset, test) {
+	test.equal(groupset.groups.length, 2, 'groupset should have 2 groups')
+	const mutGrp = groupset.groups[0]
+	const mutTvs = mutGrp.filter.lst[0].tvs
+	const wtGrp = groupset.groups[1]
+	const wtTvs = wtGrp.filter.lst[0].tvs
+	test.deepEqual(mutTvs.values, [{ key: 'ITD', label: 'ITD', value: 'ITD' }], 'mutant tvs should have mutant values')
+	test.equal(mutTvs.genotype, 'variant', 'mutant tvs should have .genotype=variant')
+	test.equal(wtTvs.genotype, 'wt', 'wildtype tvs should have .genotype=wt')
+	test.deepEqual(wtTvs.values, [], 'wildtype tvs should have empty values')
+}
+
 /**************
  test sections
 ***************/
@@ -158,9 +170,9 @@ tape('fill(): q.type=predefined-groupset', async test => {
 	if (fullTw.q.type != 'predefined-groupset') throw 'q.type must be predefined-groupset'
 	test.equal(fullTw.type, 'GvPredefinedGsTW', 'should fill in tw.type')
 	test.equal(fullTw.q.predefined_groupset_idx, 0, 'should fill q.predefined_groupset_idx to be 0')
-	test.equal(fullTw.term.childTerms.length, 5, 'should create 5 child dt terms')
+	test.equal(fullTw.term.childTerms.length, 6, 'should create 6 child dt terms')
 	if (!fullTw.term.groupsetting.lst) throw 'term.groupsetting.lst is missing'
-	test.equal(fullTw.term.groupsetting.lst.length, 5, 'should get 5 predefined groupsets')
+	test.equal(fullTw.term.groupsetting.lst.length, 6, 'should get 6 predefined groupsets')
 	for (const groupset of fullTw.term.groupsetting.lst) {
 		if (groupset.dt == 1) {
 			testSnvIndelGroupset(groupset, test)
@@ -170,6 +182,8 @@ tape('fill(): q.type=predefined-groupset', async test => {
 			testCnvGroupset(groupset, test)
 		} else if (groupset.dt == 5) {
 			testSvGroupset(groupset, test)
+		} else if (groupset.dt == 6) {
+			testItdGroupset(groupset, test)
 		} else {
 			test.fail('unexpected groupset')
 		}

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2980,6 +2980,10 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					: await getCnvByTw(ds, { term: gene, q: tw.q }, genome, q)
 				mlst.push(...cnvMlst)
 			}
+			if (ds.queries.itd && dts.includes(dtitd)) {
+				const itdMlst = await getItdByTerm(ds, gene, genome, q)
+				mlst.push(...itdMlst)
+			}
 
 			//////////////////////////////////////
 			// MUST NOT QUIT when mlst.length==0!
@@ -3140,6 +3144,9 @@ function getDtsToQuery(tw, ds) {
 		}
 		if (ds.queries.geneCnv || ds.queries.cnv) {
 			dts.add(dtcnv)
+		}
+		if (ds.queries.itd) {
+			dts.add(dtitd)
 		}
 	}
 	return [...dts]
@@ -3621,6 +3628,22 @@ async function getGenecnvByTerm(ds, term, genome, q) {
 		return await ds.queries.geneCnv.bygene.get(arg)
 	}
 	throw 'unknown queries.geneCnv method'
+}
+async function getItdByTerm(ds, term, genome, q) {
+	if (!ds.queries.itd) throw 'queries.itd not defined'
+	const arg = {
+		addFormatValues: true,
+		filter0: q.filter0, // hidden filter
+		filterObj: q.filter, // pp filter, must change key name to "filterObj" to be consistent with mds3 client
+		mapParent2Children: q.mapParent2Children,
+		sampleType: q.sampleType,
+		sessionid: q.sessionid
+	}
+	await mayMapGeneName2coord(term, genome)
+	// tw.term.chr/start/stop are set
+	arg.rglst = [term]
+	const result = await ds.queries.itd.get(arg)
+	return result.itds
 }
 
 function mayValidateViewModes(ds) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -2872,7 +2872,7 @@ async function svfusionByNameGetter_file(ds, genome) {
 }
 
 function mayAdd_mayGetGeneVariantData(ds, genome) {
-	if (!ds.queries.snvindel && !ds.queries.svfusion && !ds.queries.geneCnv && !ds.queries.cnv) {
+	if (!ds.queries.snvindel && !ds.queries.svfusion && !ds.queries.geneCnv && !ds.queries.cnv && !ds.queries.itd) {
 		// no eligible data types
 		return
 	}

--- a/shared/utils/src/common.ts
+++ b/shared/utils/src/common.ts
@@ -1373,6 +1373,16 @@ const dtTerms_temp = [
 		type: 'dtsv',
 		dt: dtsv,
 		values: {}
+	},
+	{
+		id: 'itd',
+		query: 'itd',
+		name: dt2label[dtitd],
+		parent_id: null,
+		isleaf: true,
+		type: 'dtitd',
+		dt: dtitd,
+		values: {}
 	}
 ]
 // add origin annotations to dt terms


### PR DESCRIPTION
# Description

Can now query ITDs using geneVariant term.

To test: open [TermdbTest](http://localhost:3000/?mass={%22dslabel%22:%22TermdbTest%22,%22genome%22:%22hg38-test%22,%22nav%22:{%22activeTab%22:1},%22plots%22:[{%22chartType%22:%22dictionary%22}]}) -> `Mutation/CNV/Fusion` -> radio button for `ITD` should now appear -> select ITD and enter TP53 -> barchart showing 2 samples with ITDs should appear.

Can also test with [AML dataset](http://localhost:3000/?massnative=hg38,AML).

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1405

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
