### PR TITLE
dtTerm misc fix: parentTerm duplicated per tvs, rederive q.dtLst

### DIFF
--- a/client/termsetting/TermSetting.ts
+++ b/client/termsetting/TermSetting.ts
@@ -75,6 +75,10 @@ export class TermSetting {
 	error: string | undefined
 	filter: Filter | undefined
 	groups?: any
+	/** name of the term groups[] was built for. this instance is reused across terms
+	 * (see main() in TermSettingApi.ts), so groups[] must be discarded when it no
+	 * longer matches, see makeGroupUI() in handlers/geneVariant.ts */
+	groupsTermName?: string
 
 	constructor(opts: TermSettingOpts) {
 		this.opts = this.validateOpts(opts)

--- a/client/termsetting/TermSetting.ts
+++ b/client/termsetting/TermSetting.ts
@@ -75,10 +75,6 @@ export class TermSetting {
 	error: string | undefined
 	filter: Filter | undefined
 	groups?: any
-	/** name of the term groups[] was built for. this instance is reused across terms
-	 * (see main() in TermSettingApi.ts), so groups[] must be discarded when it no
-	 * longer matches, see makeGroupUI() in handlers/geneVariant.ts */
-	groupsTermName?: string
 
 	constructor(opts: TermSettingOpts) {
 		this.opts = this.validateOpts(opts)

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -135,7 +135,14 @@ async function makeGroupUI(self: TermSetting, div) {
 	const q = self.q as any // TODO: migrate this handler to use client/tw code
 	// get groups
 	if (q.type != 'predefined-groupset' && q.type != 'custom-groupset') throw 'unexpected q.type'
+	/* groups[] is cached on the termsetting instance so that edits survive the re-render
+	that every change to it triggers. but the instance is reused when the pill is switched
+	to another term (see main() in TermSettingApi.ts), and the groups of a geneVariant term
+	are gene-specific: the gene is in every group name and in the parentTerm of every tvs.
+	so a cache built for another term is dropped rather than applied to this one */
+	if (self.groups && self.groupsTermName != self.term.name) delete self.groups
 	if (!self.groups) {
+		self.groupsTermName = self.term.name
 		let groupset
 		if (q.type == 'predefined-groupset') {
 			const groupsetting = self.term.groupsetting

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -51,6 +51,13 @@ async function makeEditMenu(self: TermSetting, _div: any) {
 	/* TODO: instead of directly modifying self.q here, should create a separate property on the handler to store pending user
 	configurations (similar to numeric continuous/discrete switching)
 	const handler = self.handlerByType.geneVariant */
+	/* groups[] is scratch state of this menu, held only so that edits survive the re-render
+	that each change to it triggers, see makeGroupUI(). it must not outlive the menu: the
+	termsetting instance is reused across tws (see main() in TermSettingApi.ts, and the pill
+	shared by every matrix row in matrix.interactivity.js), and nothing on a cached groups[]
+	says which tw it was built for. this runs once per opening of the menu, while every
+	makeGroupUI() call descends from it */
+	delete self.groups
 	const div = _div.append('div').style('margin', '10px')
 	div.append('div').style('font-size', '1.2rem').text(self.term.name)
 	const optsDiv = div.append('div').style('margin-top', '10px').style('margin-bottom', '1px')
@@ -135,14 +142,9 @@ async function makeGroupUI(self: TermSetting, div) {
 	const q = self.q as any // TODO: migrate this handler to use client/tw code
 	// get groups
 	if (q.type != 'predefined-groupset' && q.type != 'custom-groupset') throw 'unexpected q.type'
-	/* groups[] is cached on the termsetting instance so that edits survive the re-render
-	that every change to it triggers. but the instance is reused when the pill is switched
-	to another term (see main() in TermSettingApi.ts), and the groups of a geneVariant term
-	are gene-specific: the gene is in every group name and in the parentTerm of every tvs.
-	so a cache built for another term is dropped rather than applied to this one */
-	if (self.groups && self.groupsTermName != self.term.name) delete self.groups
+	// groups[] is built once per opening of the edit menu, which cleared it, and is
+	// then reused across the re-renders that the edits below trigger
 	if (!self.groups) {
-		self.groupsTermName = self.term.name
 		let groupset
 		if (q.type == 'predefined-groupset') {
 			const groupsetting = self.term.groupsetting

--- a/client/tw/geneVariant.ts
+++ b/client/tw/geneVariant.ts
@@ -24,7 +24,7 @@ import { getWrappedTvslst } from '#filter/filter'
 import { getDtTermValues } from '#filter/tvs.dt'
 import { getChildTerms, addParentTerm } from '../termdb/handlers/geneVariant'
 import { getColors, dtcnv, dtsnvindel, mclass } from '#shared/common.js'
-import { trimGvTermCopy, clearDtTermMnames, getDtsFromGroups } from '#shared/terms.js'
+import { trimGvTermCopy, clearDtTermMnames, getDtsFromGroups, setGroupsetParentTerms } from '#shared/terms.js'
 import { validateVariantFilter } from '#shared/geneVariantFilter.js'
 import { rgb } from 'd3-color'
 
@@ -330,7 +330,16 @@ export class GvCustomGS extends GvBase {
 		// saved before mnames became opt-in is also corrected. a predefined groupset needs
 		// no equivalent, since getPredefinedGroupsets() rebuilds it on every fill
 		clearDtTermMnames(q.customset)
-		if (!q.dtLst?.length) q.dtLst = getDtsFromGroups(q.customset.groups)
+		/* the parent of every customset tvs is this term. re-attached rather than trusted,
+		so that a customset built against another term cannot survive here, and validates
+		that each tvs filters by a dt. also throws on a customset whose tvs terms are not
+		dt terms, which the server would otherwise reject deep in filterByItem() */
+		setGroupsetParentTerms(q.customset, term)
+		/* always re-derived, never trusted: a dtLst that disagrees with the groups silently
+		limits the dts queried for the term, dropping a group's data (see getDtsToQuery() in
+		server/src/mds3.init.js). same reason GvPredefinedGS.fill() re-derives it from the
+		selected index, and GvValues.fill() deletes it outright */
+		q.dtLst = getDtsFromGroups(q.customset.groups)
 		set_hiddenvalues(q, term)
 		return tw as GvCustomGsTW
 	}

--- a/client/tw/test/geneVariant.integration.spec.ts
+++ b/client/tw/test/geneVariant.integration.spec.ts
@@ -424,6 +424,84 @@ tape('fill(): q.type=custom-groupset, stale mnames', async test => {
 	test.end()
 })
 
+tape('fill(): q.type=custom-groupset, re-attaches the parentTerm of each tvs', async test => {
+	/* a termsetting instance is reused when the pill is switched to another term, so a
+	customset can arrive naming a gene the tw is not about. it can also arrive with no
+	parentTerm at all, since a saved session is trimmed of them */
+	const q: any = structuredClone(customGsQ)
+	const tvsTerms = q.customset.groups.map(g => g.filter.lst[0].tvs.term)
+	tvsTerms[0].parentTerm = {
+		name: 'KRAS',
+		type: 'geneVariant',
+		genes: [{ kind: 'gene', id: 'KRAS', gene: 'KRAS', name: 'KRAS', type: 'geneVariant' }]
+	}
+	delete tvsTerms[1].parentTerm
+	const tw: any = {
+		term: {
+			name: 'TP53',
+			genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', type: 'geneVariant' }],
+			type: 'geneVariant'
+		},
+		isAtomic: true,
+		q
+	}
+	const fullTw: any = await GvBase.fill(tw, { vocabApi })
+	const filled = fullTw.q.customset.groups.map(g => g.filter.lst[0].tvs.term)
+	test.deepEqual(
+		filled.map(t => t.parentTerm?.name),
+		['TP53', 'TP53'],
+		'should attach the term of the tw as the parentTerm of every tvs'
+	)
+	test.equal(
+		filled[0].parentTerm.childTerms,
+		undefined,
+		'should not nest the derived childTerms[] in an attached parentTerm'
+	)
+	test.end()
+})
+
+tape('fill(): q.type=custom-groupset, stale q.dtLst', async test => {
+	// a dtLst that disagrees with the groups would limit the dts queried for the term,
+	// so a group of a dt missing from it would never match, see getDtsToQuery()
+	const q: any = structuredClone(customGsQ)
+	q.dtLst = [dtcnv]
+	const tw: any = {
+		term: {
+			name: 'TP53',
+			genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', type: 'geneVariant' }],
+			type: 'geneVariant'
+		},
+		isAtomic: true,
+		q
+	}
+	const fullTw: any = await GvBase.fill(tw, { vocabApi })
+	test.deepEqual(fullTw.q.dtLst, [dtsnvindel], 'should re-derive q.dtLst from the customset groups')
+	test.end()
+})
+
+tape('fill(): q.type=custom-groupset, a tvs that does not filter by dt', async test => {
+	// the groups of a geneVariant groupset can only filter by dt; the server would
+	// otherwise reject the customset deep in filterByItem()
+	const q: any = structuredClone(customGsQ)
+	q.customset.groups[0].filter.lst[0].tvs.term = { id: 'sex', type: 'categorical' }
+	const tw: any = {
+		term: {
+			name: 'TP53',
+			genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', type: 'geneVariant' }],
+			type: 'geneVariant'
+		},
+		isAtomic: true,
+		q
+	}
+	try {
+		await GvBase.fill(tw, { vocabApi })
+		test.fail('should throw on a customset tvs that is not a dt term')
+	} catch (e: any) {
+		test.ok(String(e).includes('not a dt term'), 'should throw on a customset tvs that is not a dt term')
+	}
+	test.end()
+})
+
 tape('getMinCopy(): trims the derived term properties', async test => {
 	const tw: any = {
 		term: {
@@ -466,9 +544,11 @@ tape('getMinCopy(): trims the derived term properties', async test => {
 		tvsTerms.every(t => !('mnames' in t)),
 		'should remove mnames from every tvs term'
 	)
+	/* the parent of a groupset tvs is the term of this very tw, which the payload already
+	carries. the server reads the gene off tw.term, see mayFilterCnvByOverlap() */
 	test.ok(
-		tvsTerms.every(t => t.parentTerm?.genes?.length),
-		'should keep tvs.term.parentTerm, which get_dtTerm() reads server-side'
+		tvsTerms.every(t => !('parentTerm' in t)),
+		'should remove parentTerm from every tvs term'
 	)
 
 	// the trim is destructive, so it must only ever run on the copy

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -3488,11 +3488,16 @@ function mayFilterCnvByOverlap(cnv, tvs, tw) {
 	if (!tvs.fractionOverlap) return true
 	if (!Number.isFinite(tvs.fractionOverlap)) throw new Error('tvs.fractionOverlap is non-numeric')
 	if (tvs.fractionOverlap < 0 || tvs.fractionOverlap > 1) throw new Error('tvs.fractionOverlap is out of range')
-	let gene = tvs.term.parentTerm.genes.find(g => g.gene == cnv.gene)
-	if (!gene.hasOwnProperty('start') || !gene.hasOwnProperty('stop')) {
-		// start/stop may not be annotated on tvs.term, but rather on tw.term
-		gene = tw.term.genes.find(g => g.gene == cnv.gene)
-	}
+	/* the queried gene comes off tw.term, whose genes[] mayMapGeneName2coord() annotated
+	with the coordinates when the cnv query ran. a groupset tvs is evaluated against the tw
+	that holds the groupset and carries no parentTerm of its own (see setGroupsetParentTerms()
+	in shared/utils/src/terms.ts), so there the tw is the only source. a standalone tvs of a
+	mass filter has no tw, and falls back to its own parentTerm, which is the term its caller
+	queried with and so is annotated the same way, see get_dtTerm() in termdb.filter.js */
+	const term = tw?.term || tvs.term.parentTerm
+	if (!term?.genes) throw new Error('cnv tvs has neither a tw nor a parentTerm to resolve the gene from')
+	const gene = term.genes.find(g => g.gene == cnv.gene)
+	if (!gene) throw new Error(`no queried gene matches cnv.gene='${cnv.gene}'`)
 	for (const v of [gene.start, gene.stop, cnv.start, cnv.stop]) {
 		if (!Number.isInteger(v)) throw new Error(`${v} is not an integer`)
 	}

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -601,7 +601,8 @@ async function get_dtTerm(tvs, CTEname, ds) {
 		const mlst = value[$id]?.values
 		if (!mlst) throw 'mlst is missing'
 		const filter = { type: 'tvs', tvs }
-		const [pass, tested] = filterByItem(filter, mlst)
+		// the tw is what a cnv tvs resolves the queried gene from, see mayFilterCnvByOverlap()
+		const [pass, tested] = filterByItem(filter, mlst, undefined, tw)
 		if (pass) samples.push(sample)
 	}
 

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -47,6 +47,7 @@ Tests:
 	filterByTvsLst: in=false
 	filterByTvsLst: nested tvslst
 	filterByTvsLst: nested cnv tvs resolves gene coords from the tw
+	filterByItem: standalone cnv tvs resolves gene coords from its parentTerm
 	filterByTvsLst: values[] only collects mutations of a matching tvs
 	mayFilterByMaf: basic mafFilter
 	mayFilterByMaf: mafFilter with child ids
@@ -1756,15 +1757,10 @@ test('filterByTvsLst: nested tvslst', t => {
 
 test('filterByTvsLst: nested cnv tvs resolves gene coords from the tw', t => {
 	t.plan(4)
-	/* a cnv tvs built by the config ui always carries fractionOverlap, and the parentTerm
-	it carries never has gene coords: those are only annotated onto tw.term when the cnv
-	query runs. so the tw has to reach the tvs even when it sits in a sublist, as it does
-	in a custom groupset that mixes joins */
-	const parentTerm = {
-		name: 'TP53',
-		type: 'geneVariant',
-		genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53' }]
-	}
+	/* a cnv tvs built by the config ui always carries fractionOverlap, and a groupset tvs
+	carries no parentTerm of its own, so the tw is the only source of the queried gene. it
+	has to reach the tvs even when it sits in a sublist, as it does in a custom groupset
+	that mixes joins */
 	const tw = {
 		term: {
 			name: 'TP53',
@@ -1775,7 +1771,7 @@ test('filterByTvsLst: nested cnv tvs resolves gene coords from the tw', t => {
 	const cnvTvs = {
 		type: 'tvs',
 		tvs: {
-			term: { dt: 4, type: 'dtcnv', parentTerm },
+			term: { dt: 4, type: 'dtcnv' },
 			values: [],
 			continuousCnv: true,
 			cnvGainCutoff: 0.5,
@@ -1818,6 +1814,48 @@ test('filterByTvsLst: nested cnv tvs resolves gene coords from the tw', t => {
 		const [pass, tested] = filterByTvsLst(filter, mlst, undefined, tw)
 		t.equal(pass, false, 'Sample fails when the nested cnv segment is under the overlap')
 		t.equal(tested, true, 'Sample is tested')
+	}
+})
+
+test('filterByItem: standalone cnv tvs resolves gene coords from its parentTerm', t => {
+	t.plan(3)
+	/* a tvs of a mass filter is not evaluated against a tw. get_dtTerm() in termdb.filter.js
+	queries with tvs.term.parentTerm, so that is the term annotated with the coordinates */
+	const parentTerm = {
+		name: 'TP53',
+		type: 'geneVariant',
+		genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', chr: 'chr17', start: 0, stop: 100 }]
+	}
+	const filter = {
+		type: 'tvs',
+		tvs: {
+			term: { dt: 4, type: 'dtcnv', parentTerm },
+			values: [],
+			continuousCnv: true,
+			cnvGainCutoff: 0.5,
+			cnvLossCutoff: -0.5,
+			cnvMaxLength: null,
+			fractionOverlap: 0.8
+		}
+	}
+	{
+		const [pass] = filterByItem(filter, [{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 100 }])
+		t.equal(pass, true, 'Sample passes when the cnv segment meets the overlap')
+	}
+	{
+		const [pass] = filterByItem(filter, [{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 10 }])
+		t.equal(pass, false, 'Sample fails when the cnv segment is under the overlap')
+	}
+	{
+		// a gene the tvs was not built for cannot be measured against, and used to be
+		// read as a TypeError on the undefined result of the lookup
+		const noParent = structuredClone(filter)
+		delete noParent.tvs.term.parentTerm
+		t.throws(
+			() => filterByItem(noParent, [{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 100 }]),
+			/neither a tw nor a parentTerm/,
+			'throws when the queried gene cannot be resolved'
+		)
 	}
 })
 

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -222,16 +222,17 @@ None of it is needed to answer a data request:
 - dtTerm.mnames[] (the amino acid change tally) is only read by the tvs edit UI,
   which re-queries it in fillMenu() before rendering
 
-Trimming these shrinks a single-gene request payload by ~80%. Do NOT trim
-tvs.term.parentTerm: it is read by get_dtTerm() in server/src/termdb.filter.js
-and by the cnv gene lookup in server/src/mds3.init.js.
+Trimming these shrinks a single-gene request payload by ~80%.
 
-term{} is mutated in place, so only call this on a copy that is about to be
-serialized into a request payload, never on a tw held in state.
+term{} and q{} are mutated in place, so only call this on a copy that is about to
+be serialized into a request payload, never on a tw held in state.
 */
 export function trimGvTermCopy(term: any, q: any) {
 	if (term?.type != GENE_VARIANT) return term
 	delete term.childTerms
+	/* the parent of a groupset tvs is this very term, and the server reads it off the
+	tw rather than off the tvs, see setGroupsetParentTerms() */
+	if (q?.customset) clearGroupsetParentTerms(q.customset)
 	const lst = term.groupsetting?.lst
 	if (!lst?.length) return term
 	if (q?.type == 'predefined-groupset') {
@@ -240,6 +241,7 @@ export function trimGvTermCopy(term: any, q: any) {
 		const idx = q.predefined_groupset_idx
 		term.groupsetting.lst = lst.map((groupset: any, i: number) => (i === idx ? groupset : null))
 		clearDtTermMnames(term.groupsetting.lst[idx])
+		clearGroupsetParentTerms(term.groupsetting.lst[idx])
 	} else {
 		// no predefined groupset is in use, so no entry of lst[] is read server-side
 		delete term.groupsetting.lst
@@ -264,9 +266,10 @@ Between them these are ~91% of a serialized single-gene tw, and the ratio climbs
 gene count: term.genes[] is serialized once per childTerm.parentTerm and once per tvs of the
 selected groupset, so a 200-gene tw carries ~9 copies of it.
 
-A tw is identified by a term{} paired with a q{}, so that the dt term of a tvs, which does
-need its parentTerm server-side, is never mistaken for one. q is left alone: q.customset is
-user-authored and no fill() rebuilds it.
+A tw is identified by a term{} paired with a q{}, so that the dt term of a tvs of a mass
+filter, which does need its own parentTerm, is never mistaken for one. Of q{}, only the
+parentTerm of a customset tvs is trimmed, which GvCustomGS.fill() re-attaches; the rest of
+q.customset is user-authored and no fill() rebuilds it.
 */
 export function trimGvTermsForSave(obj: any) {
 	if (!obj || typeof obj != 'object') return obj
@@ -274,9 +277,71 @@ export function trimGvTermsForSave(obj: any) {
 		delete obj.term.childTerms
 		// deleting rather than emptying, since GvBase.fill() recreates it from scratch
 		delete obj.term.groupsetting
+		if (obj.q.customset) clearGroupsetParentTerms(obj.q.customset)
 	}
 	for (const k in obj) trimGvTermsForSave(obj[k])
 	return obj
+}
+
+/*
+The dt term of a tvs carries a parentTerm, but for two unrelated reasons:
+
+- a tvs of a mass filter stands alone, so its parentTerm is the only record of which gene
+  it is about. get_dtTerm() in server/src/termdb.filter.js reads it to run the query, and
+  the tvs edit UI reads it to label the pill. it must be kept.
+- a tvs of a groupset (q.customset, or term.groupsetting.lst[]) has no such need: its
+  parent is by definition the term of the tw that holds the groupset. storing one there is
+  a copy of term.genes[] per tvs that nothing keeps in sync with the term it was copied
+  from, and a termsetting instance is reused across terms, so it does go stale (see
+  makeGroupUI() in client/termsetting/handlers/geneVariant.ts).
+
+So a groupset gets its parentTerms rebuilt on every fill() instead of storing them, which
+lets both trims above drop them, and lets the server read the gene off tw.term (see
+mayFilterCnvByOverlap() in server/src/mds3.init.js).
+
+One snapshot is shared by reference across the tvs, as the child dt terms of a predefined
+groupset already are. That is only safe because the trims drop it before it is ever
+serialized, which would turn the one shared copy back into one copy per tvs.
+
+Throws on a tvs whose term is not a dt term: the groups of a geneVariant groupset can only
+filter by dt, and the server would otherwise fail deep in filterByItem().
+*/
+export function setGroupsetParentTerms(groupset: any, term: any) {
+	if (term?.type != GENE_VARIANT) throw 'parent of a groupset tvs must be a geneVariant term'
+	const parentTerm = structuredClone(term)
+	// the parent of a dt term is the gene(s), not the derived properties of the term
+	delete parentTerm.childTerms
+	delete parentTerm.groupsetting
+	walkTvs(groupset, (tvs: any) => {
+		if (!dtTermTypes.has(tvs.term?.type)) throw `groupset tvs term is not a dt term`
+		tvs.term.parentTerm = parentTerm
+	})
+	return groupset
+}
+
+/* drop what setGroupsetParentTerms() re-attaches. tolerates a malformed tvs, since a trim
+must never be the thing that throws on the way into a request or a saved session */
+function clearGroupsetParentTerms(groupset: any) {
+	walkTvs(groupset, (tvs: any) => {
+		if (tvs.term) delete tvs.term.parentTerm
+	})
+	return groupset
+}
+
+/* run fn on every tvs of a groupset, a group, or a filter.
+
+A tvs is a leaf: a nested tvslst is a sibling of it in filter.lst[], never inside it. Not
+descending matters, because a tvs can hold a filter of its own that is not part of the
+groupset structure -- tvs.mafFilter wraps a maf term, which is a dictionary term rather
+than a dt term (see getMafFilter() in client/tw/geneVariant.ts). getDtsFromFilter() above
+reads a filter the same way. */
+function walkTvs(obj: any, fn: (tvs: any) => void) {
+	if (!obj || typeof obj != 'object') return
+	if (obj.type == 'tvs' && obj.tvs) {
+		fn(obj.tvs)
+		return
+	}
+	for (const k in obj) walkTvs(obj[k], fn)
 }
 
 /* the dts queried by a set of groups, read off the dt term of each tvs of their filters */
@@ -309,9 +374,9 @@ that is re-serialized once per tvs. Walks any object, so it accepts a groupset, 
 or a filter.
 */
 export function clearDtTermMnames(obj: any) {
-	if (!obj || typeof obj != 'object') return obj
-	if (obj.type == 'tvs' && obj.tvs?.term) delete obj.tvs.term.mnames
-	for (const k in obj) clearDtTermMnames(obj[k])
+	walkTvs(obj, (tvs: any) => {
+		if (tvs.term) delete tvs.term.mnames
+	})
 	return obj
 }
 

--- a/shared/utils/src/test/terms.unit.spec.ts
+++ b/shared/utils/src/test/terms.unit.spec.ts
@@ -1,11 +1,12 @@
 import tape from 'tape'
 import { DTCNV, DTFUSION, DTITD, DTSNVINDEL, DTSV, TermTypes } from '#types'
-import { dtTermTypes, trimGvTermsForSave } from '../terms.js'
+import { dtTermTypes, setGroupsetParentTerms, trimGvTermsForSave } from '../terms.js'
 
 /* test sections
 
 dt term types are declared in TermTypes
 trimGvTermsForSave()
+setGroupsetParentTerms()
 */
 
 // a filled-in geneVariant tw, reduced to the properties the trim reads
@@ -130,11 +131,80 @@ tape('trimGvTermsForSave(): terms it must not trim', t => {
 	trimGvTermsForSave(state)
 
 	t.ok(state.plots[0].term.q.customset.groups.length, 'should keep q.customset of a custom groupset')
-	t.ok(
+	t.equal(
 		state.plots[0].term.q.customset.groups[0].filter.lst[0].tvs.term.parentTerm,
-		'should keep the parentTerm of a customset tvs term'
+		undefined,
+		'should drop the parentTerm of a customset tvs term, which GvCustomGS.fill() re-attaches'
 	)
 	t.ok(state.termfilter.filter.lst[0].tvs.term.parentTerm, 'should keep the parentTerm of a filter tvs term')
+	t.end()
+})
+
+tape('setGroupsetParentTerms()', t => {
+	const tw: any = getFilledGvTw()
+	// a customset built against another term, as a termsetting instance reused across
+	// terms produces (see makeGroupUI() in client/termsetting/handlers/geneVariant.ts)
+	const staleTerm = { type: 'geneVariant', id: 'KRAS', name: 'KRAS', genes: [{ kind: 'gene', gene: 'KRAS' }] }
+	/* a snvindel tvs of a dataset with a maf filter nests a tvs of its own, over a maf term
+	rather than a dt term. it is not part of the groupset structure and must be left alone,
+	see getNonCnvGroupset() in client/tw/geneVariant.ts */
+	const mafFilter = {
+		type: 'tvslst',
+		join: '',
+		in: true,
+		lst: [{ type: 'tvs', tvs: { term: { id: 'AD', type: 'float' }, ranges: [{ start: 0.6 }] } }]
+	}
+	const tvs1: any = { term: { type: 'dtsnvindel', dt: DTSNVINDEL, parentTerm: staleTerm }, values: [], mafFilter }
+	const tvs2: any = { term: { type: 'dtcnv', dt: DTCNV }, values: [] }
+	const customset = {
+		groups: [
+			{ name: 'g1', type: 'filter', filter: { type: 'tvslst', in: true, join: '', lst: [{ type: 'tvs', tvs: tvs1 }] } },
+			{
+				name: 'g2',
+				type: 'filter',
+				filter: {
+					type: 'tvslst',
+					in: true,
+					join: 'or',
+					// a tvs nested in a sublist must be reached too
+					lst: [{ type: 'tvslst', in: true, join: '', lst: [{ type: 'tvs', tvs: tvs2 }] }]
+				}
+			}
+		]
+	}
+	setGroupsetParentTerms(customset, tw.term)
+
+	t.equal(tvs1.term.parentTerm.name, 'TP53', 'should replace a parentTerm of another term')
+	t.equal(tvs2.term.parentTerm.name, 'TP53', 'should attach a parentTerm to a tvs of a sublist')
+	t.equal(tvs1.term.parentTerm.childTerms, undefined, 'should not nest childTerms[] in the parentTerm')
+	t.equal(tvs1.term.parentTerm.groupsetting, undefined, 'should not nest groupsetting in the parentTerm')
+	t.equal(tvs1.term.parentTerm, tvs2.term.parentTerm, 'should share one parentTerm across the tvs')
+	t.notEqual(tvs1.term.parentTerm, tw.term, 'should attach a copy, not the term itself')
+	t.equal(
+		tvs1.mafFilter.lst[0].tvs.term.parentTerm,
+		undefined,
+		'should not reach the tvs of a maf filter nested in a tvs'
+	)
+
+	const notDt = {
+		groups: [
+			{
+				name: 'g',
+				type: 'filter',
+				filter: {
+					type: 'tvslst',
+					in: true,
+					join: '',
+					lst: [{ type: 'tvs', tvs: { term: { id: 'sex', type: 'categorical' }, values: [] } }]
+				}
+			}
+		]
+	}
+	t.throws(
+		() => setGroupsetParentTerms(notDt, tw.term),
+		/not a dt term/,
+		'should throw on a groupset tvs that does not filter by dt'
+	)
 	t.end()
 })
 


### PR DESCRIPTION
# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
