### PR TITLE
server route by member term type instead of isCustom flag

### DIFF
--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -1,4 +1,12 @@
-import { TermTypes, getBin, dictionaryNumericTypes, isParentType, getSampleType, dtTermTypes } from '#shared/terms.js'
+import {
+	TermTypes,
+	getBin,
+	dictionaryNumericTypes,
+	isParentType,
+	getSampleType,
+	dtTermTypes,
+	isNonDictionaryType
+} from '#shared/terms.js'
 import { validateTermCollectionTvs, getTvsDenominators } from '#shared/filter.js'
 import { getSnpData, getData } from './termdb.matrix.js'
 import { filterByItem } from './mds3.init.js'
@@ -308,7 +316,19 @@ async function get_termCollection_custom(tvs, CTEname, ds, mapParent2Children) {
 	return numericSampleData2tvs(tvs, CTEname, values)
 }
 
-/** Fraction filter for custom (non-dictionary) termCollections, e.g. isoform
+/** True when the member terms of a termCollection are non-dictionary terms, e.g.
+ *  isoformExpression. Decided by the member term type, the same way getData() routes
+ *  a term to a query handler instead of the sqlite db; the client-supplied isCustom
+ *  flag is not consulted, it only tells if the collection is termdbConfig-supplied.
+ *  All members share one term type, as required by validateTermCollectionTerm().
+ *  A term without termlst[] is assumed to be a dictionary collection: only the
+ *  termdbConfig-supplied ones are addressable by termIds[] alone. */
+function isNonDictMemberType(term) {
+	const memberType = term.termlst?.[0]?.type
+	return memberType ? isNonDictionaryType(memberType) : false
+}
+
+/** Fraction filter for termCollections of non-dictionary member terms, e.g. isoform
  *  expression collections created dynamically. The fraction is on a 0 to 1 scale,
  *  same as the value of a TermCollectionTWFraction tw.
  *
@@ -317,14 +337,16 @@ async function get_termCollection_custom(tvs, CTEname, ds, mapParent2Children) {
  *  evaluation path. Instead, call the underlying query handlers (e.g.
  *  isoformExpression HDF5 handler) directly for each member term, then compute
  *  the numerator/denominator fraction client-side and filter samples. */
-async function get_termCollection_custom_fraction(tvs, CTEname, ds, mapParent2Children) {
+async function get_termCollection_nonDict_fraction(tvs, CTEname, ds, mapParent2Children) {
 	const range = tvs.ranges?.[0]
 	if (!range) return emptyFilterResult(CTEname, mapParent2Children, ds)
-	const termlst = tvs.term.termlst || []
-	const numerators = tvs.term.numerators || []
-	const denominators = getTvsDenominators(tvs.term)
-	if (!termlst.length) return emptyFilterResult(CTEname, mapParent2Children, ds)
+	// only the fraction is supported here, so numerators[] is required, unlike a dictionary
+	// collection tvs that may instead brush on a single member
+	if (!tvs.term.numerators) throw new Error('termCollection tvs is missing term.numerators[]')
 	validateTermCollectionTvs(tvs.term)
+	const termlst = tvs.term.termlst // nonempty, as required to route here
+	const numerators = tvs.term.numerators
+	const denominators = getTvsDenominators(tvs.term)
 
 	// Fetch values for all member terms via query handlers directly.
 	// Group members by data type so each handler is called once with all its
@@ -399,13 +421,11 @@ async function get_termCollection(tvs, CTEname, ds, mapParent2Children) {
 		throw new Error('termcollection memberType=categorical not supported yet')
 	}
 	if (tvs.term.memberType !== 'numeric') throw new Error('termcollection memberType not categorical/numeric')
-	if (tvs.term.isCustom) {
-		// TODO shaky flag to rely on!!
-
-		// Custom collections bypass the getData() path below because getData()
-		// requires __protected__ auth context that is unavailable during filter
-		// CTE evaluation. Use direct query handler calls instead.
-		return await get_termCollection_custom_fraction(tvs, CTEname, ds, mapParent2Children)
+	if (isNonDictMemberType(tvs.term)) {
+		// Members are non-dictionary terms, which are not in the sqlite db: their values come
+		// from a ds.queries[] handler. Also bypasses the getData() path below because getData()
+		// requires __protected__ auth context that is unavailable during filter CTE evaluation.
+		return await get_termCollection_nonDict_fraction(tvs, CTEname, ds, mapParent2Children)
 	}
 	const denominators = getTvsDenominators(tvs.term)
 	// only validate a fraction tvs: a tvs brushed on a single member may not carry term.termlst[]

--- a/server/src/test/termdb.filter.unit.spec.js
+++ b/server/src/test/termdb.filter.unit.spec.js
@@ -276,6 +276,66 @@ tape('custom termCollection fraction filter', async function (test) {
 	test.end()
 })
 
+tape('termCollection fraction filter routes by member term type, not term.isCustom', async function (test) {
+	// same collection as above without the isCustom flag: the member term type decides that
+	// the values come from a ds.queries[] handler, since such terms are not in the sqlite db
+	let requestedTerms
+	const isoformExpression = tdb.ds.queries.isoformExpression
+	tdb.ds.queries.isoformExpression = {
+		get: async (param, ds) => {
+			requestedTerms = param.terms
+			return await isoformExpression.get(param, ds)
+		}
+	}
+
+	const filter = await getFilterCTEs(
+		{
+			type: 'tvslst',
+			in: true,
+			join: '',
+			lst: [
+				{
+					type: 'tvs',
+					tvs: {
+						term: {
+							type: 'termCollection',
+							memberType: 'numeric',
+							name: 'Test Isoforms (TPM)',
+							termlst: [
+								{
+									id: 'ENST00000256078',
+									name: 'ENST00000256078',
+									type: 'isoformExpression',
+									isoform: 'ENST00000256078'
+								},
+								{
+									id: 'ENST00000311936',
+									name: 'ENST00000311936',
+									type: 'isoformExpression',
+									isoform: 'ENST00000311936'
+								}
+							],
+							numerators: ['ENST00000256078'],
+							propsByTermId: {}
+						},
+						ranges: [{ start: 0, startinclusive: false, stopunbounded: true }]
+					}
+				}
+			]
+		},
+		tdb.ds
+	)
+
+	tdb.ds.queries.isoformExpression = isoformExpression
+	test.deepEqual(
+		requestedTerms?.map(tw => tw.term.isoform),
+		['ENST00000256078', 'ENST00000311936'],
+		'queries both member terms with the isoformExpression handler'
+	)
+	test.ok(filter.values.length > 0, 'should return matching samples (fraction > 0)')
+	test.end()
+})
+
 tape('custom termCollection fraction filter passes junction members intact', async function (test) {
 	// a splice junction event collection: the members are junction terms, whose handler
 	// requires chr/start/stop/strand on the term


### PR DESCRIPTION
# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
