### PR TITLE
render x, y-axis in large 2D scatter plot

### DIFF
--- a/client/plots/scatter/model/ScatterModelBase.ts
+++ b/client/plots/scatter/model/ScatterModelBase.ts
@@ -6,7 +6,6 @@ import { regressionPoly } from 'd3-regression'
 import type { Scatter } from '../scatter'
 import { getDateFromNumber } from '#shared/terms.js'
 import type { ColorLegendItem, ScatterChart, ScatterDataResult, ScatterRanges, ShapeLegendItem } from '../scatterTypes'
-import { maxSvgSamplesCutoff, noExpColor, expColor } from '../settings/defaults'
 import { type SingleCellPlotDataResult, SINGLECELL_GENE_EXPRESSION } from '#types'
 import { xAxisOffSet, yAxisOffSet, getCoordinate, calculatePadding } from '#shared'
 
@@ -39,7 +38,7 @@ export abstract class ScatterModelBase {
 		// isRef marks reference-cloud dots; the server sets it once (from sampleId presence, before any
 		// anonymization) so a denied request that drops sampleId still classifies cohort dots correctly.
 		const cohortSamples: any[] = data.samples ? data.samples.filter(sample => !sample.isRef) : []
-		if (cohortSamples.length > maxSvgSamplesCutoff) this.is2DLarge = true
+		if (cohortSamples.length > this.scatter.settings.maxSvgSamplesCutoff) this.is2DLarge = true
 		const colorLegend: Map<string, ColorLegendItem> = new Map(data.colorLegend)
 		const shapeLegend: Map<string, ShapeLegendItem> = new Map(data.shapeLegend)
 		const chart: ScatterChart = { id, data, cohortSamples, colorLegend, shapeLegend }
@@ -70,7 +69,7 @@ export abstract class ScatterModelBase {
 			}
 			return
 		}
-		if (samples.length > maxSvgSamplesCutoff) this.is2DLarge = true
+		if (samples.length > settings.maxSvgSamplesCutoff) this.is2DLarge = true
 		const s0 = samples[0] //First sample to start reduce comparisons
 		const [xMin, xMax, yMin, yMax, zMin, zMax, scaleMin, scaleMax, geMin, geMax] = samples.reduce(
 			(s, d) => [
@@ -176,8 +175,8 @@ export abstract class ScatterModelBase {
 	getColor(c, chart) {
 		if (this.scatter.config.colorTW?.term.type == SINGLECELL_GENE_EXPRESSION) {
 			let color
-			if (!c.geneExp) color = noExpColor
-			else if (c.geneExp > chart.ranges.geMax) color = expColor
+			if (!c.geneExp) color = this.scatter.settings.noExpColor
+			else if (c.geneExp > chart.ranges.geMax) color = this.scatter.settings.expColor
 			else color = chart.colorGenerator(c.geneExp)
 			return color
 		}
@@ -276,14 +275,14 @@ export abstract class ScatterModelBase {
 		if (!config.startColor[chart.id]) {
 			config.startColor[chart.id] =
 				config.colorTW?.term.type == SINGLECELL_GENE_EXPRESSION
-					? noExpColor
+					? settings.noExpColor
 					: config.colorTW?.term.continuousColorScale?.minColor || gradientColor.brighter().brighter().toString()
 		}
 
 		if (!config.stopColor[chart.id]) {
 			config.stopColor[chart.id] =
 				config.colorTW?.term.type == SINGLECELL_GENE_EXPRESSION
-					? expColor
+					? settings.expColor
 					: config.colorTW?.term.continuousColorScale?.maxColor || gradientColor.darker().toString()
 		}
 		// Handle continuous color scaling when color term wrapper is in continuous mode

--- a/client/plots/scatter/model/ScatterSingleCellModel.ts
+++ b/client/plots/scatter/model/ScatterSingleCellModel.ts
@@ -1,6 +1,5 @@
 import { ScatterModelBase } from './ScatterModelBase'
 import type { Scatter } from '../scatter'
-import { maxSvgSamplesCutoff, noExpColor, expColor } from '../settings/defaults'
 import { rgb } from 'd3-color'
 import type { TermdbSingleCellPlotsResponse } from '#types'
 
@@ -29,7 +28,7 @@ export class ScatterSingleCellModel extends ScatterModelBase {
 			filter: state.termfilter.filter,
 			filter0: state.termfilter.filter0,
 			canvasSettings: {
-				cutoff: maxSvgSamplesCutoff,
+				cutoff: this.scatter.settings.maxSvgSamplesCutoff,
 				width: this.scatter.settings.svgw,
 				height: this.scatter.settings.svgh,
 				radius: this.scatter.settings.size,
@@ -37,8 +36,8 @@ export class ScatterSingleCellModel extends ScatterModelBase {
 				maxXScale: this.scatter.settings.maxXScale,
 				minYScale: this.scatter.settings.minYScale,
 				maxYScale: this.scatter.settings.maxYScale,
-				startColor: c.startColor?.['Default'] || rgb(noExpColor).toString(),
-				stopColor: c.stopColor?.['Default'] || rgb(expColor).toString(),
+				startColor: c.startColor?.['Default'] || rgb(this.scatter.settings.noExpColor).toString(),
+				stopColor: c.stopColor?.['Default'] || rgb(this.scatter.settings.expColor).toString(),
 				opacity: this.scatter.settings.opacity,
 				devicePixelRatio: window.devicePixelRatio || 1
 			}

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -201,10 +201,22 @@ export class Scatter extends PlotBase implements RxComponent {
 	 * transparent and overlaid on chart.svg, which carries the axes, titles, legend and the white
 	 * plot-area background. A plain canvas.toDataURL() would therefore export only the points on a
 	 * transparent background, so composite the svg and the webgl canvas onto one export canvas.
-	 * When there is no co-located svg to composite (e.g. a server-rendered single-cell image), fall
-	 * back to serializing the canvas on its own. */
+	 * For a server-rendered single-cell plot there is no webgl canvas — renderLargeSingleCell() puts
+	 * the server image into an SVG <image> — so return that image source directly. When there is no
+	 * co-located svg to composite, fall back to serializing the canvas on its own. */
 	async getWebglImage(): Promise<string> {
-		const canvas = this.vm.canvas
+		// this.vm.canvas is an HTMLCanvasElement for the webgl point cloud, but renderLargeSingleCell()
+		// assigns a d3 selection wrapping an SVG <image>; normalize either to a DOM node
+		const rawCanvas: any = this.vm.canvas
+		const canvasNode = typeof rawCanvas?.node === 'function' ? rawCanvas.node() : rawCanvas
+
+		// server-rendered single-cell plot: no HTML canvas to composite, so return the server image's
+		// source (the <image> href) directly rather than calling toDataURL() on a non-canvas node
+		if (canvasNode instanceof SVGImageElement) {
+			return canvasNode.href?.baseVal || canvasNode.getAttribute('href') || canvasNode.getAttribute('xlink:href') || ''
+		}
+
+		const canvas = canvasNode as HTMLCanvasElement
 		const container = canvas?.parentNode as HTMLElement | null
 		const svgNode = container?.querySelector('svg') as SVGSVGElement | null
 		if (!svgNode) return canvas.toDataURL('image/png')

--- a/client/plots/scatter/scatter.ts
+++ b/client/plots/scatter/scatter.ts
@@ -186,7 +186,7 @@ export class Scatter extends PlotBase implements RxComponent {
 
 	async download(event) {
 		if (this.model.is2DLarge || this.model.is3D) {
-			const url = this.vm.canvas.toDataURL('image/png')
+			const url = await this.getWebglImage()
 			downloadImage(url)
 		} else {
 			const name2svg = this.getChartImages()
@@ -195,6 +195,52 @@ export class Scatter extends PlotBase implements RxComponent {
 			})
 			menu.show(event.clientX, event.clientY, event.target)
 		}
+	}
+
+	/** Build the downloadable image for the webgl (2D large / 3D) plots. The webgl canvas is now
+	 * transparent and overlaid on chart.svg, which carries the axes, titles, legend and the white
+	 * plot-area background. A plain canvas.toDataURL() would therefore export only the points on a
+	 * transparent background, so composite the svg and the webgl canvas onto one export canvas.
+	 * When there is no co-located svg to composite (e.g. a server-rendered single-cell image), fall
+	 * back to serializing the canvas on its own. */
+	async getWebglImage(): Promise<string> {
+		const canvas = this.vm.canvas
+		const container = canvas?.parentNode as HTMLElement | null
+		const svgNode = container?.querySelector('svg') as SVGSVGElement | null
+		if (!svgNode) return canvas.toDataURL('image/png')
+
+		const width = svgNode.width.baseVal.value || Number(svgNode.getAttribute('width'))
+		const height = svgNode.height.baseVal.value || Number(svgNode.getAttribute('height'))
+
+		// serialize the svg, copying font styles onto the clone so the axis/legend text renders
+		// correctly when the svg is drawn as a standalone image
+		const svgClone = svgNode.cloneNode(true) as SVGSVGElement
+		svgClone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+		const computed = window.getComputedStyle(svgNode)
+		svgClone.style.setProperty('font-family', computed.getPropertyValue('font-family'))
+		svgClone.style.setProperty('font-size', computed.getPropertyValue('font-size'))
+		const svgStr = new XMLSerializer().serializeToString(svgClone)
+		const svgImg = await new Promise<HTMLImageElement>((resolve, reject) => {
+			const img = new Image()
+			img.onload = () => resolve(img)
+			img.onerror = reject
+			img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgStr)
+		})
+
+		const out = document.createElement('canvas')
+		out.width = width
+		out.height = height
+		const ctx = out.getContext('2d')!
+		// restore the former opaque white background of the exported image
+		ctx.fillStyle = 'white'
+		ctx.fillRect(0, 0, width, height)
+		// axes, titles, legend and the plot-area background
+		ctx.drawImage(svgImg, 0, 0, width, height)
+		// the webgl points, overlaid on the plot area at the same axis-margin offset used on screen
+		const offsetX = parseFloat(canvas.style.left) || this.model.axisOffset.x
+		const offsetY = parseFloat(canvas.style.top) || this.model.axisOffset.y
+		ctx.drawImage(canvas, offsetX, offsetY, this.settings.svgw, this.settings.svgh)
+		return out.toDataURL('image/png')
 	}
 	toText() {
 		const lines: string[] = []

--- a/client/plots/scatter/scatterTypes.ts
+++ b/client/plots/scatter/scatterTypes.ts
@@ -127,6 +127,9 @@ export type ScatterChart = {
 	colorValues?: number[]
 	/** Current min/max range used by the color generator */
 	currentColorRange?: { min: number; max: number }
+	/** 2D large (webgl) only: the zoom level this chart's axes were last drawn at, tracked per chart
+	 * so each chart's animation loop only redraws its own axes when the shared zoom changes */
+	currentAxisZoom?: number
 }
 
 export type ValidScatterDataResponse = { range: DataRange; result: { [index: string]: ScatterDataResult } }

--- a/client/plots/scatter/settings/Settings.ts
+++ b/client/plots/scatter/settings/Settings.ts
@@ -32,6 +32,10 @@ export type Settings = {
 	threeSize: number
 	/** Field of vision for 2D large plots */
 	threeFOV: number
+	/** Sample-count threshold: cohorts larger than this switch from SVG to WebGL/canvas rendering
+	 * (ScatterViewModel2DLarge). Kept in the recoverable defaults so it can be lowered — e.g. in a
+	 * unit/integration test — to exercise the large-plot path with a small dataset like TermdbTest. */
+	maxSvgSamplesCutoff: number
 	// Color scale configuration settings
 	// These settings control how numerical values are mapped to colors
 	/** Default to automatic scaling based on data range
@@ -48,6 +52,10 @@ export type Settings = {
 	/** User-defined maximum value for fixed mode
 	 * Null indicates this hasn't been set yet */
 	colorScaleMaxFixed: null | number
+	/** Color for dots with no gene expression value (gene-expression color term) */
+	noExpColor: string
+	/** Color for dots at/above the maximum gene expression value (gene-expression color term) */
+	expColor: string
 	//3D Plot settings
 	/** Shows the density of point clouds.
 	 * If 'Color' is used in continous mode,

--- a/client/plots/scatter/settings/defaults.ts
+++ b/client/plots/scatter/settings/defaults.ts
@@ -21,11 +21,15 @@ export function getDefaultScatterSettings(opts: any = {}): Settings {
 		fov: 50,
 		threeSize: 0.005,
 		threeFOV: 70,
+		maxSvgSamplesCutoff: 20000, // if a cohort is larger than this, switch from svg to webgl/canvas rendering
+
 		//ColorScale settings
 		colorScaleMode: 'auto',
 		colorScalePercentile: 95,
 		colorScaleMinFixed: null,
 		colorScaleMaxFixed: null,
+		noExpColor: '#F5F5F5', // light gray, for dots with no gene expression value
+		expColor: '#ff000d', // default color for the maximum gene expression value
 		//3D Plot settings
 		showContour: false,
 		colorContours: false,
@@ -45,7 +49,3 @@ export function getDefaultScatterSettings(opts: any = {}): Settings {
 
 	return Object.assign(defaults, overrides)
 }
-
-export const maxSvgSamplesCutoff = 20000 // if map is greater than cutoff, switch from svg to canvas rendering
-export const noExpColor = '#F5F5F5' //light gray
-export const expColor = '#ff000d' //default color for gene expression

--- a/client/plots/scatter/test/scatter.integration.spec.ts
+++ b/client/plots/scatter/test/scatter.integration.spec.ts
@@ -33,6 +33,7 @@ Tests:
     - Render TermdbTest scatter plot adding age as Z to render a 3D plot
     - Render 3D plot with age as Z and showContour set to true to apply contour on 3D plot
     - dynamic scatter of agedx & hrtavg
+    - 2D large (webgl) scatter renders a canvas with x/y axes
     - dynamic scatter of 2-gene expression
     - dynamic scatter of 2-ssgsea
     - dynamic scatter of 2-dnameth
@@ -355,6 +356,47 @@ tape('dynamic scatter of agedx & hrtavg', function (test) {
 			contourG != null,
 			'Scatter should have contour showing the density of points after selecting show contour'
 		)
+		if (test['_ok']) holder.remove()
+		test.end()
+	}
+})
+
+tape('2D large (webgl) scatter renders a canvas with x/y axes', function (test) {
+	test.timeoutAfter(10000)
+	const holder = getHolder()
+	runpp({
+		holder,
+		state: {
+			plots: [
+				{
+					chartType: 'sampleScatter',
+					term: { id: 'agedx', q: { mode: 'continuous' } },
+					term2: { id: 'hrtavg', q: { mode: 'continuous' } },
+					// lower the cutoff so the small TermdbTest cohort renders via the webgl/canvas path
+					settings: { sampleScatter: { maxSvgSamplesCutoff: 1 } }
+				}
+			]
+		},
+		sampleScatter: {
+			callbacks: {
+				'postRender.test': runTests
+			}
+		}
+	})
+
+	async function runTests(scatter) {
+		scatter.on('postRender.test', null)
+		test.true(
+			scatter.Inner.model.is2DLarge,
+			'Should switch to 2D large (webgl) rendering when the cohort exceeds the lowered maxSvgSamplesCutoff'
+		)
+		// the webgl canvas is overlaid on the plot area within the same div as the axis svg
+		const canvas = await detectGte({ elem: holder.node(), selector: 'canvas' })
+		test.equal(canvas.length, 1, 'Should render a single webgl canvas for the 2D large scatter')
+		const yTicks = await detectGte({ elem: holder.node(), selector: '.sjpcb-scatter-y-axis .tick' })
+		test.true(yTicks.length > 0, 'Should render y-axis ticks around the 2D large canvas')
+		const xTicks = await detectGte({ elem: holder.node(), selector: '.sjpcb-scatter-x-axis .tick' })
+		test.true(xTicks.length > 0, 'Should render x-axis ticks around the 2D large canvas')
 		if (test['_ok']) holder.remove()
 		test.end()
 	}

--- a/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
+++ b/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
@@ -6,6 +6,8 @@ import { xAxisOffSet, yAxisOffSet } from '#shared'
 /** Tests:
  *  - getVertices maps larger data-y to a higher WebGL clip-space y (not inverted)
  *  - getVertices does not mutate the shared chart axis scales
+ *  - renderAxes maps the data range onto the plot-area pixels with a non-inverted y-axis
+ *  - renderAxes scales the axes about the plot center by the zoom factor
  */
 
 /**************
@@ -87,5 +89,93 @@ tape('getVertices does not mutate the shared chart axis scales', function (test)
 		'Should leave chart.yAxisScale range intact for the axis, zoom and hover quadtree.'
 	)
 	test.deepEqual(chart.xAxisScale.range(), xRangeBefore, 'Should leave chart.xAxisScale range intact.')
+	test.end()
+})
+
+/** renderAxes only reads this.axisChart, this.scatter.settings/vm.scatterZoom and this.model.axisOffset,
+ * and calls chart.xAxis/yAxis.call(chart.axisBottom/Left.scale(newScale)). Capture the scale handed to
+ * each axis so we can assert where data values land in plot-area pixels. */
+function getAxisMockViewModel(zoom = 1) {
+	const vm: any = Object.create(ScatterViewModel2DLarge.prototype)
+	vm.model = { axisOffset: { x: xAxisOffSet, y: yAxisOffSet } }
+	vm.scatter = {
+		settings: { svgw: 600, svgh: 600 },
+		vm: { scatterZoom: { zoom } }
+	}
+	return vm
+}
+
+function getAxisMockChart() {
+	const capture: any = {}
+	// an axis generator stub: .scale(s) records the scale and returns itself for chaining
+	const makeAxis = () => ({
+		scale(s: any) {
+			;(this as any)._scale = s
+			return this
+		}
+	})
+	return {
+		// domain like ScatterModelBase.initAxes(): x normal, y flipped (yMax first) for SVG's downward y
+		xAxisScale: d3Linear()
+			.domain([0, 10])
+			.range([xAxisOffSet, 600 + xAxisOffSet]),
+		yAxisScale: d3Linear()
+			.domain([100, 0])
+			.range([yAxisOffSet, 600 + yAxisOffSet]),
+		axisBottom: makeAxis(),
+		axisLeft: makeAxis(),
+		xAxis: {
+			call(gen: any) {
+				capture.x = gen._scale
+			}
+		},
+		yAxis: {
+			call(gen: any) {
+				capture.y = gen._scale
+			}
+		},
+		_capture: capture
+	}
+}
+
+tape('renderAxes maps the data range onto the plot-area pixels with a non-inverted y-axis', function (test) {
+	test.timeoutAfter(100)
+	const vm = getAxisMockViewModel(1)
+	const chart = getAxisMockChart()
+	vm.axisChart = chart
+
+	vm.renderAxes()
+
+	const xScale = chart._capture.x
+	const yScale = chart._capture.y
+
+	test.equal(xScale(0), xAxisOffSet, 'Should place the x minimum at the left plot edge (offsetX).')
+	test.equal(xScale(10), 600 + xAxisOffSet, 'Should place the x maximum at the right plot edge (svgw + offsetX).')
+	test.equal(yScale(100), yAxisOffSet, 'Should place the y maximum at the top plot edge (offsetY).')
+	test.equal(yScale(0), 600 + yAxisOffSet, 'Should place the y minimum at the bottom plot edge (svgh + offsetY).')
+	test.ok(yScale(100) < yScale(0), 'Should map the larger y value higher (smaller pixel), not inverted.')
+	test.equal(vm.currentAxisZoom, 1, 'Should record the zoom the axes were drawn at.')
+	test.end()
+})
+
+tape('renderAxes scales the axes about the plot center by the zoom factor', function (test) {
+	test.timeoutAfter(100)
+	const vm = getAxisMockViewModel(2)
+	const chart = getAxisMockChart()
+	vm.axisChart = chart
+
+	vm.renderAxes()
+
+	const xScale = chart._capture.x
+	const cx = xAxisOffSet + 600 / 2
+	const cy = yAxisOffSet + 600 / 2
+	const yScale = chart._capture.y
+
+	// value 5 is the domain center and must stay fixed at the plot center under zoom
+	test.equal(xScale(5), cx, 'Should keep the plot center fixed under zoom (x).')
+	test.equal(yScale(50), cy, 'Should keep the plot center fixed under zoom (y).')
+	// range half-width doubles at zoom 2: xScale(0) = cx - 2*(svgw/2) = cx - 600
+	test.equal(xScale(0), cx - 600, 'Should widen the x range about the center by the zoom factor.')
+	test.equal(vm.currentAxisZoom, 2, 'Should record the current zoom.')
 	test.end()
 })

--- a/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
+++ b/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
@@ -12,6 +12,7 @@ import { xAxisOffSet, yAxisOffSet } from '#shared'
  *  - renderAxes drops ticks outside the data range when zoomed out
  *  - renderAxes tracks zoom per chart so multiple charts stay in sync (categorical term0)
  *  - renderAxes rescales the time scale for date terms, keeping date ticks
+ *  - animate releases the canvas and renderer when its loop becomes stale
  */
 
 /**************
@@ -285,5 +286,37 @@ tape('renderAxes rescales the time scale for date terms, keeping date ticks', fu
 		'Should rescale the time scale (its invert returns a Date) for a date x term.'
 	)
 	test.equal(typeof yScale.invert(yAxisOffSet), 'number', 'Should keep the numeric scale for the non-date y axis.')
+	test.end()
+})
+
+tape('animate releases the canvas and renderer when its loop becomes stale', function (test) {
+	test.timeoutAfter(100)
+	// a re-render swaps scatter.vm; the old loop must clean up rather than leave a stale overlay canvas
+	// (which would cover a plot that switched back to the SVG path) and a retained WebGL context
+	const vm: any = Object.create(ScatterViewModel2DLarge.prototype)
+	vm.scatter = { vm: {} } // scatter.vm !== vm, so this loop is stale
+	let removed = false
+	let disposed = false
+	let rendered = false
+	const renderer = {
+		domElement: {
+			remove() {
+				removed = true
+			}
+		},
+		dispose() {
+			disposed = true
+		},
+		render() {
+			rendered = true
+		}
+	}
+	const camera = { updateProjectionMatrix() {} }
+
+	vm.animate({}, camera, {}, renderer)
+
+	test.ok(removed, 'Should remove the overlay canvas.')
+	test.ok(disposed, 'Should dispose the WebGL renderer.')
+	test.notOk(rendered, 'Should not render again after the loop is stale.')
 	test.end()
 })

--- a/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
+++ b/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
@@ -10,6 +10,7 @@ import { xAxisOffSet, yAxisOffSet } from '#shared'
  *  - renderAxes scales the axes about the plot center by the zoom factor
  *  - renderAxes keeps the axis range pinned to the plot edges at any zoom
  *  - renderAxes drops ticks outside the data range when zoomed out
+ *  - renderAxes tracks zoom per chart so multiple charts stay in sync (categorical term0)
  */
 
 /**************
@@ -94,9 +95,9 @@ tape('getVertices does not mutate the shared chart axis scales', function (test)
 	test.end()
 })
 
-/** renderAxes only reads this.axisChart, this.scatter.settings/vm.scatterZoom and this.model.axisOffset,
- * and calls chart.xAxis/yAxis.call(chart.axisBottom/Left.scale(newScale)). Capture the scale handed to
- * each axis so we can assert where data values land in plot-area pixels. */
+/** renderAxes(chart) reads the passed chart, this.scatter.settings/vm.scatterZoom and
+ * this.model.axisOffset, and calls chart.xAxis/yAxis.call(chart.axisBottom/Left.scale(newScale)).
+ * Capture the scale handed to each axis so we can assert where data values land in plot-area pixels. */
 function getAxisMockViewModel(zoom = 1) {
 	const vm: any = Object.create(ScatterViewModel2DLarge.prototype)
 	vm.model = { axisOffset: { x: xAxisOffSet, y: yAxisOffSet } }
@@ -142,6 +143,8 @@ function getAxisMockChart() {
 				capture.yTicks = gen._tickValues
 			}
 		},
+		// renderAxes() records the per-chart zoom here
+		currentAxisZoom: undefined as number | undefined,
 		_capture: capture
 	}
 }
@@ -150,9 +153,8 @@ tape('renderAxes maps the data range onto the plot-area pixels with a non-invert
 	test.timeoutAfter(100)
 	const vm = getAxisMockViewModel(1)
 	const chart = getAxisMockChart()
-	vm.axisChart = chart
 
-	vm.renderAxes()
+	vm.renderAxes(chart)
 
 	const xScale = chart._capture.x
 	const yScale = chart._capture.y
@@ -162,7 +164,7 @@ tape('renderAxes maps the data range onto the plot-area pixels with a non-invert
 	test.equal(yScale(100), yAxisOffSet, 'Should place the y maximum at the top plot edge (offsetY).')
 	test.equal(yScale(0), 600 + yAxisOffSet, 'Should place the y minimum at the bottom plot edge (svgh + offsetY).')
 	test.ok(yScale(100) < yScale(0), 'Should map the larger y value higher (smaller pixel), not inverted.')
-	test.equal(vm.currentAxisZoom, 1, 'Should record the zoom the axes were drawn at.')
+	test.equal(chart.currentAxisZoom, 1, 'Should record the zoom the axes were drawn at on the chart.')
 	test.end()
 })
 
@@ -170,9 +172,8 @@ tape('renderAxes scales the axes about the plot center by the zoom factor', func
 	test.timeoutAfter(100)
 	const vm = getAxisMockViewModel(2)
 	const chart = getAxisMockChart()
-	vm.axisChart = chart
 
-	vm.renderAxes()
+	vm.renderAxes(chart)
 
 	const xScale = chart._capture.x
 	const cx = xAxisOffSet + 600 / 2
@@ -184,7 +185,7 @@ tape('renderAxes scales the axes about the plot center by the zoom factor', func
 	test.equal(yScale(50), cy, 'Should keep the plot center fixed under zoom (y).')
 	// range half-width doubles at zoom 2: xScale(0) = cx - 2*(svgw/2) = cx - 600
 	test.equal(xScale(0), cx - 600, 'Should widen the x range about the center by the zoom factor.')
-	test.equal(vm.currentAxisZoom, 2, 'Should record the current zoom.')
+	test.equal(chart.currentAxisZoom, 2, 'Should record the current zoom on the chart.')
 	test.end()
 })
 
@@ -196,8 +197,7 @@ tape('renderAxes keeps the axis range pinned to the plot edges at any zoom', fun
 	for (const zoom of [0.5, 2]) {
 		const vm = getAxisMockViewModel(zoom)
 		const chart = getAxisMockChart()
-		vm.axisChart = chart
-		vm.renderAxes()
+		vm.renderAxes(chart)
 		test.deepEqual(
 			chart._capture.x.range(),
 			[xAxisOffSet, 600 + xAxisOffSet],
@@ -218,8 +218,7 @@ tape('renderAxes drops ticks outside the data range when zoomed out', function (
 	// out-of-range values should not be labeled with tick marks
 	const vm = getAxisMockViewModel(0.5)
 	const chart = getAxisMockChart()
-	vm.axisChart = chart
-	vm.renderAxes()
+	vm.renderAxes(chart)
 
 	const xTicks = chart._capture.xTicks
 	const yTicks = chart._capture.yTicks
@@ -232,5 +231,31 @@ tape('renderAxes drops ticks outside the data range when zoomed out', function (
 		yTicks.every((t: number) => t >= 0 && t <= 100),
 		'Should not render y ticks below the min or above the max.'
 	)
+	test.end()
+})
+
+tape('renderAxes tracks zoom per chart so multiple charts stay in sync (categorical term0)', function (test) {
+	test.timeoutAfter(100)
+	// A categorical term0 renders multiple charts, each with its own canvas and animation loop but a
+	// single shared zoom. The zoom must be tracked per chart, not on the view model, so that every
+	// chart's axes are redrawn — not just the last one rendered.
+	const vm = getAxisMockViewModel(1)
+	const chartA = getAxisMockChart()
+	const chartB = getAxisMockChart()
+
+	vm.renderAxes(chartA)
+	vm.renderAxes(chartB)
+	test.equal(chartA.currentAxisZoom, 1, 'Should record zoom 1 on chartA.')
+	test.equal(chartB.currentAxisZoom, 1, 'Should record zoom 1 on chartB.')
+
+	// the shared zoom changes; chartA's loop redraws chartA
+	vm.scatter.vm.scatterZoom.zoom = 3
+	vm.renderAxes(chartA)
+	test.equal(chartA.currentAxisZoom, 3, 'Should redraw chartA and record the new zoom.')
+	test.equal(chartB.currentAxisZoom, 1, 'Should leave chartB tracked independently until its own loop redraws it.')
+
+	// chartB's own loop redraws chartB to the same shared zoom
+	vm.renderAxes(chartB)
+	test.equal(chartB.currentAxisZoom, 3, 'Should redraw chartB to the shared zoom independently.')
 	test.end()
 })

--- a/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
+++ b/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { scaleLinear as d3Linear } from 'd3-scale'
+import { scaleLinear as d3Linear, scaleTime as d3Time } from 'd3-scale'
 import { ScatterViewModel2DLarge } from '../viewmodel/scatterViewModel2DLarge.ts'
 import { xAxisOffSet, yAxisOffSet } from '#shared'
 
@@ -11,6 +11,7 @@ import { xAxisOffSet, yAxisOffSet } from '#shared'
  *  - renderAxes keeps the axis range pinned to the plot edges at any zoom
  *  - renderAxes drops ticks outside the data range when zoomed out
  *  - renderAxes tracks zoom per chart so multiple charts stay in sync (categorical term0)
+ *  - renderAxes rescales the time scale for date terms, keeping date ticks
  */
 
 /**************
@@ -145,6 +146,9 @@ function getAxisMockChart() {
 		},
 		// renderAxes() records the per-chart zoom here
 		currentAxisZoom: undefined as number | undefined,
+		// optional time scales set by tests to simulate a date term (as ScatterModelBase.initAxes does)
+		xAxisScaleTime: undefined as any,
+		yAxisScaleTime: undefined as any,
 		_capture: capture
 	}
 }
@@ -257,5 +261,29 @@ tape('renderAxes tracks zoom per chart so multiple charts stay in sync (categori
 	// chartB's own loop redraws chartB to the same shared zoom
 	vm.renderAxes(chartB)
 	test.equal(chartB.currentAxisZoom, 3, 'Should redraw chartB to the shared zoom independently.')
+	test.end()
+})
+
+tape('renderAxes rescales the time scale for date terms, keeping date ticks', function (test) {
+	test.timeoutAfter(100)
+	// initAxes() binds the axis generator to a time scale for a date term; renderAxes must rescale
+	// that time scale (so date ticks/formatting survive) rather than replacing it with the numeric
+	// coordinate scale used for the WebGL points.
+	const vm = getAxisMockViewModel(1)
+	const chart = getAxisMockChart()
+	// simulate a date x term: numeric xAxisScale (for WebGL coords) plus a time scale for the axis
+	chart.xAxisScaleTime = d3Time()
+		.domain([new Date(2000, 0, 1), new Date(2020, 0, 1)])
+		.range([xAxisOffSet, 600 + xAxisOffSet])
+
+	vm.renderAxes(chart)
+
+	const xScale = chart._capture.x
+	const yScale = chart._capture.y
+	test.ok(
+		xScale.invert(xAxisOffSet) instanceof Date,
+		'Should rescale the time scale (its invert returns a Date) for a date x term.'
+	)
+	test.equal(typeof yScale.invert(yAxisOffSet), 'number', 'Should keep the numeric scale for the non-date y axis.')
 	test.end()
 })

--- a/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
+++ b/client/plots/scatter/test/scatterViewModel2DLarge.unit.spec.ts
@@ -8,6 +8,8 @@ import { xAxisOffSet, yAxisOffSet } from '#shared'
  *  - getVertices does not mutate the shared chart axis scales
  *  - renderAxes maps the data range onto the plot-area pixels with a non-inverted y-axis
  *  - renderAxes scales the axes about the plot center by the zoom factor
+ *  - renderAxes keeps the axis range pinned to the plot edges at any zoom
+ *  - renderAxes drops ticks outside the data range when zoomed out
  */
 
 /**************
@@ -107,10 +109,14 @@ function getAxisMockViewModel(zoom = 1) {
 
 function getAxisMockChart() {
 	const capture: any = {}
-	// an axis generator stub: .scale(s) records the scale and returns itself for chaining
+	// an axis generator stub: .scale(s)/.tickValues(v) record their args and return itself for chaining
 	const makeAxis = () => ({
 		scale(s: any) {
 			;(this as any)._scale = s
+			return this
+		},
+		tickValues(v: any) {
+			;(this as any)._tickValues = v
 			return this
 		}
 	})
@@ -127,11 +133,13 @@ function getAxisMockChart() {
 		xAxis: {
 			call(gen: any) {
 				capture.x = gen._scale
+				capture.xTicks = gen._tickValues
 			}
 		},
 		yAxis: {
 			call(gen: any) {
 				capture.y = gen._scale
+				capture.yTicks = gen._tickValues
 			}
 		},
 		_capture: capture
@@ -177,5 +185,52 @@ tape('renderAxes scales the axes about the plot center by the zoom factor', func
 	// range half-width doubles at zoom 2: xScale(0) = cx - 2*(svgw/2) = cx - 600
 	test.equal(xScale(0), cx - 600, 'Should widen the x range about the center by the zoom factor.')
 	test.equal(vm.currentAxisZoom, 2, 'Should record the current zoom.')
+	test.end()
+})
+
+tape('renderAxes keeps the axis range pinned to the plot edges at any zoom', function (test) {
+	test.timeoutAfter(100)
+	// Rescaling adjusts the domain, not the range, so the axis spines stay at the plot edges and the
+	// two axes remain joined at the corner — never spilling past the canvas (zoom in) or pulling
+	// inward (zoom out).
+	for (const zoom of [0.5, 2]) {
+		const vm = getAxisMockViewModel(zoom)
+		const chart = getAxisMockChart()
+		vm.axisChart = chart
+		vm.renderAxes()
+		test.deepEqual(
+			chart._capture.x.range(),
+			[xAxisOffSet, 600 + xAxisOffSet],
+			`Should pin the x-axis range to the plot edges at zoom ${zoom}.`
+		)
+		test.deepEqual(
+			chart._capture.y.range(),
+			[yAxisOffSet, 600 + yAxisOffSet],
+			`Should pin the y-axis range to the plot edges at zoom ${zoom}.`
+		)
+	}
+	test.end()
+})
+
+tape('renderAxes drops ticks outside the data range when zoomed out', function (test) {
+	test.timeoutAfter(100)
+	// zoomed out, the visible window extends past the data domain ([0,10] x, [0,100] y); those
+	// out-of-range values should not be labeled with tick marks
+	const vm = getAxisMockViewModel(0.5)
+	const chart = getAxisMockChart()
+	vm.axisChart = chart
+	vm.renderAxes()
+
+	const xTicks = chart._capture.xTicks
+	const yTicks = chart._capture.yTicks
+	test.ok(Array.isArray(xTicks) && xTicks.length > 0, 'Should still render x ticks within the data range.')
+	test.ok(
+		xTicks.every((t: number) => t >= 0 && t <= 10),
+		'Should not render x ticks below the min or above the max.'
+	)
+	test.ok(
+		yTicks.every((t: number) => t >= 0 && t <= 100),
+		'Should not render y ticks below the min or above the max.'
+	)
 	test.end()
 })

--- a/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
@@ -7,10 +7,6 @@ import type { Scatter } from '../scatter'
 
 export class ScatterViewModel2DLarge extends ScatterViewModel {
 	isSingleCell: boolean = false
-	/** the chart whose x/y axes this view model keeps in sync with the WebGL zoom */
-	axisChart: any
-	/** the zoom level the axes were last drawn at, so animate() only redraws on change */
-	currentAxisZoom: number | null = null
 
 	constructor(scatter: Scatter) {
 		super(scatter)
@@ -97,20 +93,21 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 			zoomState.zoom = Math.max(0.1, Math.min(10, zoomState.zoom * factor))
 		})
 
-		this.axisChart = chart
-		this.currentAxisZoom = null
-		this.renderAxes()
-		this.animate(camera, scene, renderer)
+		this.renderAxes(chart)
+		this.animate(chart, camera, scene, renderer)
 	}
 
-	/** Redraw the x/y axes to match the current WebGL zoom. camera.zoom scales the point cloud by k
-	 * about the plot center, so express that as a d3 zoom transform and rescale the axes the way
-	 * ScatterZoom.handleZoom() does for the small plots. Rescaling keeps each axis RANGE pinned to the
-	 * plot edges (only the visible data window is relabeled), so the two axes stay joined at the corner
-	 * and neither the ticks nor the spine spill past the canvas when zoomed in. Ticks that fall outside
-	 * the data range (e.g. when zoomed out past the data) are dropped. */
-	renderAxes() {
-		const chart = this.axisChart
+	/** Redraw the given chart's x/y axes to match the current WebGL zoom. camera.zoom scales the point
+	 * cloud by k about the plot center, so express that as a d3 zoom transform and rescale the axes the
+	 * way ScatterZoom.handleZoom() does for the small plots. Rescaling keeps each axis RANGE pinned to
+	 * the plot edges (only the visible data window is relabeled), so the two axes stay joined at the
+	 * corner and neither the ticks nor the spine spill past the canvas when zoomed in. Ticks that fall
+	 * outside the data range (e.g. when zoomed out past the data) are dropped.
+	 *
+	 * The zoom is tracked per chart (chart.currentAxisZoom), not on the view model, because a
+	 * categorical term0 renders multiple charts — each with its own canvas and animation loop — that
+	 * all share one zoom level; per-chart tracking keeps every chart's axes in sync, not just the last. */
+	renderAxes(chart) {
 		if (!chart?.axisBottom || !chart?.axisLeft || !chart.xAxis || !chart.yAxis) return
 		const s = this.scatter.settings
 		const k = this.scatter.vm.scatterZoom.zoom || 1
@@ -124,7 +121,7 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		const yScale = transform.rescaleY(chart.yAxisScale)
 		chart.xAxis.call(chart.axisBottom.scale(xScale).tickValues(this.ticksWithinData(xScale, chart.xAxisScale)))
 		chart.yAxis.call(chart.axisLeft.scale(yScale).tickValues(this.ticksWithinData(yScale, chart.yAxisScale)))
-		this.currentAxisZoom = k
+		chart.currentAxisZoom = k
 	}
 
 	/** Ticks of the zoomed scale that still fall within the base (data) domain, so zooming out past
@@ -136,15 +133,15 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		return zoomedScale.ticks().filter((t: number) => t >= lo && t <= hi)
 	}
 
-	animate(camera, scene, renderer) {
+	animate(chart, camera, scene, renderer) {
 		// a re-render replaces scatter.vm with a fresh view model; stop this now-stale loop so old
 		// loops don't keep rendering to a detached canvas or fight over the shared axes
 		if (this.scatter.vm !== this) return
-		requestAnimationFrame(() => this.animate(camera, scene, renderer))
+		requestAnimationFrame(() => this.animate(chart, camera, scene, renderer))
 		const k = this.scatter.vm.scatterZoom.zoom
 		camera.zoom = k
 		camera.updateProjectionMatrix()
-		if (k !== this.currentAxisZoom) this.renderAxes()
+		if (k !== chart.currentAxisZoom) this.renderAxes(chart)
 		renderer.render(scene, camera)
 	}
 

--- a/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
@@ -1,10 +1,15 @@
 import { rgb } from 'd3-color'
+import { select } from 'd3-selection'
 import * as THREE from 'three'
 import { ScatterViewModel } from './scatterViewModel'
 import type { Scatter } from '../scatter'
 
 export class ScatterViewModel2DLarge extends ScatterViewModel {
 	isSingleCell: boolean = false
+	/** the chart whose x/y axes this view model keeps in sync with the WebGL zoom */
+	axisChart: any
+	/** the zoom level the axes were last drawn at, so animate() only redraws on change */
+	currentAxisZoom: number | null = null
 
 	constructor(scatter: Scatter) {
 		super(scatter)
@@ -17,23 +22,40 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 			return
 		}
 		const DragControls = await import('three/examples/jsm/controls/DragControls.js')
-		this.view.dom.mainDiv.selectAll('*').remove()
+		const s = this.scatter.settings
+		const offsetX = this.model.axisOffset.x
+		const offsetY = this.model.axisOffset.y
 
-		this.canvas = this.view.dom.mainDiv.insert('div').style('display', 'inline-block').append('canvas').node()
-		this.canvas.width = this.scatter.settings.svgw
-		this.canvas.height = this.scatter.settings.svgh
-		chart.chartDiv.style('margin', '20px 20px')
+		// fillSvgSubElems() has already drawn the x/y axes, axis titles and legend into chart.svg;
+		// keep that svg and overlay the WebGL canvas on the plot area (offset by the axis margins)
+		// so the axes remain visible around the point cloud, instead of wiping the whole mainDiv.
+		const div = select(chart.svg.node().parentNode)
+		div.style('position', 'relative')
+		div.selectAll('canvas').remove()
+		this.canvas = div
+			.append('canvas')
+			.style('position', 'absolute')
+			.style('left', `${offsetX}px`)
+			.style('top', `${offsetY}px`)
+			.node()
+		this.canvas.width = s.svgw
+		this.canvas.height = s.svgh
 
-		const fov = this.scatter.settings.threeFOV
+		const fov = s.threeFOV
 		const near = 0.1
 		const far = 1000
 		const camera = new THREE.PerspectiveCamera(fov, 1, near, far)
 		const scene = new THREE.Scene()
-		camera.position.set(0, 0, 1.5)
+		// Place the camera so the data range (mapped to world [-1, 1] by getVertices) exactly fills
+		// the canvas: with a vertical fov, the visible half-height at the data plane is
+		// distance * tan(fov/2), so distance = 1 / tan(fov/2) makes that half-height equal 1. This
+		// keeps the point cloud aligned with the SVG axes, which map the same data range to the same
+		// plot-area pixels.
+		camera.position.set(0, 0, 1 / Math.tan((fov * Math.PI) / 180 / 2))
 		camera.lookAt(scene.position)
 		camera.updateMatrix()
-		const whiteColor = new THREE.Color('rgb(255,255,255)')
-		scene.background = whiteColor
+		// leave the scene background unset so the canvas is transparent and the underlying svg
+		// (its plot-area background and the x/y axis spines) shows through around the points
 
 		const geometry = new THREE.BufferGeometry()
 		const { vertices, colors } = this.getVertices(chart)
@@ -53,24 +75,63 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		const particles = new THREE.Points(geometry, material)
 
 		scene.add(particles)
-		const renderer = new THREE.WebGLRenderer({ antialias: true, canvas: this.canvas, preserveDrawingBuffer: true })
+		const renderer = new THREE.WebGLRenderer({
+			antialias: true,
+			canvas: this.canvas,
+			preserveDrawingBuffer: true,
+			alpha: true
+		})
+		renderer.setClearColor(0x000000, 0) // fully transparent clear so the svg shows through
 		renderer.setSize(this.scatter.settings.svgw, this.scatter.settings.svgh)
 		renderer.setPixelRatio(window.devicePixelRatio)
 
 		new DragControls.DragControls([particles], camera, renderer.domElement)
 
-		document.addEventListener('mousewheel', (event: any) => {
-			if (event.ctrlKey) camera.position.z += event.deltaY / 500
+		// drive zoom through the shared scatterZoom so the WebGL camera and the SVG axes stay in sync
+		this.canvas.addEventListener('wheel', (event: any) => {
+			if (!event.ctrlKey) return
+			event.preventDefault()
+			const zoomState = this.scatter.vm.scatterZoom
+			const factor = event.deltaY < 0 ? 1.1 : 0.9
+			zoomState.zoom = Math.max(0.1, Math.min(10, zoomState.zoom * factor))
 		})
 
-		this.addLegendSVG(chart)
+		this.axisChart = chart
+		this.currentAxisZoom = null
+		this.renderAxes()
 		this.animate(camera, scene, renderer)
 	}
 
+	/** Redraw the x/y axes to match the current WebGL zoom. The point cloud is scaled about the
+	 * canvas center by camera.zoom, so scale each axis range about the same center by the same
+	 * factor — mirroring how ScatterZoom.handleZoom() rescales the svg axes for the small plots. */
+	renderAxes() {
+		const chart = this.axisChart
+		if (!chart?.axisBottom || !chart?.axisLeft || !chart.xAxis || !chart.yAxis) return
+		const s = this.scatter.settings
+		const k = this.scatter.vm.scatterZoom.zoom || 1
+		const offsetX = this.model.axisOffset.x
+		const offsetY = this.model.axisOffset.y
+		const cx = offsetX + s.svgw / 2
+		const cy = offsetY + s.svgh / 2
+		const halfW = (s.svgw / 2) * k
+		const halfH = (s.svgh / 2) * k
+		const xScale = chart.xAxisScale.copy().range([cx - halfW, cx + halfW])
+		const yScale = chart.yAxisScale.copy().range([cy - halfH, cy + halfH])
+		chart.xAxis.call(chart.axisBottom.scale(xScale))
+		chart.yAxis.call(chart.axisLeft.scale(yScale))
+		this.currentAxisZoom = k
+	}
+
 	animate(camera, scene, renderer) {
+		// a re-render replaces scatter.vm with a fresh view model; stop this now-stale loop so old
+		// loops don't keep rendering to a detached canvas or fight over the shared axes
+		if (this.scatter.vm !== this) return
 		requestAnimationFrame(() => this.animate(camera, scene, renderer))
-		camera.zoom = this.scatter.vm.scatterZoom.zoom
+		const k = this.scatter.vm.scatterZoom.zoom
+		camera.zoom = k
 		camera.updateProjectionMatrix()
+		if (k !== this.currentAxisZoom) this.renderAxes()
 		renderer.render(scene, camera)
 	}
 

--- a/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
@@ -18,7 +18,6 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 			this.renderLargeSingleCell(chart)
 			return
 		}
-		const DragControls = await import('three/examples/jsm/controls/DragControls.js')
 		const s = this.scatter.settings
 		const offsetX = this.model.axisOffset.x
 		const offsetY = this.model.axisOffset.y
@@ -29,6 +28,11 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		const div = select(chart.svg.node().parentNode)
 		div.style('position', 'relative')
 		div.selectAll('canvas').remove()
+		// When a chart crosses from the SVG path to this WebGL path, chart.svg is reused. Clear its data
+		// layers — the dots/contour in chart.serie and the regression curve in chart.regressionG — so
+		// stale SVG points don't show through the transparent canvas. Axes, labels and legend are kept.
+		chart.serie?.selectAll('*').remove()
+		chart.regressionG?.selectAll('*').remove()
 		this.canvas = div
 			.append('canvas')
 			.style('position', 'absolute')
@@ -82,7 +86,9 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		renderer.setSize(this.scatter.settings.svgw, this.scatter.settings.svgh)
 		renderer.setPixelRatio(window.devicePixelRatio)
 
-		new DragControls.DragControls([particles], camera, renderer.domElement)
+		// Note: no DragControls here. Dragging the point cloud would translate the particles directly
+		// while the SVG axes stay fixed, so the points would no longer line up with their axis values.
+		// Zoom (below and via the zoom buttons) is the only navigation, and it keeps the axes in sync.
 
 		// drive zoom through the shared scatterZoom so the WebGL camera and the SVG axes stay in sync
 		this.canvas.addEventListener('wheel', (event: any) => {
@@ -141,9 +147,15 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 	}
 
 	animate(chart, camera, scene, renderer) {
-		// a re-render replaces scatter.vm with a fresh view model; stop this now-stale loop so old
-		// loops don't keep rendering to a detached canvas or fight over the shared axes
-		if (this.scatter.vm !== this) return
+		// a re-render replaces scatter.vm with a fresh view model; stop this now-stale loop and release
+		// its canvas + WebGL context. Otherwise, if the plot switched back to the SVG path (which does
+		// not remove this absolute canvas), the stale overlay would cover the new SVG plot, and the
+		// renderer's GPU resources would be retained until garbage collection.
+		if (this.scatter.vm !== this) {
+			renderer.domElement.remove()
+			renderer.dispose()
+			return
+		}
 		requestAnimationFrame(() => this.animate(chart, camera, scene, renderer))
 		const k = this.scatter.vm.scatterZoom.zoom
 		camera.zoom = k

--- a/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
@@ -1,5 +1,6 @@
 import { rgb } from 'd3-color'
 import { select } from 'd3-selection'
+import { zoomIdentity } from 'd3-zoom'
 import * as THREE from 'three'
 import { ScatterViewModel } from './scatterViewModel'
 import type { Scatter } from '../scatter'
@@ -102,9 +103,12 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		this.animate(camera, scene, renderer)
 	}
 
-	/** Redraw the x/y axes to match the current WebGL zoom. The point cloud is scaled about the
-	 * canvas center by camera.zoom, so scale each axis range about the same center by the same
-	 * factor — mirroring how ScatterZoom.handleZoom() rescales the svg axes for the small plots. */
+	/** Redraw the x/y axes to match the current WebGL zoom. camera.zoom scales the point cloud by k
+	 * about the plot center, so express that as a d3 zoom transform and rescale the axes the way
+	 * ScatterZoom.handleZoom() does for the small plots. Rescaling keeps each axis RANGE pinned to the
+	 * plot edges (only the visible data window is relabeled), so the two axes stay joined at the corner
+	 * and neither the ticks nor the spine spill past the canvas when zoomed in. Ticks that fall outside
+	 * the data range (e.g. when zoomed out past the data) are dropped. */
 	renderAxes() {
 		const chart = this.axisChart
 		if (!chart?.axisBottom || !chart?.axisLeft || !chart.xAxis || !chart.yAxis) return
@@ -114,13 +118,22 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		const offsetY = this.model.axisOffset.y
 		const cx = offsetX + s.svgw / 2
 		const cy = offsetY + s.svgh / 2
-		const halfW = (s.svgw / 2) * k
-		const halfH = (s.svgh / 2) * k
-		const xScale = chart.xAxisScale.copy().range([cx - halfW, cx + halfW])
-		const yScale = chart.yAxisScale.copy().range([cy - halfH, cy + halfH])
-		chart.xAxis.call(chart.axisBottom.scale(xScale))
-		chart.yAxis.call(chart.axisLeft.scale(yScale))
+		// a scale by k about (cx, cy): applyX(p) = p*k + cx*(1-k), applyY(p) = p*k + cy*(1-k)
+		const transform = zoomIdentity.translate(cx * (1 - k), cy * (1 - k)).scale(k)
+		const xScale = transform.rescaleX(chart.xAxisScale)
+		const yScale = transform.rescaleY(chart.yAxisScale)
+		chart.xAxis.call(chart.axisBottom.scale(xScale).tickValues(this.ticksWithinData(xScale, chart.xAxisScale)))
+		chart.yAxis.call(chart.axisLeft.scale(yScale).tickValues(this.ticksWithinData(yScale, chart.yAxisScale)))
 		this.currentAxisZoom = k
+	}
+
+	/** Ticks of the zoomed scale that still fall within the base (data) domain, so zooming out past
+	 * the data does not render tick marks for values below the minimum or above the maximum. */
+	ticksWithinData(zoomedScale: any, baseScale: any) {
+		const [d0, d1] = baseScale.domain()
+		const lo = Math.min(d0, d1)
+		const hi = Math.max(d0, d1)
+		return zoomedScale.ticks().filter((t: number) => t >= lo && t <= hi)
 	}
 
 	animate(camera, scene, renderer) {

--- a/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
+++ b/client/plots/scatter/viewmodel/scatterViewModel2DLarge.ts
@@ -117,10 +117,17 @@ export class ScatterViewModel2DLarge extends ScatterViewModel {
 		const cy = offsetY + s.svgh / 2
 		// a scale by k about (cx, cy): applyX(p) = p*k + cx*(1-k), applyY(p) = p*k + cy*(1-k)
 		const transform = zoomIdentity.translate(cx * (1 - k), cy * (1 - k)).scale(k)
-		const xScale = transform.rescaleX(chart.xAxisScale)
-		const yScale = transform.rescaleY(chart.yAxisScale)
-		chart.xAxis.call(chart.axisBottom.scale(xScale).tickValues(this.ticksWithinData(xScale, chart.xAxisScale)))
-		chart.yAxis.call(chart.axisLeft.scale(yScale).tickValues(this.ticksWithinData(yScale, chart.yAxisScale)))
+		// initAxes() binds the axis generators to time scales for date terms (xAxisScaleTime/
+		// yAxisScaleTime); rescale those when present so date ticks and formatting survive the zoom,
+		// and fall back to the numeric coordinate scale otherwise. Both share the same pixel range, so
+		// the same transform applies. The WebGL points always use the numeric chart.xAxisScale/
+		// yAxisScale (see getVertices), which is left untouched.
+		const xBase = chart.xAxisScaleTime || chart.xAxisScale
+		const yBase = chart.yAxisScaleTime || chart.yAxisScale
+		const xScale = transform.rescaleX(xBase)
+		const yScale = transform.rescaleY(yBase)
+		chart.xAxis.call(chart.axisBottom.scale(xScale).tickValues(this.ticksWithinData(xScale, xBase)))
+		chart.yAxis.call(chart.axisLeft.scale(yScale).tickValues(this.ticksWithinData(yScale, yBase)))
 		chart.currentAxisZoom = k
 	}
 


### PR DESCRIPTION
# Description

Tests:
- used SJLife+CCSS numeric terms to see a large 2D scatter plot with axis, zoom in and out
- all unit and integration tests

## Checklist

[Check each task](https://github.com/stjude/proteinpaint/wiki/Pull-Request-Checklist) that has been performed or verified to be not applicable.

- [ ] Tests: Added and/or passed unit and integration tests, or N/A
- [ ] Todos: Commented or documented, or N/A
- [ ] Notable Changes: updated release.txt, prefixed a commit message with "fix:" or "feat:", added to an internal tracking document, or N/A
- [ ] Rust: Checked to see whether Rust needs to be re-compiled because of this PR, or N/A
