### PR TITLE
store.init() calls gvTw walker to seed all custom-set, allowing those…

### DIFF
--- a/client/mass/store.ts
+++ b/client/mass/store.ts
@@ -92,6 +92,19 @@ session accumulates, since state.reuse is serialized into every session saved fr
 const maxGvQPerGene = 5
 const maxGvQGenes = 30
 
+/* The cache is keyed by gene names a url or an embedder can supply (see getGvGeneKey()),
+while it has to stay a plain object, since state.reuse is serialized into saved sessions.
+A key that collides with an inherited name must therefore never be read through the
+prototype -- 'constructor' would read a function whose .some()/.findIndex() throws -- so
+every read checks hasGvQKey() first. Inserting goes through defineProperty because
+assigning to '__proto__' would replace the cache's prototype instead of storing the list. */
+function hasGvQKey(cache: any, key: string) {
+	return Object.prototype.hasOwnProperty.call(cache, key)
+}
+function setGvQLst(cache: any, key: string, lst: any) {
+	Object.defineProperty(cache, key, { value: lst, enumerable: true, writable: true, configurable: true })
+}
+
 // one store for the whole MASS app
 class MassStore extends StoreBase implements RxStore {
 	static type = 'store'
@@ -214,8 +227,11 @@ class MassStore extends StoreBase implements RxStore {
 			if (!isCustomizedGvQ(q)) return
 			const key = getGvGeneKey(term)
 			if (!key) return // a term whose genes cannot all be named, see getGvGeneKey()
-			if (!(key in cache) && Object.keys(cache).length >= maxGvQGenes) return
-			const lst = cache[key] || (cache[key] = [])
+			if (!hasGvQKey(cache, key)) {
+				if (Object.keys(cache).length >= maxGvQGenes) return
+				setGvQLst(cache, key, [])
+			}
+			const lst = cache[key]
 			if (lst.length >= maxGvQPerGene) return
 			const trimmed = trimGvQForCache(q)
 			if (lst.some(entry => deepEqual(entry.q, trimmed))) return
@@ -503,7 +519,7 @@ MassStore.prototype.actions = {
 		if (!key) return // a term whose genes cannot all be named, see getGvGeneKey()
 		const cache = this.state.reuse.gvQByGene
 		const trimmed = trimGvQForCache(q)
-		const lst = cache[key] || []
+		const lst = hasGvQKey(cache, key) ? cache[key] : []
 		const i = lst.findIndex(entry => deepEqual(entry.q, trimmed))
 		if (i != -1) lst.splice(i, 1)
 		lst.unshift({ label: getGvQLabel(term, q), q: trimmed })
@@ -511,7 +527,7 @@ MassStore.prototype.actions = {
 		/* re-inserted rather than assigned in place, so that the gene keys are in recency
 		order too and the eviction below drops the least recently used gene */
 		delete cache[key]
-		cache[key] = lst
+		setGvQLst(cache, key, lst)
 		const keys = Object.keys(cache)
 		if (keys.length > maxGvQGenes) delete cache[keys[0]]
 	},

--- a/client/mass/store.ts
+++ b/client/mass/store.ts
@@ -4,7 +4,7 @@ import { getSamplelstTW, getFilter } from './groups.js'
 import { rehydrateFilter } from '../filter/rehydrateFilter.js'
 import { importPlot } from '#plots/importPlot.js'
 import { CustomError } from '#shared/helpers.js'
-import { getGvGeneKey, trimGvQForCache } from '#shared/terms.js'
+import { forEachGvTw, getGvGeneKey, trimGvQForCache } from '#shared/terms.js'
 import { getGvQLabel, isCustomizedGvQ } from '../tw/geneVariant'
 
 /*
@@ -78,7 +78,8 @@ const defaultState = {
 		/* settings a user has built for a geneVariant term, keyed by gene(s) and most recent
 		first, so that a term built later for the same gene can offer them, see remember_gvq().
 		Filled as a side effect of building one, unlike the removed Reuse menu that required the
-		user to save a setting by hand before it could be reused. */
+		user to save a setting by hand before it could be reused, and seeded from the settings
+		the opened plots already carry, see seedGvQCache(). */
 		gvQByGene: {}
 	},
 	groups: [], // element: {name=str, filter={}}, to show in Groups tab
@@ -185,10 +186,41 @@ class MassStore extends StoreBase implements RxStore {
 					this.state.plots.splice(i, 1)
 				}
 			}
+			// after the loop above, so that every tw walked has been filled by getPlotConfig()
+			this.seedGvQCache()
 		} catch (e) {
 			console.log('store.init() error', e)
 			throw e
 		}
+	}
+
+	/*
+	Remember the geneVariant settings that the plots this app opened with already carry, so
+	that one supplied by a url, by an embedder, or by a session saved before these were
+	remembered can be offered for a term built later, the same as one built by hand here.
+	Without this, only the Apply button of the edit menu fills the cache, see remember_gvq().
+
+	Appended rather than unshifted, and skipped when already remembered, since a setting that
+	merely arrived in the opened state has no recency to claim over what a recovered session
+	carries in state.reuse: the entries a user built stay in front, and the seeded ones follow
+	in the order the plots list them.
+
+	Neither cap evicts here for the same reason -- a remembered setting is never dropped to
+	make room for a seeded one.
+	*/
+	seedGvQCache() {
+		const cache = this.state.reuse.gvQByGene
+		forEachGvTw(this.state.plots, ({ term, q }) => {
+			if (!isCustomizedGvQ(q)) return
+			const key = getGvGeneKey(term)
+			if (!key) return // a term whose genes cannot all be named, see getGvGeneKey()
+			if (!(key in cache) && Object.keys(cache).length >= maxGvQGenes) return
+			const lst = cache[key] || (cache[key] = [])
+			if (lst.length >= maxGvQPerGene) return
+			const trimmed = trimGvQForCache(q)
+			if (lst.some(entry => deepEqual(entry.q, trimmed))) return
+			lst.push({ label: getGvQLabel(term, q), q: trimmed })
+		})
 	}
 
 	setId(item) {
@@ -458,7 +490,8 @@ MassStore.prototype.actions = {
 	and rememberGvQ() in client/termdb/Vocab.js.
 
 	A setting the user returns to moves back to the front of its gene rather than being stored
-	twice, so each list reads as most recent first.
+	twice, so each list reads as most recent first. The settings that arrive already built, in
+	the plots of an opened state, are seeded behind these by seedGvQCache().
 
 	Keyed by gene and never shared across genes: the tvs of a custom groupset filter by the dt
 	terms of that gene, so a BCR-ABL1 fusion grouping is meaningless on another gene.

--- a/client/mass/store.ts
+++ b/client/mass/store.ts
@@ -4,7 +4,7 @@ import { getSamplelstTW, getFilter } from './groups.js'
 import { rehydrateFilter } from '../filter/rehydrateFilter.js'
 import { importPlot } from '#plots/importPlot.js'
 import { CustomError } from '#shared/helpers.js'
-import { forEachGvTw, getGvQCacheKey, trimGvQForCache } from '#shared/terms.js'
+import { forEachGvTw, getGvQCacheKey, gvQCacheKeyPrefix, trimGvQForCache } from '#shared/terms.js'
 import { getGvQLabel, isCustomizedGvQ } from '../tw/geneVariant'
 
 /*
@@ -85,7 +85,8 @@ const defaultState = {
 		it is keyed by gene names a url or an embedder can supply. Both the reads and the writes
 		below are therefore plain property access on a key that getGvQCacheKey() has prefixed
 		out of the namespace of Object.prototype -- see there for what an unprefixed '__proto__'
-		would do to a reopened session. */
+		would do to a reopened session, and withMigratedGvQCache() for the incoming states that
+		have to be normalized before they are merged. */
 		gvQByGene: {}
 	},
 	groups: [], // element: {name=str, filter={}}, to show in Groups tab
@@ -97,6 +98,44 @@ const defaultState = {
 session accumulates, since state.reuse is serialized into every session saved from it */
 const maxGvQPerGene = 5
 const maxGvQGenes = 30
+
+/*
+Normalize the gvQ cache of a state that arrives from outside this store -- a url, an
+embedder, a saved session -- into keys this store can hold, and return the state to merge.
+
+Required before copyMerge(), not merely nice to have: copyMerge() walks the parsed keys of
+its source with for..in and recurses into a matching object target, so an own '__proto__'
+key resolves through the getter to Object.prototype and the list under it is written onto
+that global prototype, while the entry itself is dropped. A session saved before the keys
+were prefixed carries exactly such a key when a gene was named '__proto__', so prefixing the
+accesses in this store is not enough on its own -- the key has to be gone before the merge.
+
+Legacy keys are migrated rather than dropped, so that the settings a user built before the
+prefix stay readable instead of sitting unreadable under the cap. The caps are applied here
+too, since an incoming state is not otherwise bounded by remember_gvq().
+
+Returns a copy: the state belongs to the caller, which may be an embedder holding it.
+*/
+function withMigratedGvQCache(state: any) {
+	const cache = state?.reuse?.gvQByGene
+	if (!cache || typeof cache != 'object' || Array.isArray(cache)) return state
+	const migrated: { [key: string]: any } = {}
+	// own properties only, read by descriptor so that no accessor of the prototype chain runs
+	for (const key of Object.getOwnPropertyNames(cache)) {
+		const lst = Object.getOwnPropertyDescriptor(cache, key)?.value
+		// a hand-edited or crafted session may hold anything here
+		if (!Array.isArray(lst)) continue
+		const migratedKey = key.startsWith(gvQCacheKeyPrefix) ? key : gvQCacheKeyPrefix + key
+		/* a legacy key and its prefixed form may both be present, in which case the later one
+		is re-inserted rather than kept in place, so that the keys stay in recency order */
+		delete migrated[migratedKey]
+		migrated[migratedKey] = lst.slice(0, maxGvQPerGene)
+	}
+	// least recently used first, the order that the eviction in remember_gvq() relies on
+	const keys = Object.keys(migrated)
+	for (const key of keys.slice(0, keys.length - maxGvQGenes)) delete migrated[key]
+	return { ...state, reuse: { ...state.reuse, gvQByGene: migrated } }
+}
 
 // one store for the whole MASS app
 class MassStore extends StoreBase implements RxStore {
@@ -131,7 +170,12 @@ class MassStore extends StoreBase implements RxStore {
 			// okay to ignore error of not being able to recover state
 			savedState = {}
 		}
-		this.state = this.copyMerge(this.toJson(defaultState), opts.state, savedState)
+		// both states are supplied from outside this store, see withMigratedGvQCache()
+		this.state = this.copyMerge(
+			this.toJson(defaultState),
+			withMigratedGvQCache(opts.state),
+			withMigratedGvQCache(savedState)
+		)
 		this.prevGeneratedId = 0
 	}
 
@@ -325,7 +369,8 @@ MassStore.prototype.actions = {
 		// without action.state as the current state at the
 		// initial render is not meant to be modified yet
 		//
-		this.state = this.copyMerge(this.toJson(this.state), action.state || {})
+		// action.state may be a session reopened in this app, see withMigratedGvQCache()
+		this.state = this.copyMerge(this.toJson(this.state), withMigratedGvQCache(action.state || {}))
 
 		// Subactions cause existing action methods to be called in parallel,
 		// to update unrelated parts of the state.

--- a/client/mass/store.ts
+++ b/client/mass/store.ts
@@ -4,7 +4,7 @@ import { getSamplelstTW, getFilter } from './groups.js'
 import { rehydrateFilter } from '../filter/rehydrateFilter.js'
 import { importPlot } from '#plots/importPlot.js'
 import { CustomError } from '#shared/helpers.js'
-import { forEachGvTw, getGvGeneKey, trimGvQForCache } from '#shared/terms.js'
+import { forEachGvTw, getGvQCacheKey, trimGvQForCache } from '#shared/terms.js'
 import { getGvQLabel, isCustomizedGvQ } from '../tw/geneVariant'
 
 /*
@@ -79,7 +79,13 @@ const defaultState = {
 		first, so that a term built later for the same gene can offer them, see remember_gvq().
 		Filled as a side effect of building one, unlike the removed Reuse menu that required the
 		user to save a setting by hand before it could be reused, and seeded from the settings
-		the opened plots already carry, see seedGvQCache(). */
+		the opened plots already carry, see seedGvQCache().
+
+		Has to stay a plain object, since state.reuse is serialized into saved sessions, while
+		it is keyed by gene names a url or an embedder can supply. Both the reads and the writes
+		below are therefore plain property access on a key that getGvQCacheKey() has prefixed
+		out of the namespace of Object.prototype -- see there for what an unprefixed '__proto__'
+		would do to a reopened session. */
 		gvQByGene: {}
 	},
 	groups: [], // element: {name=str, filter={}}, to show in Groups tab
@@ -91,19 +97,6 @@ const defaultState = {
 session accumulates, since state.reuse is serialized into every session saved from it */
 const maxGvQPerGene = 5
 const maxGvQGenes = 30
-
-/* The cache is keyed by gene names a url or an embedder can supply (see getGvGeneKey()),
-while it has to stay a plain object, since state.reuse is serialized into saved sessions.
-A key that collides with an inherited name must therefore never be read through the
-prototype -- 'constructor' would read a function whose .some()/.findIndex() throws -- so
-every read checks hasGvQKey() first. Inserting goes through defineProperty because
-assigning to '__proto__' would replace the cache's prototype instead of storing the list. */
-function hasGvQKey(cache: any, key: string) {
-	return Object.prototype.hasOwnProperty.call(cache, key)
-}
-function setGvQLst(cache: any, key: string, lst: any) {
-	Object.defineProperty(cache, key, { value: lst, enumerable: true, writable: true, configurable: true })
-}
 
 // one store for the whole MASS app
 class MassStore extends StoreBase implements RxStore {
@@ -225,11 +218,11 @@ class MassStore extends StoreBase implements RxStore {
 		const cache = this.state.reuse.gvQByGene
 		forEachGvTw(this.state.plots, ({ term, q }) => {
 			if (!isCustomizedGvQ(q)) return
-			const key = getGvGeneKey(term)
+			const key = getGvQCacheKey(term)
 			if (!key) return // a term whose genes cannot all be named, see getGvGeneKey()
-			if (!hasGvQKey(cache, key)) {
+			if (!cache[key]) {
 				if (Object.keys(cache).length >= maxGvQGenes) return
-				setGvQLst(cache, key, [])
+				cache[key] = []
 			}
 			const lst = cache[key]
 			if (lst.length >= maxGvQPerGene) return
@@ -515,11 +508,11 @@ MassStore.prototype.actions = {
 	remember_gvq(this: MassStore, { term, q }) {
 		// the caller is a UI, so a q that is not a setting of its own is ignored rather than an error
 		if (!isCustomizedGvQ(q)) return
-		const key = getGvGeneKey(term)
+		const key = getGvQCacheKey(term)
 		if (!key) return // a term whose genes cannot all be named, see getGvGeneKey()
 		const cache = this.state.reuse.gvQByGene
 		const trimmed = trimGvQForCache(q)
-		const lst = hasGvQKey(cache, key) ? cache[key] : []
+		const lst = cache[key] || []
 		const i = lst.findIndex(entry => deepEqual(entry.q, trimmed))
 		if (i != -1) lst.splice(i, 1)
 		lst.unshift({ label: getGvQLabel(term, q), q: trimmed })
@@ -527,7 +520,7 @@ MassStore.prototype.actions = {
 		/* re-inserted rather than assigned in place, so that the gene keys are in recency
 		order too and the eviction below drops the least recently used gene */
 		delete cache[key]
-		setGvQLst(cache, key, lst)
+		cache[key] = lst
 		const keys = Object.keys(cache)
 		if (keys.length > maxGvQGenes) delete cache[keys[0]]
 	},

--- a/client/mass/test/store.integration.spec.ts
+++ b/client/mass/test/store.integration.spec.ts
@@ -7,12 +7,15 @@ import { getGvQCacheKey } from '#shared/terms.js'
  reusable helper functions
 **************************/
 
-async function getStore() {
+/* opts.state{} is what a url, an embedder, or a session supplies to the app, so a test that
+covers what the store does with an incoming state passes it here */
+async function getStore(optsState: any = {}) {
 	const state = {
 		vocab: {
 			genome: 'hg38-test',
 			dslabel: 'TermdbTest'
-		}
+		},
+		...optsState
 	}
 
 	const app: any = { state, opts: {} }
@@ -296,6 +299,77 @@ tape('a remembered geneVariant setting survives a saved session round trip', asy
 	)
 	const unrelated: any = {}
 	test.equal(unrelated[0], undefined, 'leaves an unrelated plain object unpolluted')
+	test.end()
+})
+
+/* what a session saved before the keys were prefixed holds, and what a crafted one can hold:
+JSON.parse() turns the '__proto__' entry into an own key of the cache, which copyMerge()
+would resolve to Object.prototype. Written as text rather than as an object literal, since a
+literal's '__proto__' would set the prototype instead of creating that key. */
+function getLegacySession() {
+	const lst = (label: string) => `[{"label":"${label} / Others","q":{"type":"custom-groupset"}}]`
+	return JSON.parse(`{
+		"plots": [],
+		"reuse": { "gvQByGene": { "BCR": ${lst('legacy')}, "__proto__": ${lst('crafted')} } }
+	}`)
+}
+
+/* the numeric own properties that the entries of a cached list are written as, when
+copyMerge() recurses into Object.prototype rather than into a cache entry */
+function getPollutedProps() {
+	return Object.getOwnPropertyNames(Object.prototype).filter(k => /^\d+$/.test(k))
+}
+
+tape('a session saved before the gvQ cache keys were prefixed is migrated', async test => {
+	// supplied by a url or an embedder, merged by the store constructor
+	const constructed = await getStore(getLegacySession())
+	// the same session reopened in a running app, merged by app_refresh
+	const reopened = await getStore()
+	await reopened.actions.app_refresh.call(reopened, { type: 'app_refresh', state: getLegacySession() })
+
+	for (const [path, store] of [
+		['constructor', constructed],
+		['app_refresh', reopened]
+	] as [string, any][]) {
+		const cache = store.state.reuse.gvQByGene
+		test.deepEqual(
+			Object.keys(cache),
+			[gvKey('BCR'), gvKey('__proto__')],
+			`${path}: migrates every legacy key to its prefixed form`
+		)
+		test.deepEqual(
+			cache[gvKey('BCR')].map(entry => entry.label),
+			['legacy / Others'],
+			`${path}: keeps a legacy setting readable rather than dropping it`
+		)
+		test.deepEqual(
+			cache[gvKey('__proto__')].map(entry => entry.label),
+			['crafted / Others'],
+			`${path}: keeps the setting of a gene named '__proto__' under an own key`
+		)
+		test.equal(Object.getPrototypeOf(cache), Object.prototype, `${path}: leaves the cache a plain object`)
+	}
+	test.deepEqual(getPollutedProps(), [], 'writes no cached list entry onto Object.prototype')
+	const unrelated: any = {}
+	test.equal(unrelated[0], undefined, 'leaves an unrelated plain object unpolluted')
+	test.end()
+})
+
+tape('an incoming gvQ cache is bounded and holds only lists', async test => {
+	const entry = { label: 'legacy / Others', q: { type: 'custom-groupset' } }
+	const gvQByGene: any = { notAList: 'dropped', alsoNotAList: { label: 'dropped' } }
+	// an incoming state is not otherwise bounded, since remember_gvq() never saw it
+	for (let i = 0; i < 40; i++) gvQByGene[`GENE${i}`] = Array.from({ length: 8 }, () => entry)
+	const store = await getStore({ reuse: { gvQByGene } })
+
+	const cache = store.state.reuse.gvQByGene
+	const keys = Object.keys(cache)
+	test.equal(keys.length, 30, 'keeps at most 30 genes')
+	test.equal(keys.includes(gvKey('GENE39')), true, 'keeps the most recently used gene')
+	test.equal(keys.includes(gvKey('GENE0')), false, 'drops the least recently used gene')
+	test.equal(cache[gvKey('GENE39')].length, 5, 'keeps at most 5 settings per gene')
+	test.equal(gvKey('notAList') in cache, false, 'drops a key whose value is not a list of settings')
+	test.equal(gvKey('alsoNotAList') in cache, false, 'drops a key whose value is an object')
 	test.end()
 })
 

--- a/client/mass/test/store.integration.spec.ts
+++ b/client/mass/test/store.integration.spec.ts
@@ -230,6 +230,27 @@ tape('seeded geneVariant settings follow the remembered ones', async test => {
 	test.end()
 })
 
+tape('a gene named like an inherited object property is cached as an own key', async test => {
+	const store = await getStore()
+	const cache = store.state.reuse.gvQByGene
+	// the key comes from a gene name a url or an embedder supplies, see setGvQLst()
+	for (const gene of ['constructor', '__proto__', 'toString']) {
+		store.state.plots = [getGvPlot(gene, ['seeded', 'Others'])]
+		store.seedGvQCache()
+		rememberGvQ(store, gene, ['remembered', 'Others'])
+	}
+	test.deepEqual(Object.keys(cache), ['constructor', '__proto__', 'toString'], 'stores each gene as an own key')
+	for (const gene of ['constructor', '__proto__', 'toString']) {
+		test.deepEqual(
+			cache[gene].map(entry => entry.label),
+			['remembered / Others', 'seeded / Others'],
+			`keeps both the seeded and the remembered setting of ${gene}`
+		)
+	}
+	test.equal(Object.getPrototypeOf(cache), Object.prototype, 'never assigns through the __proto__ setter')
+	test.end()
+})
+
 tape('seeding never evicts a remembered geneVariant setting', async test => {
 	const store = await getStore()
 	for (let i = 0; i < 5; i++) rememberGvQ(store, 'BCR', [`group ${i}`, 'Others'])

--- a/client/mass/test/store.integration.spec.ts
+++ b/client/mass/test/store.integration.spec.ts
@@ -47,6 +47,12 @@ function getCustomGsQ(groupNames: string[]) {
 	}
 }
 
+/* a plot config as it is once getPlotConfig() has filled its tws, reduced to the tw that
+seedGvQCache() walks it for */
+function getGvPlot(gene: string, groupNames: string[], q?: any) {
+	return { chartType: 'summary', term: { term: getGvTerm(gene), q: q || getCustomGsQ(groupNames) } }
+}
+
 function rememberGvQ(store, gene: string, groupNames: string[], q?: any) {
 	store.actions.remember_gvq.call(store, {
 		type: 'remember_gvq',
@@ -175,5 +181,70 @@ tape('remembered geneVariant settings are bounded', async test => {
 	test.equal(keys.length, 30, 'keeps at most 30 genes')
 	test.equal(keys.includes('BCR'), false, 'evicts the least recently used gene')
 	test.equal(keys.includes('GENE39'), true, 'keeps the most recently used gene')
+	test.end()
+})
+
+tape('seedGvQCache remembers the geneVariant settings that opened plots carry', async test => {
+	const store = await getStore()
+	store.state.plots = [
+		getGvPlot('BCR', ['BCR-ABL1 fusion', 'Others']),
+		// a tw nested deeper than plot.term, as in a matrix termgroup
+		{
+			chartType: 'matrix',
+			termgroups: [{ lst: [{ term: getGvTerm('KRAS'), q: getCustomGsQ(['KRAS G12D', 'Wildtype']) }] }]
+		},
+		// not a setting of its own, see isCustomizedGvQ()
+		getGvPlot('TP53', [], { type: 'predefined-groupset', predefined_groupset_idx: 0 })
+	]
+	store.seedGvQCache()
+
+	const cache = store.state.reuse.gvQByGene
+	test.deepEqual(Object.keys(cache), ['BCR', 'KRAS'], 'seeds a gene per plot tw that carries a setting')
+	test.equal(cache.BCR[0].label, 'BCR-ABL1 fusion / Others', 'labels a seeded entry by its groups')
+	test.equal('isAtomic' in cache.KRAS[0].q, false, 'stores a trimmed q')
+	test.deepEqual(
+		cache.KRAS[0].q.customset.groups.map(g => g.name),
+		['KRAS G12D', 'Wildtype'],
+		'stores the groups of a tw that a plot carries'
+	)
+	test.equal('TP53' in cache, false, 'ignores a q that picking the gene again would produce')
+	test.end()
+})
+
+tape('seeded geneVariant settings follow the remembered ones', async test => {
+	const store = await getStore()
+	// a setting built by hand in this app, or one that a recovered session carries
+	rememberGvQ(store, 'BCR', ['BCR-JAK2 fusion', 'Others'])
+	store.state.plots = [
+		getGvPlot('BCR', ['BCR-ABL1 fusion', 'Others']),
+		getGvPlot('BCR', ['BCR-JAK2 fusion', 'Others']), // already remembered
+		getGvPlot('BCR', ['BCR-PDGFRA fusion', 'Others'])
+	]
+	store.seedGvQCache()
+
+	test.deepEqual(
+		store.state.reuse.gvQByGene.BCR.map(entry => entry.label),
+		['BCR-JAK2 fusion / Others', 'BCR-ABL1 fusion / Others', 'BCR-PDGFRA fusion / Others'],
+		'appends the seeded settings in plot order, behind a remembered one that is not stored twice'
+	)
+	test.end()
+})
+
+tape('seeding never evicts a remembered geneVariant setting', async test => {
+	const store = await getStore()
+	for (let i = 0; i < 5; i++) rememberGvQ(store, 'BCR', [`group ${i}`, 'Others'])
+	for (let i = 0; i < 29; i++) rememberGvQ(store, `GENE${i}`, ['mutated', 'Others'])
+	store.state.plots = [getGvPlot('BCR', ['seeded', 'Others']), getGvPlot('NEWGENE', ['seeded', 'Others'])]
+	store.seedGvQCache()
+
+	const cache = store.state.reuse.gvQByGene
+	test.equal(cache.BCR.length, 5, 'keeps at most 5 settings per gene')
+	test.equal(
+		cache.BCR.some(entry => entry.label == 'seeded / Others'),
+		false,
+		'drops a seeded setting rather than a remembered one'
+	)
+	test.equal(Object.keys(cache).length, 30, 'keeps at most 30 genes')
+	test.equal('NEWGENE' in cache, false, 'drops a seeded gene rather than a remembered one')
 	test.end()
 })

--- a/client/mass/test/store.integration.spec.ts
+++ b/client/mass/test/store.integration.spec.ts
@@ -1,6 +1,7 @@
 import tape from 'tape'
 import { storeInit } from '../store.ts'
 import { vocabInit } from '#termdb/vocabulary'
+import { getGvQCacheKey } from '#shared/terms.js'
 
 /*************************
  reusable helper functions
@@ -51,6 +52,12 @@ function getCustomGsQ(groupNames: string[]) {
 seedGvQCache() walks it for */
 function getGvPlot(gene: string, groupNames: string[], q?: any) {
 	return { chartType: 'summary', term: { term: getGvTerm(gene), q: q || getCustomGsQ(groupNames) } }
+}
+
+/* the cache key of a single-gene term, prefixed the same way the store keys it, so that the
+assertions below read by gene without repeating the prefix, see getGvQCacheKey() */
+function gvKey(gene: string) {
+	return getGvQCacheKey(getGvTerm(gene))
 }
 
 function rememberGvQ(store, gene: string, groupNames: string[], q?: any) {
@@ -129,7 +136,7 @@ tape('remember_gvq remembers a geneVariant setting by gene', async test => {
 	const store = await getStore()
 	rememberGvQ(store, 'BCR', ['BCR-ABL1 fusion', 'Others'])
 
-	const lst = store.state.reuse.gvQByGene.BCR
+	const lst = store.state.reuse.gvQByGene[gvKey('BCR')]
 	test.equal(lst?.length, 1, 'remembers the setting under the gene of the term')
 	test.equal(lst[0].label, 'BCR-ABL1 fusion / Others', 'labels the entry by its groups')
 	test.equal('isAtomic' in lst[0].q, false, 'stores a trimmed q')
@@ -141,10 +148,10 @@ tape('remember_gvq remembers a geneVariant setting by gene', async test => {
 
 	// a predefined groupset is what the gene search radio already offers, see isCustomizedGvQ()
 	rememberGvQ(store, 'KRAS', [], { type: 'predefined-groupset', predefined_groupset_idx: 0, isAtomic: true })
-	test.equal('KRAS' in store.state.reuse.gvQByGene, false, 'ignores a predefined groupset')
+	test.equal(gvKey('KRAS') in store.state.reuse.gvQByGene, false, 'ignores a predefined groupset')
 
 	rememberGvQ(store, 'TP53', [], { type: 'custom-groupset', customset: { groups: [] } })
-	test.equal('TP53' in store.state.reuse.gvQByGene, false, 'ignores a custom groupset with no groups')
+	test.equal(gvKey('TP53') in store.state.reuse.gvQByGene, false, 'ignores a custom groupset with no groups')
 	test.end()
 })
 
@@ -152,7 +159,7 @@ tape('remembered geneVariant settings de-duplicate and stay in recency order', a
 	const store = await getStore()
 	rememberGvQ(store, 'BCR', ['BCR-ABL1 fusion', 'Others'])
 	rememberGvQ(store, 'BCR', ['BCR-JAK2 fusion', 'Others'])
-	let lst = store.state.reuse.gvQByGene.BCR
+	let lst = store.state.reuse.gvQByGene[gvKey('BCR')]
 	test.deepEqual(
 		lst.map(entry => entry.label),
 		['BCR-JAK2 fusion / Others', 'BCR-ABL1 fusion / Others'],
@@ -164,7 +171,7 @@ tape('remembered geneVariant settings de-duplicate and stay in recency order', a
 	again.hiddenValues = { WT: 1 }
 	again.dtLst = [2]
 	rememberGvQ(store, 'BCR', [], again)
-	lst = store.state.reuse.gvQByGene.BCR
+	lst = store.state.reuse.gvQByGene[gvKey('BCR')]
 	test.equal(lst.length, 2, 'does not store an equivalent setting twice')
 	test.equal(lst[0].label, 'BCR-ABL1 fusion / Others', 'moves a setting the user returned to back to the front')
 	test.end()
@@ -173,14 +180,14 @@ tape('remembered geneVariant settings de-duplicate and stay in recency order', a
 tape('remembered geneVariant settings are bounded', async test => {
 	const store = await getStore()
 	for (let i = 0; i < 8; i++) rememberGvQ(store, 'BCR', [`group ${i}`, 'Others'])
-	test.equal(store.state.reuse.gvQByGene.BCR.length, 5, 'keeps at most 5 settings per gene')
-	test.equal(store.state.reuse.gvQByGene.BCR[0].label, 'group 7 / Others', 'keeps the most recent ones')
+	test.equal(store.state.reuse.gvQByGene[gvKey('BCR')].length, 5, 'keeps at most 5 settings per gene')
+	test.equal(store.state.reuse.gvQByGene[gvKey('BCR')][0].label, 'group 7 / Others', 'keeps the most recent ones')
 
 	for (let i = 0; i < 40; i++) rememberGvQ(store, `GENE${i}`, ['mutated', 'Others'])
 	const keys = Object.keys(store.state.reuse.gvQByGene)
 	test.equal(keys.length, 30, 'keeps at most 30 genes')
-	test.equal(keys.includes('BCR'), false, 'evicts the least recently used gene')
-	test.equal(keys.includes('GENE39'), true, 'keeps the most recently used gene')
+	test.equal(keys.includes(gvKey('BCR')), false, 'evicts the least recently used gene')
+	test.equal(keys.includes(gvKey('GENE39')), true, 'keeps the most recently used gene')
 	test.end()
 })
 
@@ -199,15 +206,15 @@ tape('seedGvQCache remembers the geneVariant settings that opened plots carry', 
 	store.seedGvQCache()
 
 	const cache = store.state.reuse.gvQByGene
-	test.deepEqual(Object.keys(cache), ['BCR', 'KRAS'], 'seeds a gene per plot tw that carries a setting')
-	test.equal(cache.BCR[0].label, 'BCR-ABL1 fusion / Others', 'labels a seeded entry by its groups')
-	test.equal('isAtomic' in cache.KRAS[0].q, false, 'stores a trimmed q')
+	test.deepEqual(Object.keys(cache), [gvKey('BCR'), gvKey('KRAS')], 'seeds a gene per plot tw that carries a setting')
+	test.equal(cache[gvKey('BCR')][0].label, 'BCR-ABL1 fusion / Others', 'labels a seeded entry by its groups')
+	test.equal('isAtomic' in cache[gvKey('KRAS')][0].q, false, 'stores a trimmed q')
 	test.deepEqual(
-		cache.KRAS[0].q.customset.groups.map(g => g.name),
+		cache[gvKey('KRAS')][0].q.customset.groups.map(g => g.name),
 		['KRAS G12D', 'Wildtype'],
 		'stores the groups of a tw that a plot carries'
 	)
-	test.equal('TP53' in cache, false, 'ignores a q that picking the gene again would produce')
+	test.equal(gvKey('TP53') in cache, false, 'ignores a q that picking the gene again would produce')
 	test.end()
 })
 
@@ -223,31 +230,72 @@ tape('seeded geneVariant settings follow the remembered ones', async test => {
 	store.seedGvQCache()
 
 	test.deepEqual(
-		store.state.reuse.gvQByGene.BCR.map(entry => entry.label),
+		store.state.reuse.gvQByGene[gvKey('BCR')].map(entry => entry.label),
 		['BCR-JAK2 fusion / Others', 'BCR-ABL1 fusion / Others', 'BCR-PDGFRA fusion / Others'],
 		'appends the seeded settings in plot order, behind a remembered one that is not stored twice'
 	)
 	test.end()
 })
 
+/* the gene names below are ones a url or an embedder can supply, see getGvQCacheKey():
+'__proto__' and 'constructor' name inherited properties of the plain object the cache is,
+and '0' is integer-like, which Object.keys() would sort ahead of the rest and break the
+least-recently-used eviction that reads those keys as insertion order */
+const hazardousGenes = ['constructor', '__proto__', 'toString', '0']
+
 tape('a gene named like an inherited object property is cached as an own key', async test => {
 	const store = await getStore()
 	const cache = store.state.reuse.gvQByGene
-	// the key comes from a gene name a url or an embedder supplies, see setGvQLst()
-	for (const gene of ['constructor', '__proto__', 'toString']) {
+	for (const gene of hazardousGenes) {
 		store.state.plots = [getGvPlot(gene, ['seeded', 'Others'])]
 		store.seedGvQCache()
 		rememberGvQ(store, gene, ['remembered', 'Others'])
 	}
-	test.deepEqual(Object.keys(cache), ['constructor', '__proto__', 'toString'], 'stores each gene as an own key')
-	for (const gene of ['constructor', '__proto__', 'toString']) {
+	test.deepEqual(Object.keys(cache), hazardousGenes.map(gvKey), 'stores each gene as an own key, in insertion order')
+	for (const gene of hazardousGenes) {
 		test.deepEqual(
-			cache[gene].map(entry => entry.label),
+			cache[gvKey(gene)].map(entry => entry.label),
 			['remembered / Others', 'seeded / Others'],
 			`keeps both the seeded and the remembered setting of ${gene}`
 		)
 	}
 	test.equal(Object.getPrototypeOf(cache), Object.prototype, 'never assigns through the __proto__ setter')
+	test.end()
+})
+
+/* state.reuse is serialized into every saved session, and reopening one merges the parsed
+state into a store: by construction when a url supplies it (see the MassStore constructor),
+or by an app_refresh carrying the full state (see sessionBtn.js). Both go through
+copyMerge(), which walks the parsed keys with for..in and recurses into a matching object
+target -- so an unprefixed '__proto__' key would survive JSON.parse() as an own key whose
+target resolves to Object.prototype through the getter, and the cached list would be written
+onto that global prototype while the cache entry itself was dropped. */
+tape('a remembered geneVariant setting survives a saved session round trip', async test => {
+	const store = await getStore()
+	for (const gene of hazardousGenes) rememberGvQ(store, gene, ['remembered', 'Others'])
+	const savedSession = JSON.parse(store.toJson(store.state))
+
+	// reopened in a new app, as clicking a saved session does
+	const reopened = await getStore()
+	await reopened.actions.app_refresh.call(reopened, { type: 'app_refresh', state: savedSession })
+	const cache = reopened.state.reuse.gvQByGene
+
+	test.deepEqual(Object.keys(cache), hazardousGenes.map(gvKey), 'keeps every cached gene through the round trip')
+	for (const gene of hazardousGenes) {
+		test.deepEqual(
+			cache[gvKey(gene)].map(entry => entry.label),
+			['remembered / Others'],
+			`keeps the remembered setting of ${gene}`
+		)
+	}
+	test.equal(Object.getPrototypeOf(cache), Object.prototype, 'leaves the reopened cache a plain object')
+	test.deepEqual(
+		Object.getOwnPropertyNames(Object.prototype).filter(k => /^\d+$/.test(k)),
+		[],
+		'writes no cached list entry onto Object.prototype'
+	)
+	const unrelated: any = {}
+	test.equal(unrelated[0], undefined, 'leaves an unrelated plain object unpolluted')
 	test.end()
 })
 
@@ -259,13 +307,13 @@ tape('seeding never evicts a remembered geneVariant setting', async test => {
 	store.seedGvQCache()
 
 	const cache = store.state.reuse.gvQByGene
-	test.equal(cache.BCR.length, 5, 'keeps at most 5 settings per gene')
+	test.equal(cache[gvKey('BCR')].length, 5, 'keeps at most 5 settings per gene')
 	test.equal(
-		cache.BCR.some(entry => entry.label == 'seeded / Others'),
+		cache[gvKey('BCR')].some(entry => entry.label == 'seeded / Others'),
 		false,
 		'drops a seeded setting rather than a remembered one'
 	)
 	test.equal(Object.keys(cache).length, 30, 'keeps at most 30 genes')
-	test.equal('NEWGENE' in cache, false, 'drops a seeded gene rather than a remembered one')
+	test.equal(gvKey('NEWGENE') in cache, false, 'drops a seeded gene rather than a remembered one')
 	test.end()
 })

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -279,7 +279,11 @@ export class Vocab {
 	hand a q to fillTermWrapper(), which fills in place. */
 	getGvQLst(term) {
 		const key = getGvGeneKey(term)
-		const lst = key && this.state.reuse?.gvQByGene?.[key]
+		const cache = this.state.reuse?.gvQByGene
+		/* own entries only: the key is a gene name a url or an embedder can supply, and one
+		that collides with an inherited name (constructor, ...) would read Object.prototype
+		off this plain object, see setGvQLst() in client/mass/store.ts */
+		const lst = key && cache && Object.prototype.hasOwnProperty.call(cache, key) && cache[key]
 		return lst ? structuredClone(lst) : []
 	}
 

--- a/client/termdb/Vocab.js
+++ b/client/termdb/Vocab.js
@@ -1,5 +1,5 @@
 import { dofetch3, isInSession, getRequiredAuth, getSavedToken, setTokenByDsRoute } from '#common/dofetch'
-import { isDictionaryType, trimGvTermCopy, getGvGeneKey } from '#shared/terms.js'
+import { isDictionaryType, trimGvTermCopy, getGvQCacheKey } from '#shared/terms.js'
 
 export class Vocab {
 	termdbConfig = {}
@@ -278,12 +278,11 @@ export class Vocab {
 	Returns [] in a host app whose store does not track them, and copies so that a caller can
 	hand a q to fillTermWrapper(), which fills in place. */
 	getGvQLst(term) {
-		const key = getGvGeneKey(term)
+		/* the key is prefixed, so a gene named like an inherited property (__proto__,
+		constructor, ...) cannot read one off this plain object, see getGvQCacheKey() */
+		const key = getGvQCacheKey(term)
 		const cache = this.state.reuse?.gvQByGene
-		/* own entries only: the key is a gene name a url or an embedder can supply, and one
-		that collides with an inherited name (constructor, ...) would read Object.prototype
-		off this plain object, see setGvQLst() in client/mass/store.ts */
-		const lst = key && cache && Object.prototype.hasOwnProperty.call(cache, key) && cache[key]
+		const lst = key && cache?.[key]
 		return lst ? structuredClone(lst) : []
 	}
 

--- a/client/termsetting/handlers/geneVariant.ts
+++ b/client/termsetting/handlers/geneVariant.ts
@@ -99,6 +99,7 @@ async function makeEditMenu(self: TermSetting, _div: any) {
 		.append('div')
 		.style('margin-top', '25px')
 		.append('button')
+		.attr('data-testid', 'sjpp-ts-gv-editui-applyBtn')
 		.text('Apply')
 		.on('click', () => {
 			const q = self.q as any // TODO: migrate this handler to use client/tw code

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -264,7 +264,8 @@ cycle reaches this walk (see setGroupsetParentTerms()).
 export function forEachGvTw(obj: any, callback: (tw: any) => void) {
 	if (!obj || typeof obj != 'object') return
 	if (obj.q && obj.term?.type == GENE_VARIANT) callback(obj)
-	for (const k in obj) forEachGvTw(obj[k], callback)
+	// own values only, to not descend into inherited props/methods, as in StoreBase.deepFreeze()
+	for (const value of Object.values(obj)) forEachGvTw(value, callback)
 }
 
 /*

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -340,6 +340,31 @@ export function getGvGeneKey(term: any): string {
 	return keys.sort().join(',')
 }
 
+/*
+The key a remembered geneVariant setting is cached under, see remember_gvq() in
+client/mass/store.ts. Returns '' for a term that getGvGeneKey() cannot key.
+
+Prefixed because the cache is a plain object keyed by gene names a url or an embedder can
+supply, and is serialized into every session saved from the state:
+
+- an unprefixed gene named '__proto__' or 'constructor' would name an inherited property of
+  the cache, so a read would resolve to Object.prototype or to a function instead of missing
+- worse, such a key survives JSON.parse() as an own key that copyMerge() then walks when a
+  session is reopened, resolving target['__proto__'] to Object.prototype through the getter
+  and writing the cached list onto it, see copyMerge() in client/rx/src/StoreBase.ts
+
+- an unprefixed integer-like gene name would also sort ahead of the rest in Object.keys(),
+  which the least-recently-used eviction in remember_gvq() reads as insertion order
+
+The prefix cannot itself be produced by getGvGeneKey(), since a gene symbol or a coord
+region never starts with it, so prefixed keys stay one-to-one with the terms they key.
+*/
+export const gvQCacheKeyPrefix = 'gv:'
+export function getGvQCacheKey(term: any): string {
+	const key = getGvGeneKey(term)
+	return key ? gvQCacheKeyPrefix + key : ''
+}
+
 /** the kind of a geneVariant gene entry, inferred exactly as GvBase.fill() infers it for an
  * entry that predates term.kind, so that a term keys the same before and after it is filled */
 function getGvGeneKind(gene: any): string | undefined {

--- a/shared/utils/src/terms.ts
+++ b/shared/utils/src/terms.ts
@@ -250,6 +250,24 @@ export function trimGvTermCopy(term: any, q: any) {
 }
 
 /*
+Call back on every geneVariant tw of an object, at any depth, so that a caller can accept a
+whole state, a state.plots[], or one plot config without knowing where a plot keeps its tws
+(term/term0/term2 of a chart, termgroups[].lst[] of a matrix, and so on).
+
+A tw is identified by a term{} paired with a q{}, so that the dt term of a tvs of a mass
+filter, which is a bare term, is never mistaken for one.
+
+Descends into a matched tw as well, since a tw can nest one: the tvs of a custom groupset
+carry a parentTerm, which is a copy and not a reference back to the term walked here, so no
+cycle reaches this walk (see setGroupsetParentTerms()).
+*/
+export function forEachGvTw(obj: any, callback: (tw: any) => void) {
+	if (!obj || typeof obj != 'object') return
+	if (obj.q && obj.term?.type == GENE_VARIANT) callback(obj)
+	for (const k in obj) forEachGvTw(obj[k], callback)
+}
+
+/*
 Strip every derived property of a geneVariant term from a state that is about to be
 serialized into a saved session, in place. Walks any object and trims the term of each
 geneVariant tw it finds, so it accepts a whole state, a state.plots[], or one plot config.
@@ -266,20 +284,18 @@ Between them these are ~91% of a serialized single-gene tw, and the ratio climbs
 gene count: term.genes[] is serialized once per childTerm.parentTerm and once per tvs of the
 selected groupset, so a 200-gene tw carries ~9 copies of it.
 
-A tw is identified by a term{} paired with a q{}, so that the dt term of a tvs of a mass
-filter, which does need its own parentTerm, is never mistaken for one. Of q{}, only the
-parentTerm of a customset tvs is trimmed, which GvCustomGS.fill() re-attaches; the rest of
-q.customset is user-authored and no fill() rebuilds it.
+Only the parentTerm of a customset tvs is trimmed out of q{}, which GvCustomGS.fill()
+re-attaches; the rest of q.customset is user-authored and no fill() rebuilds it. The dt term
+of a tvs of a mass filter does need its own parentTerm, and keeps it, since forEachGvTw()
+only reaches a term paired with a q.
 */
 export function trimGvTermsForSave(obj: any) {
-	if (!obj || typeof obj != 'object') return obj
-	if (obj.q && obj.term?.type == GENE_VARIANT) {
-		delete obj.term.childTerms
+	forEachGvTw(obj, tw => {
+		delete tw.term.childTerms
 		// deleting rather than emptying, since GvBase.fill() recreates it from scratch
-		delete obj.term.groupsetting
-		if (obj.q.customset) clearGroupsetParentTerms(obj.q.customset)
-	}
-	for (const k in obj) trimGvTermsForSave(obj[k])
+		delete tw.term.groupsetting
+		if (tw.q.customset) clearGroupsetParentTerms(tw.q.customset)
+	})
 	return obj
 }
 

--- a/shared/utils/src/test/terms.unit.spec.ts
+++ b/shared/utils/src/test/terms.unit.spec.ts
@@ -3,6 +3,7 @@ import { DTCNV, DTFUSION, DTITD, DTSNVINDEL, DTSV, TermTypes } from '#types'
 import {
 	dtTermTypes,
 	getGvGeneKey,
+	getGvQCacheKey,
 	getGvQueryKey,
 	matchesGvQueryEntry,
 	internGvQueryEntry,
@@ -18,6 +19,7 @@ dt term types are declared in TermTypes
 trimGvTermsForSave()
 setGroupsetParentTerms()
 getGvGeneKey()
+getGvQCacheKey()
 trimGvQForCache()
 query entry wire format: round trip
 query entry wire format: values without an entry
@@ -300,6 +302,36 @@ tape('getGvGeneKey()', t => {
 		getGvGeneKey({ type: 'geneVariant', genes: [gene('BCR'), { kind: 'gene' }] }),
 		'',
 		'returns no key rather than a partial one that another term could share'
+	)
+	t.end()
+})
+
+tape('getGvQCacheKey()', t => {
+	const gene = (name: string) => ({ kind: 'gene', id: name, gene: name, name, type: 'geneVariant' })
+	const cache = {}
+	/* gene names a url or an embedder can supply. Kept out of the namespace of the plain
+	object the cache is, so that a read finds nothing rather than an inherited property, and
+	so that a saved session carries no key that copyMerge() would resolve to Object.prototype
+	when it is reopened, see the round trip test in client/mass/test/store.integration.spec.ts */
+	for (const name of ['__proto__', 'constructor', 'toString', 'hasOwnProperty', '0']) {
+		const key = getGvQCacheKey({ type: 'geneVariant', genes: [gene(name)] })
+		t.equal(key, `gv:${name}`, `prefixes the key of a gene named '${name}'`)
+		t.equal(key in cache, false, `does not name an inherited property for a gene named '${name}'`)
+	}
+	t.equal(
+		getGvQCacheKey({ type: 'geneVariant', genes: [gene('BCR'), gene('ABL1')] }),
+		'gv:ABL1,BCR',
+		'prefixes the whole key of a multi-gene term once'
+	)
+	t.equal(
+		getGvQCacheKey({ type: 'geneVariant', genes: [{ chr: 'chr1', start: 100, stop: 200 }] }),
+		'gv:chr1:101-200',
+		'prefixes the key of a coord entry'
+	)
+	t.equal(
+		getGvQCacheKey({ type: 'geneVariant', genes: [{ kind: 'gene' }] }),
+		'',
+		'returns no key, not a bare prefix, for a term that cannot be keyed'
 	)
 	t.end()
 })


### PR DESCRIPTION
… from url param to be reused

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
