### PR TITLE
wrap all ds init steps in a try-catch block

### DIFF
--- a/server/src/health.ts
+++ b/server/src/health.ts
@@ -2,8 +2,9 @@ import serverconfig from './serverconfig.js'
 import fs from 'fs'
 import path from 'path'
 //import pkg from '../package.json' with {type: "json"}
-import type { VersionInfo, GenomeBuildInfo, HealthCheckResponse } from '#types'
+import type { VersionInfo, GenomeBuildInfo, HealthCheckResponse, DsInitStatus, DsSummary } from '#types'
 import { authApi } from './auth.js'
+import { trackedDatasets } from './initGenomesDs.js'
 
 const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, '../package.json'), { encoding: 'utf8' }))
 
@@ -11,15 +12,56 @@ export async function getStat(genomes) {
 	if (!versionInfo.deps) setVersionInfoDeps() // set only once
 	const auth = (await authApi.getHealth()) as undefined | { errors?: string[] }
 	const health = {
+		// NOTE: status describes the server process, not its datasets: a failed dataset must not
+		// make an otherwise working server look down, since the k8s liveness and readiness probes
+		// both request this route. Dataset failures are reported in dsSummary and dsInitStatus.
 		status: auth?.errors?.length ? 'error' : 'ok',
 		genomes: {},
 		versionInfo,
 		auth,
-		dsInitStatus: []
+		...getDsInitStatus()
 	} satisfies HealthCheckResponse
 
 	setGenomeDbInfo(genomes, health)
 	return health
+}
+
+/*
+	report the init status of every configured dataset, using the tracked datasets from
+	initGenomesDs() as the source of truth: a dataset that failed to load is deleted from
+	genomes[].datasets{}, so it would otherwise be missing from this response and be
+	indistinguishable from a dataset that was never configured
+*/
+export function getDsInitStatus(): { dsSummary: DsSummary; dsInitStatus: DsInitStatus[] } {
+	const dsSummary: DsSummary = { total: 0, done: 0, nonblocking: 0, retrying: 0, failed: 0 }
+	const dsInitStatus: DsInitStatus[] = []
+	for (const ds of trackedDatasets) {
+		dsSummary.total++
+		if (ds.init?.status == 'done') dsSummary.done++
+		else if (ds.init?.status == 'nonblocking') dsSummary.nonblocking++
+		else if (ds.init?.status == 'recoverableError') dsSummary.retrying++
+		else dsSummary.failed++
+
+		dsInitStatus.push({
+			genome: ds.genomename,
+			label: ds.label,
+			url: `/healthcheck?dslabel=${ds.label}`,
+			// deep copy to not expose the mutable ds.init object, and to drop any function value
+			// such as init.notReadyMessage(); tolerate a non-serializable value to not fail the route
+			init: copyInit(ds)
+		})
+	}
+	return { dsSummary, dsInitStatus }
+}
+
+function copyInit(ds) {
+	try {
+		const init = JSON.parse(JSON.stringify(ds.init || {}))
+		init.ignoredErrors = ds._ignoredErrors || []
+		return init
+	} catch (e: any) {
+		return { status: ds.init?.status, error: `cannot serialize ds.init: ${e.message || e}` }
+	}
 }
 
 function setGenomeDbInfo(genomes, health) {
@@ -47,18 +89,7 @@ function setGenomeDbInfo(genomes, health) {
 			}
 			genome.dbInfo = Object.keys(dbInfo).length ? dbInfo : undefined
 		}
-		if (typeof genome.datasets == 'object') {
-			for (const [label, ds] of Object.entries(genome.datasets as any[])) {
-				const init = JSON.parse(JSON.stringify(ds.init))
-				init.ignoredErrors = ds._ignoredErrors || []
-				health.dsInitStatus.push({
-					genome: gn,
-					label,
-					url: `/healthcheck?dslabel=${label}`,
-					init
-				})
-			}
-		}
+		// NOTE: dataset init status is reported from the tracked datasets, see getDsInitStatus()
 		health.genomes[gn] = genome.dbInfo
 	}
 }

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -431,6 +431,7 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 		*/
 		g.datasets = {}
 		for (const d of g.rawdslst) {
+			let ds
 			// wrap ds init execution in a try-catch, to not crash when at least 1 dataset loaded successfully
 			try {
 				/*
@@ -452,7 +453,7 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 				const overrideFile = path.join(process.cwd(), d.jsfile)
 				const dsFile = fs.existsSync(overrideFile) ? overrideFile : path.join(serverconfig.binpath, d.jsfile)
 				const _ds = (await import(dsFile)).default
-				const ds =
+				ds =
 					typeof _ds == 'function'
 						? await _ds(common, { serverconfig, clinsig, dsHelpers })
 						: typeof _ds?.default == 'function'

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -38,6 +38,17 @@ const dsHelpers = {
 
 export const genomes = {} // { hg19: {...}, ... }
 
+/*
+	tracks the init status of every dataset entry from serverconfig genomes[].datasets[],
+	including entries that failed to load and are therefore deleted from genomes[].datasets{}.
+
+	This is the single source of truth for dataset init status:
+	- app.ts processTrackedDs() summarizes it in the startup log and optional slack notification
+	- health.ts reports it in the /healthcheck response, so that a failed dataset is visible
+	  as a failure, instead of being indistinguishable from a dataset that was never configured
+*/
+export const trackedDatasets = []
+
 const features = serverconfig.features
 
 export async function initGenomesDs(serverconfig, opts = {}) {
@@ -54,7 +65,10 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 			// allow the server process to boot
 			// we want the node server to keep running so it can inform user with some meaningful msg rather than http error
 			console.log('\n!!! ' + message + '\n')
-			return
+			// must return the empty tracked list, not undefined, otherwise app.ts processTrackedDs()
+			// throws on it and exits the process, which defeats the intent above
+			trackedDatasets.length = 0
+			return trackedDatasets
 		}
 	}
 
@@ -189,8 +203,8 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 		}
 	}
 
-	// will be used to track dataset loading status
-	const trackedDatasets = []
+	// reset the tracked status, in case this is called more than once in the same process
+	trackedDatasets.length = 0
 
 	for (const genomename in genomes) {
 		/*
@@ -498,12 +512,53 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 				// no error bubbled up to be caught, and there are no nonblocking step being performed, init is done
 				if (ds.init.status == 'started') ds.init.status = 'done'
 			} catch (e) {
+				/*
+					ds is undefined or only partially constructed when the error is thrown before or while
+					the dataset js file is imported and evaluated, such as when its exported function throws.
+					An untracked ds must therefore be replaced with a stub, so that
+					- mayRetryInit() below does not crash on an undefined ds/ds.init, which would defeat this try-catch
+					- the failure is still tracked and reported in the startup log, optional slack notification,
+					  and the /healthcheck response, instead of the dataset silently disappearing
+				*/
+				if (!trackedDatasets.includes(ds)) {
+					// the error happened before the ds object was ready to be init'ed, so retrying init() against
+					// it would not be meaningful; use a stub that fails without retries, and reuse the same label
+					// so that mayRetryInit() also deletes any reference under g.datasets{}
+					ds = {
+						label: ds?.label || d.name,
+						genomename,
+						init: {
+							retryMax: 0,
+							retryDelay: 1000 * 60 * 5,
+							fatalError: `did not load ${d.jsfile || d.name}: ${stringifyInitError(e)}`
+						}
+					}
+					trackedDatasets.push(ds)
+				}
 				mayRetryInit(g, ds, d, e, totalRawDsLst)
 			}
 		}
 		delete g.rawdslst
 	}
 	return trackedDatasets
+}
+
+/*
+	serialize an init error for the startup log, optional slack notification, and /healthcheck response.
+	JSON.stringify() alone emits '{}' for an Error instance, which would report a failed dataset
+	without its cause; note that ds init code may also throw a string or a {error} object
+*/
+function stringifyInitError(e) {
+	if (typeof e == 'string') return e
+	if (typeof e?.error == 'string') return e.error
+	if (typeof e?.message == 'string') return e.message
+	try {
+		// JSON.stringify() returns undefined for an undefined value, fallback to String()
+		return JSON.stringify(e) ?? String(e)
+	} catch {
+		// e may have a circular reference
+		return String(e)
+	}
 }
 
 function mayRetryInit(g, ds, d, e, totalRawDsLst) {
@@ -539,21 +594,20 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 	}
 
 	if (ds.init.fatalError) {
-		// will not be able to recover even with retries
+		// will not be able to recover even with retries.
+		// NOTE: a failed dataset must not crash the server, even when it is the only configured
+		// dataset; the failure is reported in the startup log, optional slack notification, and
+		// the /healthcheck response. app.ts processTrackedDs() still exits the process when NO
+		// dataset loaded successfully, in order to trigger a deployment rollback.
 		ds.init.status = `fatalError`
-		if (!ds.init.error) ds.init.error = JSON.stringify(e)
-		if (totalRawDsLst === 1)
-			setImmediate(() => {
-				const msg = ds.init.fatalError === e ? e : ds.init.fatalError + ': ' + e
-				throw new Error(gdlabel + ' fatal error: ' + msg)
-			})
+		if (!ds.init.error) ds.init.error = stringifyInitError(e)
 		return
 	}
 	if (!ds.init.retryMax) {
 		// default ds.init.retryMax is 0, assumes that
 		// most dataset init errors are not recoverable, unless overriden
 		ds.init.status = `zeroRetries`
-		if (!ds.init.error) ds.init.error = JSON.stringify(e)
+		if (!ds.init.error) ds.init.error = stringifyInitError(e)
 		return
 	}
 	console.log(`${gdlabel} recoverableError:`, ds.init.recoverableError)
@@ -581,18 +635,17 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 				console.log(msg)
 				clearInterval(interval) // cancel since retrying will not change the outcome
 				ds.init.status = 'fatalError'
+				if (!ds.init.error) ds.init.error = msg // to be reported by health.ts getStat()
 				if (serverconfig.slackWebhookUrl) {
+					// must catch, an unhandled rejection from a failed slack post would crash the server
 					sendMessageToSlack(
 						serverconfig.slackWebhookUrl,
 						`\n${serverconfig.URL}: ${msg}`,
 						path.join(serverconfig.cachedir, '/slack/last_message_hash.txt')
-					)
+					).catch(console.log)
 				}
-				// this will crash the server with a fatal error message, the server will not respond to HTTP requests
-				if (totalRawDsLst === 1)
-					setImmediate(() => {
-						throw new Error(msg)
-					})
+				// NOTE: the server is not crashed here, even when this is the only configured dataset,
+				// the failed status is reported in the /healthcheck response instead
 			} else {
 				console.warn(
 					`${gdlabel} init() failed. Retrying in ${Math.round(ds.init.retryDelay / 1000)} second(s) ... (${
@@ -603,18 +656,24 @@ function mayRetryInit(g, ds, d, e, totalRawDsLst) {
 					clearInterval(interval) // cancel retries
 					const msg = `Max retry attempts for ${gdlabel} reached. Failing with error:`
 					console.error(msg)
-					if (ds.init.errorCallback) ds.init.errorCallback(response)
+					if (ds.init.errorCallback) ds.init.errorCallback(e)
 					else {
 						// allow to fail silently to not affect other loaded datasets
 						console.log(e)
 					}
 					if (serverconfig.slackWebhookUrl) {
+						// must catch, an unhandled rejection from a failed slack post would crash the server
 						sendMessageToSlack(
 							serverconfig.slackWebhookUrl,
 							`\n${serverconfig.URL}: ${msg}`,
 							path.join(serverconfig.cachedir, '/slack/last_message_hash.txt')
-						)
+						).catch(console.log)
 					}
+					// retries are exhausted and cancelled, so this must not be reported as an active
+					// retry by app.ts processTrackedDs() and the /healthcheck response
+					ds.init.status = `fatalError`
+					if (!ds.init.error) ds.init.error = `${msg} ${stringifyInitError(e)}`
+					return
 				}
 
 				ds.init.status = `recoverableError`

--- a/server/src/initGenomesDs.js
+++ b/server/src/initGenomesDs.js
@@ -431,64 +431,64 @@ export async function initGenomesDs(serverconfig, opts = {}) {
 		*/
 		g.datasets = {}
 		for (const d of g.rawdslst) {
-			/*
-			for each raw dataset
-			*/
-			if (d.skip) continue
-			if (!d.name) throw 'a nameless dataset from ' + genomename
-			if (dslabelFilter && !dslabelFilter?.includes(d.name)) continue
-			if (g.datasets[d.name]) throw genomename + ' has duplicate dataset name: ' + d.name
-			if (!d.jsfile) throw 'jsfile not available for dataset ' + d.name + ' of ' + genomename
-
-			/*
-				When using a Docker container, the mounted app directory
-				may have an optional dataset directory, which if present
-				will be symlinked to the app directory and potentially override any
-				similarly named dataset js file that are part of the standard
-				Proteinpaint packaged files[] 
-			*/
-			const overrideFile = path.join(process.cwd(), d.jsfile)
-			const dsFile = fs.existsSync(overrideFile) ? overrideFile : path.join(serverconfig.binpath, d.jsfile)
-			const _ds = (await import(dsFile)).default
-			const ds =
-				typeof _ds == 'function'
-					? await _ds(common, { serverconfig, clinsig, dsHelpers })
-					: typeof _ds?.default == 'function'
-					? await _ds.default(common, { serverconfig, clinsig, dsHelpers })
-					: _ds.default || _ds
-
-			if (d.updateAttr) {
-				utils.doUpdateAttr(ds, d.updateAttr)
-				// do not re-update the attributes in case a dataset is reloaded, by itself without a full server restart
-				if (ds.label) delete d.updateAttr
-			}
-			ds.noHandleOnClient = d.noHandleOnClient
-			ds.label = d.name
-			ds.genomename = genomename
-			ds.genomeObj = g // this makes genome obj readily accessible to functions that already accepts ds obj as argument, avoid retrofit to add in additional genome obj argument
-			g.datasets[ds.label] = ds
-
-			// populate possibly missing ds.init option values
-			// retryMax or retryDelay override may be specified without the other
-			ds.init = {
-				...{ retryMax: 0, retryDelay: 1000 * 60 * 5 }, // default, 0 retry, every 5 minutes
-				...(ds.init || {}), // overrides from dataset js file
-				...(d.init || {}) // overrides from raw dataset entry in serverconfig, highest priority
-			}
-
-			trackedDatasets.push(ds)
-			// do this check after trackedDatasets.push so that datasets with auth requirement
-			// but no provided creds can still be tracked with fatalError status, to be emitted
-			// in app.ts processTrackedDs() and inform user about missing creds via log and optional slack notification
-			if (ds.requiresAuthCred && !opts.credDslabels?.includes(ds.label)) {
-				ds.init.status = 'fatalError'
-				ds.init.fatalError = `${ds.label} ds.requiresAuthCred is true but no credential provided`
-				delete g.datasets[ds.label] // do not keep reference to this dataset since it will not be loaded
-				continue
-			}
-
 			// wrap ds init execution in a try-catch, to not crash when at least 1 dataset loaded successfully
 			try {
+				/*
+				for each raw dataset
+				*/
+				if (d.skip) continue
+				if (!d.name) throw 'a nameless dataset from ' + genomename
+				if (dslabelFilter && !dslabelFilter?.includes(d.name)) continue
+				if (g.datasets[d.name]) throw genomename + ' has duplicate dataset name: ' + d.name
+				if (!d.jsfile) throw 'jsfile not available for dataset ' + d.name + ' of ' + genomename
+
+				/*
+					When using a Docker container, the mounted app directory
+					may have an optional dataset directory, which if present
+					will be symlinked to the app directory and potentially override any
+					similarly named dataset js file that are part of the standard
+					Proteinpaint packaged files[] 
+				*/
+				const overrideFile = path.join(process.cwd(), d.jsfile)
+				const dsFile = fs.existsSync(overrideFile) ? overrideFile : path.join(serverconfig.binpath, d.jsfile)
+				const _ds = (await import(dsFile)).default
+				const ds =
+					typeof _ds == 'function'
+						? await _ds(common, { serverconfig, clinsig, dsHelpers })
+						: typeof _ds?.default == 'function'
+						? await _ds.default(common, { serverconfig, clinsig, dsHelpers })
+						: _ds.default || _ds
+
+				if (d.updateAttr) {
+					utils.doUpdateAttr(ds, d.updateAttr)
+					// do not re-update the attributes in case a dataset is reloaded, by itself without a full server restart
+					if (ds.label) delete d.updateAttr
+				}
+				ds.noHandleOnClient = d.noHandleOnClient
+				ds.label = d.name
+				ds.genomename = genomename
+				ds.genomeObj = g // this makes genome obj readily accessible to functions that already accepts ds obj as argument, avoid retrofit to add in additional genome obj argument
+				g.datasets[ds.label] = ds
+
+				// populate possibly missing ds.init option values
+				// retryMax or retryDelay override may be specified without the other
+				ds.init = {
+					...{ retryMax: 0, retryDelay: 1000 * 60 * 5 }, // default, 0 retry, every 5 minutes
+					...(ds.init || {}), // overrides from dataset js file
+					...(d.init || {}) // overrides from raw dataset entry in serverconfig, highest priority
+				}
+
+				trackedDatasets.push(ds)
+				// do this check after trackedDatasets.push so that datasets with auth requirement
+				// but no provided creds can still be tracked with fatalError status, to be emitted
+				// in app.ts processTrackedDs() and inform user about missing creds via log and optional slack notification
+				if (ds.requiresAuthCred && !opts.credDslabels?.includes(ds.label)) {
+					ds.init.status = 'fatalError'
+					ds.init.fatalError = `${ds.label} ds.requiresAuthCred is true but no credential provided`
+					delete g.datasets[ds.label] // do not keep reference to this dataset since it will not be loaded
+					continue
+				}
+
 				ds.init.status = 'started'
 				// initial attempt is awaited, so that the server startup logs/CI can summarize status
 				if (ds.isMds3) await mds3_init.init(ds, g, totalRawDsLst)

--- a/server/src/test/dsInitStatus.unit.spec.ts
+++ b/server/src/test/dsInitStatus.unit.spec.ts
@@ -1,0 +1,106 @@
+/********************************************
+Unit tests for dataset init failure reporting (server/src/health.ts getDsInitStatus())
+
+A dataset that fails to load is deleted from genomes[].datasets{} by mayRetryInit(), so /healthcheck
+must report it from the tracked datasets instead -- otherwise a failed dataset is missing from the
+response and is indistinguishable from a dataset that was never configured.
+
+The tracked list is populated directly here: loading a real dataset requires the full tp/ data dir and
+the R/htslib binaries that CI does not have, the same reason src/test/omnisearch.unit.spec.ts hardcodes
+its inputs instead of calling initGenomesDs().
+
+Run with (must use tsx + the sjpp/dev condition):
+  cd proteinpaint/server && npx tsx --conditions=sjpp/dev src/test/dsInitStatus.unit.spec.ts
+or run the whole unit suite (as CI does):
+  cd proteinpaint/server && npm run test:unit
+*********************************************/
+import tape from 'tape'
+import { trackedDatasets } from '#src/initGenomesDs.js'
+import { getDsInitStatus } from '#src/health.ts'
+
+/**************
+ helper functions
+***************/
+
+// replace the tracked datasets for the duration of one test, then restore, so that
+// these tests do not leak state into other specs that share the same process
+function withTrackedDs(entries: any[], callback: () => void) {
+	const saved = trackedDatasets.splice(0, trackedDatasets.length)
+	trackedDatasets.push(...entries)
+	try {
+		callback()
+	} finally {
+		trackedDatasets.splice(0, trackedDatasets.length)
+		trackedDatasets.push(...saved)
+	}
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- src/health getDsInitStatus() -***-')
+	test.end()
+})
+
+tape('dsSummary counts by init status', function (test) {
+	withTrackedDs(
+		[
+			{ genomename: 'hg38', label: 'ds1', init: { status: 'done' } },
+			{ genomename: 'hg38', label: 'ds2', init: { status: 'nonblocking' } },
+			{ genomename: 'hg38', label: 'ds3', init: { status: 'recoverableError', currentRetry: 2 } },
+			{ genomename: 'hg38', label: 'ds4', init: { status: 'fatalError', fatalError: 'no' } },
+			{ genomename: 'hg19', label: 'ds5', init: { status: 'zeroRetries', error: 'no' } }
+		],
+		() => {
+			const { dsSummary } = getDsInitStatus()
+			test.deepEqual(
+				dsSummary,
+				{ total: 5, done: 1, nonblocking: 1, retrying: 1, failed: 2 },
+				'should count done, nonblocking, retrying, and failed datasets'
+			)
+			test.equal(
+				dsSummary.done + dsSummary.nonblocking + dsSummary.retrying + dsSummary.failed,
+				dsSummary.total,
+				'should account for every tracked dataset'
+			)
+		}
+	)
+	test.end()
+})
+
+tape('failed dataset is reported', function (test) {
+	// a dataset whose js file threw while being imported or constructed: it never became a ds object,
+	// so initGenomesDs() tracks a stub for it and it is absent from genomes[].datasets{}
+	const stub = {
+		genomename: 'hg38',
+		label: 'BrokenDs',
+		init: { retryMax: 0, retryDelay: 300000, status: 'fatalError', fatalError: 'did not load ./dataset/broken.js: x' }
+	}
+	withTrackedDs([{ genomename: 'hg38', label: 'GoodDs', init: { status: 'done' } }, stub], () => {
+		const { dsSummary, dsInitStatus } = getDsInitStatus()
+		test.equal(dsSummary.failed, 1, 'should report one failed dataset')
+		const entry = dsInitStatus.find(d => d.label == 'BrokenDs')
+		test.ok(entry, 'should include the failed dataset that is not in genomes[].datasets{}')
+		test.equal(entry?.genome, 'hg38', 'should report the genome of the failed dataset')
+		test.equal(entry?.init.status, 'fatalError', 'should report the failed init status')
+		test.equal(entry?.init.fatalError, stub.init.fatalError, 'should report the init error message')
+		test.notEqual(entry?.init, stub.init, 'should not expose the mutable ds.init object')
+	})
+	test.end()
+})
+
+tape('non-serializable ds.init does not break the response', function (test) {
+	const init: any = { status: 'fatalError' }
+	init.self = init // circular reference, would throw in JSON.stringify()
+	withTrackedDs([{ genomename: 'hg38', label: 'CircularDs', init }], () => {
+		let result
+		test.doesNotThrow(() => {
+			result = getDsInitStatus()
+		}, 'should not throw on a ds.init that cannot be serialized')
+		test.equal(result?.dsSummary.failed, 1, 'should still count the dataset as failed')
+		test.equal(result?.dsInitStatus[0].init.status, 'fatalError', 'should still report the init status')
+	})
+	test.end()
+})

--- a/shared/types/src/routes/healthcheck.ts
+++ b/shared/types/src/routes/healthcheck.ts
@@ -39,9 +39,46 @@ type DbInfo = {
 }
 
 /**
+ * Counts of configured datasets by init status, to quickly detect a dataset that did not load.
+ * total == done + nonblocking + retrying + failed
+ */
+export type DsSummary = {
+	/** number of datasets configured in serverconfig genomes[].datasets[], minus skipped/filtered entries */
+	total: number
+	/** finished loading and ready to serve requests */
+	done: number
+	/** usable, still running non-blocking init steps */
+	nonblocking: number
+	/** failed with a recoverable error, with active init retries */
+	retrying: number
+	/** did not load, will not retry; the dataset does not serve requests */
+	failed: number
+}
+
+/** init status of a single configured dataset, including one that failed to load */
+export type DsInitStatus = {
+	genome: string
+	label: string
+	/** healthcheck url for the dataset-specific getHealth(), if implemented by the dataset */
+	url: string
+	/** copy of the server-side ds.init, e.g. {status, error, fatalError, currentRetry, ignoredErrors} */
+	init: {
+		status?: string
+		error?: any
+		fatalError?: any
+		[key: string]: any
+	}
+}
+
+/**
  * Server status and data related to it's health
  */
 export type HealthCheckResponse = {
+	/**
+	 * status of the server process itself, NOT of its datasets: a server that is up with a failed
+	 * dataset still reports 'ok', since the k8s liveness and readiness probes request this route.
+	 * Use dsSummary.failed and dsInitStatus[] to detect dataset failures.
+	 */
 	status: 'ok' | 'error'
 	genomes: BuildByGenome
 	versionInfo: VersionInfo
@@ -53,7 +90,8 @@ export type HealthCheckResponse = {
 	}
 	w?: number[]
 	rs?: number
-	dsInitStatus: any[]
+	dsSummary: DsSummary
+	dsInitStatus: DsInitStatus[]
 }
 
 // TODO: write payload examples to help with automated testing and documentation, for non-prod use only


### PR DESCRIPTION
# Description

This branch catches dataset preliminary validation errors like missing file (likely due to misspelled file paths or names). 

Tested with:
- have at least 2 dataset entries, then misspell one of the entries (such as `./dataset/gdc/index.ts-000`) in `serverconfig.json`, the restart should not crash in this branch but crashes in master
- do the above but with only 1 dataset entry: the server should crash, because there is no other dataset to load so the validation error should stop the startup. For GDC and MMRF container where there is only one dataset loaded, we want the server to crash in this case to trigger devops notification.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
