### PR TITLE
Pass the request path through to getSessionId in getDsAuth

### DIFF
--- a/server/src/auth/AuthApi.ts
+++ b/server/src/auth/AuthApi.ts
@@ -79,7 +79,15 @@ export class AuthApi implements AuthInterface {
 					if (embedderHostPattern != '*' && !isMatch(embedder, embedderHostPattern)) continue
 					const cred: any = _cred
 					const query = Object.assign({}, req.query, { dslabel: dslabelPattern })
-					const id = this.#auth.getSessionId({ query, headers: req.headers, cookies: req.cookies }, cred)
+					// path must be included: getSessionId -> mayAddSessionFromJwt matches
+					// req.path against cred.route, and without it the bearer-jwt branch
+					// throws and is discarded, leaving only the session cookie to prove
+					// insession — a cookie some browsers (webkit) won't send over plain
+					// http since it is flagged Secure
+					const id = this.#auth.getSessionId(
+						{ query, headers: req.headers, cookies: req.cookies, path: req.path },
+						cred
+					)
 					const activeSession = this.#auth.sessions[dslabelPattern]?.[id]
 					const sessionStart = activeSession?.time || 0
 					// support a dataset-specific override to maxSessionAge


### PR DESCRIPTION
Fixed using Claude: Please review

Root cause (server, not the test): getDsAuth in server/src/auth/AuthApi.ts builds a synthetic request without .path. Inside getSessionId → mayAddSessionFromJwt, the route-match line req.path[0] threw, the catch silently discarded the Bearer-jwt branch, and insession could then only be proven by the x-ds-access-token session cookie. That cookie is flagged Secure — Chromium and Firefox still send it to http://localhost (they treat localhost as trustworthy), but WebKit never does. So on WebKit a jwt-authorized user failed the userCanAccessDsData sign-in gate and sample search returned nothing. I proved it by pairing each chat request's real headers with its response: identical jwts, and the cookie was the only differing bit.

Fix: pass path: req.path into the synthetic object so the Bearer jwt can establish the session in getDsAuth the same way it already does in the request middleware

# Description

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
