### PR TITLE
geneVariant: avoid using term.gene=string for both gene and coord ent…

### DIFF
--- a/client/dom/variantConfig.ts
+++ b/client/dom/variantConfig.ts
@@ -326,6 +326,12 @@ export function renderVariantConfig(arg: Arg) {
 			different query entries can be told apart */
 			const showGene = new Set(mnames.map(scopeLabel).filter(s => s)).size > 1
 			showGeneInMnames = showGene
+			/* the column can hold either kind, so it is only headed Gene or Region when every
+			row is of that kind. A term mixing the two gets both, rather than heading a column
+			of coordinates as genes */
+			const hasGeneScope = mnames.some(m => m.gene)
+			const hasRegionScope = mnames.some(m => !m.gene && m.region)
+			const scopeColumnLabel = hasGeneScope && hasRegionScope ? 'Gene/Region' : hasRegionScope ? 'Region' : 'Gene'
 			const mnameRows: any[] = []
 			const selectedMnameIdxs: number[] = []
 			// count cell of each variant, k: index in mnames[]. refilled by
@@ -350,7 +356,7 @@ export function renderVariantConfig(arg: Arg) {
 					selectedMnameIdxs.push(i)
 			}
 			const mnameColumns: any[] = [{ label: 'Variant' }, { label: 'Class' }, { label: 'Samples', align: 'right' }]
-			if (showGene) mnameColumns.unshift({ label: mnames.some(m => m.gene) ? 'Gene' : 'Region' })
+			if (showGene) mnameColumns.unshift({ label: scopeColumnLabel })
 			if (canSelectBreakpoint) mnameColumns.push({ label: 'Breakpoint' })
 			renderTable({
 				rows: mnameRows,

--- a/client/dom/variantConfig.ts
+++ b/client/dom/variantConfig.ts
@@ -2,9 +2,10 @@ import { make_radios, renderTable } from '#dom'
 import { Menu } from './menu'
 import { isoformRangeSelect, isoformPairRangeSelect } from './isoformSelect'
 import type { GeneModel, BreakpointMarker, ScaleMode } from './types/isoformSelect'
-import type { TermValues, BaseValue, BreakpointRange, BreakpointEntry } from '#types'
+import type { TermValues, BaseValue, BreakpointRange, BreakpointEntry, GvQueryRegion } from '#types'
 import { filterInit } from '#filter'
 import { dt2label, dtsnvindel, dtsv, dtfusionrna, mclass } from '#shared/common.js'
+import { matchesGvQueryEntry } from '#shared/terms.js'
 
 // a selectable value: either a mutation class (no .mname) or a
 // specific variant, i.e. amino acid change (.mname set, .key is its class)
@@ -12,6 +13,9 @@ type VariantValue = BaseValue & {
 	value?: string
 	mname?: string
 	gene?: string
+	/** the queried region an mname was found in, for a term that has no gene to name.
+	 * scopes the entry the way .gene does, see matchesGvQueryEntry() */
+	region?: GvQueryRegion
 	/** sv/fusion only: restricts the breakpoint on the partner gene named by .mname */
 	partnerBreakpointRange?: BreakpointRange
 }
@@ -24,8 +28,17 @@ type MnameItem = {
 	class: string
 	samplecount: number
 	gene?: string
+	region?: GvQueryRegion
 	breakpoints?: BreakpointEntry[]
 	noPositionCount?: number
+}
+
+/* what an mname was found through, as a label: a gene names itself, a region names its
+coordinates 1-based, the way a region term is named elsewhere. Empty when the data carries
+neither, which is the single-gene case where there is nothing to disambiguate. */
+function scopeLabel(m: { gene?: string; region?: GvQueryRegion }) {
+	if (m.gene) return m.gene
+	return m.region ? `${m.region.chr}:${m.region.start + 1}-${m.region.stop}` : ''
 }
 
 type Config = {
@@ -83,10 +96,11 @@ export function renderVariantConfig(arg: Arg) {
 	// zero-count entry so that it stays checked and is not silently widened to
 	// its class on apply
 	const preservedMnames: MnameItem[] = selectedMnames
-		.filter(s => !arg.mnames?.some(m => m.mname == s.mname && m.class == s.key && (!s.gene || s.gene == m.gene)))
+		.filter(s => !arg.mnames?.some(m => m.mname == s.mname && m.class == s.key && matchesGvQueryEntry(s, m)))
 		.map(s => {
 			const m: MnameItem = { mname: s.mname as string, class: s.key as string, samplecount: 0 }
 			if (s.gene) m.gene = s.gene
+			else if (s.region) m.region = s.region
 			return m
 		})
 	const mnames: MnameItem[] = [...(arg.mnames || []), ...preservedMnames]
@@ -121,7 +135,7 @@ export function renderVariantConfig(arg: Arg) {
 	// ranges on the partner gene of a variant, k: index of the variant in mnames[]
 	const partnerBreakpointRanges = new Map<number, BreakpointRange>()
 	for (const [i, m] of mnames.entries()) {
-		const selected = selectedMnames.find(s => s.mname == m.mname && s.key == m.class && (!s.gene || s.gene == m.gene))
+		const selected = selectedMnames.find(s => s.mname == m.mname && s.key == m.class && matchesGvQueryEntry(s, m))
 		if (selected?.partnerBreakpointRange) partnerBreakpointRanges.set(i, selected.partnerBreakpointRange)
 	}
 	/* one menu for both controls, so that opening one closes the other. created on first
@@ -307,9 +321,10 @@ export function renderVariantConfig(arg: Arg) {
 					.style('display', 'none')
 			}
 			const mnameListDiv = listWrapper.append('div').style('font-size', '0.8rem')
-			// when the term covers multiple genes (geneset), indicate the gene of
-			// each variant in its own column
-			const showGene = new Set(mnames.map(m => m.gene).filter(g => g)).size > 1
+			/* when the term covers more than one gene or region, name the one each variant
+			was found through in its own column, so that two identical amino acid changes of
+			different query entries can be told apart */
+			const showGene = new Set(mnames.map(scopeLabel).filter(s => s)).size > 1
 			showGeneInMnames = showGene
 			const mnameRows: any[] = []
 			const selectedMnameIdxs: number[] = []
@@ -325,17 +340,17 @@ export function renderVariantConfig(arg: Arg) {
 				}
 				countCells[i] = countCell
 				const row = [{ value: m.mname }, { value: arg.values[m.class]?.label || m.class }, countCell]
-				if (showGene) row.unshift({ value: m.gene || '' })
+				if (showGene) row.unshift({ value: scopeLabel(m) })
 				// cell to fill with the breakpoint control of this variant after render
 				if (canSelectBreakpoint) row.push({ value: '' })
 				mnameRows.push(row)
 				// a selected value without .gene matches regardless of gene, so that
 				// a selection saved before gene was tracked still displays as checked
-				if (selectedMnames.some(s => s.mname == m.mname && s.key == m.class && (!s.gene || s.gene == m.gene)))
+				if (selectedMnames.some(s => s.mname == m.mname && s.key == m.class && matchesGvQueryEntry(s, m)))
 					selectedMnameIdxs.push(i)
 			}
 			const mnameColumns: any[] = [{ label: 'Variant' }, { label: 'Class' }, { label: 'Samples', align: 'right' }]
-			if (showGene) mnameColumns.unshift({ label: 'Gene' })
+			if (showGene) mnameColumns.unshift({ label: mnames.some(m => m.gene) ? 'Gene' : 'Region' })
 			if (canSelectBreakpoint) mnameColumns.push({ label: 'Breakpoint' })
 			renderTable({
 				rows: mnameRows,
@@ -547,11 +562,13 @@ export function renderVariantConfig(arg: Arg) {
 					for (const { m, i } of checkedMnames) {
 						const v: VariantValue = {
 							key: m.class,
-							label: showGeneInMnames && m.gene ? `${m.gene} ${m.mname}` : m.mname,
+							label: showGeneInMnames && scopeLabel(m) ? `${scopeLabel(m)} ${m.mname}` : m.mname,
 							value: m.mname,
 							mname: m.mname
 						}
+						// scope the selection to the query entry it was found through
 						if (m.gene) v.gene = m.gene
+						else if (m.region) v.region = m.region
 						// a range on the partner gene only applies to this variant
 						const partnerRange = partnerBreakpointRanges.get(i)
 						if (partnerRange) v.partnerBreakpointRange = partnerRange

--- a/client/plots/matrix/matrix.controls.download.ts
+++ b/client/plots/matrix/matrix.controls.download.ts
@@ -94,7 +94,11 @@ export function setDownloadBtn(self: MatrixControls) {
 												(v.origin ? `${v.origin} ` : '') +
 													(hasAssayAvailability ? `${dt2label[v.dt]}:` : '') +
 													`${mclass[v.class]?.label}` +
-													(v.gene && v.mname ? `(${v.gene}::${v.mname})` : '')
+													/* mname is the partner gene of the fusion, so it is emitted whenever
+													present. The queried gene prefixes it as the usual BCR::ABL1 notation;
+													a queried region has no gene to name, and its coordinates are not put
+													in an export, so the partner stands alone there */
+													(v.mname ? `(${v.gene ? `${v.gene}::` : ''}${v.mname})` : '')
 											)
 										} else {
 											allVariant.push(`DO NOT SUPPORT dt='${v.dt}'`)

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -2,7 +2,7 @@ import { Vocab } from './Vocab'
 import { getNormalRoot } from '#filter'
 import { isUsableTerm } from '#shared/termdb.usecase.js'
 import { throwMsgWithFilePathAndFnName } from '../dom/sayerror'
-import { isDictionaryType, isSingleCellTerm } from '#shared/terms.js'
+import { isDictionaryType, isSingleCellTerm, restoreGvQueryEntry } from '#shared/terms.js'
 
 export class TermdbVocab extends Vocab {
 	// getAbortSignal() will be used to cancel async fetch requests or canvas rendering that may
@@ -906,12 +906,10 @@ export class TermdbVocab extends Vocab {
 
 									if (d.values) {
 										for (const v of d.values) {
-											// the query entry this value was found through. Applies to
-											// every value, not only the class-coded ones below
-											if (queries && v.$q !== undefined) {
-												Object.assign(v, queries[v.$q])
-												delete v.$q
-											}
+											/* the query entry this value was found through, the inverse of
+											the interning in termdb.get_matrix.js. Applies to every value,
+											not only the class-coded ones below */
+											restoreGvQueryEntry(v, queries)
 											if (!v.class && v.$) {
 												// rehydrate stripped props
 												Object.assign(v, $objAssign[v.$])

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -865,7 +865,9 @@ export class TermdbVocab extends Vocab {
 						const $objAssign = data.refs.$codes.objAssign || {}
 
 						for (const tw of copies) {
-							const { shortId, gene } = data.refs.byTermId[tw.$id] || frozenEmptyObj // avoid unnecessarily creating placeholder objects
+							// queries[] holds the distinct geneVariant query entries of the term,
+							// which each value references by index, see internQueryEntry()
+							const { shortId, queries } = data.refs.byTermId[tw.$id] || frozenEmptyObj // avoid unnecessarily creating placeholder objects
 							const origTw = opts.terms.find(o => o.$id === tw.$id)
 
 							for (const [sampleId, sample] of Object.entries(data.samples)) {
@@ -902,10 +904,15 @@ export class TermdbVocab extends Vocab {
 									// rehydrate stripped props
 									if (d.$) d[$copyAs[d.$]] = d.key
 
-									if (gene && d.values) {
+									if (d.values) {
 										for (const v of d.values) {
+											// the query entry this value was found through. Applies to
+											// every value, not only the class-coded ones below
+											if (queries && v.$q !== undefined) {
+												Object.assign(v, queries[v.$q])
+												delete v.$q
+											}
 											if (!v.class && v.$) {
-												v.gene = gene
 												// rehydrate stripped props
 												Object.assign(v, $objAssign[v.$])
 												delete v.$

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -54,7 +54,7 @@ import {
 } from './aiProjectAdmin/aiProjectSelectedWSImages.ts'
 import { validate_query_getWSISamples } from '#routes/wsisamples.ts'
 import { mds3InitNonblocking } from './mds3.init.nonblocking.js'
-import { dtTermTypes } from '#shared/terms.js'
+import { dtTermTypes, getGvQueryRegion, getGvQueryKey } from '#shared/terms.js'
 import { TermTypes } from '#types'
 import { isNumeric } from '#shared/helpers.js'
 import { makeAdHocDicTermdbQueries } from './adHocDictionary/buildAdHocDictionary.ts'
@@ -3025,7 +3025,6 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					if (s.sample_id === null || s.sample_id === undefined) continue
 					// create new m2{} for each mutation in each sample
 					const m2 = {
-						gene: gene.name,
 						isoform: m.isoform,
 						dt: m.dt,
 						chr: gene.chr,
@@ -3033,6 +3032,12 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 						mname: m.mname,
 						label: termdbmclass?.[m.class]?.label || mclass[m.class].label
 					}
+					/* which entry of term.genes[] this value came from. .gene is a symbol and
+					is absent for a queried region, which has none; .region carries the query
+					either way. See getGvQueryRegion() in shared/utils/src/terms.ts */
+					if (gene.gene) m2.gene = gene.gene
+					const queryRegion = getGvQueryRegion(gene)
+					if (queryRegion) m2.region = queryRegion
 					if (m.start) m2.start = m.start
 					if (m.stop) m2.stop = m.stop
 					if (m.pos) m2.pos = m.pos
@@ -3117,7 +3122,7 @@ function mayAdd_mayGetGeneVariantData(ds, genome) {
 					if (group.type != 'filter') throw 'unexpected group.type'
 					values = []
 					const filter = group.filter
-					const [pass, tested] = filterByTvsLst(filter, mlst, values, tw)
+					const [pass, tested] = filterByTvsLst(filter, mlst, values)
 					return pass
 				})
 
@@ -3217,24 +3222,33 @@ function addDataAvailability(sid, sample2mlst, dtKey, c, origin, sampleFilter, g
 	if (sampleFilter && !sampleFilter.has(sid)) return
 	if (!sample2mlst.has(sid)) sample2mlst.set(sid, [])
 	const mlst = sample2mlst.get(sid)
+	// a status value records its query entry the same way a mutation does, see the m2{}
+	// built in mayGetGeneVariantData()
+	const status = { dt: Number(dtKey), class: c, label: mclass[c].label, _SAMPLEID_: sid }
+	if (gene.gene) status.gene = gene.gene
+	const queryRegion = getGvQueryRegion(gene)
+	if (queryRegion) status.region = queryRegion
+	// matched on the query entry rather than on a name, so that a term over several genes
+	// or regions gets one status per entry
+	const key = getGvQueryKey(status)
 	if (origin) {
-		if (!mlst.some(m => m.gene == gene.name && m.dt == dtKey && m.origin == origin)) {
+		if (!mlst.some(m => getGvQueryKey(m) == key && m.dt == dtKey && m.origin == origin)) {
 			// sample does not have a mutation with this origin for this dt
 			// sample will be annotated with the given class for the given origin
-			mlst.push({ gene: gene.name, dt: Number(dtKey), class: c, label: mclass[c].label, origin, _SAMPLEID_: sid })
+			mlst.push({ ...status, origin })
 		}
 	} else {
-		if (!mlst.some(m => m.gene == gene.name && m.dt == dtKey)) {
+		if (!mlst.some(m => getGvQueryKey(m) == key && m.dt == dtKey)) {
 			// sample does not have a mutation for this dt
 			// sample will be annotated with the given class
-			mlst.push({ gene: gene.name, dt: Number(dtKey), class: c, label: mclass[c].label, _SAMPLEID_: sid })
+			mlst.push(status)
 		}
 	}
 	sample2mlst.set(sid, mlst)
 }
 
 // function to filter a sample based on its mlst and a tvslst
-export function filterByTvsLst(filter, mlst, values, tw) {
+export function filterByTvsLst(filter, mlst, values) {
 	if (filter.type != 'tvslst') throw 'unexpected filter.type'
 	const passLst = []
 	const testedLst = []
@@ -3244,7 +3258,7 @@ export function filterByTvsLst(filter, mlst, values, tw) {
 	positive evidence, and its matches must not be drawn as the variants of the group */
 	const matched = values ? [] : undefined
 	for (const item of filter.lst) {
-		const [pass, tested] = filterByItem(item, mlst, matched, tw)
+		const [pass, tested] = filterByItem(item, mlst, matched)
 		passLst.push(pass)
 		testedLst.push(tested)
 	}
@@ -3265,10 +3279,8 @@ export function filterByTvsLst(filter, mlst, values, tw) {
 }
 
 // function to filter a sample based on its mlst and a filter item
-export function filterByItem(filter, mlst, values, tw) {
-	// tw must be passed along: a cnv tvs nested in a sublist still needs it to
-	// resolve the coordinates of the queried gene, see mayFilterCnvByOverlap()
-	if (filter.type == 'tvslst') return filterByTvsLst(filter, mlst, values, tw)
+export function filterByItem(filter, mlst, values) {
+	if (filter.type == 'tvslst') return filterByTvsLst(filter, mlst, values)
 	if (filter.type != 'tvs') throw 'unexpected filter.type'
 	const tvs = filter.tvs
 	if (!dtTermTypes.has(tvs.term.type)) throw 'tvs term is not dt term'
@@ -3303,7 +3315,7 @@ export function filterByItem(filter, mlst, values, tw) {
 				const cnvLength = m.stop - m.start
 				if (!cnvLength) return false
 				if (tvs.cnvMaxLength && cnvLength > tvs.cnvMaxLength) return false
-				if (tvs.fractionOverlap && !mayFilterCnvByOverlap(m, tvs, tw)) return false
+				if (tvs.fractionOverlap && !mayFilterCnvByOverlap(m, tvs)) return false
 				let intvs
 				if (m.value > 0) {
 					// cnv gain
@@ -3483,26 +3495,24 @@ function addAlleleCnts(m, mafFieldId, alleleCnts) {
 	return true
 }
 
-// may filter cnv segment by a minimum overlap with query
-function mayFilterCnvByOverlap(cnv, tvs, tw) {
+/* may filter cnv segment by a minimum overlap with the region that was queried.
+
+The region comes off the segment itself, which records it as .region (see the m2{} built in
+mayGetGeneVariantData). Nothing has to be looked up: this used to search the tw's genes[]
+for the entry whose name matched cnv.gene, which coupled the filter to a term it is not
+otherwise given, and silently failed for a kind='coord' entry -- those have no .gene, so a
+region term never matched and every cnv tvs carrying a fractionOverlap threw. */
+function mayFilterCnvByOverlap(cnv, tvs) {
 	if (!tvs.fractionOverlap) return true
 	if (!Number.isFinite(tvs.fractionOverlap)) throw new Error('tvs.fractionOverlap is non-numeric')
 	if (tvs.fractionOverlap < 0 || tvs.fractionOverlap > 1) throw new Error('tvs.fractionOverlap is out of range')
-	/* the queried gene comes off tw.term, whose genes[] mayMapGeneName2coord() annotated
-	with the coordinates when the cnv query ran. a groupset tvs is evaluated against the tw
-	that holds the groupset and carries no parentTerm of its own (see setGroupsetParentTerms()
-	in shared/utils/src/terms.ts), so there the tw is the only source. a standalone tvs of a
-	mass filter has no tw, and falls back to its own parentTerm, which is the term its caller
-	queried with and so is annotated the same way, see get_dtTerm() in termdb.filter.js */
-	const term = tw?.term || tvs.term.parentTerm
-	if (!term?.genes) throw new Error('cnv tvs has neither a tw nor a parentTerm to resolve the gene from')
-	const gene = term.genes.find(g => g.gene == cnv.gene)
-	if (!gene) throw new Error(`no queried gene matches cnv.gene='${cnv.gene}'`)
-	for (const v of [gene.start, gene.stop, cnv.start, cnv.stop]) {
+	const query = cnv.region
+	if (!query) throw new Error('cnv value has no .region to measure the overlap against')
+	for (const v of [query.start, query.stop, cnv.start, cnv.stop]) {
 		if (!Number.isInteger(v)) throw new Error(`${v} is not an integer`)
 	}
-	const queryLength = gene.stop - gene.start
-	const overlapLength = Math.max(0, Math.min(gene.stop, cnv.stop) - Math.max(gene.start, cnv.start))
+	const queryLength = query.stop - query.start
+	const overlapLength = Math.max(0, Math.min(query.stop, cnv.stop) - Math.max(query.start, cnv.start))
 	const fractionOverlap = overlapLength / queryLength
 	return fractionOverlap >= tvs.fractionOverlap
 }

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -3506,11 +3506,13 @@ function mayFilterCnvByOverlap(cnv, tvs) {
 	if (!tvs.fractionOverlap) return true
 	if (!Number.isFinite(tvs.fractionOverlap)) throw new Error('tvs.fractionOverlap is non-numeric')
 	if (tvs.fractionOverlap < 0 || tvs.fractionOverlap > 1) throw new Error('tvs.fractionOverlap is out of range')
+	/* Gene-level cnv never reaches here. A ds reporting it (ds.queries.geneCnv, as gdc does)
+	returns calls with no coordinates, which the caller drops on `if (!cnvLength) return false`
+	two lines above -- so this is only ever handed a segment. That also means mapping the query
+	to coordinates for such a ds would not help: there would still be no segment to measure. */
 	const query = cnv.region
-	if (!query) throw new Error('cnv value has no .region to measure the overlap against')
-	for (const v of [query.start, query.stop, cnv.start, cnv.stop]) {
-		if (!Number.isInteger(v)) throw new Error(`${v} is not an integer`)
-	}
+	if (!Number.isInteger(query?.start) || !Number.isInteger(query?.stop))
+		throw new Error('tvs.fractionOverlap needs the queried region, which this cnv value does not carry')
 	const queryLength = query.stop - query.start
 	const overlapLength = Math.max(0, Math.min(query.stop, cnv.stop) - Math.max(query.start, cnv.start))
 	const fractionOverlap = overlapLength / queryLength

--- a/server/src/mds3.init.js
+++ b/server/src/mds3.init.js
@@ -54,7 +54,7 @@ import {
 } from './aiProjectAdmin/aiProjectSelectedWSImages.ts'
 import { validate_query_getWSISamples } from '#routes/wsisamples.ts'
 import { mds3InitNonblocking } from './mds3.init.nonblocking.js'
-import { dtTermTypes, getGvQueryRegion, getGvQueryKey } from '#shared/terms.js'
+import { dtTermTypes, getGvQueryRegion, getGvQueryKey, matchesGvQueryEntry } from '#shared/terms.js'
 import { TermTypes } from '#types'
 import { isNumeric } from '#shared/helpers.js'
 import { makeAdHocDicTermdbQueries } from './adHocDictionary/buildAdHocDictionary.ts'
@@ -3349,7 +3349,7 @@ export function filterByItem(filter, mlst, values) {
 						tvs.values.some(
 							v =>
 								v.key == m.class &&
-								(!v.mname || (v.mname == m.mname && (!v.gene || v.gene == m.gene))) &&
+								(!v.mname || (v.mname == m.mname && matchesGvQueryEntry(v, m))) &&
 								(!v.partnerBreakpointRange || isPartnerBreakpointInRange(m, v.partnerBreakpointRange))
 						)
 					) {

--- a/server/src/routes/termdb.categories.ts
+++ b/server/src/routes/termdb.categories.ts
@@ -164,6 +164,8 @@ export function getCategories(data, q, ds, $id, opts: { withMnames?: boolean } =
 								origin,
 								class: value.class,
 								gene,
+								// the query entry, so that a selection can be scoped back to it
+								region: value.region,
 								mname: value.mname,
 								samplecount: 1
 							})
@@ -219,10 +221,13 @@ export function getCategories(data, q, ds, $id, opts: { withMnames?: boolean } =
 		for (const lst of breakpointsByMname.values()) {
 			lst.sort((a, b) => a.pos - b.pos || a.partnerPos - b.partnerPos)
 		}
-		// gene is only reported when annotated on the mutation data
+		/* the query entry an mname was found through is reported so that selecting it can be
+		scoped back, see matchesGvQueryEntry(). A gene entry names its gene; one over a region
+		has no gene and names the region instead. Only one of the two is ever set. */
 		const formatMname = (e: any) => {
 			const m: any = { mname: e.mname, class: e.class, samplecount: e.samplecount }
 			if (e.gene) m.gene = e.gene
+			else if (e.region) m.region = e.region
 			const breakpoints = breakpointsByMname.get(e.key)
 			if (breakpoints) m.breakpoints = breakpoints
 			const noPositionCount = noPositionCountMap.get(e.key)

--- a/server/src/routes/termdb.categories.ts
+++ b/server/src/routes/termdb.categories.ts
@@ -5,6 +5,7 @@ import { getOrderedLabels } from '#src/termdb.barchart.js'
 import { getData } from '#src/termdb.matrix.js'
 import { getSelfBreakpoint, getPartnerBreakpoints } from '#src/svfusion.breakpoint.ts'
 import { dtsv, dtfusionrna } from '#shared/common.js'
+import { getGvQueryKey } from '#shared/terms.js'
 
 export const payload: RoutePayload = {
 	init,
@@ -146,8 +147,11 @@ export function getCategories(data, q, ds, $id, opts: { withMnames?: boolean } =
 				if (opts.withMnames && value.mname != undefined) {
 					// synthetic WT/Blank rows lack mname, so are naturally skipped
 					const origin = dtClasses.byOrigin ? value.origin : ''
+					/* keyed on the query entry, not on .gene alone: a region entry has no gene,
+					and two of them would otherwise share a key. See getGvQueryKey() */
 					const gene = value.gene || ''
-					const mnameKey = `mname:${value.dt}|${origin}|${value.class}|${gene}|${value.mname}`
+					const queryKey = getGvQueryKey(value)
+					const mnameKey = `mname:${value.dt}|${origin}|${value.class}|${queryKey}|${value.mname}`
 					if (!sampleCountedFor.has(mnameKey)) {
 						// count each sample once per dt/origin/class/gene/mname
 						sampleCountedFor.add(mnameKey)

--- a/server/src/termdb.filter.js
+++ b/server/src/termdb.filter.js
@@ -601,8 +601,7 @@ async function get_dtTerm(tvs, CTEname, ds) {
 		const mlst = value[$id]?.values
 		if (!mlst) throw 'mlst is missing'
 		const filter = { type: 'tvs', tvs }
-		// the tw is what a cnv tvs resolves the queried gene from, see mayFilterCnvByOverlap()
-		const [pass, tested] = filterByItem(filter, mlst, undefined, tw)
+		const [pass, tested] = filterByItem(filter, mlst)
 		if (pass) samples.push(sample)
 	}
 

--- a/server/src/termdb.get_matrix.js
+++ b/server/src/termdb.get_matrix.js
@@ -4,7 +4,7 @@ import { authApi } from './auth.js'
 import { Readable, pipeline } from 'stream'
 import zlib from 'zlib'
 import { mclass } from '#shared/common.js'
-import { getGvQueryKey } from '#shared/terms.js'
+import { getGvQueryKey, internGvQueryEntry } from '#shared/terms.js'
 
 // based on a 64-bit hard constraint in V8 for string processing
 const maxStrLength = 5.12e8 - 1e5 // subtract 100KB for error message, etc
@@ -63,39 +63,25 @@ for (const [code, m] of Object.entries($codes.objAssign)) {
 Object.freeze($objAssign)
 
 /*
-Intern the geneVariant query entry of a value.
+Intern the geneVariant query entry of a value into refs.byTermId[$id].queries[].
 
-Every value records the entry of term.genes[] it was found through, as .gene and/or .region
-(see getGvQueryRegion() in shared/utils/src/terms.ts). Those repeat across every value of
-every sample, and a .region object is far bigger than the index that replaces it, so the
-distinct entries are collected once into refs.byTermId[$id].queries[] and each value keeps
-only its index in .$q. TermdbVocab.js reverses this on arrival.
-
-This supersedes keying by one gene per term, which mislabelled the values of every gene but
-the first, and could not compress a term over a queried region at all since it has no gene.
+The format itself lives in shared/utils/src/terms.ts, paired with the restore that
+TermdbVocab.js applies, so that the two stay inverse and can be round-tripped in a test.
+This only owns the per-term bookkeeping: queries[] is created on the first value that has
+an entry, so a term whose values have none never grows an empty array.
 
 refs is pushed to the stream only after every sample has been walked, so filling queries[]
 as values are visited is safe.
 */
 function internQueryEntry(ref, queryIdxByTerm, termId, v) {
-	const key = getGvQueryKey(v)
-	if (!key) return
-	if (!ref.queries) ref.queries = []
-	let idxByKey = queryIdxByTerm.get(termId)
-	if (!idxByKey) {
-		idxByKey = new Map()
-		queryIdxByTerm.set(termId, idxByKey)
+	if (!getGvQueryKey(v)) return
+	let ctx = queryIdxByTerm.get(termId)
+	if (!ctx) {
+		ctx = { queries: [], idxByKey: new Map() }
+		queryIdxByTerm.set(termId, ctx)
+		ref.queries = ctx.queries
 	}
-	let i = idxByKey.get(key)
-	if (i === undefined) {
-		i = ref.queries.length
-		const entry = {}
-		if (v.gene) entry.gene = v.gene
-		if (v.region) entry.region = v.region
-		ref.queries.push(entry)
-		idxByKey.set(key, i)
-	}
-	return i
+	internGvQueryEntry(v, ctx.queries, ctx.idxByKey)
 }
 
 export async function get_matrix(q, req, res, ds, genome) {
@@ -162,7 +148,7 @@ export async function get_matrix(q, req, res, ds, genome) {
 	res.setHeader('Content-Encoding', 'gzip')
 	res.status(200)
 
-	// termId -> Map(query key -> index into refs.byTermId[termId].queries[])
+	// termId -> { queries[], idxByKey } shared with refs.byTermId[termId].queries
 	const queryIdxByTerm = new Map()
 
 	let jsonStrlen = 0,
@@ -214,12 +200,7 @@ export async function get_matrix(q, req, res, ds, genome) {
 					for (const v of d.values) {
 						delete v._SAMPLEID_ // not needed in client code
 						// intern the query entry, see internQueryEntry()
-						const qi = internQueryEntry(byTermId[termId], queryIdxByTerm, termId, v)
-						if (qi !== undefined) {
-							v.$q = qi
-							delete v.gene
-							delete v.region
-						}
+						internQueryEntry(byTermId[termId], queryIdxByTerm, termId, v)
 						const code = v.dt && $objAssign[v.class]?.[v.origin || '']
 						if (!code) continue
 						// these props can be rehydrated from refs.$codes.objAssign[code]

--- a/server/src/termdb.get_matrix.js
+++ b/server/src/termdb.get_matrix.js
@@ -4,6 +4,7 @@ import { authApi } from './auth.js'
 import { Readable, pipeline } from 'stream'
 import zlib from 'zlib'
 import { mclass } from '#shared/common.js'
+import { getGvQueryKey } from '#shared/terms.js'
 
 // based on a 64-bit hard constraint in V8 for string processing
 const maxStrLength = 5.12e8 - 1e5 // subtract 100KB for error message, etc
@@ -60,6 +61,42 @@ for (const [code, m] of Object.entries($codes.objAssign)) {
 	$objAssign[m.class][m.origin || ''] = parseInt(code)
 }
 Object.freeze($objAssign)
+
+/*
+Intern the geneVariant query entry of a value.
+
+Every value records the entry of term.genes[] it was found through, as .gene and/or .region
+(see getGvQueryRegion() in shared/utils/src/terms.ts). Those repeat across every value of
+every sample, and a .region object is far bigger than the index that replaces it, so the
+distinct entries are collected once into refs.byTermId[$id].queries[] and each value keeps
+only its index in .$q. TermdbVocab.js reverses this on arrival.
+
+This supersedes keying by one gene per term, which mislabelled the values of every gene but
+the first, and could not compress a term over a queried region at all since it has no gene.
+
+refs is pushed to the stream only after every sample has been walked, so filling queries[]
+as values are visited is safe.
+*/
+function internQueryEntry(ref, queryIdxByTerm, termId, v) {
+	const key = getGvQueryKey(v)
+	if (!key) return
+	if (!ref.queries) ref.queries = []
+	let idxByKey = queryIdxByTerm.get(termId)
+	if (!idxByKey) {
+		idxByKey = new Map()
+		queryIdxByTerm.set(termId, idxByKey)
+	}
+	let i = idxByKey.get(key)
+	if (i === undefined) {
+		i = ref.queries.length
+		const entry = {}
+		if (v.gene) entry.gene = v.gene
+		if (v.region) entry.region = v.region
+		ref.queries.push(entry)
+		idxByKey.set(key, i)
+	}
+	return i
+}
 
 export async function get_matrix(q, req, res, ds, genome) {
 	if (q.getPlotDataByName) {
@@ -125,6 +162,9 @@ export async function get_matrix(q, req, res, ds, genome) {
 	res.setHeader('Content-Encoding', 'gzip')
 	res.status(200)
 
+	// termId -> Map(query key -> index into refs.byTermId[termId].queries[])
+	const queryIdxByTerm = new Map()
+
 	let jsonStrlen = 0,
 		currShortId = 1,
 		sampleIndex = 1
@@ -144,6 +184,9 @@ export async function get_matrix(q, req, res, ds, genome) {
 				if (!byTermId[termId]?.shortId) {
 					if (!byTermId[termId]) byTermId[termId] = {}
 					byTermId[termId].shortId = currShortId++
+					/* the term's first gene, read by the optional urlTemplates.gene link (see
+					matrix.interactivity.js). Only meaningful for a single-gene term, and NOT
+					what the values are rehydrated from -- that is byTermId[].queries below */
 					const gene = d.values?.[0]?.gene
 					if (gene) byTermId[termId].gene = gene
 				}
@@ -167,15 +210,20 @@ export async function get_matrix(q, req, res, ds, genome) {
 				sample[shortId] = sample[termId]
 				delete sample[termId]
 
-				if (gene && d.values) {
+				if (d.values) {
 					for (const v of d.values) {
-						delete v._SAMPLEID_
+						delete v._SAMPLEID_ // not needed in client code
+						// intern the query entry, see internQueryEntry()
+						const qi = internQueryEntry(byTermId[termId], queryIdxByTerm, termId, v)
+						if (qi !== undefined) {
+							v.$q = qi
+							delete v.gene
+							delete v.region
+						}
 						const code = v.dt && $objAssign[v.class]?.[v.origin || '']
 						if (!code) continue
-						v.$ = code
-						// this can be rehydrated from refs.byTermId[tw.$id].gene
-						delete v.gene
 						// these props can be rehydrated from refs.$codes.objAssign[code]
+						v.$ = code
 						delete v.class
 						delete v.label
 						delete v.origin

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -1755,7 +1755,7 @@ test('filterByTvsLst: nested tvslst', t => {
 })
 
 test("filterByItem: cnv overlap is measured against the value's own region", t => {
-	t.plan(7)
+	t.plan(9)
 	/* a cnv value records the region that was queried as .region, distinct from its own
 	start/stop, so the overlap needs no lookup and no tw. See mayGetGeneVariantData() */
 	const cnvTvs = {
@@ -1797,7 +1797,20 @@ test("filterByItem: cnv overlap is measured against the value's own region", t =
 	}
 	{
 		const seg = { dt: 4, gene: 'TP53', value: -1, start: 0, stop: 100 }
-		t.throws(() => filterByItem(cnvTvs, [seg]), /no .region/, 'throws on a value carrying no region')
+		t.throws(
+			() => filterByItem(cnvTvs, [seg]),
+			/needs the queried region/,
+			'throws on a segment carrying no queried region'
+		)
+	}
+	{
+		/* gene-level cnv, as ds.queries.geneCnv returns it: a call with neither coordinates nor
+		a region. It never reaches the overlap, being dropped by the caller's cnvLength guard,
+		so a ds on gene-level cnv cannot hit the region error above */
+		const call = { dt: 4, gene: 'TP53', class: 'CNV_loss' }
+		const [pass, tested] = filterByItem(cnvTvs, [call])
+		t.equal(pass, false, 'a gene-level cnv call is excluded rather than measured')
+		t.equal(tested, true, 'and the sample still counts as tested')
 	}
 	{
 		// a nested sublist, as a custom groupset that mixes joins produces. No tw is

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -47,6 +47,7 @@ Tests:
 	filterByTvsLst: in=false
 	filterByTvsLst: nested tvslst
 	filterByItem: cnv overlap is measured against the value's own region
+	filterByItem: an mname entry is scoped to its queried region
 	filterByTvsLst: values[] only collects mutations of a matching tvs
 	mayFilterByMaf: basic mafFilter
 	mayFilterByMaf: mafFilter with child ids
@@ -2594,3 +2595,40 @@ const mafFilter_childIds = {
 		}
 	]
 }
+
+test('filterByItem: an mname entry is scoped to its queried region', t => {
+	t.plan(5)
+	/* two queried regions can carry the same amino acid change, and a values[] entry naming
+	one must not match the other. .gene used to hold the entry's name, so a coordinate string
+	scoped this by accident; a region entry does it explicitly now, see matchesGvQueryEntry() */
+	const tal1 = { chr: 'chr1', start: 47213990, stop: 47318918 }
+	const lmo2 = { chr: 'chr11', start: 33859000, stop: 33913000 }
+	const inTal1 = { dt: 1, class: 'M', mname: 'R100C', region: tal1 }
+	const inLmo2 = { dt: 1, class: 'M', mname: 'R100C', region: lmo2 }
+
+	const scoped = region => ({
+		type: 'tvs',
+		tvs: {
+			term: { dt: 1, type: 'dtsnvindel' },
+			values: [{ key: 'M', label: 'MISSENSE', value: 'M', mname: 'R100C', region }],
+			genotype: 'variant',
+			mcount: 'any'
+		}
+	})
+	t.equal(filterByItem(scoped(tal1), [inTal1])[0], true, 'matches the change of the region it names')
+	t.equal(filterByItem(scoped(tal1), [inLmo2])[0], false, 'does not match the same change of another region')
+	t.equal(filterByItem(scoped(lmo2), [inLmo2])[0], true, 'and the other way round')
+
+	// an entry naming no region stays unscoped, as a single-region term emits
+	const unscoped = {
+		type: 'tvs',
+		tvs: {
+			term: { dt: 1, type: 'dtsnvindel' },
+			values: [{ key: 'M', label: 'MISSENSE', value: 'M', mname: 'R100C' }],
+			genotype: 'variant',
+			mcount: 'any'
+		}
+	}
+	t.equal(filterByItem(unscoped, [inTal1])[0], true, 'an unscoped entry matches either region')
+	t.equal(filterByItem(unscoped, [inLmo2])[0], true, 'an unscoped entry matches either region')
+})

--- a/server/src/test/mds3.init.unit.spec.js
+++ b/server/src/test/mds3.init.unit.spec.js
@@ -46,8 +46,7 @@ Tests:
 	filterByTvsLst: multiple tvs, AND join
 	filterByTvsLst: in=false
 	filterByTvsLst: nested tvslst
-	filterByTvsLst: nested cnv tvs resolves gene coords from the tw
-	filterByItem: standalone cnv tvs resolves gene coords from its parentTerm
+	filterByItem: cnv overlap is measured against the value's own region
 	filterByTvsLst: values[] only collects mutations of a matching tvs
 	mayFilterByMaf: basic mafFilter
 	mayFilterByMaf: mafFilter with child ids
@@ -1755,107 +1754,76 @@ test('filterByTvsLst: nested tvslst', t => {
 	}
 })
 
-test('filterByTvsLst: nested cnv tvs resolves gene coords from the tw', t => {
-	t.plan(4)
-	/* a cnv tvs built by the config ui always carries fractionOverlap, and a groupset tvs
-	carries no parentTerm of its own, so the tw is the only source of the queried gene. it
-	has to reach the tvs even when it sits in a sublist, as it does in a custom groupset
-	that mixes joins */
-	const tw = {
-		term: {
-			name: 'TP53',
-			type: 'geneVariant',
-			genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', chr: 'chr17', start: 0, stop: 100 }]
-		}
-	}
+test("filterByItem: cnv overlap is measured against the value's own region", t => {
+	t.plan(7)
+	/* a cnv value records the region that was queried as .region, distinct from its own
+	start/stop, so the overlap needs no lookup and no tw. See mayGetGeneVariantData() */
 	const cnvTvs = {
 		type: 'tvs',
 		tvs: {
 			term: { dt: 4, type: 'dtcnv' },
 			values: [],
 			continuousCnv: true,
-			cnvGainCutoff: 0.5,
-			cnvLossCutoff: -0.5,
+			cnvGainCutoff: 0.1,
+			cnvLossCutoff: -0.1,
 			cnvMaxLength: null,
 			fractionOverlap: 0.8
 		}
 	}
-	const snvTvs = {
-		type: 'tvs',
-		tvs: {
-			term: { dt: 1, type: 'dtsnvindel' },
-			values: [{ key: 'M', label: 'MISSENSE', value: 'M' }],
-			genotype: 'variant',
-			mcount: 'any'
-		}
-	}
-	const filter = {
-		type: 'tvslst',
-		in: true,
-		join: 'and',
-		lst: [snvTvs, { type: 'tvslst', in: true, join: 'or', lst: [cnvTvs] }]
+	// a value found through a gene entry: .gene is the symbol, .region its coordinates
+	const geneRegion = { chr: 'chr17', start: 0, stop: 100 }
+	{
+		const seg = { dt: 4, gene: 'TP53', region: geneRegion, value: -1, start: 0, stop: 100 }
+		const [pass, tested] = filterByItem(cnvTvs, [seg])
+		t.equal(pass, true, 'segment spanning the queried gene passes')
+		t.equal(tested, true, 'sample is tested')
 	}
 	{
-		// segment spans the whole gene
-		const mlst = [
-			{ dt: 1, class: 'M' },
-			{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 100 }
-		]
-		const [pass, tested] = filterByTvsLst(filter, mlst, undefined, tw)
-		t.equal(pass, true, 'Sample passes when the nested cnv segment meets the overlap')
-		t.equal(tested, true, 'Sample is tested')
+		const seg = { dt: 4, gene: 'TP53', region: geneRegion, value: -1, start: 0, stop: 10 }
+		t.equal(filterByItem(cnvTvs, [seg])[0], false, 'segment under the overlap fails')
 	}
-	{
-		// segment spans 10% of the gene, under the 0.8 fraction
-		const mlst = [
-			{ dt: 1, class: 'M' },
-			{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 10 }
-		]
-		const [pass, tested] = filterByTvsLst(filter, mlst, undefined, tw)
-		t.equal(pass, false, 'Sample fails when the nested cnv segment is under the overlap')
-		t.equal(tested, true, 'Sample is tested')
-	}
-})
 
-test('filterByItem: standalone cnv tvs resolves gene coords from its parentTerm', t => {
-	t.plan(3)
-	/* a tvs of a mass filter is not evaluated against a tw. get_dtTerm() in termdb.filter.js
-	queries with tvs.term.parentTerm, so that is the term annotated with the coordinates */
-	const parentTerm = {
-		name: 'TP53',
-		type: 'geneVariant',
-		genes: [{ kind: 'gene', id: 'TP53', gene: 'TP53', name: 'TP53', chr: 'chr17', start: 0, stop: 100 }]
+	/* a value found through a kind='coord' entry has no .gene at all. Matching a queried
+	gene by name used to be the only way to size the overlap, so a region term threw */
+	const region = { chr: 'chr1', start: 47213990, stop: 47318918 }
+	{
+		const seg = { dt: 4, region, value: -1, start: 47213990, stop: 47318918 }
+		t.equal(filterByItem(cnvTvs, [seg])[0], true, 'segment spanning the queried region passes')
 	}
-	const filter = {
-		type: 'tvs',
-		tvs: {
-			term: { dt: 4, type: 'dtcnv', parentTerm },
-			values: [],
-			continuousCnv: true,
-			cnvGainCutoff: 0.5,
-			cnvLossCutoff: -0.5,
-			cnvMaxLength: null,
-			fractionOverlap: 0.8
+	{
+		// a focal deletion, ~10kb of a ~105kb region
+		const seg = { dt: 4, region, value: -1, start: 47213990, stop: 47223990 }
+		t.equal(filterByItem(cnvTvs, [seg])[0], false, 'focal segment is under the overlap')
+	}
+	{
+		const seg = { dt: 4, gene: 'TP53', value: -1, start: 0, stop: 100 }
+		t.throws(() => filterByItem(cnvTvs, [seg]), /no .region/, 'throws on a value carrying no region')
+	}
+	{
+		// a nested sublist, as a custom groupset that mixes joins produces. No tw is
+		// threaded anywhere, since the value carries everything the overlap needs
+		const filter = {
+			type: 'tvslst',
+			in: true,
+			join: 'and',
+			lst: [
+				{
+					type: 'tvs',
+					tvs: {
+						term: { dt: 1, type: 'dtsnvindel' },
+						values: [{ key: 'M', label: 'MISSENSE', value: 'M' }],
+						genotype: 'variant',
+						mcount: 'any'
+					}
+				},
+				{ type: 'tvslst', in: true, join: 'or', lst: [cnvTvs] }
+			]
 		}
-	}
-	{
-		const [pass] = filterByItem(filter, [{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 100 }])
-		t.equal(pass, true, 'Sample passes when the cnv segment meets the overlap')
-	}
-	{
-		const [pass] = filterByItem(filter, [{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 10 }])
-		t.equal(pass, false, 'Sample fails when the cnv segment is under the overlap')
-	}
-	{
-		// a gene the tvs was not built for cannot be measured against, and used to be
-		// read as a TypeError on the undefined result of the lookup
-		const noParent = structuredClone(filter)
-		delete noParent.tvs.term.parentTerm
-		t.throws(
-			() => filterByItem(noParent, [{ dt: 4, gene: 'TP53', value: 1, start: 0, stop: 100 }]),
-			/neither a tw nor a parentTerm/,
-			'throws when the queried gene cannot be resolved'
-		)
+		const mlst = [
+			{ dt: 1, class: 'M', gene: 'TP53', region: geneRegion },
+			{ dt: 4, gene: 'TP53', region: geneRegion, value: -1, start: 0, stop: 100 }
+		]
+		t.equal(filterByTvsLst(filter, mlst)[0], true, 'a cnv tvs nested in a sublist is measured the same way')
 	}
 })
 

--- a/shared/types/src/filter.ts
+++ b/shared/types/src/filter.ts
@@ -76,6 +76,14 @@ export type BreakpointRange = {
 	stop: number
 }
 
+/** the region a geneVariant query entry covers, carried by every value found through it.
+ * A kind='gene' entry also has a .gene naming it; a kind='coord' entry has only this */
+export type GvQueryRegion = {
+	chr: string
+	start: number
+	stop: number
+}
+
 export type GeneVariantValue = {
 	key?: string
 	label?: string | number
@@ -91,6 +99,10 @@ export type GeneVariantValue = {
 	/** gene of the amino acid change; when set, restricts an mname entry to this
 	 * gene, so that e.g. KRAS G12D of a geneset term does not match NRAS G12D */
 	gene?: string
+	/** region the amino acid change was found in; the equivalent of .gene for a term
+	 * over queried regions, which have no gene. Only one of the two is ever set,
+	 * see matchesGvQueryEntry() in shared/utils/src/terms.ts */
+	region?: GvQueryRegion
 	/** for a sv/fusion entry, restricts the breakpoint on the partner gene (the
 	 * gene named by .mname) to this range. the gene is implied by .mname and is
 	 * not stored. must be satisfied by the same event that matches .mname, so

--- a/shared/utils/src/geneVariantFilter.ts
+++ b/shared/utils/src/geneVariantFilter.ts
@@ -1,4 +1,5 @@
 import { mclass } from './common.js'
+import { matchesGvQueryEntry } from './terms.js'
 
 /*
 tw.q.variantFilter of a geneVariant termwrapper, i.e. the per-row variant filter
@@ -118,13 +119,11 @@ function matchTvs(v: VariantValue, tvs: VariantTvs): boolean {
 	let match = false
 	if (v.dt == tvs.term.dt && (!tvs.term.origin || v.origin == tvs.term.origin)) {
 		/* an entry without .mname matches any variant of its class; with .mname
-		(e.g. "G12D") it matches only that amino acid change, further restricted to
-		.gene when set, for a term over a gene set. mirrors filterByItem() in
+		(e.g. "G12D") it matches only that amino acid change, further restricted to the
+		gene or region it names, see matchesGvQueryEntry(). mirrors filterByItem() in
 		server/src/mds3.init.js, so that the same tvs means the same thing on both
 		sides */
-		match = tvs.values.some(
-			e => e.key == v.class && (!e.mname || (e.mname == v.mname && (!e.gene || e.gene == v.gene)))
-		)
+		match = tvs.values.some(e => e.key == v.class && (!e.mname || (e.mname == v.mname && matchesGvQueryEntry(e, v))))
 	}
 	return tvs.isnot ? !match : match
 }

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -284,6 +284,37 @@ export function trimGvTermsForSave(obj: any) {
 }
 
 /*
+A geneVariant term is queried per entry of term.genes[], and every value it yields records
+which entry it came from. That record used to be a single .gene holding the entry's NAME,
+which for a kind='coord' entry is a coordinate string -- so consumers reading .gene as a
+gene symbol got a region, e.g. a matrix export labelling a variant "chr1:47213991-47318918".
+
+The two things are now separate: .gene is a gene symbol and is simply absent for a region,
+while .region below is what was queried and is present either way. The helpers here are the
+one place that knows the shape.
+*/
+
+/* the region a query entry covers, which every value found through it carries. Distinct
+from the value's own .start/.stop, which are the event's -- a cnv segment is not the region
+that found it.
+
+Coordinates are annotated onto a gene entry by mayMapGeneName2coord() when a query needing
+them runs, so this is undefined for a gene only queried by dts that never map coords. A
+coord entry always carries them, since fill() requires them. */
+export function getGvQueryRegion(gene: any) {
+	if (!gene?.chr || !Number.isInteger(gene.start) || !Number.isInteger(gene.stop)) return
+	return { chr: gene.chr, start: gene.start, stop: gene.stop }
+}
+
+/* identity of the query entry a value came from, for grouping and de-duplicating the values
+of a term over several genes or regions. The gene symbol when there is one, else the region. */
+export function getGvQueryKey(v: any) {
+	if (v?.gene) return v.gene
+	const r = v?.region
+	return r ? `${r.chr}:${r.start}-${r.stop}` : ''
+}
+
+/*
 The dt term of a tvs carries a parentTerm, but for two unrelated reasons:
 
 - a tvs of a mass filter stands alone, so its parentTerm is the only record of which gene

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -315,6 +315,46 @@ export function getGvQueryKey(v: any) {
 }
 
 /*
+The wire format for the query entry of a value, as the two halves that must stay inverse of
+each other: get_matrix.js interns on the way out, TermdbVocab.js restores on the way in.
+
+A term's values repeat their query entry endlessly -- one .region object per value, tens of
+thousands of them in a matrix request -- so the distinct entries are collected once into
+refs.byTermId[$id].queries[] and each value keeps only its index in .$q.
+
+Both live here so the format has one definition and can be round-tripped in a test.
+*/
+
+/** replace a value's query entry with its index into queries[], interning it if new.
+ * returns false for a value that records no query entry, which is left untouched */
+export function internGvQueryEntry(v: any, queries: any[], idxByKey: Map<string, number>) {
+	const key = getGvQueryKey(v)
+	if (!key) return false
+	let i = idxByKey.get(key)
+	if (i === undefined) {
+		i = queries.length
+		const entry: any = {}
+		if (v.gene) entry.gene = v.gene
+		if (v.region) entry.region = v.region
+		queries.push(entry)
+		idxByKey.set(key, i)
+	}
+	v.$q = i
+	delete v.gene
+	delete v.region
+	return true
+}
+
+/** the inverse: put the query entry back on a value. returns false when there is nothing
+ * to restore, e.g. a term whose values carry no query entry */
+export function restoreGvQueryEntry(v: any, queries: any[] | undefined) {
+	if (!queries || v?.$q === undefined) return false
+	Object.assign(v, queries[v.$q])
+	delete v.$q
+	return true
+}
+
+/*
 The dt term of a tvs carries a parentTerm, but for two unrelated reasons:
 
 - a tvs of a mass filter stands alone, so its parentTerm is the only record of which gene

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -355,6 +355,25 @@ export function restoreGvQueryEntry(v: any, queries: any[] | undefined) {
 }
 
 /*
+Whether a values[] entry of a tvs, naming an amino acid change, is scoped to the query entry
+a variant came from.
+
+An entry may name a .gene, so that KRAS G12D of a gene-set term does not match NRAS G12D, or
+a .region for the same reason over a term of several queried regions. Naming neither leaves
+it unscoped, matching that change wherever it was found -- which is what a single-entry term
+wants, and what the variant config emits for one.
+
+Both matchers call this so a tvs means the same thing on either side: filterByItem() in
+server/src/mds3.init.js and matchTvs() in geneVariantFilter.ts.
+*/
+export function matchesGvQueryEntry(entry: any, v: any) {
+	if (entry.gene) return entry.gene == v.gene
+	const r = entry.region
+	if (r) return !!v.region && r.chr == v.region.chr && r.start == v.region.start && r.stop == v.region.stop
+	return true
+}
+
+/*
 The dt term of a tvs carries a parentTerm, but for two unrelated reasons:
 
 - a tvs of a mass filter stands alone, so its parentTerm is the only record of which gene

--- a/shared/utils/src/test/terms.unit.spec.ts
+++ b/shared/utils/src/test/terms.unit.spec.ts
@@ -1,12 +1,21 @@
 import tape from 'tape'
 import { DTCNV, DTFUSION, DTITD, DTSNVINDEL, DTSV, TermTypes } from '#types'
-import { dtTermTypes, setGroupsetParentTerms, trimGvTermsForSave } from '../terms.js'
+import {
+	dtTermTypes,
+	getGvQueryKey,
+	internGvQueryEntry,
+	restoreGvQueryEntry,
+	setGroupsetParentTerms,
+	trimGvTermsForSave
+} from '../terms.js'
 
 /* test sections
 
 dt term types are declared in TermTypes
 trimGvTermsForSave()
 setGroupsetParentTerms()
+query entry wire format: round trip
+query entry wire format: values without an entry
 */
 
 // a filled-in geneVariant tw, reduced to the properties the trim reads
@@ -217,5 +226,92 @@ tape('trimGvTermsForSave(): leaves other term types alone', t => {
 	const copy = structuredClone(state)
 	trimGvTermsForSave(state)
 	t.deepEqual(state, copy, 'should not modify a non-geneVariant tw')
+	t.end()
+})
+
+/* The geneVariant query entry is stripped from every value on the way out of
+termdb.get_matrix.js and put back on the way in by TermdbVocab.js. The two halves are
+exercised together here, over a term holding BOTH gene and coordinate entries, which is
+what distinguishes the format from the single-gene-per-term keying it replaced. */
+
+// values of a term over KRAS, NRAS and a region, as mayGetGeneVariantData() emits them
+function getMixedValues() {
+	const kras = { chr: 'chr12', start: 25205245, stop: 25250928 }
+	const nras = { chr: 'chr1', start: 114704468, stop: 114716770 }
+	const tal1 = { chr: 'chr1', start: 47213990, stop: 47318918 }
+	return [
+		{ dt: DTSNVINDEL, class: 'M', mname: 'G12D', gene: 'KRAS', region: { ...kras } },
+		{ dt: DTCNV, class: 'CNV_loss', value: -0.4, start: 25200000, stop: 25260000, gene: 'KRAS', region: { ...kras } },
+		{ dt: DTSNVINDEL, class: 'M', mname: 'G12D', gene: 'NRAS', region: { ...nras } },
+		// a coord entry has no gene at all, which is the case the old keying could not carry
+		{ dt: DTCNV, class: 'CNV_loss', value: -0.6, start: 47220000, stop: 47230000, region: { ...tal1 } },
+		{ dt: DTSNVINDEL, class: 'insertion', region: { ...tal1 } },
+		// a second value of an entry already seen must reuse its index, not add one
+		{ dt: DTSNVINDEL, class: 'M', mname: 'G12V', gene: 'KRAS', region: { ...kras } }
+	]
+}
+
+tape('query entry wire format: round trip', t => {
+	const original = getMixedValues()
+	const values = structuredClone(original)
+
+	// --- server half, as termdb.get_matrix.js applies it
+	const queries: any[] = []
+	const idxByKey = new Map()
+	const interned = values.map(v => internGvQueryEntry(v, queries, idxByKey))
+
+	t.ok(interned.every(Boolean), 'should intern every value that records a query entry')
+	t.deepEqual(
+		queries,
+		[
+			{ gene: 'KRAS', region: { chr: 'chr12', start: 25205245, stop: 25250928 } },
+			{ gene: 'NRAS', region: { chr: 'chr1', start: 114704468, stop: 114716770 } },
+			{ region: { chr: 'chr1', start: 47213990, stop: 47318918 } }
+		],
+		'should collect one entry per distinct gene or region, in first-seen order'
+	)
+	t.deepEqual(
+		values.map(v => v.$q),
+		// KRAS, KRAS, NRAS, region, region, KRAS
+		[0, 0, 1, 2, 2, 0],
+		'should index each value to its own entry, reusing an index already seen'
+	)
+	t.ok(
+		values.every(v => !('gene' in v) && !('region' in v)),
+		'should strip the query entry from every value'
+	)
+
+	// --- client half, as TermdbVocab.js applies it
+	const restored = values.map(v => restoreGvQueryEntry(v, queries))
+	t.ok(restored.every(Boolean), 'should restore every interned value')
+	t.ok(
+		values.every(v => !('$q' in v)),
+		'should leave no index behind'
+	)
+	t.deepEqual(values, original, 'should round trip to exactly the values the server produced')
+
+	// the region objects are shared with queries[] after a restore, so a term over one
+	// region no longer pays for a copy per value
+	t.equal(values[3].region, values[4].region, 'values of one entry should share its region object')
+	t.end()
+})
+
+tape('query entry wire format: values without an entry', t => {
+	// a non-geneVariant term's values record no query entry and must pass through untouched
+	const values: any[] = [
+		{ key: 'F', value: 1 },
+		{ key: 'M', value: 2 }
+	]
+	const before = structuredClone(values)
+	const queries: any[] = []
+	const idxByKey = new Map()
+
+	t.equal(values.map(v => internGvQueryEntry(v, queries, idxByKey)).filter(Boolean).length, 0, 'should intern nothing')
+	t.equal(queries.length, 0, 'should not create a queries[] entry')
+	t.deepEqual(values, before, 'should leave the values untouched')
+
+	t.equal(restoreGvQueryEntry(values[0], queries), false, 'should restore nothing')
+	t.equal(restoreGvQueryEntry({ $q: 0 }, undefined), false, 'should restore nothing without queries[]')
+	t.equal(getGvQueryKey({}), '', 'a value with no entry has no key')
 	t.end()
 })

--- a/shared/utils/src/test/terms.unit.spec.ts
+++ b/shared/utils/src/test/terms.unit.spec.ts
@@ -3,6 +3,7 @@ import { DTCNV, DTFUSION, DTITD, DTSNVINDEL, DTSV, TermTypes } from '#types'
 import {
 	dtTermTypes,
 	getGvQueryKey,
+	matchesGvQueryEntry,
 	internGvQueryEntry,
 	restoreGvQueryEntry,
 	setGroupsetParentTerms,
@@ -16,6 +17,7 @@ trimGvTermsForSave()
 setGroupsetParentTerms()
 query entry wire format: round trip
 query entry wire format: values without an entry
+matchesGvQueryEntry()
 */
 
 // a filled-in geneVariant tw, reduced to the properties the trim reads
@@ -313,5 +315,37 @@ tape('query entry wire format: values without an entry', t => {
 	t.equal(restoreGvQueryEntry(values[0], queries), false, 'should restore nothing')
 	t.equal(restoreGvQueryEntry({ $q: 0 }, undefined), false, 'should restore nothing without queries[]')
 	t.equal(getGvQueryKey({}), '', 'a value with no entry has no key')
+	t.end()
+})
+
+tape('matchesGvQueryEntry()', t => {
+	const kras = { gene: 'KRAS', region: { chr: 'chr12', start: 25205245, stop: 25250928 } }
+	const nras = { gene: 'NRAS', region: { chr: 'chr1', start: 114704468, stop: 114716770 } }
+	const tal1 = { region: { chr: 'chr1', start: 47213990, stop: 47318918 } }
+	const lmo2 = { region: { chr: 'chr11', start: 33859000, stop: 33913000 } }
+
+	// an entry naming neither is unscoped, which is what a single-entry term emits
+	t.equal(matchesGvQueryEntry({}, kras), true, 'an unscoped entry matches a gene value')
+	t.equal(matchesGvQueryEntry({}, tal1), true, 'an unscoped entry matches a region value')
+
+	// a gene entry, as a gene-set term emits
+	t.equal(matchesGvQueryEntry({ gene: 'KRAS' }, kras), true, 'a gene entry matches its gene')
+	t.equal(matchesGvQueryEntry({ gene: 'KRAS' }, nras), false, 'a gene entry does not match another gene')
+	t.equal(matchesGvQueryEntry({ gene: 'KRAS' }, tal1), false, 'a gene entry does not match a region value')
+
+	/* a region entry, as a term over several queried regions emits. Before .gene stopped
+	holding a coordinate string this had no equivalent, so such an entry matched everywhere */
+	t.equal(matchesGvQueryEntry({ region: tal1.region }, tal1), true, 'a region entry matches its region')
+	t.equal(matchesGvQueryEntry({ region: tal1.region }, lmo2), false, 'a region entry does not match another region')
+	t.equal(
+		matchesGvQueryEntry({ region: kras.region }, kras),
+		true,
+		'a region entry matches on the region even when the value also has a gene'
+	)
+	t.equal(
+		matchesGvQueryEntry({ region: { chr: 'chr1', start: 47213990, stop: 47318918 } }, tal1),
+		true,
+		'a region entry is compared by value, not by identity'
+	)
 	t.end()
 })


### PR DESCRIPTION
…ities

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
