### PR TITLE
GDC: Added detailed reporting to DE pre-analysis panel

### DIFF
--- a/client/mass/groups.js
+++ b/client/mass/groups.js
@@ -658,6 +658,64 @@ function addGroupCountRow(table, role, samplelstTW, i, count, sampleLabel) {
 	c2.text(`${count} ${sampleLabel}`)
 }
 
+/* Provenance for datasets that assemble their counts matrix per run (gdc today): which files
+back the cohort, how the one-file-per-case choice was made, and how much of the fetch is
+already cached. Absent for datasets with a static counts file, so this renders nothing.
+
+The counts above say how many cases are comparable; this says what data those cases resolve
+to. Both are needed to read a result: a case with three rna-seq aliquots contributes exactly
+one column, and which one is not obvious from the case count alone.
+
+ponytail: summary only. countsFiles.multiCases[] carries the per-case candidate lists and is
+not shown -- render it in an expandable table if someone actually needs to audit a specific
+case, and drop it from the payload if nobody does. */
+function renderCountsFileInfo(holder, preview, sampleLabel) {
+	if (!preview) return
+
+	/* every line is stated even when it is unremarkable. "0 cases had more than one file" and
+	"all Tumor" are the answers a reader needs; suppressing them as boring leaves the reader unable
+	to tell a clean cohort from a report that skipped the check. */
+	const lines = []
+
+	const missing = preview.casesRequested - preview.cases
+	lines.push(
+		`${preview.cases} of ${preview.casesRequested} ${sampleLabel} resolve to a counts file` +
+			(missing > 0 ? ` — ${missing} have no open-access file` : '')
+	)
+	lines.push(
+		`${preview.candidateFiles} candidate ${preview.candidateFiles == 1 ? 'file' : 'files'}; ` +
+			`${preview.casesWithMultiple} ${sampleLabel} had more than one`
+	)
+	lines.push(
+		'Aliquots: ' +
+			Object.entries(preview.byTissueType)
+				.map(([t, n]) => `${n} ${t}`)
+				.join(', ')
+	)
+
+	/* only when the dataset knows what its cache is keyed on. matrixCached is the decisive case --
+	an assembled cohort fetches nothing regardless of the per-file counts -- so it is worded as a
+	fact, while the per-file numbers are a disk probe and are worded as what the run would do */
+	if (preview.axisKnown && preview.toDownload != null)
+		lines.push(
+			preview.matrixCached
+				? 'Fetch: none, this cohort is already assembled'
+				: preview.toDownload
+				? `Fetch: ${preview.cached} cached, ${preview.toDownload} to download`
+				: 'Fetch: none, every file is already cached'
+		)
+
+	lines.push(`Rule: ${preview.selectionRule}`)
+
+	const div = holder
+		.append('div')
+		.style('margin', '2px 0 0 5px')
+		.style('padding', '0 10px')
+		.style('font-size', '.85em')
+		.style('opacity', 0.65)
+	for (const l of lines) div.append('div').text(l)
+}
+
 /* Renders the group sample counts and the "Run Differential X Analysis" button, for both
 differential gene expression and differential DNA methylation.
 
@@ -705,6 +763,8 @@ export function renderPreAnalysisData(arg) {
 	table.table.style('margin-left', '5px').style('padding', '5px 10px')
 	addGroupCountRow(table, 'CONTROL', samplelstTW, 0, numControl, sampleLabel)
 	addGroupCountRow(table, 'CASE', samplelstTW, 1, numCase, sampleLabel)
+
+	renderCountsFileInfo(menuDiv, preAnalysisData.countsFiles, sampleLabel)
 
 	// display errors
 	const alertDiv = menuDiv.append('div')

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Features:
+- GDC: Added detailed reporting to DE pre-analysis panel

--- a/server/src/routes/termdb.DE.ts
+++ b/server/src/routes/termdb.DE.ts
@@ -1,5 +1,5 @@
 import type { RoutePayload, RouteApi } from '#types'
-import type { DEFullResponse, DEImage, DERequest, ExpressionInput, GeneDEEntry } from '#types'
+import type { CountsFilePreview, DEFullResponse, DEImage, DERequest, ExpressionInput, GeneDEEntry } from '#types'
 import { mayLog } from '#src/helpers.ts'
 import serverconfig from '#src/serverconfig.js'
 import { run_R } from '@sjcrh/proteinpaint-r'
@@ -47,7 +47,7 @@ export function init({ genomes }) {
 			// preAnalysis short-circuit: just sample counts, no cache touch.
 			if ((q as any).preAnalysis) {
 				const { ds, term_results, term_results2 } = await resolveDaContext(q, genomes)
-				const { allSampleSet, maxSamples } = resolveDE(q, ds)
+				const { allSampleSet, maxSamples, previewCountsFiles } = resolveDE(q, ds)
 				const groups = await resolveSampleGroups(q, allSampleSet, ds, term_results, term_results2)
 				const group1Name = q.samplelst.groups[0].name
 				const group2Name = q.samplelst.groups[1].name
@@ -61,6 +61,18 @@ export function init({ genomes }) {
 					const noun = ds.cohort?.termdb?.uiLabels?.samples || 'samples'
 					alerts.push(`${total} ${noun} selected exceeds the limit of ${maxSamples} per run. Please narrow the cohort.`)
 				}
+				/* describe the counts files this run would use. skipped when an alert already stands,
+				since the client hides the run button and the preview costs a live metadata query.
+				a throw here is not a failed pre-analysis -- the counts are the answer, this is only
+				provenance -- so it degrades to no countsFiles{} in the response. */
+				let countsFiles: CountsFilePreview | undefined
+				if (previewCountsFiles && !alerts.length) {
+					try {
+						countsFiles = await previewCountsFiles([...groups.group1names, ...groups.group2names], q)
+					} catch (e: any) {
+						mayLog('[DE] counts file preview failed:', e?.message || e)
+					}
+				}
 				// the alert is a sibling of data{}, not a key in it: data{} is keyed by group name, and a
 				// group named 'alert' would otherwise be indistinguishable from this message
 				res.send({
@@ -68,7 +80,8 @@ export function init({ genomes }) {
 						[group1Name]: groups.group1names.length,
 						[group2Name]: groups.group2names.length
 					},
-					...(alerts.length ? { alert: alerts.join(' | ') } : {})
+					...(alerts.length ? { alert: alerts.join(' | ') } : {}),
+					...(countsFiles ? { countsFiles } : {})
 				})
 				return
 			}
@@ -153,7 +166,18 @@ export async function getDeCacheResult(
 	return { result, cacheId }
 }
 
-function resolveDE(req, ds) {
+/* the pseudobulk branch below fills in only the first two, so the rest are optional. named
+because the two returns have different shapes and the union would otherwise hide the
+builder-only fields from callers */
+type ResolvedDE = {
+	countsFile?: string
+	allSampleSet: Set<string>
+	buildCountsFile?: (samples: string[], q: any) => Promise<{ file: string; samples: string[] }>
+	previewCountsFiles?: (samples: string[], q: any) => Promise<CountsFilePreview>
+	maxSamples?: number
+}
+
+function resolveDE(req, ds): ResolvedDE {
 	if (req.pseudobulk) {
 		const co =
 			ds.queries?.singleCell?.pseudobulk?.[req.pseudobulk.assay]?.[req.pseudobulk.memberId]?.categories?.[
@@ -161,7 +185,7 @@ function resolveDE(req, ds) {
 			]
 		if (!co) throw 'pseudobulk category obj not found for DE'
 		if (!co.totalFile) throw 'pseudobulk category obj totalFile not found'
-		return { countsFile: co.totalFile, allSampleSet: co.totalSampleset }
+		return { countsFile: co.totalFile, allSampleSet: co.totalSampleset } as ResolvedDE
 	}
 	const c = ds.queries?.rnaseqGeneCount
 	if (!c) throw 'no rnaseqGeneCount for DE'
@@ -172,6 +196,7 @@ function resolveDE(req, ds) {
 		countsFile: c.file,
 		allSampleSet: c.allSampleSet,
 		buildCountsFile: c.buildCountsFile,
+		previewCountsFiles: c.previewCountsFiles,
 		maxSamples: c.maxSamples
 	}
 }

--- a/shared/types/src/dataset.ts
+++ b/shared/types/src/dataset.ts
@@ -1,7 +1,7 @@
 import type { Mclass } from './Mclass.ts'
 import type { BaseTerm } from './terms/term.ts'
 import type { CategoryKey } from './terms/termCollection.ts'
-import type { TermdbSingleCellSamplesRequest } from './index.ts'
+import type { TermdbSingleCellSamplesRequest, CountsFilePreview } from './index.ts'
 /*** General usage types ***/
 type FileObj = {
 	file: string
@@ -753,7 +753,15 @@ type RnaseqGeneCount = {
 	 * from open-access STAR-Counts files). called by the DE route only after the sample groups are
 	 * resolved, since the matrix is built for exactly the samples in the two groups. returns the
 	 * h5 path plus the samples that actually landed in it, which may be fewer than requested. */
-	buildCountsFile?: (samples: string[], q: any) => Promise<{ file: string; samples: string[] }>
+	buildCountsFile?: (
+		samples: string[],
+		q: any
+	) => Promise<{ file: string; samples: string[]; countsFiles?: CountsFilePreview }>
+	/** describe the counts files behind a run without building it, so preAnalysis can tell the user
+	 * which files back the cohort and how much of the fetch is already cached. costs one metadata
+	 * query and no downloads. only for datasets with buildCountsFile; may throw, and the DE route
+	 * treats a throw as "no preview" rather than a failed pre-analysis. */
+	previewCountsFiles?: (samples: string[], q: any) => Promise<CountsFilePreview>
 	/** max samples one DE run may build a matrix for. reported during preAnalysis so the client can
 	 * warn before the user submits, and enforced by buildCountsFile itself */
 	maxSamples?: number

--- a/shared/types/src/routes/termdb.DE.ts
+++ b/shared/types/src/routes/termdb.DE.ts
@@ -187,6 +187,41 @@ export type ExpressionInput = {
 	cachedir?: string
 }
 
+/** What a build-on-demand dataset can say about the counts files behind a run, before
+ * running it: which files back the requested cases, how the one-file-per-case choice was
+ * made, and how much of the fetch is already on disk. Produced by
+ * RnaseqGeneCount.previewCountsFiles; gdc is the only implementer today. */
+export type CountsFilePreview = {
+	/** cases the run asked about */
+	casesRequested: number
+	/** cases that actually have a usable counts file; <= casesRequested */
+	cases: number
+	/** counts files found across those cases, before one-per-case selection */
+	candidateFiles: number
+	/** cases that had more than one candidate file. always the true count, even when
+	 * multiCases[] below is capped */
+	casesWithMultiple: number
+	/** the chosen files broken down by the tissue type of the aliquot each came from */
+	byTissueType: Record<string, number>
+	/** per-case detail for the multi-file cases, capped by the dataset */
+	multiCases: { case: string; chosen: string; candidates: { file_id: string; tissueType: string }[] }[]
+	/** true when multiCases[] was capped */
+	multiCasesTruncated: boolean
+	/** human-readable statement of how the one file per case was chosen */
+	selectionRule: string
+	/** false when the dataset could not tell what its cached files are keyed on, in which case
+	 * cached/toDownload are absent rather than guessed */
+	axisKnown: boolean
+	/** true when the whole matrix is already assembled, so the run fetches nothing */
+	matrixCached?: boolean
+	/** files already on disk */
+	cached?: number
+	/** files the run would download */
+	toDownload?: number
+	/** when the cache key this estimate rests on was last established */
+	axisSeenAt?: string
+}
+
 /** Response when DERequest.preAnalysis === true. Returns per-group sample
  * counts (keyed by group name) plus an optional validation alert. No volcano
  * is rendered; the client uses this to show counts before the user submits. */
@@ -196,6 +231,10 @@ export type DEPreAnalysisResponse = {
 	data: Record<string, number>
 	/** validation message; the client hides the run button while it is present */
 	alert?: string
+	/** only for datasets that build their counts matrix on demand; absent otherwise, and
+	 * absent when the preview query itself failed -- it is descriptive, so a failure there
+	 * must not fail the pre-analysis */
+	countsFiles?: CountsFilePreview
 }
 
 /** Response for a full DE run (DERequest.preAnalysis absent/false). */


### PR DESCRIPTION
# Description
Adding support for detailed file provenance within GDC DE pre-analysis panel. Can be expanded to other non-sqlite backed datasets (e.g. MMRF) in the future. Sqlite data sets remain unchanged. Companion to this SJPP [PR](https://github.com/stjude/sjpp/pull/1522). All GDC tests pass

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
