### PR TITLE
fix: server getCategories apply opts.withMnames to gate mname returni…

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- server getCategories apply opts.withMnames to gate mname returning to cutdown matrix payload

--- a/server/src/routes/termdb.categories.ts
+++ b/server/src/routes/termdb.categories.ts
@@ -59,14 +59,21 @@ async function trigger_getcategories(
 
 	const data = await getData(arg, ds)
 	if (data.error) throw data.error
-	const [lst, orderedLabels] = getCategories(data, q, ds, $id)
+	// only this route serves the term-editing UIs that list amino acid changes,
+	// so it is the only caller that asks for the mname tally
+	const [lst, orderedLabels] = getCategories(data, q, ds, $id, { withMnames: true })
 	res.send({
 		lst: lst as any,
 		orderedLabels: orderedLabels as any
 	} satisfies CategoriesResponse)
 }
 
-export function getCategories(data, q, ds, $id) {
+/* opts.withMnames: tally the amino acid changes of each dt, in addition to the
+mutation classes. Off by default because getData() calls this for every
+geneVariant term of every matrix/barchart request (see mayGetCategories() in
+termdb.matrix.js), where the mname list is unused and can be large: it holds one
+entry per distinct dt/origin/class/gene/mname of the cohort */
+export function getCategories(data, q, ds, $id, opts: { withMnames?: boolean } = {}) {
 	const lst: any[] = []
 	if (q.tw.term.type == 'geneVariant' && q.tw.q.type != 'predefined-groupset' && q.tw.q.type != 'custom-groupset') {
 		// specialized data processing for geneVariant term when
@@ -125,7 +132,7 @@ export function getCategories(data, q, ds, $id) {
 						dtClasses[value.class] += 1
 					}
 				}
-				if (value.mname != undefined) {
+				if (opts.withMnames && value.mname != undefined) {
 					// synthetic WT/Blank rows lack mname, so are naturally skipped
 					const origin = dtClasses.byOrigin ? value.origin : ''
 					const gene = value.gene || ''
@@ -148,17 +155,17 @@ export function getCategories(data, q, ds, $id) {
 				}
 			}
 		}
+		// gene is only reported when annotated on the mutation data
+		const formatMname = (e: any) => {
+			const m: any = { mname: e.mname, class: e.class, samplecount: e.samplecount }
+			if (e.gene) m.gene = e.gene
+			return m
+		}
 		for (const [dt, classes] of dtClassMap) {
 			const entry: any = { dt, classes }
-			const mnameEntries = [...mnameCountMap.values()]
-				.filter(e => e.dt == dt)
-				.sort((a, b) => b.samplecount - a.samplecount)
-			// gene is only reported when annotated on the mutation data
-			const formatMname = (e: any) => {
-				const m: any = { mname: e.mname, class: e.class, samplecount: e.samplecount }
-				if (e.gene) m.gene = e.gene
-				return m
-			}
+			const mnameEntries = opts.withMnames
+				? [...mnameCountMap.values()].filter(e => e.dt == dt).sort((a, b) => b.samplecount - a.samplecount)
+				: []
 			if (mnameEntries.length) {
 				if (classes.byOrigin) {
 					const byOrigin: { [origin: string]: any[] } = {}

--- a/server/src/termdb.matrix.js
+++ b/server/src/termdb.matrix.js
@@ -1340,6 +1340,10 @@ function mayGetCategories(data, q, ds) {
 	if (!twLst.length) return
 	const categories = {}
 	for (const tw of twLst) {
+		// deliberately not asking for the mname tally (withMnames): this runs for
+		// every geneVariant term of every data request and the result is attached
+		// to the response, where no consumer reads mnames. only the
+		// termdb/categories route needs them, for the term-editing UIs
 		const [lst, orderedLabels] = getCategories(data, { tw }, ds, tw.$id)
 		categories[tw.$id] = { lst, orderedLabels }
 	}

--- a/server/src/test/termdb.categories.unit.spec.ts
+++ b/server/src/test/termdb.categories.unit.spec.ts
@@ -10,6 +10,7 @@ Tests
 	getCategories: same mname in both origins
 	getCategories: origin bucket without mnames stays empty
 	getCategories: gene of variants in a geneset term
+	getCategories: mnames are omitted without withMnames
 */
 
 tape('\n', t => {
@@ -40,7 +41,7 @@ tape('getCategories: geneVariant classes and mnames tally', t => {
 			6: { sample: 6, [$id]: { values: [{ dt: 4, class: 'CNV_amp' }] } }
 		}
 	}
-	const [lst] = getCategories(data, getQ(), {}, $id)
+	const [lst] = getCategories(data, getQ(), {}, $id, { withMnames: true })
 	const snvindel = lst.find(e => e.dt == 1)
 	t.deepEqual(snvindel.classes, { M: 3, F: 1, WT: 1 }, 'classes tallied per sample')
 	t.deepEqual(
@@ -81,7 +82,7 @@ tape('getCategories: geneVariant tally with byOrigin', t => {
 			}
 		}
 	}
-	const [lst] = getCategories(data, getQ(), ds, $id)
+	const [lst] = getCategories(data, getQ(), ds, $id, { withMnames: true })
 	const snvindel = lst.find(e => e.dt == 1)
 	t.deepEqual(
 		snvindel.mnames.byOrigin,
@@ -109,7 +110,7 @@ tape('getCategories: mname sample-level dedupe', t => {
 			}
 		}
 	}
-	const [lst] = getCategories(data, getQ(), {}, $id)
+	const [lst] = getCategories(data, getQ(), {}, $id, { withMnames: true })
 	const snvindel = lst.find(e => e.dt == 1)
 	t.deepEqual(snvindel.mnames, [{ mname: 'G12D', class: 'M', samplecount: 1 }], 'sample counted once per mname')
 	t.end()
@@ -130,7 +131,7 @@ tape('getCategories: mnames partition by dt', t => {
 			}
 		}
 	}
-	const [lst] = getCategories(data, getQ(), {}, $id)
+	const [lst] = getCategories(data, getQ(), {}, $id, { withMnames: true })
 	const snvindel = lst.find(e => e.dt == 1)
 	const fusion = lst.find(e => e.dt == 2)
 	t.deepEqual(snvindel.mnames, [{ mname: 'G12D', class: 'M', samplecount: 1 }], 'snvindel entry has only its mname')
@@ -157,7 +158,7 @@ tape('getCategories: same mname in both origins', t => {
 			}
 		}
 	}
-	const [lst] = getCategories(data, getQ(), ds, $id)
+	const [lst] = getCategories(data, getQ(), ds, $id, { withMnames: true })
 	const snvindel = lst.find(e => e.dt == 1)
 	t.deepEqual(
 		snvindel.mnames.byOrigin,
@@ -186,10 +187,46 @@ tape('getCategories: origin bucket without mnames stays empty', t => {
 			}
 		}
 	}
-	const [lst] = getCategories(data, getQ(), ds, $id)
+	const [lst] = getCategories(data, getQ(), ds, $id, { withMnames: true })
 	const snvindel = lst.find(e => e.dt == 1)
 	t.deepEqual(snvindel.mnames.byOrigin.somatic, [{ mname: 'G12D', class: 'M', samplecount: 1 }], 'somatic has mname')
 	t.deepEqual(snvindel.mnames.byOrigin.germline, [], 'germline bucket is an empty list')
+	t.end()
+})
+
+tape('getCategories: mnames are omitted without withMnames', t => {
+	// the mname tally is opt-in, so that data requests (which call this for
+	// every geneVariant term and never read mnames) do not carry it
+	const data = {
+		samples: {
+			1: {
+				sample: 1,
+				[$id]: {
+					values: [
+						{ dt: 1, class: 'M', mname: 'G12D', gene: 'KRAS' },
+						{ dt: 1, class: 'WT' }
+					]
+				}
+			}
+		}
+	}
+	{
+		const [lst] = getCategories(data, getQ(), {}, $id)
+		const snvindel = lst.find(e => e.dt == 1)
+		t.deepEqual(snvindel.classes, { M: 1, WT: 1 }, 'classes are tallied as usual')
+		t.equal('mnames' in snvindel, false, 'no mnames property by default')
+	}
+	{
+		const ds = { assayAvailability: { byDt: { 1: { byOrigin: { germline: {}, somatic: {} } } } } }
+		const originData = {
+			samples: {
+				1: { sample: 1, [$id]: { values: [{ dt: 1, class: 'M', mname: 'G12D', origin: 'somatic' }] } }
+			}
+		}
+		const [lst] = getCategories(originData, getQ(), ds, $id)
+		const snvindel = lst.find(e => e.dt == 1)
+		t.equal('mnames' in snvindel, false, 'no mnames property by default, byOrigin dataset')
+	}
 	t.end()
 })
 
@@ -210,7 +247,7 @@ tape('getCategories: gene of variants in a geneset term', t => {
 			2: { sample: 2, [$id]: { values: [{ dt: 1, class: 'M', mname: 'G12D', gene: 'KRAS' }] } }
 		}
 	}
-	const [lst] = getCategories(data, getQ(), {}, $id)
+	const [lst] = getCategories(data, getQ(), {}, $id, { withMnames: true })
 	const snvindel = lst.find(e => e.dt == 1)
 	t.deepEqual(
 		snvindel.mnames,

--- a/shared/types/src/routes/termdb.categories.ts
+++ b/shared/types/src/routes/termdb.categories.ts
@@ -38,8 +38,10 @@ export type MnameEntry = {
 export type GvCategoryEntry = {
 	dt: number
 	classes: DtClasses | { byOrigin: { [origin: string]: DtClasses } }
-	/** amino acid changes present for this dt, sorted by descending sample count;
-	 * only present when mutation data carries mname */
+	/** amino acid changes present for this dt, sorted by descending sample count.
+	 * only served by the termdb/categories route, and only when the mutation data
+	 * carries mname; the same entries returned within a data request (see
+	 * mayGetCategories() in termdb.matrix.js) omit this field */
 	mnames?: MnameEntry[] | { byOrigin: { [origin: string]: MnameEntry[] } }
 }
 


### PR DESCRIPTION
…ng to cutdown matrix payload

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
