### PR TITLE
Replace AButler/upload-release-assets with gh release upload (drop th…

### DIFF
--- a/.github/actions/upload-rust-assets/action.yml
+++ b/.github/actions/upload-rust-assets/action.yml
@@ -30,8 +30,13 @@ runs:
         tar -czvf "$RENAMED" -C rust-binaries .
         echo "renamed_rust_binaries=$RENAMED" >> "$GITHUB_OUTPUT"
 
-    - uses: AButler/upload-release-assets@v3.0
-      with:
-        files: "${{ steps.rename_rust_binaries.outputs.renamed_rust_binaries }}"
-        repo-token: ${{ inputs.GITHUB_TOKEN }}
-        release-tag: ${{ steps.rename_rust_binaries.outputs.pp_tag }}
+    - name: Upload rust assets
+      shell: bash  # required for composite `run:` steps
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }} # gh auth
+        PP_TAG: ${{ steps.rename_rust_binaries.outputs.pp_tag }} # release tag to upload to
+        RENAMED: "${{ steps.rename_rust_binaries.outputs.renamed_rust_binaries }}" # tarball to attach
+      run: |
+        # Attach the rust-binaries tarball to the EXISTING release for this tag.
+        # --clobber overwrites an asset of the same name, so the step is safe to re-run.
+        gh release upload $PP_TAG $RENAMED --clobber


### PR DESCRIPTION
…ird-party node20 action)

# Description
Replaces the third-party AButler/upload-release-assets@v3.0 (Node 20, unmaintained, no Node 24 version exists) with the GitHub CLI gh release upload. gh is a compiled binary pre-installed on hosted runners. No Node runtime, so it's permanently immune to the runtime-deprecation treadmill. Same behavior: uploads the renamed rust-binaries tarball to the existing release for the tag (--clobber to overwrite on re-runs). Removes a third-party dependency.
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
