### PR TITLE
GDC: Various Cleanups

### DIFF
--- a/container/deps/GDC-GRIN2-README.md
+++ b/container/deps/GDC-GRIN2-README.md
@@ -24,8 +24,11 @@ npm run cjs
 Copy the generated dataset file to the proteinpaint container:
 
 ```bash
-cp dataset/cjs/gdc.hg38.js proteinpaint/container/dataset/
+cp -r dataset/cjs/gdc proteinpaint/container/dataset/
 ```
+
+The whole folder is copied, not just `gdc/index.js`: esbuild runs without `--bundle`, so the compiled
+entry still does `require('./queries.ts')` etc. and needs its sibling modules alongside it.
 
 ### 3. Prepare Dependencies Directory
 

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,9 @@
+General:
+- ds.queries.singleCell.geneExpression.get() now takes (q, sample, gene) instead of a single reconstructed object, so callers forward their own request and the getter can read auth and abort off it. The GDC dataset (ppgdc) supplies this getter, so its deployed image must be updated together with this server release — an older ppgdc image would come up with a getter of the wrong shape and single-cell gene expression would break. As a consequence GDC now sends sessionid/token on the scrna gene-expression request where it previously sent none; that endpoint is open-access today so behavior is unchanged, but this is the path that would carry credentials for controlled-access data
 
+Fixes:
+- Screen the sample id in the built-in single-cell getters before it is used to build a file path: /termdb/singlecellData accepted any non-empty string as q.sample.sID/.eID, which is not sufficient validation for a value that becomes part of a path under tpmasterdir. It is now screened with illegalpath(), matching how termdb.singleSampleMutation already screens its sample name, and the check sits at the getters so every caller is covered rather than only the HTTP route
+- Add the missing request validator for /termdb/singleSampleMutation: the declared string|number sample is normalized to a non-empty string at the route boundary, so a missing or repeated ?sample= returns a 400 instead of a TypeError 500, and per-getter input handling no longer diverges between the native and GDC getters
+
+DevOps:
+- A dataset entry may now be a folder holding an index.ts (dataset/<name>/index.ts) as well as the existing dataset/<name>.ts form; emitImports.js collects both, so a folder-form entry stays in the dev server's tsx watch restart graph

--- a/server/emitImports.js
+++ b/server/emitImports.js
@@ -38,6 +38,15 @@ if (mode == 'dev') {
 
 		for (const cwd in cwds) {
 			const files = fs.globSync('*.ts', { cwd })
+			// An entry may also be a folder holding an index.ts (gdc, whose entry sits alongside the modules
+			// it imports). Must be collected, or `tsx watch` drops that entry -- and everything it imports --
+			// from the restart graph, and edits to it silently stop reloading the dev server.
+			// A glob wildcard cannot reach it: these folders are symlinks into sibling repos (dataset/gdc ->
+			// ../ppgdc/active/dataset/gdc), and fs.globSync will not descend into a symlinked dir, since its
+			// dirent reports isDirectory() false. existsSync does follow the symlink.
+			for (const name of fs.readdirSync(cwd)) {
+				if (fs.existsSync(path.join(cwd, name, 'index.ts'))) files.push(`${name}/index.ts`)
+			}
 			for (const f of files) {
 				const abspath = `${cwd}/${f}`
 				const dotpath = cwds[cwd]

--- a/server/src/routes/termdb.singleSampleMutation.ts
+++ b/server/src/routes/termdb.singleSampleMutation.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { read_file, file_is_readable, fileurl, illegalpath } from '#src/utils.js'
+import { validGenomeDs } from '#routes/common.ts'
 import type {
 	TermdbSingleSampleMutationRequest,
 	TermdbSingleSampleMutationResponse,
@@ -9,8 +10,25 @@ import type {
 
 export const payload: RoutePayload = {
 	init,
-	request: { typeId: 'TermdbSingleSampleMutationRequest' /*, checkers: TODO write validator */ },
+	request: {
+		typeId: 'TermdbSingleSampleMutationRequest',
+		checker: validTermdbSingleSampleMutationRequest
+	},
 	response: { typeId: 'TermdbSingleSampleMutationResponse' }
+}
+
+/* q.skipDt and (for gdc) q.cnvType are server-internal, set only by callers that invoke the getter
+directly (GRIN2); they never arrive over http, and the middleware merges this return onto req.query
+rather than replacing it, so not listing them here does not drop them. */
+function validTermdbSingleSampleMutationRequest(input): TermdbSingleSampleMutationRequest {
+	// sample is typed string|number -- termdbtest and possibly other ds use integer sample names.
+	// normalize to string, which is what every getter and path.join() actually needs. rejects a
+	// missing sample and the array express yields for a repeated ?sample=
+	const vt = typeof input.sample
+	if (vt != 'string' && vt != 'number') throw 'sample must be a string or number'
+	const sample = String(input.sample)
+	if (!sample) throw 'sample is blank'
+	return { ...validGenomeDs(input), sample }
 }
 
 export const api: RouteApi = {
@@ -56,19 +74,10 @@ export async function validate_query_singleSampleMutation(ds: any, _genome: any)
 		throws on any error
 		*/
 		_q.get = async (q: TermdbSingleSampleMutationRequest) => {
-			let sample: string
-			{
-				const vt = typeof q.sample // to only compute value type once
-				if (vt == 'string') {
-					if (q.sample == '') throw 'sample is blank string'
-					sample = q.sample as string // accepted
-				} else if (vt == 'number') {
-					// termdbtest and possibly other ds may use integer as sample name, which is not allowed by path.join(), thus need to call toString()
-					sample = q.sample.toString()
-				} else {
-					throw 'sample value is not string or number'
-				}
-			}
+			// the route checker already normalizes sample to a non-empty string, but GRIN2 calls this
+			// getter directly and bypasses it, so normalize here too
+			const sample = typeof q.sample == 'number' ? String(q.sample) : q.sample
+			if (typeof sample != 'string' || !sample) throw 'sample must be a non-empty string or number'
 
 			// *pre* screening of file name. in case sample name has "../" to traverse back on dir structure, this will be allowed by path.join() resulting in unauthorized access, thus must be screened outside of fileurl()
 			if (illegalpath(sample)) throw 'invalid sample name'

--- a/server/src/routes/termdb.singleSampleMutation.ts
+++ b/server/src/routes/termdb.singleSampleMutation.ts
@@ -17,9 +17,13 @@ export const payload: RoutePayload = {
 	response: { typeId: 'TermdbSingleSampleMutationResponse' }
 }
 
-/* q.skipDt and (for gdc) q.cnvType are server-internal, set only by callers that invoke the getter
-directly (GRIN2); they never arrive over http, and the middleware merges this return onto req.query
-rather than replacing it, so not listing them here does not drop them. */
+/* q.skipDt and (for gdc) q.cnvType are server-internal, set by callers that invoke the getter
+directly (GRIN2), and are deliberately not listed here. That does NOT mean a request cannot carry
+them: POST bodies merge into req.query, and the middleware Object.assign()s this return onto
+req.query rather than replacing it, so any key not named here survives onto q. Treat both as
+untrusted on the http path -- each getter validates them by type/shape before use (the instanceof
+Set guard below, and the equivalents in ppgdc's singleSampleMutation.ts) rather than assuming
+they are absent. */
 function validTermdbSingleSampleMutationRequest(input): TermdbSingleSampleMutationRequest {
 	// sample is typed string|number -- termdbtest and possibly other ds use integer sample names.
 	// normalize to string, which is what every getter and path.join() actually needs. rejects a

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -16,7 +16,7 @@ import type {
 } from '#types'
 import fs from 'fs'
 import path from 'path'
-import { read_file, file_is_readable } from '#src/utils.js'
+import { read_file, file_is_readable, illegalpath } from '#src/utils.js'
 import { mayLog } from '#src/helpers.ts'
 import serverconfig from '#src/serverconfig.js'
 import { validGenomeDs } from '#routes/common.ts'
@@ -301,6 +301,19 @@ function validateDataPlots(D: SingleCellData, needFolders: boolean): void {
 	}
 }
 
+/** The sample id from the request becomes a path segment under tpmasterdir. path.join() honors "../",
+ * so an unscreened id escapes tpmasterdir -- worst on the checkPlotAvailability path, whose
+ * file_is_readable() then reports back whether an arbitrary path exists. Screen it the same way the
+ * sibling route does (termdb.singleSampleMutation.ts). Native sample names come from file names in
+ * plot.folder, so illegalpath()'s whitespace/quote rules never reject a legitimate one.
+ * @param sample req.query.sample {sID, eID}
+ */
+function validSampleId(sample: any): string {
+	const id = sample?.eID || sample?.sID
+	if (typeof id != 'string' || !id || illegalpath(id)) throw new Error('invalid sample id')
+	return id
+}
+
 /** Adds ds.queries.singleCell.data.get() on init(), for a ds that does not supply its own getter.
  * @param D ds.queries.singleCell.data{}
  * @param ds Entire dataset configuration from the ds file
@@ -310,7 +323,7 @@ function validateDataNative(D: SingleCellData, ds: any): void {
 	const file2Lines = {} // key: file path, value: string[]
 
 	D.get = async (q: TermdbSingleCellDataRequest & ReqQueryAddons) => {
-		const sampleId = q.sample?.eID || q.sample?.sID
+		const sampleId = validSampleId(q.sample)
 		/** Only return plots with available data files. */
 		if (q.checkPlotAvailability) {
 			return await getAvailablePlots(q.plots, D.plots, ds, sampleId)
@@ -319,11 +332,7 @@ function validateDataNative(D: SingleCellData, ds: any): void {
 		if (ds.queries.singleCell.geneExpression && q.gene) {
 			const sample = q.sample || q.singleCellPlot.sample
 			if (!sample) throw new Error('sample is required for gene expression query')
-			geneExpMap = await ds.queries.singleCell.geneExpression.get({
-				sample,
-				gene: q.gene,
-				__abortSignal: q.__abortSignal
-			})
+			geneExpMap = await ds.queries.singleCell.geneExpression.get(q, sample, q.gene)
 		}
 		const checkGeneExpMap = geneExpMap && Object.keys(geneExpMap).length > 0
 		// given a sample name, collect every plot data for this sample and return
@@ -440,12 +449,13 @@ function validateGeneExpressionNative(G: SingleCellGeneExpression): void {
 	if (!G.folder) throw new Error('singleCell.geneExpression.folder missing')
 	// per-sample rds files are not validated up front, and simply used as-is on the fly
 
-	G.get = async (q: TermdbSingleCellDataRequest & ReqQueryAddons) => {
-		// q {sample:str, gene:str}
-		const h5file = path.join(serverconfig.tpmasterdir, G.folder!, (q.sample?.eID || q.sample?.sID) + '.h5')
+	G.get = async (_q: TermdbSingleCellDataRequest & ReqQueryAddons, sample: any, gene: string) => {
+		// _q is the caller's request, forwarded only so a ds-supplied getter can read auth/abort off it;
+		// sample and gene are explicit because callers query by a term's sample/gene, not the request's
+		const h5file = path.join(serverconfig.tpmasterdir, G.folder!, validSampleId(sample) + '.h5')
 		await file_is_readable(h5file)
 
-		const query_gene = q.gene
+		const query_gene = gene
 		if (!query_gene) {
 			throw new Error('Gene parameter is undefined')
 		}

--- a/server/src/singleCell/test/samplesRoute.unit.spec.ts
+++ b/server/src/singleCell/test/samplesRoute.unit.spec.ts
@@ -8,6 +8,7 @@ import { validate_query_singleCell } from '../samplesRoute.ts'
  *  - missing plots[] is rejected for every ds, including one supplying every getter
  *  - missing plot.folder is rejected whenever a built-in file-based path will read it
  *  - missing geneExpression.folder is rejected when no geneExpression.get is supplied
+ *  - the built-in file-based getters reject a sample id that would traverse out of tpmasterdir
  */
 
 /** plots[] as GDC declares them: color/coords columns, but no folder, since data comes from an API */
@@ -96,6 +97,39 @@ tape('validate_query_singleCell: rejects an incomplete ds that supplies no gette
 		'singleCell.geneExpression.folder missing',
 		'should reject geneExpression without a folder'
 	)
+
+	test.end()
+})
+
+tape('built-in getters screen the sample id for path traversal', async test => {
+	// no data.get / geneExpression.get, so the built-in file-based getters are installed
+	const ds = makeDs({
+		samples: { get: async () => ({}) },
+		data: { plots: [{ ...apiPlots[0], folder: 'files/sc' }] },
+		geneExpression: { folder: 'files/sc/geneExp' }
+	})
+	await validate_query_singleCell(ds, {})
+	const { data, geneExpression } = ds.queries.singleCell
+
+	// checkPlotAvailability is the worst case: it reports back which files are readable, so an
+	// unscreened id is a file-existence oracle for any path outside tpmasterdir
+	const escaping = { sID: '../../../../etc/passwd' }
+	for (const [label, fn] of [
+		['data.get', () => data.get({ sample: escaping, plots: ['UMAP'], checkPlotAvailability: true })],
+		['geneExpression.get', () => geneExpression.get({}, escaping, 'TP53')]
+	] as [string, () => Promise<any>][]) {
+		try {
+			await fn()
+			test.fail(`${label} did not reject a traversing sample id`)
+		} catch (e: any) {
+			test.equal(e.message || e, 'invalid sample id', `${label} should reject a traversing sample id`)
+		}
+	}
+
+	// a native sample name (derived from a file name in plot.folder) must still pass the screen;
+	// its missing data file is reported as an unavailable plot, not as an invalid id
+	const re = await data.get({ sample: { sID: 'SJALL040053_D1' }, plots: ['UMAP'], checkPlotAvailability: true })
+	test.deepEqual(re, { plots: [] }, 'should accept a legitimate sample name')
 
 	test.end()
 })

--- a/server/src/termdb.getDefaultBins.js
+++ b/server/src/termdb.getDefaultBins.js
@@ -27,12 +27,7 @@ export async function trigger_getDefaultBins(q, ds, res) {
 			binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample]
 			if (!binsCache) binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample] = {}
 			else if (binsCache[tw.$id]) return res.send(binsCache[tw.$id])
-			const args = {
-				sample: tw.term.sample,
-				gene: tw.term.gene,
-				__abortSignal: q.__abortSignal
-			}
-			const data = await ds.queries.singleCell.geneExpression.get(args)
+			const data = await ds.queries.singleCell.geneExpression.get(q, tw.term.sample, tw.term.gene)
 			for (const cell in data) {
 				const value = data[cell]
 				if (value < min) min = value

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -339,11 +339,7 @@ async function getSampleData(q, ds) {
 				}
 				byTermId[tw.$id] = { bins: lst }
 			}
-			const geneExpMap = await q.ds.queries.singleCell.geneExpression.get({
-				sample: tw.term.sample,
-				gene: tw.term.gene,
-				__abortSignal: q.__abortSignal
-			})
+			const geneExpMap = await q.ds.queries.singleCell.geneExpression.get(q, tw.term.sample, tw.term.gene)
 			let filteredSamples = new Set()
 			if ((q.filter?.lst?.length || q.filter0) && tw.term.sample?.isMetaResult) {
 				filteredSamples = await q.ds.queries.singleCell.samples.getFilteredSingleCellSamples(q)

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -934,8 +934,12 @@ export type SingleCellGeneExpression = {
 	each is a gene-by-cell matrix for a sample, with ".h5" suffix. missing files are detected and handled.
 	REQUIRED unless the ds supplies get(); enforced at runtime in validateGeneExpressionNative() */
 	folder?: string
-	/** ds-supplied, or added on init() by validateGeneExpressionNative() */
-	get?: (q: any) => any
+	/** ds-supplied, or added on init() by validateGeneExpressionNative().
+	q is the caller's own request object, forwarded (not reconstructed) so the getter can read auth
+	and abort off it -- the gdc getter passes q to ds.getHostHeaders() and would otherwise build
+	unauthenticated headers. sample and gene are explicit since callers query by a term's sample/gene,
+	which is not the request's. */
+	get?: (q: any, sample: any, gene: string) => any
 	/** cached gene exp bins, seeded on init() in validate_query_singleCell() */
 	sample2gene2expressionBins?: { [sample: string]: { [gene: string]: any } }
 	/** gene expression unit (e.g. 'FPKM') */


### PR DESCRIPTION
# Description

Two things, both fallout from the GDC de-special-casing work (gdc.8). Three commits,
each self-contained.

⚠️ **Needs a coordinated ppgdc deploy.** The `singleCell.geneExpression.get()`
signature change cuts both ways — an old ppgdc image on this server, or a new one
on an older server, breaks single-cell gene expression. Called out in release.txt
under General; the paired sjpp PR carries the ppgdc half.

## Route hardening

Three findings I deliberately kept out of the earlier PRs — they were either
pre-existing or behavior changes I didn't want riding along in a refactor.

**Path traversal in `/termdb/singlecellData`.** `q.sample.sID`/`.eID` came
straight off the request and went into a path under `tpmasterdir`. `validString()`
only checks it's a non-empty string, and `path.join()` is perfectly happy to honor
`../`. The `checkPlotAvailability` branch is the bad one: it reports back which
plot files are readable, so you get a clean file-existence oracle for arbitrary
paths. The sibling route already guards this exact pattern with `illegalpath()`,
comment and all, so it's screened the same way now. I put the guard on the getters
rather than the route checker so every caller is covered, not just the HTTP one,
and checked real tp data first to be sure no actual sample name trips
`illegalpath()`'s whitespace rule.

**`/termdb/singleSampleMutation` had no validator** — literally
`/*, checkers: TODO write validator */` — which is why each getter was hardening
`q.sample` on its own and doing it differently. There's a checker now. One thing I
didn't do that the original issue called for: the getters keep a minimal
normalize, because GRIN2 calls this getter directly from its own `/grin2` endpoint
and never passes through the middleware. Dropping it would have reopened the
TypeError we just fixed.

**`singleCell.geneExpression.get()` was losing auth.** All four callers built a
fresh `{sample, gene}` literal instead of forwarding their request, so
`ds.getHostHeaders(q)` in the GDC getter saw no sessionid/token and built
unauthenticated headers. It only works today because the scrna endpoint is open
access. Signature is now `get(q, sample, gene)`. I used explicit params rather than
spreading `{...q, sample, gene}` because `getHostHeaders` also does a WeakMap
lookup keyed on the request object's identity, and a spread quietly breaks that.

## Folder-form dataset entries

`emitImports.js` globbed `dataset/` non-recursively, so an entry at
`dataset/<name>/index.ts` was invisible to it — which matters because the paired
sjpp PR moves GDC there, and this file is what keeps dataset files in the
`tsx watch` restart graph. Worth knowing if you touch this: I first tried a
`*/index.ts` glob and it silently matched nothing, because `dataset/gdc` is a
symlink and `fs.globSync` won't descend into a symlinked dir (its dirent reports
`isDirectory()` false). It's an explicit `readdirSync` + `existsSync` scan instead.


## Testing

Server unit suite green (1697/1697), including 3 new assertions covering the
traversal guard — both getters reject an escaping id, and a legitimate sample name
still passes, so it can't silently over-reject. `tsc -p server` clean, which covers
the `shared/types` change too. Dev server verified end to end against the sjpp
side: GDC loads, and editing a module under `dataset/gdc/` still restarts the server.

## Needs a second pair of eyes

The auth change is the one piece I couldn't verify locally — GDC will now send
credentials on a path where it currently doesn't. Worth running against a
controlled-access scrna case before this goes in.


## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
