### PR TITLE
GDC: Route GDC dictionary term data through dictionary.get()

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- Route GDC dictionary term data through the ds.cohort.termdb.dictionary.get() hook, removing the GDC-specific getSampleData_dictionaryTerms_v2s path (and its variant2samples fallback) from shared server code

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -11,7 +11,13 @@ import * as mds3_init from './mds3.init.js'
 import { parse_textfilewithheader } from './parse_textfilewithheader.js'
 import { clinsig } from '../dataset/clinvar.ts'
 // will pass below as argument to mds3_init()
-import { mayMapRefseq2ensembl, flattenCaseByFields, may_add_readdepth, mapGenes2isoforms } from './mds3.gdc.js'
+import {
+	mayMapRefseq2ensembl,
+	flattenCaseByFields,
+	may_add_readdepth,
+	mapGenes2isoforms,
+	querySamples_gdcapi
+} from './mds3.gdc.js'
 import { isUsableTerm, joinUrl, ezFetch } from '@sjcrh/proteinpaint-shared'
 import { SelectionPrefixes, createSelectionID, FlagStatus } from '#types'
 import { mayLog } from './helpers.ts'
@@ -22,6 +28,7 @@ const dsHelpers = {
 	flattenCaseByFields,
 	may_add_readdepth,
 	mapGenes2isoforms,
+	querySamples_gdcapi,
 	isUsableTerm,
 	joinUrl,
 	ezFetch,

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -473,7 +473,8 @@ function getSampleId4Cell(ds, tw, cell, filteredSamples) {
 	}
 	if (!sampleName) return
 	if (filteredSamples.size > 0 && !filteredSamples.has(sampleName)) return
-	const sampleId = sampleMappingCache?.sampleName2IntId?.get?.(sampleName) ?? ds.cohort?.termdb?.q?.sampleName2id?.(sampleName)
+	const sampleId =
+		sampleMappingCache?.sampleName2IntId?.get?.(sampleName) ?? ds.cohort?.termdb?.q?.sampleName2id?.(sampleName)
 	if (sampleId == undefined) {
 		throw new Error(`single cell meta result cannot map sample name = ${sampleName} to sample id`)
 	}
@@ -701,15 +702,14 @@ termWrappers[]
 
 output:
 
-{
+[
 	samples: {}
 		key: stringified integer id
 		val: {}
 			sample: int id
-			<term id>: { key: str, value: str }
-	refs:{}
-		{ byTermId: {} }
-}
+			<tw.$id>: { key: str, value: str }
+	byTermId: {}
+]
 */
 async function getSampleData_dictionaryTerms(q, termWrappers) {
 	if (!termWrappers.length) return [{}, {}]
@@ -720,12 +720,6 @@ async function getSampleData_dictionaryTerms(q, termWrappers) {
 	if (q.ds.cohort.termdb.dictionary?.get) {
 		// ds-supplied getter to retrieve dictionary term data
 		return await q.ds.cohort.termdb.dictionary.get(q, termWrappers)
-	}
-	/* gdc ds has no cohort.db. thus call v2s.get() to return sample annotations for its dictionary terms
-	 */
-	if (q.ds?.variant2samples?.get) {
-		// ds is not using sqlite db but has v2s method
-		return await getSampleData_dictionaryTerms_v2s(q, termWrappers)
 	}
 	if (q.ds.cohort.termdb.q?.getAdHocTermValues) {
 		//ds is not using sqlite db but has getAdHocTermValues method
@@ -939,90 +933,6 @@ async function mayQueryMutatedSamples(q) {
 		}
 	}
 	return sampleSet
-}
-
-/*
-using mds3 dataset, that's without server-side sqlite db and will not execute any sql query
-so far it's only gdc
-later can be other api-based datasets
-*/
-async function getSampleData_dictionaryTerms_v2s(q, termWrappers) {
-	const q2 = Object.assign(
-		{
-			filter0: q.filter0, // must pass on gdc filter0 if present
-			filterObj: q.filter, // must rename key as "filterObj" but not "filter" to go with what mds3 backend is using
-			genome: q.genome,
-			get: 'samples',
-			twLst: termWrappers,
-			isHierCluster: q.isHierCluster, // !! gdc specific parameter !!
-			__abortSignal: q.__abortSignal
-		},
-		q.ds.mayGetGeneVariantDataParam || {}
-	)
-	if (q.rglst) {
-		// !! gdc specific parameter !! present for block tk in genomic mode
-		q2.rglst = q.rglst
-	}
-	if (q.currentGeneNames) {
-		q2.geneTwLst = []
-		for (const n of q.currentGeneNames) {
-			q2.geneTwLst.push({ term: { id: n, gene: n, name: n, type: 'geneVariant' } })
-		}
-	} else {
-		/* do not throw here
-		gene list is not required for loading dict term for gdc gene exp clustering
-		but it's required for gdc oncomatrix and will break FIXME
-		*/
-	}
-
-	const data = await q.ds.variant2samples.get(q2, q.ds)
-	/* data={samples[], byTermId{}}
-	data.samples[] is converted to samples{}
-	data.byTermId{} is returned without change
-	*/
-
-	const samples = {} // data.samples[] converts into this
-
-	for (const s of data.samples) {
-		const s2 = {
-			sample: s.sample_id
-		}
-		for (const tw of termWrappers) {
-			const id = tw.term.id || tw.term.name
-			const $id = tw.$id || id
-			if (!tw.$id) tw.$id = $id
-			const v = s[id]
-
-			////////////////////////////
-			// somehow value can be undefined! must skip them
-			////////////////////////////
-
-			if (Array.isArray(v) && v[0] != undefined && v[0] != null) {
-				////////////////////////////
-				// "v" can be array
-				// e.g. "age of diagnosis"
-				////////////////////////////
-				s2[$id] = {
-					key: v[0],
-					value: v[0]
-				}
-			} else if (v != undefined && v != null) {
-				if (typeof v == 'object') {
-					// v is {key,value}, should be for survival term
-					// now also for discrete numeric term to support {key: bin, value: value}
-					s2[$id] = v
-				} else {
-					// v is number/string, should be for non-survival term
-					s2[$id] = {
-						key: v,
-						value: v
-					}
-				}
-			}
-		}
-		samples[s.sample_id] = s2
-	}
-	return [samples, data.byTermId || {}]
 }
 
 /*

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -164,14 +164,20 @@ type AiApi = {
 }
 
 /** configuration for api-based dictionary
-NOTE: currently used by mmrf, but may also be used
-by other api-based datasets (e.g. gdc) */
+NOTE: used by mmrf and gdc, may also be used
+by other api-based datasets */
 type DictApi = {
 	// builds dictionary and sets standard
 	// helpers at ds.cohort.termdb.q{}
 	build?: (ds: any) => void
-	// gets dictionary term data
-	get?: (q: any, twLst: any, onlyChildren?: boolean, useCache?: boolean) => void
+	/** gets dictionary term data; returns [samples{}, byTermId{}]
+	see getSampleData_dictionaryTerms() of server/src/termdb.matrix.js
+
+	sample hierarchy is signaled on q (q.mapParent2Children, with
+	ds.cohort.termdb.sampleTypes and .term2SampleType), not by an arg here.
+	do not add an onlyChildren arg: that one belongs to barchart_data() of
+	server/src/termdb.barchart.js, and passing it here would land on useCache */
+	get?: (q: any, twLst: any[], useCache?: boolean) => Promise<[any, any]>
 }
 
 type SnvIndelFormat = {


### PR DESCRIPTION
# Description
Lets GDC supply `ds.cohort.termdb.dictionary.get()`, the same hook mmrf already
uses, so `getData()` dispatches at [termdb.matrix.js:720] and no longer falls
through to the GDC-specific `variant2samples` path at :726.

This is the server-side half. The GDC getter itself lives in the sjpp repo
(ppgdc dataset) — see companion PR stjude/sjpp#<sjpp PR>.

## Why

The `getSampleData_dictionaryTerms` dispatcher only reached GDC via a fallback
branch that existed purely because GDC has no `cohort.db`. That branch dragged
GDC-specific plumbing (a `q2` shim renaming `filter`→`filterObj`, hardcoding
`get:'samples'`, fabricating `geneTwLst`, passing `isHierCluster`/`rglst`) into
generic server code. Underneath, the `variant2samples.get` hop is a pure
pass-through for GDC. Moving the getter into the dataset lets us delete the
whole fallback.

## Changes

- **`server/src/initGenomesDs.js`** — export `querySamples_gdcapi` through
  `dsHelpers`, alongside the `mds3.gdc.js` internals already re-exported there
  (`flattenCaseByFields`, `may_add_readdepth`, `mapGenes2isoforms`). This is
  what the ppgdc getter calls.
- **`server/src/termdb.matrix.js`** — delete the `variant2samples.get` branch
  and `getSampleData_dictionaryTerms_v2s` (−~100 lines); fix the stale doc
  comment (every branch returns the `[samples, byTermId]` tuple, not an object).
- **`shared/types/src/dataset.ts`** — `DictApi.get` now returns
  `Promise<[any, any]>` and drops the fictional `onlyChildren` param (it belongs
  to `barchart_data`, was never passed here); added a note on where sample
  hierarchy is actually signaled (`q.mapParent2Children`).

Net: +24 / −101.

## Notes for reviewers

- Branch `:726` is dead for every dataset once GDC has `dictionary.get`:
  `termdb.test` and `clingen` have `cohort.db` (→ `:718`); mmrf has
  `dictionary.get` (→ `:720`). `variant2samples.get` retains its other caller
  (`mds3.load.js:299`, the mds3 track path) untouched.
- `tsc` clean on `server` and `shared/types`.

## Merge ordering

Merge/publish this **before** the ppgdc getter goes live — the getter imports
`querySamples_gdcapi` from the published server. ppgdc's Dockerfile pins
`ppserver:<version>`, so the sjpp PR also bumps that pin to a build containing
this change.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
