### PR TITLE
introduce mayMapFilterToTermSamples() to resolve bug for survival not…

### DIFF
--- a/server/src/termdb.sql.js
+++ b/server/src/termdb.sql.js
@@ -7,7 +7,7 @@ import { sampleLstSql } from './termdb.sql.samplelst.js'
 import { multivalueCTE } from './termdb.sql.multivalue.js'
 import { termCollectionCategorical, termCollectionNumeric } from './termdb.sql.termCollection.js'
 import { boxplot_getvalue } from '#shared/boxplot.js'
-import { DEFAULT_SAMPLE_TYPE, isNumericTerm, dictionaryNumericTypes } from '#shared/terms.js'
+import { DEFAULT_SAMPLE_TYPE, isNumericTerm, dictionaryNumericTypes, getSampleType } from '#shared/terms.js'
 import { authApi } from '#src/auth.js'
 /*
 
@@ -478,6 +478,9 @@ export async function get_term_cte(q, values, index, filter, termWrapper = null)
 		later.  
 	*/
 	// TODO: investigate the utility of 'filter' argument (since get_rows() already performs filtering)
+	/* a term CTE that restricts its own rows by the filter must do so in the id space of the
+	table it reads, which is not always the id space the filter resolved to */
+	const termFilter = mayMapFilterToTermSamples(filter, q, term)
 	let CTE
 	if (term.type == 'categorical') {
 		const groupset = get_active_groupset(term, termq)
@@ -485,12 +488,12 @@ export async function get_term_cte(q, values, index, filter, termWrapper = null)
 	} else if (isNumericTerm(term)) {
 		const mode = termq.mode == 'spline' ? 'cubicSpline' : termq.mode || 'discrete'
 		// the error is coming from this
-		CTE = await numericSql[mode].getCTE(tablename, term, q.ds, termq, values, index, filter)
+		CTE = await numericSql[mode].getCTE(tablename, term, q.ds, termq, values, index, termFilter)
 	} else if (term.type == 'condition') {
 		const mode = termq.mode || 'discrete'
 		CTE = await conditionSql[mode].getCTE(tablename, term, q.ds, termq, values)
 	} else if (term.type == 'survival') {
-		CTE = makesql_survival(tablename, term, q, values, filter)
+		CTE = makesql_survival(tablename, term, q, values, termFilter)
 	} else if (term.type == 'samplelst') {
 		CTE = await sampleLstSql.getCTE(q.ds, tablename, termWrapper || { term, q: termq }, values)
 	} else if (term.type == 'multivalue') {
@@ -626,6 +629,38 @@ export function getUncomputableClause(term, q, tableAlias = '') {
 	return {
 		values,
 		clause: values.length ? `AND ${aliasValue} NOT IN (${values.map(() => '?').join(',')})` : ''
+	}
+}
+
+/*
+Resolve the filter into the id space of the table a term CTE reads from.
+
+When q.mapParent2Children is on, getFilterCTEs() resolves the filter down to child samples
+(q.sampleType) so that the child-level output of getAnnotationRows()/get_samples() can be
+restricted by it. A parent-level term (e.g. patient-level survival or age in a dataset whose
+mutation data is sample-level) is annotated against parent ids, so a CTE that restricts its
+own rows with `sample IN <filter>` would compare parent ids against child ids and match
+nothing -- silently emptying the term for every sample. Map the filtered child ids back to
+their parents for such terms; the caller still applies the child-level filter to the mapped
+output, so no sample escapes the filter.
+
+Returns the filter unchanged when there is nothing to map: no filter, no parent/child
+mapping in effect, or a term already annotating the query sample type.
+*/
+export function mayMapFilterToTermSamples(filter, q, term) {
+	if (!filter || !q?.mapParent2Children) return filter
+	const ds = q.ds
+	const querySampleType = ds?.cohort?.termdb?.sampleTypes?.[q.sampleType]
+	if (!querySampleType) return filter
+	const parentType = querySampleType.parent_id
+	if (parentType == undefined || parentType != getSampleType(term, ds)) return filter
+	// used as `sample IN <CTEname>`, thus the parentheses
+	return {
+		...filter,
+		CTEname: `(SELECT sa.ancestor_id
+			FROM sample_ancestry sa
+			JOIN sampleidmap sm ON sa.ancestor_id = sm.id
+			WHERE sa.sample_id IN ${filter.CTEname} AND sm.sample_type = ${parentType})`
 	}
 }
 

--- a/server/src/test/termdb.sql.unit.spec.ts
+++ b/server/src/test/termdb.sql.unit.spec.ts
@@ -1,5 +1,11 @@
 import tape from 'tape'
+import Database from 'better-sqlite3'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
 import { mayMapFilterToTermSamples } from '../termdb.sql.js'
+import { getSampleData_dictionaryTerms_termdb } from '../termdb.matrix.js'
+import { server_init_db_queries } from '../termdb.server.init.ts'
 
 /* a two-level dataset: patients (type 1) are the parents of samples (type 2).
 survival and subtype annotate patients, purity annotates samples, and a geneVariant
@@ -81,5 +87,169 @@ tape('mayMapFilterToTermSamples() leaves a non-dictionary term unmapped', test =
 	const q = { ds: getDs(), mapParent2Children: true, sampleType: 2 }
 	const geneVariantTerm = { type: 'geneVariant', name: 'KRAS' }
 	test.equal(mayMapFilterToTermSamples(filter, q, geneVariantTerm), filter, 'should return the filter unchanged')
+	test.end()
+})
+
+/**************************************************************************************
+db-backed regression coverage for a parent-level term going blank under a filter.
+
+The tests above only pin down the helper's string output; they stay green if
+get_term_cte() stops handing the mapped filter to a term CTE, which is the defect
+itself. These run the real getFilterCTEs() -> get_term_cte() -> getAnnotationRows()
+cascade against SQLite, covering both CTEs that restrict their own rows by the filter:
+the survival term (which went empty, the reported bug) and the numeric term (whose bins
+were computed over an empty value set). Reverting either call site fails them.
+***************************************************************************************/
+
+const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'termdbSql-'))
+
+// the schema of the TermdbTest fixture, so the temp db has every table the query cascade touches
+const schemaSql: string = new Database(path.join(import.meta.dirname, '../../test/tp/files/hg38/TermdbTest/db'), {
+	readonly: true,
+	fileMustExist: true
+})
+	.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND sql IS NOT NULL AND name NOT LIKE 'sqlite_%'`)
+	.all()
+	.map((r: any) => r.sql)
+	.join(';\n')
+
+const efsTerm = { id: 'efs', name: 'Event-free survival', type: 'survival' }
+const subtypeTerm = { id: 'subtype', name: 'Subtype', type: 'categorical' }
+const ageTerm = { id: 'age', name: 'Age', type: 'float' }
+
+/* a minimal two-level dataset in the shape that triggers the bug: both the survival term
+and the filter term annotate patients, while the queried sample type is their children.
+	patient 1 (subtype=A, efs, age 45) -> samples 11, 12
+	patient 2 (subtype=B, efs, age 200) -> sample 21
+the TermdbTest fixture cannot stand in for this: its survival terms are sample_type=2,
+so no parent-to-children mapping is ever triggered for them */
+function mkDs() {
+	const dbfile = path.join(tmpdir, 'db')
+	const cn = new Database(dbfile)
+	cn.pragma('foreign_keys = OFF') // only the rows seeded below are needed
+	cn.exec(schemaSql)
+
+	const sampleTypes = cn.prepare('INSERT INTO sample_types (id, name, plural_name, parent_id) VALUES (?,?,?,?)')
+	sampleTypes.run(1, 'patient', 'patients', null)
+	sampleTypes.run(2, 'sample', 'samples', 1)
+
+	const sample = cn.prepare('INSERT INTO sampleidmap (id, name, sample_type) VALUES (?,?,?)')
+	sample.run(1, 'P1', 1)
+	sample.run(2, 'P2', 1)
+	sample.run(11, 'P1_s1', 2)
+	sample.run(12, 'P1_s2', 2)
+	sample.run(21, 'P2_s1', 2)
+
+	const ancestry = cn.prepare('INSERT INTO sample_ancestry (sample_id, ancestor_id, distance) VALUES (?,?,?)')
+	ancestry.run(11, 1, 1)
+	ancestry.run(12, 1, 1)
+	ancestry.run(21, 2, 1)
+
+	const term = cn.prepare(
+		'INSERT INTO terms (id, name, jsondata, child_order, type, isleaf, sample_type) VALUES (?,?,?,?,?,?,?)'
+	)
+	for (const [i, t] of [efsTerm, subtypeTerm, ageTerm].entries()) {
+		term.run(t.id, t.name, JSON.stringify(t), i, t.type, 1, 1)
+	}
+
+	const anno = cn.prepare('INSERT INTO anno_categorical (sample, term_id, value) VALUES (?,?,?)')
+	anno.run(1, 'subtype', 'A')
+	anno.run(2, 'subtype', 'B')
+
+	const float = cn.prepare('INSERT INTO anno_float (sample, term_id, value) VALUES (?,?,?)')
+	float.run(1, 'age', 45)
+	float.run(2, 'age', 200)
+
+	const surv = cn.prepare('INSERT INTO survival (sample, term_id, tte, exit_code) VALUES (?,?,?,?)')
+	surv.run(1, 'efs', 5, 1)
+	surv.run(2, 'efs', 7, 0)
+
+	cn.close()
+
+	// sampleTypes{} is set by mds3.init.js before server_init_db_queries() runs
+	const ds: any = { label: 'termdbSqlTest', cohort: { db: { file_fullpath: dbfile }, termdb: { sampleTypes: {} } } }
+	server_init_db_queries(ds)
+	return ds
+}
+
+let cachedDs: any
+function getSeededDs() {
+	// every test below only reads, so one seeded db serves them all
+	if (!cachedDs) cachedDs = mkDs()
+	return cachedDs
+}
+
+const subtypeIsA = {
+	type: 'tvslst',
+	in: true,
+	join: '',
+	lst: [{ type: 'tvs', tvs: { term: subtypeTerm, values: [{ key: 'A', label: 'A' }] } }]
+}
+
+tape('patient-level survival is served under a patient-level filter mapped to child samples', async test => {
+	const ds = getSeededDs()
+	const efsTw = { $id: 'efs$id', term: efsTerm, q: {} }
+	// a sample-level term in the same request is what puts the query in the child sample type,
+	// e.g. a geneVariant overlay; here that state is supplied directly
+	const q = { ds, filter: subtypeIsA, mapParent2Children: true, sampleType: 2 }
+
+	const [samples] = await getSampleData_dictionaryTerms_termdb(q, [efsTw])
+
+	test.deepEqual(
+		Object.keys(samples).sort(),
+		['11', '12'],
+		'should annotate both child samples of the filtered patient, and no other sample'
+	)
+	test.deepEqual(
+		samples[11],
+		{ sample: 11, efs$id: { key: 1, value: 5 } },
+		`should carry the parent's survival value onto the child sample`
+	)
+	test.equal(samples[21], undefined, 'should exclude the child of the patient that the filter excludes')
+	test.end()
+})
+
+tape('a patient-level filter still applies when there is no parent-to-children mapping', async test => {
+	const ds = getSeededDs()
+	const efsTw = { $id: 'efs$id', term: efsTerm, q: {} }
+	// all terms in this request annotate patients, so the query stays in the patient sample type
+	const q = { ds, filter: subtypeIsA, mapParent2Children: false }
+
+	const [samples] = await getSampleData_dictionaryTerms_termdb(q, [efsTw])
+
+	test.deepEqual(Object.keys(samples), ['1'], 'should return the filtered patient only')
+	test.deepEqual(samples[1], { sample: 1, efs$id: { key: 1, value: 5 } }, 'should return that patient survival value')
+	test.end()
+})
+
+tape('a patient-level numeric term bins over the filtered patients, not an empty set', async test => {
+	const ds = getSeededDs()
+	// the bin boundaries are computed from the min/max of the values the filter admits,
+	// which get_numericMinMaxPct() reads with the same filter the term CTE uses
+	const ageTw = {
+		$id: 'age$id',
+		term: ageTerm,
+		q: { mode: 'discrete', type: 'regular-bin', bin_size: 20, first_bin: { startunbounded: true, stop: 20 } }
+	}
+	const q = { ds, filter: subtypeIsA, mapParent2Children: true, sampleType: 2 }
+
+	const [samples, byTermId] = await getSampleData_dictionaryTerms_termdb(q, [ageTw])
+
+	test.deepEqual(
+		byTermId['age$id'].bins.map((b: any) => b.name || b.label),
+		['<20', '20 to <40', '≥40'],
+		'should bin up to the filtered patient age of 45, not the unfiltered max of 200'
+	)
+	test.deepEqual(
+		Object.keys(samples).sort(),
+		['11', '12'],
+		'should bin both child samples of the filtered patient, and no other sample'
+	)
+	test.deepEqual(samples[11], { sample: 11, age$id: { key: '≥40', value: 45 } }, 'should assign the parent age bin')
+	test.end()
+})
+
+tape('teardown', test => {
+	fs.rmSync(tmpdir, { recursive: true, force: true })
 	test.end()
 })

--- a/server/src/test/termdb.sql.unit.spec.ts
+++ b/server/src/test/termdb.sql.unit.spec.ts
@@ -1,0 +1,85 @@
+import tape from 'tape'
+import { mayMapFilterToTermSamples } from '../termdb.sql.js'
+
+/* a two-level dataset: patients (type 1) are the parents of samples (type 2).
+survival and subtype annotate patients, purity annotates samples, and a geneVariant
+term is non-dictionary and thus annotates the default (leaf) sample type */
+function getDs() {
+	return {
+		cohort: {
+			termdb: {
+				sampleTypes: {
+					1: { name: 'patient', plural_name: 'patients', parent_id: null },
+					2: { name: 'sample', plural_name: 'samples', parent_id: 1 }
+				},
+				term2SampleType: new Map([
+					['Event-free_survival', 1],
+					['AGE_YRS', 1],
+					['purity', 2]
+				])
+			}
+		}
+	}
+}
+
+const filter = { filters: 'f_0 AS (...), f AS (SELECT * FROM f_0)', CTEname: 'f', values: ['Subtype'] }
+const survivalTerm = { id: 'Event-free_survival', type: 'survival' }
+const sampleLevelTerm = { id: 'purity', type: 'float' }
+
+tape('\n', test => {
+	test.pass('-***- termdb.sql mayMapFilterToTermSamples -***-')
+	test.end()
+})
+
+tape('mayMapFilterToTermSamples() maps a parent-level term back to parent ids', test => {
+	const q = { ds: getDs(), mapParent2Children: true, sampleType: 2 }
+	const mapped = mayMapFilterToTermSamples(filter, q, survivalTerm)
+	test.notEqual(mapped.CTEname, filter.CTEname, 'should not reuse the child-level CTE name')
+	test.ok(
+		mapped.CTEname.includes('sample_ancestry') && mapped.CTEname.includes('sa.sample_id IN f'),
+		'should resolve the filtered child ids to their ancestors'
+	)
+	test.ok(mapped.CTEname.includes('sm.sample_type = 1'), 'should restrict the ancestors to the parent sample type')
+	test.equal(mapped.filters, filter.filters, 'should carry over the filter CTE definitions unchanged')
+	test.deepEqual(mapped.values, filter.values, 'should carry over the filter values unchanged')
+	test.equal(filter.CTEname, 'f', 'should not mutate the supplied filter')
+	test.end()
+})
+
+tape('mayMapFilterToTermSamples() returns the filter unchanged when there is nothing to map', test => {
+	const ds = getDs()
+	test.equal(
+		mayMapFilterToTermSamples(filter, { ds, mapParent2Children: false, sampleType: 2 }, survivalTerm),
+		filter,
+		'no parent-to-children mapping in effect'
+	)
+	test.equal(
+		mayMapFilterToTermSamples(null, { ds, mapParent2Children: true, sampleType: 2 }, survivalTerm),
+		null,
+		'no filter'
+	)
+	test.equal(
+		mayMapFilterToTermSamples(filter, { ds, mapParent2Children: true, sampleType: 2 }, sampleLevelTerm),
+		filter,
+		'term already annotates the query sample type'
+	)
+	test.equal(
+		mayMapFilterToTermSamples(filter, { ds, mapParent2Children: true, sampleType: 1 }, survivalTerm),
+		filter,
+		'query sample type is the root, thus has no parent to map to'
+	)
+	test.equal(
+		mayMapFilterToTermSamples(filter, { ds, mapParent2Children: true, sampleType: 3 }, survivalTerm),
+		filter,
+		'unknown query sample type'
+	)
+	test.end()
+})
+
+tape('mayMapFilterToTermSamples() leaves a non-dictionary term unmapped', test => {
+	// a geneVariant term annotates the leaf sample type, which is what the filter already resolved to
+	const q = { ds: getDs(), mapParent2Children: true, sampleType: 2 }
+	const geneVariantTerm = { type: 'geneVariant', name: 'KRAS' }
+	test.equal(mayMapFilterToTermSamples(filter, q, geneVariantTerm), filter, 'should return the filter unchanged')
+	test.end()
+})


### PR DESCRIPTION
… showing with patient filter

# Description
err on master: http://localhost:3000/?massnative=hg38,AML open survival, overlay MYC mut. add local filter subtype->some (which is patient-level term). shows `No data` and is wrong
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
