### PR TITLE
GDC: Enable hier clustering in volcano

### DIFF
--- a/client/plots/DEinput.ts
+++ b/client/plots/DEinput.ts
@@ -488,7 +488,8 @@ class DEinputPlot extends PlotBase implements RxComponent {
 			samplelstTW.term.values[g.name] = {
 				color: g.color,
 				key: g.name,
-				label: g.name
+				label: g.name,
+				list: sampleIds //samples need to be passed for the samplelst filter to work
 			}
 		}
 

--- a/client/plots/matrix/matrix.js
+++ b/client/plots/matrix/matrix.js
@@ -266,6 +266,9 @@ export class Matrix extends PlotBase {
 			})
 			await this.adjustSvgDimensions(prevTranspose)
 			this.controlsRenderer.main()
+			// sayerror() appends, and main() reruns on every zoom/layout/control change, so clear
+			// first or the same skipped-terms messages stack up one copy per render
+			this.dom.errorDiv.selectAll('*').remove()
 			if (this.data.removedHierClusterTerms) {
 				for (const r of this.data.removedHierClusterTerms) {
 					sayerror(this.dom.errorDiv, r.text + ': ' + r.lst.join(', '))

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- GDC: Enable hier clustering in volcano


### PR DESCRIPTION
# Description
The DE samplelst tw was built without `list`, so the clustering filter
carried no sample ids. Every other builder of a samplelst tw sets it
(see getSamplelstTW2 in mass/groups.js), and both consumers read
`term.values[].list`: get_samplelst() in server termdb.filter.js, and
the volcano's own clustering filter.

- client/plots/DEinput.ts — add `list: sampleIds` to the samplelst tw
- client/plots/matrix/matrix.js — clear errorDiv before rendering
  skipped-terms messages; main() reruns on every zoom/layout change,
  so they stacked one copy per render

Pairs with stjude/sjpp#1516, which added the GDC-side samplelst →
cases.case_id filter translation. That is already on sjpp master, so
until this merges, GDC volcano → hierarchical clustering fails with
"samplelst filter has no samples".

Verified against a live GDC dev server

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
