### PR TITLE
replace 'supportedChartsFromOverrideOnly' dataset option 

### DIFF
--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -600,7 +600,7 @@ export function setSupportedChartTypes(ds) {
 		a curated dataset (e.g. gdc/mmrf) can set supportedChartsFromOverrideOnly=true to opt out of the
 		shared defaults entirely, so its isSupportedChartOverride{} is the complete allowlist of chart types
 	*/
-	const base = ds.supportedChartsFromOverrideOnly ? {} : defaultCommonCharts
+	const base = ds.commonCharts || defaultCommonCharts
 	const commonCharts = Object.assign({}, base, (ds.isSupportedChartOverride as isSupportedChartCallbacks) || {})
 
 	mayComputeTermtypeByCohort(ds) // ds.cohort.termdb.termtypeByCohort[] is set. needed by getSupportedChartTypes()
@@ -620,6 +620,12 @@ export function setSupportedChartTypes(ds) {
 			supportedChartTypes[cohort] = []
 
 			for (const [chartType, isSupported] of Object.entries(commonCharts)) {
+				if (typeof isSupported === 'boolean') {
+					// chart support is known in advance, does not require context info about data availability or auth
+					if (isSupported === true) supportedChartTypes[cohort].push(chartType)
+					continue
+				}
+
 				if (isSupported({ ds, cohortTermTypes, cohort, ...authInfo })) {
 					// this chart type is supported based on context
 					supportedChartTypes[cohort].push(chartType)

--- a/server/src/termdb.server.init.ts
+++ b/server/src/termdb.server.init.ts
@@ -597,11 +597,15 @@ export function setSupportedChartTypes(ds) {
 		this is used by getSupportedChartTypes()
 		scope commonCharts inside this function; also compute it once on server startup and no need to repeat it in getSupportedChartTypes()
 
-		a curated dataset (e.g. gdc/mmrf) can set supportedChartsFromOverrideOnly=true to opt out of the
-		shared defaults entirely, so its isSupportedChartOverride{} is the complete allowlist of chart types
+		a curated dataset (e.g. gdc/mmrf) can set commonCharts={} to opt out of the
+ 		shared defaults entirely, so its isSupportedChartOverride{} becomes the complete allowlist of chart types
 	*/
 	const base = ds.commonCharts || defaultCommonCharts
-	const commonCharts = Object.assign({}, base, (ds.isSupportedChartOverride as isSupportedChartCallbacks) || {})
+	const commonCharts: isSupportedChartCallbacks = Object.assign(
+		{},
+		base,
+		(ds.isSupportedChartOverride as isSupportedChartCallbacks) || {}
+	)
 
 	mayComputeTermtypeByCohort(ds) // ds.cohort.termdb.termtypeByCohort[] is set. needed by getSupportedChartTypes()
 

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -2336,7 +2336,7 @@ export type PreInit = {
 /** see details in termdb.server.init.ts
  */
 export type isSupportedChartCallbacks = {
-	[chartType: string]: (f: any) => boolean | undefined
+	[chartType: string]: boolean | ((f: any) => boolean | undefined)
 }
 
 export type Mds3 = BaseMds & {
@@ -2378,12 +2378,12 @@ export type Mds3 = BaseMds & {
 	dsinfo?: KeyVal[]
 	queries?: Mds3Queries
 	cohort?: Cohort
+	/** this will be used instead of relying on the pp server's default common charts  */
+	commonCharts?: isSupportedChartCallbacks
+	/** this is usually provided when commonCharts is not specified and
+	 * the pp server provides a set of default charts that is mostly based on
+	 * a dataset's available data, assay, and/or auth credentials */
 	isSupportedChartOverride?: isSupportedChartCallbacks
-	/** when true, isSupportedChartOverride is the COMPLETE allowlist of supported chart types:
-	the shared defaultCommonCharts are NOT inherited, only the chart types declared in
-	isSupportedChartOverride are considered. for curated datasets (e.g. gdc, mmrf) whose chart
-	list does not derive from the common defaults. see setSupportedChartTypes() in termdb.server.init.ts */
-	supportedChartsFromOverrideOnly?: boolean
 	// TODO FIXME nest termdb under cohort
 	termdb?: Termdb
 	/** if ds uses filter0, ds must supply this method


### PR DESCRIPTION
# Description

... with `commonCharts` option

Simplify common charts option and overrides, to make the logic easier to follow. Test with https://github.com/stjude/sjpp/pull/1442

Test:
- http://localhost:3000/profile/?role=admin should have more charts than `?role=user`, `?role=public` should have least number of chart buttons
- http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22GDC%22} should have same chart buttons as in [prp2](https://proteinpaint.stjude.org/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22GDC%22}) + Cox
- [local SJLife ](http://localhost:3000/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22})chart buttons should be the same as in [survivorship server](https://survivorship.proteinpaint.stjude.org/?noheader=1&mass={%22genome%22:%22hg38%22,%22dslabel%22:%22SJLife%22})

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
