### PR TITLE
Use `mapParent2Children` in top variably expressed genes route and clustering route

### DIFF
--- a/server/src/routes/termdb.cluster.ts
+++ b/server/src/routes/termdb.cluster.ts
@@ -18,7 +18,7 @@ import { getH5samples } from '../utils/h5samples.ts'
 import serverconfig from '#src/serverconfig.js'
 import { mayLimitSamples } from '#src/mds3.filter.js'
 import { clusterMethodLst, distanceMethodLst } from '#shared/clustering.js'
-import { getData, id2sampleRef } from '#src/termdb.matrix.js'
+import { getData, id2sampleRef, maySetMapParent2Children } from '#src/termdb.matrix.js'
 import {
 	GENE_EXPRESSION,
 	termType2label,
@@ -86,6 +86,7 @@ export function init({ genomes }) {
 				if (tw?.q?.mode && tw.q.mode != 'continuous')
 					throw `clustering requires terms in continuous mode, but '${ttype}' term has q.mode='${tw.q.mode}'`
 			}
+			maySetMapParent2Children(q, ds)
 			result = (await getResult(q, ds)) as TermdbClusterResponse
 		} catch (e: any) {
 			if (e.stack) console.log(e.stack)

--- a/server/src/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/src/routes/termdb.topVariablyExpressedGenes.ts
@@ -97,7 +97,9 @@ function topVeKeyInputs(q: TermdbTopVariablyExpressedGenesRequest) {
 			typeof q.filter_extreme_values === 'number' ? Boolean(q.filter_extreme_values) : !!q.filter_extreme_values,
 		rank_type: q.rank_type?.type ?? 'var',
 		filter: (q as any).filter ?? null,
-		filter0: (q as any).filter0 ?? null
+		filter0: (q as any).filter0 ?? null,
+		mapParent2Children: q.mapParent2Children,
+		sampleType: q.sampleType
 	}
 }
 

--- a/server/src/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/src/routes/termdb.topVariablyExpressedGenes.ts
@@ -116,6 +116,7 @@ async function resolveNativeSamples(q: TermdbTopVariablyExpressedGenesRequest, g
 		if (!n) throw 'sample id cannot convert to string name'
 		samples.push(n)
 	}
+	mayLog('topVE', samples.length, 'samples')
 	return samples
 }
 

--- a/server/src/routes/termdb.topVariablyExpressedGenes.ts
+++ b/server/src/routes/termdb.topVariablyExpressedGenes.ts
@@ -10,6 +10,7 @@ import { mayLog } from '#src/helpers.ts'
 import { formatElapsedTime } from '#shared'
 import { cacheOrRecompute } from '#src/utils/cacheOrRecompute.ts'
 import type { TopVeCacheResult } from '../../routes/types.ts'
+import { maySetMapParent2Children } from '#src/termdb.matrix.js'
 
 export const payload: RoutePayload = {
 	init,
@@ -36,6 +37,10 @@ function init({ genomes }) {
 			if (!ds) throw 'invalid dslabel'
 			if (!ds.queries?.topVariablyExpressedGenes) throw 'not supported on dataset'
 			q.ds = ds // helps ds getter
+
+			// map parent term annotations to child samples, since assuming
+			// gene expression data is at sample-level
+			maySetMapParent2Children(q, ds, true)
 
 			const t = Date.now()
 			result = {
@@ -98,7 +103,11 @@ function topVeKeyInputs(q: TermdbTopVariablyExpressedGenesRequest) {
 
 async function resolveNativeSamples(q: TermdbTopVariablyExpressedGenesRequest, gE: any, ds: any): Promise<string[]> {
 	const samples: string[] = []
-	const limitSamples = await mayLimitSamples({ filter: q.filter, filter0: q.filter0 }, gE.samples, ds)
+	const limitSamples = await mayLimitSamples(
+		{ filter: q.filter, filter0: q.filter0, mapParent2Children: q.mapParent2Children, sampleType: q.sampleType },
+		gE.samples,
+		ds
+	)
 	const sourceIds = limitSamples ?? gE.samples
 	for (const sid of sourceIds) {
 		const n: string = ds.cohort.termdb.q.id2sampleName(sid)

--- a/shared/types/src/routes/termdb.topVariablyExpressedGenes.ts
+++ b/shared/types/src/routes/termdb.topVariablyExpressedGenes.ts
@@ -33,6 +33,10 @@ export type TermdbTopVariablyExpressedGenesRequest = {
 	filter0?: any //GdcFilter0
 	/** helps ds getter */
 	ds?: any
+	/** whether to map parent annotations onto child samples */
+	mapParent2Children?: boolean
+	/** query sample type */
+	sampleType?: number
 }
 
 type ValidResponse = {


### PR DESCRIPTION
# Description

Fixes issue when filter0 is specified in gene expression clustering for mmrf.

Can test as follows:
- http://localhost:3000/example.mmrf.exp.html (no filter0) -> submit -> clustering works on master
- http://localhost:3000/example.mmrf.exp.html?cohort=female (filter0 specified) -> submit -> no data on master

Now that the `mapParent2Children` flag is passed, case-level annotations can be mapped to samples and used for clustering analysis.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
