### PR TITLE
GDC: Case-sample hierarchy foundation

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
 Fixes:
-- Declare the GDC case/sample-type hierarchy on the termdb (sampleTypes, per-term term2SampleType, getFilter0SampleTypes) to match the API-based dataset abstraction; inert (hasSampleAncestry=false) so behavior is unchanged
+- Align GDC case/sample-type mapping with the termdb dictionary hierarchy (map case ids to ROOT_SAMPLE_TYPE and stop overriding termdb.sampleTypes during init). No behavior change while hasSampleAncestry=false.

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Declare the GDC case/sample-type hierarchy on the termdb (sampleTypes, per-term term2SampleType, getFilter0SampleTypes) to match the API-based dataset abstraction; inert (hasSampleAncestry=false) so behavior is unchanged

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -1,7 +1,7 @@
 import ky from 'ky'
 import serverconfig from './serverconfig.js'
 import { cachedFetch, isRecoverableError } from './utils.js'
-import { deepEqual, joinUrl, isUsableTerm, clearMemFetchDataCache } from '#shared/index.js'
+import { deepEqual, joinUrl, isUsableTerm, clearMemFetchDataCache, ROOT_SAMPLE_TYPE } from '#shared/index.js'
 
 // wait time for next check on stale case-id cache, 5min. feature flag allows testing with short internal
 const cacheCheckWait = serverconfig.features.gdcCacheCheckWait || 5 * 60 * 1000
@@ -671,10 +671,11 @@ async function getAnalysisTsv2loom4scrna(ds, ref) {
 }
 
 async function setSampleTypes(ds, ref) {
-	const sampleType = 3 // cases will have sampleType=3
-	ds.cohort.termdb.sampleTypes = { [sampleType]: { name: 'case', plural_name: 'cases', parent_id: null } }
+	// ds.cohort.termdb.sampleTypes is declared by the dictionary builder
+	// (ppgdc gdc.buildDictionary.ts), which runs earlier in init; here we only map
+	// each case id to the case (root) sample type
 	for (const caseid of ref.caseid2submitter.keys()) {
-		ds.sampleId2Type.set(caseid, sampleType)
+		ds.sampleId2Type.set(caseid, ROOT_SAMPLE_TYPE)
 	}
 }
 

--- a/server/src/gdc.initCache.js
+++ b/server/src/gdc.initCache.js
@@ -671,9 +671,9 @@ async function getAnalysisTsv2loom4scrna(ds, ref) {
 }
 
 async function setSampleTypes(ds, ref) {
-	// ds.cohort.termdb.sampleTypes is declared by the dictionary builder
-	// (ppgdc gdc.buildDictionary.ts), which runs earlier in init; here we only map
-	// each case id to the case (root) sample type
+	// ds.cohort.termdb.sampleTypes is initialized in mds3.init.js and populated by the
+	// dataset's termdb dictionary builder earlier in init; here we only map each case id
+	// to the root (case) sample type
 	for (const caseid of ref.caseid2submitter.keys()) {
 		ds.sampleId2Type.set(caseid, ROOT_SAMPLE_TYPE)
 	}


### PR DESCRIPTION
# Description
Companion to the **stjude/sjpp** `gdc.sjpp.2` PR (this repo is its submodule). That PR makes GDC's termdb declare the case/sample hierarchy (`sampleTypes`, `hasSampleAncestry`, per-term `term2SampleType`) in the ppgdc dictionary builder, mirroring MMRF.

This PR fixes the one server-side piece. `gdc.initCache.js`'s `setSampleTypes` previously set `ds.cohort.termdb.sampleTypes = {3:{case…}}` and mapped case ids to type `3` — inconsistent with the terms (stamped `2`) and now with the builder's canonical keys (`case = 1 = ROOT_SAMPLE_TYPE`, `sample = 2 = DEFAULT_SAMPLE_TYPE`). Harmless today only because `hasSampleAncestry` was never set.

### Changes (`server/src/gdc.initCache.js`)
- `setSampleTypes`: **drop** the `ds.cohort.termdb.sampleTypes` assignment (now owned by the dictionary builder, which runs earlier in init) and map each case id to `ROOT_SAMPLE_TYPE` (1) instead of `3`.
- Import `ROOT_SAMPLE_TYPE` from `#shared`.

### Behavior
Behavior-preserving — these values are inert while `hasSampleAncestry` is `false` (see the sjpp PR). No functional change; this only makes the sample-type keys consistent and MMRF-shaped.

Merge with **stjude/sjpp** `gdc.sjpp.2`.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
