### PR TITLE
deprioritize not-tested dt/mclass when sorting matrix samples; fix th…

### DIFF
--- a/client/plots/matrix/matrix.sort.js
+++ b/client/plots/matrix/matrix.sort.js
@@ -407,6 +407,10 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 		}
 	}
 
+	const cnvClasses = [mclasscnvAmp, mclasscnvHomozygousDel, mclasscnvgain, mclasscnvloss, mclasscnvloh]
+	const proteinChangingClasses = s.proteinChangingMutations.filter(mcls => !s.truncatingMutations.includes(mcls))
+	const sortedClasses = ['Fuserna', ...s.truncatingMutations, ...cnvClasses, ...proteinChangingClasses]
+
 	// Similar to Oncoprint sorting
 	sortOptions.a = s.sortOptions?.a
 		? reshapeSortPriority(s.sortOptions.a, l)
@@ -481,7 +485,7 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 								by: 'class',
 								isOrdered: true,
 								disabled: true, // visible, can be enabled
-								order: [mclasscnvAmp, mclasscnvHomozygousDel, mclasscnvgain, mclasscnvloss, mclasscnvloh]
+								order: cnvClasses
 							},
 							{
 								disabled: false,
@@ -498,8 +502,24 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 								isOrdered: false,
 								// by default, do not include truncating mutations here since they may
 								// already be used in the tiebreaker with truncating mutations
-								order: s.proteinChangingMutations.filter(mcls => !s.truncatingMutations.includes(mcls)),
+								order: proteinChangingClasses,
 								notUsed: s.truncatingMutations
+							},
+							{
+								disabled: false,
+								mayToggle: true,
+								label: `${l.Samples} with other classification > without`,
+								filter: {
+									values: [
+										{
+											dt: dtsnvindel
+										}
+									]
+								},
+								by: 'class',
+								isOrdered: false,
+								order: s.mutationClasses.filter(cls => !sortedClasses.includes(cls) && cls != 'Blank'),
+								notUsed: []
 							}
 						]
 					},
@@ -522,7 +542,6 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 		value: 'name',
 		order: Object.values(sortOptions).length
 	}
-
 	return sortOptions
 }
 
@@ -628,6 +647,9 @@ export function reshapeSortPriority(sortOption, labels) {
 
 	for (const tb of geneVariantsEntry.tiebreakers) {
 		//if (tb.by != 'class') continue
+		// Object.apply() ignores the target object when used directly as another argument, need to use a copy;
+		// the pattern Object.assign(tb, defaults, origClone) will only fill-in default key-values that are not already in the orig tb object
+		const origClone = structuredClone(tb)
 		if (tb.filter?.values?.find(v => v.dt == dtfusionrna)) {
 			const defaults = {
 				label: `${l.Samples} with Fusion RNASeq > without`,
@@ -635,7 +657,7 @@ export function reshapeSortPriority(sortOption, labels) {
 				disabled: false,
 				mayToggle: true
 			}
-			Object.assign(tb, defaults, tb)
+			Object.assign(tb, defaults, origClone)
 		} else if (tb.filter?.values?.find(v => v.dt == dtsnvindel)) {
 			const label =
 				tb.order.includes(mclasscnvgain) || tb.order.includes(mclasscnvloss)
@@ -647,7 +669,7 @@ export function reshapeSortPriority(sortOption, labels) {
 				disabled: false,
 				mayToggle: true
 			}
-			Object.assign(tb, defaults, tb)
+			Object.assign(tb, defaults, origClone)
 		} else if (tb.order.length == 2 && tb.order.includes(mclasscnvgain) && tb.order.includes(mclasscnvloss)) {
 			const defaults = {
 				label: `${l.Samples} with CNV only > without`,
@@ -657,7 +679,7 @@ export function reshapeSortPriority(sortOption, labels) {
 				disabled: false,
 				mayToggle: true
 			}
-			Object.assign(tb, defaults, tb)
+			Object.assign(tb, defaults, origClone)
 		}
 	}
 

--- a/client/plots/matrix/matrix.sort.js
+++ b/client/plots/matrix/matrix.sort.js
@@ -408,8 +408,10 @@ export function getSortOptions(termdbConfig, controlLabels = {}, matrixSettings)
 	}
 
 	const cnvClasses = [mclasscnvAmp, mclasscnvHomozygousDel, mclasscnvgain, mclasscnvloss, mclasscnvloh]
-	const proteinChangingClasses = s.proteinChangingMutations.filter(mcls => !s.truncatingMutations.includes(mcls))
-	const sortedClasses = ['Fuserna', ...s.truncatingMutations, ...cnvClasses, ...proteinChangingClasses]
+	const proteinChangingClasses = (s.proteinChangingMutations || []).filter(
+		mcls => !s.truncatingMutations.includes(mcls)
+	)
+	const sortedClasses = ['Fuserna', ...(s.truncatingMutations || []), ...cnvClasses, ...proteinChangingClasses]
 
 	// Similar to Oncoprint sorting
 	sortOptions.a = s.sortOptions?.a
@@ -647,8 +649,8 @@ export function reshapeSortPriority(sortOption, labels) {
 
 	for (const tb of geneVariantsEntry.tiebreakers) {
 		//if (tb.by != 'class') continue
-		// Object.apply() ignores the target object when used directly as another argument, need to use a copy;
-		// the pattern Object.assign(tb, defaults, origClone) will only fill-in default key-values that are not already in the orig tb object
+		// Using `Object.assign(tb, defaults, tb)` would copy `tb` back over the defaults (including undefined values); clone first.
+		// The pattern `Object.assign(tb, defaults, origClone)` fills in defaults while preserving any existing keys from the original tiebreaker.
 		const origClone = structuredClone(tb)
 		if (tb.filter?.values?.find(v => v.dt == dtfusionrna)) {
 			const defaults = {


### PR DESCRIPTION
…e recovery of matrix sorting options from a saved session

# Description

Fixes 
- BUG: open [oncomatrix](http://localhost:3000/example.mmrf.matrix.html) -> small number of samples are not tested -> edit genes -> submit kras, nras, braf -> a lot more samples are not tested.

The bug resulted from not sorting samples that are tested but wildtype, versus not tested samples.

@congyu-lu Please check that this does not affect published oncomatrix links for neuroonc. If it does, we can make the WT vs Not tested sorting customizable by dataset.

@xzhou82 Is it confusing to see the 3rd grouping of gene variants, where `Sequence deleteion/insertion` might be more appropriate for the 1st/2nd grouping (which is based on GDC requirements)? Or maybe this is okay, not a lot of people look in the `Advanced` sorting options.
<img width="611" height="403" alt="Screenshot 2026-07-10 at 1 08 45 PM" src="https://github.com/user-attachments/assets/373e146d-0215-4c3a-bd88-2ce2c5ad1bb1" />

Also tested locally with all unit and integration tests, getting genomeBrowser test failures which I assume is an unrelated issue in the master branch.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
