### PR TITLE
Enforce dataset chart override before assessing chart btn visibility

### DIFF
--- a/client/mass/charts.ts
+++ b/client/mass/charts.ts
@@ -52,7 +52,12 @@ class MassCharts {
 	}
 
 	main() {
-		this.dom.btns.style('display', d => (d.isVisible ? d.isVisible() : this.state.currentCohortChartTypes.includes(d.chartType) ? '' : 'none'))
+		this.dom.btns.style('display', d => {
+			if (this.state.currentCohortChartTypes.includes(d.chartType)) {
+				if (d.isVisible) return d.isVisible() 
+				else return ''
+			} else return 'none'
+		})
 	}
 
 	getBtnLabel_dict(state) {
@@ -358,7 +363,7 @@ function getChartTypeList(self, state) {
 				 * to be visible within the SC app but not appropriate to show here. 
 				 * Limit its visibility to appropriate contexts. */
 				const isAvailable = getSelectableGETermTypes(state.termdbConfig)
-				return isAvailable.length > 0
+				return isAvailable.length > 0 ? '' : 'none'
 			}
 		},
 		{


### PR DESCRIPTION
# Description

Fixes the gene expression button incorrectly showing in the MMRF. 

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
