### PR TITLE
regression: support numeric termCollection fraction as independent; v…

### DIFF
--- a/client/plots/regression/regression.inputs.term.ts
+++ b/client/plots/regression/regression.inputs.term.ts
@@ -1,5 +1,5 @@
 import { termsettingInit, get$id } from '#termsetting'
-import { isDictionaryType, get_bin_label, isNumericTerm, getValueConversionFactor, roundValue } from '#shared'
+import { isDictionaryType, get_bin_label, isNumericTw, getValueConversionFactor, roundValue } from '#shared'
 import { InputValuesTable } from './regression.inputs.values.table'
 import { Menu } from '#dom'
 import { select } from 'd3-selection'
@@ -14,7 +14,7 @@ class instance is an input
 export class InputTerm {
 	opts: any
 	section: any
-	term: any 
+	term: any
 	parent: any
 	vocabApi: any
 	dom!: {
@@ -36,7 +36,6 @@ export class InputTerm {
 		sampleCounts: any[] | undefined
 		excludeCounts: any[] | undefined
 		allowToSelectRefGrp: boolean
-
 	}
 	orderedLabels!: any[]
 
@@ -233,15 +232,17 @@ export class InputTerm {
 			else tw.q.mode = 'continuous'
 		}
 
-		// need to supply tw.q in body, otherwise getCategories() will
-		// generate a default .q for the term
-		const body = tw.term.type == 'snplst' || tw.term.type == 'snplocus' ? { cacheid: tw.q.cacheid } : { term1_q: tw.q }
+		// cacheid identifies the genotype file of a snplst/snplocus term, which is queried by
+		// a route of its own rather than by the term's own q{}
+		const body = tw.term.type == 'snplst' || tw.term.type == 'snplocus' ? { cacheid: tw.q.cacheid } : {}
 
-		// get term categories
-		const wait = this.dom.holder.append('div').style('padding', '5px').text('Loading...') // getCategories may wait long time e.g. gdc. adding this to indicate its loading to avoid just showing a nopill prompt
+		/* get term categories. the whole wrapper is passed, not term + q: tw.type decides how the
+		term is reduced to categories, and a fraction termCollection is listed one category per
+		sample without it */
+		const wait = this.dom.holder.append('div').style('padding', '5px').text('Loading...') // getTwCategories may wait long time e.g. gdc. adding this to indicate its loading to avoid just showing a nopill prompt
 		let data
 		try {
-			data = await this.vocabApi.getCategories(tw.term, this.parent.parent.filter, body)
+			data = await this.vocabApi.getTwCategories(tw, this.parent.parent.filter, body)
 			if (!data) throw `no data for term.id='${tw.term.id}'`
 			if (data.error) throw data.error
 		} finally {
@@ -301,7 +302,10 @@ export class InputTerm {
 
 			this.summarizeSample(tw, data.lst)
 
-			if (isNumericTerm(tw.term)) {
+			/* isNumericTw(), not isNumericTerm(): a fraction termCollection resolves to one numeric
+			value per sample, so it is analyzed exactly like a numeric term here — binned into
+			reference-group categories, or used raw in continuous/spline mode */
+			if (isNumericTw(tw)) {
 				if (tw.q.mode != 'continuous' && tw.q.mode != 'spline') {
 					this.termStatus.allowToSelectRefGrp = true
 				}
@@ -541,7 +545,7 @@ export class InputTerm {
 			.style('margin', '5px')
 			.each(function (tw: any) {
 				const elem = select(this).append('label')
-				/*const checkbox =*/elem
+				/*const checkbox =*/ elem
 					.append('input')
 					.attr('type', 'checkbox')
 					.property('checked', self.term.interactions.includes(tw.$id))

--- a/client/termdb/FrontendVocab.js
+++ b/client/termdb/FrontendVocab.js
@@ -285,6 +285,12 @@ export class FrontendVocab extends Vocab {
 		const data = getCategoryData(q, this.datarows)
 		return data
 	}
+
+	/** same split as TermdbVocab: a caller holding a whole wrapper passes it here. a frontend vocab
+	tallies the rows it was handed, so nothing beyond the term is read yet */
+	async getTwCategories(tw, filter, lst = null) {
+		return await this.getCategories(tw.term, filter, lst)
+	}
 	getNumericUncomputableCategories(term, filter) {
 		throw 'to be implemented!! getNumericUncomputableCategories'
 	}

--- a/client/termdb/TermdbVocab.js
+++ b/client/termdb/TermdbVocab.js
@@ -586,8 +586,28 @@ export class TermdbVocab extends Vocab {
 	accepts one term of any type, including categorical, non-categorical, and non-dictionary
 	return number of samples per category/bin/grade/group etc
 	optionally, caller can supply a {term1_q: {...}} key-object value in _body to customize categories
+
+	for a caller that holds a term but no wrapper, e.g. a filter tvs editor: a tvs is not a tw, and
+	its q-shaped fields are assembled into term1_q here rather than a wrapper being faked for it.
+	a caller that does hold a wrapper must call getTwCategories() instead
 	*/
 	async getCategories(term, filter, _body = {}) {
+		// destructured rather than deleted: _body may be an object the caller reuses across calls
+		const { term1_q, ...body } = _body
+		return await this.getTwCategories({ term, q: term1_q || {} }, filter, body)
+	}
+
+	/*
+	same as getCategories(), for a caller that holds the whole term wrapper.
+
+	tw.type is what makes this more than a convenience: it decides how the server reduces the term
+	to categories, and the term alone does not imply it. a fraction termCollection resolves to one
+	number per sample only for tw.type='TermCollectionTWFraction'; without it the collection stays
+	one value per member term and the server returns one "category" per sample rather than the
+	fraction's bins
+	*/
+	async getTwCategories(tw, filter, _body = {}) {
+		const term = tw.term
 		const signal = this.getAbortSignal()
 		const headers = await this.mayGetAuthHeaders()
 		if (term.type == 'snplst' || term.type == 'snplocus') {
@@ -631,8 +651,6 @@ export class TermdbVocab extends Vocab {
 		}
 
 		// no need to supply tw.$id: 1) this method is one term only and no need to distinguish multiple terms 2) backend will auto fill $id before retrieving data
-		const tw = { term, q: _body.term1_q || {} }
-		delete _body.term1_q // is now tw.q, so no longer needed
 		const body = {
 			genome: this.state.vocab.genome,
 			dslabel: this.state.vocab.dslabel,

--- a/client/termsetting/TermSettingApi.ts
+++ b/client/termsetting/TermSettingApi.ts
@@ -20,6 +20,21 @@ const testClickTermDelay = 0 // 5000
  */
 const fractionOverlayTargets = new Set(['barchart', 'violin', 'boxplot', 'survival'])
 
+/** True when this pill can consume a numeric term collection reduced to a scalar fraction, which
+is what turns the fraction chooser on: see handlers/termCollectionFractionSelection.ts, and
+allowsCollectionFraction() in TermTypeSearch.ts, where the mode doubles as the permission to offer
+collections for a usecase that otherwise excludes them. */
+function allowsCollectionFraction(usecase: { target: string; detail?: string }): boolean {
+	/* all summary childTypes, not just barchart: selecting a continuous overlay switches childType
+	(see plots/summary.ts mayAdjustConfig), so the same pill is later opened with the violin/boxplot
+	usecase and must still offer collections as fractions */
+	if (fractionOverlayTargets.has(usecase.target)) return usecase.detail === 'term2' || usecase.detail === 'term0'
+	/* a regression variable is one number per sample, which a fraction supplies; the outcome is
+	excluded because it must be a dictionary term, per TermdbVocab.getRegressionData() */
+	if (usecase.target === 'regression') return usecase.detail === 'independent'
+	return false
+}
+
 export class TermSettingApi {
 	#termsetting: TermSetting
 	Inner?: TermSetting
@@ -118,14 +133,7 @@ export class TermSettingApi {
 			},
 			tree: {
 				disable_terms: self.disable_terms,
-				/* all summary childTypes, not just barchart: selecting a continuous overlay switches
-				childType (see plots/summary.ts mayAdjustConfig), so the same pill is later opened
-				with the violin/boxplot usecase and must still offer collections as fractions */
-				termCollectionSelectionMode:
-					fractionOverlayTargets.has(self.usecase.target) &&
-					(self.usecase.detail === 'term2' || self.usecase.detail === 'term0')
-						? 'fraction'
-						: undefined,
+				termCollectionSelectionMode: allowsCollectionFraction(self.usecase) ? 'fraction' : undefined,
 				click_term: async t => {
 					self.dom.nopilldiv.style('display', 'none')
 					self.dom.pilldiv.style('display', 'none')

--- a/server/src/routes/termdb.regression.ts
+++ b/server/src/routes/termdb.regression.ts
@@ -10,6 +10,7 @@ import { boxplot_getvalue } from '#shared/boxplot.js'
 import { getValueConversionFactor } from '#shared/helpers.js'
 import { runCumincR } from './termdb.cuminc.ts'
 import { isDictionaryType } from '#shared/terms.js'
+import { FRACTION_TW_TYPE, validateTermCollectionFraction } from '#shared/termCollection.js'
 import { getData } from '../termdb.matrix.js'
 
 type TermWrapperLike = {
@@ -222,6 +223,8 @@ snplocusPostprocess
 
 // list of supported types
 const regressionTypes = ['linear', 'logistic', 'cox']
+// q.modes of a fraction term collection that resolve to a usable regression variable
+const fractionModes = new Set(['continuous', 'spline', 'discrete'])
 // minimum number of samples to run analysis
 const minimumSample = 1
 
@@ -309,7 +312,21 @@ function parse_q(q, ds) {
 		if (isDictionaryType(tw.term.type)) {
 			// dictionary term
 			tw.q.computableValuesOnly = true // will prevent appending uncomputable values in CTE constructors
-			if (tw.term.type != 'samplelst') {
+			if (tw.term.type == 'termCollection') {
+				/* a termCollection has no term.id to rehydrate by: it is identified by its name and its
+				member terms, which the client posts whole. only the fraction wrapper reduces the collection
+				to one value per sample, as a regression variable requires; the other wrappers keep one
+				value per member term, which has no meaning as a single model variable */
+				if (tw.type != FRACTION_TW_TYPE)
+					throw `independent variable '${tw.term.name}' is a term collection and must be a fraction`
+				// getData() validates this too, but only after a full sample query
+				validateTermCollectionFraction(tw.q as any, tw.term)
+				/* getData() returns the raw fraction for every mode but 'discrete', which it bins.
+				continuous and spline analyze that number directly; any other mode would hand R the
+				unbinned fraction as a factor level, i.e. one category per sample */
+				if (!fractionModes.has(tw.q.mode))
+					throw `term collection '${tw.term.name}' cannot be analyzed in q.mode='${tw.q.mode}'`
+			} else if (tw.term.type != 'samplelst') {
 				// samplelst terms are client-made and cannot be rehydrated
 				if (!tw.term.id) throw 'tw.term.id missing'
 				const term = ds.cohort.termdb.q.termjsonByOneid(tw.term.id)
@@ -1312,9 +1329,16 @@ Returns an array with elemenents:
 		},
 */
 async function getSampleData(q: RegressionQuery, ds: any): Promise<SampleDataEntry[]> {
+	/* keep the request tws in a local array rather than reading them back off q2.terms:
+	getData() replaces q.terms with the expanded member tws of a custom termCollection, so the
+	collection tw itself, which is the key its resolved value is returned under, is no longer there */
+	const terms = [q.outcome, ...q.independent]
 	const q2 = Object.assign({}, q)
-	q2.terms = [q.outcome, ...q.independent]
+	q2.terms = terms
 	const result = await getData(q2, ds)
+	/* an error from getData() is not thrown, and leaves result.samples undefined: without this
+	the analysis proceeds on zero samples and reports 'too few samples to fit model' instead */
+	if (result.error) throw result.error
 
 	const filteredSamples = mayProcessSampleByCoxOutcome(q, ds, result.samples) // array of objects, same shape as result.samples{} values
 	const samples: any[] = [] // collect reshaped sample objs and return
@@ -1326,8 +1350,9 @@ async function getSampleData(q: RegressionQuery, ds: any): Promise<SampleDataEnt
 			id2value: new Map<string, any>()
 		}
 
-		for (const tw of q2.terms) {
-			if (tw.$id in sample) {
+		for (const tw of terms) {
+			// a tw without $id has no key to read its sample data by; makeRinput() drops such a variable
+			if (tw.$id && tw.$id in sample) {
 				obj.id2value.set(tw.$id, sample[tw.$id])
 				mayAddAncestryPCs(tw, obj, ds)
 			}

--- a/shared/utils/src/termdb.usecase.ts
+++ b/shared/utils/src/termdb.usecase.ts
@@ -245,6 +245,17 @@ export function isUsableTerm(term, _usecase, termdbConfig?: any, ds?: any) {
 			}
 
 			if (usecase.detail == 'independent') {
+				/* a term collection holds one value per member term, which is not a model variable.
+				only a numeric collection is offered, and only as a fraction: selecting it opens the
+				numerator/denominator chooser (client/termdb/handlers/termCollectionFractionSelection.ts),
+				which reduces the collection to one numeric value per sample. a categorical collection
+				has no such scalar form. the outcome is excluded above: it must be a dictionary term,
+				as enforced by TermdbVocab.getRegressionData() */
+				if (term.type == TermTypes.TERM_COLLECTION) {
+					// memberType is read directly: isNumTermCollection() does not yet test it
+					if (term.memberType == 'numeric') uses.add('plot')
+					return uses
+				}
 				if (term.type == 'float' || term.type == 'integer' || term.type == 'categorical' || term.type == 'samplelst')
 					uses.add('plot')
 				if (hasChildTypes(child_types, ['categorical', 'float', 'integer'])) uses.add('branch')


### PR DESCRIPTION
…ocab getCategories() shim getTwCategories

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
