### PR TITLE
Replace martinbeentjes/npm-get-version-action with inline node (drop …

### DIFF
--- a/.github/actions/publish-ppfull-ppserver-image/action.yml
+++ b/.github/actions/publish-ppfull-ppserver-image/action.yml
@@ -59,21 +59,15 @@ runs:
 
         echo "docker_version=$TAG-$HASH" >> "$GITHUB_OUTPUT"
 
-    - name: get pp version
-      id: pp-version
-      uses: martinbeentjes/npm-get-version-action@main
-
-    - name: get front version
-      id: front-version
-      uses: martinbeentjes/npm-get-version-action@main
-      with:
-        path: front
-
-    - name: get server version
-      id: server-version
-      uses: martinbeentjes/npm-get-version-action@main
-      with:
-        path: server
+    # Reads versions inline with node (repo's existing idiom), replacing the
+    # third-party martinbeentjes/npm-get-version-action@main (mutable @main branch pin).
+    - name: Get package versions
+      id: versions
+      shell: bash
+      run: |
+        echo "pp_version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        echo "front_version=$(node -p "require('./front/package.json').version")" >> "$GITHUB_OUTPUT"
+        echo "server_version=$(node -p "require('./server/package.json').version")" >> "$GITHUB_OUTPUT" 
 
     - name: Run deploy action
       uses: peter-evans/repository-dispatch@v4
@@ -82,4 +76,4 @@ runs:
         token: ${{ inputs.PAT }}
         repository: stjude/sj-pp
         event-type: version-update
-        client-payload: '{"pp_version": "${{ steps.pp-version.outputs.current-version }}", "front_version": "${{ steps.front-version.outputs.current-version }}", "server_version": "${{ steps.server-version.outputs.current-version}}", "docker_version": "${{ steps.docker-publish.outputs.docker_version}}", "branch": "${{ steps.docker-publish.outputs.branch }}"}'
+        client-payload: '{"pp_version": "${{ steps.versions.outputs.pp_version }}", "front_version": "${{ steps.versions.outputs.front_version }}", "server_version": "${{ steps.versions.outputs.server_version }}", "docker_version": "${{ steps.docker-publish.outputs.docker_version }}", "branch": "${{ steps.docker-publish.outputs.branch }}"}'


### PR DESCRIPTION
…third-party @main action)

# Description
Replaces the third-party martinbeentjes/npm-get-version-action@main (pinned to a mutable @main branch — supply-chain risk) with an inline node -p read. The same idiom used elsewhere in this repo (create-release, upload-rust-assets). Consolidates 3 steps into 1 and updates the repository-dispatch payload refs accordingly. No behavior change: reads the same package.json versions at the same point. peter-evans/repository-dispatch kept (well-maintained, node24, and gh api handles nested client_payload poorly).
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
