### PR TITLE
accept a GDC_API argument for IDCViewer to avoid CORS error in prod w…

### DIFF
--- a/client/gdc/idcviewer/IDCViewer.ts
+++ b/client/gdc/idcviewer/IDCViewer.ts
@@ -8,11 +8,20 @@ import { IDCViewerDefaults } from './settings/defaults'
 import { IDCSearchView } from './view/IDCSearchView'
 import { applyStyles, idcViewerStyles } from './styling'
 
+type IDCViewerInitArg = {
+	/** GDC cohort filter */
+	filter0: any
+	/** a constant that's declared in portal-proto/.env.* files, with the following expected values:
+	 * - "https://api.gdc.cancer.gov" in dev, works with 'http(s)://localhost' URLs, but has CORS error when used in portal.gdc.cancer.gov URLs
+	 * - "https://portal.gdc.cancer.gov/auth/api/v0" or relative path "/auth/api/v0" in prod, works with with portal.gdc.cancer.gov URLs */
+	GDC_API: string
+}
+
 export async function init(
-	{ filter0 },
+	{ filter0, GDC_API }: IDCViewerInitArg,
 	holder: Selection<HTMLDivElement, unknown, any, any>
 ): Promise<{ update: (arg: { filter0: any }) => Promise<void> }> {
-	const viewer = new IDCViewer(holder)
+	const viewer = new IDCViewer(holder, GDC_API)
 	viewer.main({ ...IDCViewerDefaults, filter0: filter0 }, true).catch(e => {
 		sayerror(viewer.dom.errorDiv, `Error running IDCViewer: ${e.message || e}`)
 	})
@@ -25,14 +34,15 @@ export async function init(
 }
 
 export class IDCViewer {
-	private model = new IDCModel()
+	private model: IDCModel
 	private viewModel = new IDCViewModel()
 	private tableView: IDCTableView | undefined
 	private searchView: IDCSearchView | undefined
 	private loadResult: IDCParquetLoadResult | undefined
 	public dom: { [name: string]: any } = {}
 
-	constructor(holder: Selection<HTMLDivElement, unknown, any, any>) {
+	constructor(holder: Selection<HTMLDivElement, unknown, any, any>, GDC_API: undefined | string) {
+		this.model = new IDCModel(GDC_API || 'https://api.gdc.cancer.gov')
 		this.dom = {
 			holder: holder,
 			errorDiv: holder.append('div').attr('class', 'idcviewer-error-holder'),

--- a/client/gdc/idcviewer/IDCViewer.ts
+++ b/client/gdc/idcviewer/IDCViewer.ts
@@ -14,7 +14,7 @@ type IDCViewerInitArg = {
 	/** a constant that's declared in portal-proto/.env.* files, with the following expected values:
 	 * - "https://api.gdc.cancer.gov" in dev, works with 'http(s)://localhost' URLs, but has CORS error when used in portal.gdc.cancer.gov URLs
 	 * - "https://portal.gdc.cancer.gov/auth/api/v0" or relative path "/auth/api/v0" in prod, works with with portal.gdc.cancer.gov URLs */
-	GDC_API: string
+	GDC_API?: string
 }
 
 export async function init(
@@ -41,8 +41,8 @@ export class IDCViewer {
 	private loadResult: IDCParquetLoadResult | undefined
 	public dom: { [name: string]: any } = {}
 
-	constructor(holder: Selection<HTMLDivElement, unknown, any, any>, GDC_API: undefined | string) {
-		this.model = new IDCModel(GDC_API || 'https://api.gdc.cancer.gov')
+	constructor(holder: Selection<HTMLDivElement, unknown, any, any>, GDC_API?: string) {
+		this.model = new IDCModel(GDC_API)
 		this.dom = {
 			holder: holder,
 			errorDiv: holder.append('div').attr('class', 'idcviewer-error-holder'),

--- a/client/gdc/idcviewer/model/IDCModel.ts
+++ b/client/gdc/idcviewer/model/IDCModel.ts
@@ -51,6 +51,12 @@ async function verifyParquetUrlWithSidecar(parquetBuffer: ArrayBuffer, sidecarRe
 
 /** Handles all data fetching for the IDC viewer: parquet loading and GDC API calls. */
 export class IDCModel {
+	#GDC_API: string
+
+	constructor(GDC_API: string) {
+		this.#GDC_API = GDC_API
+	}
+
 	/** Load the IDC parquet mapping, falling back through versioned archives if "current" is unavailable or invalid. */
 	async loadParquetWithFallback(retries: number): Promise<IDCParquetLoadResult | undefined> {
 		const current = await this.tryLoadValidatedParquet(IDC_PARQUET_CURRENT_URL, IDC_CURRENT_VERSION_LABEL)
@@ -147,7 +153,7 @@ export class IDCModel {
 			expand: 'samples.portions.slides,project.program',
 			sort: `${sortBy}:${sortDirection}`
 		}
-		const re: CasesResponse = await fetch('https://api.gdc.cancer.gov/cases', {
+		const re: CasesResponse = await fetch(`${this.#GDC_API}/cases`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json', Accept: 'application/json', connection: 'close' },
 			body: JSON.stringify(body)

--- a/client/gdc/idcviewer/model/IDCModel.ts
+++ b/client/gdc/idcviewer/model/IDCModel.ts
@@ -53,8 +53,8 @@ async function verifyParquetUrlWithSidecar(parquetBuffer: ArrayBuffer, sidecarRe
 export class IDCModel {
 	#GDC_API: string
 
-	constructor(GDC_API: string) {
-		this.#GDC_API = GDC_API
+	constructor(GDC_API?: string) {
+		this.#GDC_API = (GDC_API || 'https://api.gdc.cancer.gov').replace(/\/+$/, '')
 	}
 
 	/** Load the IDC parquet mapping, falling back through versioned archives if "current" is unavailable or invalid. */

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- accept a GDC_API argument for IDCViewer to avoid CORS error in prod when requesting /cases data


### PR DESCRIPTION
…hen requesting /cases data

# Description

This branch fixes a CORS request error in qa-int/prod GDC environments.

Test:
- http://localhost:3000/example.idc.html should work as usual
- https://localhost.gdc.cancer.gov:3010/analysis_page?app=IDCViewerApp should also work as usual
- https://portal.gdc.cancer.gov/analysis_page?app=IDCViewerApp should work and not show the error in the screenshot below
<img width="1475" height="656" alt="Screenshot 2026-07-16 at 9 15 33 PM" src="https://github.com/user-attachments/assets/a0fd7222-07f8-42a0-9d91-01365b2336f0" />


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
