### PR TITLE
use sample.isRef instead of requiring sampleId property 

### DIFF
--- a/client/plots/scatter/model/ScatterModelBase.ts
+++ b/client/plots/scatter/model/ScatterModelBase.ts
@@ -36,7 +36,9 @@ export abstract class ScatterModelBase {
 	abstract initData(): Promise<void>
 
 	createChart(id: string, data: ScatterDataResult | SingleCellPlotDataResult) {
-		const cohortSamples: any[] = data.samples ? data.samples.filter(sample => 'sampleId' in sample) : []
+		// isRef marks reference-cloud dots; the server sets it once (from sampleId presence, before any
+		// anonymization) so a denied request that drops sampleId still classifies cohort dots correctly.
+		const cohortSamples: any[] = data.samples ? data.samples.filter(sample => !sample.isRef) : []
 		if (cohortSamples.length > maxSvgSamplesCutoff) this.is2DLarge = true
 		const colorLegend: Map<string, ColorLegendItem> = new Map(data.colorLegend)
 		const shapeLegend: Map<string, ShapeLegendItem> = new Map(data.shapeLegend)
@@ -102,7 +104,7 @@ export abstract class ScatterModelBase {
 	}
 
 	getOpacity(c) {
-		if ('sampleId' in c) {
+		if (!c.isRef) {
 			const hidden = c.hidden?.['category'] || c.hidden?.['shape']
 			if (this.filterSampleStr) {
 				if (!c.sample?.toLowerCase().includes(this.filterSampleStr.toLowerCase())) {
@@ -137,10 +139,10 @@ export abstract class ScatterModelBase {
 	}
 
 	getScale(chart, c, factor = 1) {
-		const isRef = !('sampleId' in c)
+		const isRef = !!c.isRef
 		let scale
 		if (!this.scatter.config.scaleDotTW || isRef) {
-			scale = 'sampleId' in c ? this.scatter.settings.size : this.scatter.settings.refSize
+			scale = isRef ? this.scatter.settings.refSize : this.scatter.settings.size
 		} else {
 			const range = this.scatter.settings.maxShapeSize - this.scatter.settings.minShapeSize
 			if (this.scatter.settings.scaleDotOrder == 'Ascending')
@@ -179,7 +181,7 @@ export abstract class ScatterModelBase {
 			else color = chart.colorGenerator(c.geneExp)
 			return color
 		}
-		if (this.scatter.config.colorTW?.q.mode == 'continuous' && 'sampleId' in c) {
+		if (this.scatter.config.colorTW?.q.mode == 'continuous' && !c.isRef) {
 			const [min, max] = chart.colorGenerator.domain()
 			if (c.category < min) return chart.colorGenerator(min)
 			if (c.category > max) return chart.colorGenerator(max)

--- a/client/plots/scatter/test/scatter.ui.integration.spec.ts
+++ b/client/plots/scatter/test/scatter.ui.integration.spec.ts
@@ -19,7 +19,7 @@ Tests:
     - Show tooltip for sample
     - Test scale dot
     - Test lasso menus options
-    - Lasso menu is suppressed for anonymized samples (hideSampleId)
+    - Lasso menu is suppressed for anonymized samples (no sampleId)
     - (commented out) Test continuous mode with age color
     - Test legend
     - Render color groups
@@ -84,7 +84,7 @@ tape('Show tooltip for sample', function (test) {
 		scatter.on('postRender.test', null)
 		const chart = scatter.Inner.model.charts[0]
 		const scatterTooltip = scatter.Inner.vm.scatterTooltip
-		const dot = chart.data.samples.find(s => 'sampleId' in s && scatterTooltip.isVisible(s))
+		const dot = chart.data.samples.find(s => !s.isRef && scatterTooltip.isVisible(s))
 
 		mousemoveOverDot(scatter, chart, dot)
 
@@ -224,7 +224,7 @@ tape('Test lasso menus options', function (test) {
 	}
 })
 
-tape('Lasso menu is suppressed for anonymized samples (hideSampleId)', function (test) {
+tape('Lasso menu is suppressed for anonymized samples (no sampleId)', function (test) {
 	test.timeoutAfter(8000)
 
 	runpp({
@@ -239,13 +239,14 @@ tape('Lasso menu is suppressed for anonymized samples (hideSampleId)', function 
 	async function runTests(scatter) {
 		scatter.on('postRender.test', null)
 
-		// Simulate the response to a request that may not display sample ids: the server
-		// (anonymizeSampleIds) replaces each real sampleId with a non-numeric surrogate and flags
-		// hideSampleId. Because a surrogate id cannot resolve to a real sample, none of the
-		// sample-specific lasso actions (list, grouping, filtering, sample view) should be offered.
-		const anonymizedItems = mockGroups[0].items.map((it, i) => {
-			const clone: any = { ...it, sampleId: `anonymous-${i}`, hideSampleId: true }
+		// Simulate the response to a request that may not display sample ids: the server marks each dot's
+		// isRef, then anonymizeSampleIds deletes the sampleId and name from cohort dots (isRef stays false,
+		// so they still render as cohort dots). With no real sampleId, none of the sample-specific lasso
+		// actions (list, grouping, filtering, sample view) should be offered.
+		const anonymizedItems = mockGroups[0].items.map(it => {
+			const clone: any = { ...it, isRef: false }
 			delete clone.sample
+			delete clone.sampleId
 			return clone
 		})
 		scatter.Inner.vm.scatterLasso.showLassoMenu(new PointerEvent('click'), anonymizedItems)

--- a/client/plots/scatter/test/scatterModel.unit.spec.ts
+++ b/client/plots/scatter/test/scatterModel.unit.spec.ts
@@ -195,7 +195,11 @@ tape('getOpacity, getStrokeWidth, getShape and getCoordinates return expected va
 		0,
 		'Should return no stroke width for a hidden sample.'
 	)
-	test.equal(model.getOpacity({ x: 0, y: 0 }), 0.6, 'Should return reference opacity based on the showRef setting.')
+	test.equal(
+		model.getOpacity({ x: 0, y: 0, isRef: true }),
+		0.6,
+		'Should return reference opacity based on the showRef setting.'
+	)
 
 	const shape = model.getShape(chart, sample)
 	test.ok(!!shape, 'Should return a valid shape entry.')
@@ -217,7 +221,7 @@ tape('getScale and transform support fixed and data-driven sizing', function (te
 	})
 
 	const sample = { sampleId: 's1', sample: 'Alpha', x: 10, y: 10, scale: 15 }
-	const ref = { x: 10, y: 10, scale: 15 }
+	const ref = { x: 10, y: 10, scale: 15, isRef: true }
 
 	const s = scatter.settings
 
@@ -285,13 +289,15 @@ tape('getColor supports categorical and continuous clamping', function (test) {
 		'rgb(12,0,0)',
 		'Should pass through continuous values within the domain.'
 	)
+	// reference-cloud dots (isRef) skip the continuous branch even under a continuous colorTW, falling to
+	// the Default/categorical color path
 	test.equal(
-		model.getColor({ category: 'Default' }, chart),
+		model.getColor({ category: 'Default', isRef: true }, chart),
 		'#ce768e',
 		'Should use the scatter default color for the Default category.'
 	)
 	test.equal(
-		model.getColor({ category: 'A' }, chart),
+		model.getColor({ category: 'A', isRef: true }, chart),
 		'#f00',
 		'Should use the color legend mapping for categorical values.'
 	)

--- a/client/plots/scatter/test/scatterTooltip.unit.spec.ts
+++ b/client/plots/scatter/test/scatterTooltip.unit.spec.ts
@@ -10,7 +10,7 @@ import { xAxisOffSet, yAxisOffSet } from '#shared'
  * 	- Neighbours are the dots that overlap at 100% zoom, held constant in screen px
  * 	- scaleDotTW dots get a neighbourhood matching their larger radius
  * 	- isVisible() excludes hidden dots and the suppressed reference cloud
- * 	- getActions() gates sample-specific actions for reference dots and anonymized (hideSampleId) samples
+ * 	- getActions() gates sample-specific actions for reference dots and anonymized (sampleId-less) samples
  *
  * These cover what the deleted distance() got wrong. It clamped both points into
  * [xAxisScale.invert(0), xAxisScale.invert(svgw)] — but the axis range starts at
@@ -89,9 +89,9 @@ tape('dotRadius() tracks the rendered dot size', function (test) {
 
 	const ref = getScatterStub({ refSize: 3 })
 	test.equal(
-		new ScatterTooltip(ref).dotRadius(getChart(ref), { x: 0, y: 0, hidden: {} }),
+		new ScatterTooltip(ref).dotRadius(getChart(ref), { x: 0, y: 0, hidden: {}, isRef: true }),
 		(8 * 3) / 3,
-		'a reference dot (no sampleId) uses refSize'
+		'a reference dot (isRef true) uses refSize'
 	)
 	test.end()
 })
@@ -245,13 +245,19 @@ tape('isVisible() excludes hidden dots and the suppressed reference cloud', func
 		tooltip.isVisible(sample(1, 1, { hidden: { category: true } })),
 		'a dot hidden by a color legend click is excluded'
 	)
-	test.true(tooltip.isVisible({ x: 1, y: 1, hidden: {} }), 'a reference dot is visible by default')
+	test.true(tooltip.isVisible({ x: 1, y: 1, hidden: {}, isRef: true }), 'a reference dot is visible by default')
 
 	const noRef = new ScatterTooltip(getScatterStub({ showRef: false }))
-	test.false(noRef.isVisible({ x: 1, y: 1, hidden: {} }), 'reference dots are excluded when showRef is off')
+	test.false(
+		noRef.isVisible({ x: 1, y: 1, hidden: {}, isRef: true }),
+		'reference dots are excluded when showRef is off'
+	)
 
 	const zeroRef = new ScatterTooltip(getScatterStub({ refSize: 0 }))
-	test.false(zeroRef.isVisible({ x: 1, y: 1, hidden: {} }), 'reference dots are excluded when refSize is 0')
+	test.false(
+		zeroRef.isVisible({ x: 1, y: 1, hidden: {}, isRef: true }),
+		'reference dots are excluded when refSize is 0'
+	)
 	test.end()
 })
 
@@ -274,18 +280,18 @@ tape('getActions() gates sample-specific actions for reference and anonymized sa
 	test.timeoutAfter(100)
 	const tooltip = new ScatterTooltip(getActionsStub())
 
-	const cohortActions = tooltip.getActions({ sampleId: 1, sample: 'S1' })
+	const cohortActions = tooltip.getActions({ isRef: false, sampleId: 1, sample: 'S1' })
 	test.ok(
 		cohortActions.some((a: any) => a.label === 'Sample view'),
 		'a real cohort sample offers the Sample view action'
 	)
 
 	test.deepEqual(
-		tooltip.getActions({ sampleId: 'anonymous-0', hideSampleId: true }),
+		tooltip.getActions({ isRef: false }),
 		[],
-		'an anonymized sample (hideSampleId) offers no sample-specific actions even though the sampleId key is present'
+		'an anonymized cohort dot (isRef false, but no sampleId) offers no sample-specific actions'
 	)
 
-	test.deepEqual(tooltip.getActions({ x: 1, y: 2 }), [], 'a reference dot (no sampleId) offers no actions')
+	test.deepEqual(tooltip.getActions({ isRef: true }), [], 'a reference dot (isRef true) offers no actions')
 	test.end()
 })

--- a/client/plots/scatter/view/scatterView.ts
+++ b/client/plots/scatter/view/scatterView.ts
@@ -85,7 +85,7 @@ export class ScatterView {
 
 	getControlInputs() {
 		const labels = this.scatter.config.controlLabels
-		const hasRef = this.scatter.model.charts?.[0]?.data?.samples?.find(s => !('sampleId' in s)) || false
+		const hasRef = this.scatter.model.charts?.[0]?.data?.samples?.find(s => s.isRef) || false
 		const chartType = 'sampleScatter'
 		const itemLabel = this.scatter.settings.itemLabel
 		const scaleDotOption = {

--- a/client/plots/scatter/viewmodel/scatterLasso.ts
+++ b/client/plots/scatter/viewmodel/scatterLasso.ts
@@ -65,7 +65,7 @@ export class ScatterLasso {
 			this.selectedItems = []
 			for (const item of chart.lasso.selectedItems()) {
 				const data = item.__data__
-				if ('sampleId' in data && !(data.hidden['category'] || data.hidden['shape'])) this.selectedItems.push(item)
+				if (!data.isRef && !(data.hidden['category'] || data.hidden['shape'])) this.selectedItems.push(item)
 			}
 			chart.lasso.notSelectedItems().attr('transform', c => this.model.transform(chart, c))
 			const samples = this.selectedItems.map(item => item.__data__)
@@ -76,10 +76,10 @@ export class ScatterLasso {
 	showLassoMenu(event, samples) {
 		this.view.dom.tip.clear().hide()
 		if (samples.length == 0) return
-		// hideSampleId marks cohort dots whose ids were anonymized because the request may not display
-		// sample ids. Their surrogate ids cannot resolve to real samples, so listing, grouping, filtering
-		// and sample view would all submit nonexistent ids or build empty filters — offer no menu.
-		if (samples.some(s => s.hideSampleId)) return
+		// A request not authorized to display sample ids yields cohort dots with no sampleId (the server
+		// dropped it). Listing, grouping, filtering and sample view would all submit nothing or build an
+		// empty filter, so offer no menu when any selected dot lacks a real sample id.
+		if (samples.some(s => s.sampleId == null)) return
 		this.view.dom.tip.show(event.clientX, event.clientY)
 
 		const labels = this.scatter.config.controlLabels

--- a/client/plots/scatter/viewmodel/scatterTooltip.ts
+++ b/client/plots/scatter/viewmodel/scatterTooltip.ts
@@ -63,7 +63,7 @@ export class ScatterTooltip {
 
 	isVisible(s) {
 		// getOpacity() honours showRef for reference dots but not refSize == 0
-		if (!('sampleId' in s) && (!this.scatter.settings.showRef || this.scatter.settings.refSize == 0)) return false
+		if (s.isRef && (!this.scatter.settings.showRef || this.scatter.settings.refSize == 0)) return false
 		return this.scatter.model.getOpacity(s) > 0
 	}
 
@@ -292,11 +292,11 @@ export class ScatterTooltip {
 		const interactivity = this.scatter.interactivity
 		const actions: ActionMenuItem[] = []
 
-		// reference-cloud dots carry no mutation data, so none of these apply to them; the plots
-		// below are also for cohort samples only, and not in the single cell plot. hideSampleId marks a
-		// sample whose id was anonymized because the request may not display sample ids — its surrogate id
-		// cannot resolve to a real sample, so gate every sample-specific action here.
-		if (!('sampleId' in sample) || sample.hideSampleId || config.singleCellPlot) return actions
+		// reference-cloud dots carry no mutation data, so none of these apply to them; the plots below are
+		// also for cohort samples only, and not in the single cell plot. A cohort dot from a request not
+		// authorized to display sample ids has no sampleId (the server dropped it), so gate every
+		// sample-specific action when the real id is absent — it would submit nothing / build an empty filter.
+		if (sample.isRef || sample.sampleId == null || config.singleCellPlot) return actions
 
 		// the gene may be carried by either term — the old tooltip offered Lollipop from
 		// whichever of the color/shape rows happened to be a geneVariant

--- a/client/plots/scatter/viewmodel/scatterViewModelBase.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModelBase.ts
@@ -304,9 +304,7 @@ export class ScatterViewModelBase {
 	mayRenderSampleLabels(chart) {
 		const g = chart.serie
 		const labelData =
-			this.scatter.config.bySample && chart.data?.samples
-				? chart.data.samples.filter(c => 'sampleId' in c && c.sample)
-				: []
+			this.scatter.config.bySample && chart.data?.samples ? chart.data.samples.filter(c => !c.isRef && c.sample) : []
 		const labels = g.selectAll('text[name="sampleLabel"]').data(labelData, (c: any) => c.sample)
 		labels.exit().remove()
 		labels

--- a/server/src/routes/termdb.sampleScatter.ts
+++ b/server/src/routes/termdb.sampleScatter.ts
@@ -177,6 +177,10 @@ export function init({ genomes }) {
 				range = { xMin, xMax, yMin, yMax }
 			}
 			if (!result) result = await colorAndShapeSamples(refSamples, cohortSamples, data as ValidGetDataResponse, q)
+			// classify each dot as cohort vs reference cloud ONCE, from sampleId presence, before any
+			// anonymization. The client renders/sizes/labels by this flag instead of sampleId presence, so a
+			// denied request may drop sampleId (below) without a dot being misclassified as a reference dot.
+			markRefDots(result)
 			// the real sampleId was needed above for the server-side annotation join; it must not leave the
 			// server for a request not authorized to display sample ids (see anonymizeSampleIds)
 			if (!authApi.canDisplaySampleIds(req, ds)) anonymizeSampleIds(result)
@@ -208,30 +212,43 @@ export async function getSamples(req: any, ds: any, plot: any) {
 	}
 }
 
-/** Replace every real sampleId in the scatter response with an anonymous surrogate and mark the sample.
+/** Mark every dot as reference-cloud (isRef=true) or cohort (isRef=false), from sampleId presence.
+ *
+ * Must run BEFORE anonymizeSampleIds, while sampleId presence still reflects reality. The client uses this
+ * flag — not sampleId presence — to tell cohort dots from reference dots, to size them (cohort = size,
+ * reference = refSize), to decide labels, and to gate sample-specific actions. Deriving it here, once,
+ * lets a denied request drop sampleId entirely without a cohort dot being reclassified as a reference dot.
+ *
+ * Note this deliberately mirrors the old `!('sampleId' in dot)` test: colorColumn (non-bySample) plots set
+ * a sampleId on their reference dots so they render at the regular size, and those therefore stay
+ * isRef=false — exactly as before. */
+export function markRefDots(result: { [index: string]: { samples: any[] } }) {
+	for (const divideBy in result) {
+		for (const sample of result[divideBy].samples || []) {
+			sample.isRef = !('sampleId' in sample)
+		}
+	}
+}
+
+/** Remove every real sampleId and sample name from the scatter response.
  *
  * Called only when the request is NOT authorized to display sample ids. Both sample sources put a real,
- * identifying value on .sampleId: getSampleCoordinatesByTerms() uses the db sample id, and loadFile()
- * assigns the integer sample id (or, for colorColumn plots, the sample name) to prebuilt cohort/reference
- * entries. That value was needed for the server-side annotation join (colorAndShapeSamples) but must not
- * reach the client: without this, the client download fallback (scatter.ts toText: `s.sample || s.sampleId`)
- * would still expose it even after the sample NAME was stripped.
+ * identifying value on .sampleId (getSampleCoordinatesByTerms uses the db sample id; loadFile assigns the
+ * integer sample id, or the sample name for colorColumn plots) and, when authorized, a .sample name. Those
+ * were needed for the server-side annotation join and labeling, but must not reach the client: the client
+ * download fallback (scatter.ts toText: `s.sample || s.sampleId`) and its sample-specific actions would
+ * otherwise expose or submit a real id.
  *
- * The client uses the presence of the .sampleId key to tell cohort dots from reference dots and to size
- * them, so the key is preserved and given a non-numeric surrogate that cannot resolve back to a real
- * (integer) sample id. But the client also submits the sampleId VALUE for sample-specific actions (open
- * sample view, lasso grouping/filtering); a surrogate there would offer denied users actions that submit
- * a nonexistent id or build an empty filter. So each anonymized sample is also flagged with .hideSampleId,
- * which the client uses to gate all such sample-specific actions and grouping. */
+ * Classification/rendering no longer depends on sampleId (markRefDots set .isRef first), so the id can be
+ * deleted outright — no surrogate needed. Deleting .sample and .sampleId is also the fail-closed choice:
+ * authorization is evaluated once while building samples and again here; if it flips to "denied" between
+ * those points, this unconditionally strips whatever was already copied in. A cohort dot then has no
+ * sampleId, which is how the client gates its sample-specific actions. */
 export function anonymizeSampleIds(result: { [index: string]: { samples: any[] } }) {
-	let n = 0
 	for (const divideBy in result) {
 		for (const sample of result[divideBy].samples || []) {
 			delete sample.sample
-			if ('sampleId' in sample) {
-				sample.sampleId = `anonymous-${n++}`
-				sample.hideSampleId = true
-			}
+			delete sample.sampleId
 		}
 	}
 }

--- a/server/src/routes/test/sampleScatter.unit.spec.ts
+++ b/server/src/routes/test/sampleScatter.unit.spec.ts
@@ -20,7 +20,7 @@ or run the whole unit suite (as CI does):
   cd proteinpaint/server && npm run test:unit
 *********************************************/
 import tape from 'tape'
-import { getSampleCoordinatesByTerms, getSamples, anonymizeSampleIds } from '../termdb.sampleScatter.ts'
+import { getSampleCoordinatesByTerms, getSamples, markRefDots, anonymizeSampleIds } from '../termdb.sampleScatter.ts'
 import { getAuthApi, authApi } from '../../auth.js'
 
 // assign the shared open-access authApi once (idempotent — the live-binding is process-global)
@@ -101,26 +101,28 @@ tape('getSampleCoordinatesByTerms: hides sample name when displaying sample ids 
 
 tape('coordinate branch response is anonymized end-to-end when access is denied', async t => {
 	// getSampleCoordinatesByTerms returns the raw sampleId (needed for annotation), so the route must
-	// anonymize it before responding — otherwise the client export `sample || sampleId` still leaks an
-	// identifier. This is the assertion the name-only checks above cannot make.
+	// classify (markRefDots) then anonymize (delete sampleId + name) before responding — otherwise the
+	// client export `sample || sampleId` still leaks an identifier. This is the assertion the name-only
+	// checks above cannot make.
 	await ensureOpenAuth()
 	const [samples] = await getSampleCoordinatesByTerms(req, coordQ, makeDs(false), makeCoordData())
-	// mirror the route: the coordinate-branch samples flow into the response result unchanged
+	// mirror the route: classify each dot, then anonymize, on the response result
 	const result: any = { Default: { samples } }
+	markRefDots(result)
 	anonymizeSampleIds(result)
 	const out = result.Default.samples
 
 	t.ok(
-		out.every((s: any) => 'sampleId' in s),
-		'the sampleId key should remain so the client can still tell cohort dots from reference dots'
+		out.every((s: any) => s.isRef === false),
+		'coordinate-branch dots are cohort dots (isRef false), so the client still distinguishes them from reference dots after the sampleId is gone'
 	)
 	t.notOk(
-		out.some((s: any) => s.sampleId === '1' || s.sampleId === '2'),
-		'no raw sampleId should remain in the anonymized response'
+		out.some((s: any) => 'sampleId' in s),
+		'no sampleId (real or surrogate) should remain in the anonymized response'
 	)
 	t.notOk(
 		out.some((s: any) => 'sample' in s),
-		'and no sample name should be present either (so `sample || sampleId` exposes only a surrogate)'
+		'and no sample name should be present either (so `sample || sampleId` exposes nothing)'
 	)
 	t.end()
 })
@@ -180,13 +182,34 @@ tape('getSamples: hides sample names when displaying sample ids is not allowed',
 	t.end()
 })
 
-/*** response anonymization: anonymizeSampleIds() ***/
+/*** dot classification and response anonymization ***/
 
-tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate while keeping the key', t => {
+tape('markRefDots: classifies dots by sampleId presence, mirroring the old cohort-vs-reference test', t => {
+	// Cohort dots carry a real sampleId; reference-cloud dots carry none — EXCEPT colorColumn (non-bySample)
+	// reference dots, which carry a sampleId so they render at the regular size and must stay isRef=false.
+	const result: any = {
+		Default: {
+			samples: [
+				{ sampleId: 41, x: 3, y: 4 }, // cohort dot
+				{ x: 7, y: 8 }, // plain reference-cloud dot, no sampleId
+				{ sampleId: 'CC-1', x: 9, y: 10 } // colorColumn reference dot with a sampleId
+			]
+		}
+	}
+	markRefDots(result)
+	const samples = result.Default.samples
+	t.equal(samples[0].isRef, false, 'a dot with a sampleId is a cohort dot (isRef false)')
+	t.equal(samples[1].isRef, true, 'a dot without a sampleId is a reference-cloud dot (isRef true)')
+	t.equal(samples[2].isRef, false, 'a colorColumn reference dot keeps isRef false so it renders regular size')
+	t.end()
+})
+
+tape('anonymizeSampleIds: deletes sampleId and name so no identifier leaves the server', t => {
 	// a response shape as built after annotation: cohort entries carry a real sampleId, reference entries
 	// (e.g. the "Ref" cloud) carry none. Each entry here still carries a .sample name — this models the
 	// fail-closed case where the name was copied into result while the request was authorized, then the
-	// final auth decision at the response boundary is "denied" (see the fail-closed test below).
+	// final auth decision at the response boundary is "denied" (see the fail-closed test below). Classify
+	// first (as the route does) so we can assert the client can still tell cohort from reference dots.
 	const result: any = {
 		Default: {
 			samples: [
@@ -196,32 +219,23 @@ tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate whi
 			]
 		}
 	}
+	markRefDots(result)
 	anonymizeSampleIds(result)
 	const samples = result.Default.samples
 
-	t.ok(
-		samples.slice(0, 2).every((s: any) => 'sampleId' in s),
-		'cohort dots should keep the sampleId key so the client can still tell them from reference dots'
-	)
 	t.notOk(
-		samples.some((s: any) => s.sampleId === 41 || s.sampleId === 52),
-		'no real sampleId value should remain in the response'
-	)
-	t.notOk(
-		samples.some((s: any) => typeof s.sampleId == 'number'),
-		'surrogates should be non-numeric so they cannot resolve back to a real (integer) sample id'
-	)
-	t.equal(new Set(samples.slice(0, 2).map((s: any) => s.sampleId)).size, 2, 'surrogates should be unique')
-	t.ok(
-		samples.slice(0, 2).every((s: any) => s.hideSampleId === true),
-		'each anonymized cohort dot should be flagged with hideSampleId so the client gates sample actions'
+		samples.some((s: any) => 'sampleId' in s),
+		'no sampleId (real or surrogate) should remain on any dot'
 	)
 	t.notOk(
 		samples.some((s: any) => 'sample' in s),
 		'no sample name should survive, on cohort or reference dots (fail-closed at the response boundary)'
 	)
-	t.notOk('sampleId' in samples[2], 'a reference dot without a sampleId should keep no sampleId key')
-	t.notOk('hideSampleId' in samples[2], 'a reference dot should not be flagged with hideSampleId')
+	t.deepEqual(
+		samples.map((s: any) => s.isRef),
+		[false, false, true],
+		'isRef still distinguishes cohort dots from the reference dot after the sampleId is gone'
+	)
 	t.deepEqual(
 		samples.map((s: any) => [s.x, s.y]),
 		[
@@ -234,19 +248,19 @@ tape('anonymizeSampleIds: replaces real sampleId with an anonymous surrogate whi
 	t.end()
 })
 
-tape('anonymizeSampleIds: is fail-closed — deletes sample names even when sampleId was already anonymized', t => {
+tape('anonymizeSampleIds: is fail-closed — deletes sampleId and name unconditionally', t => {
 	// Guards the response-boundary sanitizer. Authorization is evaluated twice: once while building samples
 	// and again here at the boundary. If a session expires (or a function policy flips) between those two
-	// points, names may already have been copied into result. anonymizeSampleIds must strip .sample
-	// unconditionally so the final denied decision wins — rewriting only sampleId is not enough.
+	// points, the id and name may already have been copied into result. anonymizeSampleIds must strip both
+	// unconditionally so the final denied decision wins.
 	const result: any = {
 		Group1: { samples: [{ sampleId: 7, sample: 'Alice', x: 1, y: 2 }] },
 		Group2: { samples: [{ sample: 'Bob', x: 3, y: 4 }] } // a name with no sampleId must also be removed
 	}
 	anonymizeSampleIds(result)
-	t.notOk('sample' in result.Group1.samples[0], 'a cohort name copied in before the auth flip should be removed')
+	t.notOk('sampleId' in result.Group1.samples[0], 'the real sampleId copied in before the auth flip should be removed')
+	t.notOk('sample' in result.Group1.samples[0], 'the cohort name copied in before the auth flip should be removed')
 	t.notOk('sample' in result.Group2.samples[0], 'a name without a sampleId should be removed too')
-	t.equal(result.Group1.samples[0].sampleId, 'anonymous-0', 'the sampleId should still be anonymized')
 	t.end()
 })
 

--- a/shared/types/src/routes/termdb.sampleScatter.ts
+++ b/shared/types/src/routes/termdb.sampleScatter.ts
@@ -22,12 +22,14 @@ export type TermdbSampleScatterRequest = {
 export type ScatterSample = {
 	category: string
 	sample?: string
-	/** real db sample id (or a non-numeric anonymous surrogate when the request may not display sample ids) */
+	/** real db sample id. Absent on reference-cloud dots, and also dropped from cohort dots when the request
+	 * is not authorized to display sample ids (see anonymizeSampleIds) — so its presence is NOT a reliable
+	 * cohort-vs-reference test; use isRef for that. */
 	sampleId?: number | string
-	/** set by the server (anonymizeSampleIds) when this cohort sample's id has been anonymized. The client
-	 * uses it to gate all sample-specific actions and grouping, since the surrogate sampleId cannot resolve
-	 * back to a real sample. */
-	hideSampleId?: boolean
+	/** set by the server (markRefDots) for every dot: true = reference-cloud dot (rendered small/unlabeled,
+	 * no sample actions), false = cohort dot. Derived from sampleId presence BEFORE any anonymization, so the
+	 * client can classify/size/label dots even when a denied request has dropped the sampleId. */
+	isRef?: boolean
 	info?: { [index: string]: any }
 	shape: string
 	x: number


### PR DESCRIPTION
# Description

…to distinguish from reference. 

Tests
- all unit and integration tests
- sjlife and PNET scatter plots

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
