### PR TITLE
Return tw.term when launching geneExpression tvs menu

### DIFF
--- a/client/termdb/TermTypeSearch.ts
+++ b/client/termdb/TermTypeSearch.ts
@@ -476,7 +476,12 @@ export class TermTypeSearch {
 				type: 'submenu_set',
 				submenu: {
 					type: 'tvs',
-					term: term.term?.type == 'geneVariant' ? this.getDtTerm(term) : term
+					term:
+						term.term?.type == 'geneVariant'
+							? this.getDtTerm(term)
+							: term.term?.type == 'geneExpression'
+							? term.term
+							: term
 				}
 			})
 		}


### PR DESCRIPTION
# Description

Fixed geneExpression tvs error that was introduced here: https://github.com/stjude/proteinpaint/pull/4897/changes#diff-d1ce823d9f4ab016709ac7700d5fed585c1b8bf5aa0acabae2bd2cd85e8a2336

Can test in http://localhost:3000/?massnative=hg38,ASH and create geneExpression filter.

Will add test coverage later.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
