### PR TITLE
fix: Downgrade libhdf5 to fix hdf5 reader issue

### DIFF
--- a/container/deps/Dockerfile
+++ b/container/deps/Dockerfile
@@ -26,6 +26,14 @@ RUN apt-get update && apt-get install --allow-downgrades -y \
 	libgsl0-dev \
 	libhdf5-dev \
 	hdf5-tools \
+	# Runtime HDF5 for the rust binaries, which are compiled elsewhere (container/rust/Dockerfile)
+	# and copied in by pack.sh. They link libhdf5_serial.so.310, but this image is based on r-base,
+	# which tracks Debian sid/testing -- so libhdf5-dev above now resolves to HDF5 2.x and provides
+	# only .320. Nothing then loads DEanalysis or dmrcate, and the failure surfaces as a dead child
+	# process on a live request. The package name IS the soname, so this pins what actually matters.
+	# The two versions co-install; -dev stays for anything needing headers. Must move in lockstep
+	# with the HDF5 the rust builder compiles against (hdf5-metno 0.9 accepts only 1.x).
+	libhdf5-310 \
 	liblzma-dev \
     libdatrie1=0.2.14-2 \
 	libncurses5-dev \
@@ -143,6 +151,36 @@ RUN if [ -f /home/root/pp/tmppack/sjcrh-proteinpaint-server-${SERVERPKGVER}.tgz 
       npm install /home/root/pp/tmppack/sjcrh-proteinpaint-server-${SERVERPKGVER}.tgz; \
     else \
       npm install @sjcrh/proteinpaint-server@${SERVERPKGVER}; \
+    fi
+
+# The rust binaries are compiled in a different image (container/rust/Dockerfile, Debian trixie) and
+# arrive here inside the npm package, so this is the first point where they meet the libraries they
+# will actually run against. This image is based on r-base, which tracks Debian sid, so an apt bump
+# can silently withdraw a soname they link -- exactly how a build once shipped binaries that could
+# not load and 502'd every wilcoxon DE request. An unloadable binary must not reach a published
+# image, so fail the build here rather than at request time.
+#
+# Note the equivalent check in rust/extract_binaries.sh only proves the BUILDER is self-consistent;
+# because the builder deliberately does NOT share this base (hdf5-metno 0.9 cannot compile against
+# the HDF5 2.x that r-base provides), this is the check that actually catches drift.
+RUN bindir=node_modules/@sjcrh/proteinpaint-rust/target/release; \
+    if [ ! -d "$bindir" ]; then \
+      echo "WARNING: $bindir not found, skipping shared library check" >&2; \
+    else \
+      unresolved=0; \
+      for bin in "$bindir"/*; do \
+        [ -f "$bin" ] && [ -x "$bin" ] || continue; \
+        if ldd "$bin" 2>/dev/null | grep -q "not found"; then \
+          echo "ERROR: $bin cannot resolve:" >&2; \
+          ldd "$bin" 2>/dev/null | grep "not found" >&2; \
+          unresolved=1; \
+        fi; \
+      done; \
+      if [ "$unresolved" -ne 0 ]; then \
+        echo "unloadable rust binaries: this image lacks a shared library they were linked against" >&2; \
+        exit 1; \
+      fi; \
+      echo "all rust binaries resolve their shared libraries"; \
     fi
 
 # enable ssh into this stage, for troubleshooting

--- a/container/rust/Dockerfile
+++ b/container/rust/Dockerfile
@@ -1,3 +1,9 @@
+# Must stay on a base whose libhdf5-dev is 1.14.x. hdf5-metno 0.9 hardcodes the accepted HDF5
+# versions (build.rs: `^(1)\.(8|10|12|14)\.`) and panics with `Invalid H5_VERSION` on anything 2.x.
+# Do NOT "align" this with the runtime image (r-base, in container/deps/Dockerfile): r-base tracks
+# Debian sid/testing and installs HDF5 2.x, which this crate cannot compile against at all.
+# The two images are matched at the *soname* instead -- deps installs libhdf5-310 so the runtime
+# carries the .310 these binaries link. See the comment there before changing either.
 FROM debian:trixie
 
 LABEL org.opencontainers.image.source="https://github.com/stjude/proteinpaint" \

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,5 @@
+Fixes:
+- GDC differential expression with the wilcoxon method failed with a 502. The server image now installs libhdf5-310, the HDF5 runtime the rust binaries are linked against; its base image (r-base) tracks Debian sid, where libhdf5-dev has moved on to HDF5 2.x and no longer provides that soname.
 
+DevOps:
+- The rust build now fails if any extracted binary has unresolved shared libraries, instead of shipping one that cannot load.

--- a/rust/extract_binaries.sh
+++ b/rust/extract_binaries.sh
@@ -31,3 +31,36 @@ for item in * .*; do
         cp -r "$item" "./../../$dest_dir"
     fi
 done
+
+# back to the workspace root, so $dest_dir resolves again
+cd ../.. || exit 1
+
+: '
+Refuse to publish a binary that cannot resolve its shared libraries.
+
+Nothing downstream catches this: pack.sh copies the binaries and chmod +x makes them look runnable,
+rust/index.js only checks that target/release is non-empty, and the loader failure then surfaces as
+a dead child process on a live request. That is how DEanalysis and dmrcate shipped linked against
+libhdf5_serial.so.310 while the runtime image had a different HDF5 soname -- broken for months,
+because no gate between here and production ever tried to load them.
+
+Only meaningful while this runs in an image with the same base as the runtime (see the note in
+container/rust/Dockerfile). ldd prints "not a dynamic executable" for a static binary, which does
+not match and is correctly ignored.
+'
+unresolved=0
+for bin in "$dest_dir"/*; do
+    [ -f "$bin" ] && [ -x "$bin" ] || continue
+    if ldd "$bin" 2>/dev/null | grep -q "not found"; then
+        echo "ERROR: $bin cannot resolve:" >&2
+        ldd "$bin" 2>/dev/null | grep "not found" >&2
+        unresolved=1
+    fi
+done
+
+if [ "$unresolved" -ne 0 ]; then
+    echo "refusing to publish binaries that cannot load; the build base and the runtime base have drifted" >&2
+    exit 1
+fi
+
+echo "all extracted binaries resolve their shared libraries"

--- a/rust/test/rust.unit.spec.js
+++ b/rust/test/rust.unit.spec.js
@@ -1,6 +1,35 @@
 // Import necessary modules
 import tape from 'tape'
+import fs from 'fs'
+import path from 'path'
 import { run_rust } from '@sjcrh/proteinpaint-rust'
+
+const binDir = path.join(import.meta.dirname, '../target/release')
+
+/* A child that dies before reading its input used to take the whole node process down with it: the
+write landed on a closed pipe, and the resulting 'error' event on ps.stdin had no listener, so node
+threw it as an uncaught exception. In production one binary that would not start turned into a
+crashed server and a gateway 502 for every in-flight request -- and the child's stderr died with the
+process, hiding why it failed to start at all.
+
+This test reaching its assertion is itself the proof: an unhandled 'error' event would abort the
+tape run outright rather than fail a test. */
+tape('run_rust survives a child that dies before reading stdin', async test => {
+	const binfile = '__test-diesfast'
+	const stub = path.join(binDir, binfile)
+	// exit 127 is what a missing binary or a dynamic-loader failure reports
+	fs.writeFileSync(stub, '#!/bin/sh\nexit 127\n', { mode: 0o755 })
+	try {
+		// large enough that the write is still in flight once the child is already gone
+		await run_rust(binfile, 'x'.repeat(200000))
+		test.fail('should reject when the child exits with a non-zero status')
+	} catch (e) {
+		test.ok(String(e).includes('non-zero status'), 'rejects with the child exit status rather than crashing')
+	} finally {
+		fs.unlinkSync(stub)
+	}
+	test.end()
+})
 
 tape.skip('indel', async test => {
 	const message = 'should match the expected indel output'


### PR DESCRIPTION
# Description
We must downgrade libhdf5 to be compatible with our rust hdf5 reader 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
