### PR TITLE
upload-rust-assets: fix deprecated ::set-output, bump checkout

### DIFF
--- a/.github/actions/upload-rust-assets/action.yml
+++ b/.github/actions/upload-rust-assets/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: Download Rust Binaries
       uses: actions/download-artifact@v4
@@ -22,13 +22,13 @@ runs:
         BRANCH=$(git rev-parse --abbrev-ref HEAD)
         git pull origin $BRANCH 
         PP_TAG="v$(node -p "require('./package.json').version")"
-        echo "::set-output name=pp_tag::$PP_TAG"; 
+        echo "pp_tag=$PP_TAG" >> "$GITHUB_OUTPUT"
         git fetch --tags --quiet origin $PP_TAG # always use tagged commit for build 
         
         PP_RUST_TAG="$(node -p "require('./rust/package.json').version")";
         RENAMED="rust-binaries-$PP_RUST_TAG-linux-x64.tar.gz"
         tar -czvf "$RENAMED" -C rust-binaries .
-        echo "::set-output name=renamed_rust_binaries::$RENAMED";
+        echo "renamed_rust_binaries=$RENAMED" >> "$GITHUB_OUTPUT"
 
     - uses: AButler/upload-release-assets@v3.0
       with:


### PR DESCRIPTION
# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
