### PR TITLE
Improve run_rust so server error gets reported

### DIFF
--- a/rust/index.js
+++ b/rust/index.js
@@ -47,6 +47,21 @@ export function run_rust(binfile, input_data, args = [], { signal } = {}) {
 			ps.on('close', () => signal.removeEventListener('abort', onAbort))
 		}
 
+		/* A child that dies before reading its input -- missing binary, dynamic-loader failure,
+		immediate panic -- leaves the write below on a closed pipe. An 'error' event with no listener
+		throws, and the server registers no process-level uncaughtException handler, so without this
+		the whole node process exits: the client gets a gateway 502 instead of an error message, and
+		the child's stderr is destroyed along with the process, hiding why it died in the first place.
+		The try/catch below does not cover this -- the error is emitted asynchronously on the stream,
+		not thrown by .pipe().
+
+		Recorded rather than rejected here, because ps.on('close') fires immediately after with the
+		child's exit code and stderr, which is the actual cause; EPIPE on its own says nothing useful. */
+		let stdinError
+		ps.stdin.on('error', err => {
+			stdinError = err
+		})
+
 		try {
 			Readable.from(input_data).pipe(ps.stdin)
 		} catch (error) {
@@ -69,6 +84,10 @@ export function run_rust(binfile, input_data, args = [], { signal } = {}) {
 				const err = stderr.join('').trim()
 				const errmsg = `run_rust('${binfile}') emitted standard error\n stderr: ${err}`
 				reject(errmsg)
+			} else if (stdinError) {
+				// exited cleanly but never read all of its input, so it did not act on the full request:
+				// the stdout it did produce is computed from a truncated payload, not a valid result
+				reject(`run_rust('${binfile}'): could not write input, ${stdinError.message || stdinError}`)
 			} else if (stdout.join('').includes('Cannot read bigWig file') == true) {
 				// When bigfile is not found, the promise should be rejected with message given below
 				reject(stdout.join(''))


### PR DESCRIPTION
# Description
Improve `run_rust` to capture child process errors instead of swallowing them 
## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
