### PR TITLE
making the sv/fusion breakpoint UI in variantConfig intuitive: paired…

### DIFF
--- a/client/dom/isoformSelect.ts
+++ b/client/dom/isoformSelect.ts
@@ -5,10 +5,14 @@ import type {
 	ExonRegion,
 	IsoformSelectOpts,
 	IsoformRangeSelectOpts,
+	IsoformPairRangeSelectOpts,
+	BreakpointMarker,
+	BreakpointLink,
 	LinearScale,
+	ScaleMode,
 	SelectedRange
 } from './types/isoformSelect'
-import type { Td } from '../types/d3'
+import type { Div, Td } from '../types/d3'
 
 /*
 Standalone reusable component for displaying and selecting gene model isoforms.
@@ -28,7 +32,9 @@ Multi-select (multiSelect: true):
   from multiple isoforms.
 
 See isoformRangeSelect() at the bottom of this file for a related component that
-marks breakpoints over the isoform structure and selects a genomic range of them.
+marks breakpoints over the isoform structure and selects a genomic range of them,
+and isoformPairRangeSelect() for the two-gene form of it, which links the paired
+breakpoints of sv/fusion events between the two genes they join.
 
 ******* required (both modes)
 .holder     d3 selection to render into
@@ -300,20 +306,83 @@ export function isoformSelect(opts: IsoformSelectOpts) {
 	}
 }
 
-/**
- * Linear genomic scale over a chr region covering the gene models and markers, padded.
- *
- * Deliberately not the exon-collapsed layout of allgm2sum(): sv/fusion breakpoints are
- * mostly intronic (e.g. the two BCR breakpoint clusters of BCR::ABL1 sit in introns), so
- * a collapsed intron would squeeze them into a few px and make a dragged range
- * unmappable back to a genomic coordinate.
- */
-export function makeLinearScale(arg: {
+type ScaleArg = {
 	chr: string
 	gms: GeneModel[]
 	markers?: { pos: number }[]
 	pxwidth: number
-}): LinearScale {
+	/** range already selected on the gene. only used to keep it within a zoomed window */
+	range?: { start: number; stop: number }
+}
+
+/** exons of context kept on each side of the breakpoints when zooming (see focusRegions) */
+const zoomPadExons = 1
+/** a gene of fewer exons than this is not zoomed, as there is little width to win */
+const zoomMinExons = 6
+/** zoom only when the window leaves out at least this share of the exons: below it the
+ * width won does not repay the context lost */
+const zoomMinDropped = 1 / 3
+
+/**
+ * The exons to draw of a gene: the ones the breakpoints fall on, one exon of context on
+ * each side, and every exon between them.
+ *
+ * The window is one contiguous run, so it is a zoom of the gene rather than a splice of it:
+ * every gap within it is a real intron, and nothing inside it is left out. An exon of a
+ * many-exon gene is only a few px of the full width, too small to read a breakpoint on or
+ * to drag a range over; a window of them gets the whole width to share.
+ *
+ * The whole gene is kept when the window would leave out too little to repay the context.
+ */
+function focusRegions(
+	rglst: ExonRegion[],
+	markers: { pos: number }[] | undefined,
+	range: { start: number; stop: number } | undefined
+): ExonRegion[] {
+	if (rglst.length < zoomMinExons) return rglst
+	/* what the window must cover: the breakpoints, and the ends of a range already selected,
+	so that a window cannot silently narrow a saved selection when it is clamped (see the
+	setRange of each component) */
+	const positions: number[] = []
+	for (const m of markers || []) if (Number.isFinite(m.pos)) positions.push(m.pos)
+	if (range) positions.push(range.start, range.stop)
+	if (!positions.length) return rglst
+	const lo = Math.min(...positions)
+	const hi = Math.max(...positions)
+	// rglst runs 3' to 5' on the minus strand, so walk the regions by position instead
+	const byPos = [...rglst].sort((a, b) => a.start - b.start)
+	let first = 0
+	while (first < byPos.length - 1 && byPos[first].stop < lo) first++
+	let last = byPos.length - 1
+	while (last > first && byPos[last].start > hi) last--
+	first = Math.max(0, first - zoomPadExons)
+	last = Math.min(byPos.length - 1, last + zoomPadExons)
+	const kept = new Set(byPos.slice(first, last + 1))
+	if (kept.size > rglst.length * (1 - zoomMinDropped)) return rglst
+	return rglst.filter(r => kept.has(r))
+}
+
+/** compact locus of a zoomed track, e.g. chr22:23180-23240kb, to fit the label column it
+ * is shown in. the exact coordinates are in the range inputs below the chart */
+function locusLabel(chr: string, start: number, stop: number) {
+	if (stop - start >= 1e6) return `${chr}:${(start / 1e6).toFixed(2)}-${(stop / 1e6).toFixed(2)}Mb`
+	return `${chr}:${Math.round(start / 1000)}-${Math.round(stop / 1000)}kb`
+}
+
+/**
+ * Scale of a gene to place breakpoints and a range over, in the layout of the given mode
+ * (see ScaleMode): 'genomic' keeps introns at their real width, 'rna' collapses them.
+ *
+ * The mode follows the dt of the events being charted, not the gene: a genomic sv breaks
+ * mostly in introns, so collapsing them would squeeze its breakpoints into a few px, while
+ * a rna fusion joins transcripts at exon boundaries, where intronic space is only noise.
+ */
+export function makeScale(arg: ScaleArg & { mode?: ScaleMode }): LinearScale {
+	return arg.mode == 'rna' ? makeExonScale(arg) : makeLinearScale(arg)
+}
+
+/** Linear genomic scale over a chr region covering the gene models and markers, padded. */
+export function makeLinearScale(arg: ScaleArg): LinearScale {
 	const { chr, gms, pxwidth } = arg
 	const positions: number[] = []
 	for (const gm of gms) positions.push(gm.start, gm.stop)
@@ -332,12 +401,15 @@ export function makeLinearScale(arg: {
 	const rglst: ExonRegion[] = [{ chr, bstart: start, bstop: stop, start, stop, reverse, width: pxwidth }]
 	return {
 		chr,
+		mode: 'genomic',
+		zoomed: false,
 		start,
 		stop,
 		reverse,
 		pxwidth,
 		exonsf,
 		rglst,
+		intronpx: 0,
 		pos2px: (pos: number) => (reverse ? stop - pos : pos - start) * exonsf,
 		px2pos: (px: number) => {
 			const pos = Math.round(reverse ? stop - px / exonsf : start + px / exonsf)
@@ -347,10 +419,262 @@ export function makeLinearScale(arg: {
 }
 
 /**
+ * Scale over the exon structure of a gene, the exons of all its isoforms merged (see
+ * allgm2sum) and the introns between them collapsed to fixed narrow gaps.
+ *
+ * A position off the exon structure, i.e. in a collapsed intron or outside the gene, has no
+ * px of its own and maps to the start of the exon after it, which is also where a px of the
+ * gap it sits in maps back to; so a dragged range snaps to exon boundaries and an off-exon
+ * position stays put through a round trip. The range stays genomic, so it still covers the
+ * introns its ends span over: for a rna fusion nothing breaks there, and an event that did
+ * would be matched by the range but drawn at an exon edge.
+ *
+ * Falls back to makeLinearScale() for a gene with no isoform, e.g. a fusion partner that is
+ * an unannotated locus, as there is no exon structure to lay its breakpoints over.
+ */
+export function makeExonScale(arg: ScaleArg): LinearScale {
+	const { chr, gms, pxwidth } = arg
+	const [allrg] = allgm2sum(gms.filter(gm => gm.chr == chr))
+	if (!allrg.length) return makeLinearScale(arg)
+	// zoom to the exons the breakpoints fall on, when there is enough width to win by it
+	const rglst = focusRegions(allrg, arg.markers, arg.range)
+	const zoomed = rglst.length < allrg.length
+	// rglst is in display order, 5' to 3', so a minus strand gene runs right to left
+	const reverse = !!rglst[0].reverse
+	const gaps = rglst.length - 1
+	// a gap is a fixed 10px, narrowed for a gene of many exons so that the gaps together
+	// cannot take more than 40% of the width from the exons
+	const intronpx = gaps ? Math.min(10, (pxwidth * 0.4) / gaps) : 0
+	const exonlen = rglst.reduce((n, r) => n + r.stop - r.start, 0)
+	const exonsf = (pxwidth - intronpx * gaps) / exonlen
+	/* x of the left edge of each region, accumulated exactly as sketchGmsum() advances over
+	rglst, so that a mark and the sketch below it land on the same px. NOTE the widths are
+	kept unrounded for that reason */
+	const offsets: number[] = []
+	let x = 0
+	for (const r of rglst) {
+		r.width = (r.stop - r.start) * exonsf
+		offsets.push(x)
+		x += r.width + intronpx
+	}
+	const start = Math.min(...rglst.map(r => r.start))
+	const stop = Math.max(...rglst.map(r => r.stop))
+	// regions in ascending position, to find the one a position falls in or before
+	const byPos = rglst.map((r, i) => ({ r, offset: offsets[i] })).sort((a, b) => a.r.start - b.r.start)
+	return {
+		chr,
+		mode: 'rna',
+		zoomed,
+		start,
+		stop,
+		reverse,
+		pxwidth,
+		exonsf,
+		rglst,
+		intronpx,
+		pos2px: (pos: number) => {
+			const p = Math.max(start, Math.min(stop, pos))
+			for (const { r, offset } of byPos) {
+				if (p > r.stop) continue
+				// within this exon, or in the intron before it, which has no px of its own
+				const q = Math.max(p, r.start)
+				return offset + (reverse ? r.stop - q : q - r.start) * exonsf
+			}
+			// unreachable, as p is clamped to the last stop
+			return pxwidth
+		},
+		px2pos: (px: number) => {
+			const x = Math.max(0, Math.min(pxwidth, px))
+			for (const [i, r] of rglst.entries()) {
+				if (x > offsets[i] + r.width!) continue
+				// within this exon, or in the gap before it, which maps to its leading edge
+				const within = Math.max(0, x - offsets[i]) / exonsf
+				return Math.round(reverse ? r.stop - within : r.start + within)
+			}
+			const last = rglst[rglst.length - 1]
+			return reverse ? last.start : last.stop
+		}
+	}
+}
+
+/** color of a selected range and of the breakpoints falling within it */
+const selectColor = '#1e6edc'
+/** color of a breakpoint mark or link with no range to be in or out of */
+const markColor = '#5A5A5A'
+/** color of a breakpoint excluded by the range on its own gene */
+const outColor = '#b0b0b0'
+/** color of a breakpoint excluded by the range on the other gene of a pair. lighter than
+ * outColor, as it fails a constraint that is not editable in this component */
+const otherOutColor = '#d6d6d6'
+/** color of a hovered link, the same highlight as the default isoform label */
+const hoverColor = '#cc0000'
+
+/** direction breakpoint marks grow in from their baseline: 'up' for a track whose isoform
+ * sketches are below the marks, 'down' for one whose sketches are above them */
+type MarkDirection = 'up' | 'down'
+
+/** draw the breakpoint marks of one gene, their height scaled by sample count */
+function renderBreakpointMarks(a: {
+	canvas: HTMLCanvasElement
+	markers: BreakpointMarker[]
+	scale: LinearScale
+	pxwidth: number
+	height: number
+	direction: MarkDirection
+	/** color of each mark, defaults to markColor */
+	getColor?: (m: BreakpointMarker) => string
+}) {
+	const { canvas, markers, scale, pxwidth, height, direction } = a
+	const ctx = setupCanvas(canvas, pxwidth, height)
+	// baseline the marks stand on, at the level of the isoform sketches beside them
+	const baseY = direction == 'up' ? height - 0.5 : 0.5
+	ctx.strokeStyle = '#ccc'
+	ctx.beginPath()
+	ctx.moveTo(0, baseY)
+	ctx.lineTo(pxwidth, baseY)
+	ctx.stroke()
+	if (!markers.length) return
+	const maxCount = Math.max(...markers.map(m => m.samplecount || 1))
+	for (const m of markers) {
+		// sqrt scale, so that a few high-count breakpoints do not flatten the rest
+		const h = 5 + (height - 8) * Math.sqrt((m.samplecount || 1) / maxCount)
+		const x = Math.round(scale.pos2px(m.pos)) + 0.5
+		const y0 = direction == 'up' ? height - 1 : 1
+		ctx.strokeStyle = a.getColor ? a.getColor(m) : markColor
+		ctx.beginPath()
+		ctx.moveTo(x, y0)
+		ctx.lineTo(x, direction == 'up' ? y0 - h : y0 + h)
+		ctx.stroke()
+	}
+}
+
+/** one row per isoform, its name in the label column and its exon structure sketched
+ * over the scale in the graph column */
+function renderIsoformRows(a: {
+	labelCol: Div
+	graphCol: Div
+	gms: GeneModel[]
+	scale: LinearScale
+	pxwidth: number
+	rowHeight: number
+}) {
+	for (const gm of visibleGms(a.gms, a.scale)) {
+		a.labelCol
+			.append('div')
+			.style('height', a.rowHeight + 'px')
+			.style('overflow', 'hidden')
+			.style('white-space', 'nowrap')
+			.style('font-size', '.8em')
+			.style('color', gm.isdefault ? hoverColor : '#545454')
+			.attr('title', gm.isoform)
+			.text(gm.isoform)
+		const row = a.graphCol.append('div').style('height', a.rowHeight + 'px')
+		// the same intron width the scale accumulates its regions with, or the sketch would
+		// not line up with the marks and links placed over it
+		sketchGmsum(row, a.scale.rglst, gm, a.scale.exonsf, a.scale.intronpx, a.pxwidth, a.rowHeight - 2, exoncolor, {
+			// a zoomed layout gives an exon box the room for its number; an unzoomed one
+			// of a many-exon gene does not, and none is drawn
+			exonNumbers: true
+		})
+	}
+}
+
+/** the isoforms with something to draw over the scale. one lying outside a zoomed window
+ * has no exon and no backbone within it, so it would take a row to render nothing */
+function visibleGms(gms: GeneModel[], scale: LinearScale) {
+	return gms.filter(gm => gm.stop >= scale.start && gm.start <= scale.stop)
+}
+
+/** drag over an element to select a range of px on it, reported as [x0, x1] of that element */
+function attachRangeDrag(sel: any, pxwidth: number, onDrag: (x0: number, x1: number) => void) {
+	const clampPx = (px: number) => Math.max(0, Math.min(pxwidth, px))
+	sel.on('mousedown', (event: MouseEvent) => {
+		event.preventDefault()
+		const rect = (sel.node() as HTMLElement).getBoundingClientRect()
+		const x0 = clampPx(event.clientX - rect.left)
+		// listening on window so that a drag continuing outside the element still tracks
+		const onMove = (e: MouseEvent) => {
+			const x1 = clampPx(e.clientX - rect.left)
+			// below this the pointer has not really moved, e.g. the jitter of a click,
+			// which must not select a zero width range
+			if (Math.abs(x1 - x0) < 2) return
+			onDrag(x0, x1)
+		}
+		const onUp = () => {
+			window.removeEventListener('mousemove', onMove)
+			window.removeEventListener('mouseup', onUp)
+		}
+		window.addEventListener('mousemove', onMove)
+		window.addEventListener('mouseup', onUp)
+	})
+}
+
+/** coordinate inputs of the selected range, an exact way to place it that a drag cannot
+ * give, with the buttons to apply and clear it */
+function renderRangeControls(a: {
+	holder: Div
+	chr: string
+	/** a range typed into the inputs, sorted by position; undefined when an input was
+	 * emptied or is unparsable, which restores the displayed range */
+	onTyped: (r: { start: number; stop: number } | undefined) => void
+	onApply: () => void
+	onClear: () => void
+}) {
+	const controlDiv = a.holder.append('div').style('margin-top', '6px').style('font-size', '.8em')
+	controlDiv
+		.append('span')
+		.style('opacity', 0.7)
+		.text(a.chr + ':')
+	const startInput = addPosInput()
+	controlDiv.append('span').style('opacity', 0.7).text('-')
+	const stopInput = addPosInput()
+	const applyBtn = controlDiv
+		.append('button')
+		.attr('data-testid', 'sjpp-isoformRangeSelect-apply')
+		.style('margin-left', '8px')
+		.text('Apply')
+		.on('click', a.onApply)
+	const clearBtn = controlDiv
+		.append('button')
+		.attr('data-testid', 'sjpp-isoformRangeSelect-clear')
+		.style('margin-left', '5px')
+		.text('Clear')
+		.on('click', a.onClear)
+
+	return {
+		/** show the given range on the inputs, and enable the buttons only when there is one */
+		update(range: { start: number; stop: number } | null) {
+			startInput.property('value', range ? range.start : '')
+			stopInput.property('value', range ? range.stop : '')
+			applyBtn.property('disabled', !range)
+			clearBtn.property('disabled', !range)
+		}
+	}
+
+	function addPosInput() {
+		return controlDiv
+			.append('input')
+			.attr('type', 'number')
+			.attr('data-testid', 'sjpp-isoformRangeSelect-pos')
+			.style('width', '85px')
+			.style('margin', '0 3px')
+			.on('change', () => {
+				const start = Number(startInput.property('value'))
+				const stop = Number(stopInput.property('value'))
+				if (!Number.isFinite(start) || !Number.isFinite(stop)) {
+					a.onTyped(undefined)
+					return
+				}
+				a.onTyped({ start: Math.min(start, stop), stop: Math.max(start, stop) })
+			})
+	}
+}
+
+/**
  * Mark breakpoints over the isoform structure of a gene and select a genomic range of them.
  *
  * Renders a canvas of breakpoint marks on top of the isoform models, all on one linear
- * scale (see makeLinearScale), and allows dragging a range over them. The range may also
+ * scale (see makeScale, laid out per opts.mode), and allows dragging a range over them. The range may also
  * be typed in, as a drag over a gene of a hundred kb is too coarse to place a cluster
  * boundary. Calls callback(range) on apply and callback(null) when the range is cleared.
  *
@@ -370,7 +694,8 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 		holder.append('div').style('opacity', 0.6).text('No gene model or breakpoint to display')
 		return
 	}
-	const scale = makeLinearScale({ chr, gms, markers, pxwidth })
+	// the range is passed so that a zoomed window cannot leave it out (see focusRegions)
+	const scale = makeScale({ chr, gms, markers, pxwidth, mode: opts.mode, range: opts.range })
 
 	// current selection, kept in genomic coordinates so that it survives a re-render
 	let range: { start: number; stop: number } | null = opts.range
@@ -396,29 +721,49 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 		.style('position', 'relative')
 		.style('width', pxwidth + 'px')
 
-	// blank label cell to keep the isoform names aligned with their sketches
-	labelCol.append('div').style('height', markerHeight + 'px')
+	/* label cell beside the marks, keeping the isoform names aligned with their sketches. it
+	names the locus when only a window of the gene is drawn, so that the view is not taken
+	for the whole gene */
+	const locusCell = labelCol
+		.append('div')
+		.attr('data-testid', 'sjpp-isoformRangeSelect-locus')
+		.style('height', markerHeight + 'px')
+		.style('display', 'flex')
+		.style('align-items', 'flex-end')
+	if (scale.zoomed) {
+		locusCell
+			.append('div')
+			.style('font-size', '.7em')
+			.style('opacity', 0.6)
+			.style('overflow', 'hidden')
+			.style('white-space', 'nowrap')
+			.attr('title', `${chr}:${scale.start.toLocaleString()}-${scale.stop.toLocaleString()}`)
+			.text(locusLabel(chr, scale.start, scale.stop))
+	}
 
-	const markerCanvas = graphCol
+	/* the marks and the isoform sketches under them are one track, and a range is dragged
+	over the whole of it: the highlight spans it, so anything less would leave part of what
+	the drag selects looking inert */
+	const track = graphCol
+		.append('div')
+		.attr('data-testid', 'sjpp-isoformRangeSelect-track')
+		.attr('data-scale-mode', scale.mode)
+		.style('cursor', 'crosshair')
+	const markerCanvas = track
 		.append('canvas')
 		.attr('data-testid', 'sjpp-isoformRangeSelect-marks')
 		.style('display', 'block')
-		.style('cursor', 'crosshair')
-	renderMarks()
+	renderBreakpointMarks({
+		canvas: markerCanvas.node() as HTMLCanvasElement,
+		markers,
+		scale,
+		pxwidth,
+		height: markerHeight,
+		// the isoform sketches are below the marks, so the marks stand on them
+		direction: 'up'
+	})
 
-	for (const gm of gms) {
-		labelCol
-			.append('div')
-			.style('height', rowHeight + 'px')
-			.style('overflow', 'hidden')
-			.style('white-space', 'nowrap')
-			.style('font-size', '.8em')
-			.style('color', gm.isdefault ? '#cc0000' : '#545454')
-			.attr('title', gm.isoform)
-			.text(gm.isoform)
-		const row = graphCol.append('div').style('height', rowHeight + 'px')
-		sketchGmsum(row, scale.rglst, gm, scale.exonsf, 0, pxwidth, rowHeight - 2, exoncolor)
-	}
+	renderIsoformRows({ labelCol, graphCol: track, gms, scale, pxwidth, rowHeight })
 
 	// highlight of the selected range, spanning the marks and all isoform sketches
 	const overlay = graphCol
@@ -428,59 +773,27 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 		.style('top', 0)
 		.style('bottom', 0)
 		.style('background', 'rgba(30,110,220,.18)')
-		.style('border-left', '1px solid #1e6edc')
-		.style('border-right', '1px solid #1e6edc')
+		.style('border-left', `1px solid ${selectColor}`)
+		.style('border-right', `1px solid ${selectColor}`)
 		.style('pointer-events', 'none')
 		.style('display', 'none')
 
-	// coordinate inputs, an exact way to place a range that a drag cannot give
-	const controlDiv = holder.append('div').style('margin-top', '6px').style('font-size', '.8em')
-	controlDiv
-		.append('span')
-		.style('opacity', 0.7)
-		.text(chr + ':')
-	const startInput = addPosInput()
-	controlDiv.append('span').style('opacity', 0.7).text('-')
-	const stopInput = addPosInput()
-	const applyBtn = controlDiv
-		.append('button')
-		.attr('data-testid', 'sjpp-isoformRangeSelect-apply')
-		.style('margin-left', '8px')
-		.text('Apply')
-		.on('click', () => {
+	const controls = renderRangeControls({
+		holder,
+		chr,
+		onTyped: r => setRange(r || range),
+		onApply: () => {
 			if (!range) return
 			callback({ chr, start: range.start, stop: range.stop })
-		})
-	const clearBtn = controlDiv
-		.append('button')
-		.attr('data-testid', 'sjpp-isoformRangeSelect-clear')
-		.style('margin-left', '5px')
-		.text('Clear')
-		.on('click', () => {
+		},
+		onClear: () => {
 			setRange(null)
 			callback(null)
-		})
-
-	// drag over the marks to select a range
-	markerCanvas.on('mousedown', (event: MouseEvent) => {
-		event.preventDefault()
-		const rect = (markerCanvas.node() as HTMLCanvasElement).getBoundingClientRect()
-		const x0 = clampPx(event.clientX - rect.left)
-		// listening on window so that a drag continuing outside the canvas still tracks
-		const onMove = (e: MouseEvent) => {
-			const x1 = clampPx(e.clientX - rect.left)
-			// below this the pointer has not really moved, e.g. the jitter of a click,
-			// which must not select a zero width range
-			if (Math.abs(x1 - x0) < 2) return
-			setRangeFromPx(x0, x1)
 		}
-		const onUp = () => {
-			window.removeEventListener('mousemove', onMove)
-			window.removeEventListener('mouseup', onUp)
-		}
-		window.addEventListener('mousemove', onMove)
-		window.addEventListener('mouseup', onUp)
 	})
+
+	// drag anywhere over the track, marks or isoforms alike, to select a range
+	attachRangeDrag(track, pxwidth, (x0, x1) => setRangeFromPx(x0, x1))
 
 	markerCanvas.on('mousemove', (event: MouseEvent) => {
 		const rect = (markerCanvas.node() as HTMLCanvasElement).getBoundingClientRect()
@@ -503,29 +816,6 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 		setRange: (r: SelectedRange | null) => setRange(r)
 	}
 
-	function addPosInput() {
-		return controlDiv
-			.append('input')
-			.attr('type', 'number')
-			.attr('data-testid', 'sjpp-isoformRangeSelect-pos')
-			.style('width', '85px')
-			.style('margin', '0 3px')
-			.on('change', () => {
-				const start = Number(startInput.property('value'))
-				const stop = Number(stopInput.property('value'))
-				if (!Number.isFinite(start) || !Number.isFinite(stop)) {
-					// an emptied or unparsable input, restore the displayed range
-					setRange(range)
-					return
-				}
-				setRange({ start: Math.min(start, stop), stop: Math.max(start, stop) })
-			})
-	}
-
-	function clampPx(px: number) {
-		return Math.max(0, Math.min(pxwidth, px))
-	}
-
 	function setRangeFromPx(x0: number, x1: number) {
 		const a = scale.px2pos(x0)
 		const b = scale.px2pos(x1)
@@ -542,15 +832,10 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 				.style('display', '')
 				.style('left', Math.min(x0, x1) + 'px')
 				.style('width', Math.max(1, Math.abs(x1 - x0)) + 'px')
-			startInput.property('value', range.start)
-			stopInput.property('value', range.stop)
 		} else {
 			overlay.style('display', 'none')
-			startInput.property('value', '')
-			stopInput.property('value', '')
 		}
-		applyBtn.property('disabled', !range)
-		clearBtn.property('disabled', !range)
+		controls.update(range)
 		updateInfo()
 	}
 
@@ -567,27 +852,392 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 				(samples ? `, ${samples} samples` : '')
 		)
 	}
+}
 
-	function renderMarks() {
-		const canvas = markerCanvas.node() as HTMLCanvasElement
-		const ctx = setupCanvas(canvas, pxwidth, markerHeight)
-		// baseline the marks stand on, at the level of the isoform sketches below
-		ctx.strokeStyle = '#ccc'
-		ctx.beginPath()
-		ctx.moveTo(0, markerHeight - 0.5)
-		ctx.lineTo(pxwidth, markerHeight - 0.5)
-		ctx.stroke()
-		if (!markers.length) return
-		const maxCount = Math.max(...markers.map(m => m.samplecount || 1))
-		ctx.strokeStyle = '#5A5A5A'
-		for (const m of markers) {
-			// sqrt scale, so that a few high-count breakpoints do not flatten the rest
-			const h = 5 + (markerHeight - 8) * Math.sqrt((m.samplecount || 1) / maxCount)
-			const x = Math.round(scale.pos2px(m.pos)) + 0.5
-			ctx.beginPath()
-			ctx.moveTo(x, markerHeight - 1)
-			ctx.lineTo(x, markerHeight - 1 - h)
-			ctx.stroke()
-		}
+/**
+ * Chart the paired breakpoints of sv/fusion events over both genes they join, and select
+ * a genomic range on the partner gene.
+ *
+ * The two genes are stacked as parallel tracks, each on its own scale of its own
+ * chr (see makeScale, laid out per opts.mode), with a line between the two breakpoints of every distinct
+ * event: the term's own gene above, the partner below. The strength of a line is its
+ * sample count, so that a recurrent breakpoint pair, e.g. the major BCR::ABL1 junction,
+ * reads at a glance. Which breakpoint of one gene goes with which of the other is lost by
+ * charting either gene alone (see isoformRangeSelect), and is what this view recovers.
+ *
+ * Only the range on the partner gene is selected here, by dragging over its marks, typing
+ * coordinates, or clicking a link to take its breakpoint. The range on the term's own gene
+ * is owned by a separate control that applies term-wide (see variantConfig.ts), so it is
+ * shown as context only: it is highlighted, and the links failing it are dimmed, as those
+ * events cannot match however the partner range is placed.
+ *
+ * Returns undefined, having said so in the holder, when neither track can be scaled.
+ */
+export function isoformPairRangeSelect(opts: IsoformPairRangeSelectOpts) {
+	const { holder, self, partner, callback } = opts
+	const pxwidth = opts.pxwidth ?? 400
+	const labelWidth = opts.labelWidth ?? 110
+	const rowHeight = 18
+	// breathing room between the link band and the isoform sketches it runs to
+	const trackGap = 10
+	const linkHeight = 70
+
+	const selfGms = self.allgm.filter(gm => gm.chr == self.chr && !gm.hidden)
+	const partnerGms = partner.allgm.filter(gm => gm.chr == partner.chr && !gm.hidden)
+	// a pair missing a coordinate on either side cannot be drawn as a link
+	const links = opts.links.filter(l => Number.isFinite(l.selfPos) && Number.isFinite(l.partnerPos))
+	if (!links.length && (!selfGms.length || !partnerGms.length)) {
+		// without links, a track holds only its isoform sketches, and one of them has none
+		holder.append('div').style('opacity', 0.6).text('No gene model or breakpoint to display')
+		return
 	}
+	/* marks of a track are the distinct breakpoints of its gene, summing the samples of
+	every pair converging on the same position. NOTE that sums a sample with two events at
+	one position, to different breakpoints of the other gene, once per event */
+	const selfMarks = collapseMarks(l => l.selfPos)
+	const partnerMarks = collapseMarks(l => l.partnerPos)
+	// both genes are of the same events, so they are laid out the same way. each range is
+	// passed so that a zoomed window of its gene cannot leave it out (see focusRegions)
+	const selfScale = makeScale({
+		chr: self.chr,
+		gms: selfGms,
+		markers: selfMarks,
+		pxwidth,
+		mode: opts.mode,
+		range: self.range
+	})
+	const partnerScale = makeScale({
+		chr: partner.chr,
+		gms: partnerGms,
+		markers: partnerMarks,
+		pxwidth,
+		mode: opts.mode,
+		range: partner.range
+	})
+	const maxCount = Math.max(...links.map(l => l.samplecount || 1), 1)
+
+	// current selection on the partner gene, kept in genomic coordinates
+	let range: { start: number; stop: number } | null = partner.range
+		? { start: partner.range.start, stop: partner.range.stop }
+		: null
+	// link under the pointer, highlighted and read out while it is
+	let hoveredLink: BreakpointLink | undefined
+
+	// readout of the hovered link, or of the current selection when not hovering
+	const infoDiv = holder
+		.append('div')
+		.attr('data-testid', 'sjpp-isoformPairSelect-info')
+		.style('font-size', '.8em')
+		.style('opacity', 0.7)
+		.style('margin-bottom', '3px')
+		/* room for two lines, as a readout naming both genes may wrap: with the height
+		following the text, the chart would shift under the pointer on hovering a link */
+		.style('height', '2.4em')
+		.style('overflow', 'hidden')
+
+	const flexDiv = holder.append('div').style('display', 'flex')
+	const labelCol = flexDiv
+		.append('div')
+		.style('width', labelWidth + 'px')
+		.style('flex', '0 0 auto')
+	const graphCol = flexDiv
+		.append('div')
+		.style('position', 'relative')
+		.style('width', pxwidth + 'px')
+
+	/* the two genes, joined by the band of links. NOTE no strip of breakpoint marks between
+	a gene and the band: the links already converge on each breakpoint, so marks would draw
+	the same positions twice over and cost the chart the height of two more rows */
+	// the isoforms each track actually renders, which a zoomed window may narrow
+	const selfRows = visibleGms(selfGms, selfScale)
+	const partnerRows = visibleGms(partnerGms, partnerScale)
+	const selfTrack = graphCol
+		.append('div')
+		.attr('data-testid', 'sjpp-isoformPairSelect-selfTrack')
+		.attr('data-scale-mode', selfScale.mode)
+	renderIsoformRows({ labelCol, graphCol: selfTrack, gms: selfRows, scale: selfScale, pxwidth, rowHeight })
+	// breathing room either side of the band, so that the links do not run into the exon
+	// boxes they lead to, and so that a track of one isoform is still a fair drag target
+	selfTrack.append('div').style('height', trackGap + 'px')
+	labelCol.append('div').style('height', trackGap + 'px')
+
+	/* the gene names sit either side of the link band, each next to its own track. one label
+	cell holds both, so that they stay level with the band however tall it is */
+	const geneLabels = labelCol
+		.append('div')
+		.style('height', linkHeight + 'px')
+		.style('display', 'flex')
+		.style('flex-direction', 'column')
+		.style('justify-content', 'space-between')
+	addGeneLabel(geneLabels, self.gene, selfScale)
+	addGeneLabel(geneLabels, partner.gene, partnerScale)
+	const linkCanvas = graphCol
+		.append('canvas')
+		.attr('data-testid', 'sjpp-isoformPairSelect-links')
+		.style('display', 'block')
+
+	/* the range is dragged over the whole of the partner track, isoform sketches included:
+	its highlight spans them, and with no strip of marks to drag over they are all there is */
+	const partnerTrack = graphCol
+		.append('div')
+		.attr('data-testid', 'sjpp-isoformPairSelect-partnerTrack')
+		.attr('data-scale-mode', partnerScale.mode)
+		.style('cursor', 'crosshair')
+	partnerTrack.append('div').style('height', trackGap + 'px')
+	labelCol.append('div').style('height', trackGap + 'px')
+	renderIsoformRows({ labelCol, graphCol: partnerTrack, gms: partnerRows, scale: partnerScale, pxwidth, rowHeight })
+
+	// vertical extent of each track within the graph column, to place the highlights over
+	const selfHeight = selfRows.length * rowHeight + trackGap
+	const partnerTop = selfHeight + linkHeight
+	const partnerHeight = trackGap + partnerRows.length * rowHeight
+
+	/* the range on the term's own gene, shown as context. it is not editable here, so it
+	is drawn muted and dashed, to read differently from the selection below */
+	if (self.range) {
+		const overlay = graphCol
+			.append('div')
+			.attr('data-testid', 'sjpp-isoformPairSelect-selfOverlay')
+			.style('position', 'absolute')
+			.style('top', 0)
+			.style('height', selfHeight + 'px')
+			.style('background', 'rgba(120,120,120,.14)')
+			.style('border-left', '1px dashed #999')
+			.style('border-right', '1px dashed #999')
+			.style('pointer-events', 'none')
+		const x0 = selfScale.pos2px(Math.max(selfScale.start, self.range.start))
+		const x1 = selfScale.pos2px(Math.min(selfScale.stop, self.range.stop))
+		overlay.style('left', Math.min(x0, x1) + 'px').style('width', Math.max(1, Math.abs(x1 - x0)) + 'px')
+	}
+
+	// highlight of the selected range, spanning the marks and sketches of the partner only
+	const overlay = graphCol
+		.append('div')
+		.attr('data-testid', 'sjpp-isoformPairSelect-overlay')
+		.style('position', 'absolute')
+		.style('top', partnerTop + 'px')
+		.style('height', partnerHeight + 'px')
+		.style('background', 'rgba(30,110,220,.18)')
+		.style('border-left', `1px solid ${selectColor}`)
+		.style('border-right', `1px solid ${selectColor}`)
+		.style('pointer-events', 'none')
+		.style('display', 'none')
+
+	const controls = renderRangeControls({
+		holder,
+		chr: partner.chr,
+		onTyped: r => setRange(r || range),
+		onApply: () => {
+			if (!range) return
+			callback({ chr: partner.chr, start: range.start, stop: range.stop })
+		},
+		onClear: () => {
+			setRange(null)
+			callback(null)
+		}
+	})
+
+	// drag anywhere over the partner track, isoform sketches included, to select a range
+	attachRangeDrag(partnerTrack, pxwidth, (x0, x1) => {
+		const a = partnerScale.px2pos(x0)
+		const b = partnerScale.px2pos(x1)
+		// on the minus strand the left px is the higher position, so sort by position
+		setRange({ start: Math.min(a, b), stop: Math.max(a, b) })
+	})
+
+	partnerTrack.on('mousemove', (event: MouseEvent) => {
+		const rect = (partnerTrack.node() as HTMLElement).getBoundingClientRect()
+		const x = event.clientX - rect.left
+		// the breakpoints of the gene, which the links converging on them stand for
+		const hovered = partnerMarks.find(m => Math.abs(partnerScale.pos2px(m.pos) - x) <= 3)
+		if (hovered) {
+			infoDiv.text(
+				`${partner.gene} ${partner.chr}:${hovered.pos.toLocaleString()}` +
+					(hovered.samplecount ? ` · ${hovered.samplecount} samples` : '')
+			)
+		} else {
+			updateInfo()
+		}
+	})
+	partnerTrack.on('mouseleave', () => updateInfo())
+
+	// a link is the finest selection there is, so clicking one takes its breakpoint as the
+	// range; the bounds are inclusive, so a range of one position matches that breakpoint
+	linkCanvas.on('click', () => {
+		if (hoveredLink) setRange({ start: hoveredLink.partnerPos, stop: hoveredLink.partnerPos })
+	})
+	linkCanvas.on('mousemove', (event: MouseEvent) => {
+		const rect = (linkCanvas.node() as HTMLCanvasElement).getBoundingClientRect()
+		const hovered = findLink(event.clientX - rect.left, event.clientY - rect.top)
+		if (hovered != hoveredLink) {
+			hoveredLink = hovered
+			linkCanvas.style('cursor', hovered ? 'pointer' : 'default')
+			render()
+		}
+		if (hovered) infoDiv.text(linkLabel(hovered))
+		else updateInfo()
+	})
+	linkCanvas.on('mouseleave', () => {
+		if (hoveredLink) {
+			hoveredLink = undefined
+			render()
+		}
+		updateInfo()
+	})
+
+	setRange(range)
+
+	return {
+		selfScale,
+		partnerScale,
+		getRange: () => (range ? { chr: partner.chr, start: range.start, stop: range.stop } : null),
+		setRange: (r: SelectedRange | null) => setRange(r)
+	}
+
+	function collapseMarks(get: (l: BreakpointLink) => number): BreakpointMarker[] {
+		const byPos = new Map<number, number>()
+		for (const l of links) {
+			const pos = get(l)
+			byPos.set(pos, (byPos.get(pos) || 0) + (l.samplecount || 0))
+		}
+		return [...byPos].map(([pos, samplecount]) => ({ pos, samplecount }))
+	}
+
+	/** name and locus of one gene, beside the end of the link band that runs to its track */
+	function addGeneLabel(holder: Div, gene: string, scale: LinearScale) {
+		const div = holder.append('div')
+		div
+			.append('div')
+			.style('font-size', '.8em')
+			.style('font-weight', 'bold')
+			.style('overflow', 'hidden')
+			.style('white-space', 'nowrap')
+			.attr('title', gene)
+			.text(gene)
+		/* the locus when only a window of the gene is drawn, so that the view is not taken
+		for the whole gene; the chr alone when it is */
+		div
+			.append('div')
+			.attr('data-testid', 'sjpp-isoformPairSelect-locus')
+			.style('font-size', '.7em')
+			.style('opacity', 0.6)
+			.style('overflow', 'hidden')
+			.style('white-space', 'nowrap')
+			.attr('title', `${scale.chr}:${scale.start.toLocaleString()}-${scale.stop.toLocaleString()}`)
+			.text(scale.zoomed ? locusLabel(scale.chr, scale.start, scale.stop) : scale.chr)
+	}
+
+	function inPartnerRange(l: BreakpointLink) {
+		return !range || (l.partnerPos >= range.start && l.partnerPos <= range.stop)
+	}
+
+	function inSelfRange(l: BreakpointLink) {
+		return !self.range || (l.selfPos >= self.range.start && l.selfPos <= self.range.stop)
+	}
+
+	function linkColor(l: BreakpointLink) {
+		if (!inSelfRange(l)) return otherOutColor
+		if (!range) return markColor
+		return inPartnerRange(l) ? selectColor : outColor
+	}
+
+	/** nearest link within a few px of the point, in the coordinates of the link canvas */
+	function findLink(x: number, y: number) {
+		let best: BreakpointLink | undefined
+		let bestDist = 4
+		for (const l of links) {
+			const d = distToSegment(x, y, selfScale.pos2px(l.selfPos), 0, partnerScale.pos2px(l.partnerPos), linkHeight)
+			if (d < bestDist) {
+				bestDist = d
+				best = l
+			}
+		}
+		return best
+	}
+
+	function linkLabel(l: BreakpointLink) {
+		return (
+			`${self.gene} ${self.chr}:${l.selfPos.toLocaleString()} → ` +
+			`${partner.gene} ${partner.chr}:${l.partnerPos.toLocaleString()}` +
+			(l.samplecount ? ` · ${l.samplecount} samples` : '') +
+			(inSelfRange(l) ? '' : `, outside the ${self.gene} range`)
+		)
+	}
+
+	function setRange(r: { start: number; stop: number } | null) {
+		range = r ? { start: Math.max(partnerScale.start, r.start), stop: Math.min(partnerScale.stop, r.stop) } : null
+		if (range) {
+			const x0 = partnerScale.pos2px(range.start)
+			const x1 = partnerScale.pos2px(range.stop)
+			overlay
+				.style('display', '')
+				.style('left', Math.min(x0, x1) + 'px')
+				.style('width', Math.max(1, Math.abs(x1 - x0)) + 'px')
+		} else {
+			overlay.style('display', 'none')
+		}
+		controls.update(range)
+		render()
+		updateInfo()
+	}
+
+	function updateInfo() {
+		if (!range) {
+			infoDiv.text(`${links.length} breakpoint pairs · drag over ${partner.gene}, or click a link, to select a range`)
+			return
+		}
+		const inRange = links.filter(inPartnerRange)
+		const reachable = inRange.filter(inSelfRange)
+		const samples = reachable.reduce((n, l) => n + (l.samplecount || 0), 0)
+		infoDiv.text(
+			`${partner.chr}:${range.start.toLocaleString()}-${range.stop.toLocaleString()} · ` +
+				`${inRange.length} of ${links.length} breakpoint pairs` +
+				// the two ranges are applied together, so say when this one is not what narrows
+				(reachable.length == inRange.length ? '' : `, ${reachable.length} within the ${self.gene} range`) +
+				(samples ? `, ${samples} samples` : '')
+		)
+	}
+
+	/** redraw the links against the current selection */
+	function render() {
+		renderLinks()
+	}
+
+	function renderLinks() {
+		const ctx = setupCanvas(linkCanvas.node() as HTMLCanvasElement, pxwidth, linkHeight)
+		// draw the faint links first, so that a recurrent pair is not buried under the rest
+		const sorted = [...links].sort((a, b) => (a.samplecount || 1) - (b.samplecount || 1))
+		for (const l of sorted) {
+			if (l != hoveredLink) drawLink(ctx, l, linkColor(l))
+		}
+		// the hovered link is drawn last, so that it reads over the ones crossing it
+		if (hoveredLink) drawLink(ctx, hoveredLink, hoverColor)
+	}
+
+	function drawLink(ctx: CanvasRenderingContext2D, l: BreakpointLink, color: string) {
+		// sqrt scale, as for the mark heights, so that a few frequent pairs do not flatten
+		// the rest into hairlines
+		const strength = Math.sqrt((l.samplecount || 1) / maxCount)
+		ctx.strokeStyle = color
+		ctx.lineWidth = 0.75 + 3.25 * strength
+		/* the width alone carries the sample count: fading a link by its count as well
+		would make an infrequent pair that is still reachable look like an excluded one,
+		which is what the color says. slightly transparent, so that crossings are legible */
+		ctx.globalAlpha = l == hoveredLink ? 1 : 0.85
+		ctx.beginPath()
+		ctx.moveTo(selfScale.pos2px(l.selfPos), 0)
+		ctx.lineTo(partnerScale.pos2px(l.partnerPos), linkHeight)
+		ctx.stroke()
+		ctx.globalAlpha = 1
+	}
+}
+
+/** distance from a point to a line segment, to hit test the links */
+function distToSegment(px: number, py: number, x1: number, y1: number, x2: number, y2: number) {
+	const dx = x2 - x1
+	const dy = y2 - y1
+	const len2 = dx * dx + dy * dy
+	// fraction along the segment of the point nearest to (px,py), clamped to its ends
+	const t = len2 ? Math.max(0, Math.min(1, ((px - x1) * dx + (py - y1) * dy) / len2)) : 0
+	return Math.hypot(px - (x1 + t * dx), py - (y1 + t * dy))
 }

--- a/client/dom/isoformSelect.ts
+++ b/client/dom/isoformSelect.ts
@@ -659,9 +659,16 @@ function renderRangeControls(a: {
 			.style('width', '85px')
 			.style('margin', '0 3px')
 			.on('change', () => {
-				const start = Number(startInput.property('value'))
-				const stop = Number(stopInput.property('value'))
-				if (!Number.isFinite(start) || !Number.isFinite(stop)) {
+				/* a number input reports an emptied field, and one holding something it cannot
+				parse, as the empty string. NOTE test the raw strings rather than what they
+				convert to: Number('') is 0, a finite value that would be taken as a typed
+				coordinate and clamp the range to the start of the scale, so clearing an input
+				to retype it silently widened the range instead of restoring it */
+				const startText = String(startInput.property('value')).trim()
+				const stopText = String(stopInput.property('value')).trim()
+				const start = Number(startText)
+				const stop = Number(stopText)
+				if (!startText || !stopText || !Number.isFinite(start) || !Number.isFinite(stop)) {
 					a.onTyped(undefined)
 					return
 				}
@@ -801,7 +808,7 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 		const hovered = markers.find(m => Math.abs(scale.pos2px(m.pos) - x) <= 3)
 		if (hovered) {
 			const count = hovered.samplecount
-			infoDiv.text(`${chr}:${hovered.pos.toLocaleString()}${count ? ` · ${count} samples` : ''}`)
+			infoDiv.text(`${chr}:${hovered.pos.toLocaleString()}${count ? ` · ${sampleLabel(count)}` : ''}`)
 		} else {
 			updateInfo()
 		}
@@ -849,8 +856,14 @@ export function isoformRangeSelect(opts: IsoformRangeSelectOpts) {
 		infoDiv.text(
 			`${chr}:${range.start.toLocaleString()}-${range.stop.toLocaleString()} · ` +
 				`${inRange.length} of ${markers.length} breakpoints` +
-				(samples ? `, ${samples} samples` : '')
+				(samples ? `, ${sampleLabel(samples)}` : '')
 		)
+	}
+
+	/** a count of samples, said as an upper bound when the caller declares that the tally it
+	 * was summed from may hold one sample more than once (see opts.samplesAreUpperBound) */
+	function sampleLabel(n: number) {
+		return opts.samplesAreUpperBound ? `up to ${n} samples` : `${n} samples`
 	}
 }
 
@@ -1053,7 +1066,7 @@ export function isoformPairRangeSelect(opts: IsoformPairRangeSelectOpts) {
 		if (hovered) {
 			infoDiv.text(
 				`${partner.gene} ${partner.chr}:${hovered.pos.toLocaleString()}` +
-					(hovered.samplecount ? ` · ${hovered.samplecount} samples` : '')
+					(hovered.samplecount ? ` · ${sampleLabel(hovered.samplecount)}` : '')
 			)
 		} else {
 			updateInfo()
@@ -1194,8 +1207,15 @@ export function isoformPairRangeSelect(opts: IsoformPairRangeSelectOpts) {
 				`${inRange.length} of ${links.length} breakpoint pairs` +
 				// the two ranges are applied together, so say when this one is not what narrows
 				(reachable.length == inRange.length ? '' : `, ${reachable.length} within the ${self.gene} range`) +
-				(samples ? `, ${samples} samples` : '')
+				(samples ? `, ${sampleLabel(samples)}` : '')
 		)
+	}
+
+	/** a count of samples, said as an upper bound when the caller declares that the tally it
+	 * was summed from may hold one sample more than once (see opts.samplesAreUpperBound). a
+	 * single link is one pair of breakpoints, so its own count is exact either way */
+	function sampleLabel(n: number) {
+		return opts.samplesAreUpperBound ? `up to ${n} samples` : `${n} samples`
 	}
 
 	/** redraw the links against the current selection */

--- a/client/dom/sketchGm.ts
+++ b/client/dom/sketchGm.ts
@@ -175,7 +175,44 @@ export function sketchSplicerna(holder: Div | Td, gm: GeneModelWithDomains, pxwi
 }
 
 /**
+ * px of a genomic position over the sketched regions of the given chr.
+ *
+ * A position outside them has no px of its own and takes the nearest edge of the layout, so
+ * that a gene model running past the regions is clipped to them rather than dropped: the
+ * regions may be a window of the gene, e.g. the exons a fusion breaks on and their context
+ * (see makeExonScale in isoformSelect.ts), which no gene model of it begins or ends within.
+ *
+ * Returns undefined only when no region is of the gene's chr, i.e. there is nothing to draw.
+ */
+function posToPx(rglst: ExonRegion[], chr: string, pos: number, exonsf: number, intronw: number) {
+	let x = 0
+	let nearest: number | undefined
+	let nearestDist = Infinity
+	for (const r of rglst) {
+		if (r.chr !== chr) {
+			x += r.width! + intronw
+			continue
+		}
+		if (pos >= r.start && pos <= r.stop) {
+			return x + (r.reverse ? r.stop - pos : pos - r.start) * exonsf
+		}
+		// keep the edge of the region nearest to it, for when no region holds it
+		const dist = pos < r.start ? r.start - pos : pos - r.stop
+		if (dist < nearestDist) {
+			nearestDist = dist
+			const edge = pos < r.start ? r.start : r.stop
+			nearest = x + (r.reverse ? r.stop - edge : edge - r.start) * exonsf
+		}
+		x += r.width! + intronw
+	}
+	return nearest
+}
+
+/**
  * Sketches a gene model summary across multiple regions.
+ *
+ * The regions are the whole of what is drawn: everything is clipped to them, so passing a
+ * window of a gene's exons sketches only that window.
  *
  * @param holder - D3 selection to append canvas to
  * @param rglst - List of exon regions
@@ -185,6 +222,7 @@ export function sketchSplicerna(holder: Div | Td, gm: GeneModelWithDomains, pxwi
  * @param pxwidth - Total width in pixels
  * @param h - Height in pixels
  * @param color - Color for coding regions
+ * @param opts.exonNumbers - number the exons, in those boxes wide enough to hold the number
  */
 export function sketchGmsum(
 	holder: Div | Td,
@@ -194,38 +232,15 @@ export function sketchGmsum(
 	intronw: number,
 	pxwidth: number,
 	h: number,
-	color: string
+	color: string,
+	opts: { exonNumbers?: boolean } = {}
 ): void {
 	const canvas = holder.append('canvas').node() as HTMLCanvasElement
 	const pad = Math.ceil(h / 5)
 	const ctx = setupCanvas(canvas, pxwidth, h)
 
-	let start: number | undefined
-	let x = 0
-	for (const r of rglst) {
-		if (r.chr !== gm.chr) {
-			x += r.width! + intronw
-			continue
-		}
-		if (gm.start >= r.start && gm.start <= r.stop) {
-			start = x + (r.reverse ? r.stop - gm.start : gm.start - r.start) * exonsf
-			break
-		}
-		x += r.width! + intronw
-	}
-	let stop: number | undefined
-	x = 0
-	for (const r of rglst) {
-		if (r.chr !== gm.chr) {
-			x += r.width! + intronw
-			continue
-		}
-		if (gm.stop >= r.start && gm.stop <= r.stop) {
-			stop = x + (r.reverse ? r.stop - gm.stop : gm.stop - r.start) * exonsf
-			break
-		}
-		x += r.width! + intronw
-	}
+	const start = posToPx(rglst, gm.chr, gm.start, exonsf, intronw)
+	const stop = posToPx(rglst, gm.chr, gm.stop, exonsf, intronw)
 
 	if (start !== undefined && stop !== undefined) {
 		ctx.strokeStyle = color
@@ -286,6 +301,61 @@ export function sketchGmsum(
 				x += r.width! + intronw
 			}
 		}
+	}
+
+	if (opts.exonNumbers) drawExonNumbers(ctx, rglst, gm, exonsf, intronw, h)
+}
+
+/**
+ * Number the exons of a gene model within its boxes, skipping any box too narrow to hold
+ * the number. Exon 1 is the 5' most, so the numbering runs against the genomic order on the
+ * minus strand.
+ *
+ * Only a wide box is labelled, which is what a zoomed layout gives (see makeExonScale in
+ * isoformSelect.ts): over a whole many-exon gene no box has the room and none is numbered.
+ */
+function drawExonNumbers(
+	ctx: CanvasRenderingContext2D,
+	rglst: ExonRegion[],
+	gm: GeneModelWithDomains,
+	exonsf: number,
+	intronw: number,
+	h: number
+) {
+	const ordered = [...gm.exon].sort((a, b) => a[0] - b[0])
+	ctx.textAlign = 'center'
+	ctx.textBaseline = 'middle'
+	ctx.font = `${Math.max(8, Math.min(10, h - 6))}px Arial`
+	for (const [i, e] of ordered.entries()) {
+		const label = String(gm.strand == '-' ? ordered.length - i : i + 1)
+		// the widest piece of the exon that is drawn, as a region may clip it
+		let bestX = 0
+		let bestW = 0
+		let bestCenter = 0
+		let x = 0
+		for (const r of rglst) {
+			if (r.chr !== gm.chr) {
+				x += r.width! + intronw
+				continue
+			}
+			const start = Math.max(e[0], r.start)
+			const stop = Math.min(e[1], r.stop)
+			const w = (stop - start) * exonsf
+			if (start < stop && w > bestW) {
+				bestW = w
+				bestX = x + (r.reverse ? (r.stop - stop) * exonsf : (start - r.start) * exonsf)
+				bestCenter = (start + stop) / 2
+			}
+			x += r.width! + intronw
+		}
+		// padded, so that a number never touches the edges of the box holding it
+		if (bestW < ctx.measureText(label).width + 4) continue
+		/* a coding box is filled dark and a non-coding one light, so read the number off
+		whichever the middle of it sits on: an exon may be part utr and part coding, and the
+		number is centered over the piece drawn, not over the coding within it */
+		const onCoding = gm.coding?.some(c => c[0] <= bestCenter && c[1] >= bestCenter)
+		ctx.fillStyle = onCoding ? '#fff' : '#333'
+		ctx.fillText(label, bestX + bestW / 2, h / 2)
 	}
 }
 

--- a/client/dom/test/isoformSelect.unit.spec.ts
+++ b/client/dom/test/isoformSelect.unit.spec.ts
@@ -1,6 +1,13 @@
 import tape from 'tape'
 import { select } from 'd3-selection'
-import { allgm2sum, makeLinearScale, isoformRangeSelect } from '../isoformSelect'
+import {
+	allgm2sum,
+	makeLinearScale,
+	makeExonScale,
+	makeScale,
+	isoformRangeSelect,
+	isoformPairRangeSelect
+} from '../isoformSelect'
 import type { GeneModel } from '../types/isoformSelect'
 
 /**
@@ -8,8 +15,10 @@ import type { GeneModel } from '../types/isoformSelect'
  *
  * Test Coverage:
  * - allgm2sum() function that merges exon regions across gene models
- * - makeLinearScale() genomic-to-px scale of isoformRangeSelect()
+ * - makeLinearScale() genomic-to-px scale, the 'genomic' layout of a breakpoint chart
+ * - makeExonScale() exon-collapsed scale, the 'rna' layout, and makeScale() dispatching
  * - isoformRangeSelect() breakpoint marks and range selection
+ * - isoformPairRangeSelect() paired breakpoints of two genes and range selection
  */
 
 /**************
@@ -414,6 +423,23 @@ const bcrMarkers = [
 	{ pos: 23290500, samplecount: 3 }
 ]
 
+/* a gene of many exons, where one exon is only a few px of the full width, too small to
+read a breakpoint on: exon i spans [1000 + 8000i, 1400 + 8000i], i of 0 to 11 */
+const exonStart = (i: number) => 1000 + i * 8000
+const exonStop = (i: number) => exonStart(i) + 400
+const manyExons: GeneModel = {
+	isoform: 'NM_many',
+	chr: 'chr1',
+	start: exonStart(0),
+	stop: exonStop(11),
+	strand: '+',
+	isdefault: true,
+	exon: Array.from({ length: 12 }, (_, i) => [exonStart(i), exonStop(i)])
+}
+const manyExonsMinus: GeneModel = { ...manyExons, isoform: 'NM_many_minus', strand: '-' }
+/** the exon each region of a zoomed scale is of, to check the window is a contiguous run */
+const keptExons = (scale: any) => scale.rglst.map((r: any) => (r.start - 1000) / 8000).sort((a, b) => a - b)
+
 tape('makeLinearScale() - plus strand round trip', test => {
 	const scale = makeLinearScale({ chr: 'chr22', gms: [bcr], markers: [], pxwidth: 400 })
 	test.equal(scale.reverse, false, 'plus strand is not reversed')
@@ -466,6 +492,175 @@ tape('makeLinearScale() - scale without a gene model', test => {
 	test.end()
 })
 
+/**************
+ * makeExonScale(), the 'rna' layout
+ **************/
+
+tape('makeExonScale() - collapses the introns', test => {
+	const scale = makeExonScale({ chr: 'chr22', gms: [bcr], markers: [], pxwidth: 400 })
+	test.equal(scale.mode, 'rna', 'is a rna mode scale')
+	test.equal(scale.rglst.length, bcr.exon.length, 'lays out one region per exon')
+	test.ok(scale.intronpx > 0, 'the introns are gaps of a fixed width')
+	// the exons and the gaps between them take up the whole width, and no more
+	const total = scale.rglst.reduce((n, r) => n + r.width!, 0) + scale.intronpx * (scale.rglst.length - 1)
+	test.ok(Math.abs(total - 400) < 0.01, 'the exons and gaps fill the width exactly')
+	test.equal(scale.start, bcr.exon[0][0], 'the scale starts at the first exon')
+	test.equal(scale.stop, bcr.exon[bcr.exon.length - 1][1], 'and stops at the last one')
+	test.equal(scale.pos2px(scale.start), 0, 'the first position maps to px 0')
+	test.equal(Math.round(scale.pos2px(scale.stop)), 400, 'the last one maps to the full width')
+	/* an exon of a few hundred bp gets a share of the width proportional to its length,
+	rather than the handful of px a linear scale over a gene of 138kb would give it */
+	const exonPx = scale.pos2px(bcr.exon[1][1]) - scale.pos2px(bcr.exon[1][0])
+	const linear = makeLinearScale({ chr: 'chr22', gms: [bcr], markers: [], pxwidth: 400 })
+	test.ok(exonPx > 50, 'an exon takes a readable share of the width')
+	test.ok(
+		exonPx > 50 * (linear.pos2px(bcr.exon[1][1]) - linear.pos2px(bcr.exon[1][0])),
+		'far more than it would linearly'
+	)
+	test.end()
+})
+
+tape('makeExonScale() - round trip within an exon', test => {
+	const scale = makeExonScale({ chr: 'chr22', gms: [bcr], markers: [], pxwidth: 400 })
+	const pos = bcr.exon[1][0] + 100
+	const backAndForth = scale.px2pos(scale.pos2px(pos))
+	test.ok(Math.abs(backAndForth - pos) <= 1 / scale.exonsf, 'a position within an exon round trips through px')
+	test.end()
+})
+
+tape('makeExonScale() - a position off the exons snaps to an edge', test => {
+	const scale = makeExonScale({ chr: 'chr22', gms: [bcr], markers: [], pxwidth: 400 })
+	/* an intronic breakpoint has no px of its own, so it is drawn at the start of the exon
+	after it, which is where the px of the gap it sits in maps back to */
+	const intronic = bcr.exon[0][1] + 5000
+	test.equal(
+		scale.pos2px(intronic),
+		scale.pos2px(bcr.exon[1][0]),
+		'an intronic position is at the start of the next exon'
+	)
+	test.equal(scale.px2pos(scale.pos2px(intronic)), bcr.exon[1][0], 'and stays there through a round trip')
+	test.equal(scale.pos2px(bcr.start - 50000), 0, 'a position before the gene is at the start of the first exon')
+	test.equal(Math.round(scale.pos2px(bcr.stop + 50000)), 400, 'one after it is at the end of the last exon')
+	const gapPx = scale.pos2px(bcr.exon[0][1]) + scale.intronpx / 2
+	test.equal(scale.px2pos(gapPx), bcr.exon[1][0], 'a px in a gap maps to the start of the exon after it')
+	test.end()
+})
+
+tape('makeExonScale() - minus strand reads 5 prime to 3 prime', test => {
+	const scale = makeExonScale({ chr: 'chr9', gms: [minusGm], markers: [], pxwidth: 400 })
+	test.equal(scale.reverse, true, 'minus strand is reversed')
+	test.equal(Math.round(scale.pos2px(scale.stop)), 0, 'the last position maps to px 0')
+	test.equal(Math.round(scale.pos2px(scale.start)), 400, 'the first one maps to the full width')
+	const pos = minusGm.exon[0][0] + 50
+	const backAndForth = scale.px2pos(scale.pos2px(pos))
+	test.ok(Math.abs(backAndForth - pos) <= 1 / scale.exonsf, 'a position round trips on the minus strand')
+	// the regions run right to left, so the gap before an exon in display order is to its right
+	const gapPx = scale.pos2px(minusGm.exon[1][0]) + scale.intronpx / 2
+	test.equal(scale.px2pos(gapPx), minusGm.exon[0][1], 'a px in a gap maps to the exon after it in display order')
+	test.end()
+})
+
+tape('makeExonScale() - falls back without an exon structure', test => {
+	// the partner of a fusion may be an unannotated locus, with breakpoints but no isoform,
+	// so there is nothing to collapse and the breakpoints are laid out linearly
+	const scale = makeExonScale({ chr: 'chr22', gms: [], markers: bcrMarkers, pxwidth: 400 })
+	test.equal(scale.mode, 'genomic', 'falls back to a linear scale')
+	test.equal(scale.intronpx, 0, 'which has no gaps')
+	test.ok(scale.start < bcrMarkers[0].pos, 'and spans the markers')
+	test.end()
+})
+
+tape('makeExonScale() - zooms to the exons of the breakpoints', test => {
+	// a breakpoint on exon 5 only, so the window is exons 4 to 6
+	const scale = makeExonScale({ chr: 'chr1', gms: [manyExons], markers: [{ pos: exonStart(5) + 200 }], pxwidth: 400 })
+	test.equal(scale.zoomed, true, 'the scale covers a window of the gene')
+	test.deepEqual(keptExons(scale), [4, 5, 6], 'the exon of the breakpoint and one of context on each side')
+	test.equal(scale.start, exonStart(4), 'the scale starts at the first exon of the window')
+	test.equal(scale.stop, exonStop(6), 'and stops at the last one')
+	// the point of it: the exon of the breakpoint gets a readable share of the width
+	const whole = makeExonScale({ chr: 'chr1', gms: [manyExons], markers: [], pxwidth: 400 })
+	test.equal(whole.zoomed, false, 'the whole gene is kept when there is no breakpoint to zoom to')
+	test.ok(scale.exonsf > 3 * whole.exonsf, 'an exon of the window is several times wider than in the whole gene')
+	test.end()
+})
+
+tape('makeExonScale() - the window is a contiguous run of exons', test => {
+	/* the window is a zoom of the gene, not a splice of it: the exons between two distant
+	breakpoints are all drawn, so that every gap within the window is a real intron */
+	const scale = makeExonScale({
+		chr: 'chr1',
+		gms: [manyExons],
+		markers: [{ pos: exonStart(3) + 100 }, { pos: exonStart(6) + 100 }],
+		pxwidth: 400
+	})
+	test.equal(scale.zoomed, true, 'the scale covers a window of the gene')
+	test.deepEqual(
+		keptExons(scale),
+		[2, 3, 4, 5, 6, 7],
+		'every exon between the two breakpoints is kept, and one each side'
+	)
+	test.end()
+})
+
+tape('makeExonScale() - the window covers the selected range', test => {
+	/* a range already selected must be within the window, or clamping it to the scale would
+	silently narrow a saved selection (see the setRange of each component) */
+	const range = { start: exonStart(9), stop: exonStop(9) }
+	const scale = makeExonScale({
+		chr: 'chr1',
+		gms: [manyExons],
+		markers: [{ pos: exonStart(5) + 200 }],
+		range,
+		pxwidth: 400
+	})
+	test.ok(scale.start <= range.start && scale.stop >= range.stop, 'the window covers the selected range')
+	test.deepEqual(keptExons(scale), [4, 5, 6, 7, 8, 9, 10], 'and every exon between it and the breakpoint')
+	test.end()
+})
+
+tape('makeExonScale() - keeps the whole gene when zooming would not pay', test => {
+	// breakpoints spread over the gene leave too little out to repay the context lost
+	const spread = makeExonScale({
+		chr: 'chr1',
+		gms: [manyExons],
+		markers: [{ pos: exonStart(1) + 100 }, { pos: exonStart(10) + 100 }],
+		pxwidth: 400
+	})
+	test.equal(spread.zoomed, false, 'a gene whose breakpoints span it is not zoomed')
+	test.equal(spread.rglst.length, 12, 'every exon is kept')
+	// and a gene of few exons has little width to win by it
+	const few = makeExonScale({ chr: 'chr22', gms: [bcr], markers: bcrMarkers, pxwidth: 400 })
+	test.equal(few.zoomed, false, 'a gene of few exons is not zoomed')
+	test.equal(few.rglst.length, bcr.exon.length, 'every exon is kept')
+	test.end()
+})
+
+tape('makeExonScale() - zooms on the minus strand', test => {
+	const scale = makeExonScale({
+		chr: 'chr1',
+		gms: [manyExonsMinus],
+		markers: [{ pos: exonStart(5) + 200 }],
+		pxwidth: 400
+	})
+	test.equal(scale.zoomed, true, 'the scale covers a window of the gene')
+	test.deepEqual(keptExons(scale), [4, 5, 6], 'the same window as on the plus strand')
+	// the regions run 3 prime to 5 prime, so the window reads right to left
+	test.equal(scale.rglst[0].start, exonStart(6), 'the highest exon of the window is drawn first')
+	test.equal(Math.round(scale.pos2px(scale.stop)), 0, 'the last position of the window maps to px 0')
+	test.equal(Math.round(scale.pos2px(scale.start)), 400, 'the first one maps to the full width')
+	const pos = exonStart(5) + 200
+	test.ok(Math.abs(scale.px2pos(scale.pos2px(pos)) - pos) <= 1 / scale.exonsf, 'a breakpoint round trips')
+	test.end()
+})
+
+tape('makeScale() - dispatches on the mode', test => {
+	const arg = { chr: 'chr22', gms: [bcr], markers: [], pxwidth: 400 }
+	test.equal(makeScale({ ...arg, mode: 'rna' }).mode, 'rna', 'rna mode collapses the introns')
+	test.equal(makeScale({ ...arg, mode: 'genomic' }).mode, 'genomic', 'genomic mode keeps them')
+	test.equal(makeScale(arg).mode, 'genomic', 'genomic is the default')
+	test.end()
+})
+
 tape('isoformRangeSelect() - render', test => {
 	const holder = select(document.body).append('div')
 	isoformRangeSelect({
@@ -475,6 +670,11 @@ tape('isoformRangeSelect() - render', test => {
 		markers: bcrMarkers,
 		callback: () => {}
 	})
+	test.equal(
+		holder.select('[data-testid="sjpp-isoformRangeSelect-track"]').attr('data-scale-mode'),
+		'genomic',
+		'lays the isoforms out genomically by default'
+	)
 	test.ok(holder.select('[data-testid="sjpp-isoformRangeSelect-marks"]').node(), 'renders the breakpoint marks')
 	// one canvas of marks plus one sketch per isoform of the chr; the chr9 isoform is not shown
 	test.equal(holder.selectAll('canvas').nodes().length, 3, 'renders a sketch for each isoform of the chr')
@@ -553,6 +753,36 @@ tape('isoformRangeSelect() - typed coordinates and clear', test => {
 	test.end()
 })
 
+tape('isoformRangeSelect() - drag over the isoform sketches', test => {
+	/* the highlight spans the marks and the isoform sketches under them, so the drag does
+	too: dragging only over the strip of marks would leave most of what it selects inert */
+	const holder = select(document.body).append('div')
+	const api = isoformRangeSelect({
+		holder,
+		allgm: [bcr, bcrShort],
+		chr: 'chr22',
+		markers: bcrMarkers,
+		callback: () => {}
+	})!
+	const track = holder.select('[data-testid="sjpp-isoformRangeSelect-track"]').node() as HTMLElement
+	const rect = track.getBoundingClientRect()
+	const x0 = api.scale.pos2px(23289000)
+	const x1 = api.scale.pos2px(23291000)
+	// at the bottom of the track, i.e. over an isoform sketch rather than over the marks
+	track.dispatchEvent(new MouseEvent('mousedown', { clientX: rect.left + x0, clientY: rect.bottom - 3, bubbles: true }))
+	window.dispatchEvent(new MouseEvent('mousemove', { clientX: rect.left + x1, clientY: rect.bottom - 3 }))
+	window.dispatchEvent(new MouseEvent('mouseup', {}))
+	const range = api.getRange()!
+	test.ok(range, 'a drag over an isoform sketch selects a range')
+	test.ok(range.start <= 23290100 && range.stop >= 23290100, 'covering the breakpoint under it')
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformRangeSelect-info"]').text().includes('of 3 breakpoints'),
+		'and it is reported'
+	)
+	holder.remove()
+	test.end()
+})
+
 tape('isoformRangeSelect() - highlight of a minus strand range', test => {
 	const holder = select(document.body).append('div')
 	const api = isoformRangeSelect({
@@ -583,6 +813,366 @@ tape('isoformRangeSelect() - nothing to display', test => {
 		callback: () => {}
 	})
 	test.equal(api, undefined, 'returns nothing when there is neither a gene model nor a marker')
+	test.equal(holder.selectAll('canvas').nodes().length, 0, 'renders no canvas')
+	test.ok(holder.text().includes('No gene model or breakpoint'), 'says there is nothing to display')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformRangeSelect() - rna mode', test => {
+	// a rna fusion joins transcripts at exon boundaries, so the introns between them are
+	// collapsed and the exons the breakpoints fall on get a readable share of the width
+	const holder = select(document.body).append('div')
+	const api = isoformRangeSelect({
+		holder,
+		allgm: [bcr],
+		chr: 'chr22',
+		markers: bcrMarkers,
+		mode: 'rna',
+		callback: () => {}
+	})!
+	test.equal(api.scale.mode, 'rna', 'the marks are placed over the collapsed layout')
+	test.equal(
+		holder.select('[data-testid="sjpp-isoformRangeSelect-track"]').attr('data-scale-mode'),
+		'rna',
+		'which the rendered marks declare'
+	)
+	test.equal(api.scale.rglst.length, bcr.exon.length, 'one region per exon of the gene')
+	// a dragged range snaps to exon boundaries, but is still reported as a genomic range
+	api.setRange({ chr: 'chr22', start: 23290000, stop: 23290300 })
+	test.deepEqual(api.getRange(), { chr: 'chr22', start: 23290000, stop: 23290300 }, 'the selected range is genomic')
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformRangeSelect-info"]').text().includes('1 of 3 breakpoints'),
+		'the breakpoints of the range are counted by position, as in genomic mode'
+	)
+	const overlay = holder.select('[data-testid="sjpp-isoformRangeSelect-overlay"]')
+	const width = Number(overlay.style('width').replace('px', ''))
+	// the exon is 300bp of a 138kb gene, a sliver of the width on a linear scale
+	test.ok(width > 50, 'the highlight of an exon-sized range is wide enough to see')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformRangeSelect() - rna mode zooms to the breakpoints', test => {
+	const holder = select(document.body).append('div')
+	const markers = [{ pos: exonStart(5) + 200, samplecount: 9 }]
+	const api = isoformRangeSelect({
+		holder,
+		allgm: [manyExons],
+		chr: 'chr1',
+		markers,
+		mode: 'rna',
+		callback: () => {}
+	})!
+	test.equal(api.scale.zoomed, true, 'the chart covers a window of the gene')
+	test.equal(api.scale.rglst.length, 3, 'the exon of the breakpoint and one of context each side')
+	// the window is named, so that the view is not taken for the whole gene
+	test.equal(
+		holder.select('[data-testid="sjpp-isoformRangeSelect-locus"]').text(),
+		'chr1:33-49kb',
+		'the locus of the window is labelled'
+	)
+	// one canvas of marks plus the sketch of the isoform, drawn over the window
+	test.equal(holder.selectAll('canvas').nodes().length, 2, 'the isoform is sketched over the window')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformRangeSelect() - a zoomed window drops the isoforms outside it', test => {
+	/* an isoform lying outside the window has no exon and no backbone within it, so its row
+	would render nothing; only its name would show, reading as an isoform with no structure */
+	const holder = select(document.body).append('div')
+	// the window is exons 4 to 6, i.e. positions 33,000 to 49,400
+	const downstream: GeneModel = {
+		isoform: 'NM_downstream',
+		chr: 'chr1',
+		start: exonStart(9),
+		stop: exonStop(11),
+		strand: '+',
+		exon: [
+			[exonStart(9), exonStop(9)],
+			[exonStart(11), exonStop(11)]
+		]
+	}
+	const api = isoformRangeSelect({
+		holder,
+		allgm: [manyExons, downstream],
+		chr: 'chr1',
+		markers: [{ pos: exonStart(5) + 200, samplecount: 9 }],
+		mode: 'rna',
+		callback: () => {}
+	})!
+	test.equal(api.scale.zoomed, true, 'the chart covers a window of the gene')
+	// one canvas of marks, and a sketch of the one isoform reaching into the window
+	test.equal(holder.selectAll('canvas').nodes().length, 2, 'the isoform outside the window is not sketched')
+	test.equal(holder.text().includes('NM_downstream'), false, 'nor is it named')
+	test.ok(holder.text().includes('NM_many'), 'the isoform of the window is')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformRangeSelect() - genomic mode is never zoomed', test => {
+	const holder = select(document.body).append('div')
+	const api = isoformRangeSelect({
+		holder,
+		allgm: [manyExons],
+		chr: 'chr1',
+		markers: [{ pos: exonStart(5) + 200, samplecount: 9 }],
+		callback: () => {}
+	})!
+	test.equal(api.scale.zoomed, false, 'a genomic chart covers the whole locus')
+	test.equal(holder.select('[data-testid="sjpp-isoformRangeSelect-locus"]').text(), '', 'so it names no window')
+	holder.remove()
+	test.end()
+})
+
+/**************
+ * isoformPairRangeSelect()
+ **************/
+
+/* modeled on BCR::ABL1: the two BCR breakpoint clusters, each joining an ABL1 breakpoint,
+so that a partner range and a range on the term's own gene select different subsets */
+const abl1: GeneModel = {
+	isoform: 'NM_005157',
+	chr: 'chr9',
+	start: 130713000,
+	stop: 130887000,
+	strand: '+',
+	isdefault: true,
+	exon: [
+		[130713000, 130713200],
+		[130886800, 130887000]
+	]
+}
+const pairLinks = [
+	// the major junction, and the same BCR breakpoint joining a second ABL1 one
+	{ selfPos: 23290100, partnerPos: 130713100, samplecount: 20 },
+	{ selfPos: 23290100, partnerPos: 130854000, samplecount: 5 },
+	// the minor cluster of BCR, back to the ABL1 breakpoint of the major junction
+	{ selfPos: 23183000, partnerPos: 130713100, samplecount: 10 }
+]
+const pairOpts = () => ({
+	self: { gene: 'BCR', chr: 'chr22', allgm: [bcr] },
+	partner: { gene: 'ABL1', chr: 'chr9', allgm: [abl1] },
+	links: pairLinks
+})
+
+/** the coordinates of a point on the link canvas, at the given fraction of its height */
+function linkPoint(api: any, canvas: HTMLCanvasElement, link: any, fraction: number) {
+	const rect = canvas.getBoundingClientRect()
+	const x0 = api.selfScale.pos2px(link.selfPos)
+	const x1 = api.partnerScale.pos2px(link.partnerPos)
+	return {
+		clientX: rect.left + x0 + (x1 - x0) * fraction,
+		clientY: rect.top + rect.height * fraction,
+		bubbles: true
+	}
+}
+
+tape('isoformPairRangeSelect() - render', test => {
+	const holder = select(document.body).append('div')
+	const api = isoformPairRangeSelect({ holder, ...pairOpts(), callback: () => {} })!
+	test.ok(api, 'renders the paired view')
+	test.ok(holder.select('[data-testid="sjpp-isoformPairSelect-links"]').node(), 'renders the links between the genes')
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-selfTrack"]').node(),
+		'renders the track of the term gene'
+	)
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-partnerTrack"]').node(),
+		'renders the track of the partner gene'
+	)
+	/* the links canvas plus one isoform sketch per track. NOTE no canvas of breakpoint marks
+	beside either gene: the links already converge on every breakpoint */
+	test.equal(holder.selectAll('canvas').nodes().length, 3, 'renders a sketch for the isoform of each gene')
+	test.ok(holder.text().includes('BCR'), 'labels the track of the term gene')
+	test.ok(holder.text().includes('ABL1'), 'labels the track of the partner gene')
+	// each gene is on its own chr, so each track has its own scale
+	test.equal(api.selfScale.chr, 'chr22', 'the top track is scaled over the term gene')
+	test.equal(api.partnerScale.chr, 'chr9', 'the bottom track is scaled over the partner gene')
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text().includes('3 breakpoint pairs'),
+		'reports the number of breakpoint pairs'
+	)
+	test.equal(
+		holder.select('[data-testid="sjpp-isoformPairSelect-overlay"]').style('display'),
+		'none',
+		'no selection highlight without an initial range'
+	)
+	test.equal(
+		holder.select('[data-testid="sjpp-isoformPairSelect-selfOverlay"]').node(),
+		null,
+		'no highlight of the term gene without a range on it'
+	)
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - the selected range is on the partner gene', test => {
+	const holder = select(document.body).append('div')
+	let applied: any = 'not called'
+	const opts = pairOpts()
+	isoformPairRangeSelect({
+		holder,
+		...opts,
+		// covers the ABL1 breakpoint of the two junctions to it, not the third pair
+		partner: { ...opts.partner, range: { start: 130713000, stop: 130713200 } },
+		callback: r => (applied = r)
+	})!
+	const overlay = holder.select('[data-testid="sjpp-isoformPairSelect-overlay"]')
+	test.notEqual(overlay.style('display'), 'none', 'initial range is highlighted')
+	// the highlight spans the partner track only, as the range is not on the term gene
+	test.ok(Number(overlay.style('top').replace('px', '')) > 0, 'the highlight starts below the top track')
+	const info = holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text()
+	test.ok(info.includes('2 of 3 breakpoint pairs'), 'counts the pairs breaking within the range')
+	test.ok(info.includes('30 samples'), 'sums the samples of those pairs')
+	const inputs = holder.selectAll('[data-testid="sjpp-isoformRangeSelect-pos"]').nodes() as HTMLInputElement[]
+	test.equal(inputs[0].value, '130713000', 'the coordinate inputs hold the range of the partner gene')
+	;(holder.select('[data-testid="sjpp-isoformRangeSelect-apply"]').node() as HTMLButtonElement).click()
+	test.deepEqual(applied, { chr: 'chr9', start: 130713000, stop: 130713200 }, 'apply calls back with the partner range')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - range on the term gene is context only', test => {
+	/* the range on the term's own gene is owned by a control that applies term-wide, so it
+	is shown here rather than edited: the pairs failing it cannot match however the partner
+	range is placed, so they are reported apart from the ones that still can */
+	const holder = select(document.body).append('div')
+	const opts = pairOpts()
+	const api = isoformPairRangeSelect({
+		holder,
+		...opts,
+		// covers the major BCR cluster only, so the pair of the minor one is unreachable
+		self: { ...opts.self, range: { start: 23290000, stop: 23290200 } },
+		partner: { ...opts.partner, range: { start: 130713000, stop: 130713200 } },
+		callback: () => {}
+	})!
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-selfOverlay"]').node(),
+		'the range on the term gene is highlighted'
+	)
+	const info = holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text()
+	test.ok(info.includes('2 of 3 breakpoint pairs'), 'counts the pairs of the partner range')
+	test.ok(info.includes('1 within the BCR range'), 'says how many of them the range on the term gene leaves')
+	test.ok(info.includes('20 samples'), 'counts the samples of those alone')
+	test.deepEqual(api.getRange(), { chr: 'chr9', start: 130713000, stop: 130713200 }, 'the range is of the partner gene')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - hovering and clicking a link', test => {
+	const holder = select(document.body).append('div')
+	const api = isoformPairRangeSelect({ holder, ...pairOpts(), callback: () => {} })!
+	const canvas = holder.select('[data-testid="sjpp-isoformPairSelect-links"]').node() as HTMLCanvasElement
+	// near the partner end of the link, where the three of them have diverged
+	canvas.dispatchEvent(new MouseEvent('mousemove', linkPoint(api, canvas, pairLinks[0], 0.85)))
+	const info = holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text()
+	test.ok(info.includes('BCR chr22:23,290,100'), 'reads out the breakpoint of the term gene')
+	test.ok(info.includes('ABL1 chr9:130,713,100'), 'reads out the one of the partner it is joined to')
+	test.ok(info.includes('20 samples'), 'reads out the samples of the pair')
+	// a link is the finest selection there is, so clicking one takes its breakpoint
+	canvas.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+	test.deepEqual(
+		api.getRange(),
+		{ chr: 'chr9', start: 130713100, stop: 130713100 },
+		'clicking a link selects the breakpoint it is joined to'
+	)
+	canvas.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text().includes('2 of 3 breakpoint pairs'),
+		'leaving the link reports the selection again'
+	)
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - drag over the partner track', test => {
+	const holder = select(document.body).append('div')
+	const api = isoformPairRangeSelect({ holder, ...pairOpts(), callback: () => {} })!
+	// the whole track is the drag surface, isoform sketches included
+	const track = holder.select('[data-testid="sjpp-isoformPairSelect-partnerTrack"]').node() as HTMLElement
+	const rect = track.getBoundingClientRect()
+	// over the ABL1 breakpoint of the major junction, which is at the right of the track
+	const x0 = api.partnerScale.pos2px(130700000)
+	const x1 = api.partnerScale.pos2px(130760000)
+	// on the isoform sketch at the bottom of the track, not on any strip of marks
+	track.dispatchEvent(new MouseEvent('mousedown', { clientX: rect.left + x0, clientY: rect.bottom - 5, bubbles: true }))
+	window.dispatchEvent(new MouseEvent('mousemove', { clientX: rect.left + x1, clientY: rect.top + 5 }))
+	window.dispatchEvent(new MouseEvent('mouseup', {}))
+	const range = api.getRange()!
+	test.equal(range.chr, 'chr9', 'the dragged range is on the partner gene')
+	// the drag is mapped through the scale of the partner track, not that of the term gene
+	test.ok(range.start <= 130713100 && range.stop >= 130713100, 'the dragged range covers the breakpoint under it')
+	test.ok(range.stop < 130854000, 'and not the one outside it')
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text().includes('2 of 3 breakpoint pairs'),
+		'the dragged range is reported'
+	)
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - rna mode', test => {
+	// both genes of one event are laid out the same way
+	const holder = select(document.body).append('div')
+	const api = isoformPairRangeSelect({ holder, ...pairOpts(), mode: 'rna', callback: () => {} })!
+	test.equal(api.selfScale.mode, 'rna', 'the top track collapses its introns')
+	test.equal(api.partnerScale.mode, 'rna', 'so does the bottom one')
+	test.equal(
+		holder.select('[data-testid="sjpp-isoformPairSelect-partnerTrack"]').attr('data-scale-mode'),
+		'rna',
+		'which the rendered marks declare'
+	)
+	test.equal(api.selfScale.rglst.length, bcr.exon.length, 'one region per exon of the term gene')
+	test.equal(api.partnerScale.rglst.length, abl1.exon.length, 'and per exon of the partner')
+	// the two scales are independent, so each collapses its own gene
+	test.notEqual(api.selfScale.exonsf, api.partnerScale.exonsf, 'each gene is scaled over its own exon length')
+	api.setRange({ chr: 'chr9', start: 130713000, stop: 130713200 })
+	test.deepEqual(api.getRange(), { chr: 'chr9', start: 130713000, stop: 130713200 }, 'the selected range is genomic')
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text().includes('2 of 3 breakpoint pairs'),
+		'the pairs of the range are counted by position, as in genomic mode'
+	)
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - rna mode zooms each track to its own breakpoints', test => {
+	const holder = select(document.body).append('div')
+	const api = isoformPairRangeSelect({
+		holder,
+		self: { gene: 'GENEA', chr: 'chr1', allgm: [manyExons] },
+		// the partner has few enough exons that there is nothing to win by zooming it
+		partner: { gene: 'ABL1', chr: 'chr9', allgm: [abl1] },
+		links: [{ selfPos: exonStart(5) + 200, partnerPos: 130713100, samplecount: 20 }],
+		mode: 'rna',
+		callback: () => {}
+	})!
+	test.equal(api.selfScale.zoomed, true, 'the track of the many-exon gene is zoomed')
+	test.equal(api.selfScale.rglst.length, 3, 'to the exon of its breakpoint and one of context each side')
+	test.equal(api.partnerScale.zoomed, false, 'the track of the few-exon gene is not')
+	// each track names its own locus, or its chr alone when the whole gene is drawn
+	const loci = holder.selectAll('[data-testid="sjpp-isoformPairSelect-locus"]').nodes() as HTMLElement[]
+	test.equal(loci[0].textContent, 'chr1:33-49kb', 'the zoomed track is labelled with its window')
+	test.equal(loci[1].textContent, 'chr9', 'the other names its chr alone, not a window it is not showing')
+	// the link still meets the mark of its breakpoint, which the window is built around
+	test.ok(api.selfScale.pos2px(exonStart(5) + 200) > 0, 'the breakpoint is within the zoomed track')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - nothing to display', test => {
+	const holder = select(document.body).append('div')
+	// a partner that is an unannotated locus has no isoform, and here no breakpoint either
+	const api = isoformPairRangeSelect({
+		holder,
+		self: { gene: 'BCR', chr: 'chr22', allgm: [bcr] },
+		partner: { gene: 'chr9', chr: 'chr9', allgm: [] },
+		links: [],
+		callback: () => {}
+	})
+	test.equal(api, undefined, 'returns nothing when a track has neither a gene model nor a breakpoint')
 	test.equal(holder.selectAll('canvas').nodes().length, 0, 'renders no canvas')
 	test.ok(holder.text().includes('No gene model or breakpoint'), 'says there is nothing to display')
 	holder.remove()

--- a/client/dom/test/isoformSelect.unit.spec.ts
+++ b/client/dom/test/isoformSelect.unit.spec.ts
@@ -783,6 +783,79 @@ tape('isoformRangeSelect() - drag over the isoform sketches', test => {
 	test.end()
 })
 
+tape('isoformRangeSelect() - clearing a coordinate restores the range', test => {
+	/* a number input reports an emptied field as the empty string, which Number() turns into
+	0: a finite value that was taken as a typed coordinate and clamped to the start of the
+	scale, so clearing an input to retype it silently widened the range */
+	const holder = select(document.body).append('div')
+	let applied: any = 'not called'
+	const api = isoformRangeSelect({
+		holder,
+		allgm: [bcr],
+		chr: 'chr22',
+		markers: bcrMarkers,
+		range: { start: 23290000, stop: 23290300 },
+		callback: r => (applied = r)
+	})!
+	const inputs = holder.selectAll('[data-testid="sjpp-isoformRangeSelect-pos"]').nodes() as HTMLInputElement[]
+	inputs[0].value = ''
+	inputs[0].dispatchEvent(new Event('change'))
+	test.deepEqual(
+		api.getRange(),
+		{ chr: 'chr22', start: 23290000, stop: 23290300 },
+		'clearing the start coordinate leaves the range as it was'
+	)
+	test.equal(inputs[0].value, '23290000', 'and puts the coordinate back in the input')
+	// the same for the other end, and for a field the input cannot parse
+	inputs[1].value = ''
+	inputs[1].dispatchEvent(new Event('change'))
+	test.deepEqual(
+		api.getRange(),
+		{ chr: 'chr22', start: 23290000, stop: 23290300 },
+		'clearing the stop coordinate leaves the range as it was'
+	)
+	test.equal(applied, 'not called', 'and nothing is applied by it')
+	// a coordinate typed over the restored one still takes effect
+	inputs[0].value = '23180000'
+	inputs[0].dispatchEvent(new Event('change'))
+	test.deepEqual(api.getRange()!.start, 23180000, 'a typed coordinate still changes the range')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformRangeSelect() - sample counts of an upper bound tally', test => {
+	// the markers may be tallied per pair of breakpoints, where a sample with two events is
+	// counted once per event, so their sums cannot be read as a number of samples
+	const holder = select(document.body).append('div')
+	isoformRangeSelect({
+		holder,
+		allgm: [bcr],
+		chr: 'chr22',
+		markers: bcrMarkers,
+		range: { start: 23180000, stop: 23300000 },
+		samplesAreUpperBound: true,
+		callback: () => {}
+	})
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformRangeSelect-info"]').text().includes('up to 55 samples'),
+		'the count is reported as an upper bound'
+	)
+	const exact = select(document.body).append('div')
+	isoformRangeSelect({
+		holder: exact,
+		allgm: [bcr],
+		chr: 'chr22',
+		markers: bcrMarkers,
+		range: { start: 23180000, stop: 23300000 },
+		callback: () => {}
+	})
+	const text = exact.select('[data-testid="sjpp-isoformRangeSelect-info"]').text()
+	test.ok(text.includes('55 samples') && !text.includes('up to'), 'and as a count when the tally is exact')
+	exact.remove()
+	holder.remove()
+	test.end()
+})
+
 tape('isoformRangeSelect() - highlight of a minus strand range', test => {
 	const holder = select(document.body).append('div')
 	const api = isoformRangeSelect({
@@ -1158,6 +1231,29 @@ tape('isoformPairRangeSelect() - rna mode zooms each track to its own breakpoint
 	test.equal(loci[1].textContent, 'chr9', 'the other names its chr alone, not a window it is not showing')
 	// the link still meets the mark of its breakpoint, which the window is built around
 	test.ok(api.selfScale.pos2px(exonStart(5) + 200) > 0, 'the breakpoint is within the zoomed track')
+	holder.remove()
+	test.end()
+})
+
+tape('isoformPairRangeSelect() - sample counts of an upper bound tally', test => {
+	const holder = select(document.body).append('div')
+	const opts = pairOpts()
+	const api = isoformPairRangeSelect({
+		holder,
+		...opts,
+		partner: { ...opts.partner, range: { start: 130713000, stop: 130713200 } },
+		samplesAreUpperBound: true,
+		callback: () => {}
+	})!
+	test.ok(
+		holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text().includes('up to 30 samples'),
+		'a sum over links is reported as an upper bound'
+	)
+	// a single link is one pair of breakpoints, so its own count is exact either way
+	const canvas = holder.select('[data-testid="sjpp-isoformPairSelect-links"]').node() as HTMLCanvasElement
+	canvas.dispatchEvent(new MouseEvent('mousemove', linkPoint(api, canvas, pairLinks[0], 0.85)))
+	const hover = holder.select('[data-testid="sjpp-isoformPairSelect-info"]').text()
+	test.ok(hover.includes('20 samples') && !hover.includes('up to'), 'the count of one link is not hedged')
 	holder.remove()
 	test.end()
 })

--- a/client/dom/test/sketchGm.unit.spec.ts
+++ b/client/dom/test/sketchGm.unit.spec.ts
@@ -176,6 +176,65 @@ tape('sketchGmsum renders gene model summary', test => {
 	test.end()
 })
 
+tape('sketchGmsum clips a gene model to a window of regions', test => {
+	/* the regions may be a window of a gene rather than the whole of it, e.g. the exons a
+	fusion breaks on and their context (see makeExonScale). the backbone of a gene model that
+	runs past the window is clipped to it: before, neither of its ends was held by a region
+	and the backbone was dropped, leaving the exons drawn with nothing joining them */
+	const holder = getHolder()
+	const gm = createSimpleGeneModel()
+	// the middle region alone, which neither gm.start (1000) nor gm.stop (5000) falls in
+	const windowRegions = [createExonRegions()[1]]
+	const pxwidth = windowRegions[0].width
+	sketchGmsum(holder, windowRegions, gm, 1, 10, pxwidth, 20, '#00ff00')
+
+	const canvas = holder.select('canvas').node() as HTMLCanvasElement
+	const ctx = canvas.getContext('2d')!
+	const dpr = canvas.width / pxwidth
+	// the backbone runs along the middle of the canvas, so read that row
+	const row = ctx.getImageData(0, Math.round(10 * dpr), canvas.width, 1).data
+	let drawn = 0
+	for (let x = 0; x < canvas.width; x++) if (row[x * 4 + 3] > 40) drawn++
+	test.ok(drawn > canvas.width * 0.9, 'the backbone spans the window rather than being dropped')
+	test.equal(Math.round(canvas.width / dpr), pxwidth, 'and is no wider than the window')
+
+	holder.remove()
+	test.end()
+})
+
+tape('sketchGmsum numbers the exons wide enough to hold a number', test => {
+	const holder = getHolder()
+	const gm = createSimpleGeneModel()
+	const rglst = createExonRegions()
+	// pixels drawn in the middle row, where a number would be, over the same sketch
+	const midRowPixels = (exonNumbers: boolean, exonsf: number) => {
+		const div = getHolder()
+		const width = 3 * 500 * exonsf + 20
+		sketchGmsum(div, rglst.map(r => ({ ...r, width: 500 * exonsf })) as any, gm, exonsf, 10, width, 20, '#00ff00', {
+			exonNumbers
+		})
+		const canvas = div.select('canvas').node() as HTMLCanvasElement
+		const dpr = canvas.width / width
+		const row = canvas.getContext('2d')!.getImageData(0, Math.round(10 * dpr), canvas.width, 1).data
+		let drawn = 0
+		/* the number is drawn white over a coding box; count only near-white pixels, as
+		neither the boxes ('#00ff00' coding, '#aaa' non-coding) nor the backbone is */
+		for (let x = 0; x < canvas.width; x++) {
+			if (row[x * 4 + 3] > 40 && row[x * 4] > 200 && row[x * 4 + 2] > 200) drawn++
+		}
+		div.remove()
+		return drawn
+	}
+	test.ok(midRowPixels(true, 1) > 0, 'a wide exon box carries its number')
+	test.equal(midRowPixels(false, 1), 0, 'not drawn unless asked for')
+	// the same gene laid out so that an exon is a few px wide, as a many-exon gene is when
+	// the whole of it is drawn: there is no room for a number and none is drawn
+	test.equal(midRowPixels(true, 0.01), 0, 'a box too narrow for its number is left alone')
+
+	holder.remove()
+	test.end()
+})
+
 tape('sketchGmsum handles missing coding regions', test => {
 	const holder = getHolder()
 	const gm = createSimpleGeneModel()

--- a/client/dom/test/variantConfig.unit.spec.ts
+++ b/client/dom/test/variantConfig.unit.spec.ts
@@ -1198,7 +1198,7 @@ const fusionMnames = [
 	// a partner without a charted breakpoint, e.g. of a query lacking coordinates
 	{ mname: 'FGFR1', class: 'Fuserna', samplecount: 2, noPositionCount: 2 }
 ]
-const getGeneModels = async () => [
+const bcrModels = [
 	{
 		isoform: 'NM_004327',
 		chr: 'chr22',
@@ -1212,6 +1212,31 @@ const getGeneModels = async () => [
 		]
 	}
 ]
+const abl1Models = [
+	{
+		isoform: 'NM_005157',
+		chr: 'chr9',
+		start: 130713000,
+		stop: 130887000,
+		strand: '+',
+		isdefault: true,
+		exon: [
+			[130713000, 130713200],
+			[130886800, 130887000]
+		]
+	}
+]
+const getGeneModels = async () => bcrModels
+/** models of both genes of the fusion, as the paired breakpoint chart needs them */
+const getPairGeneModels = async (gene: string) =>
+	gene == 'BCR' ? bcrModels : gene == 'ABL1' ? abl1Models : ([] as any[])
+
+/** the menu holding the given chart, the last one opened when several are in the document */
+function getChartMenu(testid: string) {
+	return [...document.querySelectorAll('.sja_menu_div')]
+		.filter(d => d.querySelector(`[data-testid="${testid}"]`))
+		.pop() as HTMLElement
+}
 
 tape('breakpoint controls are not offered for snvindel', test => {
 	const holder = select(document.body).append('div')
@@ -1457,8 +1482,8 @@ tape('variants list is restricted by the range on the term gene', test => {
 	test.notEqual(rows[0].style.display, 'none', 'variant with a breakpoint in the range is listed')
 	test.equal(rows[1].style.display, 'none', 'variant without a charted breakpoint is not listed')
 	test.ok(
-		holder.select('[data-testid="sjpp-variantConfig-mname"] div').text().includes('(1)'),
-		'the count of the toggle is of the listed variants only'
+		holder.select('[data-testid="sjpp-variantConfig-mname"] div').text().includes('(1/2)'),
+		'the count of the toggle is of the listed variants, against the total'
 	)
 	test.ok(
 		holder
@@ -1467,6 +1492,87 @@ tape('variants list is restricted by the range on the term gene', test => {
 			.includes('chr22:23,290,000-23,290,200'),
 		'says the list is restricted by the range'
 	)
+	holder.remove()
+	test.end()
+})
+
+tape('sample counts are restated under the range on the term gene', test => {
+	/* a range narrows the events a variant still matches, so its sample count is no longer
+	the whole of it; showing the total alone would overstate what checking it would select */
+	const holder = select(document.body).append('div')
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels,
+		// covers the ABL1 breakpoint at 23290100, of 20 of its 30 samples, not the other
+		selfBreakpointRange: { chr: 'chr22', start: 23290000, stop: 23290200 },
+		callback: () => {}
+	})
+	const counts = holder.selectAll('[data-testid="sjpp-variantConfig-mname-count"]').nodes() as HTMLElement[]
+	test.equal(counts[0].textContent, '20/30', 'the samples of the range are counted against the total')
+	test.ok(
+		counts[0].getAttribute('title')?.includes('20 of 30 samples have a BCR breakpoint in chr22:23,290,000-23,290,200'),
+		'and the two numbers are spelled out'
+	)
+	// a variant with no charted breakpoint keeps none of its samples under a range
+	test.equal(counts[1].textContent, '0/2', 'a variant the range excludes counts no sample')
+	holder.remove()
+	test.end()
+})
+
+tape('sample counts are the total when no range is set', test => {
+	const holder = select(document.body).append('div')
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels,
+		callback: () => {}
+	})
+	const counts = holder.selectAll('[data-testid="sjpp-variantConfig-mname-count"]').nodes() as HTMLElement[]
+	test.equal(counts[0].textContent, '30', 'the sample count stands alone')
+	test.equal(counts[0].getAttribute('title'), null, 'with nothing to spell out')
+	test.ok(
+		holder.select('[data-testid="sjpp-variantConfig-mname"] div').text().includes('(2)'),
+		'and the toggle counts the variants alone'
+	)
+	holder.remove()
+	test.end()
+})
+
+tape('sample counts follow a range selected in the breakpoint menu', async test => {
+	// the counts are restated as the range changes, not only as it is passed in
+	const holder = select(document.body).append('div')
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels,
+		callback: () => {}
+	})
+	const counts = holder.selectAll('[data-testid="sjpp-variantConfig-mname-count"]').nodes() as HTMLElement[]
+	test.equal(counts[0].textContent, '30', 'the whole count before a range is selected')
+	;(holder.select('[data-testid="sjpp-variantConfig-selfBreakpoint-btn"]').node() as HTMLElement).click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	const menuDiv = getChartMenu('sjpp-isoformRangeSelect-marks')
+	const inputs = menuDiv.querySelectorAll('[data-testid="sjpp-isoformRangeSelect-pos"]') as any
+	inputs[0].value = '23290000'
+	inputs[1].value = '23290200'
+	inputs[1].dispatchEvent(new Event('change'))
+	;(menuDiv.querySelector('[data-testid="sjpp-isoformRangeSelect-apply"]') as HTMLButtonElement).click()
+	test.equal(counts[0].textContent, '20/30', 'the count follows the selected range')
+	test.ok(
+		holder.select('[data-testid="sjpp-variantConfig-mname"] div').text().includes('(1/2)'),
+		'and so does the toggle'
+	)
+	menuDiv.remove()
 	holder.remove()
 	test.end()
 })
@@ -1490,8 +1596,8 @@ tape('range on the term gene excluding every variant', test => {
 		'no variant is listed'
 	)
 	test.ok(
-		holder.select('[data-testid="sjpp-variantConfig-mname"] div').text().includes('(0)'),
-		'the toggle counts no variant'
+		holder.select('[data-testid="sjpp-variantConfig-mname"] div').text().includes('(0/2)'),
+		'the toggle counts no variant of the two'
 	)
 	holder.remove()
 	test.end()
@@ -1583,6 +1689,227 @@ tape('variants list follows a range selected in the breakpoint menu', async test
 	test.notEqual(rows[0].style.display, 'none', 'variant with a breakpoint in the range stays listed')
 	test.equal(rows[1].style.display, 'none', 'variant without one is dropped from the list')
 	menuDiv.remove()
+	holder.remove()
+	test.end()
+})
+
+tape('partner breakpoint menu charts both genes of the fusion', async test => {
+	/* the breakpoints of a variant are pairs of one on the term's own gene and one on the
+	partner (see BreakpointEntry), so which breakpoint of one goes with which of the other
+	is lost by charting the partner alone */
+	const holder = select(document.body).append('div')
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels: getPairGeneModels,
+		callback: () => {}
+	})
+	const partnerBtn = holder
+		.selectAll('[data-testid="sjpp-variantConfig-partnerBreakpoint-btn"]')
+		.nodes()[0] as HTMLElement
+	partnerBtn.click()
+	// the chart is rendered after the isoform models of both genes are fetched
+	await new Promise(resolve => setTimeout(resolve, 0))
+	const menuDiv = getChartMenu('sjpp-isoformPairSelect-links')
+	test.ok(menuDiv, 'the breakpoints are charted as pairs, linking the two genes')
+	test.ok(
+		menuDiv.querySelector('[data-testid="sjpp-isoformPairSelect-selfTrack"]'),
+		'the term gene is charted as a track of its own'
+	)
+	test.equal(
+		menuDiv.querySelector('[data-testid="sjpp-isoformRangeSelect-marks"]'),
+		null,
+		'the partner gene is not charted alone'
+	)
+	test.ok(menuDiv.textContent!.includes('BCR :: ABL1 breakpoints'), 'both genes are named')
+	test.ok(menuDiv.textContent!.includes('select a range on ABL1'), 'says which gene the range is selected on')
+	test.ok(menuDiv.textContent!.includes('2 breakpoint pairs'), 'charts the breakpoint pairs of the variant')
+	menuDiv.remove()
+	holder.remove()
+	test.end()
+})
+
+tape('partner breakpoint menu shows the range on the term gene', async test => {
+	// the range on the term gene is not editable here, as it applies term-wide, but the
+	// pairs failing it cannot match however the partner range is placed
+	const holder = select(document.body).append('div')
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels: getPairGeneModels,
+		selfBreakpointRange: { chr: 'chr22', start: 23290000, stop: 23290200 },
+		callback: () => {}
+	})
+	;(holder.selectAll('[data-testid="sjpp-variantConfig-partnerBreakpoint-btn"]').nodes()[0] as HTMLElement).click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	const menuDiv = getChartMenu('sjpp-isoformPairSelect-links')
+	test.ok(
+		menuDiv.querySelector('[data-testid="sjpp-isoformPairSelect-selfOverlay"]'),
+		'the range registered on the term gene is highlighted on its track'
+	)
+	menuDiv.remove()
+	holder.remove()
+	test.end()
+})
+
+tape('range selected in the partner menu is registered on its variant', async test => {
+	const holder = select(document.body).append('div')
+	let config: any
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels: getPairGeneModels,
+		selectedValues: [{ key: 'Fuserna', label: 'ABL1', value: 'ABL1', mname: 'ABL1' }],
+		callback: c => (config = c)
+	})
+	const partnerBtn = holder
+		.selectAll('[data-testid="sjpp-variantConfig-partnerBreakpoint-btn"]')
+		.nodes()[0] as HTMLElement
+	partnerBtn.click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	// a click in a row of the variants list toggles its checkbox (see renderTable), which
+	// must not happen for the control that restricts the breakpoints of that variant
+	test.equal(
+		(holder.select('[data-testid="sjpp-variantConfig-mname"] tbody input[type=checkbox]').node() as HTMLInputElement)
+			.checked,
+		true,
+		'opening the control leaves the variant checked'
+	)
+	const menuDiv = getChartMenu('sjpp-isoformPairSelect-links')
+	const inputs = menuDiv.querySelectorAll('[data-testid="sjpp-isoformRangeSelect-pos"]') as any
+	inputs[0].value = '130713000'
+	inputs[1].value = '130713200'
+	inputs[1].dispatchEvent(new Event('change'))
+	;(menuDiv.querySelector('[data-testid="sjpp-isoformRangeSelect-apply"]') as HTMLButtonElement).click()
+	test.equal(
+		partnerBtn.textContent,
+		'chr9:130,713,000-130,713,200',
+		'the range selected on the partner track is displayed on its variant'
+	)
+	getApplyBtn(holder).click()
+	test.deepEqual(
+		config.values[0].partnerBreakpointRange,
+		{ chr: 'chr9', start: 130713000, stop: 130713200 },
+		'and rides on the applied variant'
+	)
+	menuDiv.remove()
+	holder.remove()
+	test.end()
+})
+
+tape('partner breakpoint menu of a term of multiple genes', async test => {
+	// without a single gene of the term there is no second track to pair the partner
+	// with, so it is charted alone
+	const holder = select(document.body).append('div')
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		getGeneModels: getPairGeneModels,
+		callback: () => {}
+	})
+	;(holder.selectAll('[data-testid="sjpp-variantConfig-partnerBreakpoint-btn"]').nodes()[0] as HTMLElement).click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	const menuDiv = getChartMenu('sjpp-isoformRangeSelect-marks')
+	test.ok(menuDiv, 'the partner gene is charted on its own')
+	test.equal(
+		menuDiv.querySelector('[data-testid="sjpp-isoformPairSelect-links"]'),
+		null,
+		'the breakpoints are not paired'
+	)
+	test.ok(menuDiv.textContent!.includes('ABL1 breakpoints'), 'the chart is of the partner gene')
+	menuDiv.remove()
+	holder.remove()
+	test.end()
+})
+
+tape('breakpoint charts are laid out by dt', async test => {
+	/* a rna fusion joins transcripts at exon boundaries, so the charts of a dtfusionrna term
+	collapse the introns between them; a genomic sv breaks mostly within introns, so the
+	charts of a dtsv term keep them at their real width */
+	for (const [dt, mode] of [
+		[2, 'rna'],
+		[5, 'genomic']
+	] as [number, string][]) {
+		const holder = select(document.body).append('div')
+		renderVariantConfig({
+			holder,
+			values: fusionValues,
+			mnames: fusionMnames,
+			dt,
+			gene: 'BCR',
+			getGeneModels: getPairGeneModels,
+			callback: () => {}
+		})
+		// the paired chart of a variant, and the chart of the term gene alone
+		;(holder.selectAll('[data-testid="sjpp-variantConfig-partnerBreakpoint-btn"]').nodes()[0] as HTMLElement).click()
+		await new Promise(resolve => setTimeout(resolve, 0))
+		const pairMenu = getChartMenu('sjpp-isoformPairSelect-links')
+		test.equal(
+			pairMenu.querySelector('[data-testid="sjpp-isoformPairSelect-selfTrack"]')!.getAttribute('data-scale-mode'),
+			mode,
+			`dt ${dt} lays the term gene of the paired chart out as ${mode}`
+		)
+		test.equal(
+			pairMenu.querySelector('[data-testid="sjpp-isoformPairSelect-partnerTrack"]')!.getAttribute('data-scale-mode'),
+			mode,
+			`dt ${dt} lays its partner gene out as ${mode}`
+		)
+		;(holder.select('[data-testid="sjpp-variantConfig-selfBreakpoint-btn"]').node() as HTMLElement).click()
+		await new Promise(resolve => setTimeout(resolve, 0))
+		test.equal(
+			getChartMenu('sjpp-isoformRangeSelect-marks')
+				.querySelector('[data-testid="sjpp-isoformRangeSelect-track"]')!
+				.getAttribute('data-scale-mode'),
+			mode,
+			`dt ${dt} lays the chart of the term gene alone out as ${mode}`
+		)
+		getChartMenu('sjpp-isoformRangeSelect-marks').remove()
+		holder.remove()
+	}
+	test.end()
+})
+
+tape('isoform models are fetched once per gene', async test => {
+	// the term gene is charted against every variant whose partner breakpoints are, so
+	// without a cache it would be fetched anew for each of them
+	const holder = select(document.body).append('div')
+	const calls: string[] = []
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels: async (gene: string) => {
+			calls.push(gene)
+			return getPairGeneModels(gene)
+		},
+		callback: () => {}
+	})
+	const partnerBtn = holder
+		.selectAll('[data-testid="sjpp-variantConfig-partnerBreakpoint-btn"]')
+		.nodes()[0] as HTMLElement
+	partnerBtn.click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	test.deepEqual(calls, ['ABL1', 'BCR'], 'both genes of the pair are fetched')
+	;(holder.select('[data-testid="sjpp-variantConfig-selfBreakpoint-btn"]').node() as HTMLElement).click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	test.deepEqual(calls, ['ABL1', 'BCR'], 'the term gene is not fetched again for its own chart')
+	partnerBtn.click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	test.deepEqual(calls, ['ABL1', 'BCR'], 'nor is either gene fetched again on reopening the pair')
+	getChartMenu('sjpp-isoformPairSelect-links')?.remove()
 	holder.remove()
 	test.end()
 })

--- a/client/dom/test/variantConfig.unit.spec.ts
+++ b/client/dom/test/variantConfig.unit.spec.ts
@@ -1523,6 +1523,48 @@ tape('sample counts are restated under the range on the term gene', test => {
 	test.end()
 })
 
+tape('a sample count that may double count is marked as an upper bound', test => {
+	/* the breakpoint tally counts a sample once per distinct pair of breakpoints, so a
+	variant whose pairs account for more samples than it has must have one in two of them,
+	and no subset of them sums to an exact number of samples */
+	const holder = select(document.body).append('div')
+	const doubled = [
+		{
+			mname: 'PDGFRB',
+			class: 'Fuserna',
+			samplecount: 5,
+			// 4 + 3 of 5 samples, so at least two samples have two events of this variant
+			breakpoints: [
+				{ pos: 23290100, partnerChr: 'chr5', partnerPos: 150125000, samplecount: 4 },
+				{ pos: 23183000, partnerChr: 'chr5', partnerPos: 150130000, samplecount: 3 }
+			]
+		}
+	]
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: doubled,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels,
+		// covers the breakpoint of 4 of the 5 samples
+		selfBreakpointRange: { chr: 'chr22', start: 23290000, stop: 23290200 },
+		callback: () => {}
+	})
+	const count = holder.select('[data-testid="sjpp-variantConfig-mname-count"]').node() as HTMLElement
+	test.equal(count.textContent, '≤4/5', 'the count is marked as an upper bound')
+	test.ok(
+		count.getAttribute('title')?.startsWith('Up to 4 of 5 samples'),
+		'and the title says so rather than stating a tally'
+	)
+	test.ok(
+		count.getAttribute('title')?.includes('more than one event of this variant'),
+		'and says why it cannot be exact'
+	)
+	holder.remove()
+	test.end()
+})
+
 tape('sample counts are the total when no range is set', test => {
 	const holder = select(document.body).append('div')
 	renderVariantConfig({
@@ -1877,6 +1919,35 @@ tape('breakpoint charts are laid out by dt', async test => {
 		getChartMenu('sjpp-isoformRangeSelect-marks').remove()
 		holder.remove()
 	}
+	test.end()
+})
+
+tape('a gene model lookup that throws synchronously still fills the menu', async test => {
+	/* the getter is not required to be an async function, so it may throw synchronously.
+	called as the argument of Promise.resolve() its throw escaped before a promise existed to
+	catch it, and the menu was left on "Loading..." instead of degrading to no gene model */
+	const holder = select(document.body).append('div')
+	renderVariantConfig({
+		holder,
+		values: fusionValues,
+		mnames: fusionMnames,
+		dt: 5,
+		gene: 'BCR',
+		getGeneModels: ((gene: string) => {
+			throw new Error(`no genome to look ${gene} up in`)
+		}) as any,
+		callback: () => {}
+	})
+	// the partner breakpoints carry a chr of their own, so the chart is drawn over them
+	// alone once neither gene resolves to a model
+	;(holder.selectAll('[data-testid="sjpp-variantConfig-partnerBreakpoint-btn"]').nodes()[0] as HTMLElement).click()
+	await new Promise(resolve => setTimeout(resolve, 0))
+	const menuDiv = getChartMenu('sjpp-isoformRangeSelect-marks')
+	test.ok(menuDiv, 'the breakpoints are charted without a gene model')
+	test.equal(menuDiv.textContent!.includes('Loading...'), false, 'the menu is not left loading')
+	test.ok(menuDiv.textContent!.includes('ABL1 breakpoints'), 'and names the gene it charts')
+	menuDiv.remove()
+	holder.remove()
 	test.end()
 })
 

--- a/client/dom/types/isoformSelect.ts
+++ b/client/dom/types/isoformSelect.ts
@@ -101,6 +101,10 @@ export type IsoformRangeSelectOpts = {
 	labelWidth?: number
 	/** layout of the isoform structure, default 'genomic' */
 	mode?: ScaleMode
+	/** set when the .samplecount of the markers may count one sample more than once, e.g.
+	 * when they are tallied per pair of breakpoints and a sample has two events. their sums
+	 * are then reported as an upper bound rather than as a number of samples */
+	samplesAreUpperBound?: boolean
 	/** called with the selected range on apply, and with null when it is cleared */
 	callback: (range: SelectedRange | null) => void
 }
@@ -142,6 +146,10 @@ export type IsoformPairRangeSelectOpts = {
 	labelWidth?: number
 	/** layout of the isoform structure of both tracks, default 'genomic' */
 	mode?: ScaleMode
+	/** set when the .samplecount of the links may count one sample more than once, i.e. when
+	 * a sample has two events of this gene pair. sums over links are then reported as an
+	 * upper bound rather than as a number of samples; a single link is exact either way */
+	samplesAreUpperBound?: boolean
 	/** called with the selected range on apply, and with null when it is cleared */
 	callback: (range: SelectedRange | null) => void
 }

--- a/client/dom/types/isoformSelect.ts
+++ b/client/dom/types/isoformSelect.ts
@@ -72,6 +72,19 @@ export type SelectedRange = {
 	stop: number
 }
 
+/** how the isoform structure is laid out, and how positions map to px over it.
+ *
+ * 'genomic': one linear scale over the whole locus, introns at their real width. A genomic
+ *   sv breaks mostly in introns (e.g. the two BCR breakpoint clusters of BCR::ABL1 sit in
+ *   introns), so intronic space has to be kept to place a range within it.
+ *
+ * 'rna': the exon structure collapsed, introns as fixed narrow gaps (see allgm2sum). A rna
+ *   fusion joins transcripts at exon boundaries, so intronic space is only noise between
+ *   the exons the breakpoints actually fall on. A position off the exon structure is drawn
+ *   at the nearest exon edge, and a range dragged over it snaps to exon edges; the range
+ *   itself is still genomic, and still matches events by position. */
+export type ScaleMode = 'rna' | 'genomic'
+
 export type IsoformRangeSelectOpts = {
 	holder: Div
 	/** isoforms of the gene. those hidden or on another chr are not displayed */
@@ -86,23 +99,76 @@ export type IsoformRangeSelectOpts = {
 	pxwidth?: number
 	/** width in px of the isoform name column, default 110 */
 	labelWidth?: number
+	/** layout of the isoform structure, default 'genomic' */
+	mode?: ScaleMode
 	/** called with the selected range on apply, and with null when it is cleared */
 	callback: (range: SelectedRange | null) => void
 }
 
-/** maps genomic position to px and back, over a linear scale of a chr region.
+/** a pair of breakpoints of one sv/fusion event, one on each of the two genes it joins.
+ * .samplecount is the number of samples having an event of this pair, and scales the
+ * strength of the line drawn between the two positions */
+export type BreakpointLink = {
+	/** breakpoint on the gene of the top track */
+	selfPos: number
+	/** breakpoint on the gene of the bottom track */
+	partnerPos: number
+	samplecount?: number
+}
+
+/** one of the two genes charted by isoformPairRangeSelect() */
+export type PairTrack = {
+	/** name of the gene, labels the track */
+	gene: string
+	/** chr of the gene, isoforms of another chr are not displayed */
+	chr: string
+	allgm: GeneModel[]
+	/** range already registered on this gene */
+	range?: { start: number; stop: number }
+}
+
+export type IsoformPairRangeSelectOpts = {
+	holder: Div
+	/** gene of the term, charted as the top track. its range is context only: it is
+	 * highlighted and dims the links failing it, but is not editable here */
+	self: PairTrack
+	/** partner gene of the event, charted as the bottom track. the selected range is on it */
+	partner: PairTrack
+	/** breakpoint pairs, drawn as lines between the two tracks */
+	links: BreakpointLink[]
+	/** width in px of the graph column, default 400 */
+	pxwidth?: number
+	/** width in px of the isoform name column, default 110 */
+	labelWidth?: number
+	/** layout of the isoform structure of both tracks, default 'genomic' */
+	mode?: ScaleMode
+	/** called with the selected range on apply, and with null when it is cleared */
+	callback: (range: SelectedRange | null) => void
+}
+
+/** maps genomic position to px and back, over the layout of a chr region.
  * on the minus strand the scale is flipped, so that the gene reads 5' to 3' */
 export type LinearScale = {
 	chr: string
-	/** first and last position of the scale, the gene models and markers padded */
+	mode: ScaleMode
+	/** whether the scale covers a window of the gene rather than the whole of it, i.e. the
+	 * exons the breakpoints fall on and their context. only ever true in 'rna' mode */
+	zoomed: boolean
+	/** first and last position of the scale. in 'genomic' mode the gene models and markers
+	 * padded, in 'rna' mode the extent of the exons laid out, which is a window of the gene
+	 * when zoomed */
 	start: number
 	stop: number
 	reverse: boolean
 	pxwidth: number
-	/** px per bp */
+	/** px per bp within an exon */
 	exonsf: number
-	/** single region covering the scale, for sketchGmsum() */
+	/** regions to sketch a gene model over, for sketchGmsum(): one covering the whole scale
+	 * in 'genomic' mode, one per merged exon in 'rna' mode */
 	rglst: ExonRegion[]
+	/** px between two regions of rglst, 0 in 'genomic' mode. NOTE pass this to sketchGmsum()
+	 * as its intronw, or a sketch will not line up with the marks over it */
+	intronpx: number
 	pos2px: (pos: number) => number
 	px2pos: (px: number) => number
 }

--- a/client/dom/variantConfig.ts
+++ b/client/dom/variantConfig.ts
@@ -1,7 +1,7 @@
 import { make_radios, renderTable } from '#dom'
 import { Menu } from './menu'
-import { isoformRangeSelect } from './isoformSelect'
-import type { GeneModel, BreakpointMarker } from './types/isoformSelect'
+import { isoformRangeSelect, isoformPairRangeSelect } from './isoformSelect'
+import type { GeneModel, BreakpointMarker, ScaleMode } from './types/isoformSelect'
 import type { TermValues, BaseValue, BreakpointRange, BreakpointEntry } from '#types'
 import { filterInit } from '#filter'
 import { dt2label, dtsnvindel, dtsv, dtfusionrna, mclass } from '#shared/common.js'
@@ -106,6 +106,10 @@ export function renderVariantConfig(arg: Arg) {
 	offered when the dt is a sv/fusion and the caller can supply isoform models to chart
 	them over */
 	const isSvFusion = dt == dtsv || dt == dtfusionrna
+	/* how the isoform structure is laid out in the breakpoint charts (see ScaleMode). a rna
+	fusion joins transcripts at exon boundaries, so its introns are collapsed; a genomic sv
+	breaks mostly within introns, so theirs are kept at their real width */
+	const scaleMode: ScaleMode = dt == dtfusionrna ? 'rna' : 'genomic'
 	const canSelectBreakpoint = isSvFusion && !!arg.getGeneModels && mnames.some(m => m.breakpoints?.length)
 	/* a sv/fusion has a single mutation class, hardcoded per dt by the data query, so a
 	checklist of it is a checkbox with nothing to choose between. it is not rendered, and
@@ -123,6 +127,9 @@ export function renderVariantConfig(arg: Arg) {
 	/* one menu for both controls, so that opening one closes the other. created on first
 	use, as a menu attaches to the document body and this ui is rendered anew on each edit */
 	let breakpointTip: Menu | undefined
+	/* isoform models by gene, so that the term's own gene is not fetched again for every
+	variant whose partner breakpoints are charted against it */
+	const geneModelCache = new Map<string, Promise<GeneModel[]>>()
 
 	holder.style('margin', '10px')
 
@@ -267,7 +274,10 @@ export function renderVariantConfig(arg: Arg) {
 			// number of variants displayed in the list, quoted in the toggle label
 			let visibleMnameCount = mnames.length
 			const updateToggle = () => {
-				toggle.html(`${expanded ? '&#9660;' : '&#9658;'} Specific variants (${visibleMnameCount})`)
+				// under a range on the term's own gene the list is a subset, so quote it
+				// against the total rather than leaving the count to read as all there is
+				const count = selfBreakpointRange ? `${visibleMnameCount}/${mnames.length}` : `${visibleMnameCount}`
+				toggle.html(`${expanded ? '&#9660;' : '&#9658;'} Specific variants (${count})`)
 				listWrapper.style('display', expanded ? 'block' : 'none')
 			}
 			toggle.on('click', () => {
@@ -299,11 +309,17 @@ export function renderVariantConfig(arg: Arg) {
 			showGeneInMnames = showGene
 			const mnameRows: any[] = []
 			const selectedMnameIdxs: number[] = []
+			// count cell of each variant, k: index in mnames[]. refilled by
+			// updateMnameRowDisplay() as the range on the term's own gene changes
+			const countCells: any[] = []
 			for (const [i, m] of mnames.entries()) {
 				// a preserved entry is not in the current data, flag its count cell
 				// so it reads as absent rather than as a variant with no samples
-				const countCell: any = { value: m.samplecount }
-				if (!m.samplecount) countCell.dataTestId = 'sjpp-variantConfig-mname-absent'
+				const countCell: any = {
+					value: sampleCountLabel(m),
+					dataTestId: m.samplecount ? 'sjpp-variantConfig-mname-count' : 'sjpp-variantConfig-mname-absent'
+				}
+				countCells[i] = countCell
 				const row = [{ value: m.mname }, { value: arg.values[m.class]?.label || m.class }, countCell]
 				if (showGene) row.unshift({ value: m.gene || '' })
 				// cell to fill with the breakpoint control of this variant after render
@@ -355,6 +371,10 @@ export function renderVariantConfig(arg: Arg) {
 						.attr('class', 'sja_clbtext')
 						.style('cursor', 'pointer')
 						.on('click', (event: MouseEvent) => {
+							/* the control sits in a row of the variants list, and a click anywhere in
+							such a row toggles its checkbox (see renderTable). without this the control
+							would uncheck the very variant whose breakpoints it is opened to restrict */
+							event.stopPropagation()
 							openBreakpointMenu({
 								event,
 								// the partner gene of a fusion is named by the mname
@@ -368,6 +388,14 @@ export function renderVariantConfig(arg: Arg) {
 								),
 								range: partnerBreakpointRanges.get(i),
 								noPositionCount: m.noPositionCount || 0,
+								/* the breakpoints of this variant are pairs of one on the term's own
+								gene and one on the partner (see BreakpointEntry), so chart them over
+								both genes rather than the partner alone. the range on the own gene is
+								read here rather than captured, so that the chart reflects whatever it
+								is when the menu is opened */
+								pair: arg.gene
+									? { selfGene: arg.gene, selfRange: selfBreakpointRange, links: m.breakpoints! }
+									: undefined,
 								callback: range => {
 									if (range) partnerBreakpointRanges.set(i, range)
 									else partnerBreakpointRanges.delete(i)
@@ -399,6 +427,10 @@ export function renderVariantConfig(arg: Arg) {
 						return 'none'
 					})
 				visibleMnameCount = visibleCount
+				// the samples of a variant are those it keeps under the range, so restate them
+				for (const [i, m] of mnames.entries()) {
+					countCells[i]?.__td?.text(sampleCountLabel(m)).attr('title', sampleCountTitle(m))
+				}
 				updateToggle()
 				if (selfRangeNote) {
 					selfRangeNote
@@ -564,6 +596,36 @@ export function renderVariantConfig(arg: Arg) {
 		return !!m.breakpoints?.some(b => b.pos >= start && b.pos <= stop)
 	}
 
+	/* samples of a variant whose events break within the range on the term's own gene.
+	NOTE the breakpoint tally is per pair of breakpoints (see BreakpointEntry), so a sample
+	with two events of this variant breaking in the range is counted once per event: the sum
+	is an upper bound on the samples, capped here at the total so that it cannot read as more
+	samples than the variant has. an exact count would have to be tallied per position by the
+	server, which does not report it */
+	function samplesInSelfRange(m: MnameItem) {
+		if (!selfBreakpointRange) return m.samplecount
+		const { start, stop } = selfBreakpointRange
+		const n = (m.breakpoints || []).reduce((sum, b) => (b.pos >= start && b.pos <= stop ? sum + b.samplecount : sum), 0)
+		return Math.min(n, m.samplecount)
+	}
+
+	/** samples of a variant, as "in range / total" while a range on the term's own gene
+	 * narrows them, and as the total alone otherwise */
+	function sampleCountLabel(m: MnameItem) {
+		// a preserved entry is not in the current data, and has no samples either way
+		if (!selfBreakpointRange || !m.samplecount) return `${m.samplecount}`
+		return `${samplesInSelfRange(m)}/${m.samplecount}`
+	}
+
+	/** spells out what the two numbers of a count cell are, which the column cannot */
+	function sampleCountTitle(m: MnameItem) {
+		if (!selfBreakpointRange || !m.samplecount) return null
+		return (
+			`${samplesInSelfRange(m)} of ${m.samplecount} samples have a ${arg.gene} breakpoint ` +
+			`in ${breakpointRangeLabel(selfBreakpointRange)}`
+		)
+	}
+
 	/** classes currently checked in the class table, or all of them when it is not rendered */
 	function getCheckedClasses() {
 		const checked = new Set()
@@ -614,6 +676,32 @@ export function renderVariantConfig(arg: Arg) {
 		return best
 	}
 
+	/** isoform models of a gene, fetched once per gene. a gene without them, e.g. a fusion
+	 * partner that is an unannotated locus, still has its breakpoints charted, so a failed
+	 * lookup yields none rather than throwing; it is not cached, so that a transient
+	 * failure is retried the next time the gene is charted */
+	function loadGeneModels(gene: string): Promise<GeneModel[]> {
+		if (!geneModelCache.has(gene)) {
+			geneModelCache.set(
+				gene,
+				Promise.resolve(arg.getGeneModels!(gene))
+					.then(gmlst => gmlst || [])
+					.catch((e: any) => {
+						console.warn(`no gene model for ${gene}: ${e?.message || e}`)
+						geneModelCache.delete(gene)
+						return []
+					})
+			)
+		}
+		return geneModelCache.get(gene)!
+	}
+
+	/** chr a gene is charted on, from its default isoform. this is also what the server
+	 * resolves a gene to when querying its events */
+	function geneChr(gmlst: GeneModel[]) {
+		return (gmlst.find(g => g.isdefault) || gmlst[0])?.chr
+	}
+
 	/** chart the breakpoints of a gene in a menu and select a range of them */
 	async function openBreakpointMenu(a: {
 		event: MouseEvent
@@ -621,6 +709,10 @@ export function renderVariantConfig(arg: Arg) {
 		markers: MarkerInput[]
 		range?: BreakpointRange
 		noPositionCount: number
+		/** when given, the breakpoints are charted as pairs over two tracks, .selfGene above
+		 * and .gene below, linked by the events they occur in. the range is still selected
+		 * on .gene alone; .selfRange is context, owned by the control of the term's own gene */
+		pair?: { selfGene: string; selfRange?: BreakpointRange; links: BreakpointEntry[] }
 		callback: (range: BreakpointRange | null) => void
 	}) {
 		if (!breakpointTip)
@@ -638,47 +730,83 @@ export function renderVariantConfig(arg: Arg) {
 		tip.clear().showunder(a.event.target as HTMLElement)
 		const div = tip.d.append('div')
 		div.append('div').style('opacity', 0.6).text('Loading...')
-		let gmlst: GeneModel[] = []
-		try {
-			gmlst = (await arg.getGeneModels!(a.gene)) || []
-		} catch (e: any) {
-			// the isoform models are optional context: a gene without them, e.g. a fusion
-			// partner that is an unannotated locus, still has its breakpoints charted
-			console.warn(`no gene model for ${a.gene}: ${e?.message || e}`)
-		}
+		// both genes of a pair are fetched together, so that the menu is filled in one go
+		const [gmlst, selfGmlst] = await Promise.all([
+			loadGeneModels(a.gene),
+			a.pair ? loadGeneModels(a.pair.selfGene) : Promise.resolve([] as GeneModel[])
+		])
 		div.selectAll('*').remove()
 		/* the chr of the markers decides the locus, so that the range is on the same chr
 		as the events it will match; the breakpoints of the term's own gene carry no chr,
-		so fall back to its default isoform, which is also what the server resolves a gene
-		to when querying its events */
-		const chr = mostCommonChr(a.markers) || (gmlst.find(g => g.isdefault) || gmlst[0])?.chr
+		so fall back to its default isoform */
+		const chr = mostCommonChr(a.markers) || geneChr(gmlst)
 		if (!chr) {
 			div.append('div').text(`Unknown chromosome of ${a.gene}`)
 			return
 		}
-		div
-			.append('div')
-			.style('margin-bottom', '5px')
-			.style('font-size', '.9em')
-			.style('opacity', 0.7)
-			.text(`${a.gene} breakpoints`)
+		/* the header names whichever chart is rendered, so it is filled after the attempt at
+		the paired one; the notes are placed above the chart and below the header */
+		const headerDiv = div.append('div').style('margin-bottom', '5px').style('font-size', '.9em').style('opacity', 0.7)
+		const noteDiv = div.append('div')
+		const chartDiv = div.append('div')
+		const addNote = (text: string) =>
+			noteDiv.append('div').style('font-size', '.75em').style('opacity', 0.6).style('margin-bottom', '5px').text(text)
 		if (a.noPositionCount) {
-			div
-				.append('div')
-				.style('font-size', '.75em')
-				.style('opacity', 0.6)
-				.style('margin-bottom', '5px')
-				.text(
-					`${a.noPositionCount} samples have events without a breakpoint position; they are not charted and do not match a range`
-				)
+			addNote(
+				`${a.noPositionCount} samples have events without a breakpoint position; they are not charted and do not match a range`
+			)
 		}
+		// the breakpoints of the term's own gene carry no chr, so it is that of its models
+		const selfChr = a.pair ? geneChr(selfGmlst) : undefined
+		let paired = false
+		if (a.pair && selfChr) {
+			// a pair breaking on another chr of the partner is not of this locus
+			const links = a.pair.links.filter(l => l.partnerChr == chr)
+			const rendered = isoformPairRangeSelect({
+				holder: chartDiv,
+				self: {
+					gene: a.pair.selfGene,
+					chr: selfChr,
+					allgm: selfGmlst,
+					range: a.pair.selfRange?.chr == selfChr ? a.pair.selfRange : undefined
+				},
+				partner: {
+					gene: a.gene,
+					chr,
+					allgm: gmlst,
+					// a range of another chr is not of this locus, so is not the current one
+					range: a.range?.chr == chr ? a.range : undefined
+				},
+				links: links.map(l => ({ selfPos: l.pos, partnerPos: l.partnerPos, samplecount: l.samplecount })),
+				mode: scaleMode,
+				callback: range => {
+					tip.hide()
+					a.callback(range)
+				}
+			})
+			if (rendered) {
+				paired = true
+				const dropped = a.pair.links.length - links.length
+				if (dropped) {
+					addNote(`${dropped} breakpoint pairs are on another chromosome of ${a.gene}; they are not charted`)
+				}
+			} else {
+				// neither track could be charted, fall back to the partner gene alone
+				chartDiv.selectAll('*').remove()
+			}
+		}
+		headerDiv.text(
+			paired ? `${a.pair!.selfGene} :: ${a.gene} breakpoints, select a range on ${a.gene}` : `${a.gene} breakpoints`
+		)
+		if (paired) return
 		isoformRangeSelect({
-			holder: div.append('div'),
+			holder: chartDiv,
 			allgm: gmlst,
 			chr,
 			markers: a.markers.filter(m => !m.chr || m.chr == chr),
 			// a range of another chr is not of this locus, so is not shown as the current one
 			range: a.range?.chr == chr ? a.range : undefined,
+			mode: scaleMode,
 			callback: range => {
 				tip.hide()
 				a.callback(range)

--- a/client/dom/variantConfig.ts
+++ b/client/dom/variantConfig.ts
@@ -250,6 +250,10 @@ export function renderVariantConfig(arg: Arg) {
 					noPositionCount: mnames
 						.filter(m => checkedClasses.has(m.class))
 						.reduce((n, m) => n + (m.noPositionCount || 0), 0),
+					/* the marks merge the breakpoints of every checked variant, so a sample with
+					events to two partners at one position is counted once per event and no total
+					here can be shown as an exact tally */
+					samplesAreUpperBound: true,
 					callback: range => {
 						selfBreakpointRange = range || undefined
 						updateSelfBtn()
@@ -388,6 +392,7 @@ export function renderVariantConfig(arg: Arg) {
 								),
 								range: partnerBreakpointRanges.get(i),
 								noPositionCount: m.noPositionCount || 0,
+								samplesAreUpperBound: !hasExactBreakpointCounts(m),
 								/* the breakpoints of this variant are pairs of one on the term's own
 								gene and one on the partner (see BreakpointEntry), so chart them over
 								both genes rather than the partner alone. the range on the own gene is
@@ -609,20 +614,35 @@ export function renderVariantConfig(arg: Arg) {
 		return Math.min(n, m.samplecount)
 	}
 
+	/* whether the breakpoints of a variant can be summed into an exact number of samples.
+	the tally counts a sample once per distinct pair of breakpoints (see BreakpointEntry), so
+	a sample with two events of this variant sits in two entries and would be counted twice.
+	when the entries and the events with no position together account for no more than the
+	variant's samples, no sample is in two of them, and any subset of them sums exactly */
+	function hasExactBreakpointCounts(m: MnameItem) {
+		const pairs = (m.breakpoints || []).reduce((n, b) => n + b.samplecount, 0)
+		return pairs + (m.noPositionCount || 0) <= m.samplecount
+	}
+
 	/** samples of a variant, as "in range / total" while a range on the term's own gene
-	 * narrows them, and as the total alone otherwise */
+	 * narrows them, and as the total alone otherwise. a sum that may have counted a sample
+	 * more than once is an upper bound, and is marked as one rather than read as a tally */
 	function sampleCountLabel(m: MnameItem) {
 		// a preserved entry is not in the current data, and has no samples either way
 		if (!selfBreakpointRange || !m.samplecount) return `${m.samplecount}`
-		return `${samplesInSelfRange(m)}/${m.samplecount}`
+		return `${hasExactBreakpointCounts(m) ? '' : '≤'}${samplesInSelfRange(m)}/${m.samplecount}`
 	}
 
 	/** spells out what the two numbers of a count cell are, which the column cannot */
 	function sampleCountTitle(m: MnameItem) {
 		if (!selfBreakpointRange || !m.samplecount) return null
+		const exact = hasExactBreakpointCounts(m)
 		return (
-			`${samplesInSelfRange(m)} of ${m.samplecount} samples have a ${arg.gene} breakpoint ` +
-			`in ${breakpointRangeLabel(selfBreakpointRange)}`
+			`${exact ? '' : 'Up to '}${samplesInSelfRange(m)} of ${m.samplecount} samples have a ${arg.gene} ` +
+			`breakpoint in ${breakpointRangeLabel(selfBreakpointRange)}` +
+			(exact
+				? ''
+				: '. Some samples have more than one event of this variant, which the breakpoint tally cannot tell apart')
 		)
 	}
 
@@ -684,7 +704,11 @@ export function renderVariantConfig(arg: Arg) {
 		if (!geneModelCache.has(gene)) {
 			geneModelCache.set(
 				gene,
-				Promise.resolve(arg.getGeneModels!(gene))
+				/* NOTE the getter is called inside then(), not as the argument of resolve():
+				there its own synchronous throw would escape before a promise existed to catch
+				it, leaving the menu on "Loading..." rather than degrading as documented */
+				Promise.resolve()
+					.then(() => arg.getGeneModels!(gene))
 					.then(gmlst => gmlst || [])
 					.catch((e: any) => {
 						console.warn(`no gene model for ${gene}: ${e?.message || e}`)
@@ -709,6 +733,8 @@ export function renderVariantConfig(arg: Arg) {
 		markers: MarkerInput[]
 		range?: BreakpointRange
 		noPositionCount: number
+		/** whether a sum of the .samplecount of the markers may hold one sample twice */
+		samplesAreUpperBound: boolean
 		/** when given, the breakpoints are charted as pairs over two tracks, .selfGene above
 		 * and .gene below, linked by the events they occur in. the range is still selected
 		 * on .gene alone; .selfRange is context, owned by the control of the term's own gene */
@@ -779,6 +805,7 @@ export function renderVariantConfig(arg: Arg) {
 				},
 				links: links.map(l => ({ selfPos: l.pos, partnerPos: l.partnerPos, samplecount: l.samplecount })),
 				mode: scaleMode,
+				samplesAreUpperBound: a.samplesAreUpperBound,
 				callback: range => {
 					tip.hide()
 					a.callback(range)
@@ -807,6 +834,7 @@ export function renderVariantConfig(arg: Arg) {
 			// a range of another chr is not of this locus, so is not shown as the current one
 			range: a.range?.chr == chr ? a.range : undefined,
 			mode: scaleMode,
+			samplesAreUpperBound: a.samplesAreUpperBound,
 			callback: range => {
 				tip.hide()
 				a.callback(range)

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- improve sv/fusion tw and tvs edit ui to show geneA-geneB breakpoint diagram


### PR DESCRIPTION
… two-gene charts, rna zoom, exon numbers

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
