### PR TITLE
Centralize supportedChartTypes into setSupportedChartTypes(); add allowlist mode

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,6 @@
+Features:
+- Centralize supported chart-type setup into a dataset-agnostic setSupportedChartTypes() step, extracted out of server_init_db_queries() and run from mds3.init.js validate_termdb() so every dataset — including non-sqlite ones (GDC, MMRF) — flows through the shared ds.isSupportedChartOverride{} mechanism
+- Add allowlist mode via the new Mds3 supportedChartsFromOverrideOnly flag: curated datasets opt out of the shared defaultCommonCharts and declare their complete chart list through isSupportedChartOverride{}
 
+General:
+- the GDC and MMRF datasets (ppgdc, ppmmrf) now declare their chart lists via isSupportedChartOverride{} and rely on this centralized step; their deployed images must be updated together with this server release

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -5,7 +5,7 @@ import * as utils from './utils.js'
 import { checkDependenciesAndVersions } from './checkDependenciesAndVersions.js'
 import { initLegacyDataset } from './initLegacyDataset.js'
 import serverconfig from './serverconfig.js'
-import { server_init_db_queries, listDbTables } from './termdb.server.init.ts'
+import { server_init_db_queries, setSupportedChartTypes, listDbTables } from './termdb.server.init.ts'
 import { mds_init } from './mds.init.js'
 import * as mds3_init from './mds3.init.js'
 import { parse_textfilewithheader } from './parse_textfilewithheader.js'
@@ -315,6 +315,7 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 				if (g.termdbs[key].cohort?.termdb?.isGeneSetTermdb != true)
 					throw 'genome-level geneset db lacks flag of cohort.termdb.isGeneSetTermdb=true' // this flag is part of termdbconfig and used by tree app
 				server_init_db_queries(g.termdbs[key])
+				setSupportedChartTypes(g.termdbs[key]) // preserve prior behavior (has db.connection, no override → default)
 				if (!Array.isArray(g.termdbs[key].analysisGenesetGroups)) throw '.analysisGenesetGroups[] not array'
 				if (g.termdbs[key].analysisGenesetGroups.length == 0) throw '.analysisGenesetGroups[] blank'
 				for (const a of g.termdbs[key].analysisGenesetGroups) {

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -30,7 +30,7 @@ import {
 	getColors
 } from '#shared/common.js'
 import { get_samples, get_active_groupset } from './termdb.sql.js'
-import { server_init_db_queries } from './termdb.server.init.ts'
+import { server_init_db_queries, setSupportedChartTypes } from './termdb.server.init.ts'
 import { barchart_data } from './termdb.barchart.js'
 import { mayInitiateScatterplots } from '#routes/termdb.sampleScatter.ts'
 import { mayInitiateMatrixplots, mayInitiateNumericDictionaryTermplots } from './termdb.matrix.js'
@@ -311,6 +311,7 @@ export async function validate_termdb(ds) {
 		throw 'unknown method to initiate dictionary'
 	}
 	// ds.cohort.termdb.q={} ready
+	setSupportedChartTypes(ds) // centralized: runs for every dataset regardless of the init path above
 
 	// blocking launch-time case-sample caching, for datasets whose preInit.cacheSamples must
 	// run before queries (e.g. mmrf: it sets q.id2sampleName/convertSampleId, needed by the

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -510,43 +510,6 @@ export function server_init_db_queries(ds) {
 		}
 	}
 
-	/* 
-		generates commonCharts with optional overrides to ensure that ds-specific overrides are not shared across different datasets
-		this is used by getSupportedChartTypes()
-		scope commonCharts inside the init function; also compute it once on server startup and no need to repeat it in getSupportedChartTypes()
-	*/
-	const commonCharts = Object.assign(
-		{},
-		defaultCommonCharts,
-		(ds.isSupportedChartOverride as isSupportedChartCallbacks) || {}
-	)
-
-	mayComputeTermtypeByCohort(ds) // ds.cohort.termdb.termtypeByCohort[] is set. needed by getSupportedChartTypes()
-
-	/*
-	compute and return list of chart types based on term types from each subcohort, and non-dictionary query data
-	for showing as chart buttons in mass ui
-	*/
-	q.getSupportedChartTypes = req => {
-		// based on request, derive forbiddenRoutes and clientAuthResult that ds can use to tailor chart support
-		const info = authApi.getNonsensitiveInfo(req)
-		// must do the check so as not to fail tsc compiler check (auth.js is not ts)
-		const authInfo = typeof info == 'object' ? info : { forbiddenRoutes: [] }
-		const supportedChartTypes = {} // key: subcohort string, value: list of chart types allowed for this cohort
-
-		for (const [cohort, cohortTermTypes] of Object.entries(ds.cohort.termdb.termtypeByCohort.nested)) {
-			supportedChartTypes[cohort] = []
-
-			for (const [chartType, isSupported] of Object.entries(commonCharts)) {
-				if (isSupported({ ds, cohortTermTypes, cohort, ...authInfo })) {
-					// this chart type is supported based on context
-					supportedChartTypes[cohort].push(chartType)
-				}
-			}
-		}
-		return supportedChartTypes
-	}
-
 	q.getSingleSampleData = async function (q, ds) {
 		const { sampleId, term_ids } = q
 		if (!sampleId) throw new Error('sampleId is missing for q.getSingleSampleData() request.')
@@ -602,12 +565,68 @@ export function server_init_db_queries(ds) {
 	}
 
 	q.getProfileFacilities = function () {
-		const query = `select name from sampleidmap join 
+		const query = `select name from sampleidmap join
 		anno_categorical on sampleidmap.id = anno_categorical.sample
 		where term_id = 'sampleType' and value = 'Facility'`
 		const sql = cn.prepare(query)
 		const rows = sql.all()
 		return rows
+	}
+}
+
+/*
+	Centralized (dataset-agnostic) setup of q.getSupportedChartTypes, run once per dataset as a later
+	init step (mds3.init.js validate_termdb) regardless of how the dataset built its q{} — so every ds,
+	including non-sqlite ones (gdc/mmrf), can customize chart support via ds.isSupportedChartOverride{}.
+
+	Extracted out of server_init_db_queries() so it no longer depends on sqlite db setup.
+
+	Guards keep this a no-op for datasets that don't need it:
+	- a ds that supplies its own getSupportedChartTypes (gdc/mmrf/etc.) is left untouched
+	- a ds with no way to compute term types (no preset termtypeByCohort and no db connection) is skipped,
+	  same as before (only sqlite datasets got a getSupportedChartTypes previously)
+*/
+export function setSupportedChartTypes(ds) {
+	const tdb = ds.cohort?.termdb
+	if (!tdb?.q) return // no query object to attach to
+	if (tdb.q.getSupportedChartTypes) return // ds supplied its own; don't clobber
+	if (!tdb.termtypeByCohort && !ds.cohort.db?.connection) return // can't compute term types; leave unset
+
+	/*
+		generates commonCharts with optional overrides to ensure that ds-specific overrides are not shared across different datasets
+		this is used by getSupportedChartTypes()
+		scope commonCharts inside this function; also compute it once on server startup and no need to repeat it in getSupportedChartTypes()
+	*/
+	const commonCharts = Object.assign(
+		{},
+		defaultCommonCharts,
+		(ds.isSupportedChartOverride as isSupportedChartCallbacks) || {}
+	)
+
+	mayComputeTermtypeByCohort(ds) // ds.cohort.termdb.termtypeByCohort[] is set. needed by getSupportedChartTypes()
+
+	/*
+	compute and return list of chart types based on term types from each subcohort, and non-dictionary query data
+	for showing as chart buttons in mass ui
+	*/
+	tdb.q.getSupportedChartTypes = req => {
+		// based on request, derive forbiddenRoutes and clientAuthResult that ds can use to tailor chart support
+		const info = authApi.getNonsensitiveInfo(req)
+		// must do the check so as not to fail tsc compiler check (auth.js is not ts)
+		const authInfo = typeof info == 'object' ? info : { forbiddenRoutes: [] }
+		const supportedChartTypes = {} // key: subcohort string, value: list of chart types allowed for this cohort
+
+		for (const [cohort, cohortTermTypes] of Object.entries(ds.cohort.termdb.termtypeByCohort.nested)) {
+			supportedChartTypes[cohort] = []
+
+			for (const [chartType, isSupported] of Object.entries(commonCharts)) {
+				if (isSupported({ ds, cohortTermTypes, cohort, ...authInfo })) {
+					// this chart type is supported based on context
+					supportedChartTypes[cohort].push(chartType)
+				}
+			}
+		}
+		return supportedChartTypes
 	}
 }
 

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -596,12 +596,12 @@ export function setSupportedChartTypes(ds) {
 		generates commonCharts with optional overrides to ensure that ds-specific overrides are not shared across different datasets
 		this is used by getSupportedChartTypes()
 		scope commonCharts inside this function; also compute it once on server startup and no need to repeat it in getSupportedChartTypes()
+
+		a curated dataset (e.g. gdc/mmrf) can set supportedChartsFromOverrideOnly=true to opt out of the
+		shared defaults entirely, so its isSupportedChartOverride{} is the complete allowlist of chart types
 	*/
-	const commonCharts = Object.assign(
-		{},
-		defaultCommonCharts,
-		(ds.isSupportedChartOverride as isSupportedChartCallbacks) || {}
-	)
+	const base = ds.supportedChartsFromOverrideOnly ? {} : defaultCommonCharts
+	const commonCharts = Object.assign({}, base, (ds.isSupportedChartOverride as isSupportedChartCallbacks) || {})
 
 	mayComputeTermtypeByCohort(ds) // ds.cohort.termdb.termtypeByCohort[] is set. needed by getSupportedChartTypes()
 

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -2379,6 +2379,11 @@ export type Mds3 = BaseMds & {
 	queries?: Mds3Queries
 	cohort?: Cohort
 	isSupportedChartOverride?: isSupportedChartCallbacks
+	/** when true, isSupportedChartOverride is the COMPLETE allowlist of supported chart types:
+	the shared defaultCommonCharts are NOT inherited, only the chart types declared in
+	isSupportedChartOverride are considered. for curated datasets (e.g. gdc, mmrf) whose chart
+	list does not derive from the common defaults. see setSupportedChartTypes() in termdb.server.init.ts */
+	supportedChartsFromOverrideOnly?: boolean
 	// TODO FIXME nest termdb under cohort
 	termdb?: Termdb
 	/** if ds uses filter0, ds must supply this method


### PR DESCRIPTION
## Context
Per the Edgar/Xin thread: a dataset should not *fully* override `q.getSupportedChartTypes()`
— it should go through the shared `ds.isSupportedChartOverride{}` mechanism. But that setup
lived inside `server_init_db_queries()`, which only runs for SQLite-backed datasets. Non-SQLite
datasets (GDC, MMRF) take the `termdb.dictionary.build` branch and never reached it, so their
declared overrides were dead code and each hand-rolled its own `getSupportedChartTypes`.

This PR pulls that step out of `server_init_db_queries()` and runs it as a later, dataset-agnostic
init step so **every** dataset flows through one place — enabling the dataset-side migrations in the
companion sjpp PR.

## Changes
- **`termdb.server.init.ts`** — extract the `getSupportedChartTypes` setup (commonCharts merge +
  `mayComputeTermtypeByCohort` + the getter) out of `server_init_db_queries()` into a new exported
  `setSupportedChartTypes(ds)`. Guards make it a no-op for datasets that supply their own getter or
  can't compute term types.
- **`mds3.init.js`** — call `setSupportedChartTypes(ds)` centrally in `validate_termdb()`, right
  after `ds.cohort.termdb.q` is finalized, so it runs for every init path (sqlite / dictionary.build / direct q).
- **`initGenomesDs.js`** — call it for genome-level geneset termdbs too (preserves prior behavior).
- **`shared/types/src/dataset.ts`** — add `supportedChartsFromOverrideOnly?: boolean` to `Mds3`.
  When set, `setSupportedChartTypes` starts the merge from `{}` instead of `defaultCommonCharts`, so
  `isSupportedChartOverride` becomes the **complete allowlist** — the right fit for curated datasets
  (GDC/MMRF) whose chart lists don't derive from the shared defaults.

## Behavior
No-op for all existing datasets. SQLite datasets get an identical list (built a few lines later in
the same init pass); datasets that supply their own getter are untouched by the guard.

## Testing
- `tsc` clean.
- `npm run test:unit` — 1563/1563 pass.
- Targeted self-checks: override merge (add + hide) works; allowlist mode emits exactly the declared
  charts in order; the guard preserves ds-supplied getters and skips when term types can't be computed.

## Merge order
Merge this before the sjpp dataset PR, which depends on the `supportedChartsFromOverrideOnly` field
and the centralized function.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
