### PR TITLE
fix: cut down geneVariant tw size in state using trimGvTermsForSave a…

### DIFF
--- a/client/mass/sessionBtn.js
+++ b/client/mass/sessionBtn.js
@@ -5,6 +5,7 @@ import { dofetch3 } from '#common/dofetch'
 import { parentCorsMessage } from '#common/embedder-helpers'
 import { select } from 'd3-selection'
 import { importPlot } from '#plots/importPlot.js'
+import { trimGvTermsForSave } from '#shared/terms.js'
 
 class MassSessionBtn {
 	static type = 'sessionBtn'
@@ -293,7 +294,7 @@ class MassSessionBtn {
 			)
 			.on('click', () => {
 				this.sessionName = input.property('value') || placeholder
-				this.savedSessions[this.sessionName] = this.app.getState()
+				this.savedSessions[this.sessionName] = this.getSavableState()
 				localStorage.setItem('savedMassSessions', JSON.stringify(this.savedSessions))
 				this.confirmAction(`Cached '<b>${this.sessionName}</b>' in browser`)
 			})
@@ -308,7 +309,7 @@ class MassSessionBtn {
 			)
 			.on('click', () => {
 				const name = input.property('value') || placeholder
-				this.savedSessions[name] = this.app.getState()
+				this.savedSessions[name] = this.getSavableState()
 				this.download(name)
 				this.confirmAction(`Downloaded '<b>${name}</b>'`)
 			})
@@ -332,13 +333,28 @@ class MassSessionBtn {
 						return
 					}
 					const name = input.property('value') || placeholder
-					this.savedSessions[name] = this.app.getState()
+					this.savedSessions[name] = this.getSavableState()
 					const res = await this.getSessionUrl(name)
 					if (res.id != name) throw `error saving ${name}`
 					// this.download(name)
 					this.confirmAction(`Saved '<b>${name}</b>' on the server`)
 				})
 		}
+	}
+
+	/* the state to serialize into a saved session: a detached copy of the app state, since
+	getState() returns a deeply frozen one, minus everything that opening the session
+	rebuilds anyway */
+	getSavableState() {
+		const state = structuredClone(this.app.getState())
+		/* the dataset config, not session data, and the largest thing in a saved session by
+		far. a saved copy is never read back: init() in mass/store.ts re-fetches it before
+		any consumer runs, and preprocessState() below deletes it outright. keeping it would
+		also pin a session to the ds config of the day it was saved */
+		delete state.termdbConfig
+		// the derived properties of a geneVariant term, which every path that opens a
+		// session re-fills, see trimGvTermsForSave()
+		return trimGvTermsForSave(state)
 	}
 
 	download(name = '') {
@@ -350,7 +366,7 @@ class MassSessionBtn {
 
 	async getSessionUrl(filename = '') {
 		const headers = await this.app.vocabApi.mayGetAuthHeaders('termdb')
-		const state = structuredClone(this.app.getState())
+		const state = this.getSavableState()
 		const { protocol, host, search, origin, href } = window.location
 		state.embedder = { protocol, host, search, origin, href }
 		if (filename) {

--- a/client/plots/brainImaging.ts
+++ b/client/plots/brainImaging.ts
@@ -2,21 +2,22 @@ import { getCompInit, copyMerge, type RxComponent, type ComponentApi } from '#rx
 import { PlotBase } from '#plots/PlotBase.ts'
 import { controlsInit } from './controls'
 import { getT0T2defaultQ } from './summaryQ.ts'
+import { fillTermWrapper } from '#termsetting'
 import { dofetch3 } from '#common/dofetch'
 import { Menu, renderTable, type TableRow, type TableColumn } from '#dom'
 import svgLegend from '#dom/svg.legend'
 import { scaleLinear } from 'd3-scale'
 import { rgb } from 'd3-color'
 
-type ImgData ={ data: any; td: any; dataUrls: any }
+type ImgData = { data: any; td: any; dataUrls: any }
 
-class BrainImaging extends PlotBase implements RxComponent{
+class BrainImaging extends PlotBase implements RxComponent {
 	static type = 'brainImaging'
 
 	type: string
 	components: { controls: any }
 	legendLabelMouseup!: any
-	imagesData!: {[index: string]: ImgData }
+	imagesData!: { [index: string]: ImgData }
 	legendRenderer!: any
 	legendItems!: any
 	legendValues!: { [index: string]: { color: string; maxLength: number; crossedOut: boolean } }
@@ -25,7 +26,7 @@ class BrainImaging extends PlotBase implements RxComponent{
 	dom!: any
 
 	constructor(opts: any, api: ComponentApi) {
-        super(opts, api)
+		super(opts, api)
 		this.type = BrainImaging.type
 		this.components = { controls: {} }
 		setInteractivity(this)
@@ -398,12 +399,18 @@ export function makeChartBtnMenu(holder, chartsInstance: any) {
 export const brainImaging = getCompInit(BrainImaging)
 export const componentInit = brainImaging
 
-export async function getPlotConfig(opts) {
+export async function getPlotConfig(opts, app) {
 	const settings = {
 		brainImaging: { brainImageL: 76, brainImageF: 116, brainImageT: 80 }
 	}
-	const config = { chartType: 'brainImaging', settings, hidePlotFilter: true }
-	return copyMerge(config, opts)
+	const config: any = { chartType: 'brainImaging', settings, hidePlotFilter: true }
+	copyMerge(config, opts)
+	/* a tw of a saved session is only raw until it is filled here, same as every other
+	chart type. required, since a session is serialized without the derived properties
+	of a geneVariant term, see trimGvTermsForSave() */
+	if (config.overlayTW) config.overlayTW = await fillTermWrapper(config.overlayTW, app.vocabApi)
+	if (config.divideByTW) config.divideByTW = await fillTermWrapper(config.divideByTW, app.vocabApi)
+	return config
 }
 
 async function getTableData(self, samples, state, refKey): Promise<[TableRow[], TableColumn[]]> {

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -3,6 +3,7 @@ import type { GvTW } from '#types'
 import { vocabInit } from '#termdb/vocabulary'
 import { GvBase, GvPredefinedGS } from '../geneVariant'
 import { dtsnvindel, dtcnv } from '#shared/common.js'
+import { trimGvTermsForSave } from '#shared/terms.js'
 
 /*************************
  reusable helper functions
@@ -292,6 +293,61 @@ tape('fill(): rehydrated predefined groupset', async test => {
 		rehydrated.term.groupsetting.lst[rehydrated.q.predefined_groupset_idx].name,
 		'SNV/indel (germline)',
 		'should keep the germline groupset selected'
+	)
+	test.end()
+})
+
+tape('trimGvTermsForSave(): a trimmed tw refills to the same tw', async test => {
+	/* a session is serialized without the derived properties of a geneVariant term, so
+	whatever is dropped there has to be rebuilt by fill() when the session is opened */
+	for (const idx of [0, 1, 2, 3, 4, 5]) {
+		const tw: any = getGsTw({ isAtomic: true, type: 'predefined-groupset', predefined_groupset_idx: idx })
+		const fullTw: any = await GvBase.fill(tw, { vocabApi })
+
+		// what sessionBtn.getSavableState() writes, then what opening the session reads
+		const saved = trimGvTermsForSave({ term: structuredClone(fullTw) }).term
+		const reopened: any = await GvBase.fill(JSON.parse(JSON.stringify(saved)), { vocabApi })
+
+		test.deepEqual(reopened, fullTw, `groupset ${idx}: should refill to the same tw as before the trim`)
+	}
+	test.end()
+})
+
+tape('trimGvTermsForSave(): shrinks a saved geneVariant tw', async test => {
+	// the ratio is measured on a real filled-in tw, since the redundancy that dominates it
+	// (a parentTerm per child dt term, a dt term per tvs of the selected groupset) only
+	// shows up at the size the dataset actually fills in
+	const tw: any = getGsTw({ isAtomic: true, type: 'predefined-groupset', predefined_groupset_idx: 0 })
+	const fullTw: any = await GvBase.fill(tw, { vocabApi })
+	const before = JSON.stringify(fullTw).length
+	const after = JSON.stringify(trimGvTermsForSave({ term: structuredClone(fullTw) }).term).length
+	test.comment(
+		`single-gene tw: ${before} -> ${after} bytes (${Math.round((100 * (before - after)) / before)}% smaller)`
+	)
+	test.ok(after < before * 0.2, `should cut a single-gene tw by more than 80% (${before} -> ${after} bytes)`)
+
+	/* term.genes[] is serialized once per childTerm.parentTerm and once per tvs of the
+	selected groupset, so both the untrimmed size and the saving grow with the gene count,
+	while the trimmed tw grows by just the one copy of genes[] that it keeps */
+	const setTw: any = {
+		term: {
+			name: 'my gene set',
+			genes: ['TP53', 'KRAS'].map(name => ({ kind: 'gene', id: name, gene: name, name, type: 'geneVariant' })),
+			type: 'geneVariant'
+		},
+		isAtomic: true,
+		q: { isAtomic: true, type: 'predefined-groupset', predefined_groupset_idx: 0 }
+	}
+	const fullSetTw: any = await GvBase.fill(setTw, { vocabApi })
+	const setBefore = JSON.stringify(fullSetTw).length
+	const setAfter = JSON.stringify(trimGvTermsForSave({ term: structuredClone(fullSetTw) }).term).length
+	const growthBefore = setBefore - before
+	const growthAfter = setAfter - after
+	test.comment(`2-gene tw: ${setBefore} -> ${setAfter} bytes`)
+	test.comment(`cost of the 2nd gene: ${growthBefore} bytes untrimmed vs ${growthAfter} bytes trimmed`)
+	test.ok(
+		growthBefore > growthAfter * 5,
+		`each added gene should cost several times more untrimmed, since genes[] is serialized once per parentTerm and per tvs (${growthBefore} vs ${growthAfter} bytes)`
 	)
 	test.end()
 })

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- cut down geneVariant tw size in state using trimGvTermsForSave as chokepoint

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -247,6 +247,38 @@ export function trimGvTermCopy(term: any, q: any) {
 	return term
 }
 
+/*
+Strip every derived property of a geneVariant term from a state that is about to be
+serialized into a saved session, in place. Walks any object and trims the term of each
+geneVariant tw it finds, so it accepts a whole state, a state.plots[], or one plot config.
+
+This goes further than trimGvTermCopy() above, which shapes a request payload and so has
+to keep whatever the server reads. Nothing here has to survive, because a saved session is
+always re-filled before it is rendered:
+- a session opened by url is filled by getPlotConfig() in init(), see client/mass/store.ts
+- a session opened in a running app is filled by preprocessState(), see client/mass/sessionBtn.js
+and GvBase.fill() rebuilds term.childTerms[] from termdbConfig, term.groupsetting from the
+child terms, and each childTerm.parentTerm from the term itself.
+
+Between them these are ~91% of a serialized single-gene tw, and the ratio climbs with the
+gene count: term.genes[] is serialized once per childTerm.parentTerm and once per tvs of the
+selected groupset, so a 200-gene tw carries ~9 copies of it.
+
+A tw is identified by a term{} paired with a q{}, so that the dt term of a tvs, which does
+need its parentTerm server-side, is never mistaken for one. q is left alone: q.customset is
+user-authored and no fill() rebuilds it.
+*/
+export function trimGvTermsForSave(obj: any) {
+	if (!obj || typeof obj != 'object') return obj
+	if (obj.q && obj.term?.type == GENE_VARIANT) {
+		delete obj.term.childTerms
+		// deleting rather than emptying, since GvBase.fill() recreates it from scratch
+		delete obj.term.groupsetting
+	}
+	for (const k in obj) trimGvTermsForSave(obj[k])
+	return obj
+}
+
 /* the dts queried by a set of groups, read off the dt term of each tvs of their filters */
 export function getDtsFromGroups(groups: any[]): any[] {
 	const dts = new Set<any>()

--- a/shared/utils/src/test/terms.unit.spec.ts
+++ b/shared/utils/src/test/terms.unit.spec.ts
@@ -1,11 +1,70 @@
 import tape from 'tape'
 import { DTCNV, DTFUSION, DTITD, DTSNVINDEL, DTSV, TermTypes } from '#types'
-import { dtTermTypes } from '../terms.js'
+import { dtTermTypes, trimGvTermsForSave } from '../terms.js'
 
 /* test sections
 
 dt term types are declared in TermTypes
+trimGvTermsForSave()
 */
+
+// a filled-in geneVariant tw, reduced to the properties the trim reads
+function getFilledGvTw() {
+	const parentTerm = {
+		type: 'geneVariant',
+		id: 'TP53',
+		name: 'TP53',
+		genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', type: 'geneVariant' }]
+	}
+	const dtTerm = {
+		id: 'snvindel_somatic',
+		name: 'SNV/indel (somatic)',
+		type: 'dtsnvindel',
+		dt: DTSNVINDEL,
+		origin: 'somatic',
+		values: { M: { key: 'M', label: 'MISSENSE' } },
+		parentTerm: structuredClone(parentTerm)
+	}
+	return {
+		isAtomic: true,
+		type: 'GvPredefinedGsTW',
+		$id: 'TwBase_0',
+		term: {
+			...structuredClone(parentTerm),
+			childTerms: [dtTerm],
+			groupsetting: {
+				disabled: false,
+				lst: [
+					{
+						name: 'SNV/indel (somatic)',
+						dt: DTSNVINDEL,
+						origin: 'somatic',
+						groups: [
+							{
+								name: 'TP53 SNV/indel Mutated (somatic)',
+								type: 'filter',
+								filter: {
+									type: 'tvslst',
+									in: true,
+									join: '',
+									lst: [{ type: 'tvs', tvs: { term: dtTerm, values: [] } }]
+								}
+							}
+						]
+					},
+					{ name: 'CNV', dt: DTCNV }
+				]
+			}
+		},
+		q: {
+			type: 'predefined-groupset',
+			predefined_groupset_idx: 0,
+			isAtomic: true,
+			dtLst: [DTSNVINDEL],
+			hiddenValues: {}
+		}
+	}
+}
 
 tape('\n', function (test) {
 	test.comment('-***- terms specs -***-')
@@ -24,5 +83,69 @@ tape('dt term types are declared in TermTypes', t => {
 	for (const dtTermType of dtTermTypes) {
 		t.ok(termTypeValues.has(dtTermType), `TermTypes has an entry for '${dtTermType}'`)
 	}
+	t.end()
+})
+
+tape('trimGvTermsForSave()', t => {
+	const state = { plots: [{ chartType: 'summary', term: getFilledGvTw() }] }
+	trimGvTermsForSave(state)
+	const tw = state.plots[0].term
+
+	t.equal(tw.term.childTerms, undefined, 'should remove term.childTerms[]')
+	t.equal(tw.term.groupsetting, undefined, 'should remove term.groupsetting')
+	t.deepEqual(
+		tw.term.genes,
+		[{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', type: 'geneVariant' }],
+		'should keep term.genes[], which fill() cannot rebuild'
+	)
+	t.deepEqual(
+		tw.q,
+		{ type: 'predefined-groupset', predefined_groupset_idx: 0, isAtomic: true, dtLst: [DTSNVINDEL], hiddenValues: {} },
+		'should not touch q, which carries the groupset selection'
+	)
+	t.equal(tw.$id, 'TwBase_0', 'should keep tw.$id')
+	t.end()
+})
+
+tape('trimGvTermsForSave(): terms it must not trim', t => {
+	// a custom groupset is user-authored and no fill() rebuilds it
+	const customTw: any = getFilledGvTw()
+	const dtTerm = customTw.term.childTerms[0]
+	customTw.q = {
+		type: 'custom-groupset',
+		customset: {
+			groups: [
+				{
+					name: 'my group',
+					type: 'filter',
+					filter: { type: 'tvslst', in: true, join: '', lst: [{ type: 'tvs', tvs: { term: dtTerm, values: [] } }] }
+				}
+			]
+		}
+	}
+	// a tvs holds a term{} without a q{}, and its dt term needs the parentTerm that
+	// get_dtTerm() reads in server/src/termdb.filter.js
+	const filterTvs = { type: 'tvs', tvs: { term: structuredClone(dtTerm), values: [] } }
+	const state = { plots: [{ chartType: 'summary', term: customTw }], termfilter: { filter: { lst: [filterTvs] } } }
+	trimGvTermsForSave(state)
+
+	t.ok(state.plots[0].term.q.customset.groups.length, 'should keep q.customset of a custom groupset')
+	t.ok(
+		state.plots[0].term.q.customset.groups[0].filter.lst[0].tvs.term.parentTerm,
+		'should keep the parentTerm of a customset tvs term'
+	)
+	t.ok(state.termfilter.filter.lst[0].tvs.term.parentTerm, 'should keep the parentTerm of a filter tvs term')
+	t.end()
+})
+
+tape('trimGvTermsForSave(): leaves other term types alone', t => {
+	const state = {
+		plots: [
+			{ term: { term: { id: 'sex', type: 'categorical', values: { 1: { label: 'M' } } }, q: { type: 'values' } } }
+		]
+	}
+	const copy = structuredClone(state)
+	trimGvTermsForSave(state)
+	t.deepEqual(state, copy, 'should not modify a non-geneVariant tw')
 	t.end()
 })


### PR DESCRIPTION
…s chokepoint

# Description
in one instance, tw size is reduced from 3766 to 283 bytes in state
also termdbConfig is dropped
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
