### PR TITLE
Bump docker/setup-buildx-action to v4 (node24)

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -59,7 +59,7 @@ runs:
         password: ${{ inputs.TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build Docker Image
       uses: docker/build-push-action@v7

--- a/.github/workflows/CI-combined-coverage.yaml
+++ b/.github/workflows/CI-combined-coverage.yaml
@@ -64,7 +64,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker
 

--- a/.github/workflows/CI-spec-coverage.yml
+++ b/.github/workflows/CI-spec-coverage.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: contains(env.HAS_INTEGRATION_TESTS, 'true')
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Prepare serverconfig.json and cachedir
         run: |


### PR DESCRIPTION
# Description
Bumps docker/setup-buildx-action@v3 → @v4 (3 usages). v4 runs on Node 24, clearing the node20 deprecation warning. Drop-in — no input changes.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
