### PR TITLE
CD-publish-tile-server-image: gate with release environment, remove n…

### DIFF
--- a/.github/workflows/CD-publish-tile-server-image.yml
+++ b/.github/workflows/CD-publish-tile-server-image.yml
@@ -2,38 +2,17 @@ name: Publish Tile Server Image
 
 on:
   workflow_dispatch:
-    inputs:
-      build_secret:
-        type: string
-        description: Build secret
 
 jobs:
-  check-user-permissions:
-    runs-on: ubuntu-22.04
-    steps:
-      - id: set-build-secret
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "::set-output name=BUILD_SECRET::${{ github.event.inputs.build_secret }}"
-          else
-            echo "::set-output name=BUILD_SECRET::${{ secrets.BUILD_SECRET }}"
-          fi
-      - name: Check user permission
-        uses: stjude/proteinpaint/.github/actions/check-user-permissions@master
-        with:
-          BUILD_SECRET: ${{ secrets.BUILD_SECRET }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_BUILD_SECRET: ${{ steps.set-build-secret.outputs.BUILD_SECRET }}
 
   build:
-    needs: check-user-permissions
-    if: github.event.pull_request.draft == false
+    environment: release
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Login to Github
         uses: docker/login-action@v3.4.0


### PR DESCRIPTION
…o-op pull_request.draft condition, bump checkout

The 'if: github.event.pull_request.draft == false' check was a no-op on this manual-only (workflow_dispatch) workflow — there is never a pull_request, so it always evaluated true via type coercion. Removed for clarity so manual runs clearly always execute.

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
