### PR TITLE
fix: matrix false positive of prevFilter0 fixed for showing cohortMsg…

### DIFF
--- a/client/plots/matrix/matrix.dom.js
+++ b/client/plots/matrix/matrix.dom.js
@@ -13,6 +13,9 @@ export function setMatrixDom(opts) {
 		.style('left', '50px')
 	const errdiv = holder.append('div').attr('class', 'sja_errorbar').style('display', 'none')
 	const warningDiv = holder.append('div').attr('class', 'sja_errorbar').style('display', 'none')
+	// kept separate from loadingDiv, which is offset to center a transient message over a hidden or faded svg;
+	// this message is displayed above an already rendered matrix and so must not be offset over the svg
+	const cohortMsgDiv = holder.append('div').style('display', 'none').style('margin', '5px 0 0 45px')
 	const svg = holder
 		.append('svg')
 		.attr('data-testid', 'sjpp-matrix-svg')
@@ -46,6 +49,7 @@ export function setMatrixDom(opts) {
 		controls,
 		errorDiv,
 		loadingDiv,
+		cohortMsgDiv,
 		svg,
 		clipRect: svg
 			.append('defs')

--- a/client/plots/matrix/matrix.js
+++ b/client/plots/matrix/matrix.js
@@ -39,6 +39,9 @@ export class Matrix extends PlotBase {
 		this.setDom(opts)
 
 		this.config = appState.plots.find(p => p.id === this.id)
+		// the cohort that this matrix is created with is the baseline for detecting a cohort change later;
+		// must be set before setControls(), which calls getState()
+		this.prevFilter0 = appState.termfilter.filter0
 		this.settings = Object.assign({}, this.config.settings.matrix)
 		this.computed = {} // will hold settings/configuration/data that are computed or derived from other data
 		if (this.dom.header) this.dom.header.html(this.config.preBuiltPlotTitle || this.holderTitle)
@@ -135,7 +138,10 @@ export class Matrix extends PlotBase {
 	getState(appState) {
 		const config = appState.plots.find(p => p.id === this.id)
 		const filter0 = appState.termfilter.filter0
-		this.prevFilter0 = this.state?.filter0 // will be used to detect cohort change
+		// will be used to detect cohort change; this.state is not set before the first update,
+		// in which case the baseline set in init() must be kept, so that the initial render of a
+		// matrix that is created with a filter0 is not detected as a cohort change
+		if (this.state) this.prevFilter0 = this.state.filter0
 
 		const parentConfig = appState.plots.find(p => p.id === this.parentId)
 		const termfilter = getCombinedTermFilter(appState, config.filter || parentConfig?.filter)
@@ -174,6 +180,8 @@ export class Matrix extends PlotBase {
 
 			this.dom.loadingDiv.selectAll('*').remove()
 			this.dom.loadingDiv.html('').style('display', '').style('position', 'relative').style('left', '45%')
+			// clear a message from a previous cohort change, in case this update returns early before it may be reshown
+			this.dom.cohortMsgDiv.html('').style('display', 'none')
 			this.dom.svg.style('opacity', 0.1).style('pointer-events', 'none')
 
 			// reset highlighted top/left dendrogram children to black when data request is triggered
@@ -236,6 +244,8 @@ export class Matrix extends PlotBase {
 			this.dom.loadingDiv.html('Rendering ...')
 			if (this.plotDendrogramHclust) this.plotDendrogramHclust()
 			this.render()
+			// the transient loading message is no longer needed once the matrix is rendered
+			this.dom.loadingDiv.style('display', 'none')
 			this.mayDisplayCohortMessage()
 			this.dom.svg.style('display', '').style('opacity', 1).style('pointer-events', '')
 
@@ -361,13 +371,8 @@ export class Matrix extends PlotBase {
 	mayDisplayCohortMessage() {
 		const msg = deepEqual(this.state.filter0, this.prevFilter0) ? '' : 'The gene list is persisted across cohorts.'
 		if (msg) {
-			this.dom.loadingDiv.html('')
-			const div = this.dom.loadingDiv
-				.append('div')
-				.style('display', 'inline-block')
-				.style('text-align', 'center')
-				.style('position', 'relative')
-				.style('left', '-150px')
+			this.dom.cohortMsgDiv.html('')
+			const div = this.dom.cohortMsgDiv.append('div').style('display', 'inline-block')
 			div.append('div').html(msg)
 
 			if (this.settings.matrix.showHints?.includes('genesetEdit')) {
@@ -398,7 +403,7 @@ export class Matrix extends PlotBase {
 					})
 			}
 		}
-		this.dom.loadingDiv.style('display', msg ? '' : 'none')
+		this.dom.cohortMsgDiv.style('display', msg ? '' : 'none')
 	}
 
 	sampleKey(s) {

--- a/client/plots/matrix/matrix.js
+++ b/client/plots/matrix/matrix.js
@@ -39,9 +39,6 @@ export class Matrix extends PlotBase {
 		this.setDom(opts)
 
 		this.config = appState.plots.find(p => p.id === this.id)
-		// the cohort that this matrix is created with is the baseline for detecting a cohort change later;
-		// must be set before setControls(), which calls getState()
-		this.prevFilter0 = appState.termfilter.filter0
 		this.settings = Object.assign({}, this.config.settings.matrix)
 		this.computed = {} // will hold settings/configuration/data that are computed or derived from other data
 		if (this.dom.header) this.dom.header.html(this.config.preBuiltPlotTitle || this.holderTitle)
@@ -138,10 +135,11 @@ export class Matrix extends PlotBase {
 	getState(appState) {
 		const config = appState.plots.find(p => p.id === this.id)
 		const filter0 = appState.termfilter.filter0
-		// will be used to detect cohort change; this.state is not set before the first update,
-		// in which case the baseline set in init() must be kept, so that the initial render of a
-		// matrix that is created with a filter0 is not detected as a cohort change
+		// will be used to detect cohort change. this.state is not set before the first update,
+		// in which case the cohort that this matrix is created with becomes the baseline, so that
+		// the initial render of a matrix that is created with a filter0 is not detected as a change
 		if (this.state) this.prevFilter0 = this.state.filter0
+		else if (this.prevFilter0 === undefined) this.prevFilter0 = filter0
 
 		const parentConfig = appState.plots.find(p => p.id === this.parentId)
 		const termfilter = getCombinedTermFilter(appState, config.filter || parentConfig?.filter)

--- a/client/plots/matrix/test/matrix.unit.spec.js
+++ b/client/plots/matrix/test/matrix.unit.spec.js
@@ -1,0 +1,128 @@
+import tape from 'tape'
+import { select } from 'd3-selection'
+import { Matrix } from '../matrix'
+
+/*************************
+ reusable helper functions
+**************************/
+
+const filter0A = { op: 'in', content: { field: 'cases.project.project_id', value: 'TCGA-PAAD' } }
+const filter0B = { op: 'in', content: { field: 'cases.project.project_id', value: 'TCGA-LAML' } }
+
+let i = 0
+
+// a minimal matrix instance, with only the properties that are used by
+// getState() and mayDisplayCohortMessage(), to avoid a server request
+function getMatrix() {
+	const id = `_${i++}`
+	const holder = select('body').append('div').attr('class', 'sja_root_holder')
+	return {
+		id,
+		app: {
+			vocabApi: {
+				hasVerifiedToken: () => true,
+				tokenVerificationMessage: undefined
+			}
+		},
+		// as assigned in main(), where settings.matrix is filled-in from config.settings
+		settings: { matrix: { showHints: ['genesetEdit'] } },
+		dom: {
+			cohortMsgDiv: holder.append('div').style('display', 'none')
+		},
+		controlsRenderer: { btns: select(null) },
+		getState: Matrix.prototype.getState,
+		mayDisplayCohortMessage: Matrix.prototype.mayDisplayCohortMessage
+	}
+}
+
+function getAppState(filter0) {
+	return {
+		plots: [],
+		termfilter: {
+			filter: { type: 'tvslst', join: '', in: 1, lst: [] },
+			filter0
+		},
+		termdbConfig: {},
+		vocab: {},
+		nav: {},
+		groups: []
+	}
+}
+
+// mimic how rx computes and assigns a component state before calling main()
+function update(matrix, filter0) {
+	const appState = getAppState(filter0)
+	appState.plots.push({ id: matrix.id, settings: { matrix: {} } })
+	matrix.state = matrix.getState(appState)
+	matrix.mayDisplayCohortMessage()
+}
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- plots/matrix -***-')
+	test.end()
+})
+
+tape('cohort message on filter0 change', function (test) {
+	const matrix = getMatrix()
+
+	// a matrix may be created with a cohort filter already applied, for example when launched
+	// from the GDC portal; that initial filter0 must not be detected as a cohort change
+	update(matrix, filter0A)
+	test.equal(
+		matrix.dom.cohortMsgDiv.style('display'),
+		'none',
+		'should not display the cohort message on the initial render with a filter0'
+	)
+
+	update(matrix, filter0A)
+	test.equal(
+		matrix.dom.cohortMsgDiv.style('display'),
+		'none',
+		'should not display the cohort message when filter0 does not change'
+	)
+
+	update(matrix, filter0B)
+	test.notEqual(
+		matrix.dom.cohortMsgDiv.style('display'),
+		'none',
+		'should display the cohort message when filter0 changes'
+	)
+	test.true(
+		matrix.dom.cohortMsgDiv.text().includes('The gene list is persisted across cohorts.'),
+		'should display the expected cohort message text'
+	)
+
+	update(matrix, filter0B)
+	test.equal(
+		matrix.dom.cohortMsgDiv.style('display'),
+		'none',
+		'should hide the cohort message on the next update after a cohort change'
+	)
+
+	test.end()
+})
+
+tape('no cohort message without filter0', function (test) {
+	const matrix = getMatrix()
+
+	// non-gdc datasets do not use filter0, the cohort message should never be displayed
+	update(matrix, undefined)
+	test.equal(
+		matrix.dom.cohortMsgDiv.style('display'),
+		'none',
+		'should not display the cohort message on the initial render without a filter0'
+	)
+
+	update(matrix, undefined)
+	test.equal(
+		matrix.dom.cohortMsgDiv.style('display'),
+		'none',
+		'should not display the cohort message on a subsequent render without a filter0'
+	)
+
+	test.end()
+})

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,2 @@
 Fixes:
-- matrix false positive of prevFilter0 fixed for showing cohortMsgDiv, also fixed placement bug
+- Fixes a false-positive cohort-change message on initial matrix render and corrects the message placement.

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- matrix false positive of prevFilter0 fixed for showing cohortMsgDiv, also fixed placement bug


### PR DESCRIPTION
…Div, also fixed placement bug

# Description

[this link](http://localhost:3000/?mass={%22dslabel%22:%22GDC%22,%22genome%22:%22hg38%22,%22nav%22:{%22activeTab%22:1},%22termfilter%22:{%22filter0%22:{%22op%22:%22in%22,%22content%22:{%22field%22:%22cases.project.project_id%22,%22value%22:%22TCGA-PAAD%22}}},%22plots%22:[{%22chartType%22:%22matrix%22,%22termgroups%22:[{%22lst%22:[{%22term%22:{%22gene%22:%22KRAS%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22KRAS%22,%22type%22:%22geneVariant%22}},{%22term%22:{%22gene%22:%22KRAS%22,%22type%22:%22geneVariant%22}}]}]}]}) directly shows view-blocking msg via a false positive bug

<img width="541" height="68" alt="image" src="https://github.com/user-attachments/assets/3f5638ba-752e-4f49-a25f-907a959eaad8" />



msg display fixed as true positive via [this](http://localhost:3000/example.gdc.matrix.html?cohort=Gliomas):

<img width="542" height="150" alt="image" src="https://github.com/user-attachments/assets/bc036d61-d46b-4423-ae11-2ef0a25c042b" />

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
