### PR TITLE
Bump artifact actions: upload-artifact@v7, download-artifact@v8 (node24)

### DIFF
--- a/.github/actions/upload-rust-assets/action.yml
+++ b/.github/actions/upload-rust-assets/action.yml
@@ -10,7 +10,7 @@ runs:
     - uses: actions/checkout@v7
 
     - name: Download Rust Binaries
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: rust-binaries
         path: rust-binaries

--- a/.github/workflows/CD-create-release.yml
+++ b/.github/workflows/CD-create-release.yml
@@ -165,7 +165,7 @@ jobs:
 
       # Download the Rust binaries built by the rust-build workflow
       - name: Download Rust Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rust-binaries
           path: rust-binaries

--- a/.github/workflows/CD-publish-deps-image.yml
+++ b/.github/workflows/CD-publish-deps-image.yml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 10
 
       - name: Download Rust binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rust-binaries
           path: rust-binaries

--- a/.github/workflows/CD-rust-build.yml
+++ b/.github/workflows/CD-rust-build.yml
@@ -21,7 +21,7 @@ jobs:
           ./extract_binaries.sh
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-binaries
           path: rust/extracted_binaries

--- a/.github/workflows/CI-integration.yml
+++ b/.github/workflows/CI-integration.yml
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 10
 
       - name: Download Rust binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rust-binaries
           path: rust-binaries


### PR DESCRIPTION
# Description
Bumps upload-artifact@v4→v7 and download-artifact@v4→v8 (node24). Backend unchanged across v4–v8, so artifacts stay cross-compatible; producer + all consumers bumped together. Note: v8 now errors on hash mismatch and checks Content-Type before unzip. Verify the rust-binaries round-trip once after merge.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
