### PR TITLE
Fix the inverted y-scale in large 2D scatter plot

### DIFF
--- a/client/plots/scatter/model/ScatterModelBase.ts
+++ b/client/plots/scatter/model/ScatterModelBase.ts
@@ -245,8 +245,12 @@ export abstract class ScatterModelBase {
 			const yMinDate = getDateFromNumber(yMin - extraSpaceY)
 			const yMaxDate = getDateFromNumber(yMax + extraSpaceY)
 
+			// Flip the domain (max first) to mirror the numeric yAxisScale above. In SVG the y range
+			// grows downward, so the numeric scale uses [yMax, yMin] to render larger values at the top;
+			// the date axis must match, otherwise the axis labels run opposite to the plotted dots
+			// (which are always positioned with yAxisScale), making the y-axis appear inverted.
 			chart.yAxisScaleTime = scaleTime()
-				.domain([yMinDate, yMaxDate])
+				.domain([yMaxDate, yMinDate])
 				.range([offsetY, settings.svgh + offsetY])
 
 			chart.axisLeft = axisLeft(chart.yAxisScaleTime)

--- a/client/plots/scatter/test/scatterModel.unit.spec.ts
+++ b/client/plots/scatter/test/scatterModel.unit.spec.ts
@@ -11,6 +11,7 @@ import { getCoordinate } from '#shared'
  *  - getScale and transform support fixed and data-driven sizing
  *  - getColor supports categorical and continuous clamping
  *  - initAxes applies continuous colorScale modes: auto, fixed, percentile
+ *  - initAxes orients the date Y-axis to match the numeric dot scale
  *  - processData sorts charts and computes polynomial regression curve
  *  - getCoordinate returns value as coordinate when min and max are null
  *  - getCoordinate returns value when value is within min and max
@@ -336,6 +337,60 @@ tape('initAxes applies continuous colorScale modes: auto, fixed, percentile', fu
 
 	scatter.config.settings.sampleScatter.colorScalePercentile = 50
 	assertRange('percentile', 1, 5, 'the percentile mode percentile-range')
+	test.end()
+})
+
+tape('initAxes orients the date Y-axis to match the numeric dot scale', function (test) {
+	test.timeoutAfter(100)
+	// Regression test: term2 (Y / overlay) is a date term. Dots are always positioned with the
+	// numeric chart.yAxisScale, whose domain is flipped to [yMax, yMin] so that larger values (later
+	// dates, since dates are encoded as year + fraction) render at the top. The date axis scale must
+	// share that orientation; otherwise the axis labels run opposite to the plotted dots and the
+	// y-axis appears inverted. See ScatterModelBase.initAxes().
+	const scatter: any = getMockScatter({
+		config: {
+			term: { term: { id: 'agedx', type: 'integer' } },
+			term2: { term: { id: 'visitdate', type: 'date' } }
+		}
+	})
+	const model = new ScatterModel(scatter)
+	const chart: any = getMockChart({
+		id: 'date-chart',
+		data: { samples: [{ sampleId: 's1', x: 5, y: 2010 }] },
+		ranges: {
+			xMin: 0,
+			xMax: 20,
+			yMin: 2000,
+			yMax: 2020,
+			zMin: 0,
+			zMax: 10,
+			scaleMin: 10,
+			scaleMax: 20,
+			geMin: 1,
+			geMax: 5
+		}
+	})
+
+	model.initAxes(chart)
+
+	const [rangeTop, rangeBottom] = chart.yAxisScaleTime.range()
+	test.ok(rangeBottom > rangeTop, 'Sanity: the SVG y range grows downward (top pixel < bottom pixel).')
+
+	const lateDate = new Date(2019, 0, 1)
+	const earlyDate = new Date(2001, 0, 1)
+	test.ok(
+		chart.yAxisScaleTime(lateDate) < chart.yAxisScaleTime(earlyDate),
+		'Should render the later date higher on the axis (smaller y pixel), not inverted.'
+	)
+
+	// The date axis must agree with the numeric yAxisScale that positions the dots.
+	const laterIsHigherOnTime = chart.yAxisScaleTime(lateDate) < chart.yAxisScaleTime(earlyDate)
+	const laterIsHigherOnLinear = chart.yAxisScale(2019) < chart.yAxisScale(2001)
+	test.equal(
+		laterIsHigherOnTime,
+		laterIsHigherOnLinear,
+		'Should orient the date Y-axis the same way as the numeric yAxisScale used for the dots.'
+	)
 	test.end()
 })
 

--- a/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
+++ b/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
@@ -1,0 +1,91 @@
+import tape from 'tape'
+import { scaleLinear as d3Linear } from 'd3-scale'
+import { ScatterViewModel2DLarge } from '../viewmodel/scatterViewModel2DLarge.ts'
+import { xAxisOffSet, yAxisOffSet } from '#shared'
+
+/** Tests:
+ *  - getVertices maps larger data-y to a higher WebGL clip-space y (not inverted)
+ *  - getVertices does not mutate the shared chart axis scales
+ */
+
+/**************
+ test sections
+***************/
+
+tape('\n', function (test) {
+	test.comment('-***- plots/scatter/viewmodel/scatterViewModel2DLarge -***-')
+	test.end()
+})
+
+/** Build a chart with axis scales like ScatterModelBase.initAxes():
+ * the y scale uses a flipped domain [yMax, yMin] mapped to SVG pixels (top -> bottom),
+ * because SVG's y grows downward. getVertices must re-map into WebGL clip space, where
+ * y grows upward, so larger data values land nearer +1 (the top). */
+function getMockChart() {
+	const svgw = 400
+	const svgh = 400
+	const xAxisScale = d3Linear()
+		.domain([0, 10])
+		.range([xAxisOffSet, svgw + xAxisOffSet])
+	const yAxisScale = d3Linear()
+		.domain([100, 0]) // flipped for SVG (yMax first), as initAxes builds it
+		.range([yAxisOffSet, svgh + yAxisOffSet])
+	return {
+		xAxisScale,
+		yAxisScale,
+		data: {
+			samples: [
+				{ sampleId: 'high', x: 5, y: 90 },
+				{ sampleId: 'low', x: 5, y: 10 }
+			]
+		}
+	}
+}
+
+/** getVertices only uses this.model.getOpacity/getColor besides the chart scales/samples,
+ * so exercise it on a bare prototype instance to avoid constructing the full view/DOM. */
+function getMockViewModel() {
+	const vm: any = Object.create(ScatterViewModel2DLarge.prototype)
+	vm.model = {
+		getOpacity: () => 1,
+		getColor: () => '#000000'
+	}
+	return vm
+}
+
+tape('getVertices maps larger data-y to a higher WebGL clip-space y (not inverted)', function (test) {
+	test.timeoutAfter(100)
+	const vm = getMockViewModel()
+	const chart = getMockChart()
+
+	const { vertices } = vm.getVertices(chart)
+
+	// vertices is a flat [x, y, z, x, y, z, ...] array; sample order is preserved
+	const highY = vertices[1] // data y = 90
+	const lowY = vertices[4] // data y = 10
+
+	test.ok(
+		highY > lowY,
+		`Should place the larger data value higher in clip space (got high=${highY}, low=${lowY}), not inverted.`
+	)
+	test.ok(highY <= 1 && lowY >= -1, 'Should keep clip-space y within [-1, 1].')
+	test.end()
+})
+
+tape('getVertices does not mutate the shared chart axis scales', function (test) {
+	test.timeoutAfter(100)
+	const vm = getMockViewModel()
+	const chart = getMockChart()
+	const yRangeBefore = chart.yAxisScale.range().slice()
+	const xRangeBefore = chart.xAxisScale.range().slice()
+
+	vm.getVertices(chart)
+
+	test.deepEqual(
+		chart.yAxisScale.range(),
+		yRangeBefore,
+		'Should leave chart.yAxisScale range intact for the axis, zoom and hover quadtree.'
+	)
+	test.deepEqual(chart.xAxisScale.range(), xRangeBefore, 'Should leave chart.xAxisScale range intact.')
+	test.end()
+})

--- a/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
@@ -75,8 +75,14 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 	}
 
 	getVertices(chart) {
-		const xAxisScale = chart.xAxisScale.range([-1, 1])
-		const yAxisScale = chart.yAxisScale.range([-1, 1])
+		// Map data coordinates into WebGL clip space [-1, 1]. Copy the shared axis scales instead of
+		// mutating their range in place, since fillSvgSubElems (axis), scatterZoom and the hover
+		// quadtree all read chart.xAxisScale/yAxisScale expecting their SVG pixel ranges.
+		// WebGL's y points up while the SVG-oriented chart.yAxisScale uses a flipped domain
+		// ([yMax, yMin]) for SVG's downward y; map y to [1, -1] so larger values render at the top,
+		// matching the SVG y-axis. x needs no flip ([-1, 1]) since both spaces grow left-to-right.
+		const xAxisScale = chart.xAxisScale.copy().range([-1, 1])
+		const yAxisScale = chart.yAxisScale.copy().range([1, -1])
 		const vertices: any = []
 		const colors: any = []
 		for (const sample of chart.data.samples) {


### PR DESCRIPTION
# Description

Map data coordinates into WebGL clip space when used for large 2D scatter plot, to fix an inverted y-scale.

Tests
-  SJLIFE+CCSS cohort dynamic scatter plot with hrtavg and agedx
- all unit and integration tests

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [x] Tests: Added and/or passed unit and integration tests, or N/A
- [x] Todos: Commented or documented, or N/A
- [x] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [x] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
