### PR TITLE
custom collection term selected from tree.js can now route to numerat…

### DIFF
--- a/client/termdb/app.ts
+++ b/client/termdb/app.ts
@@ -9,6 +9,7 @@ import { searchInit } from './search'
 import { select } from 'd3-selection'
 import { Menu, sayerror } from '#dom'
 import { dofetch3 } from '#common/dofetch'
+import { mayRenderFractionSelection } from './handlers/termCollectionFractionSelection.ts'
 
 /*
 opts{}
@@ -117,6 +118,11 @@ class TdbApp extends AppBase implements RxApp {
 						term._geneset = geneset
 					}
 
+					// a numeric term collection, such as an adhoc splice junction event listed under
+					// "Custom Variables", must be reduced to a scalar fraction for certain use cases;
+					// prompt for the numerator/denominator before calling back with a fraction tw
+					if (this.mayShowFractionSelection(term, o.tree)) return
+
 					// call the click callback
 					o.tree.click_term(term)
 				}
@@ -155,9 +161,12 @@ class TdbApp extends AppBase implements RxApp {
 		const topbar = opts.holder.append('div')
 		const termTypeSearchDiv = topbar.append('div').style('display', 'inline-block')
 		const treeDiv = topbar.append('div').style('display', 'inline-block').style('vertical-align', 'top')
+		// shown in place of the tree, when a selected term requires additional configuration
+		const fractionDiv = opts.holder.append('div').style('display', 'none')
 
 		return {
 			topbar,
+			fractionDiv,
 			holder: opts.holder,
 			termTypeSearchDiv,
 			searchDiv: treeDiv.append('div'),
@@ -169,6 +178,25 @@ class TdbApp extends AppBase implements RxApp {
 			errdiv: opts.holder.append('div'),
 			tip: new Menu({ padding: '5px' })
 		}
+	}
+
+	/* Render the numerator/denominator chooser for a numeric term collection that was clicked
+	in the tree or dictionary search, matching what the term search handlers do for the same
+	collection types. Returns true when the chooser is shown, in which case the click callback
+	is deferred until the user submits a selection.
+
+	term: the clicked term
+	treeOpts: opts.tree{}, supplies termCollectionSelectionMode and the click_term() callback
+	*/
+	mayShowFractionSelection(term, treeOpts) {
+		return mayRenderFractionSelection({
+			term,
+			selectionMode: treeOpts.termCollectionSelectionMode,
+			// the tree is hidden, not destroyed, so that the user may back out and select another term
+			listDiv: this.dom.topbar,
+			fractionDiv: this.dom.fractionDiv,
+			callback: tw => treeOpts.click_term(tw)
+		})
 	}
 
 	async preApiFreeze(api) {

--- a/client/termdb/handlers/isoformExpression.ts
+++ b/client/termdb/handlers/isoformExpression.ts
@@ -7,6 +7,13 @@ import { getColors } from '#shared/common.js'
 import { makeFractionTermWrapper, renderFractionSelection } from './termCollectionFractionSelection.ts'
 import type { RawTermCollectionTWFraction } from '#types'
 
+/*
+note:
+	the ui allows both single and multi selection
+	even when termCollectionSelectionMode=fraction, the numerator/denominator check columns are not shown up front
+	this is to avoid complicating single term selection
+*/
+
 export class SearchHandler {
 	callback!: (term: IsoformTerm | IsoformCollectionTerm | RawTermCollectionTWFraction) => void
 	app: any

--- a/client/termdb/handlers/junction.ts
+++ b/client/termdb/handlers/junction.ts
@@ -1,5 +1,5 @@
 import { junctionCustomTermSource, type JunctionCustomTerm } from './junction.customTerm.ts'
-import { makeFractionTermWrapper, renderFractionSelection } from './termCollectionFractionSelection.ts'
+import { mayRenderFractionSelection } from './termCollectionFractionSelection.ts'
 
 export class SearchHandler {
 	async init(opts) {
@@ -19,16 +19,17 @@ export function getJunctionCustomTerms(customTerms: any): JunctionCustomTerm[] {
 function render(opts, entries: JunctionCustomTerm[]) {
 	const holder = opts.holder
 	holder.selectAll('*').remove()
+	const div = holder.append('div').style('padding', '10px 0px')
 
 	if (!entries.length) {
-		holder.append('div').text('Junctions selected from genome browser will be shown here.')
+		div.append('div').text('Junctions selected from genome browser will be shown here.')
 		return
 	}
 
 	// the fraction chooser is rendered in a sibling div, so that the list may be
 	// restored without reloading, when the user backs out of the chooser
-	const listDiv = holder.append('div')
-	const fractionDiv = holder.append('div')
+	const listDiv = div.append('div')
+	const fractionDiv = div.append('div')
 
 	for (const entry of entries) {
 		if (entry.eventlabel) renderJunctionEvent(listDiv, fractionDiv, entry, opts)
@@ -80,26 +81,14 @@ function renderJunctionEvent(holder, fractionDiv, entry: JunctionCustomTerm, opt
 }
 
 function selectJunctionEvent(listDiv, fractionDiv, entry: JunctionCustomTerm, opts) {
-	if (opts.termCollectionSelectionMode !== 'fraction') {
-		opts.callback(entry.tw.term)
-		return
-	}
-	fractionDiv.selectAll('*').remove()
-	listDiv.style('display', 'none')
-	fractionDiv
-		.append('div')
-		.append('button')
-		.attr('data-testid', 'sjpp-junction-fraction-back')
-		.text('« Back')
-		.on('click', () => {
-			fractionDiv.selectAll('*').remove()
-			listDiv.style('display', '')
-		})
-	renderFractionSelection({
-		holder: fractionDiv,
-		termlst: entry.tw.term.termlst,
-		callback: selection => opts.callback(makeFractionTermWrapper(entry.tw.term, selection))
+	const isStaged = mayRenderFractionSelection({
+		term: entry.tw.term,
+		selectionMode: opts.termCollectionSelectionMode,
+		listDiv,
+		fractionDiv,
+		callback: tw => opts.callback(tw)
 	})
+	if (!isStaged) opts.callback(entry.tw.term)
 }
 
 function addDeleteButton(holder, entry: JunctionCustomTerm, opts) {

--- a/client/termdb/handlers/termCollectionFractionSelection.ts
+++ b/client/termdb/handlers/termCollectionFractionSelection.ts
@@ -1,4 +1,5 @@
 import { renderTable } from '#dom'
+import { TermTypes } from '#shared/terms.js'
 import type { RawTermCollectionTWFraction } from '#types'
 
 export type TermCollectionSelectionMode = 'fraction'
@@ -83,6 +84,46 @@ export function renderFractionSelection(opts: {
 				return window.alert('Every numerator must also be selected as a denominator.')
 			callback({ numerators, denominators })
 		})
+}
+
+/**
+ * Show the fraction chooser in place of a list of selectable terms, when both the use case
+ * (selectionMode) and the clicked term require reducing a collection to a scalar fraction.
+ * Returns true when the chooser is shown, in which case the caller must not fire its own
+ * selection callback: the callback here is called instead, once the user submits a selection.
+ */
+export function mayRenderFractionSelection(opts: {
+	term: any
+	selectionMode?: TermCollectionSelectionMode
+	/** hidden, not destroyed, while the chooser is shown, so that the user may back out of it */
+	listDiv: any
+	/** holds the chooser, must be a sibling of listDiv */
+	fractionDiv: any
+	callback: (tw: RawTermCollectionTWFraction) => void
+}): boolean {
+	const { term, listDiv, fractionDiv, callback } = opts
+	if (opts.selectionMode !== 'fraction') return false
+	if (term?.type !== TermTypes.TERM_COLLECTION || term.memberType !== 'numeric') return false
+	if (!term.termlst?.length) return false
+
+	fractionDiv.selectAll('*').remove()
+	listDiv.style('display', 'none')
+	fractionDiv.style('display', '')
+	fractionDiv
+		.append('div')
+		.append('button')
+		.attr('data-testid', 'sjpp-term-collection-fraction-back')
+		.text('« Back')
+		.on('click', () => {
+			fractionDiv.style('display', 'none').selectAll('*').remove()
+			listDiv.style('display', '')
+		})
+	renderFractionSelection({
+		holder: fractionDiv,
+		termlst: term.termlst,
+		callback: selection => callback(makeFractionTermWrapper(term, selection))
+	})
+	return true
 }
 
 export function makeFractionTermWrapper(

--- a/client/termdb/handlers/test/termCollectionFractionSelection.unit.spec.ts
+++ b/client/termdb/handlers/test/termCollectionFractionSelection.unit.spec.ts
@@ -1,0 +1,109 @@
+import tape from 'tape'
+import * as d3s from 'd3-selection'
+import { mayRenderFractionSelection } from '../termCollectionFractionSelection.ts'
+
+/*************************
+ reusable helper functions
+**************************/
+
+function getDivs() {
+	const holder = d3s.select('body').append('div')
+	return { holder, listDiv: holder.append('div'), fractionDiv: holder.append('div').style('display', 'none') }
+}
+
+function getCollectionTerm(overrides: any = {}) {
+	return {
+		type: 'termCollection',
+		isCustom: true,
+		memberType: 'numeric',
+		name: 'Splice junction event',
+		termlst: [
+			{ id: 'junction-1', name: 'junction-1' },
+			{ id: 'junction-2', name: 'junction-2' }
+		],
+		...overrides
+	}
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- termdb/handlers/termCollectionFractionSelection -***-')
+	test.end()
+})
+
+tape('mayRenderFractionSelection() renders the chooser for a numeric collection', test => {
+	const { holder, listDiv, fractionDiv } = getDivs()
+	let selected: any
+	const term = getCollectionTerm()
+
+	const isStaged = mayRenderFractionSelection({
+		term,
+		selectionMode: 'fraction',
+		listDiv,
+		fractionDiv,
+		callback: tw => (selected = tw)
+	})
+
+	test.equal(isStaged, true, 'defers the selection to the chooser')
+	test.equal(listDiv.style('display'), 'none', 'hides the term list')
+	test.ok(fractionDiv.text().includes('Denominator'), 'renders the denominator selector')
+	test.ok(fractionDiv.text().includes('Numerator'), 'renders the numerator selector')
+	;(fractionDiv.select('[data-testid="sjpp-term-collection-fraction-select"]').node() as HTMLButtonElement).click()
+	test.equal(selected?.type, 'TermCollectionTWFraction', 'submits a fraction wrapper')
+	test.deepEqual(selected?.q.denominators, ['junction-1', 'junction-2'], 'defaults all members as denominators')
+	test.deepEqual(selected?.q.numerators, ['junction-1'], 'defaults only the first member as numerator')
+	test.equal(selected?.term, term, 'wraps the clicked term as is')
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('mayRenderFractionSelection() back button restores the term list', test => {
+	const { holder, listDiv, fractionDiv } = getDivs()
+	mayRenderFractionSelection({
+		term: getCollectionTerm(),
+		selectionMode: 'fraction',
+		listDiv,
+		fractionDiv,
+		callback: () => {}
+	})
+	;(fractionDiv.select('[data-testid="sjpp-term-collection-fraction-back"]').node() as HTMLButtonElement).click()
+
+	test.notEqual(listDiv.style('display'), 'none', 'shows the term list again')
+	test.equal(fractionDiv.style('display'), 'none', 'hides the chooser')
+	test.equal(fractionDiv.selectAll('*').size(), 0, 'clears the chooser')
+
+	if (test['_ok']) holder.remove()
+	test.end()
+})
+
+tape('mayRenderFractionSelection() skips terms that do not require a fraction', test => {
+	const cases = [
+		{ label: 'no fraction selection mode', selectionMode: undefined, term: getCollectionTerm() },
+		{
+			label: 'categorical collection',
+			selectionMode: 'fraction',
+			term: getCollectionTerm({ memberType: 'categorical' })
+		},
+		{ label: 'collection without members', selectionMode: 'fraction', term: getCollectionTerm({ termlst: [] }) },
+		{ label: 'non-collection term', selectionMode: 'fraction', term: { type: 'junction', id: 'junction-1' } }
+	]
+	for (const c of cases) {
+		const { holder, listDiv, fractionDiv } = getDivs()
+		const isStaged = mayRenderFractionSelection({
+			term: c.term,
+			selectionMode: c.selectionMode as any,
+			listDiv,
+			fractionDiv,
+			callback: () => {}
+		})
+		test.equal(isStaged, false, `does not stage a selection for ${c.label}`)
+		test.equal(fractionDiv.selectAll('*').size(), 0, `renders no chooser for ${c.label}`)
+		test.notEqual(listDiv.style('display'), 'none', `keeps the term list visible for ${c.label}`)
+		if (test['_ok']) holder.remove()
+	}
+	test.end()
+})


### PR DESCRIPTION
…or/denominator ui

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
