### PR TITLE
GDC: Untangle querySamples_gdcapi: split getData vs variant2samples entry points and centralize sample-identity resolution on ds.cohort.termdb.q.id2sampleRefs()

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,3 @@
-
+Features:
+- Untangle the GDC querySamples_gdcapi() server path: split the getData/dictionary-term and variant2samples sample-query entry points so getData calls queryDictTermData_gdcapi instead of the mutation-oriented querySamples_gdcapi, drop a shared-request mutation, and extract a unit-tested ssm-occurrence field builder
+- Centralize sample-id-to-display resolution on ds.cohort.termdb.q.id2sampleRefs() with a uniform native/GDC implementation, removing the GDC-specific __gdc coupling from termdb.matrix.js and termdb.cluster.ts

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -16,7 +16,7 @@ import {
 	flattenCaseByFields,
 	may_add_readdepth,
 	mapGenes2isoforms,
-	querySamples_gdcapi
+	queryDictTermData_gdcapi
 } from './mds3.gdc.js'
 import { isUsableTerm, joinUrl, ezFetch } from '@sjcrh/proteinpaint-shared'
 import { SelectionPrefixes, createSelectionID, FlagStatus } from '#types'
@@ -28,7 +28,7 @@ const dsHelpers = {
 	flattenCaseByFields,
 	may_add_readdepth,
 	mapGenes2isoforms,
-	querySamples_gdcapi,
+	queryDictTermData_gdcapi,
 	isUsableTerm,
 	joinUrl,
 	ezFetch,

--- a/server/src/mds3.gdc.js
+++ b/server/src/mds3.gdc.js
@@ -1449,12 +1449,11 @@ returns:
 }
 */
 
-export async function querySamples_gdcapi(q, twLst, ds, geneTwLst) {
-	// step 1: separate survival vs non-survival terms
-	// survival terms requires different querying method. separate it from other dictionary terms
-
-	const survivalTwLst = [], // survival terms
-		dictTwLst = [] // non-survival dict terms
+/* split twLst into survival terms (queried separately) and non-survival dict terms.
+dict terms are re-wrapped with the full term json (termjsonByOneid); unknown terms are dropped. */
+function splitSurvivalDictTerms(twLst, ds) {
+	const survivalTwLst = [],
+		dictTwLst = []
 	for (const tw of twLst) {
 		if (tw.term.type == 'survival') {
 			survivalTwLst.push(tw)
@@ -1463,32 +1462,48 @@ export async function querySamples_gdcapi(q, twLst, ds, geneTwLst) {
 			if (t) dictTwLst.push({ $id: tw.$id, term: t, q: tw.q })
 		}
 	}
+	return { survivalTwLst, dictTwLst }
+}
+
+/* query samples harboring mutations (variant2samples: lollipop/mds3-tk sample tables, sunburst,
+summary, and the cnv tool). always scoped by a genomic filter (ssm/isoform/rglst/gene) or hardcodeCnvOnly.
+returns {byTermId, samples}; both survival and dict term data are combined into samples[]. */
+export async function querySamples_gdcapi(q, twLst, ds, geneTwLst) {
+	const { survivalTwLst, dictTwLst } = splitSurvivalDictTerms(twLst, ds)
 
 	let byTermId = {},
-		samples = [] // returned data structures. both survival and other dict term data will be combined for return
-
-	// step 2: querying dict term data
+		samples = []
 
 	if (dictTwLst.length) {
-		if (q.hardcodeCnvOnly) {
-			// user interactions from cnv tool will have this flag in request;
-			// this allows accessing sample details for cases with cnv
-			;[byTermId, samples] = await querySamplesWithCnv(q, dictTwLst, ds)
-		} else if (q.isHierCluster) {
-			// running gene exp clustering, must only restrict to cases with exp data,
-			// but not by mutated cases anymore, thus geneTwLst should not be used (and not supplied)
-			;[byTermId, samples] = await querySamplesTwlstForGeneexpclustering(q, dictTwLst, ds)
-		} else {
-			// not in gene exp clustering mode
-			;[byTermId, samples] = await querySamplesTwlstNotForGeneexpclustering(q, dictTwLst, ds, geneTwLst)
-		}
+		// cnv tool sets hardcodeCnvOnly to access sample details for cases with cnv; else the mutated-case query
+		;[byTermId, samples] = q.hardcodeCnvOnly
+			? await querySamplesWithCnv(q, dictTwLst, ds)
+			: await querySamplesTwlstNotForGeneexpclustering(q, dictTwLst, ds, geneTwLst)
 	}
 
-	// step 3: querying survival data
+	if (survivalTwLst.length) await querySamplesSurvival(q, survivalTwLst, ds, samples, geneTwLst)
 
-	if (survivalTwLst.length) {
-		await querySamplesSurvival(q, survivalTwLst, ds, samples, geneTwLst)
+	return { byTermId, samples }
+}
+
+/* query dictionary-term values for the getData/termdb path (the dataset's dictionary.get hook:
+matrix, summary charts, gene-exp clustering). identifies samples by case uuid (q.gdcUseCaseuuid).
+returns {byTermId, samples}, same shape as querySamples_gdcapi. */
+export async function queryDictTermData_gdcapi(q, twLst, ds, geneTwLst) {
+	const { survivalTwLst, dictTwLst } = splitSurvivalDictTerms(twLst, ds)
+
+	let byTermId = {},
+		samples = []
+
+	if (dictTwLst.length) {
+		// gene-exp clustering restricts to cases with exp data (no gene/mutation filter); else the
+		// standard dict-term query (/cases, or /ssm_occurrences when restricting to mutated cases for oncomatrix)
+		;[byTermId, samples] = q.isHierCluster
+			? await querySamplesTwlstForGeneexpclustering(q, dictTwLst, ds)
+			: await querySamplesTwlstNotForGeneexpclustering(q, dictTwLst, ds, geneTwLst)
 	}
+
+	if (survivalTwLst.length) await querySamplesSurvival(q, survivalTwLst, ds, samples, geneTwLst)
 
 	return { byTermId, samples }
 }
@@ -1549,11 +1564,10 @@ async function querySamplesSurvival(q, survivalTwLst, ds, samples, geneTwLst) {
 		filter.content.push(q.filter0)
 	}
 
-	if (geneTwLst) q.isoforms = mapGenes2isoforms(geneTwLst, ds.genomeObj)
+	// isoforms kept as a local and spread onto a shallow copy so the shared q is never mutated
+	const isoforms = geneTwLst ? mapGenes2isoforms(geneTwLst, ds.genomeObj) : undefined
 
-	addSsmIsoformRegion4filter(filter.content, q, 'survival')
-
-	delete q.isoforms
+	addSsmIsoformRegion4filter(filter.content, isoforms ? { ...q, isoforms } : q, 'survival')
 
 	if (q.set_id) {
 		if (typeof q.set_id != 'string') throw '.set_id value not string'
@@ -1663,59 +1677,46 @@ export function mapGenes2isoforms(geneTwLst, genome) {
 async function querySamplesTwlstNotForGeneexpclustering(q, dictTwLst, ds, geneTwLst) {
 	// not for gene exp clustering
 
-	if (geneTwLst) {
-		// temporarily create q.isoforms[] to filter for cases with ssm on these genes; will be deleted after query completes
-		q.isoforms = mapGenes2isoforms(geneTwLst, ds.genomeObj)
-	}
+	// isoforms[] filters for cases with ssm on these genes. kept as a local (not set on q)
+	// so the shared request object is never mutated; passed explicitly to the genomic-filter query
+	const isoforms = geneTwLst ? mapGenes2isoforms(geneTwLst, ds.genomeObj) : undefined
 
-	if (q.isoforms || q.isoform || q.ssm_id_lst || q.rglst) {
+	if (isoforms || q.isoform || q.ssm_id_lst || q.rglst) {
 		// using genomic filters
-		return await querySamplesTwlstNotForGeneexpclustering_withGenomicFilter(q, dictTwLst, ds, geneTwLst)
+		return await querySamplesTwlstNotForGeneexpclustering_withGenomicFilter(q, dictTwLst, ds, geneTwLst, isoforms)
 	}
 	// no genomic filter
 	return await querySamplesTwlstNotForGeneexpclustering_noGenomicFilter(q, dictTwLst, ds)
 }
 
-// using genomic filter; assuming it's filtering for mutated cases, query ssm_occurrences endpoint
-async function querySamplesTwlstNotForGeneexpclustering_withGenomicFilter(q, dictTwLst, ds, geneTwLst) {
-	const fieldset = new Set(dictTwLst.map(tw => tw.term.id)) // set of fields to request from ssm_occurrences api. tolerate insertion of duplicating fields
+/* build the fields[] list requested from the ssm_occurrences api for the genomic-filter query.
+pure: no i/o, no mutation. duplicate fields are tolerated (Set-based). */
+export function buildSsmOccurrenceFields(dictTwLst, q) {
+	const fieldset = new Set(dictTwLst.map(tw => tw.term.id))
 
 	if (fieldset.has('case.diagnoses.age_at_diagnosis') || fieldset.has('case.diagnoses.primary_diagnosis')) {
 		fieldset.add('case.diagnoses.diagnosis_is_primary_disease')
 	}
 
-	/* this function can identify sample either by case uuid, or sample submitter id
-	for simplicity, always request these two different values
-	*/
+	// this function can identify sample either by case uuid, or sample submitter id;
+	// for simplicity, always request these two different values
 	fieldset.add('case.observation.sample.tumor_sample_uuid')
 	fieldset.add('case.case_id')
 
-	if (q.get == 'samples') {
-		// getting list of samples (e.g. for table display)
-		// need following fields for table display, add to fields[] if missing:
-
-		if (q.ssm_id_lst || q.isoform) {
-			// querying using list of ssm or single isoform
-			// must be from mds3 tk; in such case should return following info
-
-			// need ssm id to associate with ssm (when displaying in sample table?)
-			fieldset.add('ssm.ssm_id')
-
-			// need read depth info
-			// TODO should only add when getting list of samples with mutation for a gene
-			// TODO not when adding a dict term in matrix?
-			fieldset.add('case.observation.read_depth.t_alt_count')
-			fieldset.add('case.observation.read_depth.t_depth')
-			fieldset.add('case.observation.read_depth.n_depth')
-		}
+	if (q.get == 'samples' && (q.ssm_id_lst || q.isoform)) {
+		// mds3-tk sample table only. these three flags are set exclusively by the variant2samples request
+		// (client/mds3/makeTk.js) and never by the getData/matrix path, so the matrix never over-fetches
+		// these mutation fields even though it shares this builder (locked by mds3.gdc.unit.spec.js).
+		// add ssm id (to link sample<->variant) and read depth (TumorAC/NormalDepth format columns).
+		fieldset.add('ssm.ssm_id')
+		fieldset.add('case.observation.read_depth.t_alt_count')
+		fieldset.add('case.observation.read_depth.t_depth')
+		fieldset.add('case.observation.read_depth.n_depth')
 	}
 
 	if (q.hiddenmclass) {
-		/* to drop mutations by pp class
-		add new fields so api returns consequence for the querying isoform for each mutation
-		then filter by class
-		this has been coded up this way but is inefficient, better method would be for gdc api filter to include transcript and consequence limit
-		*/
+		/* to drop mutations by pp class: request consequence for the querying isoform so it can be filtered by class.
+		inefficient; better would be for the gdc api filter to include transcript and consequence limit */
 		fieldset.add('ssm.consequence.transcript.consequence_type')
 		fieldset.add('ssm.consequence.transcript.transcript_id')
 		fieldset.add('ssm.consequence.transcript.is_canonical')
@@ -1726,12 +1727,19 @@ async function querySamplesTwlstNotForGeneexpclustering_withGenomicFilter(q, dic
 		fieldset.add('ssm.start_position')
 	}
 
-	const param = { size: isoform2ssm_query2_getcase.size, fields: [...fieldset].join(',') }
+	return [...fieldset]
+}
+
+// using genomic filter; assuming it's filtering for mutated cases, query ssm_occurrences endpoint
+// isoforms[] (optional) is computed by the caller and passed explicitly rather than set on q
+async function querySamplesTwlstNotForGeneexpclustering_withGenomicFilter(q, dictTwLst, ds, geneTwLst, isoforms) {
+	const param = { size: isoform2ssm_query2_getcase.size, fields: buildSsmOccurrenceFields(dictTwLst, q).join(',') }
 
 	// it may query with isoform
 	mayMapRefseq2ensembl(q, ds)
 
-	Object.assign(param, isoform2ssm_query2_getcase.filters(q, ds))
+	// spread isoforms onto a shallow copy so the shared q is never mutated
+	Object.assign(param, isoform2ssm_query2_getcase.filters(isoforms ? { ...q, isoforms } : q, ds))
 
 	const { host, headers } = ds.getHostHeaders(q) // will be reused below
 
@@ -1742,8 +1750,6 @@ async function querySamplesTwlstNotForGeneexpclustering_withGenomicFilter(q, dic
 		body: param,
 		signal: q.__abortSignal
 	})
-
-	delete q.isoforms
 
 	if (!Array.isArray(re?.data?.hits)) throw 'variant2samples re.data.hits is not array for query'
 
@@ -1792,13 +1798,13 @@ async function querySamplesTwlstNotForGeneexpclustering_withGenomicFilter(q, dic
 			url link will be just by sample_id and no need to generate separate property for it
 			*/
 			sample.sample_id = s.case.case_id
-			if (!sample.sample_id) throw 'querySamples_gdcapi: case.case_id missing'
+			if (!sample.sample_id) throw 'gdc ssm_occurrences query: case.case_id missing'
 		} else {
 			/* identify sample as sample submitter id
 			sample url link is complex and must be specifically generated
 			*/
 			const aliquot_id = s.case?.observation?.[0]?.sample?.tumor_sample_uuid
-			if (!aliquot_id) throw 'querySamples_gdcapi: aliquot_id missing'
+			if (!aliquot_id) throw 'gdc ssm_occurrences query: aliquot_id missing'
 			sample.sample_id = await ds.__gdc.aliquot2submitter.get(aliquot_id)
 			// append aliquot_id to case url so when opening the page, the sample is auto highlighted from the tree
 			// per uat feedback by bill 1/6/2023

--- a/server/src/routes/termdb.cluster.ts
+++ b/server/src/routes/termdb.cluster.ts
@@ -19,7 +19,7 @@ import serverconfig from '#src/serverconfig.js'
 import { gdc_validate_query_geneExpression } from '#src/mds3.gdc.js'
 import { mayLimitSamples } from '#src/mds3.filter.js'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
-import { getData } from '#src/termdb.matrix.js'
+import { getData, id2sampleRef } from '#src/termdb.matrix.js'
 import {
 	GENE_EXPRESSION,
 	termType2label,
@@ -390,20 +390,12 @@ async function validateNative(q: GeneExpressionQuery, ds: any) {
 		const samples = q.samples || []
 		if (limitSamples) {
 			for (const sid of limitSamples) {
-				if (ds.cohort?.termdb?.q?.id2sampleRefs) {
-					bySampleId[sid] = ds.cohort.termdb.q.id2sampleRefs(sid)
-				} else {
-					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
-				}
+				bySampleId[sid] = id2sampleRef(sid, ds)
 			}
 		} else {
 			// Use all samples with exp data
 			for (const sid of samples) {
-				if (ds.cohort?.termdb?.q?.id2sampleRefs) {
-					bySampleId[sid] = ds.cohort.termdb.q.id2sampleRefs(sid)
-				} else {
-					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
-				}
+				bySampleId[sid] = id2sampleRef(sid, ds)
 			}
 		}
 
@@ -527,19 +519,11 @@ async function validateNativeIsoform(q: IsoformExpressionQuery, ds: any) {
 		const samples = q.samples || []
 		if (limitSamples) {
 			for (const sid of limitSamples) {
-				if (ds.cohort?.termdb?.q?.id2sampleRefs) {
-					bySampleId[sid] = ds.cohort.termdb.q.id2sampleRefs(sid)
-				} else {
-					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
-				}
+				bySampleId[sid] = id2sampleRef(sid, ds)
 			}
 		} else {
 			for (const sid of samples) {
-				if (ds.cohort?.termdb?.q?.id2sampleRefs) {
-					bySampleId[sid] = ds.cohort.termdb.q.id2sampleRefs(sid)
-				} else {
-					bySampleId[sid] = { label: ds.cohort.termdb.q.id2sampleName(sid) }
-				}
+				bySampleId[sid] = id2sampleRef(sid, ds)
 			}
 		}
 

--- a/server/src/routes/termdb.cluster.ts
+++ b/server/src/routes/termdb.cluster.ts
@@ -390,12 +390,14 @@ async function validateNative(q: GeneExpressionQuery, ds: any) {
 		const samples = q.samples || []
 		if (limitSamples) {
 			for (const sid of limitSamples) {
-				bySampleId[sid] = id2sampleRef(sid, ds)
+				const ref = id2sampleRef(sid, ds)
+				if (ref) bySampleId[sid] = ref
 			}
 		} else {
 			// Use all samples with exp data
 			for (const sid of samples) {
-				bySampleId[sid] = id2sampleRef(sid, ds)
+				const ref = id2sampleRef(sid, ds)
+				if (ref) bySampleId[sid] = ref
 			}
 		}
 
@@ -519,11 +521,13 @@ async function validateNativeIsoform(q: IsoformExpressionQuery, ds: any) {
 		const samples = q.samples || []
 		if (limitSamples) {
 			for (const sid of limitSamples) {
-				bySampleId[sid] = id2sampleRef(sid, ds)
+				const ref = id2sampleRef(sid, ds)
+				if (ref) bySampleId[sid] = ref
 			}
 		} else {
 			for (const sid of samples) {
-				bySampleId[sid] = id2sampleRef(sid, ds)
+				const ref = id2sampleRef(sid, ds)
+				if (ref) bySampleId[sid] = ref
 			}
 		}
 

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import { string2pos } from '#shared/common.js'
-import { get_samples, get_term_cte, interpolateSqlValues, get_active_groupset } from './termdb.sql.js'
+import { get_samples, get_term_cte, get_active_groupset } from './termdb.sql.js'
 import { getFilterCTEs } from './termdb.filter.js'
 import serverconfig from './serverconfig.js'
 import { read_file, trackXfetch } from './utils.js'
@@ -27,6 +27,17 @@ import { trigger_getDefaultBins } from './termdb.getDefaultBins.js'
 import { getCategories } from './routes/termdb.categories.ts'
 import { authApi } from '#src/auth.js'
 import { expandCustomTermCollection, reconstituteCustomTermCollection } from './termdb.termCollection.ts'
+
+/* centralized resolution of a sample id -> display refs ({ label, ... }) for refs.bySampleId{}.
+each dataset implements ds.cohort.termdb.q.id2sampleRefs() (native/gdc/mmrf); it owns any id
+coercion since id spaces differ (integer for native/mmrf, case-uuid string for gdc).
+the id2sampleName branch is a thin fallback for datasets not yet exposing id2sampleRefs. */
+export function id2sampleRef(id, ds) {
+	const q = ds?.cohort?.termdb?.q
+	if (q?.id2sampleRefs) return q.id2sampleRefs(id)
+	if (q?.id2sampleName) return { label: q.id2sampleName(Number(id)) }
+	return undefined
+}
 
 /*
 for a list of termwrappers, get the sample annotation data to these terms, by obeying categorization method defined in tw.q{}
@@ -386,26 +397,11 @@ async function getSampleData(q, ds) {
 		}
 	}
 
-	/* for samples collected into samples{}, register them in refs.bySampleId{} with display name
-	- for native dataset, samples{} key is integer id, record string name in bySampleId for display
-	- for gdc dataset, samples{} key is case uuid, record case submitter id in bySampleId for display
-
-	note:
-	- this gets rid of awkward properties e.g. "__sampleName", used to attach alternative sample name in mds3 mutation data points, and centralize such logic here
-	- it leaks (minimum amount of) gdc-specific setting in general code 
-	- future data sources need to be handled here
-	- subject to change!
-	*/
+	// resolve each id -> display refs via the dataset's id2sampleRefs() (see id2sampleRef())
 	const bySampleId = {}
 	for (const sid in samples) {
-		const sampleId = samples[sid]?.sampleId
-		if (q.ds.cohort?.termdb?.q?.id2sampleRefs) {
-			bySampleId[sid] = q.ds.cohort.termdb.q.id2sampleRefs(Number(sampleId ?? sid))
-		} else if (q.ds.cohort?.termdb?.q?.id2sampleName) {
-			bySampleId[sid] = { label: q.ds.cohort.termdb.q.id2sampleName(Number(sampleId ?? sid)) }
-		} else if (q.ds.__gdc?.caseid2submitter) {
-			bySampleId[sid] = { label: q.ds.__gdc.caseid2submitter.get(sid) }
-		}
+		const ref = id2sampleRef(samples[sid]?.sampleId ?? sid, q.ds)
+		if (ref) bySampleId[sid] = ref
 	}
 
 	// determine the sample type

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -31,11 +31,13 @@ import { expandCustomTermCollection, reconstituteCustomTermCollection } from './
 /* centralized resolution of a sample id -> display refs ({ label, ... }) for refs.bySampleId{}.
 each dataset implements ds.cohort.termdb.q.id2sampleRefs() (native/gdc/mmrf); it owns any id
 coercion since id spaces differ (integer for native/mmrf, case-uuid string for gdc).
-the id2sampleName branch is a thin fallback for datasets not yet exposing id2sampleRefs. */
+the id2sampleName branch is a thin fallback for datasets not yet exposing id2sampleRefs; it must
+not assume an integer id space, so it tries the raw id first (string ids, e.g. uuids) and only then
+the Number()-coerced id (integer-id datasets whose samples{} key is a stringified integer). */
 export function id2sampleRef(id, ds) {
 	const q = ds?.cohort?.termdb?.q
 	if (q?.id2sampleRefs) return q.id2sampleRefs(id)
-	if (q?.id2sampleName) return { label: q.id2sampleName(Number(id)) }
+	if (q?.id2sampleName) return { label: q.id2sampleName(id) ?? q.id2sampleName(Number(id)) }
 	return undefined
 }
 

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -137,6 +137,9 @@ export function server_init_db_queries(ds) {
 		}
 		q.id2sampleName = id => i2s.get(id)
 		q.sampleName2id = s => s2i.get(s)
+		// centralized sample->display resolution (see termdb.matrix.js id2sampleRef()); wraps id2sampleName.
+		// coerce id here so callers can pass the raw samples{} key (string) or an integer id
+		q.id2sampleRefs = id => ({ label: i2s.get(Number(id)) })
 		if (tables.has('cohort_sample_types')) {
 			const rows = cn.prepare('SELECT * from cohort_sample_types').all()
 			q.getCohortSampleCount = cohortKey => {

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -137,8 +137,10 @@ export function server_init_db_queries(ds) {
 		}
 		q.id2sampleName = id => i2s.get(id)
 		q.sampleName2id = s => s2i.get(s)
-		// centralized sample->display resolution (see termdb.matrix.js id2sampleRef()); wraps id2sampleName.
-		// coerce id here so callers can pass the raw samples{} key (string) or an integer id
+		// centralized id->display resolution (see termdb.matrix.js id2sampleRef()), wrapping id2sampleName.
+		// native sample ids are integer PKs (sampleidmap.id), so Number() only normalizes a stringified
+		// map key and never NaNs a real id; non-integer id spaces (e.g. gdc case uuids) never reach here —
+		// they use their own id2sampleRefs (gdc.buildDictionary.ts) with no coercion.
 		q.id2sampleRefs = id => ({ label: i2s.get(Number(id)) })
 		if (tables.has('cohort_sample_types')) {
 			const rows = cn.prepare('SELECT * from cohort_sample_types').all()

--- a/server/src/test/mds3.gdc.unit.spec.js
+++ b/server/src/test/mds3.gdc.unit.spec.js
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { flattenCaseByFields, parseGdcCnvFile } from '../mds3.gdc.js'
+import { flattenCaseByFields, parseGdcCnvFile, buildSsmOccurrenceFields } from '../mds3.gdc.js'
 import { dtcnv, dtloh } from '#shared/common.js'
 
 tape('\n', function (test) {
@@ -52,6 +52,48 @@ tape('flattenCaseByFields(): multiple diagnoses entries', test => {
 	const sample = {}
 	flattenCaseByFields(sample, hit, tw)
 	test.deepEqual(sample, { 'case.diagnoses.age_at_diagnosis': 20 }, 'should flatten nested case data')
+	test.end()
+})
+
+tape('buildSsmOccurrenceFields(): base fields + branch add-ons', test => {
+	const dictTwLst = [{ term: { id: 'case.disease_type' } }]
+
+	// base: dict term id + the two always-added identity fields, no add-ons
+	test.deepEqual(
+		buildSsmOccurrenceFields(dictTwLst, {}),
+		['case.disease_type', 'case.observation.sample.tumor_sample_uuid', 'case.case_id'],
+		'base returns dict term id + always-added case identity fields'
+	)
+
+	// age/primary_diagnosis pulls in diagnosis_is_primary_disease
+	test.ok(
+		buildSsmOccurrenceFields([{ term: { id: 'case.diagnoses.age_at_diagnosis' } }], {}).includes(
+			'case.diagnoses.diagnosis_is_primary_disease'
+		),
+		'age_at_diagnosis adds diagnosis_is_primary_disease'
+	)
+
+	// q.get=='samples' alone does NOT add ssm/read-depth fields; needs ssm_id_lst or isoform too
+	test.notOk(
+		buildSsmOccurrenceFields(dictTwLst, { get: 'samples' }).includes('ssm.ssm_id'),
+		"get=='samples' without ssm_id_lst/isoform does not add ssm.ssm_id"
+	)
+	test.ok(
+		buildSsmOccurrenceFields(dictTwLst, { get: 'samples', isoform: 'ENST1' }).includes(
+			'case.observation.read_depth.t_depth'
+		),
+		"get=='samples' + isoform adds read depth fields"
+	)
+
+	// hiddenmclass adds consequence fields; rglst adds position fields
+	const withMclass = buildSsmOccurrenceFields(dictTwLst, { hiddenmclass: new Set(['M']) })
+	test.ok(withMclass.includes('ssm.consequence.transcript.consequence_type'), 'hiddenmclass adds consequence fields')
+	test.ok(buildSsmOccurrenceFields(dictTwLst, { rglst: [{}] }).includes('ssm.chromosome'), 'rglst adds ssm.chromosome')
+
+	// duplicate dict term ids are deduped (Set-based)
+	const dupes = buildSsmOccurrenceFields([{ term: { id: 'case.case_id' } }], {})
+	test.equal(dupes.filter(f => f == 'case.case_id').length, 1, 'duplicate fields are deduped')
+
 	test.end()
 })
 

--- a/server/src/test/termdb.matrix.unit.spec.js
+++ b/server/src/test/termdb.matrix.unit.spec.js
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { divideTerms } from '../termdb.matrix.js'
+import { divideTerms, id2sampleRef } from '../termdb.matrix.js'
 import { init } from './load.testds.js'
 import { server_init_db_queries } from '../termdb.server.init.ts'
 
@@ -14,6 +14,24 @@ divideTerms: shorthand dict terms (no type, just id) are also gated by isTermVis
 divideTerms: q.__protected__ is forwarded to the isTermVisible hook
 divideTerms: termCollection visibility decided by member terms (term.termlst)
 */
+
+tape('id2sampleRef(): prefers id2sampleRefs, falls back to id2sampleName, coerces id', test => {
+	// dataset exposing id2sampleRefs -> its object is returned as-is (raw id passed through)
+	const dsRefs = { cohort: { termdb: { q: { id2sampleRefs: id => ({ label: 'R' + id, extra: 1 }) } } } }
+	test.deepEqual(id2sampleRef('abc', dsRefs), { label: 'Rabc', extra: 1 }, 'id2sampleRefs wins and gets the raw id')
+
+	// dataset with only id2sampleName -> wrapped in { label }, id coerced to Number
+	const seen = []
+	const dsName = { cohort: { termdb: { q: { id2sampleName: id => (seen.push(id), 'name' + id) } } } }
+	test.deepEqual(id2sampleRef('7', dsName), { label: 'name7' }, 'id2sampleName fallback wrapped in { label }')
+	test.equal(seen[0], 7, 'string id is coerced to Number for id2sampleName')
+
+	// neither method -> undefined (caller skips assignment)
+	test.equal(id2sampleRef('x', { cohort: { termdb: { q: {} } } }), undefined, 'no method -> undefined')
+	test.equal(id2sampleRef('x', {}), undefined, 'missing termdb.q -> undefined, no throw')
+
+	test.end()
+})
 
 tape('\n', function (test) {
 	test.comment('-***- modules/termdb.matrix specs -***-')

--- a/server/src/test/termdb.matrix.unit.spec.js
+++ b/server/src/test/termdb.matrix.unit.spec.js
@@ -15,16 +15,24 @@ divideTerms: q.__protected__ is forwarded to the isTermVisible hook
 divideTerms: termCollection visibility decided by member terms (term.termlst)
 */
 
-tape('id2sampleRef(): prefers id2sampleRefs, falls back to id2sampleName, coerces id', test => {
+tape('id2sampleRef(): prefers id2sampleRefs, else id2sampleName raw-then-Number, no NaN on string ids', test => {
 	// dataset exposing id2sampleRefs -> its object is returned as-is (raw id passed through)
 	const dsRefs = { cohort: { termdb: { q: { id2sampleRefs: id => ({ label: 'R' + id, extra: 1 }) } } } }
 	test.deepEqual(id2sampleRef('abc', dsRefs), { label: 'Rabc', extra: 1 }, 'id2sampleRefs wins and gets the raw id')
 
-	// dataset with only id2sampleName -> wrapped in { label }, id coerced to Number
-	const seen = []
-	const dsName = { cohort: { termdb: { q: { id2sampleName: id => (seen.push(id), 'name' + id) } } } }
-	test.deepEqual(id2sampleRef('7', dsName), { label: 'name7' }, 'id2sampleName fallback wrapped in { label }')
-	test.equal(seen[0], 7, 'string id is coerced to Number for id2sampleName')
+	// integer-keyed id2sampleName (native-like): a stringified samples{} key resolves via the Number() fallthrough
+	const ints = new Map([[7, 'seven']])
+	const dsInt = { cohort: { termdb: { q: { id2sampleName: id => ints.get(id) } } } }
+	test.deepEqual(
+		id2sampleRef('7', dsInt),
+		{ label: 'seven' },
+		'integer-keyed id2sampleName resolves stringified key via Number()'
+	)
+
+	// string-keyed id2sampleName (uuid): raw lookup works, never coerced to NaN (regression guard for the review)
+	const strs = new Map([['case-uuid', 'CASE-1']])
+	const dsStr = { cohort: { termdb: { q: { id2sampleName: id => strs.get(id) } } } }
+	test.deepEqual(id2sampleRef('case-uuid', dsStr), { label: 'CASE-1' }, 'non-numeric string id resolves raw, not NaN')
 
 	// neither method -> undefined (caller skips assignment)
 	test.equal(id2sampleRef('x', { cohort: { termdb: { q: {} } } }), undefined, 'no method -> undefined')


### PR DESCRIPTION
# Description
This branch does two GDC-focused cleanups, each behavior-preserving:

1. Untangles `querySamples_gdcapi()` (per review): `getData` gets its own named `queryDictTermData_gdcapi` entry so it no longer routes through the `variant2samples` mutation function; removes the shared-object `q.isoforms` mutation; extracts a pure, unit-tested fields builder.
2. Centralizes sample-identity resolution on ds.cohort.termdb.q.id2sampleRefs(), deleting the __gdc leak from termdb.matrix.js/termdb.cluster.ts. 

Verified offline: server tsc clean; mds3.gdc 19/19 and termdb.matrix 25/25 unit specs pass.
Still needs before merge: live GDC integration (oncomatrix, lollipop sample table, gene-exp clustering, survival, CNV tool) — the query/label paths have no offline coverage; confirm refs.bySampleId labels are unchanged for native/GDC/mmrf.

Deferred (follow-ups): case-level (sampleType) configurability; convergence of the GDC↔mmrf dictionary.get pipelines; collapsing the id2sampleName fallback once all datasets are confirmed migrated.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
