### PR TITLE
Add single cell pseudobulk dataset type

### DIFF
--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1067,7 +1067,8 @@ export type SingleCellQuery = {
 	/** supplies per-sample images. will create a new tab on the ui. one image per sample */
 	images?: SCImages
 	/** Created on mds.init() from colorMap and alias within each plot. */
-	terms?: object[]
+	terms?: object[],
+	pseudobulk?: SingleCellPseudobulk
 }
 
 export type SingleCellMetaResult = {
@@ -1094,6 +1095,29 @@ export type SCImages = {
 	fileName: string
 	/**Used to name the image tab in the single cell plot */
 	label: string
+}
+
+export type SingleCellPseudobulk = {
+	/** type can be 'geneExpression', 'dnaMeth', etc. that aligns to an assay */
+	[assayType: string]: {
+		/** termId corresponds to a term ID in the assay */
+		[termId: string]: {
+			folder: string,
+			/** '*[Ext] denote the file extension for the corresponding data file
+			 * The actual file path is [folder]/[termId.value[i]]/[*Ext]*/
+
+			/** Values are average of per-cell log1p values, used for term */
+			meanExt: string
+			/** values are sum of umi count when present */
+			totalExt: string
+			/** Percentage of cells with the term (e.g. gene) expressed */
+			percentExt: string
+			values: {
+				/** Values should match the values created for the term. */
+				[index: string]: { label?: string /*color??*/}
+			}
+		}
+	}
 }
 
 /** genome browser LD track */

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1067,7 +1067,7 @@ export type SingleCellQuery = {
 	/** supplies per-sample images. will create a new tab on the ui. one image per sample */
 	images?: SCImages
 	/** Created on mds.init() from colorMap and alias within each plot. */
-	terms?: object[],
+	terms?: object[]
 	pseudobulk?: SingleCellPseudobulk
 }
 
@@ -1102,8 +1102,8 @@ export type SingleCellPseudobulk = {
 	[assayType: string]: {
 		/** termId corresponds to a term ID in the assay */
 		[termId: string]: {
-			folder: string,
-			/** '*[Ext] denote the file extension for the corresponding data file
+			folder: string
+			/** '[*]Ext denotes the file extension for the corresponding data file
 			 * The actual file path is [folder]/[termId.value[i]]/[*Ext]*/
 
 			/** Values are average of per-cell log1p values, used for term */


### PR DESCRIPTION
# Description

I added the dataset type to support the new pseudobulk data added to the BALL-scrna and MMRF ds files (see [sjpp PR](https://github.com/stjude/sjpp/pull/1409)). 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
