### PR TITLE
CD-publish-rust-binaries: gate upload-rust-assets with release enviro…

### DIFF
--- a/.github/workflows/CD-publish-rust-binaries.yml
+++ b/.github/workflows/CD-publish-rust-binaries.yml
@@ -2,26 +2,14 @@ name: "Publish rust binaries"
 
 on:
   workflow_dispatch:
-    inputs:
-      build_secret:
-        type: string
-        description: Build secret
+
 jobs:
-  check-user-permissions:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check user permission
-        uses: stjude/proteinpaint/.github/actions/check-user-permissions@master
-        with:
-          BUILD_SECRET: ${{ secrets.BUILD_SECRET }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_BUILD_SECRET: ${{ github.event.inputs.build_secret }}
 
   rust-build:
-    needs: check-user-permissions
     uses: ./.github/workflows/CD-rust-build.yml
 
   upload-rust-assets:
+    environment: release
     needs: rust-build
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
…nment, remove shared-secret gate

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A

rust-build is a reusable-workflow (uses:) job, which can't take an environment: key. So the release gate sits on upload-rust-assets — the job that actually mutates the GitHub release by uploading assets. rust-build compiles the binaries first (no publish), then the upload is the gated step.