### PR TITLE
add termdb/sampleScatter to protectedRoutes

### DIFF
--- a/client/plots/scatter/test/scatter.ui.integration.spec.ts
+++ b/client/plots/scatter/test/scatter.ui.integration.spec.ts
@@ -19,6 +19,7 @@ Tests:
     - Show tooltip for sample
     - Test scale dot
     - Test lasso menus options
+    - Lasso menu is suppressed for anonymized samples (hideSampleId)
     - (commented out) Test continuous mode with age color
     - Test legend
     - Render color groups
@@ -220,6 +221,40 @@ tape('Test lasso menus options', function (test) {
 		test.equal(samples2Check.length, foundSamples, `Should render all samples for ${group.name}`)
 
 		scatter.Inner.view.dom.tip.hide()
+	}
+})
+
+tape('Lasso menu is suppressed for anonymized samples (hideSampleId)', function (test) {
+	test.timeoutAfter(8000)
+
+	runpp({
+		state,
+		sampleScatter: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	async function runTests(scatter) {
+		scatter.on('postRender.test', null)
+
+		// Simulate the response to a request that may not display sample ids: the server
+		// (anonymizeSampleIds) replaces each real sampleId with a non-numeric surrogate and flags
+		// hideSampleId. Because a surrogate id cannot resolve to a real sample, none of the
+		// sample-specific lasso actions (list, grouping, filtering, sample view) should be offered.
+		const anonymizedItems = mockGroups[0].items.map((it, i) => {
+			const clone: any = { ...it, sampleId: `anonymous-${i}`, hideSampleId: true }
+			delete clone.sample
+			return clone
+		})
+		scatter.Inner.vm.scatterLasso.showLassoMenu(new PointerEvent('click'), anonymizedItems)
+
+		const options = scatter.Inner.view.dom.tip.d.selectAll('div.sja_menuoption').nodes()
+		test.equal(options.length, 0, 'Should not render any lasso menu option for anonymized samples')
+
+		if (test['_ok']) scatter.Inner.app.destroy()
+		test.end()
 	}
 })
 

--- a/client/plots/scatter/test/scatterTooltip.unit.spec.ts
+++ b/client/plots/scatter/test/scatterTooltip.unit.spec.ts
@@ -10,6 +10,7 @@ import { xAxisOffSet, yAxisOffSet } from '#shared'
  * 	- Neighbours are the dots that overlap at 100% zoom, held constant in screen px
  * 	- scaleDotTW dots get a neighbourhood matching their larger radius
  * 	- isVisible() excludes hidden dots and the suppressed reference cloud
+ * 	- getActions() gates sample-specific actions for reference dots and anonymized (hideSampleId) samples
  *
  * These cover what the deleted distance() got wrong. It clamped both points into
  * [xAxisScale.invert(0), xAxisScale.invert(svgw)] — but the axis range starts at
@@ -251,5 +252,40 @@ tape('isVisible() excludes hidden dots and the suppressed reference cloud', func
 
 	const zeroRef = new ScatterTooltip(getScatterStub({ refSize: 0 }))
 	test.false(zeroRef.isVisible({ x: 1, y: 1, hidden: {} }), 'reference dots are excluded when refSize is 0')
+	test.end()
+})
+
+/** Stub carrying the fields getActions() reads: config, interactivity, and the state used to decide which
+ * sample-specific actions apply. currentCohortChartTypes includes 'sampleView' so a real cohort sample
+ * yields at least the "Sample view" action; the gated cases must still return none. */
+function getActionsStub(config: any = {}) {
+	const scatter: any = {
+		settings: getDefaultScatterSettings(),
+		config,
+		interactivity: { openSampleView() {}, openDiscoPlot() {}, openMetArray() {}, openLollipop() {} },
+		state: { termdbConfig: { queries: {} }, currentCohortChartTypes: ['sampleView'] },
+		view: {}
+	}
+	scatter.model = new ScatterModel(scatter)
+	return scatter
+}
+
+tape('getActions() gates sample-specific actions for reference and anonymized samples', function (test) {
+	test.timeoutAfter(100)
+	const tooltip = new ScatterTooltip(getActionsStub())
+
+	const cohortActions = tooltip.getActions({ sampleId: 1, sample: 'S1' })
+	test.ok(
+		cohortActions.some((a: any) => a.label === 'Sample view'),
+		'a real cohort sample offers the Sample view action'
+	)
+
+	test.deepEqual(
+		tooltip.getActions({ sampleId: 'anonymous-0', hideSampleId: true }),
+		[],
+		'an anonymized sample (hideSampleId) offers no sample-specific actions even though the sampleId key is present'
+	)
+
+	test.deepEqual(tooltip.getActions({ x: 1, y: 2 }), [], 'a reference dot (no sampleId) offers no actions')
 	test.end()
 })

--- a/client/plots/scatter/viewmodel/scatterLasso.ts
+++ b/client/plots/scatter/viewmodel/scatterLasso.ts
@@ -76,6 +76,10 @@ export class ScatterLasso {
 	showLassoMenu(event, samples) {
 		this.view.dom.tip.clear().hide()
 		if (samples.length == 0) return
+		// hideSampleId marks cohort dots whose ids were anonymized because the request may not display
+		// sample ids. Their surrogate ids cannot resolve to real samples, so listing, grouping, filtering
+		// and sample view would all submit nonexistent ids or build empty filters — offer no menu.
+		if (samples.some(s => s.hideSampleId)) return
 		this.view.dom.tip.show(event.clientX, event.clientY)
 
 		const labels = this.scatter.config.controlLabels

--- a/client/plots/scatter/viewmodel/scatterTooltip.ts
+++ b/client/plots/scatter/viewmodel/scatterTooltip.ts
@@ -293,8 +293,10 @@ export class ScatterTooltip {
 		const actions: ActionMenuItem[] = []
 
 		// reference-cloud dots carry no mutation data, so none of these apply to them; the plots
-		// below are also for cohort samples only, and not in the single cell plot
-		if (!('sampleId' in sample) || config.singleCellPlot) return actions
+		// below are also for cohort samples only, and not in the single cell plot. hideSampleId marks a
+		// sample whose id was anonymized because the request may not display sample ids — its surrogate id
+		// cannot resolve to a real sample, so gate every sample-specific action here.
+		if (!('sampleId' in sample) || sample.hideSampleId || config.singleCellPlot) return actions
 
 		// the gene may be carried by either term — the old tooltip offered Lollipop from
 		// whichever of the color/shape rows happened to be a geneVariant

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -11,6 +11,7 @@ import { isNumericTw } from '#shared/terms.js'
 import { getDefaultFractionBins, getT0T2defaultQ } from './summaryQ.ts'
 import { importPlot } from './importPlot.js'
 import { filterRxCompInit } from '#filter'
+import { getCurrentCohortChartTypes } from '#mass/charts'
 
 class SummaryPlot extends PlotBase implements RxComponent {
 	static type = 'summary'
@@ -213,13 +214,7 @@ class SummaryPlot extends PlotBase implements RxComponent {
 				childType: 'sampleScatter',
 				label: 'Scatter',
 				disabled: () => false,
-				isVisible: () => {
-					const cohortLabel =
-						this.app.vocabApi.termdbConfig.selectCohort?.values?.[this.app.getState().activeCohort]?.shortLabel
-					const isSupportedChart =
-						this.app.vocabApi.termdbConfig.supportedChartTypes?.[cohortLabel || '']?.includes('sampleScatter')
-					return isSupportedChart && isNumericTw(this.config?.term) && isNumericTw(this.config?.term2)
-				},
+				isVisible: () => isScatterToggleVisible(this.app.getState(), this.config?.term, this.config?.term2),
 				getConfig: async () => {
 					const _term = await this.getWrappedTermCopy(this.config?.term, 'continuous')
 					const _term2 = await this.getWrappedTermCopy(this.config?.term2, 'continuous')
@@ -521,6 +516,22 @@ export async function getPlotConfig(opts, app) {
 	// to override ui labels from recovered session state
 	Object.assign(config.controlLabels, app.vocabApi.termdbConfig.uiLabels || {})
 	return config
+}
+
+/**
+ * Whether the summary "Scatter" toggle should be shown for the current cohort and terms.
+ *
+ * The toggle builds a DYNAMIC two-term scatter (term + term2), so it must require the `dynamicScatter`
+ * capability — NOT `sampleScatter`, which the server also reports for a cohort that only has a premade
+ * plot (see server/src/termdb.server.init.ts). supportedChartTypes is keyed by the sorted cohort keys
+ * joined with commas (getActiveCohortStr), not by the cohort's shortLabel; getCurrentCohortChartTypes()
+ * resolves that key from the active cohort, so combined cohorts (e.g. keys "ABC,XYZ") are handled.
+ *
+ * Exported so it can be tested directly.
+ */
+export function isScatterToggleVisible(appState, term, term2): boolean {
+	const isSupportedChart = getCurrentCohortChartTypes(appState).includes('dynamicScatter')
+	return isSupportedChart && isNumericTw(term) && isNumericTw(term2)
 }
 
 const discreteByContinuousPlots = new Set(['violin', 'boxplot'])

--- a/client/plots/summary.ts
+++ b/client/plots/summary.ts
@@ -214,7 +214,11 @@ class SummaryPlot extends PlotBase implements RxComponent {
 				label: 'Scatter',
 				disabled: () => false,
 				isVisible: () => {
-					return isNumericTw(this.config?.term) && isNumericTw(this.config?.term2)
+					const cohortLabel =
+						this.app.vocabApi.termdbConfig.selectCohort?.values?.[this.app.getState().activeCohort]?.shortLabel
+					const isSupportedChart =
+						this.app.vocabApi.termdbConfig.supportedChartTypes?.[cohortLabel || '']?.includes('sampleScatter')
+					return isSupportedChart && isNumericTw(this.config?.term) && isNumericTw(this.config?.term2)
 				},
 				getConfig: async () => {
 					const _term = await this.getWrappedTermCopy(this.config?.term, 'continuous')

--- a/client/plots/test/summary.unit.spec.ts
+++ b/client/plots/test/summary.unit.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { getPlotConfig, mayAdjustConfig } from '../summary.ts'
+import { getPlotConfig, mayAdjustConfig, isScatterToggleVisible } from '../summary.ts'
 
 /*
 Tests:
@@ -10,6 +10,7 @@ Tests:
 	mayAdjustConfig() - two continuous terms should set childType to sampleScatter
 	mayAdjustConfig() - single continuous term should default to violin
 	mayAdjustConfig() - discrete terms should default to barchart
+	isScatterToggleVisible() - resolves the comma-joined cohort key, requires dynamicScatter and two numeric terms
 */
 
 /*************************
@@ -248,4 +249,81 @@ tape('getPlotConfig() applies opts.getPlotConfig_mutateSummary before validating
 	test.equal(callbackCalls, 1, 'calls the Mass summary-config mutator once')
 	test.equal(config.term.term.id, 'test-term', 'uses the primary term supplied asynchronously by the mutator')
 	test.equal(config.childType, 'barchart', 'returns a valid summary config after applying the mutation')
+})
+
+/*
+	isScatterToggleVisible() — regression coverage for the summary "Scatter" toggle visibility.
+	Two prior bugs are guarded here (see client/plots/summary.ts and client/mass/charts.ts getActiveCohortStr):
+	  1. supportedChartTypes is keyed by the sorted cohort KEYS joined with commas, not by the cohort's
+	     shortLabel — so combined cohorts (keys "ABC","XYZ" -> "ABC,XYZ", shortLabel "ABC+XYZ") were losing
+	     the toggle when it was looked up by shortLabel.
+	  2. The toggle builds a dynamic two-term scatter, so it must require `dynamicScatter`, not
+	     `sampleScatter` — the latter is also reported for a cohort that only has a premade plot, which
+	     would offer an unsupported toggle.
+*/
+
+const numericTw = { term: { type: 'float', id: 'x', name: 'X', values: {} } }
+const categoricalTw = { term: { type: 'categorical', id: 'c', name: 'C', values: {} } }
+
+// build an appState shaped as getActiveCohortStr()/getCurrentCohortChartTypes() read it. `cohortKeys` are
+// the raw (unsorted) keys of the active cohort; `shortLabel` is deliberately different from the comma key.
+function makeCohortAppState(cohortKeys: string[], supportedChartTypes: Record<string, string[]>, shortLabel: string) {
+	return {
+		activeCohort: 0,
+		termdbConfig: {
+			selectCohort: { values: [{ keys: cohortKeys, shortLabel }] },
+			supportedChartTypes
+		}
+	}
+}
+
+tape('isScatterToggleVisible: shows the toggle for a combined cohort keyed by its comma-joined keys', test => {
+	// keys given out of order to prove they are sorted before joining: "XYZ","ABC" -> "ABC,XYZ"
+	const appState = makeCohortAppState(
+		['XYZ', 'ABC'],
+		{ 'ABC,XYZ': ['summary', 'sampleScatter', 'dynamicScatter'] },
+		'ABC+XYZ' // the old (wrong) shortLabel key — absent from supportedChartTypes
+	)
+	test.equal(
+		isScatterToggleVisible(appState, numericTw, numericTw),
+		true,
+		'combined cohort should keep the toggle when dynamicScatter is supported under the comma key'
+	)
+	test.end()
+})
+
+tape(
+	'isScatterToggleVisible: hides the toggle for a prebuilt-only cohort (sampleScatter but not dynamicScatter)',
+	test => {
+		const appState = makeCohortAppState(
+			['ABC'],
+			{ ABC: ['summary', 'sampleScatter'] }, // premade plot enables sampleScatter, but no dynamic scatter
+			'ABC'
+		)
+		test.equal(
+			isScatterToggleVisible(appState, numericTw, numericTw),
+			false,
+			'a cohort with only a premade scatter must not offer the dynamic two-term toggle'
+		)
+		test.end()
+	}
+)
+
+tape('isScatterToggleVisible: requires both terms to be numeric even when dynamicScatter is supported', test => {
+	const appState = makeCohortAppState(['ABC'], { ABC: ['summary', 'dynamicScatter'] }, 'ABC')
+	test.equal(isScatterToggleVisible(appState, numericTw, numericTw), true, 'two numeric terms -> visible')
+	test.equal(isScatterToggleVisible(appState, numericTw, categoricalTw), false, 'a non-numeric term2 -> hidden')
+	test.equal(isScatterToggleVisible(appState, categoricalTw, numericTw), false, 'a non-numeric term -> hidden')
+	test.end()
+})
+
+tape('isScatterToggleVisible: datasets without cohort selection use the empty-string key', test => {
+	// getActiveCohortStr returns '' when there is no selectCohort, so supportedChartTypes is keyed by ''
+	const appState = { termdbConfig: { supportedChartTypes: { '': ['summary', 'dynamicScatter'] } } }
+	test.equal(
+		isScatterToggleVisible(appState, numericTw, numericTw),
+		true,
+		'a non-subcohort dataset should resolve the empty-string key'
+	)
+	test.end()
 })

--- a/release.txt
+++ b/release.txt
@@ -1,1 +1,2 @@
-
+Fixes:
+- do not show sample IDs in /termdb/sampleScatter route

--- a/server/src/auth/Auth.ts
+++ b/server/src/auth/Auth.ts
@@ -25,9 +25,18 @@ export class Auth {
 
 	// TODO: should create a checker function for each route group that may be protected
 	protectedRoutes = {
+		// below is used in getRequiredCred as the default protected routes
 		termdb: ['matrix'],
-		samples: ['singleSampleData', 'getAllSamples', 'scatter', 'convertSampleId', 'getSamplesByName'],
-		minSampleSize: ['/termdb/barsql', 'matrix', 'cuminc', 'survival', 'regression', 'scatter']
+		// below is used in AuthApi.canDisplaySampleIds()
+		samples: [
+			'singleSampleData',
+			'getAllSamples',
+			'convertSampleId',
+			'getSamplesByName',
+			'scatter',
+			'/termdb/sampleScatter'
+		],
+		minSampleSize: ['/termdb/barsql', 'matrix', 'cuminc', 'survival', 'regression', 'scatter', '/termdb/sampleScatter']
 	}
 
 	constructor(creds, app, genomes, serverconfig) {

--- a/server/src/auth/AuthApi.ts
+++ b/server/src/auth/AuthApi.ts
@@ -37,8 +37,22 @@ export class AuthApi implements AuthInterface {
 	}
 
 	canDisplaySampleIds(req, ds) {
-		if (!ds.cohort.termdb.displaySampleIds) return false
-		return this.isUserLoggedIn(req, ds, this.#auth.protectedRoutes.samples)
+		const displaySampleIds = ds?.cohort?.termdb?.displaySampleIds
+		if (!displaySampleIds) return false
+		// the sample-id-bearing routes require the request to be logged in
+		if (!this.isUserLoggedIn(req, ds, this.#auth.protectedRoutes.samples)) return false
+		// displaySampleIds may be a boolean or a per-request policy (a function of the request's
+		// clientAuthResult). A truthy non-function value is an unconditional allow; a function must be
+		// evaluated for THIS request's role and fail closed, so a role the dataset denies never leaks
+		// names even when the request is authenticated (e.g. a non-admin whose policy returns false).
+		if (typeof displaySampleIds != 'function') return true
+		try {
+			const clientAuthResult =
+				req?.query?.__protected__?.clientAuthResult ?? this.getNonsensitiveInfo(req)?.clientAuthResult ?? {}
+			return !!displaySampleIds(clientAuthResult)
+		} catch {
+			return false
+		}
 	}
 
 	/*

--- a/server/src/auth/AuthApiOpen.ts
+++ b/server/src/auth/AuthApiOpen.ts
@@ -28,9 +28,18 @@ export const AuthApiOpen: AuthInterface = {
 		return
 	},
 
-	canDisplaySampleIds(_, ds) {
-		if (!ds.cohort.termdb.displaySampleIds) return false
-		return true //AuthApiOpen.isUserLoggedIn(req, ds, protectedRoutes.samples)
+	canDisplaySampleIds(req, ds) {
+		const displaySampleIds = ds?.cohort?.termdb?.displaySampleIds
+		if (!displaySampleIds) return false
+		// displaySampleIds may be a boolean or a per-request policy (a function of clientAuthResult);
+		// a truthy non-function value is an unconditional allow, a function must be evaluated for this
+		// request's role and fail closed. Open access carries no clientAuthResult (only sessionid).
+		if (typeof displaySampleIds != 'function') return true //AuthApiOpen.isUserLoggedIn(req, ds, protectedRoutes.samples)
+		try {
+			return !!displaySampleIds(req?.query?.__protected__?.clientAuthResult ?? {})
+		} catch {
+			return false
+		}
 	},
 
 	// these open-acces, default methods may be replaced by maySetAuthRoutes()

--- a/server/src/auth/test/AuthApi.unit.spec.ts
+++ b/server/src/auth/test/AuthApi.unit.spec.ts
@@ -136,6 +136,87 @@ tape('AuthApi.canDisplaySampleIds: returns false when user is not logged in', fu
 	test.end()
 })
 
+// Regression guard for the /termdb/sampleScatter entry in Auth.protectedRoutes.samples — this list is the
+// privacy boundary for the route. If that entry were missing or misspelled, getRequiredCred() would find no
+// required cred for the exact path, isUserLoggedIn() would short-circuit to true, and a LOGGED-OUT request
+// would wrongly be allowed to display sample ids. The generic '/termdb' + typeof-boolean test above cannot
+// catch that, so assert the exact path with the session both absent and present.
+tape(
+	'AuthApi.canDisplaySampleIds: denies a logged-out request on the exact /termdb/sampleScatter path',
+	function (test) {
+		test.timeoutAfter(500)
+		test.plan(1)
+
+		const { authApi } = makeAuthApi()
+		const ds = { cohort: { termdb: { displaySampleIds: true } }, label: dslabel }
+		const req = { query: { embedder, dslabel }, headers: {}, path: '/termdb/sampleScatter', cookies: {} }
+		test.equal(
+			authApi.canDisplaySampleIds(req, ds as any),
+			false,
+			'a logged-out request on the protected scatter route must not display sample ids'
+		)
+		test.end()
+	}
+)
+
+tape(
+	'AuthApi.canDisplaySampleIds: allows a logged-in request on the exact /termdb/sampleScatter path',
+	async function (test) {
+		test.timeoutAfter(1000)
+		test.plan(1)
+
+		const genomes = { hg38: { datasets: { [dslabel]: {} } } }
+		// Token without a 'datasets' field so the dsnames check is skipped
+		const loginToken = jsonwebtoken.sign(
+			{ iat: time, exp: time + 300, ip: '127.0.0.1', email: 'user@test.com' },
+			secret
+		)
+		const { authApi, app } = await makeAuthApiWithRoutes({}, genomes)
+
+		// Establish a session via /jwt-status and capture the session cookie (same pattern as the getDsAuth test)
+		let capturedSessionCookieId = ''
+		let capturedSessionId = ''
+		await new Promise<void>(resolve => {
+			const req = {
+				query: { embedder, dslabel },
+				headers: { [headerKey]: loginToken },
+				path: '/jwt-status',
+				ip: '127.0.0.1',
+				cookies: {}
+			}
+			const res = {
+				send() {
+					resolve()
+				},
+				header(key: string, val: string) {
+					if (key === 'Set-Cookie') {
+						const parts = val.split(';')[0].split('=')
+						capturedSessionCookieId = parts[0]
+						capturedSessionId = parts[1]
+					}
+				},
+				status() {}
+			}
+			app.routes['/jwt-status'].post(req, res)
+		})
+		await sleep(50)
+
+		const ds = { cohort: { termdb: { displaySampleIds: true } }, label: dslabel }
+		const req = {
+			query: { embedder, dslabel },
+			headers: {},
+			path: '/termdb/sampleScatter',
+			cookies: { [capturedSessionCookieId]: capturedSessionId }
+		}
+		test.equal(
+			authApi.canDisplaySampleIds(req, ds as any),
+			true,
+			'a logged-in request on the protected scatter route should display sample ids'
+		)
+		test.end()
+	}
+)
+
 tape(
 	'AuthApi.canDisplaySampleIds: evaluates a function displaySampleIds policy against the request role',
 	function (test) {

--- a/server/src/auth/test/AuthApi.unit.spec.ts
+++ b/server/src/auth/test/AuthApi.unit.spec.ts
@@ -136,6 +136,82 @@ tape('AuthApi.canDisplaySampleIds: returns false when user is not logged in', fu
 	test.end()
 })
 
+tape(
+	'AuthApi.canDisplaySampleIds: evaluates a function displaySampleIds policy against the request role',
+	function (test) {
+		test.timeoutAfter(500)
+		test.plan(3)
+
+		// no creds => the samples-route login gate (isUserLoggedIn) passes, isolating the policy evaluation.
+		// A truthy function object must NOT be treated as an unconditional allow: it is evaluated for the
+		// request's clientAuthResult and must fail closed when the role is denied.
+		const authApi = new AuthApi({}, makeMockApp(), {}, { port: 3000, cachedir: '/tmp' })
+		const policy = (clientAuthResult: any) => clientAuthResult?.role == 'admin'
+		const ds = { cohort: { termdb: { displaySampleIds: policy } }, label: dslabel }
+
+		const adminReq = {
+			query: { embedder, dslabel, __protected__: { clientAuthResult: { role: 'admin' } } },
+			headers: {},
+			path: '/termdb/sampleScatter',
+			cookies: {}
+		}
+		const nonAdminReq = {
+			query: { embedder, dslabel, __protected__: { clientAuthResult: { role: 'public' } } },
+			headers: {},
+			path: '/termdb/sampleScatter',
+			cookies: {}
+		}
+		const noRoleReq = {
+			query: { embedder, dslabel, __protected__: { clientAuthResult: {} } },
+			headers: {},
+			path: '/termdb/sampleScatter',
+			cookies: {}
+		}
+
+		test.equal(
+			authApi.canDisplaySampleIds(adminReq, ds as any),
+			true,
+			'should allow when the policy returns true for the role'
+		)
+		test.equal(
+			authApi.canDisplaySampleIds(nonAdminReq, ds as any),
+			false,
+			'should deny an authenticated non-admin whose policy returns false'
+		)
+		test.equal(
+			authApi.canDisplaySampleIds(noRoleReq, ds as any),
+			false,
+			'should deny when clientAuthResult carries no role'
+		)
+		test.end()
+	}
+)
+
+tape('AuthApi.canDisplaySampleIds: fails closed when the displaySampleIds policy throws', function (test) {
+	test.timeoutAfter(500)
+	test.plan(1)
+
+	const authApi = new AuthApi({}, makeMockApp(), {}, { port: 3000, cachedir: '/tmp' })
+	const ds = {
+		cohort: {
+			termdb: {
+				displaySampleIds: () => {
+					throw new Error('policy blew up')
+				}
+			}
+		},
+		label: dslabel
+	}
+	const req = {
+		query: { embedder, dslabel, __protected__: { clientAuthResult: {} } },
+		headers: {},
+		path: '/termdb/sampleScatter',
+		cookies: {}
+	}
+	test.equal(authApi.canDisplaySampleIds(req, ds as any), false, 'should return false when the policy throws')
+	test.end()
+})
+
 tape('AuthApi.getDsAuth: returns empty array when no active genomes', function (test) {
 	test.timeoutAfter(500)
 	test.plan(1)

--- a/server/src/auth/test/AuthApiOpen.unit.spec.ts
+++ b/server/src/auth/test/AuthApiOpen.unit.spec.ts
@@ -68,8 +68,16 @@ tape('AuthApiOpen.isUserLoggedIn: always returns true', function (test) {
 	test.timeoutAfter(500)
 	test.plan(2)
 
-	test.equal(AuthApiOpen.isUserLoggedIn({} as any, null as any, null as any), true, 'should return true for any request')
-	test.equal(AuthApiOpen.isUserLoggedIn({} as any, {} as any, []), true, 'should always return true regardless of arguments')
+	test.equal(
+		AuthApiOpen.isUserLoggedIn({} as any, null as any, null as any),
+		true,
+		'should return true for any request'
+	)
+	test.equal(
+		AuthApiOpen.isUserLoggedIn({} as any, {} as any, []),
+		true,
+		'should always return true regardless of arguments'
+	)
 	test.end()
 })
 
@@ -108,9 +116,57 @@ tape('AuthApiOpen.canDisplaySampleIds: respects ds.cohort.termdb.displaySampleId
 	const dsWithoutFlag = { cohort: { termdb: {} } }
 	const dsFalseFlag = { cohort: { termdb: { displaySampleIds: false } } }
 
-	test.equal(AuthApiOpen.canDisplaySampleIds({} as any, dsWithFlag as any), true, 'should return true when displaySampleIds is truthy')
-	test.equal(AuthApiOpen.canDisplaySampleIds({} as any, dsWithoutFlag as any), false, 'should return false when displaySampleIds is not set')
-	test.equal(AuthApiOpen.canDisplaySampleIds({} as any, dsFalseFlag as any), false, 'should return false when displaySampleIds is false')
+	test.equal(
+		AuthApiOpen.canDisplaySampleIds({} as any, dsWithFlag as any),
+		true,
+		'should return true when displaySampleIds is truthy'
+	)
+	test.equal(
+		AuthApiOpen.canDisplaySampleIds({} as any, dsWithoutFlag as any),
+		false,
+		'should return false when displaySampleIds is not set'
+	)
+	test.equal(
+		AuthApiOpen.canDisplaySampleIds({} as any, dsFalseFlag as any),
+		false,
+		'should return false when displaySampleIds is false'
+	)
+	test.end()
+})
+
+tape('AuthApiOpen.canDisplaySampleIds: evaluates a function displaySampleIds policy and fails closed', function (test) {
+	test.timeoutAfter(500)
+	test.plan(3)
+
+	const ds = { cohort: { termdb: { displaySampleIds: (car: any) => car?.role == 'admin' } } }
+	const adminReq = { query: { __protected__: { clientAuthResult: { role: 'admin' } } } }
+	const publicReq = { query: { __protected__: { clientAuthResult: { role: 'public' } } } }
+
+	test.equal(
+		AuthApiOpen.canDisplaySampleIds(adminReq as any, ds as any),
+		true,
+		'should allow when the policy returns true'
+	)
+	test.equal(
+		AuthApiOpen.canDisplaySampleIds(publicReq as any, ds as any),
+		false,
+		'should deny when the policy returns false'
+	)
+
+	const throwingDs = {
+		cohort: {
+			termdb: {
+				displaySampleIds: () => {
+					throw new Error('policy blew up')
+				}
+			}
+		}
+	}
+	test.equal(
+		AuthApiOpen.canDisplaySampleIds({ query: {} } as any, throwingDs as any),
+		false,
+		'should fail closed when the policy throws'
+	)
 	test.end()
 })
 
@@ -144,7 +200,9 @@ tape('AuthApiOpen.maySetAuthRoutes: sets a global middleware that adds __protect
 	const req: any = { query: {}, cookies: {} }
 	const res: any = {}
 	let nextCalled = false
-	function next() { nextCalled = true }
+	function next() {
+		nextCalled = true
+	}
 
 	registeredMiddlewares[0](req, res, next)
 

--- a/server/src/routes/termdb.sampleScatter.ts
+++ b/server/src/routes/termdb.sampleScatter.ts
@@ -177,6 +177,9 @@ export function init({ genomes }) {
 				range = { xMin, xMax, yMin, yMax }
 			}
 			if (!result) result = await colorAndShapeSamples(refSamples, cohortSamples, data as ValidGetDataResponse, q)
+			// the real sampleId was needed above for the server-side annotation join; it must not leave the
+			// server for a request not authorized to display sample ids (see anonymizeSampleIds)
+			if (!authApi.canDisplaySampleIds(req, ds)) anonymizeSampleIds(result)
 			res.send({ result, range } satisfies TermdbSampleScatterResponse)
 		} catch (e: any) {
 			if (e.stack) console.log(e.stack)
@@ -195,11 +198,34 @@ export async function getSamples(req: any, ds: any, plot: any) {
 		const result: number[] = []
 		// must make in-memory duplication of the objects as they will be modified by assigning .color/shape
 		for (const i of JSON.parse(JSON.stringify(samples))) {
-			// only expose the sample name/id when the request is authorized to display sample ids
+			// only expose the sample name when the request is authorized to display sample ids. The real
+			// .sampleId is still needed downstream for the server-side annotation join and is anonymized
+			// out of the response later by anonymizeSampleIds()
 			if (!canDisplay) delete i.sample
 			result.push(i)
 		}
 		return result
+	}
+}
+
+/** Replace every real sampleId in the scatter response with an anonymous surrogate.
+ *
+ * Called only when the request is NOT authorized to display sample ids. Both sample sources put a real,
+ * identifying value on .sampleId: getSampleCoordinatesByTerms() uses the db sample id, and loadFile()
+ * assigns the integer sample id (or, for colorColumn plots, the sample name) to prebuilt cohort/reference
+ * entries. That value was needed for the server-side annotation join (colorAndShapeSamples) but must not
+ * reach the client: without this, the client download fallback (scatter.ts toText: `s.sample || s.sampleId`)
+ * would still expose it even after the sample NAME was stripped.
+ *
+ * The client uses only the presence of the .sampleId key — not its value — to tell cohort dots from
+ * reference dots and to size them, so the key is preserved and given a non-numeric surrogate that cannot
+ * resolve back to a real (integer) sample id on any subsequent request. */
+export function anonymizeSampleIds(result: { [index: string]: { samples: any[] } }) {
+	let n = 0
+	for (const divideBy in result) {
+		for (const sample of result[divideBy].samples || []) {
+			if ('sampleId' in sample) sample.sampleId = `anonymous-${n++}`
+		}
 	}
 }
 

--- a/server/src/routes/termdb.sampleScatter.ts
+++ b/server/src/routes/termdb.sampleScatter.ts
@@ -115,7 +115,7 @@ export function init({ genomes }) {
 				const plot = ds.cohort.scatterplots.plots.find(p => p.name == q.plotName)
 				if (!plot) throw new Error(`plot not found with plotName ${q.plotName}`)
 
-				const tmp = await getSamples(ds, plot)
+				const tmp = await getSamples(req, ds, plot)
 				refSamples = tmp[0]
 				cohortSamples = tmp[1]
 
@@ -185,17 +185,18 @@ export function init({ genomes }) {
 	}
 }
 
-async function getSamples(ds: any, plot: any) {
+export async function getSamples(req: any, ds: any, plot: any) {
 	if (!plot.filterableSamples) await loadFile(plot, ds) // this is the first time the plot is accessed. load the data in mem
 
+	const canDisplay = authApi.canDisplaySampleIds(req, ds)
 	return [readSamples(plot.referenceSamples), readSamples(plot.filterableSamples)]
 
 	function readSamples(samples) {
 		const result: number[] = []
 		// must make in-memory duplication of the objects as they will be modified by assigning .color/shape
 		for (const i of JSON.parse(JSON.stringify(samples))) {
-			//When reading from a file coordinates can be displayed
-			//if (!authApi.canDisplaySampleIds(req, ds)) delete i.sample
+			// only expose the sample name/id when the request is authorized to display sample ids
+			if (!canDisplay) delete i.sample
 			result.push(i)
 		}
 		return result

--- a/server/src/routes/termdb.sampleScatter.ts
+++ b/server/src/routes/termdb.sampleScatter.ts
@@ -227,6 +227,7 @@ export function anonymizeSampleIds(result: { [index: string]: { samples: any[] }
 	let n = 0
 	for (const divideBy in result) {
 		for (const sample of result[divideBy].samples || []) {
+			delete sample.sample
 			if ('sampleId' in sample) {
 				sample.sampleId = `anonymous-${n++}`
 				sample.hideSampleId = true

--- a/server/src/routes/termdb.sampleScatter.ts
+++ b/server/src/routes/termdb.sampleScatter.ts
@@ -208,7 +208,7 @@ export async function getSamples(req: any, ds: any, plot: any) {
 	}
 }
 
-/** Replace every real sampleId in the scatter response with an anonymous surrogate.
+/** Replace every real sampleId in the scatter response with an anonymous surrogate and mark the sample.
  *
  * Called only when the request is NOT authorized to display sample ids. Both sample sources put a real,
  * identifying value on .sampleId: getSampleCoordinatesByTerms() uses the db sample id, and loadFile()
@@ -217,14 +217,20 @@ export async function getSamples(req: any, ds: any, plot: any) {
  * reach the client: without this, the client download fallback (scatter.ts toText: `s.sample || s.sampleId`)
  * would still expose it even after the sample NAME was stripped.
  *
- * The client uses only the presence of the .sampleId key — not its value — to tell cohort dots from
- * reference dots and to size them, so the key is preserved and given a non-numeric surrogate that cannot
- * resolve back to a real (integer) sample id on any subsequent request. */
+ * The client uses the presence of the .sampleId key to tell cohort dots from reference dots and to size
+ * them, so the key is preserved and given a non-numeric surrogate that cannot resolve back to a real
+ * (integer) sample id. But the client also submits the sampleId VALUE for sample-specific actions (open
+ * sample view, lasso grouping/filtering); a surrogate there would offer denied users actions that submit
+ * a nonexistent id or build an empty filter. So each anonymized sample is also flagged with .hideSampleId,
+ * which the client uses to gate all such sample-specific actions and grouping. */
 export function anonymizeSampleIds(result: { [index: string]: { samples: any[] } }) {
 	let n = 0
 	for (const divideBy in result) {
 		for (const sample of result[divideBy].samples || []) {
-			if ('sampleId' in sample) sample.sampleId = `anonymous-${n++}`
+			if ('sampleId' in sample) {
+				sample.sampleId = `anonymous-${n++}`
+				sample.hideSampleId = true
+			}
 		}
 	}
 }

--- a/server/src/routes/test/sampleScatter.unit.spec.ts
+++ b/server/src/routes/test/sampleScatter.unit.spec.ts
@@ -1,0 +1,154 @@
+/********************************************
+Unit tests for the sample-id exposure guard in the /termdb/sampleScatter route
+(server/src/routes/termdb.sampleScatter.ts).
+
+Sample coordinates are retrieved from one of two sources, and BOTH must hide the sample
+name/id when the request is not authorized to display sample ids
+(authApi.canDisplaySampleIds):
+  1. getSampleCoordinatesByTerms() — coordinates derived from two numeric terms
+  2. getSamples()                  — a prebuilt plot, read from the plot's in-memory samples
+
+Rather than load the full genome/ds (CI has no tp/ data dir or R/htslib binaries), the two
+helper functions are called directly with hardcoded, minimal inputs. Under open access
+authApi.canDisplaySampleIds keys off ds.cohort.termdb.displaySampleIds, which is exactly the
+allowed-vs-not-allowed toggle these tests exercise (see omnisearch.unit.spec.ts for the same
+approach).
+
+Run with (must use tsx + the sjpp/dev condition):
+  cd proteinpaint/server && npx tsx --conditions=sjpp/dev src/routes/test/sampleScatter.unit.spec.ts
+or run the whole unit suite (as CI does):
+  cd proteinpaint/server && npm run test:unit
+*********************************************/
+import tape from 'tape'
+import { getSampleCoordinatesByTerms, getSamples } from '../termdb.sampleScatter.ts'
+import { getAuthApi, authApi } from '../../auth.js'
+
+// assign the shared open-access authApi once (idempotent — the live-binding is process-global)
+async function ensureOpenAuth() {
+	if (authApi) return
+	// minimal express-app stand-in; getAuthApi only stores it in a WeakMap for open access
+	const app: any = { doNotFreezeAuthApi: true, get() {}, post() {}, all() {}, use() {} }
+	await getAuthApi(app, {}, {}, true)
+}
+
+// displaySampleIds is the dataset's per-role sample-ID visibility policy — the same value
+// /termdb/config computes; under open access canDisplaySampleIds returns it (plus isUserLoggedIn).
+function makeDs(displaySampleIds: boolean): any {
+	return { cohort: { termdb: { displaySampleIds } } }
+}
+
+const req: any = { query: {} }
+
+// a request carrying a clientAuthResult role, for exercising a function-based displaySampleIds policy
+function reqWithRole(role: string): any {
+	return { query: { __protected__: { clientAuthResult: { role } } } }
+}
+
+// a per-request policy: only the admin role may see sample ids. A truthy-but-denying function like this
+// is exactly what must NOT leak names — canDisplaySampleIds evaluates it rather than treating it as a
+// blanket allow (see AuthApi/AuthApiOpen.canDisplaySampleIds).
+function makeDsPolicy(): any {
+	return { cohort: { termdb: { displaySampleIds: (car: any) => car?.role == 'admin' } } }
+}
+
+/*** coordinate branch: getSampleCoordinatesByTerms() ***/
+
+// data as returned by getData(): samples keyed by id, coord values under each term's $id, plus
+// refs.bySampleId providing the human-readable label.
+function makeCoordData(): any {
+	return {
+		samples: {
+			'1': { x_id: { value: 10 }, y_id: { value: 20 } },
+			'2': { x_id: { value: 30 }, y_id: { value: 40 } }
+		},
+		refs: { bySampleId: { '1': { label: 'SampleA' }, '2': { label: 'SampleB' } } }
+	}
+}
+
+const coordQ: any = {
+	coordTWs: [
+		{ $id: 'x_id', term: {} },
+		{ $id: 'y_id', term: {} }
+	]
+}
+
+tape('getSampleCoordinatesByTerms: exposes sample name when displaying sample ids is allowed', async t => {
+	await ensureOpenAuth()
+	const [samples] = await getSampleCoordinatesByTerms(req, coordQ, makeDs(true), makeCoordData())
+	t.equal(samples.length, 2, 'should return both samples')
+	t.equal((samples[0] as any).sample, 'SampleA', 'first sample should carry its label')
+	t.equal((samples[1] as any).sample, 'SampleB', 'second sample should carry its label')
+	t.end()
+})
+
+tape('getSampleCoordinatesByTerms: hides sample name when displaying sample ids is not allowed', async t => {
+	await ensureOpenAuth()
+	const [samples] = await getSampleCoordinatesByTerms(req, coordQ, makeDs(false), makeCoordData())
+	t.equal(samples.length, 2, 'should still return both samples (coordinates are shown)')
+	t.notOk('sample' in (samples[0] as any), 'first sample should not carry a sample name/id')
+	t.notOk('sample' in (samples[1] as any), 'second sample should not carry a sample name/id')
+	t.end()
+})
+
+tape('getSampleCoordinatesByTerms: hides sample name for a non-admin under a function policy', async t => {
+	await ensureOpenAuth()
+	const [denied] = await getSampleCoordinatesByTerms(reqWithRole('public'), coordQ, makeDsPolicy(), makeCoordData())
+	t.notOk('sample' in (denied[0] as any), 'a role the policy denies should not receive sample names')
+	const [allowed] = await getSampleCoordinatesByTerms(reqWithRole('admin'), coordQ, makeDsPolicy(), makeCoordData())
+	t.equal((allowed[0] as any).sample, 'SampleA', 'a role the policy allows should receive sample names')
+	t.end()
+})
+
+/*** prebuilt-plot branch: getSamples() ***/
+
+// a plot already loaded in memory (filterableSamples set => loadFile is skipped). Each sample
+// object carries a .sample name that must be dropped when display is not allowed.
+function makePlot(): any {
+	return {
+		referenceSamples: [{ sample: 'Ref1', x: 1, y: 2 }],
+		filterableSamples: [
+			{ sample: 'Cohort1', x: 3, y: 4 },
+			{ sample: 'Cohort2', x: 5, y: 6 }
+		]
+	}
+}
+
+tape('getSamples: exposes sample names when displaying sample ids is allowed', async t => {
+	await ensureOpenAuth()
+	const [refSamples, cohortSamples] = await getSamples(req, makeDs(true), makePlot())
+	t.equal((refSamples[0] as any).sample, 'Ref1', 'reference sample should carry its name')
+	t.deepEqual(
+		cohortSamples.map((s: any) => s.sample),
+		['Cohort1', 'Cohort2'],
+		'cohort samples should carry their names'
+	)
+	t.end()
+})
+
+tape('getSamples: hides sample names when displaying sample ids is not allowed', async t => {
+	await ensureOpenAuth()
+	const [refSamples, cohortSamples] = await getSamples(req, makeDs(false), makePlot())
+	t.notOk('sample' in (refSamples[0] as any), 'reference sample should not carry a name')
+	t.equal(cohortSamples.length, 2, 'should still return both cohort samples (coordinates are shown)')
+	t.notOk(
+		cohortSamples.some((s: any) => 'sample' in s),
+		'no cohort sample should carry a name/id'
+	)
+	t.end()
+})
+
+tape('getSamples: hides sample names for a non-admin under a function policy', async t => {
+	await ensureOpenAuth()
+	const [, deniedCohort] = await getSamples(reqWithRole('public'), makeDsPolicy(), makePlot())
+	t.notOk(
+		deniedCohort.some((s: any) => 'sample' in s),
+		'a role the policy denies should not receive sample names'
+	)
+	const [, allowedCohort] = await getSamples(reqWithRole('admin'), makeDsPolicy(), makePlot())
+	t.deepEqual(
+		allowedCohort.map((s: any) => s.sample),
+		['Cohort1', 'Cohort2'],
+		'a role the policy allows should receive sample names'
+	)
+	t.end()
+})

--- a/server/src/routes/test/sampleScatter.unit.spec.ts
+++ b/server/src/routes/test/sampleScatter.unit.spec.ts
@@ -184,13 +184,15 @@ tape('getSamples: hides sample names when displaying sample ids is not allowed',
 
 tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate while keeping the key', t => {
 	// a response shape as built after annotation: cohort entries carry a real sampleId, reference entries
-	// (e.g. the "Ref" cloud) carry none.
+	// (e.g. the "Ref" cloud) carry none. Each entry here still carries a .sample name — this models the
+	// fail-closed case where the name was copied into result while the request was authorized, then the
+	// final auth decision at the response boundary is "denied" (see the fail-closed test below).
 	const result: any = {
 		Default: {
 			samples: [
-				{ sampleId: 41, x: 3, y: 4 },
-				{ sampleId: 52, x: 5, y: 6 },
-				{ x: 7, y: 8 } // reference dot, no sampleId
+				{ sampleId: 41, sample: 'SampleA', x: 3, y: 4 },
+				{ sampleId: 52, sample: 'SampleB', x: 5, y: 6 },
+				{ sample: 'RefName', x: 7, y: 8 } // reference dot, no sampleId
 			]
 		}
 	}
@@ -214,7 +216,11 @@ tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate whi
 		samples.slice(0, 2).every((s: any) => s.hideSampleId === true),
 		'each anonymized cohort dot should be flagged with hideSampleId so the client gates sample actions'
 	)
-	t.notOk('sampleId' in samples[2], 'a reference dot without a sampleId should be left untouched')
+	t.notOk(
+		samples.some((s: any) => 'sample' in s),
+		'no sample name should survive, on cohort or reference dots (fail-closed at the response boundary)'
+	)
+	t.notOk('sampleId' in samples[2], 'a reference dot without a sampleId should keep no sampleId key')
 	t.notOk('hideSampleId' in samples[2], 'a reference dot should not be flagged with hideSampleId')
 	t.deepEqual(
 		samples.map((s: any) => [s.x, s.y]),
@@ -225,6 +231,22 @@ tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate whi
 		],
 		'coordinates should be preserved'
 	)
+	t.end()
+})
+
+tape('anonymizeSampleIds: is fail-closed — deletes sample names even when sampleId was already anonymized', t => {
+	// Guards the response-boundary sanitizer. Authorization is evaluated twice: once while building samples
+	// and again here at the boundary. If a session expires (or a function policy flips) between those two
+	// points, names may already have been copied into result. anonymizeSampleIds must strip .sample
+	// unconditionally so the final denied decision wins — rewriting only sampleId is not enough.
+	const result: any = {
+		Group1: { samples: [{ sampleId: 7, sample: 'Alice', x: 1, y: 2 }] },
+		Group2: { samples: [{ sample: 'Bob', x: 3, y: 4 }] } // a name with no sampleId must also be removed
+	}
+	anonymizeSampleIds(result)
+	t.notOk('sample' in result.Group1.samples[0], 'a cohort name copied in before the auth flip should be removed')
+	t.notOk('sample' in result.Group2.samples[0], 'a name without a sampleId should be removed too')
+	t.equal(result.Group1.samples[0].sampleId, 'anonymous-0', 'the sampleId should still be anonymized')
 	t.end()
 })
 

--- a/server/src/routes/test/sampleScatter.unit.spec.ts
+++ b/server/src/routes/test/sampleScatter.unit.spec.ts
@@ -210,7 +210,12 @@ tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate whi
 		'surrogates should be non-numeric so they cannot resolve back to a real (integer) sample id'
 	)
 	t.equal(new Set(samples.slice(0, 2).map((s: any) => s.sampleId)).size, 2, 'surrogates should be unique')
+	t.ok(
+		samples.slice(0, 2).every((s: any) => s.hideSampleId === true),
+		'each anonymized cohort dot should be flagged with hideSampleId so the client gates sample actions'
+	)
 	t.notOk('sampleId' in samples[2], 'a reference dot without a sampleId should be left untouched')
+	t.notOk('hideSampleId' in samples[2], 'a reference dot should not be flagged with hideSampleId')
 	t.deepEqual(
 		samples.map((s: any) => [s.x, s.y]),
 		[

--- a/server/src/routes/test/sampleScatter.unit.spec.ts
+++ b/server/src/routes/test/sampleScatter.unit.spec.ts
@@ -20,7 +20,7 @@ or run the whole unit suite (as CI does):
   cd proteinpaint/server && npm run test:unit
 *********************************************/
 import tape from 'tape'
-import { getSampleCoordinatesByTerms, getSamples } from '../termdb.sampleScatter.ts'
+import { getSampleCoordinatesByTerms, getSamples, anonymizeSampleIds } from '../termdb.sampleScatter.ts'
 import { getAuthApi, authApi } from '../../auth.js'
 
 // assign the shared open-access authApi once (idempotent — the live-binding is process-global)
@@ -85,8 +85,43 @@ tape('getSampleCoordinatesByTerms: hides sample name when displaying sample ids 
 	await ensureOpenAuth()
 	const [samples] = await getSampleCoordinatesByTerms(req, coordQ, makeDs(false), makeCoordData())
 	t.equal(samples.length, 2, 'should still return both samples (coordinates are shown)')
-	t.notOk('sample' in (samples[0] as any), 'first sample should not carry a sample name/id')
-	t.notOk('sample' in (samples[1] as any), 'second sample should not carry a sample name/id')
+	t.notOk('sample' in (samples[0] as any), 'first sample should not carry a sample name')
+	t.notOk('sample' in (samples[1] as any), 'second sample should not carry a sample name')
+	// the raw sampleId is intentionally still present at the helper level — it is the internal lookup key
+	// used by colorAndShapeSamples during annotation, and is only anonymized at the response boundary
+	// (see the end-to-end test below). Dropping the name alone is NOT sufficient: the client exports
+	// `sample || sampleId`, so a raw sampleId here would still leak an identifier.
+	t.deepEqual(
+		samples.map((s: any) => s.sampleId),
+		['1', '2'],
+		'the raw sampleId (the internal lookup key) should still be present in the helper output'
+	)
+	t.end()
+})
+
+tape('coordinate branch response is anonymized end-to-end when access is denied', async t => {
+	// getSampleCoordinatesByTerms returns the raw sampleId (needed for annotation), so the route must
+	// anonymize it before responding — otherwise the client export `sample || sampleId` still leaks an
+	// identifier. This is the assertion the name-only checks above cannot make.
+	await ensureOpenAuth()
+	const [samples] = await getSampleCoordinatesByTerms(req, coordQ, makeDs(false), makeCoordData())
+	// mirror the route: the coordinate-branch samples flow into the response result unchanged
+	const result: any = { Default: { samples } }
+	anonymizeSampleIds(result)
+	const out = result.Default.samples
+
+	t.ok(
+		out.every((s: any) => 'sampleId' in s),
+		'the sampleId key should remain so the client can still tell cohort dots from reference dots'
+	)
+	t.notOk(
+		out.some((s: any) => s.sampleId === '1' || s.sampleId === '2'),
+		'no raw sampleId should remain in the anonymized response'
+	)
+	t.notOk(
+		out.some((s: any) => 'sample' in s),
+		'and no sample name should be present either (so `sample || sampleId` exposes only a surrogate)'
+	)
 	t.end()
 })
 
@@ -101,14 +136,15 @@ tape('getSampleCoordinatesByTerms: hides sample name for a non-admin under a fun
 
 /*** prebuilt-plot branch: getSamples() ***/
 
-// a plot already loaded in memory (filterableSamples set => loadFile is skipped). Each sample
-// object carries a .sample name that must be dropped when display is not allowed.
+// a plot already loaded in memory (filterableSamples set => loadFile is skipped). Cohort entries carry
+// the real integer .sampleId that loadFile() assigns (needed for the server-side annotation join), plus
+// a .sample name that must be dropped when display is not allowed.
 function makePlot(): any {
 	return {
 		referenceSamples: [{ sample: 'Ref1', x: 1, y: 2 }],
 		filterableSamples: [
-			{ sample: 'Cohort1', x: 3, y: 4 },
-			{ sample: 'Cohort2', x: 5, y: 6 }
+			{ sampleId: 41, sample: 'Cohort1', x: 3, y: 4 },
+			{ sampleId: 52, sample: 'Cohort2', x: 5, y: 6 }
 		]
 	}
 }
@@ -132,7 +168,57 @@ tape('getSamples: hides sample names when displaying sample ids is not allowed',
 	t.equal(cohortSamples.length, 2, 'should still return both cohort samples (coordinates are shown)')
 	t.notOk(
 		cohortSamples.some((s: any) => 'sample' in s),
-		'no cohort sample should carry a name/id'
+		'no cohort sample should carry a name'
+	)
+	// the real sampleId is intentionally kept here — it is needed for the server-side annotation join and
+	// is only anonymized out of the final response by anonymizeSampleIds()
+	t.deepEqual(
+		cohortSamples.map((s: any) => s.sampleId),
+		[41, 52],
+		'cohort samples should keep their real sampleId for server-side annotation'
+	)
+	t.end()
+})
+
+/*** response anonymization: anonymizeSampleIds() ***/
+
+tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate while keeping the key', t => {
+	// a response shape as built after annotation: cohort entries carry a real sampleId, reference entries
+	// (e.g. the "Ref" cloud) carry none.
+	const result: any = {
+		Default: {
+			samples: [
+				{ sampleId: 41, x: 3, y: 4 },
+				{ sampleId: 52, x: 5, y: 6 },
+				{ x: 7, y: 8 } // reference dot, no sampleId
+			]
+		}
+	}
+	anonymizeSampleIds(result)
+	const samples = result.Default.samples
+
+	t.ok(
+		samples.slice(0, 2).every((s: any) => 'sampleId' in s),
+		'cohort dots should keep the sampleId key so the client can still tell them from reference dots'
+	)
+	t.notOk(
+		samples.some((s: any) => s.sampleId === 41 || s.sampleId === 52),
+		'no real sampleId value should remain in the response'
+	)
+	t.notOk(
+		samples.some((s: any) => typeof s.sampleId == 'number'),
+		'surrogates should be non-numeric so they cannot resolve back to a real (integer) sample id'
+	)
+	t.equal(new Set(samples.slice(0, 2).map((s: any) => s.sampleId)).size, 2, 'surrogates should be unique')
+	t.notOk('sampleId' in samples[2], 'a reference dot without a sampleId should be left untouched')
+	t.deepEqual(
+		samples.map((s: any) => [s.x, s.y]),
+		[
+			[3, 4],
+			[5, 6],
+			[7, 8]
+		],
+		'coordinates should be preserved'
 	)
 	t.end()
 })

--- a/shared/types/src/routes/termdb.sampleScatter.ts
+++ b/shared/types/src/routes/termdb.sampleScatter.ts
@@ -21,7 +21,7 @@ export type TermdbSampleScatterRequest = {
 
 export type ScatterSample = {
 	category: string
-	sample: string
+	sample?: string
 	/** real db sample id (or a non-numeric anonymous surrogate when the request may not display sample ids) */
 	sampleId?: number | string
 	/** set by the server (anonymizeSampleIds) when this cohort sample's id has been anonymized. The client

--- a/shared/types/src/routes/termdb.sampleScatter.ts
+++ b/shared/types/src/routes/termdb.sampleScatter.ts
@@ -22,6 +22,12 @@ export type TermdbSampleScatterRequest = {
 export type ScatterSample = {
 	category: string
 	sample: string
+	/** real db sample id (or a non-numeric anonymous surrogate when the request may not display sample ids) */
+	sampleId?: number | string
+	/** set by the server (anonymizeSampleIds) when this cohort sample's id has been anonymized. The client
+	 * uses it to gate all sample-specific actions and grouping, since the surrogate sampleId cannot resolve
+	 * back to a real sample. */
+	hideSampleId?: boolean
 	info?: { [index: string]: any }
 	shape: string
 	x: number


### PR DESCRIPTION
# Description

Test with https://github.com/stjude/sjpp/pull/1530

This fix only affects datasets with credentials, unprotected datasets would still show sample IDs in scatter plot by default.

Tested locally with all unit and integration tests.

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
