### PR TITLE
Ci/rewrite slack v3

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -119,7 +119,7 @@ runs:
       if: always()
       uses: slackapi/slack-github-action@v3
       with:
-        webhook: ${{ inputs.SLACK_WEBHOOK_URL }} #webhook URL is now an input (was the SLACK_WEBHOOK_URL env var)
+        webhook: ${{ inputs.SLACK_WEBHOOK_URL }} #webhook URL is now an input (was the SLACK_WEBHOOK_URL env var) Composite actions can't access secrets — must receive it as an input
         webhook-type: webhook-trigger #our URL is a Slack Workflow Builder trigger (accepts custom keys)
         payload: |
           {

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -117,16 +117,16 @@ runs:
 
     - name: Post build results on Slack
       if: always()
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@v3
       with:
+        webhook: ${{ inputs.SLACK_WEBHOOK_URL }} #webhook URL is now an input (was the SLACK_WEBHOOK_URL env var)
+        webhook-type: webhook-trigger #our URL is a Slack Workflow Builder trigger (accepts custom keys)
         payload: |
           {
             "status": "${{ env.INTEGRATION_TEST_PASSED == 'true' && 'success' || 'failure' }} - https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             "commit": "${{ env.SHORT_SHA }}",
             "date-time": "${{ steps.current-time.outputs.formattedTime }}"
           }
-      env:
-        SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK_URL }}
 
     - name: Fail job if integration test failed
       if: env.INTEGRATION_TEST_PASSED != 'true'

--- a/.github/workflows/CI-spec-coverage.yml
+++ b/.github/workflows/CI-spec-coverage.yml
@@ -204,7 +204,7 @@ jobs:
         if:  ${{ env.TEST_FAILED == 'true' }}
         uses: slackapi/slack-github-action@v3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }} # webhook URL is now an input (was the SLACK_WEBHOOK_URL env var)
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }} # webhook URL is now an input (was the SLACK_WEBHOOK_URL env var). Workflows can read secrets directly. So secrets.SLACK_WEBHOOK_URL is used here instead of passing it as an input to the action.
           webhook-type: webhook-trigger # our URL is a Slack Workflow Builder trigger (accepts custom keys)
           payload: |
             {

--- a/.github/workflows/CI-spec-coverage.yml
+++ b/.github/workflows/CI-spec-coverage.yml
@@ -202,16 +202,16 @@ jobs:
 
       - name: Post test results on Slack
         if:  ${{ env.TEST_FAILED == 'true' }}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }} # webhook URL is now an input (was the SLACK_WEBHOOK_URL env var)
+          webhook-type: webhook-trigger # our URL is a Slack Workflow Builder trigger (accepts custom keys)
           payload: |
             {
               "status": "Failed unit and/or integration test(s) - https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "commit": "${{ env.SHORT_SHA }}",
               "date-time": "${{ steps.current-time.outputs.formattedTime }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK_URL }}
 
       - name: Detect failure
         run: |


### PR DESCRIPTION
# Description
Bumps `slackapi/slack-github-action` v1.23.0 → v3 to move off the **deprecated Node 16** runtime (v3 = Node 24), before GitHub removes Node 16 and our CI Slack alerts silently break.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
