### PR TITLE
GDC: DE review follow-ups, and fix GSEA's missing p-value and FDR columns

### DIFF
--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -145,8 +145,10 @@ export function renderTable({
 			height: 15,
 			title: 'Download table',
 			handler: () => {
-				// no fileName supplied -> let downloadTable's date-stamped default apply
-				downloadTable(rows, columns, download.fileName)
+				// no fileName supplied -> let downloadTable's date-stamped default apply. '' has to
+				// become undefined for the default parameter to fire; otherwise link.download is empty
+				// and the browser names the file after the data: url
+				downloadTable(rows, columns, download.fileName || undefined)
 			}
 		})
 	}
@@ -779,8 +781,10 @@ export async function downloadTable(rows, cols, filename = `table-${fileDateStam
 
 	/* Create and trigger download. The leading BOM is required: without it excel on windows decodes
 	the file with the system codepage, and utf-8 in the content -- column labels like
-	"log₂(fold-change)", non-ascii sample names -- arrives as mojibake. Every other reader either
-	honors the BOM or skips it. */
+	"log₂(fold-change)", non-ascii sample names -- arrives as mojibake. R's read.delim strips it and
+	pandas' C parser strips it, but python's own csv module does not: open(p, encoding='utf-8') makes
+	the first header '\ufeffGene'. Read these with encoding='utf-8-sig', which is a no-op on a file
+	without a BOM. */
 	const dataStr = 'data:text/tsv;charset=utf-8,' + encodeURIComponent(BOM + lines)
 	const link = document.createElement('a')
 	link.setAttribute('href', dataStr)

--- a/client/dom/table.ts
+++ b/client/dom/table.ts
@@ -388,8 +388,13 @@ export function renderTable({
 				const column = columns[colIdx]
 
 				if (column.barplot) {
-					if (typeof cell.value === 'number') {
+					if (typeof cell.value === 'number' && Number.isFinite(cell.value)) {
 						drawBarplotInCell(cell.value, td, column.barplot)
+					} else if (cell.value != null && cell.value !== '') {
+						/* a value no bar can express: ±Infinity, or a label like '∞' or 'NA' that the
+						caller substituted for one. Falling through to text keeps it visible -- drawing
+						nothing left a blank cell indistinguishable from a missing value. */
+						td.text(cell.value)
 					}
 					continue
 				}

--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -14,6 +14,7 @@ import { getCurrentCohortChartTypes } from './charts'
 import { getColors } from '#shared/common.js'
 import { rgb } from 'd3-color'
 import { isNumericTerm, termType2label } from '#shared/terms.js'
+import { uiLabel } from '#shared'
 import { TermTypes } from '#types'
 import { dofetch3 } from '#common/dofetch'
 import { maxSampleCutoff, maxGESampleCutoff } from '../plots/volcano/settings/defaults.ts'
@@ -817,7 +818,7 @@ async function updateUI(self) {
 			},
 			// dataset may rename what a row counts (GDC: cases, not samples). singular, like the count
 			// cells below that already use uiLabels
-			{ label: `#${(self.app.vocabApi.termdbConfig?.uiLabels?.Sample || 'Sample').toUpperCase()}` },
+			{ label: `#${uiLabel(self.app.vocabApi.termdbConfig?.uiLabels, 'Sample', 'Sample').toUpperCase()}` },
 			{ label: 'FILTER' }
 		],
 		rows: [],

--- a/client/plots/DEinput.ts
+++ b/client/plots/DEinput.ts
@@ -14,6 +14,7 @@ import { make_radios, renderTable, Tabs } from '#dom'
 import { dofetch3 } from '#common/dofetch'
 import { renderPreAnalysisData } from '#mass/groups'
 import { TermTypeGroups, termType2label } from '#shared/terms.js'
+import { uiLabel } from '#shared'
 
 const colorScale = getColors(5)
 
@@ -255,7 +256,7 @@ class DEinputPlot extends PlotBase implements RxComponent {
 					}
 				},
 				// dataset may rename what a row counts (GDC: cases, not samples)
-				{ label: `#${(this.app.vocabApi.termdbConfig?.uiLabels?.Sample || 'Sample').toUpperCase()}` },
+				{ label: `#${uiLabel(this.app.vocabApi.termdbConfig?.uiLabels, 'Sample', 'Sample').toUpperCase()}` },
 				{ label: 'FILTER' }
 			],
 			rows: [],

--- a/client/plots/gsea/test/GSEAViewModel.unit.spec.ts
+++ b/client/plots/gsea/test/GSEAViewModel.unit.spec.ts
@@ -1,4 +1,5 @@
 import tape from 'tape'
+import { roundValueAuto } from '#shared/roundValue.js'
 import { GSEAViewModel } from '../viewModel/GSEAViewModel'
 import {
 	getMockBlitzOutputMap,
@@ -16,6 +17,10 @@ Tests:
 	- getRequestBody should include cache params and blitz permutations
 	- getOutputMap should parse blitz and cerno responses and reject invalid cerno response
 	- getTableData should keep top rows sorted by FDR and honor size cutoffs
+	- getTableData should populate the P value column in both modes
+	- getTableData should render a non-finite NES as a signed infinity symbol
+	- formatStat should cover every value shape the engines emit
+	- an infinite FDR should sort last and fail the FDR cutoff
 	- getTableData should filter by FDR for cerno mode
 	- getSelectedRows should resolve the selected gene set index
 	- getCernoPlotData should return descending ranked genes and parsed leading edge genes
@@ -23,7 +28,6 @@ Tests:
 	- getRankedDE should fetch once for cacheId mode and reuse cache on repeat calls
 	- processData should populate cerno table/stats/selection/plot data
  */
-
 
 /**************
  test sections
@@ -58,7 +62,11 @@ tape('getPathwayOpts should append blitz options in test mode and mark selected 
 	const pathwayOpts = viewModel.getPathwayOpts(settings)
 	const selectedOpt = pathwayOpts.find((opt: any) => opt.value == 'H: hallmark gene sets')
 
-	test.equal(pathwayOpts[0].value, 'H: hallmark gene sets', 'The placeholder option should be removed when pathway is set')
+	test.equal(
+		pathwayOpts[0].value,
+		'H: hallmark gene sets',
+		'The placeholder option should be removed when pathway is set'
+	)
 	test.equal(selectedOpt?.selected, true, 'The selected pathway should be marked')
 	test.ok(
 		pathwayOpts.some((opt: any) => opt.value == 'REACTOME--blitzgsea'),
@@ -145,6 +153,135 @@ tape('getTableData should keep top rows sorted by FDR and honor size cutoffs', f
 	test.end()
 })
 
+/* the engines' field is `pval` -- blitzgsea's dataframe column and cerno's output_struct both spell
+it that way. Reading `pvalue` here left the P value column silently empty for every gsea run in
+either mode, so assert the cell is actually populated. */
+tape('getTableData should populate the P value column in both modes', function (test) {
+	const viewModel = new GSEAViewModel(getMockGSEA() as any)
+	const blitzSettings = getMockGseaSettings({
+		gsea_method: 'blitzgsea',
+		fdr_or_top: 'top',
+		top_genesets: 3,
+		min_gene_set_size_cutoff: 0,
+		max_gene_set_size_cutoff: 20000
+	})
+	const blitz = viewModel.getTableData(getMockBlitzOutputMap(), blitzSettings)
+	// blitz row: [genesetName, nes, geneset_size, pvalue, fdr, leadingEdge]
+	test.equal(blitz.rows[0][3].value, 0.0008, 'Blitz P value cell should carry the pval from the engine')
+
+	const cernoSettings = getMockGseaSettings({
+		gsea_method: 'cerno',
+		fdr_or_top: 'top',
+		top_genesets: 3,
+		min_gene_set_size_cutoff: 0,
+		max_gene_set_size_cutoff: 20000
+	})
+	const cerno = viewModel.getTableData(getMockCernoOutputMap(), cernoSettings)
+	// cerno row: [genesetName, auc, es, geneset_size, pvalue, fdr, leadingEdge].
+	// SET_C is over the size cutoff, so SET_A leads on fdr
+	test.equal(cerno.rows[0][0].value, 'SET_A', 'Cerno top row should be SET_A')
+	test.equal(cerno.rows[0][4].value, 0.0012, 'Cerno P value cell should carry the pval from the engine')
+	test.end()
+})
+
+/* blitzgsea sends nes as a string when the permutation p-value underflowed, because json has no
+Infinity literal and pandas would otherwise write null -- the same as a genuine NaN. */
+tape('getTableData should render a non-finite NES as a signed infinity symbol', function (test) {
+	const viewModel = new GSEAViewModel(getMockGSEA() as any)
+	const settings = getMockGseaSettings({
+		gsea_method: 'blitzgsea',
+		fdr_or_top: 'top',
+		top_genesets: 3,
+		min_gene_set_size_cutoff: 0,
+		max_gene_set_size_cutoff: 20000
+	})
+	const outputMap: any = getMockBlitzOutputMap()
+	outputMap.SET_A.nes = '-Infinity'
+	outputMap.SET_A.pval = 0
+	outputMap.SET_B.nes = 'Infinity'
+	outputMap.SET_C.nes = null // NaN upstream, genuinely not computed
+
+	const table = viewModel.getTableData(outputMap, settings)
+	const byName = Object.fromEntries(table.rowItems.map(item => [item.genesetName, item.row]))
+	test.equal(byName.SET_A[1].value, '−∞', 'A negative infinite NES should show as −∞ rather than a blank cell')
+	test.equal(byName.SET_A[3].value, 0, 'The underflowed p-value should still be shown as 0')
+	test.equal(byName.SET_B[1].value, '∞', 'A positive infinite NES should show as ∞')
+	test.equal(byName.SET_C[1].value, null, 'A missing NES should stay blank')
+	test.notEqual(byName.SET_A[1].value, byName.SET_B[1].value, 'The two signs must not collapse to one symbol')
+	test.end()
+})
+
+/* the reading half of a cross-language contract: python/src/gsea.py writes these exact strings
+(pinned by its own selftest, python/test/gsea.unit.spec.js). Any stat can be infinite -- gsea.py
+maps the whole frame -- so every column that formatStat touches is covered here, not just nes. */
+tape('formatStat should cover every value shape the engines emit', function (test) {
+	const viewModel = new GSEAViewModel(getMockGSEA() as any)
+	const settings = getMockGseaSettings({
+		gsea_method: 'cerno',
+		fdr_or_top: 'top',
+		top_genesets: 1,
+		min_gene_set_size_cutoff: 0,
+		max_gene_set_size_cutoff: 20000
+	})
+	// cerno row: [genesetName, auc, es, geneset_size, pvalue, fdr, leadingEdge]
+	const cell = (result: any, index: number) =>
+		viewModel.getTableData({ ONLY: { geneset_size: 10, leading_edge: 'G1', ...result } } as any, settings).rows[0][
+			index
+		].value
+
+	test.equal(cell({ auc: 'Infinity' }, 1), '∞', 'An infinite AUC should render, not just NES')
+	test.equal(cell({ es: '-Infinity' }, 2), '−∞', 'An infinite ES should render')
+	test.equal(cell({ pval: 'Infinity' }, 4), '∞', 'An infinite p-value should render')
+	test.equal(cell({ fdr: '-Infinity' }, 5), '−∞', 'An infinite FDR should render')
+
+	test.equal(cell({ es: 0 }, 2), 0, 'Zero must survive: it is not the same as missing')
+	test.equal(cell({ es: -1.23456789 }, 2), roundValueAuto(-1.23456789), 'A negative float goes through roundValueAuto')
+	test.equal(cell({ es: null }, 2), null, 'null (NaN upstream) stays blank')
+	test.equal(cell({}, 2), undefined, 'an absent field stays blank')
+	test.end()
+})
+
+/* the table sorts and filters on the raw fdr, not the formatted one. Number() coerces JS's own
+spelling of infinity, which is why gsea.py sends exactly that and not 'Inf' -- Number('Inf') is NaN,
+and NaN fails every comparison silently, so an uncomputable gene set would slip past the cutoff. */
+tape('an infinite FDR should sort last and fail the FDR cutoff', function (test) {
+	const viewModel = new GSEAViewModel(getMockGSEA() as any)
+	const outputMap: any = getMockBlitzOutputMap()
+	outputMap.SET_A.fdr = 'Infinity'
+
+	const sorted = viewModel.getTableData(
+		outputMap,
+		getMockGseaSettings({
+			gsea_method: 'blitzgsea',
+			fdr_or_top: 'top',
+			top_genesets: 3,
+			min_gene_set_size_cutoff: 0,
+			max_gene_set_size_cutoff: 20000
+		})
+	)
+	test.equal(
+		sorted.rows[sorted.rows.length - 1][0].value,
+		'SET_A',
+		'A gene set with an infinite FDR should sort last, not first'
+	)
+
+	const filtered = viewModel.getTableData(
+		outputMap,
+		getMockGseaSettings({
+			gsea_method: 'blitzgsea',
+			fdr_or_top: 'fdr',
+			fdr_cutoff: 0.5,
+			min_gene_set_size_cutoff: 0,
+			max_gene_set_size_cutoff: 20000
+		})
+	)
+	test.ok(
+		!filtered.rowItems.some(item => item.genesetName == 'SET_A'),
+		'A gene set with an infinite FDR should not pass an FDR cutoff'
+	)
+	test.end()
+})
+
 tape('getTableData should filter by FDR for cerno mode', function (test) {
 	const viewModel = new GSEAViewModel(getMockGSEA() as any)
 	const settings = getMockGseaSettings({
@@ -166,13 +303,13 @@ tape('getTableData should filter by FDR for cerno mode', function (test) {
 tape('getSelectedRows should resolve the selected gene set index', function (test) {
 	const mockGsea = getMockGSEA({ stateGenesetName: 'SET_B' })
 	const viewModel = new GSEAViewModel(mockGsea as any)
-	const rowItems = [
-		{ genesetName: 'SET_A' },
-		{ genesetName: 'SET_B' },
-		{ genesetName: 'SET_C' }
-	]
+	const rowItems = [{ genesetName: 'SET_A' }, { genesetName: 'SET_B' }, { genesetName: 'SET_C' }]
 
-	test.deepEqual(viewModel.getSelectedRows(rowItems as any[]), [1], 'Should resolve the index of the selected gene set based on stateGenesetName')
+	test.deepEqual(
+		viewModel.getSelectedRows(rowItems as any[]),
+		[1],
+		'Should resolve the index of the selected gene set based on stateGenesetName'
+	)
 	test.end()
 })
 
@@ -186,7 +323,11 @@ tape('getCernoPlotData should return descending ranked genes and parsed leading 
 			test.equal(plotData.genesetName, 'SET_A', 'Geneset name should match the input')
 			test.deepEqual(plotData.leadingEdgeGenes, ['G1', 'G2'], 'Leading edge genes should be parsed from the output map')
 			test.equal(plotData.rankedGenes[0].gene, 'G3', 'Largest fold-change should be first')
-			test.equal(plotData.rankedGenes[plotData.rankedGenes.length - 1].gene, 'G2', 'Smallest fold-change should be last')
+			test.equal(
+				plotData.rankedGenes[plotData.rankedGenes.length - 1].gene,
+				'G2',
+				'Smallest fold-change should be last'
+			)
 			test.end()
 		})
 		.catch(e => {
@@ -272,12 +413,24 @@ tape('processData should populate cerno table/stats/selection/plot data', functi
 
 	viewModel
 		.processData()
-		.then(() => { 
+		.then(() => {
 			test.equal(viewModel.viewData.statsData[0].value, 3, 'Stats should report all analyzed gene sets')
-			test.equal(viewModel.viewData.tableData.rows.length, 2, 'Table should include rows under the configured FDR cutoff')
+			test.equal(
+				viewModel.viewData.tableData.rows.length,
+				2,
+				'Table should include rows under the configured FDR cutoff'
+			)
 			test.deepEqual(viewModel.viewData.selectedRows, [0], 'Selected row should match selected geneset')
-			test.equal(viewModel.viewData.cernoPlotData.genesetName, 'SET_A', 'Selected geneset should match configured geneset')
-			test.equal(viewModel.viewData.showHighlightButton, true, 'Highlight button should be shown when leading edge genes are present')
+			test.equal(
+				viewModel.viewData.cernoPlotData.genesetName,
+				'SET_A',
+				'Selected geneset should match configured geneset'
+			)
+			test.equal(
+				viewModel.viewData.showHighlightButton,
+				true,
+				'Highlight button should be shown when leading edge genes are present'
+			)
 			test.end()
 		})
 		.catch(e => {
@@ -285,4 +438,3 @@ tape('processData should populate cerno table/stats/selection/plot data', functi
 			test.end()
 		})
 })
-

--- a/client/plots/gsea/test/mockData.ts
+++ b/client/plots/gsea/test/mockData.ts
@@ -84,21 +84,21 @@ export function getMockBlitzOutputMap() {
 			geneset_size: 10,
 			leading_edge: 'G1,G2',
 			fdr: 0.0023,
-			pvalue: 0.0008,
+			pval: 0.0008,
 			nes: 1.8
 		},
 		SET_B: {
 			geneset_size: 30,
 			leading_edge: 'G2,G3',
 			fdr: 0.021,
-			pvalue: 0.008,
+			pval: 0.008,
 			nes: -1.4
 		},
 		SET_C: {
 			geneset_size: 5,
 			leading_edge: 'G4',
 			fdr: 0.11,
-			pvalue: 0.07,
+			pval: 0.07,
 			nes: 0.9
 		}
 	}
@@ -110,7 +110,7 @@ export function getMockCernoOutputMap() {
 			geneset_size: 10,
 			leading_edge: 'G1,G2',
 			fdr: 0.004,
-			pvalue: 0.0012,
+			pval: 0.0012,
 			auc: 0.83,
 			es: 1.21
 		},
@@ -118,7 +118,7 @@ export function getMockCernoOutputMap() {
 			geneset_size: 30,
 			leading_edge: 'G2,G3',
 			fdr: 0.03,
-			pvalue: 0.01,
+			pval: 0.01,
 			auc: 0.66,
 			es: -0.54
 		},
@@ -126,7 +126,7 @@ export function getMockCernoOutputMap() {
 			geneset_size: 20001,
 			leading_edge: 'G4',
 			fdr: 0.001,
-			pvalue: 0.0005,
+			pval: 0.0005,
 			auc: 0.9,
 			es: 1.8
 		}

--- a/client/plots/gsea/viewModel/GSEAViewModel.ts
+++ b/client/plots/gsea/viewModel/GSEAViewModel.ts
@@ -3,14 +3,30 @@ import { roundValueAuto } from '#shared/roundValue.js'
 
 type PathwayOpt = { label: string; value: string; selected?: boolean }
 
+/* field names are the engines' own, passed through unchanged: blitzgsea's dataframe columns
+(python/src/gsea.py) and cerno's output_struct (rust/src/cerno.rs). Both spell it `pval`.
+nes may be the string 'Infinity'/'-Infinity' -- see formatStat() below. */
 type GseaResultEntry = {
 	geneset_size: number
 	leading_edge: string
 	fdr?: number
-	pvalue?: number
-	nes?: number
+	pval?: number
+	nes?: number | string
 	auc?: number
 	es?: number
+}
+
+/* a stat as the table should show it. Three cases the engines actually produce:
+  - a number -> rounded
+  - 'Infinity'/'-Infinity' -> blitzgsea's nes when the permutation p-value underflowed its gamma
+    fit, i.e. more extreme than the null model can score. Real information, and the accompanying
+    pval is exactly 0 for the same reason; both used to render as an empty cell
+  - null/undefined -> genuinely not computed (NaN upstream), left blank */
+function formatStat(v: number | string | null | undefined) {
+	if (v == null) return v
+	if (v === 'Infinity') return '∞'
+	if (v === '-Infinity') return '−∞' // minus sign, not hyphen, to match the axis labels
+	return typeof v == 'number' ? roundValueAuto(v) : v
 }
 
 type RankedDE = {
@@ -194,13 +210,18 @@ export class GSEAViewModel {
 	}
 
 	makeRowItem(item: { genesetName: string; result: GseaResultEntry }, method: string) {
-		const pvalue = item.result.pvalue != null ? roundValueAuto(item.result.pvalue) : item.result.pvalue
-		const fdr = item.result.fdr != null ? roundValueAuto(item.result.fdr) : item.result.fdr
+		const pvalue = formatStat(item.result.pval)
+		const fdr = formatStat(item.result.fdr)
 		const leadingEdge = item.result.leading_edge
-		const genes = leadingEdge ? leadingEdge.split(',').map(gene => gene.trim()).filter(Boolean) : []
+		const genes = leadingEdge
+			? leadingEdge
+					.split(',')
+					.map(gene => gene.trim())
+					.filter(Boolean)
+			: []
 
 		if (method == 'blitzgsea') {
-			const nes = item.result.nes != null ? roundValueAuto(item.result.nes) : item.result.nes
+			const nes = formatStat(item.result.nes)
 			return {
 				genesetName: item.genesetName,
 				genes,
@@ -215,8 +236,8 @@ export class GSEAViewModel {
 			}
 		}
 
-		const auc = item.result.auc != null ? roundValueAuto(item.result.auc) : item.result.auc
-		const es = item.result.es != null ? roundValueAuto(item.result.es) : item.result.es
+		const auc = formatStat(item.result.auc)
+		const es = formatStat(item.result.es)
 		return {
 			genesetName: item.genesetName,
 			genes,
@@ -236,7 +257,13 @@ export class GSEAViewModel {
 		if (method == 'blitzgsea') {
 			return [
 				{ label: 'Gene Set', sortable: true },
-				{ label: 'Normalized Enrichment Score', barplot: { axisWidth: 200 }, sortable: true },
+				{
+					label: 'Normalized Enrichment Score',
+					barplot: { axisWidth: 200 },
+					sortable: true,
+					tooltip:
+						'Normal quantile of the permutation p-value. ±∞ means the p-value underflowed the permutation model, so the enrichment is beyond what the null distribution can score — the P value column reads 0 for the same reason. Rank these by enrichment score, not by how far off the scale they are.'
+				},
 				{ label: 'Gene Set Size', sortable: true },
 				{ label: 'P value', sortable: true },
 				{ label: 'FDR', sortable: true },
@@ -285,7 +312,10 @@ export class GSEAViewModel {
 		return {
 			auc: selected.auc,
 			genesetName,
-			leadingEdgeGenes: selected.leading_edge.split(',').map(gene => gene.trim()).filter(Boolean),
+			leadingEdgeGenes: selected.leading_edge
+				.split(',')
+				.map(gene => gene.trim())
+				.filter(Boolean),
 			rankedGenes
 		}
 	}
@@ -313,9 +343,9 @@ export class GSEAViewModel {
 			method: 'cerno',
 			...(this.gsea.gsea_params.cacheId
 				? {
-					cacheId: this.gsea.gsea_params.cacheId,
-					daRequest: this.gsea.gsea_params.daRequest
-				}
+						cacheId: this.gsea.gsea_params.cacheId,
+						daRequest: this.gsea.gsea_params.daRequest
+				  }
 				: { dapParams: this.gsea.gsea_params.dapParams })
 		})
 		if (response?.error) throw Object.assign(new Error(response.error), { code: response.code })

--- a/client/plots/volcano/Volcano.ts
+++ b/client/plots/volcano/Volcano.ts
@@ -13,6 +13,7 @@ import { VolcanoPlotView } from './view/VolcanoPlotView'
 import { VolcanoControlInputs } from './VolcanoControlInputs'
 import { getCombinedTermFilter } from '#filter'
 import { GENE_EXPRESSION, SINGLECELL_CELLTYPE } from '#types'
+import { uiLabel } from '#shared'
 
 /* Below this many samples in the smaller group, the wilcoxon p-values are worth a caveat.
 rust/src/stats_functions.rs only runs the exact test when both groups are under 50 AND no value is
@@ -163,9 +164,11 @@ export class Volcano extends PlotBase implements RxComponent {
 			if (!response.data.dots.length) notes.push('No points passed the significance thresholds.')
 			const smallestGroup = Math.min(response.sample_size1, response.sample_size2)
 			if (settings.method == 'wilcoxon' && smallestGroup < MIN_WILCOXON_GROUP_SIZE) {
+				// gdc users are the most likely readers of this sentence, and gdc calls them cases
+				const samplesLabel = uiLabel(this.app.vocabApi.termdbConfig?.uiLabels, 'samples', 'samples')
 				notes.push(
-					`The smaller group has ${smallestGroup.toLocaleString()} samples. Wilcoxon p-values are ` +
-						`approximated here, and a gene that is zero in most samples can be assigned a p-value far ` +
+					`The smaller group has ${smallestGroup.toLocaleString()} ${samplesLabel}. Wilcoxon p-values are ` +
+						`approximated here, and a gene that is zero in most ${samplesLabel} can be assigned a p-value far ` +
 						`smaller than its group sizes can support. Rank these results by fold change rather than by ` +
 						`p-value magnitude, and do not compare the p-values against another analysis.`
 				)

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -421,6 +421,12 @@ export class TermdbVocab extends Vocab {
 		returns sample list in array of [{id, name}....]
 	 */
 	async getFilteredSampleList(filterJSON, filter0) {
+		// same default as getFilteredSampleCount() below, and for the same reason: without filter0 an
+		// api-backed ds (gdc) enumerates all of GDC instead of the portal cohort. the two must agree,
+		// or a count and the list behind it describe different populations -- which is what sent the
+		// volcano "others" group the whole of GDC. undefined means "not specified"; null is a caller
+		// deliberately disabling the cohort filter
+		if (filter0 === undefined) filter0 = this.state?.termfilter?.filter0
 		const body = {
 			genome: this.vocab.genome,
 			dslabel: this.vocab.dslabel,

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,5 +17,6 @@ pillow==12.3.0
 psutil==7.2.1
 pyBigWig==0.3.25 --no-binary=pyBigWig
 pydantic==2.12.3
+statsmodels==0.14.4
 typing_extensions==4.15.0
 xlsxwriter==3.2.5

--- a/python/src/gsea.py
+++ b/python/src/gsea.py
@@ -12,6 +12,7 @@ import base64
 import io
 import numpy as np
 import pandas as pd
+from statsmodels.stats.multitest import multipletests
 
 # Helper function to extract gene symbols from a dictionary
 def extract_symbols(x):
@@ -40,6 +41,82 @@ def _safe_blitz_gsea(signature, library, permutations):
         print(f'result: {json.dumps({"error": msg})}')
         return None
 
+# blitzgsea runs multipletests(pvals, 'fdr_bh') across every gene set, including
+# the ones whose p-value came back NaN (its gamma fit does not converge for every
+# gene-set size). Benjamini-Hochberg is a whole-array operation -- it sorts, then
+# takes a running minimum -- so a single NaN makes every fdr NaN. Measured on a
+# 7309-set GO BP run over a GDC cohort: 185 NaN p-values blanked the FDR column
+# for all 7309, and FDR is what the table sorts and filters on, so the whole
+# result was unusable (354 gene sets are actually below fdr 0.05).
+# Recompute over the finite p-values only. A gene set with no p-value was not a
+# test and does not belong in the correction's denominator; it keeps NaN and the
+# client shows it as blank. Identical to blitzgsea's own output when nothing is
+# NaN, so this only ever replaces an all-NaN column.
+def _recompute_fdr(res):
+    pvals = pd.to_numeric(res['pval'], errors='coerce').to_numpy(dtype=float)
+    ok = np.isfinite(pvals)
+    if ok.all() or not ok.any():
+        return res
+    fdr = np.full(len(pvals), np.nan)
+    fdr[ok] = multipletests(pvals[ok], method='fdr_bh')[1]
+    res['fdr'] = fdr
+    # stdout, not stderr: run_python() rejects the whole call if the process writes
+    # anything to stderr. The Node side mayLog()s every line that is not `result: `.
+    print(f'blitzgsea returned {int((~ok).sum())} of {len(pvals)} gene sets with no p-value; '
+          'FDR recomputed over the remaining ones')
+    return res
+
+# blitzgsea computes nes as the normal quantile of the permutation p-value, so a
+# p-value that underflows its gamma fit comes back as +/-inf: a real "off the
+# scale" enrichment, not a missing one (pval is then exactly 0.0 alongside it).
+# JSON has no Infinity literal, and pandas' to_json() writes null for inf and NaN
+# alike -- which would make "off the scale" indistinguishable from "not computed"
+# and leave the client with a blank cell either way. Send the infinities as
+# strings so the sign survives; genuine NaN still becomes null.
+def _finite_or_label(v):
+    return ('Infinity' if v > 0 else '-Infinity') if isinstance(v, float) and np.isinf(v) else v
+
+# Offline check for the two pure helpers above, driven by python/test/gsea.unit.spec.js:
+#   echo '/{"selftest":true}' | python python/src/gsea.py
+# Neither blitzgsea nor the msigdb sqlite is touched, so this runs anywhere.
+# The spelling asserted here is a cross-language contract: client formatStat() in
+# plots/gsea/viewModel/GSEAViewModel.ts matches these exact strings, and the
+# table's FDR sort/filter relies on JS Number() coercing them, which it only does
+# for JS's own spelling ('Infinity'/'-Infinity' -- Number('Inf') is NaN). Changing
+# either side alone silently blanks a column, which is what this pins down.
+def _selftest():
+    labelled = [_finite_or_label(v) for v in
+                [float('inf'), float('-inf'), float('nan'), 0.0, -1.5, 3, 'GENE_A']]
+    assert labelled[0] == 'Infinity', f'+inf must serialize as Infinity, got {labelled[0]!r}'
+    assert labelled[1] == '-Infinity', f'-inf must serialize as -Infinity, got {labelled[1]!r}'
+    assert np.isnan(labelled[2]), 'NaN must be left alone so to_json writes null'
+    assert labelled[3] == 0.0 and labelled[4] == -1.5, 'finite floats must pass through unchanged'
+    assert labelled[5] == 3 and labelled[6] == 'GENE_A', 'non-float cells must pass through unchanged'
+
+    # the wire itself, in the shape gsea.py emits: (fields x gene sets) after .T
+    frame = pd.DataFrame({
+        'SET_POS': {'nes': float('inf'), 'pval': 0.0, 'fdr': 0.25},
+        'SET_NEG': {'nes': float('-inf'), 'pval': 0.0, 'fdr': 0.25},
+        'SET_NAN': {'nes': float('nan'), 'pval': float('nan'), 'fdr': float('nan')},
+        'SET_OK': {'nes': 1.25, 'pval': 0.01, 'fdr': 0.25},
+    }).astype(object)
+    wire = json.loads(frame.map(_finite_or_label).to_json())
+    assert wire['SET_POS']['nes'] == 'Infinity', wire['SET_POS']
+    assert wire['SET_NEG']['nes'] == '-Infinity', wire['SET_NEG']
+    assert wire['SET_NAN']['nes'] is None, 'a NaN nes must stay null, distinct from an infinity'
+    assert wire['SET_OK']['nes'] == 1.25, wire['SET_OK']
+
+    # one NaN p-value used to make every fdr NaN; the finite ones must survive it
+    mixed = pd.DataFrame({'pval': [0.0, 0.01, float('nan'), 0.9]})
+    fixed = _recompute_fdr(mixed.copy())['fdr'].to_numpy(dtype=float)
+    assert np.isfinite(fixed[[0, 1, 3]]).all(), f'finite p-values must get an fdr, got {fixed}'
+    assert np.isnan(fixed[2]), 'a gene set with no p-value keeps no fdr'
+    assert (fixed[[0, 1, 3]] <= 1).all() and (fixed[[0, 1, 3]] >= 0).all(), f'fdr out of range: {fixed}'
+    # and it must not touch a clean run: blitzgsea's own column is already correct there
+    clean = pd.DataFrame({'pval': [0.0, 0.01, 0.9], 'fdr': ['untouched'] * 3})
+    assert list(_recompute_fdr(clean.copy())['fdr']) == ['untouched'] * 3, 'clean runs must be left alone'
+    return {'selftest': 'ok'}
+
 # Main function
 try:
     # Check if there is input from stdin
@@ -48,6 +125,12 @@ try:
         for line in sys.stdin:
             # Parse the JSON input
             json_object = json.loads(line)
+            if json_object.get('selftest'):
+                try:
+                    print(f'result: {json.dumps(_selftest())}')
+                except AssertionError as e:
+                    print(f'result: {json.dumps({"selftest": "failed", "error": str(e)})}')
+                continue
             cachedir = json_object['cachedir']  # Get the cache directory from the JSON object
             genes = json_object['genes']  # Get the genes from the JSON object
             fold_change = json_object['fold_change']  # Get the fold change values from the JSON object
@@ -132,11 +215,14 @@ try:
                     gsea_result = _safe_blitz_gsea(signature, msigdb_library, num_permutations)
                     if gsea_result is None:
                         continue
-                    result = gsea_result.T
+                    result = _recompute_fdr(gsea_result).T
                     buf = io.BytesIO()
                     result.to_pickle(buf)
                     pickle_b64 = base64.b64encode(buf.getvalue()).decode('ascii')
-                    print(f'result: {{"data": {result.to_json()}, "pickle_b64": "{pickle_b64}"}}')
+                    # pickle first, json second: the detail-image path replays the
+                    # pickle through blitzgsea and needs the real floats, while only
+                    # the json crossing to the client needs the infinities labelled
+                    print(f'result: {{"data": {result.map(_finite_or_label).to_json()}, "pickle_b64": "{pickle_b64}"}}')
                 stop_gsea_time = time.time()
                 gsea_time = stop_gsea_time - start_gsea_time
                 print(f"GSEA time: {gsea_time} seconds")

--- a/python/test/gsea.unit.spec.js
+++ b/python/test/gsea.unit.spec.js
@@ -1,0 +1,44 @@
+/**
+ * gsea.unit.spec.js
+ * Run test script as follows (from 'proteinpaint/'):
+ *  	node python/test/gsea.unit.spec.js
+ *
+ * Unit test for the two pure helpers in python/src/gsea.py. Both exist because blitzgsea's output
+ * cannot be sent to the client as-is:
+ *
+ *   _finite_or_label  json has no Infinity literal and pandas' to_json() writes null for inf and
+ *                     NaN alike, so an enrichment score that is off the scale arrives looking
+ *                     exactly like one that was never computed. The infinities go over as strings.
+ *   _recompute_fdr    blitzgsea hands its NaN p-values to multipletests(..., 'fdr_bh') along with
+ *                     the rest, and BH is a whole-array operation, so one NaN blanks every FDR.
+ *
+ * The script's offline selftest asserts both, including the exact spelling 'Infinity'/'-Infinity'.
+ * That spelling is a cross-language contract with client formatStat() in
+ * plots/gsea/viewModel/GSEAViewModel.ts, which has its own test for the reading half; nothing else
+ * would catch the two halves drifting apart, and the symptom is a silently blank column rather than
+ * an error.
+ */
+
+import tape from 'tape'
+import { run_python } from '@sjcrh/proteinpaint-python'
+
+const python_script = 'gsea.py'
+
+/**************
+ * Test sections
+ **************/
+tape('\n', function (test) {
+	test.comment('-***- gsea specs -***-')
+	test.end()
+})
+
+tape('selftest: infinity labelling and FDR recomputation', async t => {
+	// the leading '/' is the sentinel byte gsea.py consumes with stdin.read(1) before reading lines,
+	// same as the server does in routes/genesetEnrichment.ts
+	const stdout = await run_python(python_script, '/' + JSON.stringify({ selftest: true }))
+	const line = stdout.split('\n').find(l => l.startsWith('result: '))
+	t.ok(line, 'gsea.py should emit a result line')
+	const out = JSON.parse(line.replace('result: ', ''))
+	t.equal(out.selftest, 'ok', out.error || 'offline helper assertions passed')
+	t.end()
+})

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,14 @@
+Fixes:
+- GDC differential expression: a full cache pool (CACHE_BUSY) now actually fails the run. mapConcurrent has allSettled semantics, so the throw only ended its own chunk and the affected cases were written to the counts matrix as all-zero columns, then cached under the cohort hash.
+- GDC differential expression: raised the gdcCounts cache pool from 100 to 200 pending entries, so a second concurrent DE run cannot exhaust it against a download concurrency of 60.
+- GDC differential expression: a counts-matrix cache hit now reports the cases actually in the h5, read from the build report, instead of the pre-drop list. A run that dropped a case previously made every later run of that cohort fail in edgeR, or overstate its group sizes in wilcoxon.
+- GDC differential expression: the bulk-download tar reader handles ustar prefix-split paths and skips pax/gnu metadata entries, and logs when a tarball yields fewer files than requested instead of silently falling back to one GET per file.
+- Differential expression (wilcoxon): the counts matrix is read over only the selected sample columns rather than whole, so a small comparison against a large static counts file no longer allocates the entire genes x samples matrix.
+- Volcano: the "others" sample group is scoped by the GDC portal cohort filter. vocabApi.getFilteredSampleList() now defaults filter0 from state, matching getFilteredSampleCount().
+- termdb getsamplecount/getsamplelist call authApi.mayAdjustFilter() on the dataset-supplied filterSamples path, so a ds getAdditionalFilter() applies there too.
+- Dataset uiLabels entries may be either a string or {label}; a shared uiLabel() accessor replaces direct lookups that would render [object Object] or throw.
+- Volcano: the wilcoxon small-group caveat uses the dataset's own word for samples (GDC: cases).
+- Table download: an empty download.fileName falls back to the date-stamped default name again.
 
+DevOps:
+- ppgdc unit tests cover the STAR-Counts tsv parser and the tar reader in dataset/gdc/geneCounts.ts.

--- a/release.txt
+++ b/release.txt
@@ -9,6 +9,11 @@ Fixes:
 - Dataset uiLabels entries may be either a string or {label}; a shared uiLabel() accessor replaces direct lookups that would render [object Object] or throw.
 - Volcano: the wilcoxon small-group caveat uses the dataset's own word for samples (GDC: cases).
 - Table download: an empty download.fileName falls back to the date-stamped default name again.
+- GSEA: the P value column is populated again. Both engines name the field `pval` — blitzgsea's dataframe column and cerno's output_struct — while the client and the response type read `pvalue`, so every gene set showed an empty P value cell in both blitzgsea and cerno mode.
+- GSEA: the FDR column is populated again. blitzgsea's gamma fit does not converge for every gene-set size, and it hands the resulting NaN p-values to multipletests(..., 'fdr_bh') along with the rest; Benjamini-Hochberg sorts and takes a running minimum, so a single NaN makes every FDR NaN. On a 7309-set GO BP run over a GDC cohort, 185 NaN p-values blanked the FDR for all 7309 — and FDR is what the results table sorts and filters on, so the ordering was arbitrary too. gsea.py now recomputes the correction over the finite p-values only (354 gene sets in that run are below FDR 0.05); gene sets with no p-value were not tests, so they stay blank and stay out of the denominator.
+- GSEA: a normalized enrichment score that is off the scale now reads ±∞ instead of an empty cell. blitzgsea computes nes as the normal quantile of the permutation p-value, so a p-value that underflows its gamma fit returns ±inf; pandas' to_json() writes null for inf and NaN alike, which made "beyond the null distribution" indistinguishable from "not computed". gsea.py now sends those two as strings, and the column header explains what the symbol means.
+- dom/table: a barplot column renders the cell text when a value cannot be drawn as a bar (±Infinity, or a label such as 'NA'), instead of leaving the cell blank.
 
 DevOps:
 - ppgdc unit tests cover the STAR-Counts tsv parser and the tar reader in dataset/gdc/geneCounts.ts.
+- gsea.py gains an offline selftest (python/test/gsea.unit.spec.js) pinning the infinity wire spelling and the FDR recomputation, and the client GSEAViewModel spec covers the reading half. The two are a cross-language contract whose failure mode is a silently blank column, not an error.

--- a/rust/src/DEanalysis.rs
+++ b/rust/src/DEanalysis.rs
@@ -15,6 +15,7 @@ use nalgebra::base::dimension::Dyn;
 //use ndarray::Array1;
 use ndarray::Array2;
 use ndarray::Dim;
+use ndarray::s;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use statrs::statistics::Data;
@@ -101,23 +102,38 @@ fn input_data_from_HDF5(
         // Skip sample if not found
     }
 
-    /* Read the matrix in a single bulk call.
+    /* Read the matrix in one bounded call, spanning only the columns actually selected.
     It is stored (genes x samples) and contiguous, so the previous one-hyperslab-per-sample approach
     made each read stride across the whole dataset -- ~59k scattered reads per sample. Measured on a
     1370-sample GDC cohort: 28.8s of system time for the per-column reads vs 0.03s to read it whole.
-    Read as f32 to match the on-disk type; widening to f64 happens per cell below, so no full-size
-    f64 copy of the source ever exists. */
-    let matrix: Array2<f32> = ds_matrix.read_2d::<f32>().unwrap();
+    But reading it whole is unbounded: the GDC counts file contains exactly the compared samples,
+    while every other ds routes this engine through a full static h5, where a 10-vs-10 comparison
+    against 3000 samples x 60660 genes would pull ~730MB to use 5MB of it. Clamping to
+    min..=max selected column keeps the single-hyperslab win with an allocation the selection bounds.
+    ponytail: the span, not the exact columns. Two samples at opposite ends of a wide file still read
+    everything between them; switch to a chunked scan if a real cohort turns out to be that sparse.
+    Read as f32 to match the on-disk type -- an f64-stored counts file is silently narrowed by HDF5's
+    soft conversion, which is exact for counts below 2^24 and is what the writer emits anyway.
+    Widening to f64 happens per cell below, so no full-size f64 copy of the source ever exists. */
+    let num_selected = selected_columns.len();
+    let mut dm = DMatrix::<f64>::zeros(num_genes, num_selected);
+    if num_selected == 0 {
+        // no requested sample matched a column; main() reports the empty matrix
+        return (dm, case_indexes, control_indexes, gene_names);
+    }
+    let first_column = *selected_columns.iter().min().unwrap();
+    let last_column = *selected_columns.iter().max().unwrap();
+    let matrix: Array2<f32> = ds_matrix
+        .read_slice_2d(s![0..num_genes, first_column..last_column + 1])
+        .unwrap();
 
     /* Build the (genes x selected samples) matrix directly, in the orientation the caller wants.
     The old code assembled the transpose and then called .transpose(), which copied the whole thing a
     second time. DMatrix is column-major, so the inner loop below writes down a column while reading
     along a source row. */
-    let num_selected = selected_columns.len();
-    let mut dm = DMatrix::<f64>::zeros(num_genes, num_selected);
     for gene in 0..num_genes {
         for (out_column, &src_column) in selected_columns.iter().enumerate() {
-            dm[(gene, out_column)] = matrix[[gene, src_column]] as f64;
+            dm[(gene, out_column)] = matrix[[gene, src_column - first_column]] as f64;
         }
     }
 

--- a/server/src/termdb.js
+++ b/server/src/termdb.js
@@ -10,6 +10,7 @@ import { authApi } from './auth.js'
 import { searchSNP } from '#routes/snp.ts'
 import { get_samples_ancestry, get_samples } from './termdb.sql.js'
 import { TermTypeGroups } from '#shared/terms.js'
+import { uiLabel } from '#shared'
 import { trigger_getDefaultBins } from './termdb.getDefaultBins.js'
 import serverconfig from './serverconfig.js'
 import { filterTerms } from './termdb.server.init.ts'
@@ -135,13 +136,20 @@ async function getSampleCount(q, ds) {
 		return await termdbsql.get_samplecount(q, ds)
 	}
 	if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
+		// !!! CRITICAL !!!
+		// same rule as termdbsql.get_samplecount(): a ds's getAdditionalFilter() must get its chance to
+		// restrict q.filter before anything counts samples, and filterSamples() below reads q.filter.
+		// no-op for a ds without getAdditionalFilter, which is every current filterSamples ds -- called
+		// anyway so the next one does not inherit the gap. empty routeTwLst: the response is an
+		// aggregate count, so no term is protected
+		authApi.mayAdjustFilter(q, ds, [])
 		// dataset supplied method. returnAllSamples: with no filter the answer is the whole cohort,
 		// not "unknown" -- unlike getSampleList(), a count has no way to express undefined
 		const samples = await ds.cohort.termdb.filterSamples(q, ds, true)
 		const n = samples?.size || 0
 		// gdc calls them cases; ds.cohort.termdb.uiLabels maps the generic word to the ds vocabulary
 		const key = n == 1 ? 'sample' : 'samples'
-		return { count: `${n} ${ds.cohort.termdb.uiLabels?.[key] || key}` }
+		return { count: `${n} ${uiLabel(ds.cohort.termdb.uiLabels, key, key)}` }
 	}
 	throw new Error('no method available to get sample count')
 }
@@ -153,7 +161,8 @@ async function getSampleList(req, q, ds) {
 		// dataset is sqlite-based
 		samples = await termdbsql.get_samples(q, ds, canDisplay)
 	} else if (typeof ds.cohort?.termdb?.filterSamples === 'function') {
-		// dataset supplied method
+		// dataset supplied method. mayAdjustFilter for the same reason as getSampleCount() above
+		authApi.mayAdjustFilter(q, ds, [])
 		const temp = await ds.cohort.termdb.filterSamples(q, ds)
 		if (temp) {
 			samples = [...temp].map(sid => {

--- a/server/src/test/CacheManager.unit.spec.ts
+++ b/server/src/test/CacheManager.unit.spec.ts
@@ -85,7 +85,7 @@ tape('defaults', function (test) {
 							maxSize: 5000000000,
 							skipMs: 43200000,
 							// many small per-case fetches rather than a few heavy computes
-							maxPending: 100,
+							maxPending: 200,
 							absPath: `${m.cachedir}/gdcCounts`,
 							skipUntil: 0
 						},

--- a/server/src/utils/cacheOrRecompute.ts
+++ b/server/src/utils/cacheOrRecompute.ts
@@ -21,11 +21,14 @@ export const cacheJobPolicies = {
 	topve: { maxPending: 5 },
 	/* per-case gene counts downloaded from GDC. unlike the analysis subdirs above, these are many
 	small fetches rather than a few heavy computes: one entry per STAR-Counts file, written from
-	inside a mapConcurrent fan-out. maxPending is therefore sized above the download concurrency
-	(gdcDEconcurrency, default 20) times a few simultaneous runs -- the real throttle is
-	mapConcurrent, not this pool. exceeding it throws 429, which the caller surfaces rather than
-	treating as a failed download. */
-	gdcCounts: { maxPending: 100 }
+	inside a mapConcurrent fan-out. the real throttle is mapConcurrent, not this pool, so size this
+	above the download concurrency (gdcDEconcurrency, default 60) times the simultaneous DE runs to
+	tolerate: one run holds up to `concurrency` distinct cacheIds at once, so at 200 the third
+	overlapping run is the first that can hit the cap. exceeding it throws 429, which the caller
+	surfaces rather than treating as a failed download -- and buildGdcCountsFile fails the whole run
+	on it, so a cap set below real concurrency would kill a legitimate second user's analysis rather
+	than queue it. raise this in step with gdcDEconcurrency. */
+	gdcCounts: { maxPending: 200 }
 } as const satisfies Record<string, { maxPending: number }>
 
 export type CacheSubdir = keyof typeof cacheJobPolicies

--- a/shared/types/src/routes/genesetEnrichment.ts
+++ b/shared/types/src/routes/genesetEnrichment.ts
@@ -42,17 +42,23 @@ export type GenesetEnrichmentRequest = {
 	dapParams?: { organism: string; assay: string; cohort: string }
 }
 
+/** blitzgsea's own column names, passed straight through by python/src/gsea.py (result.to_json()),
+so this must keep spelling them the way blitzgsea does -- notably `pval`, not `pvalue`.
+`nes` may arrive as the string 'Infinity'/'-Infinity': blitzgsea computes it as the normal quantile
+of the permutation p-value, so a p-value that underflows its gamma fit puts the score off the scale.
+JSON has no Infinity literal and pandas' to_json() writes null for inf and NaN alike, which would
+make "off the scale" indistinguishable from "not computed", so gsea.py sends those two as strings. */
 type blitzgsea_geneset_attributes = {
 	/** Absolute enrichment score */
 	es: number
-	/** Normalized enrichment score */
-	nes: number
+	/** Normalized enrichment score. 'Infinity'/'-Infinity' when the p-value underflowed */
+	nes: number | 'Infinity' | '-Infinity'
 	/** Size of gene set */
 	geneset_size: number
 	/** Leading edge genes */
 	leading_edge: string
 	/** pvalue */
-	pvalue: number
+	pval: number
 	/** sidak (multiple testing correction) */
 	sidak: number
 	/** false discovery rate */
@@ -64,6 +70,7 @@ type blitzgsea_map = {
 	[geneset_name: string]: blitzgsea_geneset_attributes
 }
 
+/** field names come from rust/src/cerno.rs output_struct, which also spells it `pval` */
 type cerno_geneset_attributes = {
 	/** Absolute enrichment score */
 	es: number
@@ -74,7 +81,7 @@ type cerno_geneset_attributes = {
 	/** Leading edge genes */
 	leading_edge: string
 	/** pvalue */
-	pvalue: number
+	pval: number
 	/** false discovery rate */
 	fdr: number
 }

--- a/shared/utils/src/helpers.ts
+++ b/shared/utils/src/helpers.ts
@@ -100,6 +100,18 @@ export function deepEqual(x, y) {
 	} else return false
 }
 
+/* one entry out of a ds's uiLabels{}, which lets a dataset rename what the ui calls things (gdc
+counts cases, not samples). an entry is `string | {label, ...}` -- the object form is what term2/term0
+use to carry a tooltip -- so a caller reaching for uiLabels[key] directly gets '[object Object]' where
+it interpolates, or a throw where it calls a string method. one accessor rather than the same
+narrowing at every call site. */
+export function uiLabel(uiLabels: any, key: string, fallback: string): string {
+	const v = uiLabels?.[key]
+	if (typeof v == 'string') return v
+	if (v && typeof v.label == 'string') return v.label
+	return fallback
+}
+
 export function deepFreeze(obj) {
 	Object.freeze(obj)
 	// not using for..in loop, in order to not descend into inherited props/methods


### PR DESCRIPTION
# Description
Two batches of work: follow-ups from the review of the merged GDC DE PR, and a set of GSEA bugs found while testing that DE result on a TCGA-ESCA cohort.

The GDC-side counterpart is [sjpp](https://github.com/stjude/sjpp/pull/1481) (ppgdc `geneCounts.ts`). The two should land together — `release.txt` already records that ppgdc must deploy with this server.

## To test
Go [here](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:2},%22termfilter%22:{%22filter0%22:{%22op%22:%22and%22,%22content%22:[{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.project.project_id%22,%22value%22:%22TCGA-ESCA%22}}]}},%22groups%22:[{%22name%22:%22Squamous%22,%22color%22:%22%231b9e77%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.diagnoses.primary_diagnosis%22},%22values%22:[{%22key%22:%22Squamous%20cell%20carcinoma,%20NOS%22}]}}]}},{%22name%22:%22Adenocarcinoma%22,%22color%22:%22%23d95f02%22,%22filter%22:{%22type%22:%22tvslst%22,%22join%22:%22%22,%22in%22:true,%22tag%22:%22filterUiRoot%22,%22lst%22:[{%22type%22:%22tvs%22,%22tvs%22:{%22term%22:{%22id%22:%22case.diagnoses.primary_diagnosis%22},%22values%22:[{%22key%22:%22Adenocarcinoma,%20NOS%22}]}}]}}]}) on master run DE and run GSEA for the first entry. See the issues discovered. Then check out this branch and run same example again. Should work as expected

**Rust will need to be recompiled because of this PR**

## GSEA

These were not GDC-specific. They affected every GSEA run, in both blitzgsea and cerno mode.

### The P value column was never populated

Both engines name the field `pval` — blitzgsea's dataframe column (`res.columns = [..., "pval", ...]`) and cerno's `output_struct` in `rust/src/cerno.rs`. Nothing renames it in transit; `gsea.py` does a bare `result.to_json()`. But `GSEAViewModel` and `GenesetEnrichmentResponse` read `pvalue`, so the cell was always `undefined` and always rendered blank.

Renamed the type and the client to match the wire rather than adding a translation layer. The client mock data also encoded `pvalue`, which is why the existing unit tests were green on a broken contract — fixed, with an assertion that the cell is populated in both modes.

### One NaN p-value blanked the FDR column for the entire run

blitzgsea's gamma fit does not converge for every gene-set size, and it hands the resulting NaN p-values to `multipletests(pvals, 'fdr_bh')` along with the rest. Benjamini–Hochberg sorts and takes a running minimum, so a single NaN propagates to every entry.

Measured on the cached response for a 7309-set GO BP run over a GDC cohort:

```
7309 gene sets, 185 NaN p-values, 49 exactly 0
fdr_bh over the full array -> NaN count: 7309   (this is what shipped)
fdr_bh over finite only    -> NaN count:  185
  gene sets with fdr < 0.05: 354
```

FDR is what the results table sorts and filters on, so the ordering was arbitrary too, and 354 significant gene sets were hidden behind an all-null column.

`gsea.py` now recomputes the correction over the finite p-values only. A gene set with no p-value was not a test and does not belong in the denominator — it keeps NaN and renders blank. When nothing is NaN this is identical to blitzgsea's own output, so it only ever replaces an all-NaN column.

### A non-finite NES rendered as an empty cell

blitzgsea computes `nes` as the normal quantile of the permutation p-value, so a p-value that underflows its gamma fit returns ±inf — a real "beyond what the null distribution can score" result, not a missing one (`pval` is exactly 0 alongside it). Two layers erased that: `pandas.to_json()` writes `null` for inf and NaN alike, and a `barplot` column in `dom/table.ts` drew nothing at all for a non-number.

- `gsea.py` sends infinities as `'Infinity'`/`'-Infinity'` strings so the sign survives; genuine NaN still goes to `null`. Applied only to the JSON — the pickle the detail-image path replays keeps real floats.
- The client renders those as `∞`/`−∞`, and the column header carries a tooltip explaining the symbol and why P value reads 0.
- `dom/table.ts` falls back to rendering the cell text for any value a bar cannot express. This fixes the class, not just GSEA — previously any non-numeric in a barplot column was an invisible blank.

The wire spelling is deliberately JS's own spelling of the value. The table sorts and filters on the raw FDR via `Number(fdr ?? Infinity)`: `Number('Infinity')` is `Infinity`, so such a gene set sorts last and fails the cutoff, whereas `Number('Inf')` would be `NaN` and `NaN > cutoff` is `false` — an uncomputable gene set would slip *past* the filter and present as a result. Both halves of that contract are now pinned by tests, and a regression test locks the sort/filter behavior.

## GDC DE review follow-ups

- **`rust/src/DEanalysis.rs`** — the bulk `read_2d()` was a memory regression for static counts files. It is free for GDC, where `buildCountsFile` produces a matrix of exactly the compared samples, but every other dataset routes this engine through a full static h5: a 10-vs-10 comparison against 3,000 samples × 60,660 genes would read ~730 MB to use ~5 MB. Now reads a bounded `read_slice_2d` over `min..=max` selected column, keeping the single-hyperslab win (28.8 s → 0.03 s vs. the old per-column striding) without the unbounded allocation. Verified byte-identical output against the previous build on two column windows, one spanning nearly the whole file and one mid-file to exercise the offset math. The f32 mem-type assumption is now documented rather than incidental.
- **`client/termdb/TermdbVocab.js`** — `getFilteredSampleList` had no `filter0` fallback while `getFilteredSampleCount` did, so the two vocab methods disagreed about who owns the default. Reached from `getGERequestBody` via `getOtherSamples` whenever a group carries `in: false`, it enumerated all of GDC rather than the portal cohort. Fixed in the shared method rather than at the one call site, so every caller is covered.
- **`server/src/termdb.js`** — the `filterSamples` branches of `getSampleCount`/`getSampleList` skipped `authApi.mayAdjustFilter()`, which `termdbsql.get_samplecount` marks `!!! CRITICAL !!!`. No-op for every current `filterSamples` dataset, but called now so the next one does not inherit the gap.
- **`cacheOrRecompute.ts`** — `gdcCounts.maxPending` raised 100 → 200. With `gdcDEconcurrency` defaulting to 60, one run holds up to 60 distinct in-flight cacheIds, so two overlapping runs reached 120 against a cap of 100 — and a full pool fails the whole run rather than queueing. The justifying comment still cited the old default of 20; rewritten against the real number. `CacheManager.unit.spec.ts` asserted the literal 100, so that moved too.
- **`shared/utils/src/helpers.ts`** — new `uiLabel()` accessor. `UiLabels` entries are typed `string | { label: string; ... }`, and `(uiLabels?.Sample || 'Sample').toUpperCase()` would throw on an object-valued entry. Latent, since no current ds does this for these keys, but it is a real hazard in a typed API. One accessor replaces the narrowing at all four sites, client and server.
- **`client/plots/volcano/Volcano.ts`** — the wilcoxon small-group caveat hardcoded "samples" in the one sentence GDC users are most likely to read, while the rest of the branch threads `uiLabels`. Now says "cases" on GDC.
- **`client/dom/table.ts`** — the BOM comment claimed "every other reader either honors the BOM or skips it". R's `read.delim` is fine and pandas' C parser strips it, but a plain `csv.DictReader` yields `'\ufeffGene'` as the first key. Kept the BOM (the Excel tradeoff is real) and corrected the comment to name `utf-8-sig`. Also restored the `|| undefined` guard on `download.fileName` so an empty string falls back to the date-stamped default instead of letting the browser derive a name from the data URL.

## Testing

- `server` unit: 1727/1727.
- `client/plots/gsea` unit: 58 assertions, up from 47 — new coverage for the p-value contract in both modes, every column `formatStat` touches, and the FDR sort/filter interaction.
- New `python/test/gsea.unit.spec.js` drives an offline `selftest` in `gsea.py` (no blitzgsea or msigdb needed, same pattern as `gdcCountsH5.py`), pinning the infinity wire spelling and the FDR recomputation.
- Both halves of the cross-language contract were mutation-tested, not just run green: changing `'Infinity'` to `'Inf'` in python fails the selftest; making `-Infinity` render as `∞` fails four client assertions.
- `tsc` clean on client, server, shared/utils, shared/types.

## Deploy note

GSEA results are cached on disk under `<cachedir>/gsea/`. Existing entries predate the python change and still carry the all-null FDR column, so that directory needs clearing for the fix to be visible.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
