### PR TITLE
Survival legend order

### DIFF
--- a/client/dom/renderPvalueTable.js
+++ b/client/dom/renderPvalueTable.js
@@ -22,7 +22,7 @@ input parameter:
 
 export function renderPvalues({
 	title,
-	titleTestid,
+	titleTestid = undefined,
 	holder,
 	plot,
 	tests,

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -542,7 +542,16 @@ class TdbSurvival extends PlotBase implements RxComponent {
 		// reordering survives session save/recover and re-triggers this component's update
 		const savedOrder = this.settings.legendOrder
 		if (savedOrder?.length) {
-			legendItems.sort((a, b) => savedOrder.indexOf(a.seriesId) - savedOrder.indexOf(b.seriesId))
+			const currentIndex = new Map(legendItems.map((d, i) => [d.seriesId, i]))
+			const savedIndex = new Map(savedOrder.map((id, i) => [id, i]))
+			legendItems.sort((a, b) => {
+				const ai = savedIndex.get(a.seriesId)
+				const bi = savedIndex.get(b.seriesId)
+				return (
+					(ai ?? savedOrder.length + (currentIndex.get(a.seriesId) ?? 0)) -
+					(bi ?? savedOrder.length + (currentIndex.get(b.seriesId) ?? 0))
+				)
+			})
 		}
 		// keep this.legendOrder in sync with the rendered order for the legend context menu
 		this.legendOrder = legendItems.map(item => item.seriesId)

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -716,8 +716,12 @@ function setRenderers(self) {
 		// order the serieses by the user-defined legend order so the hover tooltip
 		// list categories in the same order shown in the legend
 		if (self.legendOrder?.length) {
+			const currentIndex = new Map(chart.visibleSerieses.map((d, i) => [d.seriesId, i]))
+			const orderIndex = new Map(self.legendOrder.map((id, i) => [id, i]))
 			chart.visibleSerieses.sort(
-				(a: any, b: any) => self.legendOrder.indexOf(a.seriesId) - self.legendOrder.indexOf(b.seriesId)
+				(a: any, b: any) =>
+					(orderIndex.get(a.seriesId) ?? self.legendOrder.length + (currentIndex.get(a.seriesId) ?? 0)) -
+					(orderIndex.get(b.seriesId) ?? self.legendOrder.length + (currentIndex.get(b.seriesId) ?? 0))
 			)
 		}
 		const maxSeriesLabelLen = chart.visibleSerieses.reduce(

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -538,11 +538,14 @@ class TdbSurvival extends PlotBase implements RxComponent {
 			legendItems.sort((a, b) => s.indexOf(a.seriesId) - s.indexOf(b.seriesId))
 		}
 
-		if (!this.legendOrder.length) {
-			this.legendOrder = legendItems.map(item => item.seriesId)
-		} else {
-			legendItems.sort((a, b) => this.legendOrder.indexOf(a.seriesId) - this.legendOrder.indexOf(b.seriesId))
+		// the user-defined legend order is persisted in the plot config settings so that
+		// reordering survives session save/recover and re-triggers this component's update
+		const savedOrder = this.settings.legendOrder
+		if (savedOrder?.length) {
+			legendItems.sort((a, b) => savedOrder.indexOf(a.seriesId) - savedOrder.indexOf(b.seriesId))
 		}
+		// keep this.legendOrder in sync with the rendered order for the legend context menu
+		this.legendOrder = legendItems.map(item => item.seriesId)
 
 		if ((config.term.term.type == 'survival' || config.term2) && legendItems.length) {
 			const termNum = config.term.term.type == 'survival' && config.term2 ? 'term2' : 'term'
@@ -701,6 +704,13 @@ function setRenderers(self) {
 
 	function setVisibleSerieses(chart, s) {
 		chart.visibleSerieses = chart.serieses?.filter(series => !s.hidden.includes(series.seriesId)) || []
+		// order the serieses by the user-defined legend order so the hover tooltip
+		// list categories in the same order shown in the legend
+		if (self.legendOrder?.length) {
+			chart.visibleSerieses.sort(
+				(a: any, b: any) => self.legendOrder.indexOf(a.seriesId) - self.legendOrder.indexOf(b.seriesId)
+			)
+		}
 		const maxSeriesLabelLen = chart.visibleSerieses.reduce(
 			(maxlen, a) => (a.seriesLabel && a.seriesLabel.length > maxlen ? a.seriesLabel.length : maxlen),
 			0
@@ -1300,17 +1310,21 @@ function setInteractivity(self) {
 	}
 
 	self.adjustLegendOrder = (d, increment) => {
-		const oldIndex = self.legendOrder.indexOf(d.seriesId)
+		const order = [...self.legendOrder]
+		const oldIndex = order.indexOf(d.seriesId)
 		if (oldIndex == -1) return
 		let newIndex = oldIndex + increment
 		// clamp to array bounds
-		newIndex = Math.max(0, Math.min(self.legendOrder.length - 1, newIndex))
+		newIndex = Math.max(0, Math.min(order.length - 1, newIndex))
 		// remove item
-		self.legendOrder.splice(oldIndex, 1)
+		order.splice(oldIndex, 1)
 		// insert at new index
-		self.legendOrder.splice(newIndex, 0, d.seriesId)
+		order.splice(newIndex, 0, d.seriesId)
+		// persist the new order in the plot config so getState() changes and main() re-renders
 		self.app.dispatch({
-			type: 'app_refresh'
+			type: 'plot_edit',
+			id: self.id,
+			config: { settings: { survival: { legendOrder: order } } }
 		})
 		self.app.tip.hide()
 	}
@@ -1415,6 +1429,7 @@ export async function getPlotConfig(opts, app) {
 				xAxisOffset: 5,
 				yAxisOffset: -5,
 				hiddenPvalues: [],
+				legendOrder: [], // user-defined legend series order; set via the legend "Move up/down" menu
 				defaultColor: '#2077b4'
 			}
 		}


### PR DESCRIPTION
# Description
Fix the issues

1. survival plot legend up/down buttons do not work
<img width="491" height="476" alt="image" src="https://github.com/user-attachments/assets/98928b93-7609-49b3-8313-f5bcd4c9847e" />



2. hover over tooltip should show the same user-defined order



## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
