### PR TITLE
DE: allow duplicated gene identifiers in the counts HDF5

### DIFF
--- a/R/src/edge_newh5.R
+++ b/R/src/edge_newh5.R
@@ -121,7 +121,15 @@ read_counts_time <- system.time({
   if (!length(samples)) fail("HDF5 dataset 'samples' contains no samples")
   if (anyNA(geneNames) || any(!nzchar(geneNames))) fail("HDF5 gene identifiers contain missing or empty values")
   if (anyNA(samples) || any(!nzchar(samples))) fail("HDF5 sample identifiers contain missing or empty values")
-  if (anyDuplicated(geneNames)) fail(paste0("HDF5 gene identifiers are duplicated: ", format_examples(geneNames[duplicated(geneNames)])))
+  # NOTE: duplicated geneNames are deliberately allowed. Counts files keyed on gene symbol rather
+  # than Ensembl id repeat the multi-copy loci (Y_RNA, Metazoa_SRP, U3/U6, snoRNAs), and those rows
+  # are distinct features with distinct counts. edgeR is fine with them: geneNames is passed to
+  # DGEList via genes=, so it becomes a y$genes column, not rownames (R only forbids duplicate
+  # row.names on data.frames), and every step after is positional -- verified by running edgeR end
+  # to end with repeated labels. The wilcoxon engine (rust DEanalysis) has no such restriction
+  # either, so re-adding this would reject via edgeR what wilcoxon accepts. Do not "fix" it with a
+  # fail(). The line below is a different matter: duplicated sample ids ARE fatal, because
+  # match(cases, samples) silently takes the first hit and would analyze the wrong column.
   if (anyDuplicated(samples)) fail(paste0("HDF5 sample identifiers are duplicated: ", format_examples(samples[duplicated(samples)])))
 
   # Find indices of case and control samples in the HDF5 file


### PR DESCRIPTION
edge_newh5.R rejected any counts file whose 'item' dataset repeated a gene identifier. That is too strict, and it blocks analyses that run correctly.

Duplicated gene labels do not break edgeR. geneNames is handed to DGEList via genes=, so it lands in the y$genes data.frame column, not in rownames -- R only forbids duplicate row.names on data.frames, and this script never assigns them (read_counts keeps default integer rownames). Every step after is positional: y[keep,] carries the genes column along, and geneNames <- unlist(et$genes) comes back aligned 1:1 with the results rows. Verified by running the pipeline shape used here (DGEList -> filterByExpr -> normLibSizes -> estimateDisp -> glmQLFit -> glmQLFTest) with 60 rows labelled Y_RNA and 20 Metazoa_SRP: it completes, all 200 rows survive, and each duplicated-label row keeps its own distinct p-value. limma is the same shape. FDR is likewise correct, since these are separate tests on separate features.

The rows are also legitimate rather than corruption. Counts files keyed on gene symbol instead of Ensembl id repeat the genuinely multi-copy loci -- Y_RNA, Metazoa_SRP, U3/U6, snoRNAs -- which are distinct genomic features with distinct count vectors. A label check would not detect real corruption anyway; that would need a duplicate-row check.

The guard was also inconsistent: wilcoxon runs through the rust DEanalysis binary, which treats gene names as a positional Vec<String> and has no such restriction. The same file was rejected by edgeR/limma and accepted by wilcoxon depending only on group size and the method radio.

Kept the adjacent sample check, which is load-bearing for a different reason: match(cases, samples) returns only the first hit, so a duplicated sample id would silently pull the wrong column into the analysis. Left a comment saying so, and why the gene case is not the same, to stop this being re-added.

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
