### PR TITLE
Computing cell-type fractions and generating cell-type fraction terms

### DIFF
--- a/client/plots/DEinput.ts
+++ b/client/plots/DEinput.ts
@@ -207,9 +207,7 @@ class DEinputPlot extends PlotBase implements RxComponent {
 				holder: this.dom.addGroup,
 				vocabApi: this.app.vocabApi,
 				emptyLabel: 'Add group',
-				/** 'hide_search' by default expands all terms. Passing the
-				 * header_mode in opts gives the caller the flexibility to choose. */
-				header_mode: this.opts?.header_mode || 'hide_search',
+				header_mode: this.opts?.header_mode,
 				callback: async f => {
 					const filter = getNormalRoot(f)
 					this.addNewGroup(filter, this.groups)

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -653,15 +653,16 @@ function setRenderers(self) {
 				.style('display', 'none')
 
 			// p-values legend
+			let pvalueHolder
 			if (self.tests && chart.rawChartId in self.tests) {
-				const holder = div
+				pvalueHolder = div
 					.select('.pp-survival-chartLegends')
 					.style('display', 'inline-block')
 					.append('div')
 					.style('margin-bottom', '30px')
 				renderPvalues({
 					title: 'Group comparisons (log-rank test)',
-					holder,
+					holder: pvalueHolder,
 					plot: 'survival',
 					tests: self.tests[chart.rawChartId],
 					s,
@@ -676,7 +677,12 @@ function setRenderers(self) {
 			if (self.msg) {
 				const fontSize = s.axisTitleFontSize ? s.axisTitleFontSize - 2 : 15
 				const holder = div.select('.pp-survival-chartLegends').style('display', 'inline-block').append('div')
+				const pvalueWidth = pvalueHolder?.node()?.getBoundingClientRect?.().width
+				if (pvalueWidth) holder.style('max-width', `${Math.ceil(pvalueWidth)}px`)
+				else holder.style('max-width', null)
 				holder
+					.style('white-space', 'normal')
+					.style('overflow-wrap', 'break-word')
 					.style('font-size', fontSize + 'px')
 					.style('font-style', 'italic')
 					.text(self.msg)
@@ -734,15 +740,16 @@ function setRenderers(self) {
 		div.select('.pp-survival-chartLegends').style('display', 'none').selectAll('*').remove()
 
 		// p-values legend
+		let pvalueHolder
 		if (self.tests && chart.rawChartId in self.tests) {
-			const holder = div
+			pvalueHolder = div
 				.select('.pp-survival-chartLegends')
 				.style('display', 'inline-block')
 				.append('div')
 				.style('margin-bottom', '30px')
 			renderPvalues({
 				title: 'Group comparisons (log-rank test)',
-				holder,
+				holder: pvalueHolder,
 				plot: 'survival',
 				tests: self.tests[chart.rawChartId],
 				s,
@@ -757,7 +764,12 @@ function setRenderers(self) {
 		if (self.msg) {
 			const fontSize = s.axisTitleFontSize ? s.axisTitleFontSize - 2 : 15
 			const holder = div.select('.pp-survival-chartLegends').style('display', 'inline-block').append('div')
+			const pvalueWidth = pvalueHolder?.node()?.getBoundingClientRect?.().width
+			if (pvalueWidth) holder.style('max-width', `${Math.ceil(pvalueWidth)}px`)
+			else holder.style('max-width', null)
 			holder
+				.style('white-space', 'normal')
+				.style('overflow-wrap', 'break-word')
 				.style('font-size', fontSize + 'px')
 				.style('font-style', 'italic')
 				.text(self.msg)

--- a/server/src/singleCell/SingleCellMetaCache.ts
+++ b/server/src/singleCell/SingleCellMetaCache.ts
@@ -49,6 +49,8 @@ export class SingleCellMetaCache {
 		if (!Number.isInteger(yIdx) || yIdx < 0 || yIdx >= headerColumnCount)
 			throw new Error('Y column index is invalid in ds file')
 
+		const hasCellTypeIdx = Number.isInteger(cellTypeIdx)
+
 		const n = lines.length - 1
 
 		const cellIds: string[] = new Array(n)
@@ -79,19 +81,23 @@ export class SingleCellMetaCache {
 
 			byCellId.set(cellId, rowIdx)
 
-			const cellType = row[cellTypeIdx]
-			if (!cellType) throw new Error(`meta result row missing cell type at row index ${rowIdx + 1}`)
-			cellTypes[rowIdx] = cellType
+			if (hasCellTypeIdx) {
+				const cellType = row[cellTypeIdx]
+				if (!cellType) throw new Error(`meta result row missing cell type at row index ${rowIdx + 1}`)
+				cellTypes[rowIdx] = cellType
+			}
 		}
 
-		return {
+		const cellCache = {
 			cellIds,
 			sampleIds,
 			x,
 			y,
-			byCellId,
-			cellTypes
+			byCellId
 		}
+		if (hasCellTypeIdx) cellCache.cellTypes = cellTypes
+
+		return cellCache
 	}
 
 	private mapMetaResult(
@@ -105,10 +111,8 @@ export class SingleCellMetaCache {
 		for (let i = 0; i < cellCache.cellIds.length; i++) {
 			const cellId = cellCache.cellIds[i]
 			const sampleName = cellCache.sampleIds[i]
-			const cellType = cellCache.cellTypes[i]
 			if (!cellId) throw new Error(`meta result row missing cell id at row index ${i + 1}`)
 			if (!sampleName) throw new Error(`meta result row missing sample id at row index ${i + 1}`)
-			if (!cellType) throw new Error(`meta result row missing cell type at row index ${i + 1}`)
 
 			byCellId.set(cellId, sampleName)
 
@@ -117,28 +121,34 @@ export class SingleCellMetaCache {
 				this.registerCohortSample(sampleName, sampleIntId)
 			}
 
-			// determine cell type abundances in each sample
-			if (!sample2cellType2abundance.has(sampleIntId)) sample2cellType2abundance.set(sampleIntId, new Map())
-			const cellType2abundance = sample2cellType2abundance.get(sampleIntId)
-			if (!cellType2abundance.has(cellType)) cellType2abundance.set(cellType, 0)
-			const abundance = cellType2abundance.get(cellType)
-			cellType2abundance.set(cellType, abundance + 1)
-		}
-
-		// compute cell type fractions
-		const cellType2sample2fraction = new Map()
-		for (const [sample, cellType2abundance] of sample2cellType2abundance) {
-			const totalAbundance = [...cellType2abundance.values()].reduce((total, value) => total + value, 0)
-			for (const [cellType, abundance] of cellType2abundance) {
-				const fraction = abundance / totalAbundance
-				if (!cellType2sample2fraction.has(cellType)) cellType2sample2fraction.set(cellType, new Map())
-				const sample2fraction = cellType2sample2fraction.get(cellType)
-				sample2fraction.set(sample, fraction)
+			if (cellCache.cellTypes) {
+				// cell types are cached, determine abundances in each sample
+				const cellType = cellCache.cellTypes[i]
+				if (!cellType) throw new Error(`meta result row missing cell type at row index ${i + 1}`)
+				if (!sample2cellType2abundance.has(sampleIntId)) sample2cellType2abundance.set(sampleIntId, new Map())
+				const cellType2abundance = sample2cellType2abundance.get(sampleIntId)
+				if (!cellType2abundance.has(cellType)) cellType2abundance.set(cellType, 0)
+				const abundance = cellType2abundance.get(cellType)
+				cellType2abundance.set(cellType, abundance + 1)
 			}
 		}
 
 		this.metaResultNames.add(metaResultName)
 		this.metaIdMap.set(metaResultName, byCellId)
-		this.cellTypeFractions = cellType2sample2fraction
+
+		if (cellCache.cellTypes) {
+			// cell types are cached, determine cell type fractions in each sample
+			const cellType2sample2fraction = new Map()
+			for (const [sample, cellType2abundance] of sample2cellType2abundance) {
+				const totalAbundance = [...cellType2abundance.values()].reduce((total, value) => total + value, 0)
+				for (const [cellType, abundance] of cellType2abundance) {
+					const fraction = abundance / totalAbundance
+					if (!cellType2sample2fraction.has(cellType)) cellType2sample2fraction.set(cellType, new Map())
+					const sample2fraction = cellType2sample2fraction.get(cellType)
+					sample2fraction.set(sample, fraction)
+				}
+			}
+			this.cellTypeFractions = cellType2sample2fraction
+		}
 	}
 }

--- a/server/src/singleCell/SingleCellMetaCache.ts
+++ b/server/src/singleCell/SingleCellMetaCache.ts
@@ -1,5 +1,3 @@
-import initBinConfig from '#shared/termdb.initbinconfig.js'
-
 type CellCache = {
 	cellIds: string[]
 	sampleIds: string[]
@@ -15,7 +13,7 @@ export class SingleCellMetaCache {
 	sampleName2IntId = new Map<string, any>()
 	metaIdMap = new Map<string, Map<string, string>>()
 	metaResultNames = new Set<string>()
-	cellTypeFractions?: { anno: any; terms: any }
+	cellTypeFractions?: Map<any, any>
 
 	registerCohortSample(sampleName: string, sampleIntId: any): void {
 		/** Sample INT ids correspond to the primary key in the termdb */
@@ -28,14 +26,13 @@ export class SingleCellMetaCache {
 		metaResultName: string,
 		text: string,
 		idxs: any, // TODO: update type
-		plot: any, // TODO: update type
 		sampleName2id: (sampleName: string) => any
 	): void {
 		const cellCache = this.initCellCacheFromText(text, idxs)
-		this.mapMetaResult(metaResultName, cellCache, plot, sampleName2id)
+		this.mapMetaResult(metaResultName, cellCache, sampleName2id)
 	}
 
-	// TODO: update type of idxs/plot
+	// TODO: update type of idxs
 	private initCellCacheFromText(text: string, idxs): CellCache {
 		const lines = text.trim().split('\n')
 		if (!lines[0]) throw new Error('meta result file is empty')
@@ -100,7 +97,6 @@ export class SingleCellMetaCache {
 	private mapMetaResult(
 		metaResultName: string,
 		cellCache: CellCache,
-		plot, // TODO: update type
 		sampleName2id: (sampleName: string) => any
 	): void {
 		const byCellId = new Map<string, string>()
@@ -116,20 +112,20 @@ export class SingleCellMetaCache {
 
 			byCellId.set(cellId, sampleName)
 
-			// determine cell type abundances in each sample
-			if (!sample2cellType2abundance.has(sampleName)) sample2cellType2abundance.set(sampleName, new Map())
-			const cellType2abundance = sample2cellType2abundance.get(sampleName)
-			if (!cellType2abundance.has(cellType)) cellType2abundance.set(cellType, 0)
-			const abundance = cellType2abundance.get(cellType)
-			cellType2abundance.set(cellType, abundance + 1)
-
 			const sampleIntId = sampleName2id(sampleName)
 			if (sampleIntId !== undefined) {
 				this.registerCohortSample(sampleName, sampleIntId)
 			}
+
+			// determine cell type abundances in each sample
+			if (!sample2cellType2abundance.has(sampleIntId)) sample2cellType2abundance.set(sampleIntId, new Map())
+			const cellType2abundance = sample2cellType2abundance.get(sampleIntId)
+			if (!cellType2abundance.has(cellType)) cellType2abundance.set(cellType, 0)
+			const abundance = cellType2abundance.get(cellType)
+			cellType2abundance.set(cellType, abundance + 1)
 		}
 
-		// determine cell-type fractions in each sample
+		// compute cell type fractions
 		const cellType2sample2fraction = new Map()
 		for (const [sample, cellType2abundance] of sample2cellType2abundance) {
 			const totalAbundance = [...cellType2abundance.values()].reduce((total, value) => total + value, 0)
@@ -141,23 +137,8 @@ export class SingleCellMetaCache {
 			}
 		}
 
-		// create cell type fraction terms
-		const cellTypeFractionTerms = []
-		for (const [cellType, sample2fraction] of cellType2sample2fraction) {
-			const id = cellType + '_' + plot.cellTypeColumn.name
-			const name = cellType + ' ' + plot.cellTypeColumn.name
-			const term = {
-				id,
-				name,
-				type: 'float',
-				cellType,
-				bins: { default: initBinConfig([...sample2fraction.values()]) }
-			}
-			cellTypeFractionTerms.push(term)
-		}
-
 		this.metaResultNames.add(metaResultName)
 		this.metaIdMap.set(metaResultName, byCellId)
-		this.cellTypeFractions = { anno: cellType2sample2fraction, terms: cellTypeFractionTerms }
+		this.cellTypeFractions = cellType2sample2fraction
 	}
 }

--- a/server/src/singleCell/SingleCellMetaCache.ts
+++ b/server/src/singleCell/SingleCellMetaCache.ts
@@ -1,115 +1,163 @@
-import type { CoordColumns } from '#types'
+import initBinConfig from '#shared/termdb.initbinconfig.js'
 
 type CellCache = {
-  cellIds: string[]
-  sampleIds: string[]
-  x: Float32Array
-  y: Float32Array
+	cellIds: string[]
+	sampleIds: string[]
+	x: Float32Array
+	y: Float32Array
 
-  byCellId: Map<string, number>
+	byCellId: Map<string, number>
 }
 
 export class SingleCellMetaCache {
-  sampleIntIds = new Set<any>()
-  sampleIntId2Name = new Map<any, string>()
-  sampleName2IntId = new Map<string, any>()
-  metaIdMap = new Map<string, Map<string, string>>()
-  metaResultNames = new Set<string>()
+	sampleIntIds = new Set<any>()
+	sampleIntId2Name = new Map<any, string>()
+	sampleName2IntId = new Map<string, any>()
+	metaIdMap = new Map<string, Map<string, string>>()
+	metaResultNames = new Set<string>()
+	cellTypeFractions?: { anno: any; terms: any }
 
-  registerCohortSample(sampleName: string, sampleIntId: any): void {
-    /** Sample INT ids correspond to the primary key in the termdb */
-    this.sampleIntIds.add(sampleIntId)
-    this.sampleIntId2Name.set(sampleIntId, sampleName)
-    this.sampleName2IntId.set(sampleName, sampleIntId)
-  }
+	registerCohortSample(sampleName: string, sampleIntId: any): void {
+		/** Sample INT ids correspond to the primary key in the termdb */
+		this.sampleIntIds.add(sampleIntId)
+		this.sampleIntId2Name.set(sampleIntId, sampleName)
+		this.sampleName2IntId.set(sampleName, sampleIntId)
+	}
 
-  addMetaResult(
-    metaResultName: string,
-    text: string,
-    coordsColumns: CoordColumns,
-    sampleName2id: (sampleName: string) => any,
-    cellIdxCols?: {cellIdx: number, sampleIdx: number}
-  ): void {
-    const cellCache = this.initCellCacheFromText(text, coordsColumns, cellIdxCols)
-    this.mapMetaResult(metaResultName, cellCache, sampleName2id)
-  }
+	addMetaResult(
+		metaResultName: string,
+		text: string,
+		idxs: any, // TODO: update type
+		plot: any, // TODO: update type
+		sampleName2id: (sampleName: string) => any
+	): void {
+		const cellCache = this.initCellCacheFromText(text, idxs)
+		this.mapMetaResult(metaResultName, cellCache, plot, sampleName2id)
+	}
 
-  private initCellCacheFromText(text: string, coordsColumns: CoordColumns, cellIdxCols?: {cellIdx: number, sampleIdx: number}): CellCache {
-    const lines = text.trim().split('\n')
-    if (!lines[0]) throw new Error('meta result file is empty')
-    const headerColumnCount = lines[0].split('\t').length
+	// TODO: update type of idxs/plot
+	private initCellCacheFromText(text: string, idxs): CellCache {
+		const lines = text.trim().split('\n')
+		if (!lines[0]) throw new Error('meta result file is empty')
+		const headerColumnCount = lines[0].split('\t').length
 
-    const cellIdIdx = cellIdxCols?.cellIdx ?? 0
-    const sampleIdIdx = cellIdxCols?.sampleIdx ?? 1
-    const xIdx = coordsColumns.x
-    const yIdx = coordsColumns.y
+		const cellIdIdx = idxs?.cell ?? 0
+		const sampleIdIdx = idxs?.sample ?? 1
+		const xIdx = idxs.x
+		const yIdx = idxs.y
+		const cellTypeIdx = idxs.cellType
 
-    if (!Number.isInteger(xIdx) || xIdx < 0 || xIdx >= headerColumnCount)
-      throw new Error('X column index is invalid in ds file')
-    if (!Number.isInteger(yIdx) || yIdx < 0 || yIdx >= headerColumnCount)
-      throw new Error('Y column index is invalid in ds file')
+		if (!Number.isInteger(xIdx) || xIdx < 0 || xIdx >= headerColumnCount)
+			throw new Error('X column index is invalid in ds file')
+		if (!Number.isInteger(yIdx) || yIdx < 0 || yIdx >= headerColumnCount)
+			throw new Error('Y column index is invalid in ds file')
 
-    const n = lines.length - 1
+		const n = lines.length - 1
 
-    const cellIds: string[] = new Array(n)
-    const sampleIds: string[] = new Array(n)
-    const x = new Float32Array(n)
-    const y = new Float32Array(n)
+		const cellIds: string[] = new Array(n)
+		const sampleIds: string[] = new Array(n)
+		const x = new Float32Array(n)
+		const y = new Float32Array(n)
+		const cellTypes: string[] = new Array(n)
 
-    const byCellId = new Map<string, number>()
+		const byCellId = new Map<string, number>()
 
-    for (let i = 1; i < lines.length; i++) {
-      const row = lines[i].split('\t').map(s => s.trim())
-      const rowIdx = i - 1
+		for (let i = 1; i < lines.length; i++) {
+			const row = lines[i].split('\t').map(s => s.trim())
+			const rowIdx = i - 1
 
-      const cellId = row[cellIdIdx]
-      const sampleName = row[sampleIdIdx]
+			const cellId = row[cellIdIdx]
+			const sampleName = row[sampleIdIdx]
 
-      cellIds[rowIdx] = cellId
-      sampleIds[rowIdx] = sampleName
-      x[rowIdx] = Number(row[xIdx])
-      y[rowIdx] = Number(row[yIdx])
+			cellIds[rowIdx] = cellId
+			sampleIds[rowIdx] = sampleName
+			x[rowIdx] = Number(row[xIdx])
+			y[rowIdx] = Number(row[yIdx])
 
-      if (!cellId) throw new Error(`meta result row missing cell id at row index ${rowIdx + 1}`)
-      if (!sampleName) throw new Error(`meta result row missing sample id at row index ${rowIdx + 1}`)
-      if (!Number.isFinite(x[rowIdx]) || !Number.isFinite(y[rowIdx])) {
-        throw new Error(`meta result row has non-numeric x/y at row index ${rowIdx + 1}`)
-      }
+			if (!cellId) throw new Error(`meta result row missing cell id at row index ${rowIdx + 1}`)
+			if (!sampleName) throw new Error(`meta result row missing sample id at row index ${rowIdx + 1}`)
+			if (!Number.isFinite(x[rowIdx]) || !Number.isFinite(y[rowIdx])) {
+				throw new Error(`meta result row has non-numeric x/y at row index ${rowIdx + 1}`)
+			}
 
-      byCellId.set(cellId, rowIdx)
-    }
+			byCellId.set(cellId, rowIdx)
 
-    return {
-      cellIds,
-      sampleIds,
-      x,
-      y,
-      byCellId
-    }
-  }
+			const cellType = row[cellTypeIdx]
+			if (!cellType) throw new Error(`meta result row missing cell type at row index ${rowIdx + 1}`)
+			cellTypes[rowIdx] = cellType
+		}
 
-  private mapMetaResult(
-    metaResultName: string,
-    cellCache: CellCache,
-    sampleName2id: (sampleName: string) => any
-  ): void {
-    const byCellId = new Map<string, string>()
+		return {
+			cellIds,
+			sampleIds,
+			x,
+			y,
+			byCellId,
+			cellTypes
+		}
+	}
 
-    for (let i = 0; i < cellCache.cellIds.length; i++) {
-      const cellId = cellCache.cellIds[i]
-      const sampleName = cellCache.sampleIds[i]
-      if (!cellId) throw new Error(`meta result row missing cell id at row index ${i + 1}`)
-      if (!sampleName) throw new Error(`meta result row missing sample id at row index ${i + 1}`)
+	private mapMetaResult(
+		metaResultName: string,
+		cellCache: CellCache,
+		plot, // TODO: update type
+		sampleName2id: (sampleName: string) => any
+	): void {
+		const byCellId = new Map<string, string>()
+		const sample2cellType2abundance = new Map() // sample => cellType => abundance
 
-      byCellId.set(cellId, sampleName)
+		for (let i = 0; i < cellCache.cellIds.length; i++) {
+			const cellId = cellCache.cellIds[i]
+			const sampleName = cellCache.sampleIds[i]
+			const cellType = cellCache.cellTypes[i]
+			if (!cellId) throw new Error(`meta result row missing cell id at row index ${i + 1}`)
+			if (!sampleName) throw new Error(`meta result row missing sample id at row index ${i + 1}`)
+			if (!cellType) throw new Error(`meta result row missing cell type at row index ${i + 1}`)
 
-      const sampleIntId = sampleName2id(sampleName)
-      if (sampleIntId !== undefined) {
-        this.registerCohortSample(sampleName, sampleIntId)
-      }
-    }
+			byCellId.set(cellId, sampleName)
 
-    this.metaResultNames.add(metaResultName)
-    this.metaIdMap.set(metaResultName, byCellId)
-  }
+			// determine cell type abundances in each sample
+			if (!sample2cellType2abundance.has(sampleName)) sample2cellType2abundance.set(sampleName, new Map())
+			const cellType2abundance = sample2cellType2abundance.get(sampleName)
+			if (!cellType2abundance.has(cellType)) cellType2abundance.set(cellType, 0)
+			const abundance = cellType2abundance.get(cellType)
+			cellType2abundance.set(cellType, abundance + 1)
+
+			const sampleIntId = sampleName2id(sampleName)
+			if (sampleIntId !== undefined) {
+				this.registerCohortSample(sampleName, sampleIntId)
+			}
+		}
+
+		// determine cell-type fractions in each sample
+		const cellType2sample2fraction = new Map()
+		for (const [sample, cellType2abundance] of sample2cellType2abundance) {
+			const totalAbundance = [...cellType2abundance.values()].reduce((total, value) => total + value, 0)
+			for (const [cellType, abundance] of cellType2abundance) {
+				const fraction = abundance / totalAbundance
+				if (!cellType2sample2fraction.has(cellType)) cellType2sample2fraction.set(cellType, new Map())
+				const sample2fraction = cellType2sample2fraction.get(cellType)
+				sample2fraction.set(sample, fraction)
+			}
+		}
+
+		// create cell type fraction terms
+		const cellTypeFractionTerms = []
+		for (const [cellType, sample2fraction] of cellType2sample2fraction) {
+			const id = cellType + '_' + plot.cellTypeColumn.name
+			const name = cellType + ' ' + plot.cellTypeColumn.name
+			const term = {
+				id,
+				name,
+				type: 'float',
+				cellType,
+				bins: { default: initBinConfig([...sample2fraction.values()]) }
+			}
+			cellTypeFractionTerms.push(term)
+		}
+
+		this.metaResultNames.add(metaResultName)
+		this.metaIdMap.set(metaResultName, byCellId)
+		this.cellTypeFractions = { anno: cellType2sample2fraction, terms: cellTypeFractionTerms }
+	}
 }

--- a/server/src/singleCell/SingleCellMetaCache.ts
+++ b/server/src/singleCell/SingleCellMetaCache.ts
@@ -21,7 +21,7 @@ export class SingleCellMetaCache {
 	sampleName2IntId = new Map<string, any>()
 	metaIdMap = new Map<string, Map<string, string>>()
 	metaResultNames = new Set<string>()
-	cellTypeFractions?: Map<any, any>
+	cellTypeFractions = new Map<string, Map<string, number>>()
 
 	registerCohortSample(sampleName: string, sampleIntId: any): void {
 		/** Sample INT ids correspond to the primary key in the termdb */
@@ -127,23 +127,21 @@ export class SingleCellMetaCache {
 			const sampleIntId = sampleName2id(sampleName)
 			if (sampleIntId !== undefined) {
 				this.registerCohortSample(sampleName, sampleIntId)
-			}
-
-			if (cellCache.cellTypes) {
-				// cell types are cached, determine abundances in each sample
-				const cellType = cellCache.cellTypes[i]
-				if (!cellType) throw new Error(`meta result row missing cell type at row index ${i + 1}`)
-				if (!sample2cellType2abundance.has(sampleIntId)) sample2cellType2abundance.set(sampleIntId, new Map())
-				const cellType2abundance = sample2cellType2abundance.get(sampleIntId)
-				if (!cellType2abundance.has(cellType)) cellType2abundance.set(cellType, 0)
-				const abundance = cellType2abundance.get(cellType)
-				cellType2abundance.set(cellType, abundance + 1)
+				if (cellCache.cellTypes) {
+					// cell types are cached, determine abundances in each sample
+					const cellType = cellCache.cellTypes[i]
+					if (!cellType) throw new Error(`meta result row missing cell type at row index ${i + 1}`)
+					if (!sample2cellType2abundance.has(sampleIntId)) sample2cellType2abundance.set(sampleIntId, new Map())
+					const cellType2abundance = sample2cellType2abundance.get(sampleIntId)
+					if (!cellType2abundance.has(cellType)) cellType2abundance.set(cellType, 0)
+					const abundance = cellType2abundance.get(cellType)
+					cellType2abundance.set(cellType, abundance + 1)
+				}
 			}
 		}
 
 		this.metaResultNames.add(metaResultName)
 		this.metaIdMap.set(metaResultName, byCellId)
-
 		if (cellCache.cellTypes) {
 			// cell types are cached, determine cell type fractions in each sample
 			const cellType2sample2fraction = new Map()

--- a/server/src/singleCell/SingleCellMetaCache.ts
+++ b/server/src/singleCell/SingleCellMetaCache.ts
@@ -3,8 +3,16 @@ type CellCache = {
 	sampleIds: string[]
 	x: Float32Array
 	y: Float32Array
-
 	byCellId: Map<string, number>
+	cellTypes?: string[]
+}
+
+type MetaResultIdxs = {
+	cell: number
+	sample: number
+	x: number
+	y: number
+	cellType?: number
 }
 
 export class SingleCellMetaCache {
@@ -25,15 +33,14 @@ export class SingleCellMetaCache {
 	addMetaResult(
 		metaResultName: string,
 		text: string,
-		idxs: any, // TODO: update type
+		idxs: MetaResultIdxs,
 		sampleName2id: (sampleName: string) => any
 	): void {
 		const cellCache = this.initCellCacheFromText(text, idxs)
 		this.mapMetaResult(metaResultName, cellCache, sampleName2id)
 	}
 
-	// TODO: update type of idxs
-	private initCellCacheFromText(text: string, idxs): CellCache {
+	private initCellCacheFromText(text: string, idxs: MetaResultIdxs): CellCache {
 		const lines = text.trim().split('\n')
 		if (!lines[0]) throw new Error('meta result file is empty')
 		const headerColumnCount = lines[0].split('\t').length
@@ -82,13 +89,14 @@ export class SingleCellMetaCache {
 			byCellId.set(cellId, rowIdx)
 
 			if (hasCellTypeIdx) {
-				const cellType = row[cellTypeIdx]
+				const cti = cellTypeIdx as number
+				const cellType = row[cti]
 				if (!cellType) throw new Error(`meta result row missing cell type at row index ${rowIdx + 1}`)
 				cellTypes[rowIdx] = cellType
 			}
 		}
 
-		const cellCache = {
+		const cellCache: CellCache = {
 			cellIds,
 			sampleIds,
 			x,

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -186,8 +186,14 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 				const text = await read_file(tsvfile)
 				const t1 = Date.now()
 				mayLog(ds.label, 'sc meta read file time:', t1 - t0)
-				const cellIdxCols = { cellIdx: plot.cellIdx ?? 0, sampleIdx: hasSample?.index ?? 1 }
-				metaCache.addMetaResult(sampleName, text, plot.coordsColumns, ds.cohort.termdb.q.sampleName2id, cellIdxCols)
+				const idxs = {
+					cell: plot.cellIdx ?? 0,
+					sample: hasSample?.index ?? 1,
+					x: plot.coordsColumns.x,
+					y: plot.coordsColumns.y,
+					cellType: plot.cellTypeColumn?.index
+				}
+				metaCache.addMetaResult(sampleName, text, idxs, plot, ds.cohort.termdb.q.sampleName2id)
 				mayLog(ds.label, 'sc meta caching time:', Date.now() - t0)
 			} catch (e: any) {
 				throw new Error(`meta result data file missing or unreadable: ${sampleName} (${tsvfile}): ${e.message || e}`)
@@ -215,6 +221,11 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 	if (samples.size == 0) throw new Error('no scrna samples found')
 	S.sampleMappingCache = metaCache
 	if (metaCache.metaIdMap.size) D.metaIdMap = metaCache.metaIdMap
+	if (metaCache.cellTypeFractions) {
+		D.cellTypeFractions = metaCache.cellTypeFractions
+		if (!D.addCellTypeFractionTerms) throw new Error('missing addCellTypeFractionTerms() method')
+		D.addCellTypeFractionTerms(ds)
+	}
 
 	// samples map populated with samples with sc data
 	if (S.sampleColumns) {

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -200,13 +200,13 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 					// create cell type fraction terms
 					const cellType2sample2fraction = metaCache.cellTypeFractions
 					const cellTypeFractionTerms = []
-					for (const [cellType, sample2fraction] of cellType2sample2fraction) {
-						const id = cellType + '_' + plot.cellTypeColumn.name + '_frac'
-						const name = cellType + ' ' + plot.cellTypeColumn.name + ' ' + 'fraction'
+					// iterating over plot.cellType2label to preserve order of cell types
+					for (const [cellType, label] of plot.cellType2label) {
+						const sample2fraction = cellType2sample2fraction.get(cellType)
 						const values = [...sample2fraction.values()]
 						const term = {
-							id,
-							name,
+							id: cellType,
+							name: label,
 							type: 'float',
 							cellType,
 							bins: {

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -221,7 +221,7 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 					if (!D.addCellTypeFractionTerms) throw new Error('missing addCellTypeFractionTerms() method')
 					D.addCellTypeFractionTerms(cellTypeFractionTerms, ds)
 					// cache term data
-					ds.termid2sample2value = new Map()
+					if (!ds.termid2sample2value) ds.termid2sample2value = new Map()
 					for (const term of cellTypeFractionTerms) {
 						const sample2fraction = cellType2sample2fraction.get(term.cellType)
 						ds.termid2sample2value.set(term.id, sample2fraction)

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -28,6 +28,7 @@ import { SingleCellMetaCache } from './SingleCellMetaCache.ts'
 import { run_python } from '@sjcrh/proteinpaint-python'
 import { validatePseudobulk } from './validatePseudobulk.ts'
 import type { ReqQueryAddons } from '#routes/types.js'
+import initBinConfig from '#shared/termdb.initbinconfig.js'
 
 export const payload: RoutePayload = {
 	init,
@@ -193,7 +194,39 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 					y: plot.coordsColumns.y,
 					cellType: plot.cellTypeColumn?.index
 				}
-				metaCache.addMetaResult(sampleName, text, idxs, plot, ds.cohort.termdb.q.sampleName2id)
+				metaCache.addMetaResult(sampleName, text, idxs, ds.cohort.termdb.q.sampleName2id)
+				if (metaCache.cellTypeFractions) {
+					// cell type fractions have been computed
+					// create cell type fraction terms
+					const cellType2sample2fraction = metaCache.cellTypeFractions
+					const cellTypeFractionTerms = []
+					for (const [cellType, sample2fraction] of cellType2sample2fraction) {
+						const id = cellType + '_' + plot.cellTypeColumn.name + '_frac'
+						const name = cellType + ' ' + plot.cellTypeColumn.name + ' ' + 'fraction'
+						const values = [...sample2fraction.values()]
+						const term = {
+							id,
+							name,
+							type: 'float',
+							cellType,
+							bins: {
+								default: initBinConfig(values),
+								min: Math.min(...values),
+								max: Math.max(...values)
+							}
+						}
+						cellTypeFractionTerms.push(term)
+					}
+					// inject terms into ds dictionary
+					if (!D.addCellTypeFractionTerms) throw new Error('missing addCellTypeFractionTerms() method')
+					D.addCellTypeFractionTerms(cellTypeFractionTerms, ds)
+					// cache term data
+					ds.termid2sample2value = new Map()
+					for (const term of cellTypeFractionTerms) {
+						const sample2fraction = cellType2sample2fraction.get(term.cellType)
+						ds.termid2sample2value.set(term.id, sample2fraction)
+					}
+				}
 				mayLog(ds.label, 'sc meta caching time:', Date.now() - t0)
 			} catch (e: any) {
 				throw new Error(`meta result data file missing or unreadable: ${sampleName} (${tsvfile}): ${e.message || e}`)
@@ -221,11 +254,6 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 	if (samples.size == 0) throw new Error('no scrna samples found')
 	S.sampleMappingCache = metaCache
 	if (metaCache.metaIdMap.size) D.metaIdMap = metaCache.metaIdMap
-	if (metaCache.cellTypeFractions) {
-		D.cellTypeFractions = metaCache.cellTypeFractions
-		if (!D.addCellTypeFractionTerms) throw new Error('missing addCellTypeFractionTerms() method')
-		D.addCellTypeFractionTerms(ds)
-	}
 
 	// samples map populated with samples with sc data
 	if (S.sampleColumns) {

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -199,8 +199,9 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 					// cell type fractions have been computed
 					// create cell type fraction terms
 					const cellType2sample2fraction = metaCache.cellTypeFractions
-					const cellTypeFractionTerms = []
+					const cellTypeFractionTerms: any[] = []
 					// iterating over plot.cellType2label to preserve order of cell types
+					if (!plot.cellType2label) throw new Error('plot.cellType2label is undefined')
 					for (const [cellType, label] of plot.cellType2label) {
 						const sample2fraction = cellType2sample2fraction.get(cellType)
 						const values = [...sample2fraction.values()]

--- a/server/src/singleCell/samplesRoute.ts
+++ b/server/src/singleCell/samplesRoute.ts
@@ -195,7 +195,7 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 					cellType: plot.cellTypeColumn?.index
 				}
 				metaCache.addMetaResult(sampleName, text, idxs, ds.cohort.termdb.q.sampleName2id)
-				if (metaCache.cellTypeFractions) {
+				if (metaCache.cellTypeFractions.size) {
 					// cell type fractions have been computed
 					// create cell type fraction terms
 					const cellType2sample2fraction = metaCache.cellTypeFractions
@@ -204,6 +204,7 @@ async function validateSamples(q: SingleCellQuery, ds: any): Promise<void> {
 					if (!plot.cellType2label) throw new Error('plot.cellType2label is undefined')
 					for (const [cellType, label] of plot.cellType2label) {
 						const sample2fraction = cellType2sample2fraction.get(cellType)
+						if (!sample2fraction) throw new Error('cell type not found')
 						const values = [...sample2fraction.values()]
 						const term = {
 							id: cellType,

--- a/server/src/termdb.getDefaultBins.js
+++ b/server/src/termdb.getDefaultBins.js
@@ -23,7 +23,7 @@ export async function trigger_getDefaultBins(q, ds, res) {
 	let max = -Infinity
 	let binsCache // fine to cache bins for scrna genes, but not for cohort level data that's subject to filtering
 	try {
-		if (ds.termid2sample2value.has(tw.term.id)) {
+		if (ds.termid2sample2value?.has(tw.term.id)) {
 			// term data is cached
 			// use the cached data to compute bins
 			const sample2value = ds.termid2sample2value.get(tw.term.id)

--- a/server/src/termdb.getDefaultBins.js
+++ b/server/src/termdb.getDefaultBins.js
@@ -1,6 +1,7 @@
 import { SINGLECELL_GENE_EXPRESSION, PROTEOME_ABUNDANCE, PSEUDOBULK } from '#types'
 import initBinConfig from '#shared/termdb.initbinconfig.js'
 import { maySetMapParent2Children } from './termdb.matrix.js'
+import { mayLimitSamples } from './mds3.filter.js'
 
 // TODO convert to route
 
@@ -26,7 +27,9 @@ export async function trigger_getDefaultBins(q, ds, res) {
 			// term data is cached
 			// use the cached data to compute bins
 			const sample2value = ds.termid2sample2value.get(tw.term.id)
-			for (const value of sample2value.values()) {
+			const limitSamples = await mayLimitSamples(q, [...sample2value.keys()], ds)
+			for (const [sample, value] of sample2value) {
+				if (limitSamples && !limitSamples.has(sample)) continue
 				lst.push(value)
 				if (value < min) min = value
 				if (value > max) max = value

--- a/server/src/termdb.getDefaultBins.js
+++ b/server/src/termdb.getDefaultBins.js
@@ -22,7 +22,16 @@ export async function trigger_getDefaultBins(q, ds, res) {
 	let max = -Infinity
 	let binsCache // fine to cache bins for scrna genes, but not for cohort level data that's subject to filtering
 	try {
-		if (tw.term.type == SINGLECELL_GENE_EXPRESSION) {
+		if (ds.termid2sample2value.has(tw.term.id)) {
+			// term data is cached
+			// use the cached data to compute bins
+			const sample2value = ds.termid2sample2value.get(tw.term.id)
+			for (const value of sample2value.values()) {
+				lst.push(value)
+				if (value < min) min = value
+				if (value > max) max = value
+			}
+		} else if (tw.term.type == SINGLECELL_GENE_EXPRESSION) {
 			if (!ds.queries?.singleCell?.geneExpression) throw 'term type not supported by this dataset'
 			binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample]
 			if (!binsCache) binsCache = ds.queries.singleCell.geneExpression.sample2gene2expressionBins[tw.term.sample] = {}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -728,6 +728,22 @@ output:
 */
 async function getSampleData_dictionaryTerms(q, termWrappers) {
 	if (!termWrappers.length) return [{}, {}]
+	// distinguish between dictionary terms with cached or uncached data
+	const cachedTermWrappers = []
+	const uncachedTermWrappers = []
+	for (const tw of termWrappers) {
+		q.ds?.termid2sample2value?.has(tw.term.id) ? cachedTermWrappers.push(tw) : uncachedTermWrappers.push(tw)
+	}
+	// query uncached dictionary term data
+	const [samples, byTermId] = await getSampleData_dictionaryTerms_uncached(q, uncachedTermWrappers)
+	// query cached dictionary term data
+	await getSampleData_dictionaryTerms_cached(q, cachedTermWrappers, samples, byTermId)
+	// return all queried dictionary term data
+	return [samples, byTermId]
+}
+
+async function getSampleData_dictionaryTerms_uncached(q, termWrappers) {
+	if (!termWrappers.length) return [{}, {}]
 	if (q.ds?.cohort?.db) {
 		// dataset uses server-side sqlite db, must use this method for dictionary terms
 		return await getSampleData_dictionaryTerms_termdb(q, termWrappers)
@@ -741,6 +757,28 @@ async function getSampleData_dictionaryTerms(q, termWrappers) {
 		return await q.ds.cohort.termdb.q?.getAdHocTermValues(q, termWrappers)
 	}
 	throw 'unknown method for dictionary terms'
+}
+
+async function getSampleData_dictionaryTerms_cached(q, termWrappers, samples, byTermId) {
+	for (const tw of termWrappers) {
+		const sample2value = q.ds.termid2sample2value.get(tw.term.id)
+		let lstOfBins // of this tw. only set when q.mode is discrete
+		if (tw.q?.mode == 'discrete' || tw.q?.mode == 'binary') {
+			lstOfBins = await findListOfBins(q, tw, q.ds)
+			byTermId[tw.$id] = { bins: lstOfBins }
+		}
+		for (const [sample, value] of sample2value) {
+			if (!samples[sample]) samples[sample] = { sample }
+			if (samples[sample][tw.$id]) throw 'should not have multiple values for sample'
+			let key = value
+			if (lstOfBins) {
+				// term is in binning mode, key should be bin label
+				const bin = getBin(lstOfBins, value)
+				key = get_bin_label(lstOfBins[bin], tw.q)
+			}
+			samples[sample][tw.$id] = { key, value }
+		}
+	}
 }
 
 export async function getSampleData_dictionaryTerms_termdb(q, termWrappers) {

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -34,6 +34,7 @@ import {
 	reconstituteCustomTermCollection,
 	resolveTermCollectionFractions
 } from './termdb.termCollection.ts'
+import { mayLimitSamples } from './mds3.filter.js'
 
 /* centralized resolution of a sample id -> display refs ({ label, ... }) for refs.bySampleId{}.
 each dataset implements ds.cohort.termdb.q.id2sampleRefs() (native/gdc/mmrf); it owns any id
@@ -762,12 +763,14 @@ async function getSampleData_dictionaryTerms_uncached(q, termWrappers) {
 async function getSampleData_dictionaryTerms_cached(q, termWrappers, samples, byTermId) {
 	for (const tw of termWrappers) {
 		const sample2value = q.ds.termid2sample2value.get(tw.term.id)
+		const limitSamples = await mayLimitSamples(q, [...sample2value.keys()], q.ds)
 		let lstOfBins // of this tw. only set when q.mode is discrete
 		if (tw.q?.mode == 'discrete' || tw.q?.mode == 'binary') {
 			lstOfBins = await findListOfBins(q, tw, q.ds)
 			byTermId[tw.$id] = { bins: lstOfBins }
 		}
 		for (const [sample, value] of sample2value) {
+			if (limitSamples && !limitSamples.has(sample)) continue
 			if (!samples[sample]) samples[sample] = { sample }
 			if (samples[sample][tw.$id]) throw 'should not have multiple values for sample'
 			let key = value

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1036,6 +1036,10 @@ export type SingleCellPlot = {
 	 * If .isMetaResult is true, array must include a sample column.
 	 */
 	colorColumns: ColorColumn[]
+	/** Indicates column index in text file containing cell type annotations */
+	cellTypeColumn?: { index: number }
+	/** Map between cell type and cell type label */
+	cellType2label?: Map<string, string>
 	/** if true the plot is shown by default. otherwise hidden.
 	 * Old implementation. Maybe deleted when singleCellPlot is deprecated.*/
 	selected?: boolean
@@ -1070,6 +1074,8 @@ export type SingleCellData = {
 	twLst?: object[]
 	/** available tsne type of plots for each sample */
 	plots: SingleCellPlot[]
+	/** function for adding cell type fraction terms to dictionary */
+	addCellTypeFractionTerms?: (terms: any[], ds: any) => void
 	/** created on init for meta analysis plots
 	 * <plotName(i.e metaResultID), <cellId, sampleId >> */
 	metaIdMap?: Map<string, Map<string, string>>


### PR DESCRIPTION
# Description

Associated with sjpp PR: https://github.com/stjude/sjpp/pull/1479

Support for computing cell-type fractions based on scRNA-seq metadata and caching the computed cell-type fractions in the `ds.termid2sample2value`. Also added support for generating cell-type fraction terms and allowing these terms to query the cached data.

Now `getSampleData_dictionaryTerms()` in `termdb.matrix.js` has two different methods `getSampleData_dictionaryTerms_uncached` to query uncached dictionary data and `getSampleData_dictionaryTerms_cached` to query cached dictionary data.

Can test by opening [MMRF correlation plot](http://localhost:3000/example.mmrf.correlation.html) -> select variable -> scRNA cell type fractions -> select cell-type fraction term

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
