### PR TITLE
Add test selectors for profile impression charts

### DIFF
--- a/client/emitImports.mjs
+++ b/client/emitImports.mjs
@@ -60,6 +60,11 @@ export function getCodeText(namePattern = '*.spec.*') {
 	// to prevent an early-loaded and very fast test from closing the
 	// tape harness and ignoring late-loaded tests 
 	let assertAllTestLoaded
+	// set when the imports settle before tape gets around to running the callback below, which is
+	// what happens when no spec matched the requested dir/name: Promise.all([]) resolves on the
+	// microtask queue while assertAllTestLoaded is still undefined. Without this the assertion is
+	// never made and the run reports a timeout failure rather than "nothing matched".
+	let allTestsLoaded = false
 	tape('loading of all import(spec)', test => {
 		const exp = 5000
 		test.timeoutAfter(exp)
@@ -71,6 +76,7 @@ export function getCodeText(namePattern = '*.spec.*') {
 			// else the timeoutAfter will be triggered without an assertion
 			test.end()
 		}
+		if (allTestsLoaded) assertAllTestLoaded()
 	})
 	`
 	// only keep an initial test open if there are matching specs to test
@@ -85,7 +91,13 @@ export function getCodeText(namePattern = '*.spec.*') {
 
 	output.push(`// this resolves after all test modules are loaded, 
 	// but likely before all test code are fully evaluated and completed 
-	Promise.all(promises).then(()=>assertAllTestLoaded?.()).catch(e => {throw e})
+	Promise.all(promises).then(()=>{
+		// a name/dir that matches nothing is a mistyped invocation, not a passing run — say so, since
+		// the spec name must match the whole filename before '.spec', e.g. 'foo.unit' or 'foo*'
+		if (!specsMatched.length) console.log('NOTE: no spec file matched the requested dir/name')
+		allTestsLoaded = true
+		assertAllTestLoaded?.()
+	}).catch(e => {throw e})
 	`)
 
 	output.push(`export function getSpecs() { return specsMatched }`)

--- a/client/plots/profile/profileForms.ts
+++ b/client/plots/profile/profileForms.ts
@@ -285,6 +285,9 @@ export class profileForms extends profilePlot {
 		// The whole view is driven off this config block (zones, titles, legend, axis labels), so a
 		// dataset missing it fails here with a named cause rather than downstream on a member access.
 		if (!texts) throw `Missing impression config for the plot ${this.type} in this dataset`
+		// legend.sc names the SC series and doubles as the group label for an SC-only module, which the
+		// card attribute and the chart testids are both derived from.
+		if (!texts.legend?.sc) throw `Missing impression.legend.sc for the plot ${this.type} in this dataset`
 		const scColor = this.impressionScColor || '#888'
 		const data = this.data
 
@@ -320,11 +323,14 @@ export class profileForms extends profilePlot {
 			comparison line, and the applied-filters + n line, above a single bordered box holding the two
 			charts. Tagged so getChartImages() can collect this block's svgs for download and name them.
 			*/
+			// The group's display name, falling back to the SC legend label for an SC-only module. One
+			// source for the card's attribute and for the testid suffix each chart svg carries.
+			const groupLabel = g.groupLabel || texts.legend.sc
 			const block = holder
 				.append('div')
 				.attr('class', 'sjpp-impression-card')
 				.attr('data-testid', 'sjpp-profileForms-impression-card')
-				.attr('data-group-label', g.groupLabel || texts.legend.sc)
+				.attr('data-group-label', groupLabel)
 				.style('width', 'fit-content')
 				.style('max-width', '100%')
 				.style('margin', '18px auto')
@@ -406,6 +412,7 @@ export class profileForms extends profilePlot {
 			renderImpressionThermometer({
 				holder: thermo.chartHolder,
 				id: `${this.id}-g${i}`,
+				groupLabel,
 				sc: { median: data.scMedian, total: data.scTotal },
 				poc: g.poc,
 				ratingAxisLabel: texts.ratingAxisLabel,
@@ -427,6 +434,7 @@ export class profileForms extends profilePlot {
 				renderResponseDistribution({
 					holder: dist.chartHolder,
 					id: `${this.id}-dist-g${i}`,
+					groupLabel,
 					maxScore: IMPRESSION_MAX_SCORE,
 					scDistribution: data.scDistribution || [],
 					pocDistribution: g.pocDistribution,

--- a/client/plots/profile/profileForms.ts
+++ b/client/plots/profile/profileForms.ts
@@ -323,6 +323,7 @@ export class profileForms extends profilePlot {
 			const block = holder
 				.append('div')
 				.attr('class', 'sjpp-impression-card')
+				.attr('data-testid', 'sjpp-profileForms-impression-card')
 				.attr('data-group-label', g.groupLabel || texts.legend.sc)
 				.style('width', 'fit-content')
 				.style('max-width', '100%')
@@ -334,6 +335,7 @@ export class profileForms extends profilePlot {
 			const header = block.append('div').style('text-align', 'center')
 			header
 				.append('div')
+				.attr('data-testid', 'sjpp-profileForms-impression-title')
 				.style('font-size', '1.25rem')
 				.style('font-weight', 'bold')
 				.style('padding', '4px 0')
@@ -341,6 +343,7 @@ export class profileForms extends profilePlot {
 			if (g.poc)
 				header
 					.append('div')
+					.attr('data-testid', 'sjpp-profileForms-impression-comparison')
 					.style('font-size', '1.05rem')
 					.style('font-weight', 'bold')
 					.text(texts.comparisonTitle.replace('{group}', g.groupLabel))
@@ -372,9 +375,10 @@ export class profileForms extends profilePlot {
 			// A panel holds a title, the chart svg (vertically centered in the stretched height), and the
 			// chart's own two-row legend at the bottom. `divider` draws the vertical line to the next
 			// panel as a right border on this one.
-			const chartPanel = (title: string, divider: boolean) => {
+			const chartPanel = (title: string, divider: boolean, testid: string) => {
 				const panel = body
 					.append('div')
+					.attr('data-testid', testid)
 					.style('padding', '12px 18px')
 					.style('display', 'flex')
 					.style('flex-direction', 'column')
@@ -398,7 +402,7 @@ export class profileForms extends profilePlot {
 			}
 
 			// Thermometer panel (left); a divider follows it only when a distribution panel does.
-			const thermo = chartPanel(texts.chartTitles.thermometer, !!g.poc)
+			const thermo = chartPanel(texts.chartTitles.thermometer, !!g.poc, 'sjpp-profileForms-thermometer-panel')
 			renderImpressionThermometer({
 				holder: thermo.chartHolder,
 				id: `${this.id}-g${i}`,
@@ -419,7 +423,7 @@ export class profileForms extends profilePlot {
 			})
 
 			if (g.poc) {
-				const dist = chartPanel(texts.chartTitles.distribution, false)
+				const dist = chartPanel(texts.chartTitles.distribution, false, 'sjpp-profileForms-distribution-panel')
 				renderResponseDistribution({
 					holder: dist.chartHolder,
 					id: `${this.id}-dist-g${i}`,

--- a/client/plots/profile/profilePlot.ts
+++ b/client/plots/profile/profilePlot.ts
@@ -63,7 +63,7 @@ export abstract class profilePlot extends PlotBase implements RxComponent {
 		super(opts)
 		this.type = type
 		this.downloadCount = 0
-		this.tip = new Menu({ padding: '4px', offsetX: 10, offsetY: 15 })
+		this.tip = new Menu({ padding: '4px', offsetX: 10, offsetY: 15, testid: 'sjpp-profile-tooltip' })
 		this.scoreTerms = []
 		this.scScoreTerms = []
 		this.isRadarFacility = false

--- a/client/plots/profile/renderImpressionLegend.ts
+++ b/client/plots/profile/renderImpressionLegend.ts
@@ -42,7 +42,7 @@ const textWidth = (sel: any) => (sel.node() as SVGTextElement).getBBox().width
 
 export function renderImpressionLegend(a: ImpressionLegendArgs) {
 	const holder = a.holder.style('display', 'flex').style('justify-content', 'center').style('padding-top', '8px')
-	const svg = holder.append('svg')
+	const svg = holder.append('svg').attr('data-testid', 'sjpp-profileForms-impression-legend')
 	const g = svg.append('g')
 
 	// Row 1 — series swatches (SC / POC). Laid out from x=0, then the whole row is centered below.

--- a/client/plots/profile/renderImpressionThermometer.ts
+++ b/client/plots/profile/renderImpressionThermometer.ts
@@ -221,7 +221,11 @@ export function renderImpressionThermometer(a: ImpressionThermometerArgs) {
 	const pocMedian: number | null = a.poc?.median ?? null
 	const pocTotal: number = a.poc?.total || 0
 
-	const svg = a.holder.append('svg').attr('width', SVG_W).attr('height', SVG_H)
+	const svg = a.holder
+		.append('svg')
+		.attr('data-testid', 'sjpp-profileForms-thermometer')
+		.attr('width', SVG_W)
+		.attr('height', SVG_H)
 	const root = svg.append('g')
 	const defs = root.append('defs')
 	const vessel = vesselPath()
@@ -347,6 +351,7 @@ export function renderImpressionThermometer(a: ImpressionThermometerArgs) {
 		const scFill = liquidG
 			.append('path')
 			.attr('class', 'sc-fill')
+			.attr('data-testid', 'sjpp-profileForms-sc-fill')
 			.attr('d', liquidPath(yOf(scMedian), 'left'))
 			.attr('fill', scColor)
 			.style('transition', `fill ${HOVER_MS}ms ease-out`)
@@ -360,6 +365,7 @@ export function renderImpressionThermometer(a: ImpressionThermometerArgs) {
 		const pocFill = liquidG
 			.append('path')
 			.attr('class', 'poc-fill')
+			.attr('data-testid', 'sjpp-profileForms-poc-fill')
 			.attr('d', liquidPath(yOf(pocMedian), 'right'))
 			.attr('fill', POC_FILL)
 			.style('transition', `fill ${HOVER_MS}ms ease-out`)

--- a/client/plots/profile/renderImpressionThermometer.ts
+++ b/client/plots/profile/renderImpressionThermometer.ts
@@ -65,6 +65,10 @@ export type ImpressionThermometerArgs = {
 	holder: Div
 	// Unique per rendered thermometer (one per responder group); prefixes this svg's defs ids.
 	id: string
+	// This chart's responder group, e.g. 'Clinicians'. Suffixes the svg's data-testid so a module's
+	// groups are told apart within a plot; queries still scope to the card, since a comparison plot
+	// renders a second card for the same group.
+	groupLabel: string
 	// Shared SC median across eligible sites + the site count (n) — the left (module-color) fill.
 	sc: { median: number | null; total: number }
 	// This group's POC median/total, or null for SC-only modules — the right (grey) fill.
@@ -221,9 +225,10 @@ export function renderImpressionThermometer(a: ImpressionThermometerArgs) {
 	const pocMedian: number | null = a.poc?.median ?? null
 	const pocTotal: number = a.poc?.total || 0
 
+	// Suffixed with the responder group so a module's groups are told apart within a plot.
 	const svg = a.holder
 		.append('svg')
-		.attr('data-testid', 'sjpp-profileForms-thermometer')
+		.attr('data-testid', `sjpp-profileForms-thermometer-${a.groupLabel.toLowerCase().replace(/\s/g, '-')}`)
 		.attr('width', SVG_W)
 		.attr('height', SVG_H)
 	const root = svg.append('g')

--- a/client/plots/profile/renderImpressionThermometer.ts
+++ b/client/plots/profile/renderImpressionThermometer.ts
@@ -16,6 +16,19 @@ const FALLBACK_COLOR = '#888'
 export const POC_FILL = '#9e9e9e'
 
 /*
+Responder group -> the suffix its chart svgs carry in data-testid, so a module's groups are told
+apart within a plot. Every run of non-alphanumerics collapses to one hyphen: real group names carry
+punctuation ('PHO & Nurses' -> 'pho-nurses'), which has no business inside an attribute value.
+Exported so the distribution chart derives the suffix the same way rather than repeating the rule.
+*/
+export function impressionTestIdSuffix(groupLabel: string): string {
+	return groupLabel
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '')
+}
+
+/*
 Hover cue for a liquid column: the fill eases to a lighter shade and back, so the column reads as
 responding rather than having a border drawn around it. The easing is declared as a CSS transition
 on the element itself, so the shared profilePlot delegation — which only sets the attribute —
@@ -228,7 +241,7 @@ export function renderImpressionThermometer(a: ImpressionThermometerArgs) {
 	// Suffixed with the responder group so a module's groups are told apart within a plot.
 	const svg = a.holder
 		.append('svg')
-		.attr('data-testid', `sjpp-profileForms-thermometer-${a.groupLabel.toLowerCase().replace(/\s/g, '-')}`)
+		.attr('data-testid', `sjpp-profileForms-thermometer-${impressionTestIdSuffix(a.groupLabel)}`)
 		.attr('width', SVG_W)
 		.attr('height', SVG_H)
 	const root = svg.append('g')

--- a/client/plots/profile/renderResponseDistribution.ts
+++ b/client/plots/profile/renderResponseDistribution.ts
@@ -2,7 +2,7 @@ import { scaleBand, scaleLinear } from 'd3-scale'
 import { axisBottom, axisLeft, axisRight } from 'd3-axis'
 import { line } from 'd3-shape'
 import { axisstyle } from '../../dom/axisstyle.js'
-import type { ImpressionZone } from './renderImpressionThermometer.js'
+import { impressionTestIdSuffix, type ImpressionZone } from './renderImpressionThermometer.js'
 
 /*
 Response-distribution combo chart, one per POC responder group. x = impression rating
@@ -73,7 +73,7 @@ export function renderResponseDistribution(a: ResponseDistributionArgs) {
 	// Suffixed with the responder group so a module's groups are told apart within a plot.
 	const svg = a.holder
 		.append('svg')
-		.attr('data-testid', `sjpp-profileForms-distribution-${a.groupLabel.toLowerCase().replace(/\s/g, '-')}`)
+		.attr('data-testid', `sjpp-profileForms-distribution-${impressionTestIdSuffix(a.groupLabel)}`)
 		.attr('width', svgW)
 		.attr('height', svgH)
 	const plot = svg.append('g').attr('transform', `translate(${MARGIN.left}, ${MARGIN.top})`)

--- a/client/plots/profile/renderResponseDistribution.ts
+++ b/client/plots/profile/renderResponseDistribution.ts
@@ -30,6 +30,10 @@ export type ResponseDistributionArgs = {
 	// d3 selection of the div that will hold this chart's own <svg> (inside profilePlot.dom.rightDiv).
 	holder: any
 	id: any
+	// This chart's responder group, e.g. 'Clinicians'. Suffixes the svg's data-testid so a module's
+	// groups are told apart within a plot; queries still scope to the card, since a comparison plot
+	// renders a second card for the same group.
+	groupLabel: string
 	maxScore: number
 	// Shared SC frequency distribution (site counts per rating) — the line series.
 	scDistribution: RatingBin[]
@@ -66,9 +70,10 @@ export function renderResponseDistribution(a: ResponseDistributionArgs) {
 
 	const svgW = MARGIN.left + PLOT_W + MARGIN.right
 	const svgH = MARGIN.top + PLOT_H + MARGIN.bottom // the legend is the card's, not this chart's
+	// Suffixed with the responder group so a module's groups are told apart within a plot.
 	const svg = a.holder
 		.append('svg')
-		.attr('data-testid', 'sjpp-profileForms-distribution')
+		.attr('data-testid', `sjpp-profileForms-distribution-${a.groupLabel.toLowerCase().replace(/\s/g, '-')}`)
 		.attr('width', svgW)
 		.attr('height', svgH)
 	const plot = svg.append('g').attr('transform', `translate(${MARGIN.left}, ${MARGIN.top})`)

--- a/client/plots/profile/renderResponseDistribution.ts
+++ b/client/plots/profile/renderResponseDistribution.ts
@@ -66,7 +66,11 @@ export function renderResponseDistribution(a: ResponseDistributionArgs) {
 
 	const svgW = MARGIN.left + PLOT_W + MARGIN.right
 	const svgH = MARGIN.top + PLOT_H + MARGIN.bottom // the legend is the card's, not this chart's
-	const svg = a.holder.append('svg').attr('width', svgW).attr('height', svgH)
+	const svg = a.holder
+		.append('svg')
+		.attr('data-testid', 'sjpp-profileForms-distribution')
+		.attr('width', svgW)
+		.attr('height', svgH)
 	const plot = svg.append('g').attr('transform', `translate(${MARGIN.left}, ${MARGIN.top})`)
 
 	// ~15% headroom above the tallest value on each axis so the line/columns don't touch the top edge.

--- a/client/plots/profile/test/renderImpressionThermometer.unit.spec.ts
+++ b/client/plots/profile/test/renderImpressionThermometer.unit.spec.ts
@@ -36,6 +36,7 @@ function render(holder: any, over: Partial<ImpressionThermometerArgs> = {}) {
 	renderImpressionThermometer({
 		holder,
 		id: 'test-thermo',
+		groupLabel: 'Clinicians',
 		sc: { median: 7, total: 12 },
 		poc: { median: 5, total: 340 },
 		ratingAxisLabel: 'Impression Rating',

--- a/client/plots/profile/test/renderImpressionThermometer.unit.spec.ts
+++ b/client/plots/profile/test/renderImpressionThermometer.unit.spec.ts
@@ -18,7 +18,24 @@ Tests for the impression thermometer (one welded glass vessel, two liquid column
   • null SC median → the POC fill only
   • both medians null → the empty vessel still renders
   • two instances in one holder → no defs id collision
+  • data-testid → the svg carries the group-derived suffix, for every real responder group label
 */
+
+/*
+The responder group labels the live db actually produces, with the suffix each must yield. Taken from
+the POCFimpression_* term names after the server strips the leading 'Impression ', plus the
+'Site Coordinator' fallback an SC-only module (Patients and Outcomes) renders with.
+
+The suffixes are written out rather than computed, so this pins the rule: deriving them by calling
+impressionTestIdSuffix() here would pass no matter what that function became.
+*/
+const GROUP_LABELS = [
+	{ label: 'Clinicians', suffix: 'clinicians' },
+	{ label: 'PHO', suffix: 'pho' },
+	{ label: 'PHO & PHOE', suffix: 'pho-phoe' },
+	{ label: 'PHO & Nurses', suffix: 'pho-nurses' },
+	{ label: 'Site Coordinator', suffix: 'site-coordinator' }
+]
 
 const ZONES = [
 	{ label: 'Weak', min: 1, max: 5, color: '#f4cccc' },
@@ -36,7 +53,7 @@ function render(holder: any, over: Partial<ImpressionThermometerArgs> = {}) {
 	renderImpressionThermometer({
 		holder,
 		id: 'test-thermo',
-		groupLabel: 'Clinicians',
+		groupLabel: 'PHO & Nurses',
 		sc: { median: 7, total: 12 },
 		poc: { median: 5, total: 340 },
 		ratingAxisLabel: 'Impression Rating',
@@ -411,6 +428,40 @@ tape('two thermometers in one holder: defs ids do not collide', function (test) 
 	test.equal(holder.selectAll('clipPath#grp-0-vessel-clip').size(), 1, 'the first group owns its own vessel clip')
 	test.equal(holder.selectAll('clipPath#grp-1-vessel-clip').size(), 1, 'the second group owns its own vessel clip')
 
+	holder.remove()
+	test.end()
+})
+
+tape('data-testid carries the responder group suffix', function (test) {
+	for (const { label, suffix } of GROUP_LABELS) {
+		const holder = select('body').append('div')
+		render(holder, { groupLabel: label })
+		test.equal(
+			holder.selectAll(`svg[data-testid="sjpp-profileForms-thermometer-${suffix}"]`).size(),
+			1,
+			`group '${label}' renders the thermometer as sjpp-profileForms-thermometer-${suffix}`
+		)
+		holder.remove()
+	}
+	test.end()
+})
+
+tape('two responder groups in one holder get distinct testids', function (test) {
+	// the reason the suffix exists: a module renders one card per group, so a fixed testid would repeat
+	const holder = select('body').append('div')
+	render(holder.append('div'), { id: 'g0', groupLabel: 'PHO & Nurses' })
+	render(holder.append('div'), { id: 'g1', groupLabel: 'Clinicians' })
+
+	test.equal(
+		holder.selectAll('svg[data-testid="sjpp-profileForms-thermometer-pho-nurses"]').size(),
+		1,
+		'the PHO & Nurses thermometer is uniquely addressable'
+	)
+	test.equal(
+		holder.selectAll('svg[data-testid="sjpp-profileForms-thermometer-clinicians"]').size(),
+		1,
+		'the Clinicians thermometer is uniquely addressable'
+	)
 	holder.remove()
 	test.end()
 })

--- a/client/plots/profile/test/renderResponseDistribution.unit.spec.ts
+++ b/client/plots/profile/test/renderResponseDistribution.unit.spec.ts
@@ -8,7 +8,20 @@ the right axis, three performance zones as background bands).
 
   • multi-site SC → an SC line (path.sc-line) plus a grey POC column per rating and 3 zone bands
   • single-site SC (total = 1) → a single SC point, no line
+  • data-testid → the svg carries the group-derived suffix, for every real responder group label
 */
+
+/*
+The responder group labels the live db actually produces, with the suffix each must yield — the same
+set the thermometer spec pins, since both charts derive their testid from the same group. Written out
+rather than computed so this pins the rule instead of restating it.
+*/
+const GROUP_LABELS = [
+	{ label: 'Clinicians', suffix: 'clinicians' },
+	{ label: 'PHO', suffix: 'pho' },
+	{ label: 'PHO & PHOE', suffix: 'pho-phoe' },
+	{ label: 'PHO & Nurses', suffix: 'pho-nurses' }
+]
 
 const ZONES = [
 	{ label: 'Weak', min: 1, max: 5, color: '#f4cccc' },
@@ -44,7 +57,7 @@ tape('multi-site: SC line + POC columns + zones render', function (test) {
 	renderResponseDistribution({
 		holder,
 		id: 'test-multi',
-		groupLabel: 'Clinicians',
+		groupLabel: 'PHO & Nurses',
 		maxScore: 10,
 		// reference mock-up SC + POC counts
 		scDistribution: dist([1, 5, 4, 5, 6, 7, 11, 8, 1, 1]),
@@ -69,7 +82,7 @@ tape('single-site SC (total = 1): a point, no line', function (test) {
 	renderResponseDistribution({
 		holder,
 		id: 'test-single',
-		groupLabel: 'Clinicians',
+		groupLabel: 'PHO & Nurses',
 		maxScore: 10,
 		scDistribution: dist([0, 0, 0, 0, 0, 0, 1, 0, 0, 0]), // one SC response at rating 7
 		pocDistribution: dist([2, 3, 5, 8, 9, 7, 6, 4, 1, 0]),
@@ -82,5 +95,30 @@ tape('single-site SC (total = 1): a point, no line', function (test) {
 	test.equal(holder.selectAll('circle.sc-point').size(), 1, 'exactly one SC point is drawn')
 	test.equal(holder.selectAll('rect.poc-column').size(), 10, 'POC columns still render for all ratings')
 	holder.remove()
+	test.end()
+})
+
+tape('data-testid carries the responder group suffix', function (test) {
+	for (const { label, suffix } of GROUP_LABELS) {
+		const holder = select('body').append('div')
+		renderResponseDistribution({
+			holder,
+			id: `test-${suffix}`,
+			groupLabel: label,
+			maxScore: 10,
+			scDistribution: dist([1, 5, 4, 5, 6, 7, 11, 8, 1, 1]),
+			pocDistribution: dist([14, 21, 58, 70, 99, 105, 121, 63, 24, 8]),
+			texts: TEXTS,
+			zones: ZONES,
+			colors: { sc: '#2381c3' },
+			attachTip
+		})
+		test.equal(
+			holder.selectAll(`svg[data-testid="sjpp-profileForms-distribution-${suffix}"]`).size(),
+			1,
+			`group '${label}' renders the distribution chart as sjpp-profileForms-distribution-${suffix}`
+		)
+		holder.remove()
+	}
 	test.end()
 })

--- a/client/plots/profile/test/renderResponseDistribution.unit.spec.ts
+++ b/client/plots/profile/test/renderResponseDistribution.unit.spec.ts
@@ -44,6 +44,7 @@ tape('multi-site: SC line + POC columns + zones render', function (test) {
 	renderResponseDistribution({
 		holder,
 		id: 'test-multi',
+		groupLabel: 'Clinicians',
 		maxScore: 10,
 		// reference mock-up SC + POC counts
 		scDistribution: dist([1, 5, 4, 5, 6, 7, 11, 8, 1, 1]),
@@ -68,6 +69,7 @@ tape('single-site SC (total = 1): a point, no line', function (test) {
 	renderResponseDistribution({
 		holder,
 		id: 'test-single',
+		groupLabel: 'Clinicians',
 		maxScore: 10,
 		scDistribution: dist([0, 0, 0, 0, 0, 0, 1, 0, 0, 0]), // one SC response at rating 7
 		pocDistribution: dist([2, 3, 5, 8, 9, 7, 6, 4, 1, 0]),


### PR DESCRIPTION
This pull request adds `data-testid` attributes to various elements in the profile forms and related chart components to improve testability and make it easier to select elements in automated tests. These changes do not affect the user interface or functionality, but provide hooks for more robust and maintainable UI testing.

**Testability improvements:**

* Added `data-testid` attributes to key container elements in `profileForms`, including the impression card, impression title, impression comparison, thermometer panel, and distribution panel.
* Updated the `chartPanel` function to accept a `testid` parameter and apply it to chart panels.
* Added `data-testid` attributes to SVG elements and chart fills in `renderImpressionLegend`, `renderImpressionThermometer`, and `renderResponseDistribution` for easier selection in tests. 
* Set a `data-testid` on the tooltip menu in the base `profilePlot` class for consistent test targeting.# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
