### PR TITLE
survival: add control test ids

### DIFF
--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -201,6 +201,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 							type: 'checkbox',
 							chartType: 'survival',
 							settingsKey: 'ciVisible',
+							testid: 'ciVisible',
 							title: 'Display the 95% confidence interval'
 						},
 						{
@@ -258,6 +259,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 							type: 'checkbox',
 							chartType: 'survival',
 							settingsKey: 'atRiskVisible',
+							testid: 'atRiskVisible',
 							title: 'Display the at-risk counts'
 						},
 						//{label: 'At-risk label offset', type: 'numeric', chartType: 'survival', settingsKey: 'atRiskLabelOffset'},

--- a/client/plots/survival/survival.ts
+++ b/client/plots/survival/survival.ts
@@ -201,7 +201,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 							type: 'checkbox',
 							chartType: 'survival',
 							settingsKey: 'ciVisible',
-							testid: 'ciVisible',
+							testid: 'sjpp-survival-control-ciVisible',
 							title: 'Display the 95% confidence interval'
 						},
 						{
@@ -259,7 +259,7 @@ class TdbSurvival extends PlotBase implements RxComponent {
 							type: 'checkbox',
 							chartType: 'survival',
 							settingsKey: 'atRiskVisible',
-							testid: 'atRiskVisible',
+							testid: 'sjpp-survival-control-atRiskVisible',
 							title: 'Display the at-risk counts'
 						},
 						//{label: 'At-risk label offset', type: 'numeric', chartType: 'survival', settingsKey: 'atRiskLabelOffset'},


### PR DESCRIPTION
This pull request makes a small update to the survival plot component to improve testability. Specifically, it adds `testid` attributes to the confidence interval and at-risk count checkbox controls, making them easier to select in automated tests.

- Testability improvements:
  * Added `testid: 'ciVisible'` to the confidence interval checkbox control in `survival.ts`.
  * Added `testid: 'atRiskVisible'` to the at-risk counts checkbox control in `survival.ts`.# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
